### PR TITLE
Removes face direction click delay, direction lock is now undone if you're made to face another direction.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -953,13 +953,15 @@
 
 
 /mob/proc/facedir(var/ndir)
-	if(!canface() || (client && client.moving) || (client && world.time < client.move_delay))
+	if(!canface() || (client && client.moving))
 		return 0
+	if(facing_dir != ndir)
+		facing_dir = null
 	set_dir(ndir)
 	if(buckled_to && buckled_to.buckle_movable)
 		buckled_to.set_dir(ndir)
 	if (client)//Fixing a ton of runtime errors that came from checking client vars on an NPC
-		client.move_delay += movement_delay()
+		setMoveCooldown(movement_delay())
 	return 1
 
 

--- a/html/changelogs/mattatlas-clickadjustments.yml
+++ b/html/changelogs/mattatlas-clickadjustments.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Clicking a turf no longer has a face direction cooldown, meaning that you'll always face the turf you click."
+  - tweak: "Direction lock no longer prevents facing a different direction if your direction is changed, as an example by clicking or using control and arrow keys."


### PR DESCRIPTION
It's kind of wordy, so this is what happens:

1. Facing directions by clicking a turf no longer applies a delay.
2. If you alt click to face a certain direction and you click a turf in another direction, or face it via other means like control click and arrow keys, this will reset the direction lock and you will face that direction. Essentially, people can no longer shoot behind themselves and continue facing forward.