### PR TITLE
Horizon Bugfixes 01

### DIFF
--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -75,7 +75,7 @@
 		return TOPIC_NOACTION
 
 	if (href_list["viewing"])
-		if(usr && !isAI(usr))
+		if(usr)
 			viewing_overmap(usr) ? unlook(usr) : look(usr)
 		return TOPIC_REFRESH
 
@@ -86,7 +86,7 @@
 	if(sensors)
 		if (href_list["range"])
 			var/nrange = input("Set new sensors range", "Sensor range", sensors.range) as num|null
-			if(!CanInteract(usr, physical_state))
+			if(!CanInteract(usr, default_state))
 				return TOPIC_NOACTION
 			if (nrange)
 				sensors.set_range(Clamp(nrange, 1, world.view))

--- a/html/changelogs/horizon-fixes-01.yml
+++ b/html/changelogs/horizon-fixes-01.yml
@@ -1,0 +1,10 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+    - bugfix: "AI can now use the sensors console fully."
+    - bugfix: "Operations mailing room no longer launches the rubbish off of the conveyor belt."
+    - bugfix: "Port Propulsion now has an additional valve to toggle that will send cold phoron to the starboard thruster if you wish to operate with cold propellant. Note that this mode will result in less thrust and it is preferable to use the burn chambers!"
+    - tweak: "D1 Operations areas now have some additional holopads."
+    - tweak: "CE and Journalist Officers are now better lit."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -3289,11 +3289,15 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/eva)
 "cWX" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/tvalve/digital/bypass{
+	dir = 1;
+	name = "Starboard Thruster Propellant Input Switch"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -5156,6 +5160,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "eKi" = (
@@ -5947,9 +5952,6 @@
 /obj/machinery/atmospherics/tvalve/digital{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "fnL" = (
@@ -6438,12 +6440,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/starboard)
 "fKe" = (
-/obj/machinery/meter,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/visible/purple{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "fKk" = (
 /obj/structure/table/steel,
@@ -7160,9 +7163,6 @@
 /turf/simulated/floor/plating,
 /area/hangar/control)
 "gnP" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/binary/pump/high_power{
 	layer = 2.8
 	},

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -2173,6 +2173,19 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/operations)
+"bSO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/operations/lower/machinist)
 "bUN" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4300,6 +4313,7 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 10
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/operations/lower/machinist)
 "eaO" = (
@@ -22686,6 +22700,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/storage/lower)
+"uBi" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
 "uCq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -42557,7 +42587,7 @@ pWZ
 cWd
 hhO
 tgR
-beP
+uBi
 tgR
 xwo
 eqk
@@ -45568,7 +45598,7 @@ sLn
 qIT
 iDw
 hYh
-wqs
+bSO
 fga
 wMO
 pYD

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -9843,6 +9843,9 @@
 	},
 /obj/effect/decal/warning_stripes,
 /mob/living/simple_animal/carp/fluff/ginny,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/reinforced,
 /area/crew_quarters/heads/chief)
 "ghX" = (
@@ -19884,6 +19887,7 @@
 /obj/item/modular_computer/console/preset/engineering/ce{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet/rubber,
 /area/crew_quarters/heads/chief)
 "mxO" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -1141,6 +1141,7 @@
 	layer = 2.9;
 	reversed = 1
 	},
+/obj/structure/plasticflaps,
 /turf/simulated/floor/plating,
 /area/operations/mail_room)
 "aHj" = (
@@ -27328,12 +27329,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
-"rel" = (
-/obj/structure/disposalpipe/trunk,
-/obj/effect/floor_decal/industrial/warning/full,
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/plating,
-/area/operations/mail_room)
 "reo" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -28985,6 +28980,13 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/structure/plasticflaps,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/operations/mail_room)
@@ -31883,18 +31885,20 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "tQk" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/structure/window/reinforced{
+	layer = 5;
+	name = "adjusted reinforced window"
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/machinery/conveyor{
-	dir = 5;
-	id = "sorting";
-	layer = 2.9;
-	reversed = null
 	},
 /turf/simulated/floor/plating,
 /area/operations/mail_room)
@@ -53951,7 +53955,7 @@ bOV
 kUc
 nkK
 nIi
-rel
+iuP
 tQk
 eew
 pPO

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -12446,6 +12446,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/vacantoffice2)
+"DZ" = (
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/starboard)
 "Ea" = (
 /obj/machinery/door/airlock/hatch{
 	desc = "It opens and closes. It has a small sign engraved: Bunker capacity: 6. Only facility's Command Staff is permitted.";
@@ -16266,9 +16273,6 @@
 /area/security/vacantoffice2)
 "Nj" = (
 /obj/structure/flora/pottedplant/random,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/wood,
 /area/journalistoffice)
 "Nl" = (
@@ -16606,6 +16610,7 @@
 	name = "corkboard";
 	pixel_y = -26
 	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet,
 /area/journalistoffice)
 "NV" = (
@@ -44916,7 +44921,7 @@ Od
 Tu
 Fz
 RJ
-BW
+DZ
 vx
 Oa
 Mt


### PR DESCRIPTION
Selection of small horizon bugfixes.

- Fixes #13444 -- Trash will now land on the conveyor belt instead of being thrown across the room.
- Fixes #13442 -- There is now a valve that will allow you to pipe cold phoron to the starboard thruster if desired. 
- Fixes #13441 -- AI can use the sensor console properly.
- Some extra holopads in D1 operations areas (mining area, machinist's area, lobby outside machinist's area)
- Better lighting in CEs office and Journalist's Office.