### PR TITLE
Some orion ship bugfixes & tweaks

### DIFF
--- a/html/changelogs/orion-bugfixes.yml
+++ b/html/changelogs/orion-bugfixes.yml
@@ -1,0 +1,17 @@
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Orion Traveler Shuttle has a holopad now."
+  - tweak: "Orion Traveler has CO2 fuel now."
+  - tweak: "Orion Traveler holopad is in its cockpit now."
+  - bugfix: "Orion Traveler cardinal navpoints for shuttles are in the right places now."
+  - tweak: "Orion crew get proper voidsuits that can hold full oxygen tanks."
+  - bugfix: Orion Traveler airlock now cycles.

--- a/html/changelogs/orion-bugfixes.yml
+++ b/html/changelogs/orion-bugfixes.yml
@@ -14,4 +14,5 @@ changes:
   - tweak: "Orion Traveler holopad is in its cockpit now."
   - bugfix: "Orion Traveler cardinal navpoints for shuttles are in the right places now."
   - tweak: "Orion crew get proper voidsuits that can hold full oxygen tanks."
-  - bugfix: Orion Traveler airlock now cycles.
+  - bugfix: "Orion Traveler airlock now cycles."
+  - tweak: "Orion Traveler now has a cryo-pod in the dormitory."

--- a/maps/away/ships/corporate.dm
+++ b/maps/away/ships/corporate.dm
@@ -35,7 +35,6 @@
 	max_speed = 1/(2 SECONDS)
 	burn_delay = 1 SECONDS
 	vessel_mass = 5000
-	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_SMALL
 	fore_dir = SOUTH
 	shuttle = "Orion Express Ship"

--- a/maps/away/ships/corporate.dm
+++ b/maps/away/ships/corporate.dm
@@ -37,6 +37,7 @@
 	vessel_mass = 5000
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_SMALL
+	fore_dir = SOUTH
 	shuttle = "Orion Express Ship"
 	initial_restricted_waypoints = list(
 		"Orion Express Shuttle" = list("nav_hangar_orion_express")
@@ -90,7 +91,7 @@
 	max_speed = 1/(3 SECONDS)
 	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod
-	fore_dir = SOUTH
+	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY
 
 /obj/machinery/computer/shuttle_control/explore/orion_express_shuttle

--- a/maps/away/ships/orion_express_ship.dmm
+++ b/maps/away/ships/orion_express_ship.dmm
@@ -293,10 +293,10 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/orion_express_ship)
 "eCV" = (
-/obj/machinery/portable_atmospherics/canister/hydrogen,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor,
 /area/shuttle/orion_express_ship)
 "eIb" = (
@@ -306,7 +306,7 @@
 /turf/simulated/floor,
 /area/shuttle/orion_express_ship)
 "eMT" = (
-/obj/machinery/portable_atmospherics/canister/hydrogen,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor,
 /area/shuttle/orion_express_ship)
 "eTH" = (
@@ -383,7 +383,24 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "orion_traveler_port";
+	name = "interior access button";
+	pixel_x = 24;
+	pixel_y = -8
+	},
 /turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_express_ship)
+"fXG" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "orion_traveler_in"
+	},
+/turf/simulated/floor,
 /area/shuttle/orion_express_ship)
 "fZq" = (
 /obj/machinery/door/airlock/mining{
@@ -425,6 +442,14 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/orion_express_ship)
+"gNV" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1380;
+	id_tag = "orion_traveler_pump"
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_express_ship)
 "gNW" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
@@ -446,11 +471,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_express_ship)
 "hdb" = (
-/obj/machinery/portable_atmospherics/canister/hydrogen,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8;
 	layer = 2.8
 	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor,
 /area/shuttle/orion_express_ship)
 "heP" = (
@@ -480,6 +505,19 @@
 "huE" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/white,
+/area/shuttle/orion_express_ship)
+"hzn" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "orion_traveler_port";
+	layer = 3.3;
+	pixel_y = 28;
+	tag_airpump = "orion_traveler_pump";
+	tag_chamber_sensor = "orion_traveler_sensor";
+	tag_exterior_door = "orion_traveler_out";
+	tag_interior_door = "orion_traveler_in"
+	},
+/turf/simulated/floor,
 /area/shuttle/orion_express_ship)
 "hBd" = (
 /obj/structure/table/standard,
@@ -636,6 +674,7 @@
 "lpe" = (
 /obj/effect/shuttle_landmark/orion_express_shuttle/hangar,
 /obj/effect/overmap/visitable/ship/landable/orion_express_shuttle,
+/obj/machinery/hologram/holopad/long_range,
 /turf/simulated/floor/shuttle/black,
 /area/shuttle/orion_express_shuttle)
 "lri" = (
@@ -643,6 +682,14 @@
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 4
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_express_ship)
+"lsi" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "orion_traveler_out"
 	},
 /turf/simulated/floor,
 /area/shuttle/orion_express_ship)
@@ -743,6 +790,30 @@
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/orion_express_ship)
+"nBz" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "orion_traveler_in"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_express_ship)
+"nJz" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1380;
+	id_tag = "orion_traveler_pump"
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "orion_traveler_sensor";
+	pixel_y = 26
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_express_ship)
 "nMV" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille/diagonal{
@@ -777,7 +848,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	layer = 2.8
 	},
-/obj/machinery/portable_atmospherics/canister/hydrogen,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/shuttle/black,
 /area/shuttle/orion_express_shuttle)
 "ogz" = (
@@ -789,6 +860,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/orion_express_ship)
+"oEN" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "orion_traveler_port";
+	name = "exterior access button";
+	pixel_x = -24;
+	pixel_y = -10
+	},
+/turf/template_noop,
+/area/space)
 "pbp" = (
 /obj/machinery/light{
 	icon_state = "tube1"
@@ -896,11 +978,11 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/orion_express_ship)
 "qil" = (
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/suit_storage_unit,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_express_ship)
 "que" = (
@@ -946,8 +1028,10 @@
 /turf/simulated/floor/shuttle/black,
 /area/shuttle/orion_express_shuttle)
 "spX" = (
-/obj/machinery/hologram/holopad/long_range,
-/turf/simulated/floor/wood,
+/obj/structure/table/rack,
+/obj/random/voidsuit/no_nanotrasen,
+/obj/random/voidsuit/no_nanotrasen,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_express_ship)
 "szY" = (
 /obj/machinery/shipsensors/weak,
@@ -995,6 +1079,10 @@
 /obj/effect/shuttle_landmark/orion_express_ship/start,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_express_ship)
+"tjM" = (
+/obj/machinery/hologram/holopad/long_range,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_express_ship)
 "tra" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(201)
@@ -1017,7 +1105,6 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/orion_express_ship)
 "uwT" = (
-/obj/effect/map_effect/airlock/w_to_e/long/square,
 /obj/structure/grille,
 /obj/structure/window/shuttle/scc_space_ship,
 /turf/simulated/floor/plating,
@@ -32133,7 +32220,7 @@ ccm
 ccm
 qil
 ccm
-ccm
+spX
 atj
 riA
 lFg
@@ -32660,7 +32747,7 @@ uaE
 uaE
 iNo
 wmd
-spX
+wmd
 wmd
 dHA
 riA
@@ -33435,7 +33522,7 @@ ccm
 ccm
 ccm
 sGi
-ccm
+tjM
 fnE
 bci
 gNW
@@ -35994,8 +36081,8 @@ xRX
 riA
 riA
 gNW
-mkb
-mkb
+nBz
+fXG
 uwT
 riA
 xRX
@@ -36251,8 +36338,8 @@ xRX
 xRX
 xRX
 gNW
-mkb
-mkb
+nJz
+gNV
 gNW
 xRX
 xRX
@@ -36508,7 +36595,7 @@ xRX
 xRX
 xRX
 gNW
-mkb
+hzn
 mkb
 gNW
 xRX
@@ -36765,8 +36852,8 @@ xRX
 xRX
 xRX
 gNW
-mkb
-mkb
+lsi
+lsi
 gNW
 xRX
 xRX
@@ -37021,7 +37108,7 @@ xRX
 xRX
 xRX
 xRX
-xRX
+oEN
 xRX
 xRX
 xRX

--- a/maps/away/ships/orion_express_ship.dmm
+++ b/maps/away/ships/orion_express_ship.dmm
@@ -246,6 +246,10 @@
 /obj/item/pizzabox/meat,
 /turf/simulated/floor/wood,
 /area/shuttle/orion_express_ship)
+"dKJ" = (
+/obj/machinery/cryopod,
+/turf/simulated/floor/wood,
+/area/shuttle/orion_express_ship)
 "dQZ" = (
 /obj/machinery/telecomms/allinone/ship,
 /obj/machinery/light/small,
@@ -35571,7 +35575,7 @@ ccm
 ccm
 pJZ
 riA
-uNN
+dKJ
 wmd
 riA
 xRX


### PR DESCRIPTION
Fixes #13466 
Fixes #13465 
Fixes #13464

- Airlock on Orion Traveler cycles now
- There are some more random proper voidsuits that can accept full canisters
- Fore directions are set properly on shuttle + ship
- There's CO2 canisters instead of Hydrogen so the ships can get around faster (maybe too much? will keep an eye on it)
- Holopad on the Shuttle now
- Holopad is moved to the cockpit of the Traveler
- Orion dorm has a cryo-pod so couriers can exit the round properly.