### PR TITLE
Toxins suppress natural liver healing rate

### DIFF
--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -139,8 +139,12 @@
 	tick_surge_damage() //Yes, this is intentional.
 
 /obj/item/organ/internal/proc/handle_regeneration()
-	if(!damage || BP_IS_ROBOTIC(src) || !istype(owner) || owner.chem_effects[CE_TOXIN] || (toxin_type in owner.chem_effects) || owner.is_asystole())
-		return
-	var/repair_modifier = owner.chem_effects[CE_ORGANREPAIR] || 0.1
-	if(damage < repair_modifier*max_damage)
-		heal_damage(repair_modifier)
+	SHOULD_CALL_PARENT(TRUE)
+	if(damage && !BP_IS_ROBOTIC(src) && istype(owner))
+		if(!owner.is_asystole())
+			if(!(owner.chem_effects[CE_TOXIN] || (toxin_type in owner.chem_effects)))
+				var/repair_modifier = owner.chem_effects[CE_ORGANREPAIR] || 0.1
+				if(damage < repair_modifier*max_damage)
+					heal_damage(repair_modifier)
+				return TRUE // regeneration is allowed
+	return FALSE // regeneration is prevented

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -47,13 +47,6 @@
 		if(owner.intoxication > 0)
 			owner.adjustToxLoss(0.5 * max(2 - filter_effect, 0))
 
-	// Heal a bit if needed and we're not busy. This allows recovery from low amounts of toxloss.
-	if(!owner.total_radiation && damage > 0)
-		if(damage < min_broken_damage)
-			heal_damage(0.2)
-		if(damage < min_bruised_damage)
-			heal_damage(0.3)
-
 	var/filter_strength = INTOX_FILTER_HEALTHY
 	if(is_bruised())
 		filter_strength = INTOX_FILTER_BRUISED
@@ -76,6 +69,13 @@
 		if(is_damaged())
 			owner.adjustToxLoss(owner.chem_effects[toxin_type] * 0.1 * PROCESS_ACCURACY) // as actual organ damage is handled elsewhere
 
-//We got it covered in Process with more detailed thing
 /obj/item/organ/internal/liver/handle_regeneration()
-	return
+	if(..())
+		testing("Liver regenerating!")
+		if(!owner.total_radiation && damage > 0)
+			if(damage < min_broken_damage)
+				heal_damage(0.2)
+			if(damage < min_bruised_damage)
+				heal_damage(0.3)
+			return TRUE
+	return FALSE

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -9,6 +9,7 @@
 	taste_description = "bitterness"
 	taste_mult = 1.2
 	fallback_specific_heat = 0.75
+	overdose = 10
 
 	var/target_organ // needs to be null by default
 	var/strength = 2 // How much damage it deals per unit
@@ -36,6 +37,7 @@
 					C.take_damage(removed * 2)
 		if(dam)
 			M.adjustToxLoss(target_organ ? (dam * 0.5) : dam)
+			M.add_chemical_effect(CE_TOXIN, removed * strength)
 
 /decl/reagent/toxin/plasticide
 	name = "Plasticide"

--- a/html/changelogs/toxins-do-damage-now.yml
+++ b/html/changelogs/toxins-do-damage-now.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes a bug where toxins (e.g. from giant spiders) would never do damage because they couldn't beat your liver's natural healing rate. Toxins now suppress your liver's natural healing and can become dangerous if you don't deal with the poison within several minutes."


### PR DESCRIPTION
Currently `/decl/reagent/toxin` will never do any damage to you.

`/decl/reagent/toxin` does 0.04 damage per life-tick to your organs, but livers heal 0.6 damage per life tick if they aren't badly damaged.

With this change, the presence of `CE_TOXIN` will suppress its regeneration (like it does for every other organ but the liver). It will quickly heal if you purge your system of the toxin with Dylovene or dialysis. And `/decl/reagent/toxin` now actually gives you `CE_TOXIN`.

`/decl/reagent/toxin` will kill you extremely slowly, on the order of 5-10 minutes. It does not significantly affect the time-to-kill of potent toxins like cyanide, they mostly kill you via other routes anyway like oxy loss?

---

It may be necessary to tweak the amount of poison giant spiders do... but I think it's probably okay as it is.