### PR TITLE
Fractal Reactor Message Tweak

### DIFF
--- a/code/modules/power/fractal_reactor.dm
+++ b/code/modules/power/fractal_reactor.dm
@@ -18,7 +18,7 @@
 /obj/machinery/power/fractal_reactor/New()
 	..()
 	if(!mapped_in)
-		to_world("<b><span class='alert'>WARNING:</span> Map testing power source activated at: X:[src.loc.x] Y:[src.loc.y] Z:[src.loc.z]</b>")
+		log_and_message_admins("<b><span class='alert'>WARNING:</span> Map testing power source activated at: X:[src.loc.x] Y:[src.loc.y] Z:[src.loc.z]</b>")
 
 /obj/machinery/power/fractal_reactor/machinery_process()
 	if(!powernet && !powernet_connection_failed)

--- a/html/changelogs/fractal_reactor_message.yml
+++ b/html/changelogs/fractal_reactor_message.yml
@@ -1,0 +1,6 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - tweak: "Changed the Fractal Reactor message to an admin log instead a to_world message."


### PR DESCRIPTION
* Changed the Fractal Reactor message to an admin log one instead of a to_world message.
* I do not know if this is the correct admin log command or not