### PR TITLE
Blast door buttons sync the blast doors they control when pressed

### DIFF
--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -147,16 +147,15 @@
 	desc = "It controls blast doors, remotely."
 
 /obj/machinery/button/remote/blast_door/trigger()
+	var/new_state
 	for(var/obj/machinery/door/blast/M in SSmachinery.all_machines)
-		if(M.id == src.id)
-			if(M.density)
-				spawn(0)
-					M.open()
-					return
+		if(M.id == id)
+			if(isnull(new_state))
+				new_state = M.density
+			if(new_state)
+				M.open()
 			else
-				spawn(0)
-					M.close()
-					return
+				M.close()
 
 /obj/machinery/button/remote/blast_door/open_only/trigger()
 	for(var/obj/machinery/door/blast/M in SSmachinery.all_machines)

--- a/html/changelogs/shutter-sync.yml
+++ b/html/changelogs/shutter-sync.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - tweak: "Blast door buttons will synchronise state of the blast doors they control when pressed."


### PR DESCRIPTION
Will solve issues where power outages in different areas will desync the blast doors controlled by one button.

Sets all the doors based on the state of the first door found.