### PR TITLE
Fixes the Orion Shuttle being unable to depart the Orion Ship after it has left its initial sector.

### DIFF
--- a/html/changelogs/mattatlas-fixlandmarks.yml
+++ b/html/changelogs/mattatlas-fixlandmarks.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed the Orion Shuttle being unable to depart the Orion Ship after it has moved from its starting location. As a note for future mappers: if you have a ship with a hangar for a small ship, the landmark of the hangar MUST have the MOVABLE_FLAG_EFFECTMOVE movable_flag set."

--- a/maps/away/ships/corporate.dm
+++ b/maps/away/ships/corporate.dm
@@ -117,6 +117,7 @@
 	docking_controller = "orion_express_shuttle_dock"
 	base_area = /area/shuttle/orion_express_ship
 	base_turf = /turf/simulated/floor/plating
+	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 
 /obj/effect/shuttle_landmark/orion_express_shuttle/transit
 	name = "In transit"


### PR DESCRIPTION
As a note for future mappers: if you have a ship with a hangar for a small ship, the landmark of the hangar **MUST** have the MOVABLE_FLAG_EFFECTMOVE movable_flag set.