### PR TITLE
Robotic Limbs Screw Hatch and Bleeding Fixes

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -846,7 +846,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		number_wounds += W.amount
 
 	//things tend to bleed if they are CUT OPEN
-	if (open && !clamped && (H && !(H.species.flags & NO_BLOOD)))
+	if (open && !clamped && (H && !(H.species.flags & NO_BLOOD) && !(status & ORGAN_ROBOT)))
 		status |= ORGAN_BLEEDING
 
 	if (istype(tendon))

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -99,7 +99,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("<b>[user]</b> has closed the maintenance hatch on [target]'s [affected.name] with \the [tool].", \
 		SPAN_NOTICE("You have closed the maintenance hatch on [target]'s [affected.name] with \the [tool]."),)
-	affected.open = ORGAN_OPEN_INCISION
+	affected.open = ORGAN_CLOSED
 
 /decl/surgery_step/robotics/screw_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/html/changelogs/robotic_limbs_bleed_screwhatch.yml
+++ b/html/changelogs/robotic_limbs_bleed_screwhatch.yml
@@ -1,0 +1,7 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed Robotic Limbs not properly screwing the hatch closed"
+  - bugfix: "Fixed Robotic Limbs saying they're bleeding if they get damaged when the hatch is unscrewed."


### PR DESCRIPTION
* Fixes being unable to properly screw the hatch on Robotic Limbs after you unscrewed them
* Fixes unscrewed Robotic Limbs being susceptible to bleeding when attacked even though they are unable to bleed

Basically it was impossible to screw the hatch closed, therefore being open and getting the ``ORGAN_BLEEDING`` since there wasn't a check to prevent that from happening if the organ was robotic