### PR TITLE
Fixes Invisible Blood Bags

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -61,7 +61,7 @@
 		add_overlay(image('icons/obj/bloodpack.dmi', "dongle"))
 
 	if(reagents && reagents.total_volume)
-		add_overlay(overlay_image('icons/obj/reagentfillings.dmi', "[icon_state][get_filling_state()]", color = reagents.get_color()))
+		add_overlay(overlay_image('icons/obj/bloodpack.dmi', "[icon_state][get_filling_state()]", color = reagents.get_color()))
 
 /obj/item/reagent_containers/blood/attack(mob/living/carbon/human/M as mob, mob/living/carbon/human/user as mob, var/target_zone)
 	if(user == M && (MODE_VAMPIRE in user.mind?.antag_datums))
@@ -257,7 +257,7 @@
 /obj/item/reagent_containers/blood/empty
 	name = "empty blood pack"
 	desc = "Seems pretty useless... Maybe if there were a way to fill it?"
-	icon_state = "empty"
+	icon_state = "bloodpack"
 
 /obj/item/reagent_containers/blood/ripped
 	name = "ripped blood pack"

--- a/html/changelogs/invisible_blood_bag.yml
+++ b/html/changelogs/invisible_blood_bag.yml
@@ -1,0 +1,6 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed Invisible Blood Bags and Blood Bags not displaying their internal contents right."


### PR DESCRIPTION
* Fixes #13318

Empty blood bags shouldn't spawn invisible anymore and the filled ones should properly display that red, red blood. Or saline.