### PR TITLE
Adds automatic profiling to the init subsystems

### DIFF
--- a/code/controllers/master/subsystem.dm
+++ b/code/controllers/master/subsystem.dm
@@ -161,7 +161,10 @@
 /datum/controller/subsystem/proc/StartInitialize(timeofday)
 	init_state = SS_INITSTATE_STARTED
 	init_start = timeofday
+	world.Profile(PROFILE_RESTART)
 	. = Initialize(timeofday)
+	var/profile_data = world.Profile(PROFILE_STOP)
+	log_ss_init(json_encode(profile_data))
 	init_finish = REALTIMEOFDAY
 	if (!init_time)
 		init_time = (init_finish - init_start) / 10


### PR DESCRIPTION
This is necessary to hunt down a bug that is causing the initialization subsystems to sometimes take several times longer than they should with no known cause.

They will now dump a profile to the log file each time like in the attached file:

[12_cgU-cDy5.log](https://github.com/Aurorastation/Aurora.3/files/8237932/12_cgU-cDy5.log)
