### PR TITLE
Most common melee simple mobs now have AP + damage flags, hivebot buffs.

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -169,5 +169,5 @@
 			add_logs(src, A, attacktext)
 	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	var/damage = rand(melee_damage_lower, melee_damage_upper)
-	if(A.attack_generic(src,damage,attacktext,environment_smash) && loc && attack_sound)
+	if(A.attack_generic(src, damage, attacktext, environment_smash, armor_penetration, attack_flags) && loc && attack_sound)
 		playsound(loc, attack_sound, 50, 1, 1)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -500,7 +500,7 @@
 /mob/living/carbon/human/proc/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, inrange, params)
 	return
 
-/mob/living/carbon/human/attack_generic(var/mob/user, var/damage, var/attack_message, var/environment_smash, var/armor_penetration, var/attack_flags)
+/mob/living/carbon/human/attack_generic(var/mob/user, var/damage, var/attack_message, var/armor_penetration, var/attack_flags)
 	if(!damage)
 		return
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -500,7 +500,7 @@
 /mob/living/carbon/human/proc/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, inrange, params)
 	return
 
-/mob/living/carbon/human/attack_generic(var/mob/user, var/damage, var/attack_message)
+/mob/living/carbon/human/attack_generic(var/mob/user, var/damage, var/attack_message, var/environment_smash, var/armor_penetration, var/attack_flags)
 	if(!damage)
 		return
 
@@ -516,7 +516,7 @@
 	if(!dam_zone)
 		dam_zone = pick(organs)
 	var/obj/item/organ/external/affecting = get_organ(dam_zone)
-	apply_damage(damage, BRUTE, affecting)
+	apply_damage(damage, BRUTE, affecting, armor_pen = armor_penetration, damage_flags = attack_flags)
 	updatehealth()
 	return TRUE
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -222,7 +222,7 @@
 
 // End BS12 momentum-transfer code.
 
-/mob/living/attack_generic(var/mob/user, var/damage, var/attack_message)
+/mob/living/attack_generic(var/mob/user, var/damage, var/attack_message, var/armor_penetration, var/attack_flags)
 	if(!damage)
 		return
 

--- a/code/modules/mob/living/simple_animal/constructs/constructs/artificer.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs/artificer.dm
@@ -10,6 +10,7 @@
 	response_harm = "viciously beaten"
 	melee_damage_lower = 10
 	melee_damage_upper = 10
+	armor_penetration = 20
 	attacktext = "rammed"
 	organ_names = list("core", "production array", "sensor array")
 	speed = 0

--- a/code/modules/mob/living/simple_animal/constructs/constructs/harvester.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs/harvester.dm
@@ -9,6 +9,7 @@
 	health_prefix = "harvester"
 	melee_damage_lower = 25
 	melee_damage_upper = 25
+	armor_penetration = 60
 	attacktext = "violently stabbed"
 	organ_names = list("core", "harvesting array")
 	speed = -1

--- a/code/modules/mob/living/simple_animal/constructs/constructs/juggernaut.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs/juggernaut.dm
@@ -11,6 +11,7 @@
 	harm_intent_damage = 0
 	melee_damage_lower = 30
 	melee_damage_upper = 30
+	armor_penetration = 40
 	attacktext = "smashed their armored gauntlet into"
 	organ_names = list("core", "right arm", "left arm")
 	mob_size = MOB_LARGE

--- a/code/modules/mob/living/simple_animal/friendly/adhomai.dm
+++ b/code/modules/mob/living/simple_animal/friendly/adhomai.dm
@@ -97,6 +97,7 @@
 
 	melee_damage_lower = 15
 	melee_damage_upper = 15
+	armor_penetration = 20
 	attacktext = "gored"
 	attack_sound = 'sound/weapons/bite.ogg'
 

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -26,6 +26,8 @@
 	maxHealth = 80
 	melee_damage_lower = 10
 	melee_damage_upper = 18
+	armor_penetration = 30 //Standard armor probably doesn't help against a bear, does it?
+	attack_flags = DAM_EDGE|DAM_SHARP
 	resist_mod = 4
 	break_stuff_probability = 80
 	mob_size = 17

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -25,6 +25,8 @@
 	harm_intent_damage = 4
 	melee_damage_lower = 15
 	melee_damage_upper = 15
+	armor_penetration = 15
+	attack_flags = DAM_EDGE
 	attacktext = "bitten"
 	attack_sound = 'sound/weapons/bite.ogg'
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -33,6 +33,7 @@
 	health = 200
 	melee_damage_lower = 15
 	melee_damage_upper = 20
+	armor_penetration = 10
 	resist_mod = 1.5
 	heat_damage_per_tick = 20
 	cold_damage_per_tick = 20
@@ -61,6 +62,7 @@
 	health = 40
 	melee_damage_lower = 5
 	melee_damage_upper = 10
+	armor_penetration = 20
 	poison_per_bite = 10
 	var/atom/cocoon_target
 	poison_type = /decl/reagent/soporific
@@ -78,6 +80,7 @@
 	health = 120
 	melee_damage_lower = 10
 	melee_damage_upper = 20
+	armor_penetration = 15
 	poison_per_bite = 5
 	move_to_delay = 4
 
@@ -91,6 +94,7 @@
 	health = 100
 	melee_damage_lower = 5
 	melee_damage_upper = 10
+	armor_penetration = 15
 	poison_type = /decl/reagent/perconol // mildly beneficial for organics
 	poison_per_bite = 2
 	move_to_delay = 5

--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot.dm
@@ -9,6 +9,8 @@
 	maxHealth = 15
 	melee_damage_lower = 10
 	melee_damage_upper = 10
+	armor_penetration = 40
+	attack_flags = DAM_SHARP|DAM_EDGE
 	break_stuff_probability = 25
 	attacktext = "slashed"
 	projectilesound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_beacon_projectiles.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_beacon_projectiles.dm
@@ -1,8 +1,8 @@
 /obj/item/projectile/beam/hivebot
 	name = "electrical discharge"
-	damage = 10
+	damage = 20
 	damage_type = BURN
-	agony = 30
+	agony = 20
 	armor_penetration = 40
 	muzzle_type = /obj/effect/projectile/muzzle/stun
 	tracer_type = /obj/effect/projectile/tracer/stun
@@ -18,6 +18,7 @@
 	name = "archaic energy welder"
 	damage_type = BURN
 	damage = 20
+	armor_penetration = 15
 	incinerate = 5
 	muzzle_type = /obj/effect/projectile/muzzle/laser/blue
 	tracer_type = /obj/effect/projectile/tracer/laser/blue

--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_projectiles.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_projectiles.dm
@@ -1,9 +1,11 @@
 /obj/item/projectile/bullet/pistol/hivebotspike
 	name = "spike"
 	damage = 10
+	armor_penetration = 40
 	sharp = 1
 	embed = 0
 
 /obj/item/projectile/bullet/pistol/hivebotspike/needle
 	name = "needle"
 	damage = 5
+	armor_penetration = 60

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -192,7 +192,7 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 	var/atom/target
 	if(isliving(target_mob))
 		var/mob/living/L = target_mob
-		L.attack_generic(src, rand(melee_damage_lower, melee_damage_upper), attacktext)
+		L.attack_generic(src, rand(melee_damage_lower, melee_damage_upper), attacktext, armor_penetration, attack_flags)
 		on_attack_mob(L)
 		target = L
 	else if(istype(target_mob, /obj/machinery/bot))

--- a/code/modules/mob/living/simple_animal/hostile/rogue_maint_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/rogue_maint_drone.dm
@@ -12,6 +12,7 @@
 	maxHealth = 50
 	melee_damage_lower = 5
 	melee_damage_upper = 8
+	armor_penetration = 5
 	attacktext = "sliced"
 	faction = "silicon"
 	min_oxy = 0

--- a/code/modules/mob/living/simple_animal/hostile/spider_queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/spider_queen.dm
@@ -27,6 +27,7 @@
 	health = 1100
 	melee_damage_lower = 35
 	melee_damage_upper = 40
+	armor_penetration = 30
 	resist_mod = 15 // LOL good luck pal
 	heat_damage_per_tick = 20
 	cold_damage_per_tick = 20

--- a/code/modules/mob/living/simple_animal/hostile/vannatusk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vannatusk.dm
@@ -20,6 +20,7 @@
 	harm_intent_damage = 5
 	melee_damage_lower = 30
 	melee_damage_upper = 30
+	armor_penetration = 15
 	resist_mod = 3
 	mob_size = 15
 	environment_smash = 2

--- a/code/modules/mob/living/simple_animal/hostile/viscerator.dm
+++ b/code/modules/mob/living/simple_animal/hostile/viscerator.dm
@@ -9,6 +9,7 @@
 	maxHealth = 15
 	melee_damage_lower = 10
 	melee_damage_upper = 15
+	armor_penetration = 20
 	density = 0
 	attacktext = "cut"
 	attack_sound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -82,6 +82,8 @@
 	//LETTING SIMPLE ANIMALS ATTACK? WHAT COULD GO WRONG. Defaults to zero so Ian can still be cuddly
 	var/melee_damage_lower = 0
 	var/melee_damage_upper = 0
+	var/armor_penetration = 0
+	var/attack_flags = 0
 	var/attacktext = "attacked"
 	var/attack_sound = null
 	var/friendly = "nuzzles"

--- a/html/changelogs/mattatlas-15secmainpipebombsinmymailbox.yml
+++ b/html/changelogs/mattatlas-15secmainpipebombsinmymailbox.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Most common melee simple mobs have been given armor penetration, so they should actually have teeth now."
+  - tweak: "Melee simple mobs have also been given edge or sharp damage flags, so bleeding should be more common, in addition to torn tendons."
+  - tweak: "Hivebot beams have been buffed to account for new armor."


### PR DESCRIPTION
As per title. Cult constructs like juggs should now actually do damage, for example (13.3 damage against riot armor, while it completely bypasses all other armor - be careful against those).

Most mobs have been balanced against standard armor, and do quite a bit of damage through it.

Hivebot beams were also buffed since they were objectively pretty ass.