### PR TITLE
Adds a chance to fall while moving z-levels using zmove

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -92,10 +92,13 @@
 	if(.)
 		// Chance to fail while trying to climb down a lattice structure or ladder
 		var/turf/T = GetAbove(src)
-		if (locate(/obj/structure/lattice, T) || locate(/obj/structure/ladder, T) && !CanAvoidGravity() && !species.natural_climbing && (prob(8 * species.climb_coeff)))
-			T.visible_message(SPAN_WARNING("\The [src] slips while trying to descend!"))
-			to_chat(src, SPAN_DANGER("You slip while trying to descend!"))
-			fall_impact(1, damage_mod = 0.7)
+		var/area/A = get_area(src)
+		if (locate(/obj/structure/lattice, T) || locate(/obj/structure/ladder, T))
+			if (A.has_gravity() && !CanAvoidGravity()) 
+				if (!species.natural_climbing && (prob(8 * species.climb_coeff)))
+					T.visible_message(SPAN_WARNING("\The [src] slips while trying to descend!"))
+					to_chat(src, SPAN_DANGER("You slip while trying to descend!"))
+					fall_impact(1, damage_mod = 0.7)
 
 		for(var/obj/item/grab/G in list(l_hand, r_hand))
 			if(G.state >= GRAB_NECK) //strong grip

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -94,7 +94,7 @@
 		var/turf/T = GetAbove(src)
 		var/area/A = get_area(src)
 		if (locate(/obj/structure/lattice, T) || locate(/obj/structure/ladder, T))
-			if (A.has_gravity() && !CanAvoidGravity()) 
+			if (A.has_gravity() && !CanAvoidGravity() && direction == DOWN) 
 				if (!species.natural_climbing && (prob(8 * species.climb_coeff)))
 					T.visible_message(SPAN_WARNING("\The [src] slips while trying to descend!"))
 					to_chat(src, SPAN_DANGER("You slip while trying to descend!"))

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -78,6 +78,7 @@
 		if(car.flying)
 			buckled_to.Move(destination)
 			return TRUE
+
 	// Actually move.
 	Move(destination)
 	return TRUE
@@ -89,6 +90,13 @@
 		return
 	. = ..()
 	if(.)
+		// Chance to fail while trying to climb down a lattice structure or ladder
+		var/turf/T = GetAbove(src)
+		if (locate(/obj/structure/lattice, T) || locate(/obj/structure/ladder, T) && !CanAvoidGravity() && !species.natural_climbing && (prob(8 * species.climb_coeff)))
+			T.visible_message(SPAN_WARNING("\The [src] slips while trying to descend!"))
+			to_chat(src, SPAN_DANGER("You slip while trying to descend!"))
+			fall_impact(1, damage_mod = 0.7)
+
 		for(var/obj/item/grab/G in list(l_hand, r_hand))
 			if(G.state >= GRAB_NECK) //strong grip
 				if(G.affecting && !(G.affecting.buckled_to))

--- a/html/changelogs/ramke-jungle_gym_fail_chance.yml
+++ b/html/changelogs/ramke-jungle_gym_fail_chance.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ramke
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a chance to fail descending through z levels using directional commands (not using ladders)."
+  


### PR DESCRIPTION
Remember the central hole everyone treated as a jungle gym? This PR adds a small (but not inconsequential) chance to fail while instantly descending down lattices, catwalks and ladders. Climbing down ladders normally is still perfectly safe.

Failing in this manner will deal reduced damage in a fall (70% instead of 100%), and the chance is affected by certain species' climbing skills.

Now you can laugh at your colleagues for not following health & safety regulations!