### PR TITLE
Air Pump and Air Scrubber Size Bugfix

### DIFF
--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "psiphon:0"
 	density = 1
-	w_class = ITEMSIZE_NORMAL
+	w_class = ITEMSIZE_HUGE
 
 	var/on = 0
 	var/direction_out = 0 //0 = siphoning, 1 = releasing

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/atmos.dmi'
 	icon_state = "pscrubber:0"
 	density = 1
-	w_class = ITEMSIZE_NORMAL
+	w_class = ITEMSIZE_HUGE
 
 	var/on = 0
 	var/volume_rate = 800

--- a/html/changelogs/air_pump_weight_class_bugfix.yml
+++ b/html/changelogs/air_pump_weight_class_bugfix.yml
@@ -1,0 +1,6 @@
+author: SleepyGem
+
+delete-after: True
+
+changes:
+  - bugfix: "Changed the portable air pump- and scrubber weight classes to one representing their size more accurately."

--- a/html/changelogs/air_pump_weight_class_bugfix.yml
+++ b/html/changelogs/air_pump_weight_class_bugfix.yml
@@ -3,4 +3,4 @@ author: SleepyGem
 delete-after: True
 
 changes:
-  - bugfix: "Fixes a oversight regarding the portable air pump and air scrubber's sizes, which means they no longer fit in your bag or in lockers."
+  - bugfix: "Fixes a oversight regarding the portable air pump and air scrubber's sizes, which means they no longer fit in lockers and that their size is reflected appropriately in the code."

--- a/html/changelogs/air_pump_weight_class_bugfix.yml
+++ b/html/changelogs/air_pump_weight_class_bugfix.yml
@@ -3,4 +3,4 @@ author: SleepyGem
 delete-after: True
 
 changes:
-  - bugfix: "Changed the portable air pump- and scrubber weight classes to one representing their size more accurately."
+  - bugfix: "Changed the portable air pump- and scrubber weight classes, which means they no longer fit in your bag or in lockers."

--- a/html/changelogs/air_pump_weight_class_bugfix.yml
+++ b/html/changelogs/air_pump_weight_class_bugfix.yml
@@ -3,4 +3,4 @@ author: SleepyGem
 delete-after: True
 
 changes:
-  - bugfix: "Changed the portable air pump- and scrubber weight classes, which means they no longer fit in your bag or in lockers."
+  - bugfix: "Fixes a oversight regarding the portable air pump and air scrubber's sizes, which means they no longer fit in your bag or in lockers."


### PR DESCRIPTION
title. seemed weird that the portable air pumps and scrubbers were considered normal sized items and not huge, as other machinery is. they shouldnt be normal sized machinery, both to fit in along most other (if not all) machinery aswell as to prevent code oversights in the future that rely on the weight class of an object.