### PR TITLE
VV extended list viewer requires same rights as VV

### DIFF
--- a/code/modules/admin/verbs/viewlist.dm
+++ b/code/modules/admin/verbs/viewlist.dm
@@ -13,7 +13,7 @@
     ui_interact(user)
 
 /datum/vueui_module/list_viewer/ui_interact(mob/user)
-    if(!check_rights(R_VAREDIT|R_DEV)) return
+    if(!check_rights(R_VAREDIT|R_DEV|R_MOD)) return
 
     var/datum/vueui/ui = SSvueui.get_open_ui(user, src)
     if(!ui)

--- a/html/changelogs/extended_list_viewer_rights.yml
+++ b/html/changelogs/extended_list_viewer_rights.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "The VV Extended List Viewer now has the same rights requirement as View Variables."


### PR DESCRIPTION
Fixes #13312

For some reason mods could view VV but not the extended list viewer UI.