### PR TITLE
Generic machinist outfit now looks appropriate

### DIFF
--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -345,9 +345,9 @@
 /obj/item/clothing/under/rank/machinist
 	name = "machinist's jumpsuit"
 	desc = "A practical uniform designed for industrial work."
-	icon_state = "hop"
+	icon_state = "mechanic"
 	item_state = "b_suit"
-	worn_state = "hop"
+	worn_state = "mechanic"
 
 /obj/item/clothing/under/rank/machinist/heph
 	icon = 'icons/obj/contained_items/department_uniforms/operations.dmi'

--- a/html/changelogs/machinist-outfit-icon-fix.yml
+++ b/html/changelogs/machinist-outfit-icon-fix.yml
@@ -1,0 +1,7 @@
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - tweak: "Machinists can no longer cosplay as a HoP with the machinist's uniform in their vending machine."


### PR DESCRIPTION
Available from their vending machine.

Currently it is the HoP's old uniform... changing it to the mechanic's outfit sprite is more appropriate and looks sufficiently different from their faction uniforms.