### PR TITLE
Combitool/HealthScanner Loadout item restrictions

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_augments.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_augments.dm
@@ -40,6 +40,7 @@
 	description = "An augment that allows the user to deploy a robotic combitool."
 	path = /obj/item/organ/internal/augment/tool/combitool
 	cost = 5
+	allowed_roles = list("Station Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice", "Roboticist")
 
 /datum/gear/augment/combitool/New()
 	..()
@@ -73,6 +74,7 @@
 	description = "An augment that allows the user scan their own health condition."
 	path = /obj/item/organ/internal/augment/health_scanner
 	cost = 3
+	allowed_roles = list("Physician", "Surgeon", "Chief Medical Officer", "Pharmacist", "First Responder", "Psychiatrist", "Medical Intern")
 
 /datum/gear/augment/suspension
 	display_name = "calf suspension"

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -220,11 +220,6 @@
 	glove_type = null
 	boot_type = null
 
-	initial_modules = list(
-		/obj/item/rig_module/device/healthscanner/vitalscanner,
-		/obj/item/rig_module/chem_dispenser/offworlder
-		)
-
 	species_restricted = list(BODYTYPE_HUMAN)
 
 	siemens_coefficient = 0.9

--- a/html/changelogs/loadout-cleanup.yml
+++ b/html/changelogs/loadout-cleanup.yml
@@ -1,0 +1,7 @@
+author: mikomyazaki2
+
+delete-after: True
+
+changes:
+  - tweak: "Integrated healthscanner augments and toolset augments are now locked to medical and engineering jobs respectively."
+  - tweak: "Exo-stellar exosuit no longer starts with a health-scanner & medicine dispenser included."


### PR DESCRIPTION
- Restricts two augments (toolset and health-analyzer) on the loadout menu behind appropriate jobs. 
- Removes the health-analyzer and drug dispenser from the exo-stellar exosuit.

Health-analyzers especially are non-trivial to obtain for non-medical jobs, and aren't an appropriate loadout item for everyone to be able to spawn with, in my opinion. I don't think the higher than usual loadout point cost has been enough to prevent these being used for powergaming.

I have a WIP PR that will follow this one that adds the various augments to the roboticist's printer so they can give them to people IC.