### PR TITLE
Maintenance drones properly generate their eye icon on spawning.

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -286,6 +286,10 @@
 /mob/living/silicon/robot/drone/updatename()
 	return
 
+/mob/living/silicon/robot/drone/setup_icon_cache()
+	setup_eye_cache()
+	setup_panel_cache()
+
 /mob/living/silicon/robot/drone/setup_eye_cache()
 	cached_eye_overlays = list(
 		I_HELP = image(icon, "[icon_state]-eyes_help"),

--- a/html/changelogs/maintenance-drone-eyes-on-spawn.yml
+++ b/html/changelogs/maintenance-drone-eyes-on-spawn.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Maintenance drones and subtypes will properly generate their eye icon when spawning."


### PR DESCRIPTION
Fixes #13319

They were being stopped by a check designed for generating robot icons, that are more complicated.