### PR TITLE
Autodrobe doesn't remove Vaurca mandible mask from face

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -10,7 +10,6 @@
 #define DEBUG
 // END_PREFERENCES
 // BEGIN_INCLUDE
-#include "_maps\aurora.dm"
 #include "code\global.dm"
 #include "code\hub.dm"
 #include "code\names.dm"

--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -10,6 +10,7 @@
 #define DEBUG
 // END_PREFERENCES
 // BEGIN_INCLUDE
+#include "_maps\aurora.dm"
 #include "code\global.dm"
 #include "code\hub.dm"
 #include "code\names.dm"

--- a/code/game/objects/items/weapons/vaurca_items.dm
+++ b/code/game/objects/items/weapons/vaurca_items.dm
@@ -8,6 +8,7 @@
 	icon_state = "m_garment"
 	item_state = "m_garment"
 	contained_sprite = 1
+	autodrobe_no_remove = TRUE
 
 /obj/item/clothing/mask/breath/vaurca/adjust_mask(mob/user)
 	to_chat(user, "This mask is too tight to adjust.")

--- a/html/changelogs/bugs_are_people_too.yml
+++ b/html/changelogs/bugs_are_people_too.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Autodrobe no longer tries to poison Vaurca by putting their mandible garments into their bag when the rest of their gear spawns, instead the mandible garment stays on their face."


### PR DESCRIPTION
Partially fixes #3505 - Swapping to your mandible mask won't be removed by the autodrobe anymore and thus make you start suffocating without you realizing.

Not sure how to make the default mask get swapped out for this one, because the species preequip needs to happen before the job preequip in `/datum/job/proc/pre_equip`.

Vaurca still get a bit poisoned if this isn't done *instantaneously* though. 