### PR TITLE
Disconnects the service and security sub-grids from each other

### DIFF
--- a/html/changelogs/FlamingLily-cabling-fix.yml
+++ b/html/changelogs/FlamingLily-cabling-fix.yml
@@ -1,0 +1,7 @@
+author: FlamingLily
+
+delete-after: True
+
+changes:
+  - maptweak: "Disconnected the service and security subgrids from each other."
+  - maptweak: "Made the downwards cable to the freezer go through a catwalk, instead of solid floor."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -1654,9 +1654,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -11271,9 +11268,6 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -20196,9 +20190,6 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -23282,7 +23282,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/open,
 /area/maintenance/hangar/port)
 "oBZ" = (
 /obj/structure/cable/green{


### PR DESCRIPTION
Grids got crosswired at the maintenance outside the freezer/security substation, also one of the cables was running through solid ground so I fixed that too, it's now a catwalk (like was intended, but the catwalk was deleted because it wasn't open space)


