### PR TITLE
Fixes blast doors not opening after power is restored sometimes

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -35,7 +35,7 @@
 	var/_wifi_id
 	var/datum/wifi/receiver/button/door/wifi_receiver
 
-	var/securitylock = FALSE
+	var/securitylock = TRUE
 	var/is_critical = FALSE
 
 /obj/machinery/door/blast/Initialize()
@@ -187,8 +187,8 @@
 	if(src.operating || (stat & BROKEN) || is_critical)
 		return
 	if(stat & NOPOWER)
-		INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_close)
 		securitylock = !density // blast doors will only re-open when power is restored if they were open originally
+		INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_close)
 	else if(securitylock)
 		INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_open)
 		securitylock = FALSE

--- a/html/changelogs/blast_doors_fix2.yml
+++ b/html/changelogs/blast_doors_fix2.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Blast doors will reopen when power is restored, if they were open before losing power."


### PR DESCRIPTION
Fixes #13320

WIP for the moment until I have the time to test properly + maybe add some other blast-door fixes in.