### PR TITLE
Fix lobby ready names runtiming on assistant/no pref

### DIFF
--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -51,7 +51,8 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 			for(var/mob/abstract/new_player/player in player_list)
 				totalPlayers++
 				if(player.ready)
-					stat("[copytext_char(player.client.prefs.real_name, 1, 18)]", ("[player.client.prefs.return_chosen_high_job(TRUE)]"))
+					var/job_ready = player.client.prefs.return_chosen_high_job(TRUE)
+					stat("[copytext_char(player.client.prefs.real_name, 1, 18)]", job_ready ? "[job_ready]" : "N/A")
 					totalPlayersReady++
 
 /mob/abstract/new_player/Topic(href, href_list[])

--- a/code/modules/mob/abstract/new_player/preferences_setup.dm
+++ b/code/modules/mob/abstract/new_player/preferences_setup.dm
@@ -200,10 +200,7 @@
 
 	// Determine what job is marked as 'High' priority, and dress them up as such.
 	var/datum/job/previewJob
-	if(job_civilian_low & ASSISTANT)
-		previewJob = SSjobs.GetJob("Assistant")
-	else
-		previewJob = return_chosen_high_job()
+	previewJob = return_chosen_high_job()
 
 	if(previewJob)
 		mannequin.job = previewJob.title
@@ -228,14 +225,17 @@
 
 /datum/preferences/proc/return_chosen_high_job(var/title = FALSE)
 	var/datum/job/chosenJob
-	if(job_civilian_high)
+	if(job_civilian_low & ASSISTANT)
+		// Assistant is weird, has to be checked first because it overrides
+		chosenJob = SSjobs.bitflag_to_job["[SERVICE]"]["[job_civilian_low]"]
+	else if(job_civilian_high)
 		chosenJob = SSjobs.bitflag_to_job["[SERVICE]"]["[job_civilian_high]"]
 	else if(job_medsci_high)
 		chosenJob = SSjobs.bitflag_to_job["[MEDSCI]"]["[job_medsci_high]"]
 	else if(job_engsec_high)
 		chosenJob = SSjobs.bitflag_to_job["[ENGSEC]"]["[job_engsec_high]"]
 
-	if(title)
+	if(istype(chosenJob) && title)
 		return chosenJob.title
 	return chosenJob
 

--- a/html/changelogs/johnwildkins-ready.yml
+++ b/html/changelogs/johnwildkins-ready.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed lobby ready names causing errors if no high-priority role was selected, or if assistant was enabled."


### PR DESCRIPTION
```runtime error:
[21:32:27]Cannot read null.title
[21:32:27]proc name: return chosen high job (/datum/preferences/proc/return_chosen_high_job)
[21:32:27]  source file: preferences_setup.dm,239
```

Should fix this runtime appearing 8 gorillion times, or thereabouts.