### PR TITLE
Touches up rolled cigarettes with bugfixes, cleanup, reflavouring.

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -961,6 +961,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon = 'icons/obj/cigs_lighters.dmi'
 	icon_state = "cigpaper_generic"
 	w_class = ITEMSIZE_TINY
+	can_fold = FALSE
 
 /obj/item/paper/cig/attackby(obj/item/P as obj, mob/user as mob)
 	if(istype(P, /obj/item/flame) || P.iswelder())
@@ -975,25 +976,19 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "A thin piece of trident branded paper used to make fine smokables."
 	icon_state = "cigpaper_fine"
 
-/obj/item/paper/cig/filter
+/obj/item/cigarette_filter
 	name = "cigarette filter"
 	desc = "A small nub like filter for cigarettes."
+	icon = 'icons/obj/cigs_lighters.dmi'
 	icon_state = "cigfilter"
 	w_class = ITEMSIZE_TINY
 
-/obj/item/paper/cig/filter/attackby(obj/item/P as obj, mob/user as mob)
-	if(istype(P, /obj/item/flame) || P.iswelder())
-		..()
-	else
-		return //no writing on filters now
-
-/obj/item/paper/cig/attack_self(mob/living/user as mob)
-	if(user.a_intent == I_HURT)
-		..()
-		return
-	if (user.a_intent == I_GRAB && icon_state != "scrap" && !istype(src, /obj/item/paper/carbon))
-		user.show_message(SPAN_ALERT("The cigarette paper is too small to fold into a plane."))
-		return
+/obj/item/cigarette_filter/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/clothing/mask/smokable/cigarette/rolled))
+		var/obj/item/clothing/mask/smokable/cigarette/rolled/CR = I
+		return CR.attackby(src, user)
+	. = ..()
+	
 
 //tobacco sold seperately if you're too snobby to grow it yourself.
 /obj/item/reagent_containers/food/snacks/grown/dried_tobacco
@@ -1016,17 +1011,17 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	plantname = "puretobacco"
 
 /obj/item/clothing/mask/smokable/cigarette/rolled/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/paper/cig/filter))
+	if(istype(I, /obj/item/cigarette_filter))
 		if(filter)
-			to_chat(user, SPAN_WARNING("[src] already has a filter!"))
+			to_chat(user, SPAN_WARNING("\The [src] already has a filter!"))
 			return
 		if(lit)
-			to_chat(user, SPAN_WARNING("[src] is lit already!"))
+			to_chat(user, SPAN_WARNING("\The [src] is lit already!"))
 			return
 		if(user.unEquip(I))
-			to_chat(user, SPAN_NOTICE("You stick [I] into \the [src]"))
+			user.visible_message(SPAN_NOTICE("[user] sticks a cigarette filter into \the [src]."), SPAN_NOTICE("You stick a cigarette filter into \the [src]."))
 			playsound(src, 'sound/items/drop/gloves.ogg', 25, 1)
-			filter = 1
+			filter = TRUE
 			name = "filtered [name]"
 			update_icon()
 			qdel(I)
@@ -1034,15 +1029,15 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	..()
 
 /obj/item/reagent_containers/food/snacks/grown/attackby(obj/item/I, mob/user)
-	if(is_type_in_list(I, list(/obj/item/paper/cig/, /obj/item/paper/)))
+	if(istype(I, /obj/item/paper))
 		if(!dry)
-			to_chat(user, SPAN_WARNING("You need to dry [src] first!"))
+			to_chat(user, SPAN_WARNING("You need to dry \the [src] first!"))
 			return
 		if(user.unEquip(I))
 			var/obj/item/clothing/mask/smokable/cigarette/rolled/R = new(get_turf(src))
 			R.chem_volume = reagents.total_volume
 			reagents.trans_to_holder(R.reagents, R.chem_volume)
-			to_chat(user, SPAN_NOTICE("You roll \the [src] into \the [I]"))
+			user.visible_message(SPAN_NOTICE("[user] rolls a cigarette in their hands with \the [I] and [src]."), SPAN_NOTICE("You roll a cigarette in your hands with \the [I] and [src]."))
 			playsound(src, 'sound/bureaucracy/paperfold.ogg', 25, 1)
 			user.put_in_active_hand(R)
 			qdel(I)

--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -56,8 +56,9 @@
 
 //cigarette papers
 /obj/item/storage/box/fancy/cigpaper
-	name = "\improper Gen. Eric cigarette paper"
-	desc = "A ubiquitous brand of cigarette paper, allegedly endorsed by 24th century war hero General Eric Osmundsun for rolling your own cigarettes. Osmundsun died in a freak kayak accident. As it ate him alive during his last campaign. It was pretty freaky."
+	name = "\improper callistean classic cigarette paper"
+	desc = "A now-ubiquitous brand of cigarette paper, originated on Callisto and produced by Cigaco, a Getmore subsidiary. It was first available only on Callisto, but \
+			is now found in every corner of the galaxy due to its low cost and relatively good value."
 	icon = 'icons/obj/cigs_lighters.dmi'
 	icon_state = "cigpaperbook_generic"
 	item_state = "cigpacket"
@@ -93,7 +94,7 @@
 		slot_r_hand_str = 'icons/mob/items/righthand_cigs_lighters.dmi',
 		)
 	w_class = ITEMSIZE_SMALL
-	starts_with = list(/obj/item/paper/cig/filter = 10)
+	starts_with = list(/obj/item/cigarette_filter = 10)
 	make_exact_fit()
 	drop_sound = 'sound/items/drop/gloves.ogg'
 	pickup_sound = 'sound/items/pickup/gloves.ogg'

--- a/html/changelogs/mattatlas-TheRealHorizonBugs.yml
+++ b/html/changelogs/mattatlas-TheRealHorizonBugs.yml
@@ -1,0 +1,45 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "You can now actually put cigarette filters on rolled cigarettes."
+  - tweak: "Cigarette filters are no longer paper."
+  - rscadd: "You can now put a filter on a rolled cigarette by clicking it with the cigarette, instead of having to put the box down, take out a filter and then click the cigarette with the filter."
+  - tweak: "Reflavoured the Gen. Eric cigarette paper to the Callistean Classic cigarette paper."
+  - rscadd: "Added some visible messages to cigarette rolling."


### PR DESCRIPTION
  - You can now actually put cigarette filters on rolled cigarettes.
  - Cigarette filters are no longer paper.
  - You can now put a filter on a rolled cigarette by clicking it with the cigarette, instead of having to put the box down, take out a filter and then click the cigarette with the filter.
  - Reflavoured the Gen. Eric cigarette paper to the Callistean Classic cigarette paper.
  - Added some visible messages to cigarette rolling.
