### PR TITLE
Fix firedoor runtime

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -485,8 +485,8 @@
 
 				do_set_light = TRUE
 
-		if (hashatch)
-			if (hatchstate && hatch_image)
+		if (hashatch && hatch_image)
+			if (hatchstate)
 				hatch_image.icon_state = "[hatchstyle]_open"
 			else
 				hatch_image.icon_state = hatchstyle
@@ -540,12 +540,3 @@
 		if(istype(destination)) SSair.tiles_to_update += destination
 		return 1
 */
-
-/obj/machinery/door/firedoor/multi_tile
-	icon = 'icons/obj/doors/DoorHazard2x1.dmi'
-	width = 2
-	dir = EAST
-	enable_smart_generation = FALSE
-
-	open_sound = 'sound/machines/firewideopen.ogg'
-	close_sound = 'sound/machines/firewideclose.ogg'

--- a/code/game/machinery/doors/multi_tile.dm
+++ b/code/game/machinery/doors/multi_tile.dm
@@ -35,3 +35,35 @@
 				hatch_image.pixel_x = hatch_offset_y
 				hatch_image.pixel_y = hatch_offset_x
 		add_overlay(hatch_image)
+
+/obj/machinery/door/firedoor/multi_tile
+	icon = 'icons/obj/doors/DoorHazard2x1.dmi'
+	width = 2
+	hatch_offset_x = 16
+	dir = EAST
+	enable_smart_generation = FALSE
+
+	open_sound = 'sound/machines/firewideopen.ogg'
+	close_sound = 'sound/machines/firewideclose.ogg'
+
+/obj/machinery/door/firedoor/multi_tile/Initialize()
+	. = ..()
+	if(hashatch)
+		setup_hatch()
+
+/obj/machinery/door/firedoor/multi_tile/setup_hatch()
+	if(overlays != null)
+		hatch_image = null
+		hatch_image = image('icons/obj/doors/hatches.dmi', src, hatchstyle, closed_layer+0.1)
+		hatch_image.color = hatch_colour
+		hatch_image.transform = turn(hatch_image.transform, 90)
+		// reset any rotation and transformation applied
+		switch(dir)
+			if(EAST, WEST)
+				hatch_image.pixel_x = hatch_offset_x
+				hatch_image.pixel_y = hatch_offset_y
+			if(NORTH, SOUTH)
+				hatch_image.pixel_x = hatch_offset_y
+				hatch_image.pixel_y = hatch_offset_x
+		if(density)
+			add_overlay(hatch_image)

--- a/html/changelogs/johnwildkins-firedoor.yml
+++ b/html/changelogs/johnwildkins-firedoor.yml
@@ -1,0 +1,4 @@
+author: JohnWildkins
+delete-after: True
+changes:
+  - bugfix: "Fixed double-wide firedoors not rendering their hatches correctly."


### PR DESCRIPTION
![](https://media.discordapp.net/attachments/131489773268238336/963452346615087125/unknown.png)

fixes wide fire doors not spawning a hatch image because of a bunch of reasons