### PR TITLE
Removes the skip for changeturf if the turf is the same

### DIFF
--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -29,8 +29,6 @@
 /turf/proc/ChangeTurf(N, tell_universe = TRUE, force_lighting_update = FALSE, var/ignore_override)
 	if (!N)
 		return
-	if(!use_preloader && N == type) // Don't no-op if the map loader requires it to be reconstructed
-		return src
 
 	// This makes sure that turfs are not changed to space when there's a multi-z turf below
 	if(ispath(N, /turf/space) && HasBelow(z) && !ignore_override)
@@ -107,7 +105,7 @@
 	for(var/image/I as anything in W.blueprints)
 		I.loc = W
 		I.plane = 0
-	
+
 	W.decals = old_decals
 
 	W.post_change()

--- a/html/changelogs/intrepid-airflow-bug.yml
+++ b/html/changelogs/intrepid-airflow-bug.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Shuttles should now always properly simulate their atmospheres when landing on a space that has the same turf types as itself. (e.g. Intrepid airlock turfs are the same as the hangar turfs resulting in air not moving properly into the shuttle)"


### PR DESCRIPTION
Fixes #13472

Turfs weren't recalculating all sorts of things like ZAS zones when the turf the shuttle was landing on was the same as the one in the shuttle (e.g. Intrepid airlock has platings, the hangar has platings.)

This has caused other weirdness too.

Other servers don't use this line, only negative is we're going to New a few turfs that don't need it _sometimes_ but it shouldn't be a big deal.