### PR TITLE
Lung Rescue on Vaurca Restriction

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -134,6 +134,9 @@
 			var/SM = (user == target) ? "your" : (target.name + "\'s")
 			if(!L)
 				return
+			if(isvaurca(target))
+				to_chat(usr, SPAN_WARNING("The needle won't pierce through [P] carapace!"))
+				return
 			if(L.rescued == TRUE)
 				to_chat(usr, SPAN_NOTICE("[H]'s ribs are already punctured!"))
 				return

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -135,7 +135,7 @@
 			if(!L)
 				return
 			if(isvaurca(target))
-				to_chat(usr, SPAN_WARNING("The needle won't pierce through [P] carapace!"))
+				to_chat(usr, SPAN_WARNING("\The [src] won't pierce through [P] carapace!"))
 				return
 			if(L.rescued == TRUE)
 				to_chat(usr, SPAN_NOTICE("[H]'s ribs are already punctured!"))

--- a/html/changelogs/lung_rescue_vaurca.yml
+++ b/html/changelogs/lung_rescue_vaurca.yml
@@ -1,0 +1,6 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - tweak: "Needles aren't able to lung rescue Vaurca."


### PR DESCRIPTION
* Syringes can't Lung Rescue Vaurca

Usually, I'd be very much against restricting a mechanic like this without a replacement, but this case is. Likely a very bad idea to breach through a vaurca's lungs to noxious air