### PR TITLE
IV Drip Breath Mask Fix

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -225,6 +225,7 @@
 				breather.update_inv_wear_mask()
 				breath_mask.forceMove(src)
 				breath_mask.canremove = TRUE
+				breath_mask.adjustable = TRUE
 				tank_off()
 				update_icon()
 				return
@@ -342,6 +343,7 @@
 					breather.update_inv_wear_mask()
 					breath_mask.forceMove(src)
 					breath_mask.canremove = TRUE
+					breath_mask.adjustable = TRUE
 					breath_mask.slowdown = 0
 					breather = null
 					if(valve_open)
@@ -361,7 +363,7 @@
 					to_chat(usr, SPAN_WARNING("You must remove \the [breather]'s [breather.head] first!"))
 					breather = null
 					return
-				if(breather.wear_mask && !istype(breather.wear_mask, breath_mask))
+				if(breather.wear_mask && (!istype(breather.wear_mask, breath_mask) || is_type_in_list(breather.wear_mask, mask_blacklist))) // Temporary fix
 					to_chat(usr, SPAN_WARNING("You must remove \the [breather]'s [breather.wear_mask] first!"))
 					breather = null
 					return
@@ -371,6 +373,7 @@
 				breather.equip_to_slot(breath_mask, slot_wear_mask)
 				breather.update_inv_wear_mask()
 				breath_mask.canremove = FALSE
+				breath_mask.adjustable = FALSE
 				breath_mask.slowdown = 2
 				update_icon()
 				return

--- a/html/changelogs/iv_drip_breath_mask.yml
+++ b/html/changelogs/iv_drip_breath_mask.yml
@@ -1,0 +1,7 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the IV drip overwriting Vaurca breath mask types."
+  - tweak: "Made the mask you place over patients with the IV mask non-adjustable to prevent strange behavior"


### PR DESCRIPTION
* This fix is temporary since it doesn't fix the actual source of the problem, which is the pathing of the ``obj/item/clothing/mask/breath``, aka "breath mask" item itself
* Basically putting the normal breath mask you get from the survival box/oxygen closets would end up overwriting any other type of breath mask the patient might be wearing, since all other types are subtypes of the "breath mask" itself
* This should at least stop overwriting vaurca filter ports/mandible garments until the proper fix can be done