### PR TITLE
Cyborgs are now properly deleted when despawning via cryo

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -720,10 +720,11 @@
 			H.mind.special_role = null
 
 	// Delete them from datacore.
-
-	if(!SSrecords.remove_record_by_field("fingerprint", H.get_full_print()))
-		// didn't find a record by fingerprint, fallback to deleting by name
-		SSrecords.remove_record_by_field("name", H.real_name)
+	if(ishuman(H))
+		SSrecords.remove_record_by_field("fingerprint", H.get_full_print())
+		if(H.species)
+			H.species.handle_despawn(H)
+	SSrecords.remove_record_by_field("name", H.real_name)
 	SSrecords.reset_manifest()
 
 	log_and_message_admins("([H.mind.role_alt_title]) entered cryostorage.", user = H)
@@ -732,8 +733,6 @@
 	H.ckey = null
 
 	// Delete the mob.
-	if(H.species)
-		H.species.handle_despawn(H)
 	qdel(H)
 
 // Equips a human-type with their custom loadout crap.

--- a/html/changelogs/robot_camera_removal_on_cryo.yml
+++ b/html/changelogs/robot_camera_removal_on_cryo.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Robots that go to cryo will now properly have their cameras removed from the camera network list."


### PR DESCRIPTION
Fixes #13298 -- Cyborgs are not being deleted when they go to cryo because they runtime due to not having fingerprints before being qdel'd.

This PR is a bandaid fix. The actual problem is #13311 - SSjobs assumes that the mob it is acting on is `/mob/living/carbon/human`, but this is not true because Cyborgs/AI have jobs aswell.

If desired, I can submit a fix that swaps SSjobs to treat the mob it is affecting as `/mob` instead. [I have partially implemented this here](https://github.com/mikomyazaki/Aurora.3/commit/6724d638278bf325a57e2247450afc2f71943464) - But it is getting very long for such a small issue. It also fixes a few other issues relating to outfit spawning (like #13294).