### PR TITLE
Fixes matriarch drones and other do_late_fire ghost spawners.

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -260,6 +260,7 @@
 #include "code\controllers\subsystems\evacuation\~evac.dm"
 #include "code\controllers\subsystems\initialization\atlas.dm"
 #include "code\controllers\subsystems\initialization\atoms.dm"
+#include "code\controllers\subsystems\initialization\away_maps.dm"
 #include "code\controllers\subsystems\initialization\holomap.dm"
 #include "code\controllers\subsystems\initialization\map_finalization.dm"
 #include "code\controllers\subsystems\initialization\misc_early.dm"

--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -19,13 +19,14 @@
 #define SS_INIT_ICON_UPDATE 7	// Icon update queue flush. Should run before overlays.
 #define SS_INIT_AO          6	// Wall AO neighbour build.
 #define SS_INIT_OVERLAY     5	// Overlay flush.
-#define SS_INIT_MISC        4	// Subsystems without an explicitly set initialization order start here.
-#define SS_INIT_GHOSTROLES  3
-#define SS_INIT_SUNLIGHT    2	// Sunlight setup. Creates lots of lighting & SSzcopy updates.
-#define SS_INIT_LIGHTING    1	// Generation of lighting overlays and pre-bake. May cause openturf updates, should initialize before SSzcopy.
-#define SS_INIT_ZCOPY       0	// Z-mimic flush. Should run after SSoverlay & SSicon_smooth so it copies the smoothed sprites.
-#define SS_INIT_LOBBY      -1	// Lobby timer starts here. The lobby timer won't actually start going down until the MC starts ticking, so you probably want this last
-#define SS_INIT_CHAT       -2	// To ensure chat remains smooth during init.
+#define SS_INIT_AWAY_MAPS   4   // Note: away maps (ruins, exoplanets, ...) must initialize before ghost roles in order for their spawnpoints to work.
+#define SS_INIT_GHOSTROLES  3   // Ghost roles must initialize before SS_INIT_MISC due to some roles (matriarch drones) relying on the assumption that this SS is initialized.
+#define SS_INIT_MISC        2	// Subsystems without an explicitly set initialization order start here.
+#define SS_INIT_SUNLIGHT    1	// Sunlight setup. Creates lots of lighting & SSzcopy updates.
+#define SS_INIT_LIGHTING    0	// Generation of lighting overlays and pre-bake. May cause openturf updates, should initialize before SSzcopy.
+#define SS_INIT_ZCOPY      -1	// Z-mimic flush. Should run after SSoverlay & SSicon_smooth so it copies the smoothed sprites.
+#define SS_INIT_LOBBY      -2	// Lobby timer starts here. The lobby timer won't actually start going down until the MC starts ticking, so you probably want this last
+#define SS_INIT_CHAT       -3	// To ensure chat remains smooth during init.
 
 // Something to remember when setting priorities: SS_TICKER runs before Normal, which runs before SS_BACKGROUND.
 // Each group has its own priority bracket.

--- a/code/controllers/subsystems/initialization/away_maps.dm
+++ b/code/controllers/subsystems/initialization/away_maps.dm
@@ -1,0 +1,11 @@
+/datum/controller/subsystem/away_maps
+	name = "Away Map Initialization"
+	init_order = SS_INIT_AWAY_MAPS
+	flags = SS_NO_FIRE | SS_NO_DISPLAY
+
+/datum/controller/subsystem/away_maps/Initialize(timeofday)
+	current_map.build_away_sites()
+
+	current_map.build_exoplanets()
+
+	..(timeofday)

--- a/code/controllers/subsystems/initialization/misc_late.dm
+++ b/code/controllers/subsystems/initialization/misc_late.dm
@@ -34,10 +34,6 @@
 
 	click_catchers = create_click_catcher()
 
-	current_map.build_away_sites()
-
-	current_map.build_exoplanets()
-
 	..(timeofday)
 
 /proc/sorted_add_area(area/A)

--- a/html/changelogs/mattatlas-matriarchdronefix.yml
+++ b/html/changelogs/mattatlas-matriarchdronefix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "You can now spawn in as a matriarch drone."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -24894,6 +24894,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/silicon/robot/drone/construction/matriarch,
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
 "wGn" = (


### PR DESCRIPTION
The problem is here:
```
// this covers mapped in drone fabs
for(var/atom/thing as anything in SSatoms.late_misc_firers)
	thing.do_late_fire()
	LAZYREMOVE(SSatoms.late_misc_firers, thing)
```
This is in Late Misc Init. `do_late_fire()` then calls the add_spawn_atom proc on the ghost roles subsystem. The issue is that the ghost roles subsystem is initialized _after_ late misc init, and exoplanet/away site generation (which is currently in late misc init) must happen before the ghost roles subsystem is initialized.

To fix this, I've split off exoplanet/away site generation into a separate subsystem that boots up before ghost roles, while Late Misc Init now boots up after it.

There also wasn't any mapped in matriarch drone.