### PR TITLE
Gripper code tidying + bugfixes

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -45,15 +45,8 @@
 		if(is_component_functioning("camera"))
 			ai_camera.captureimage(A, usr)
 		else
-			to_chat(src, "<span class='danger'>Your camera isn't functional.</span>")
+			to_chat(src, SPAN_DANGER("Your camera isn't functional."))
 		return
-
-	/*
-	cyborg restrained() currently does nothing
-	if(restrained())
-		RestrainedClickOn(A)
-		return
-	*/
 
 	var/obj/item/W = get_active_hand()
 
@@ -71,21 +64,12 @@
 		W.attack_self(src)
 		return
 
-	//Handling using grippers
-	if(istype(W, /obj/item/gripper))
-		var/obj/item/gripper/G = W
-		//If the gripper contains something, then we will use its contents to attack
-		if (G.wrapped && (G.wrapped.loc == G))
-			GripperClickOn(A, params, G)
-			G.update_icon() //We may need to update our gripper based on a change in the wrapped item
-			return
-
 	// cyborgs are prohibited from using storage items so we can I think safely remove (A.loc in contents)
 	if(A == loc || (A in loc) || (A in contents))
 		// No adjacency checks
 
 		var/resolved = A.attackby(W,src)
-		if(!resolved && A && W)
+		if(!resolved)
 			W.afterattack(A,src,1,params)
 		return
 
@@ -95,57 +79,11 @@
 	// cyborgs are prohibited from using storage items so we can I think safely remove (A.loc && isturf(A.loc.loc))
 	if(isturf(A) || isturf(A.loc))
 		if(A.Adjacent(src)) // see adjacent.dm
-
-			if(W)
-				var/resolved = W.resolve_attackby(A, src, params)
-				if(!resolved && A && W)
-					W.afterattack(A, src, 1, params)
-				return
+			var/resolved = W.resolve_attackby(A, src, params)
+			if(!resolved)
+				W.afterattack(A, src, 1, params)
 		else
 			W.afterattack(A, src, 0, params)
-			return
-	return
-
-
-/*
-	Gripper Handling
-	This is used when a gripper is used on anything. It does all the handling for it
-*/
-/mob/living/silicon/robot/proc/GripperClickOn(var/atom/A, var/params, var/obj/item/gripper/G)
-
-	var/obj/item/W = G.wrapped
-	if (!grippersafety(G))return
-
-
-	G.force_holder = W.force
-	W.force = 0
-	// cyborgs are prohibited from using storage items so we can I think safely remove (A.loc in contents)
-	if(A == loc || (A in loc) || (A in contents))
-		// No adjacency checks
-
-		var/resolved = A.attackby(W,src)
-		if (!grippersafety(G))return
-		if(!resolved && A && W)
-			W.afterattack(A,src,1,params)
-		if (!grippersafety(G))return
-		W.force = G.force_holder
-		return
-	if(!isturf(loc))
-		W.force = G.force_holder
-		return
-
-	// cyborgs are prohibited from using storage items so we can I think safely remove (A.loc && isturf(A.loc.loc))
-	if(isturf(A) || isturf(A.loc))
-		if(A.Adjacent(src)) // see adjacent.dm
-			var/resolved = A.attackby(W, src)
-			if (!grippersafety(G))return
-			if(!resolved && A && W)
-				W.afterattack(A, src, 1, params)
-			if (!grippersafety(G))return
-			W.force = G.force_holder
-			return
-		//No non-adjacent clicks. Can't fire guns
-	W.force = G.force_holder
 	return
 
 //Middle click cycles through selected modules.

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -3,10 +3,6 @@
 
 //Returns the thing in our active hand (whatever is in our active module-slot, in this case)
 /mob/living/silicon/robot/get_active_hand()
-	if(istype(module_active, /obj/item/gripper))
-		var/obj/item/gripper/G = module_active
-		if(G.wrapped)
-			return G.wrapped
 	return module_active
 
 /mob/living/silicon/robot/proc/return_wirecutter()

--- a/code/modules/mob/living/silicon/robot/items/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/items/gripper.dm
@@ -54,7 +54,7 @@
 		return FALSE
 	return TRUE
 
-/obj/item/gripper/proc/grip_item(var/obj/item/I, var/mob/user, var/feedback = 1)
+/obj/item/gripper/proc/grip_item(var/obj/item/I, var/mob/user, var/feedback = TRUE)
 	//This function returns 1 if we successfully took the item, or 0 if it was invalid. This information is useful to the caller
 	if(!wrapped)
 		if((can_hold && is_type_in_list(I, can_hold)) || (cant_hold && !is_type_in_list(I, cant_hold)))
@@ -125,14 +125,14 @@
 	update_icon()
 	return TRUE
 
-/obj/item/gripper/attack(mob/living/carbon/M, mob/living/carbon/user)
+/obj/item/gripper/attack(mob/M, mob/user)
 	if(wrapped) //The force of the wrapped obj gets set to zero during the attack() and afterattack().
 		force_holder = wrapped.force
 		wrapped.force = 0
-		wrapped.attack(M,user)
+		var/resolved = wrapped.attack(M,user)
 		if(QDELETED(wrapped))
-			wrapped = null
-		return TRUE
+			drop(get_turf(src), user, FALSE)
+		return resolved
 	else // mob interactions
 		switch(user.a_intent)
 			if(I_HELP)
@@ -148,26 +148,23 @@
 /obj/item/gripper/attackby(obj/item/O, mob/user)
 	if(wrapped)
 		if(O == wrapped)
-			attack_self(user) //Allows gripper to be clicked to use item. 
+			attack_self(user) //Allows gripper to be clicked to use item.
 			return
 		var/resolved = wrapped.attackby(O,user)
-		if(!resolved && wrapped && O)
-			O.afterattack(wrapped, user ,1)//We pass along things targeting the gripper, to objects inside the gripper. So that we can draw chemicals from held beakers for instance
+		if(!resolved)
+			O.afterattack(wrapped, user, TRUE)//We pass along things targeting the gripper, to objects inside the gripper. So that we can draw chemicals from held beakers for instance
 	return
 
 /obj/item/gripper/afterattack(var/atom/target, var/mob/living/user, proximity, params)
 	if(!proximity)
-		return // This will prevent them using guns at range but adminbuse can add them directly to modules, so eh.
-	//There's some weirdness with items being lost inside the arm. Trying to fix all cases. ~Z
-	if(!wrapped)
-		for(var/obj/item/thing in src.contents)
-			wrapped = thing
-			break
+		return
 	if(wrapped) //Already have an item.
-		return //This is handled in /mob/living/silicon/robot/GripperClickOn
+		wrapped.afterattack(target, user, TRUE, params)
+		if(QDELETED(wrapped))
+			drop(get_turf(src), user, FALSE)
 	else if(istype(target, /obj/item/storage) && !istype(target, /obj/item/storage/pill_bottle) && !istype(target, /obj/item/storage/secure))
-		for(var/obj/item/C in target.contents)
-			if(grip_item(C, user, 0))
+		for(var/obj/item/C in target)
+			if(grip_item(C, user, FALSE))
 				to_chat(user, SPAN_NOTICE("You grab \the [C] from inside \the [target.name]."))
 				return
 		to_chat(user, SPAN_NOTICE("There is nothing inside the box that your gripper can collect."))

--- a/html/changelogs/gripper_fixing.yml
+++ b/html/changelogs/gripper_fixing.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Grippers will now properly remove items they are holding if that item should have been dropped / used up / otherwise deleted."


### PR DESCRIPTION
- Removes a lot of hacky code around grippers, including a bunch of special handling in `GripperClickOn` that was never actually called anyway.
- A gripper attacking a thing is treated as a gripper. It no longer pretends it is not a gripper via `get_active_hand()` returning the wrapped item instead.
- Removes many redundant / unnecessary checks that served only to hide potentially useful runtime errors.

Fixes #13268 , #13288 , #12343

These bugs were largely caused by `get_active_hand()` pretending we were only attacking with the wrapped object, so the gripper never called its `afterattack()` and stuff to properly drop a deleted item.