### PR TITLE
Adds a filled syndicate lunchbox to the uplink

### DIFF
--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -4,6 +4,11 @@
 /datum/uplink_item/item/medical
 	category = /datum/uplink_category/medical
 
+/datum/uplink_item/item/medical/sinpockets
+	name = "Box of Sin-Pockets"
+	item_cost = 1
+	path = /obj/item/storage/box/sinpockets
+
 /datum/uplink_item/item/medical/lunchbox
 	name = "Syndicate Lunchbox"
 	item_cost = 1

--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -4,10 +4,10 @@
 /datum/uplink_item/item/medical
 	category = /datum/uplink_category/medical
 
-/datum/uplink_item/item/medical/sinpockets
-	name = "Box of Sin-Pockets"
+/datum/uplink_item/item/medical/lunchbox
+	name = "Syndicate Lunchbox"
 	item_cost = 1
-	path = /obj/item/storage/box/sinpockets
+	path = /obj/item/storage/toolbox/lunchbox/syndicate/filled
 
 /datum/uplink_item/item/medical/combathypo
 	name = "Combat Hypospray"

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -73,6 +73,7 @@ var/datum/uplink_random_selection/default_uplink_selection = new/datum/uplink_ra
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/implants/imp_compress)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/implants/imp_explosive)
 
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/sinpockets, reselect_propbability = 20)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/lunchbox, reselect_propbability = 20)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/surgery, reselect_propbability = 10)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/combat, reselect_propbability = 10)

--- a/code/game/objects/items/devices/uplink_random_lists.dm
+++ b/code/game/objects/items/devices/uplink_random_lists.dm
@@ -73,7 +73,7 @@ var/datum/uplink_random_selection/default_uplink_selection = new/datum/uplink_ra
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/implants/imp_compress)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/implants/imp_explosive)
 
-	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/sinpockets, reselect_propbability = 20)
+	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/lunchbox, reselect_propbability = 20)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/surgery, reselect_propbability = 10)
 	items += new/datum/uplink_random_item(/datum/uplink_item/item/medical/combat, reselect_propbability = 10)
 

--- a/html/changelogs/syndie_lunchbox.yml
+++ b/html/changelogs/syndie_lunchbox.yml
@@ -3,4 +3,4 @@ author: mikomyazaki
 delete-after: True
 
 changes:
-  - tweak: "Replaces the Box of Sin-Pockets on the Syndicate Uplink with a filled Syndicate Lunchbox, so the mercs don't go thirsty."
+  - tweak: "Adds a Syndicate Lunchbox to the uplink, so the mercs don't go hungry."

--- a/html/changelogs/syndie_lunchbox.yml
+++ b/html/changelogs/syndie_lunchbox.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - tweak: "Replaces the Box of Sin-Pockets on the Syndicate Uplink with a filled Syndicate Lunchbox, so the mercs don't go thirsty."


### PR DESCRIPTION
There was nothing on the uplink to help mercs/tator-tots deal with thirst. ~~This swaps out the box of sin-pockets for a filled syndicate lunchbox (same cost of 1 TC).~~

~~I think on average this means they will get a bit less nutrition from the item, but they will get a drink. Should be enough to keep them moving in a pinch.~~

Apparently the sin-pockets have drugs in them and are useful for that. So I'm just adding the lunchbox without touching sin-pockets.