### PR TITLE
Zo'ra Soda Rework

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -1169,12 +1169,14 @@
 		/obj/item/reagent_containers/food/drinks/cans/zorasoda/klax = 5,
 		/obj/item/reagent_containers/food/drinks/cans/zorasoda/cthur = 5,
 		/obj/item/reagent_containers/food/drinks/cans/zorasoda/venomgrass = 5,
-		/obj/item/reagent_containers/food/drinks/cans/zorasoda/hozm = 3,
 		/obj/item/reagent_containers/food/drinks/cans/zorasoda/kois = 5,
 		/obj/item/reagent_containers/food/drinks/cans/zorasoda/drone = 5
 	)
+	contraband = list(
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/hozm = 5
+	)
 	premium = list(
-		/obj/item/reagent_containers/food/drinks/cans/zorasoda/jelly = 3,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/jelly = 3
 	)
 	prices = list(
 		/obj/item/reagent_containers/food/drinks/cans/zorasoda/cherry = 29,
@@ -1182,7 +1184,6 @@
 		/obj/item/reagent_containers/food/drinks/cans/zorasoda/klax = 29,
 		/obj/item/reagent_containers/food/drinks/cans/zorasoda/cthur = 29,
 		/obj/item/reagent_containers/food/drinks/cans/zorasoda/venomgrass = 29,
-		/obj/item/reagent_containers/food/drinks/cans/zorasoda/hozm = 49,
 		/obj/item/reagent_containers/food/drinks/cans/zorasoda/kois = 29,
 		/obj/item/reagent_containers/food/drinks/cans/zorasoda/drone = 29
 	)

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -1160,34 +1160,33 @@
 	desc = "An energy drink vendor provided by the Getmore Corporation in partnership with the brood of Ta'Akaix'Xakt'yagz'isk Zo'ra."
 	icon_state = "zoda"
 	icon_vend = "zoda-vend"
-	product_slogans = "Safe for human consumption!;Made by hard-working bound drones!;The most refreshing taste in the sector!;A product of two thousand years!"
-	product_ads = "Refreshing!;Hope you're thirsty!;Thirsty? Why not Zora?;Please, have some!;Drink up!;ZZZOOODDDAAA!"
+	product_slogans = "Safe for consumption by all species!;Made by hard-working bound drones!;The most refreshing energy drink around!;A product of two thousand years!"
+	product_ads = "Tired? Try some Zo'ra Soda!;Thirsty? Why not Zo'ra Soda?;Bored? Have some Zo'ra Soda!;Zo'ra Soda. Drink up!;ZZZOOO'RRRAAA SSSOOODDDAAA!"
 	vend_id = "zora"
 	products = list(
-		/obj/item/reagent_containers/food/drinks/cans/zorasoda = 5,
-		/obj/item/reagent_containers/food/drinks/cans/zorakois = 5,
-		/obj/item/reagent_containers/food/drinks/cans/zoraklax = 4,
-		/obj/item/reagent_containers/food/drinks/cans/zoraphoron = 5,
-		/obj/item/reagent_containers/food/drinks/cans/zoravenom = 5,
-		/obj/item/reagent_containers/food/drinks/cans/zoradrone = 5,
-	)
-	contraband = list(
-		/obj/item/reagent_containers/food/drinks/cans/zoracthur = 2,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/cherry = 5,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/phoron = 5,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/klax = 5,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/cthur = 5,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/venomgrass = 5,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/hozm = 3,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/kois = 5,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/drone = 5
 	)
 	premium = list(
-		/obj/item/reagent_containers/food/drinks/cans/zorajelly = 2,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/jelly = 3,
 	)
 	prices = list(
-		/obj/item/reagent_containers/food/drinks/cans/zorasoda = 30,
-		/obj/item/reagent_containers/food/drinks/cans/zorakois = 27,
-		/obj/item/reagent_containers/food/drinks/cans/zoraklax = 30,
-		/obj/item/reagent_containers/food/drinks/cans/zoraphoron = 30,
-		/obj/item/reagent_containers/food/drinks/cans/zoravenom = 30,
-		/obj/item/reagent_containers/food/drinks/cans/zorahozm = 50,
-		/obj/item/reagent_containers/food/drinks/cans/zoraklax = 31,
-		/obj/item/reagent_containers/food/drinks/cans/zoradrone = 30,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/cherry = 29,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/phoron = 29,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/klax = 29,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/cthur = 29,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/venomgrass = 29,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/hozm = 49,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/kois = 29,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/drone = 29
 	)
-	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
+	idle_power_usage = 211
 	temperature_setting = -1
 	light_color = COLOR_CULT_REINFORCED
 

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -26,7 +26,6 @@
 		/decl/reagent/toxin/fertilizer/monoammoniumphosphate = 1,
 		/decl/reagent/saline = 2,
 		/decl/reagent/mental/kokoreed = 0.5,
-		/decl/reagent/mental/vaam = 0.5,
 		/decl/reagent/toxin/tobacco = 3,
 		/decl/reagent/stone_dust = 0.5,
 		/decl/reagent/crayon_dust = 1,

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -4618,7 +4618,7 @@
 			to_chat(M, SPAN_GOOD(pick("You feel great!", "You feel full of energy!", "You feel alert and focused!")))
 
 /decl/reagent/drink/zorasoda/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)
-	if(!(alien == IS_DIONA || !(alien == IS_VAURCA)))
+	if(!(alien in list(IS_DIONA, IS_VAURCA))
 		M.make_jittery(5)
 		M.make_dizzy(5)
 
@@ -4662,7 +4662,7 @@
 
 /decl/reagent/drink/zorasoda/hozm/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	..()
-	if(!(alien == IS_DIONA || !(alien == IS_VAURCA)))
+	if(!(alien in list(IS_DIONA, IS_VAURCA))
 		M.make_jittery(10)
 
 /decl/reagent/drink/zorasoda/kois

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -4614,7 +4614,7 @@
 
 /decl/reagent/drink/zorasoda/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(alien != IS_DIONA)
-		if(prob(5))
+		if(prob(2))
 			to_chat(M, SPAN_GOOD(pick("You feel great!", "You feel full of energy!", "You feel alert and focused!")))
 
 /decl/reagent/drink/zorasoda/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -4620,7 +4620,6 @@
 /decl/reagent/drink/zorasoda/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)
 	if(!(alien in list(IS_DIONA, IS_VAURCA)))
 		M.make_jittery(5)
-		M.make_dizzy(5)
 
 /decl/reagent/drink/zorasoda/cherry
 	name = "Zo'ra Cherry"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -4618,7 +4618,7 @@
 			to_chat(M, SPAN_GOOD(pick("You feel great!", "You feel full of energy!", "You feel alert and focused!")))
 
 /decl/reagent/drink/zorasoda/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)
-	if(!(alien in list(IS_DIONA, IS_VAURCA))
+	if(!(alien in list(IS_DIONA, IS_VAURCA)))
 		M.make_jittery(5)
 		M.make_dizzy(5)
 
@@ -4662,7 +4662,7 @@
 
 /decl/reagent/drink/zorasoda/hozm/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	..()
-	if(!(alien in list(IS_DIONA, IS_VAURCA))
+	if(!(alien in list(IS_DIONA, IS_VAURCA)))
 		M.make_jittery(10)
 
 /decl/reagent/drink/zorasoda/kois

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -4599,105 +4599,81 @@
 	glass_name = "cup of xuizi pulque"
 	glass_desc = "A variation of Mictlanian pulque that is safe to consume for Unathi."
 
-//ZZZZOOOODDDDAAAAA
-
+// Zo'ra Sodas
 /decl/reagent/drink/zorasoda
-	name = "Zo'ra Soda Cherry"
-	description = "Zo'ra Soda, cherry edition. All good drinks come in cherry."
-	color = "#102000"
-	adj_sleepy = -2
+	name = "Zo'ra Soda"
+	description = "Zo'ra Soda. You aren't supposed to see this."
+	color = "#000000"
+	adj_dizzy = -6
+	adj_drowsy = -4
+	adj_sleepy = -3
+	overdose = 45
 	caffeine = 0.4
-	taste_description = "electric cherry"
+	taste_description = "zo'ra soda"
 	carbonated = TRUE
+
+/decl/reagent/drink/zorasoda/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
+	if(alien != IS_DIONA)
+		if(prob(5))
+			to_chat(M, SPAN_GOOD(pick("You feel great!", "You feel full of energy!", "You feel alert and focused!")))
+
+/decl/reagent/drink/zorasoda/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)
+	if(alien != IS_DIONA)
+		M.make_jittery(5)
+
+/decl/reagent/drink/zorasoda/cherry
+	name = "Zo'ra Cherry"
+	description = "Zo'ra Soda, cherry edition. All good energy drinks come in cherry."
+	color = "#102000"
+	taste_description = "bitter cherry"
 
 /decl/reagent/drink/zorasoda/phoron
-	name = "Zo'ra Soda Phoron Passion"
-	description = "Reported to taste nothing like phoron, but everything like grapes."
+	name = "Zo'ra Phoron Passion"
+	description = "Tastes nothing like phoron, but everything like grapes."
 	color = "#863333"
-	adj_sleepy = -2
-	caffeine = 0.4
-	taste_description = "electric grape"
-	carbonated = TRUE
-
-/decl/reagent/drink/zorasoda/kois
-	name = "Zo'ra Soda K'ois Twist"
-	description = "Whoever approved this in marketing needs to be drawn and quartered."
-	color = "#dcd9cd"
-	adj_sleepy = -2
-	caffeine = 0.4
-	taste_description = "sugary cabbage"
-	carbonated = TRUE
-
-/decl/reagent/drink/zorasoda/kois/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	..()
-	if(alien != IS_DIONA)
-		M.make_jittery(5)
-
-/decl/reagent/drink/zorasoda/hozm
-	name = "Zo'ra Soda High Octane Zorane Might"
-	description = "It feels like someone is just driving a freezing cold spear through the bottom of your mouth."
-	color = "#365000"
-	adj_sleepy = -3
-	caffeine = 0.6
-	taste_description = "a full-body bite into an acidic lemon"
-	carbonated = TRUE
-
-/decl/reagent/drink/zorasoda/hozm/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	..()
-	if(alien != IS_DIONA)
-		M.make_jittery(20)
-		M.dizziness += 5
-		M.drowsiness = 0
-
-/decl/reagent/drink/zorasoda/venomgrass
-	name = "Zo'ra Soda Sour Venom Grass"
-	description = "The 'diet' version of High Energy Zorane Might, still tastes like a cloud of stinging polytrinic bees."
-	color = "#100800"
-	adj_sleepy = -3
-	caffeine = 0.4
-	taste_description = "fizzy nettles"
-	carbonated = TRUE
-
-/decl/reagent/drink/zorasoda/venomgrass/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	..()
-	if(alien != IS_DIONA)
-		M.make_jittery(5)
+	taste_description = "fruity grape"
 
 /decl/reagent/drink/zorasoda/klax
-	name = "Klaxan Energy Crush"
-	description = "An orange, cream soda. It's a wonder it got here."
+	name = "K'laxan Energy Crush"
+	description = "An orange zest cream soda with a delicious smooth taste."
 	color = "#E78108"
-	adj_sleepy = -3
-	caffeine = 0.4
-	unaffected_species = IS_MACHINE
-	taste_description = "orange cream"
-	carbonated = TRUE
-
-/decl/reagent/drink/zorasoda/klax/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	..()
-	if(alien != IS_DIONA)
-		M.make_jittery(5)
+	taste_description = "fizzy and creamy orange zest"
 
 /decl/reagent/drink/zorasoda/cthur
 	name = "C'thur Rockin' Raspberry"
 	description = "A raspberry concoction you're pretty sure is already on recall."
 	color = "#0000CD"
-	adj_sleepy = -3
-	caffeine = 0.4
-	taste_description = "flat raspberry"
-	carbonated = TRUE
+	taste_description = "sweet flowery raspberry"
 
-/decl/reagent/drink/zorasoda/cthur/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
+/decl/reagent/drink/zorasoda/venomgrass
+	name = "Zo'ra Sour Venom Grass"
+	description = "The milder version of High Energy Zorane Might. Still tastes like a cloud of angry stinging acidic bees, though."
+	color = "#100800"
+	taste_description = "fizzy acidic nettles"
+
+/decl/reagent/drink/zorasoda/hozm
+	name = "Zo'ra High Octane Zorane Might"
+	description = "It feels like someone is driving a freezing cold spear through the bottom of your mouth."
+	color = "#365000"
+	caffeine = 0.6
+	taste_description = "biting into an acidic lemon mixed with strong mint"
+
+/decl/reagent/drink/zorasoda/hozm/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	..()
 	if(alien != IS_DIONA)
-		M.make_jittery(15)
+		M.make_jittery(5)
+
+/decl/reagent/drink/zorasoda/kois
+	name = "Zo'ra K'ois Twist"
+	description = "Tastes exactly like how a kitchen smells after boiling brussel sprouts."
+	color = "#DCD9CD"
+	taste_description = "sugary cabbage"
 
 /decl/reagent/drink/zorasoda/drone
 	name = "Drone Fuel"
-	description = "It's thick as syrup and smells of gas. Why."
+	description = "It's as thick as syrup and smells of gasoline. Why."
 	color = "#31004A"
-	adj_sleepy = -3
-	taste_description = "viscous cola"
+	taste_description = "viscous stale cola mixed with gasoline"
 	carbonated = TRUE
 
 /decl/reagent/drink/zorasoda/drone/affect_ingest(var/mob/living/carbon/human/M, var/alien, var/removed, var/datum/reagents/holder)
@@ -4711,26 +4687,21 @@
 		M.make_jittery(5)
 	else if(alien != IS_DIONA)
 		if (prob(10+M.chem_doses[type]))
-			to_chat(M, pick("You feel nauseous!", "Ugh...", "Your stomach churns uncomfortably!", "You feel like you're about to throw up!", "You feel queasy!","You feel pressure in your abdomen!"))
-
+			to_chat(M, pick(SPAN_WARNING("You feel nauseous!"), SPAN_WARNING("Ugh... You're going to be sick!"), SPAN_WARNING("Your stomach churns uncomfortably!"), SPAN_WARNING("You feel like you're about to throw up!"), SPAN_WARNING("You feel queasy!")))
 		if (prob(M.chem_doses[type]))
 			M.vomit()
 
 /decl/reagent/drink/zorasoda/jelly
 	name = "Royal Jelly"
-	description = "It looks of mucus, but tastes like Heaven."
+	description = "It looks like mucus, but tastes like heaven."
 	color = "#FFFF00"
-	adj_sleepy = -3
 	caffeine = 0.3
-	taste_description = "a reassuring spectrum of color"
-	carbonated = TRUE
+	taste_description = "sweet flowers and nectar mixed with aromatic spices"
 
 /decl/reagent/drink/zorasoda/jelly/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	..()
 	if(alien != IS_DIONA)
 		M.druggy = max(M.druggy, 30)
-		M.dizziness += 5
-		M.drowsiness = 0
 
 /decl/reagent/drink/hrozamal_soda
 	name = "Hro'zamal Soda"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -4618,7 +4618,7 @@
 			to_chat(M, SPAN_GOOD(pick("You feel great!", "You feel full of energy!", "You feel alert and focused!")))
 
 /decl/reagent/drink/zorasoda/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)
-	if(alien == !(IS_DIONA || IS_VAURCA)
+	if(!(alien == IS_DIONA || !(alien == IS_VAURCA)))
 		M.make_jittery(5)
 		M.make_dizzy(5)
 
@@ -4662,7 +4662,7 @@
 
 /decl/reagent/drink/zorasoda/hozm/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	..()
-	if(alien == !(IS_DIONA || IS_VAURCA)
+	if(!(alien == IS_DIONA || !(alien == IS_VAURCA)))
 		M.make_jittery(10)
 
 /decl/reagent/drink/zorasoda/kois

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -4604,9 +4604,9 @@
 	name = "Zo'ra Soda"
 	description = "Zo'ra Soda. You aren't supposed to see this."
 	color = "#000000"
-	adj_dizzy = -6
-	adj_drowsy = -4
-	adj_sleepy = -3
+	adj_dizzy = -5
+	adj_drowsy = -3
+	adj_sleepy = -2
 	overdose = 45
 	caffeine = 0.4
 	taste_description = "zo'ra soda"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -4618,8 +4618,9 @@
 			to_chat(M, SPAN_GOOD(pick("You feel great!", "You feel full of energy!", "You feel alert and focused!")))
 
 /decl/reagent/drink/zorasoda/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)
-	if(alien != IS_DIONA)
+	if(alien == !(IS_DIONA || IS_VAURCA)
 		M.make_jittery(5)
+		M.make_dizzy(5)
 
 /decl/reagent/drink/zorasoda/cherry
 	name = "Zo'ra Cherry"
@@ -4651,17 +4652,18 @@
 	color = "#100800"
 	taste_description = "fizzy acidic nettles"
 
-/decl/reagent/drink/zorasoda/hozm
+/decl/reagent/drink/zorasoda/hozm // "Contraband"
 	name = "Zo'ra High Octane Zorane Might"
 	description = "It feels like someone is driving a freezing cold spear through the bottom of your mouth."
 	color = "#365000"
+	overdose = 20
 	caffeine = 0.6
 	taste_description = "biting into an acidic lemon mixed with strong mint"
 
 /decl/reagent/drink/zorasoda/hozm/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	..()
-	if(alien != IS_DIONA)
-		M.make_jittery(5)
+	if(alien == !(IS_DIONA || IS_VAURCA)
+		M.make_jittery(10)
 
 /decl/reagent/drink/zorasoda/kois
 	name = "Zo'ra K'ois Twist"
@@ -4670,7 +4672,7 @@
 	taste_description = "sugary cabbage"
 
 /decl/reagent/drink/zorasoda/drone
-	name = "Drone Fuel"
+	name = "Vaurca Drone Fuel"
 	description = "It's as thick as syrup and smells of gasoline. Why."
 	color = "#31004A"
 	taste_description = "viscous stale cola mixed with gasoline"
@@ -4686,14 +4688,13 @@
 		M.add_chemical_effect(CE_BLOODRESTORE, 2 * removed)
 		M.make_jittery(5)
 	else if(alien != IS_DIONA)
-		if (prob(10+M.chem_doses[type]))
-			to_chat(M, pick(SPAN_WARNING("You feel nauseous!"), SPAN_WARNING("Ugh... You're going to be sick!"), SPAN_WARNING("Your stomach churns uncomfortably!"), SPAN_WARNING("You feel like you're about to throw up!"), SPAN_WARNING("You feel queasy!")))
 		if (prob(M.chem_doses[type]))
+			to_chat(M, pick(SPAN_WARNING("You feel nauseous!"), SPAN_WARNING("Ugh... You're going to be sick!"), SPAN_WARNING("Your stomach churns uncomfortably!"), SPAN_WARNING("You feel like you're about to throw up!"), SPAN_WARNING("You feel queasy!")))
 			M.vomit()
 
 /decl/reagent/drink/zorasoda/jelly
-	name = "Royal Jelly"
-	description = "It looks like mucus, but tastes like heaven."
+	name = "Royal Vaurca Jelly"
+	description = "It looks like mucus, but tastes like heaven. Royal jelly is a nutritious concentrated substance commonly created by Caretaker Vaurca in order to feed larvae. It is known to have a stimulating effect in most, if not all, species."
 	color = "#FFFF00"
 	caffeine = 0.3
 	taste_description = "sweet flowers and nectar mixed with aromatic spices"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1092,33 +1092,6 @@
 /decl/reagent/mental/truthserum/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)
 	M.add_chemical_effect(CE_PACIFIED, 1)
 
-/decl/reagent/mental/vaam
-	name = "V'krexi Amino Acid Mixture"
-	description = "A mixture of several high-energy amino acids, based on the secretions and saliva of V'krexi larvae."
-	reagent_state = LIQUID
-	color = "#bcd827"
-	metabolism = 0.4 * REM
-	taste_description = "bitterness"
-	metabolism_min = 0.5
-	breathe_mul = 0
-	goodmessage = list("You feel great!","You feel full of energy!","You feel alert and focused.")
-
-/decl/reagent/mental/vaam/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	. = ..()
-	M.add_chemical_effect(CE_PAINKILLER, 5)
-	M.drowsiness = 0
-
-/decl/reagent/mental/vaam/overdose(var/mob/living/carbon/human/M, var/alien, var/removed, var/scale, var/datum/reagents/holder)
-	. = ..()
-	M.adjustOxyLoss(1 * removed * scale)
-	M.Weaken(10 * removed * scale)
-	M.make_jittery(20)
-	M.make_dizzy(10)
-
-	if (prob(10))
-		to_chat(M, pick("You feel nauseous", "Ugghh....", "Your stomach churns uncomfortably", "You feel like you're about to throw up", "You feel queasy","You feel pressure in your abdomen"))
-
-
 /decl/reagent/mental/kokoreed
 	name = "Koko Reed Juice"
 	description = "Juice from the Koko reed plant. Causes unique mental effects in Unathi."

--- a/code/modules/reagents/reagent_containers/food/cans.dm
+++ b/code/modules/reagents/reagent_containers/food/cans.dm
@@ -387,7 +387,7 @@
 
 /obj/item/reagent_containers/food/drinks/cans/zorasoda/hozm // "Contraband"
 	name = "\improper High Octane Zorane Might"
-	desc = "A can of mint flavoured Zo'ra Soda energy drink, with a lot of V'krexi additives. Tastes like impaling the roof of your mouth with a freezing cold spear laced with angry bees and road salt." + SPAN_DANGER(" WARNING: Not for the faint hearted!")
+	desc = "A can of mint flavoured Zo'ra Soda energy drink, with a lot of V'krexi additives. Tastes like impaling the roof of your mouth with a freezing cold spear laced with angry bees and road salt.<br/>" + SPAN_DANGER(" WARNING: Not for the faint hearted!")
 	icon_state = "hozm"
 	reagents_to_add = list(/decl/reagent/drink/zorasoda/hozm = 30)
 

--- a/code/modules/reagents/reagent_containers/food/cans.dm
+++ b/code/modules/reagents/reagent_containers/food/cans.dm
@@ -385,9 +385,9 @@
 	icon_state = "sourvenomgrass"
 	reagents_to_add = list(/decl/reagent/drink/zorasoda/venomgrass = 30)
 
-/obj/item/reagent_containers/food/drinks/cans/zorasoda/hozm
+/obj/item/reagent_containers/food/drinks/cans/zorasoda/hozm // "Contraband"
 	name = "\improper High Octane Zorane Might"
-	desc = "A can of mint flavoured Zo'ra Soda energy drink, with a lot of V'krexi additives. Tastes like impaling the roof of your mouth with a freezing cold spear laced with angry bees and road salt."
+	desc = "A can of mint flavoured Zo'ra Soda energy drink, with a lot of V'krexi additives. Tastes like impaling the roof of your mouth with a freezing cold spear laced with angry bees and road salt." + SPAN_DANGER(" WARNING: Not for the faint hearted!")
 	icon_state = "hozm"
 	reagents_to_add = list(/decl/reagent/drink/zorasoda/hozm = 30)
 
@@ -399,13 +399,13 @@
 
 /obj/item/reagent_containers/food/drinks/cans/zorasoda/drone
 	name = "\improper Vaurca Drone Fuel"
-	desc = "A can of industrial fluid flavoured Zo'ra Soda energy drink, with V'krexi additives, meant for Vaurca." + SPAN_WARNING(" NOTE: Known to induce vomiting in humans!")
+	desc = "A can of industrial fluid flavoured Zo'ra Soda energy drink, with V'krexi additives, meant for Vaurca." + SPAN_DANGER(" WARNING: Known to induce vomiting in humans!")
 	icon_state = "dronefuel"
 	reagents_to_add = list(/decl/reagent/drink/zorasoda/drone = 30)
 
 /obj/item/reagent_containers/food/drinks/cans/zorasoda/jelly
 	name = "\improper Royal Vaurca Jelly"
-	desc = "A can of..." + SPAN_ITALIC(" sludge?") + " You aren't sure, but it smells kind of pleasant."
+	desc = "A can of..." + SPAN_ITALIC(" sludge?") + " It smells kind of pleasant either way. Royal jelly is a nutritious concentrated substance commonly created by Caretaker Vaurca in order to feed larvae. It is known to have a stimulating effect in most, if not all, species."
 	icon_state = "royaljelly"
 	reagents_to_add = list(/decl/reagent/drink/zorasoda/jelly = 30)
 

--- a/code/modules/reagents/reagent_containers/food/cans.dm
+++ b/code/modules/reagents/reagent_containers/food/cans.dm
@@ -347,78 +347,66 @@
 
 	reagents_to_add = list(/decl/reagent/drink/root_beer = 30)
 
-//zoda
-
+// Zo'ra Sodas
 /obj/item/reagent_containers/food/drinks/cans/zorasoda
+	name = "\improper Zo'ra Soda"
+	desc = "A can of Zo'ra Soda energy drink, with V'krexi additives. You aren't supposed to see this."
+	center_of_mass = list("x" = 16, "y" = 8)
+	can_size_overrides = list("x" = 1)
+	reagents_to_add = list(/decl/reagent/drink/zorasoda = 30)
+
+/obj/item/reagent_containers/food/drinks/cans/zorasoda/cherry
 	name = "\improper Zo'ra Soda Cherry"
-	desc = "A can of cherry energy drink, with V'krexi additives. All good colas come in cherry."
+	desc = "A can of cherry flavoured Zo'ra Soda energy drink, with V'krexi additives. All good energy drinks come in cherry."
 	icon_state = "zoracherry"
-	center_of_mass = list("x"=16, "y"=8)
-	can_size_overrides = list("x" = 1)
-	reagents_to_add = list(/decl/reagent/drink/zorasoda = 20, /decl/reagent/mental/vaam = 15)
+	reagents_to_add = list(/decl/reagent/drink/zorasoda/cherry = 30)
 
-/obj/item/reagent_containers/food/drinks/cans/zorakois
-	name = "\improper Zo'ra Soda Kois Twist"
-	desc = "A can of K'ois flavored energy drink, with V'krexi additives. Contains no K'ois, probably contains no palatable flavor."
-	icon_state = "koistwist"
-	center_of_mass = list("x"=16, "y"=8)
-	can_size_overrides = list("x" = 1)
-	reagents_to_add = list(/decl/reagent/drink/zorasoda/kois = 20, /decl/reagent/mental/vaam = 15)
-
-/obj/item/reagent_containers/food/drinks/cans/zoraphoron
+/obj/item/reagent_containers/food/drinks/cans/zorasoda/phoron
 	name = "\improper Zo'ra Soda Phoron Passion"
-	desc = "A can of grape flavored energy drink, with V'krexi additives. Tastes nothing like phoron according to Unbound taste testers."
+	desc = "A can of grape flavoured Zo'ra Soda energy drink, with V'krexi additives. Tastes nothing like phoron according to Unbound vaurca taste testers."
 	icon_state = "phoronpassion"
-	center_of_mass = list("x"=16, "y"=8)
-	can_size_overrides = list("x" = 1)
-	reagents_to_add = list(/decl/reagent/drink/zorasoda/phoron = 20, /decl/reagent/mental/vaam = 15)
+	reagents_to_add = list(/decl/reagent/drink/zorasoda/phoron = 30)
 
-/obj/item/reagent_containers/food/drinks/cans/zorahozm
-	name = "\improper High Octane Zorane Might"
-	desc = "A can of fizzy, acidic energy, with plenty of V'krexi additives. Tastes like impaling the bottom of your mouth with a freezing cold spear laced with bees and salt."
-	icon_state = "hozm"
-	center_of_mass = list("x"=16, "y"=8)
-	can_size_overrides = list("x" = 1)
-	reagents_to_add = list(/decl/reagent/drink/zorasoda/hozm = 20, /decl/reagent/mental/vaam = 15)
-
-/obj/item/reagent_containers/food/drinks/cans/zoravenom
-	name = "\improper Zo'ra Soda Sour Venom Grass (Diet!)"
-	desc = "A diet can of Venom Grass flavored energy drink, with V'krexi additives. Still tastes like a cloud of stinging polytrinic bees, but calories are nowhere to be found."
-	icon_state = "sourvenomgrass"
-	center_of_mass = list("x"=16, "y"=8)
-	can_size_overrides = list("x" = 1)
-	reagents_to_add = list(/decl/reagent/drink/zorasoda/venomgrass = 20, /decl/reagent/mental/vaam = 15)
-
-/obj/item/reagent_containers/food/drinks/cans/zoraklax
-	name = "\improper Klaxan Energy Crush"
-	desc = "A can of orange cream flavored energy drink, with V'krexi additives. Engineered nearly to perfection."
+/obj/item/reagent_containers/food/drinks/cans/zorasoda/klax
+	name = "\improper K'laxan Energy Crush"
+	desc = "A can of nitrogen-infused creamy orange zest flavoured Zo'ra Soda energy drink, with V'krexi additives. The smooth taste is engineered to near perfection."
 	icon_state = "klaxancrush"
-	center_of_mass = list("x"=16, "y"=8)
-	can_size_overrides = list("x" = 1)
-	reagents_to_add = list(/decl/reagent/drink/zorasoda/klax = 20, /decl/reagent/mental/vaam = 15)
+	reagents_to_add = list(/decl/reagent/drink/zorasoda/klax = 30)
 
-/obj/item/reagent_containers/food/drinks/cans/zoracthur
+/obj/item/reagent_containers/food/drinks/cans/zorasoda/cthur
 	name = "\improper C'thur Rockin' Raspberry"
-	desc = "A can of blue raspberry flavored energy drink, with V'krexi additives. You're pretty sure this was shipped by mistake, the previous K'laxan Energy Crush wrapper is still partly visible underneath the current one."
+	desc = "A can of \"blue raspberry\" flavoured Zo'ra Soda energy drink, with V'krexi additives. Tastes like a more flowery and aromatic raspberry."
 	icon_state = "cthurberry"
-	center_of_mass = list("x"=16, "y"=8)
-	can_size_overrides = list("x" = 1)
-	reagents_to_add = list(/decl/reagent/drink/zorasoda/cthur = 20, /decl/reagent/mental/vaam = 15)
+	reagents_to_add = list(/decl/reagent/drink/zorasoda/cthur = 30)
 
-/obj/item/reagent_containers/food/drinks/cans/zoradrone
-	name = "\improper Drone Fuel"
-	desc = "A can of some kind of industrial fluid flavored energy drink, with V'krexi additives meant for Vaurca. <span class='warning'>Known to induce vomiting in humans!</span>."
+/obj/item/reagent_containers/food/drinks/cans/zorasoda/venomgrass
+	name = "\improper Zo'ra Sour Venom Grass"
+	desc = "A can of sour \"venom grass\" flavoured Zo'ra Soda energy drink, with V'krexi additives. Tastes like a cloud of angry stinging acidic bees."
+	icon_state = "sourvenomgrass"
+	reagents_to_add = list(/decl/reagent/drink/zorasoda/venomgrass = 30)
+
+/obj/item/reagent_containers/food/drinks/cans/zorasoda/hozm
+	name = "\improper High Octane Zorane Might"
+	desc = "A can of mint flavoured Zo'ra Soda energy drink, with a lot of V'krexi additives. Tastes like impaling the roof of your mouth with a freezing cold spear laced with angry bees and road salt."
+	icon_state = "hozm"
+	reagents_to_add = list(/decl/reagent/drink/zorasoda/hozm = 30)
+
+/obj/item/reagent_containers/food/drinks/cans/zorasoda/kois
+	name = "\improper Zo'ra Soda K'ois Twist"
+	desc = "A can of K'ois-imitation flavoured Zo'ra Soda energy drink, with V'krexi additives. Contains no K'ois, contrary to what the name may imply."
+	icon_state = "koistwist"
+	reagents_to_add = list(/decl/reagent/drink/zorasoda/kois = 30)
+
+/obj/item/reagent_containers/food/drinks/cans/zorasoda/drone
+	name = "\improper Vaurca Drone Fuel"
+	desc = "A can of industrial fluid flavoured Zo'ra Soda energy drink, with V'krexi additives, meant for Vaurca." + SPAN_WARNING(" NOTE: Known to induce vomiting in humans!")
 	icon_state = "dronefuel"
-	center_of_mass = list("x"=16, "y"=8)
-	can_size_overrides = list("x" = 1)
-	reagents_to_add = list(/decl/reagent/drink/zorasoda/drone = 30, /decl/reagent/mental/vaam = 10)
+	reagents_to_add = list(/decl/reagent/drink/zorasoda/drone = 30)
 
-/obj/item/reagent_containers/food/drinks/cans/zorajelly
-	name = "\improper Royal Jelly"
-	desc = "A can of... You aren't sure, but it smells pleasant already."
+/obj/item/reagent_containers/food/drinks/cans/zorasoda/jelly
+	name = "\improper Royal Vaurca Jelly"
+	desc = "A can of..." + SPAN_ITALIC(" sludge?") + " You aren't sure, but it smells kind of pleasant."
 	icon_state = "royaljelly"
-	center_of_mass = list("x"=16, "y"=8)
-	can_size_overrides = list("x" = 1)
 	reagents_to_add = list(/decl/reagent/drink/zorasoda/jelly = 30)
 
 /obj/item/reagent_containers/food/drinks/cans/adhomai_milk

--- a/code/modules/reagents/reagent_containers/food/cans.dm
+++ b/code/modules/reagents/reagent_containers/food/cans.dm
@@ -399,7 +399,7 @@
 
 /obj/item/reagent_containers/food/drinks/cans/zorasoda/drone
 	name = "\improper Vaurca Drone Fuel"
-	desc = "A can of industrial fluid flavoured Zo'ra Soda energy drink, with V'krexi additives, meant for Vaurca." + SPAN_DANGER(" WARNING: Known to induce vomiting in all species except vaurcae and dionae!")
+	desc = "A can of industrial fluid flavoured Zo'ra Soda energy drink, with V'krexi additives, meant for Vaurca.<br/>" + SPAN_DANGER(" WARNING: Known to induce vomiting in all species except vaurcae and dionae!")
 	icon_state = "dronefuel"
 	reagents_to_add = list(/decl/reagent/drink/zorasoda/drone = 30)
 

--- a/code/modules/reagents/reagent_containers/food/cans.dm
+++ b/code/modules/reagents/reagent_containers/food/cans.dm
@@ -399,7 +399,7 @@
 
 /obj/item/reagent_containers/food/drinks/cans/zorasoda/drone
 	name = "\improper Vaurca Drone Fuel"
-	desc = "A can of industrial fluid flavoured Zo'ra Soda energy drink, with V'krexi additives, meant for Vaurca." + SPAN_DANGER(" WARNING: Known to induce vomiting in humans!")
+	desc = "A can of industrial fluid flavoured Zo'ra Soda energy drink, with V'krexi additives, meant for Vaurca." + SPAN_DANGER(" WARNING: Known to induce vomiting in all species except vaurcae and dionae!")
 	icon_state = "dronefuel"
 	reagents_to_add = list(/decl/reagent/drink/zorasoda/drone = 30)
 

--- a/code/modules/reagents/reagent_containers/food/drinks/yoke.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/yoke.dm
@@ -58,26 +58,26 @@
 /obj/item/storage/box/fancy/yoke/attackby(obj/item/W, mob/user)
 	to_chat(user, SPAN_WARNING("\The [src] cannot be refilled with items!"))
 
-/obj/item/storage/box/fancy/yoke/zorasoda
-	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/zorasoda = 6)
-
-/obj/item/storage/box/fancy/yoke/zorakois
-	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/zorakois = 6)
+/obj/item/storage/box/fancy/yoke/zoracherry
+	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/zorasoda/cherry = 6)
 
 /obj/item/storage/box/fancy/yoke/zoraphoron
-	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/zoraphoron = 6)
-
-/obj/item/storage/box/fancy/yoke/zorahozm
-	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/zorahozm = 6)
-
-/obj/item/storage/box/fancy/yoke/zoravenom
-	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/zoravenom = 6)
+	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/zorasoda/phoron = 6)
 
 /obj/item/storage/box/fancy/yoke/zoraklax
-	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/zoraklax = 6)
+	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/zorasoda/klax = 6)
 
 /obj/item/storage/box/fancy/yoke/zoracthur
-	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/zoracthur = 6)
+	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/zorasoda/cthur = 6)
+
+/obj/item/storage/box/fancy/yoke/zoravenom
+	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/zorasoda/venomgrass = 6)
+
+/obj/item/storage/box/fancy/yoke/zorahozm
+	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/zorasoda/hozm = 6)
+
+/obj/item/storage/box/fancy/yoke/zorakois
+	starts_with = list(/obj/item/reagent_containers/food/drinks/cans/zorasoda/kois = 6)
 
 /obj/item/storage/box/fancy/yoke/random
 	starts_with = list()
@@ -85,13 +85,13 @@
 /obj/item/storage/box/fancy/yoke/random/fill()
 	for(var/i = 1 to 6)
 		var/list/energy_options = list(
-			/obj/item/reagent_containers/food/drinks/cans/zorasoda,
-			/obj/item/reagent_containers/food/drinks/cans/zorakois,
-			/obj/item/reagent_containers/food/drinks/cans/zoraphoron,
-			/obj/item/reagent_containers/food/drinks/cans/zorahozm,
-			/obj/item/reagent_containers/food/drinks/cans/zoravenom,
-			/obj/item/reagent_containers/food/drinks/cans/zoraklax,
-			/obj/item/reagent_containers/food/drinks/cans/zoracthur
+			/obj/item/reagent_containers/food/drinks/cans/zorasoda/cherry,
+			/obj/item/reagent_containers/food/drinks/cans/zorasoda/phoron,
+			/obj/item/reagent_containers/food/drinks/cans/zorasoda/klax,
+			/obj/item/reagent_containers/food/drinks/cans/zorasoda/cthur,
+			/obj/item/reagent_containers/food/drinks/cans/zorasoda/venomgrass,
+			/obj/item/reagent_containers/food/drinks/cans/zorasoda/hozm,
+			/obj/item/reagent_containers/food/drinks/cans/zorasoda/kois
 		)
 		var/path = pick(energy_options)
 		if(starts_with[path])

--- a/html/changelogs/zora_soda_changes.yml
+++ b/html/changelogs/zora_soda_changes.yml
@@ -1,0 +1,12 @@
+author: SleepyGem
+
+delete-after: True
+
+changes:
+  - tweak: "Zo'ra Soda effects are now similar to coffee, with a tiny bit more caffeine."
+  - tweak: "Standardizes the Zo'ra Soda energy drinks to 30 units."
+  - tweak: "The descriptions of the cans were rewritten slightly to be more interesting to read."
+  - rscadd: "Adds the C'thur Rockin' Raspberry to the Zo'ra Soda vending machine."
+  - rscdel: "The V'krexi Amino Acid Mixture chemical has been removed."
+  - tweak: "And instead the effects have been merged with the Zo'ra Soda energy drink reagents."
+  - rscdel: "Removed negative effects from Zo'ra Soda, except Drone Fuel, so it's actually drinkable in a casual manner."

--- a/html/changelogs/zora_soda_changes.yml
+++ b/html/changelogs/zora_soda_changes.yml
@@ -10,3 +10,5 @@ changes:
   - rscdel: "The V'krexi Amino Acid Mixture chemical has been removed."
   - tweak: "And instead the effects have been merged with the Zo'ra Soda energy drink reagents."
   - rscdel: "Removed negative effects from Zo'ra Soda, except Drone Fuel, so it's actually drinkable in a casual manner."
+  - tweak: "High Octane Zorane Might is now a \"contraband\" item."
+  - tweak: "Vaurcae are immune to the overdose side effects of Zo'ra Soda energy drinks."


### PR DESCRIPTION
this PR aims to increase the in-game use (and popularity) of zo'ra soda by making it less of a balance struggle between flopping on the floor from drinking too fast and casually sipping on a energy drink.

~~it basically makes it a more zoomer-friendly alternative to coffee so you can more easily larp as a gamer who chugs 58 cans of energy drinks a day.~~

what does this PR change?
* it cleans up the code and sorts the cans so they're in the same order across all files.
* it creates a parent entry for the zo'ra soda can and the zo'ra soda reagent to reduce copy and paste code.
* it removes the VAAM chemical because it was redundant and the same purpose was moved directly to the zo'ra soda reagent instead.
* it adds the c'thur rockin' raspberry to the vendor, no idea why it wasn't there in the first place.
* changes some descriptions, while keeping them true to the original, to make them more interesting and immersive to read.
* makes the zo'ra soda energy drinks actually drinkable because the old code punished you for drinking them by making you jitter like crazy, get dizzy, and eventually fall over.

i'm open to making eventual changes but i'm personally happy with it as-is.

second PR btw. 😊