### PR TITLE
Research borgs get a multitool

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -842,6 +842,7 @@ var/global/list/robot_modules = list(
 	modules += new /obj/item/device/flash(src) // Non-lethal tool that prevents any 'borg from going lethal on Crew so long as it's an option according to laws.
 	modules += new /obj/item/crowbar/robotic(src) // Base crowbar that all 'borgs should have access to.
 	modules += new /obj/item/storage/part_replacer(src)
+	modules += new /obj/item/device/multitool/robotic(src) // To enable them to connect machines that require multitools e.g. tech-processors
 	emag = new /obj/item/hand_tele(src)
 
 	var/datum/matter_synth/nanite = new /datum/matter_synth/nanite(10000)

--- a/html/changelogs/research-borg-multitool.yml
+++ b/html/changelogs/research-borg-multitool.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - tweak: "Research module borgs now have a multitool to enable them to connect machines together."


### PR DESCRIPTION
Tech Processors have become an important part of RnD. They require a multitool to attach them to the main RnD server, and it is not appropriate for a 'borg to invite an Engineer into the RnD server for them to do it for them. So this PR allows them to do the job themselves.