### PR TITLE
Gloves Not Required to Remove Bulbs and Tubes

### DIFF
--- a/code/modules/power/lights/fixtures.dm
+++ b/code/modules/power/lights/fixtures.dm
@@ -477,29 +477,6 @@
 				shatter()
 				return
 
-	// make it burn hands if not wearing fire-insulated gloves
-	if(!stat)
-		var/prot = 0
-		var/mob/living/carbon/human/H = user
-
-		if(istype(H))
-			if(H.species.heat_level_1 > LIGHT_BULB_TEMPERATURE)
-				prot = 1
-			else if(H.gloves)
-				var/obj/item/clothing/gloves/G = H.gloves
-				if(G.max_heat_protection_temperature && G.max_heat_protection_temperature > LIGHT_BULB_TEMPERATURE)
-					prot = 1
-		else
-			prot = 1
-
-		if(prot || (COLD_RESISTANCE in user.mutations))
-			to_chat(user, SPAN_NOTICE("You remove the light [fitting]."))
-		else
-			to_chat(user, SPAN_WARNING("You try to remove the light [fitting], but it's too hot and you don't want to burn your hand."))
-			return				// if burned, don't remove the light
-	else
-		to_chat(user, SPAN_NOTICE("You remove the light [fitting]."))
-
 	// create a light tube/bulb item and put it in the user's hand
 	if(inserted_light)
 		var/obj/item/light/L = new inserted_light()

--- a/code/modules/power/lights/fixtures.dm
+++ b/code/modules/power/lights/fixtures.dm
@@ -458,7 +458,6 @@
 // attack with hand - remove tube/bulb
 // if hands aren't protected and the light is on, burn the player
 /obj/machinery/light/attack_hand(mob/user)
-
 	add_fingerprint(user)
 
 	if(status == LIGHT_EMPTY)
@@ -476,6 +475,11 @@
 				H.visible_message(SPAN_WARNING("\The [user] completely shatters \the [src]!"), SPAN_WARNING("You shatter \the [src] completely!"), SPAN_WARNING("You hear the tinkle of breaking glass."))
 				shatter()
 				return
+
+	if(!stat)
+		to_chat(user, SPAN_NOTICE("You remove the light [fitting]."))
+	else
+		return
 
 	// create a light tube/bulb item and put it in the user's hand
 	if(inserted_light)

--- a/code/modules/power/lights/fixtures.dm
+++ b/code/modules/power/lights/fixtures.dm
@@ -476,11 +476,6 @@
 				shatter()
 				return
 
-	if(!stat)
-		to_chat(user, SPAN_NOTICE("You remove the light [fitting]."))
-	else
-		return
-
 	// create a light tube/bulb item and put it in the user's hand
 	if(inserted_light)
 		var/obj/item/light/L = new inserted_light()
@@ -498,6 +493,8 @@
 		L.add_fingerprint(user)
 
 		user.put_in_active_hand(L)	//puts it in our active hand
+
+		to_chat(user, SPAN_NOTICE("You remove the light [fitting]."))
 
 		inserted_light = null
 

--- a/html/changelogs/cool_bulbs_and_tubes.yml
+++ b/html/changelogs/cool_bulbs_and_tubes.yml
@@ -1,0 +1,6 @@
+author: SleepyGem
+
+delete-after: True
+
+changes:
+  - tweak: "You no longer require gloves to remove light bulbs- and tubes. LED is finally here. Rejoice!"


### PR DESCRIPTION
i assume that light bulbs in 2464 use LED or a even more modern technology that does not burn your hands.
most species (afaik) are immune to it anyways. you also can't remove bulbs with certain gloves for some reason.

what does this PR do?
* it makes it so you can remove light bulbs and tubes from their fixtures without needing to wear gloves, as the light bulbs and tubes are likely LED or equivalent technology.