### PR TITLE
Space Eel nerf

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
@@ -181,15 +181,15 @@
 	icon_dead = "eel"
 	meat_amount = 5
 
-	maxHealth = 250
-	health = 250
+	maxHealth = 150
+	health = 150
 
 	speed = 9
 
-	melee_damage_lower = 40
-	melee_damage_upper = 40
-
-/mob/living/simple_animal/hostile/carp/bloater
+	melee_damage_lower = 20
+	melee_damage_upper = 20
+	armor_penetration = 30
+/mob/living/simple_animal/hostile/carp/bloater	
 	name = "bloater"
 	desc = "A fat, mineral-devouring creature frequently herded for mining expeditions. Its actual ability to dig is less valuable than its volatile nature, however."
 	icon = 'icons/mob/npc/large_space_xenofauna.dmi'

--- a/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
@@ -188,7 +188,7 @@
 
 	melee_damage_lower = 20
 	melee_damage_upper = 20
-	armor_penetration = 30
+	armor_penetration = 25
 	
 /mob/living/simple_animal/hostile/carp/bloater	
 	name = "bloater"

--- a/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
@@ -189,6 +189,7 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 20
 	armor_penetration = 30
+	
 /mob/living/simple_animal/hostile/carp/bloater	
 	name = "bloater"
 	desc = "A fat, mineral-devouring creature frequently herded for mining expeditions. Its actual ability to dig is less valuable than its volatile nature, however."

--- a/html/changelogs/Yonnimer-Eelsmanbad.yml
+++ b/html/changelogs/Yonnimer-Eelsmanbad.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: Yonnimer
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/Yonnimer-Eelsmanbad.yml
+++ b/html/changelogs/Yonnimer-Eelsmanbad.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Nerfs space eels by giving them less HP and damage, but giving them some armor piercing.

--- a/html/changelogs/Yonnimer-Eelsmanbad.yml
+++ b/html/changelogs/Yonnimer-Eelsmanbad.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Nerfs space eels by giving them less HP and damage, but giving them some armor piercing.
+  - tweak: "Nerfs space eels by giving them less HP and damage, but giving them some armor piercing."


### PR DESCRIPTION
Eels are kinda OP right now for a mob found on mining sites, they can do about 89 damage to someone in a mining voidsuit in 2-3 hits, which is usually lethal without an EMT with them. This should help make them a bit more fair by:
- lowering their health (takes about 3 KA shots to kill them while in space)
- lowering their damage
- giving them some armor-piercing damage.