### PR TITLE
Fix security camera consoles, hopefully

### DIFF
--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -135,7 +135,8 @@
 			to_chat(user, SPAN_NOTICE("No Patient Detected"))
 
 /obj/machinery/computer/operating/Topic(href, href_list)
-	..()
+	if(..())
+		return TRUE
 	if(href_list["action"])
 		switch(href_list["action"])
 			if("update")
@@ -154,8 +155,6 @@
 			if("print_new")
 				print_new()
 				usr.visible_message("\The [src] beeps, printing a new [input_scan] after a moment.")
-	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
-		usr.set_machine(src)
 	return
 
 /obj/machinery/computer/operating/machinery_process()

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -25,7 +25,7 @@
 	return attack_hand(user)
 
 /obj/machinery/computer/security/check_eye(var/mob/user as mob)
-	if (use_check_and_message(user) || user.blinded || inoperable())
+	if (user.stat || user.blinded || inoperable())
 		return -1
 	if(!current_camera)
 		return 0
@@ -35,11 +35,8 @@
 	return viewflag
 
 /obj/machinery/computer/security/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	if(src.z > 6) return
-	if(stat & (NOPOWER|BROKEN)) return
-	if(user.stat) return
-
-	user.set_machine(src)
+	if(..())
+		return
 
 	var/data[0]
 	var/list/all_networks[0]
@@ -73,10 +70,8 @@
 
 /obj/machinery/computer/security/Topic(href, href_list)
 	if(..())
-		return 1
+		return TRUE
 	if(href_list["switch_camera"])
-		if(src.z>6 || stat&(NOPOWER|BROKEN)) return
-		if(usr.stat || ((get_dist(usr, src) > 1 || !( usr.canmove ) || usr.blinded) && !istype(usr, /mob/living/silicon))) return
 		var/obj/machinery/camera/C = locate(href_list["switch_camera"]) in cameranet.cameras
 		if(!C)
 			return
@@ -86,19 +81,13 @@
 		switch_to_camera(usr, C)
 		return 1
 	else if(href_list["switch_network"])
-		if(src.z>6 || stat&(NOPOWER|BROKEN)) return
-		if(usr.stat || ((get_dist(usr, src) > 1 || !( usr.canmove ) || usr.blinded) && !istype(usr, /mob/living/silicon))) return
 		if(href_list["switch_network"] in network)
 			current_network = href_list["switch_network"]
 		return 1
 	else if(href_list["reset"])
-		if(src.z>6 || stat&(NOPOWER|BROKEN)) return
-		if(usr.stat || ((get_dist(usr, src) > 1 || !( usr.canmove ) || usr.blinded) && !istype(usr, /mob/living/silicon))) return
 		reset_current()
 		usr.reset_view(current_camera)
 		return 1
-	else
-		. = ..()
 
 /obj/machinery/computer/security/attack_hand(var/mob/user as mob)
 	if (src.z > 6)
@@ -123,7 +112,7 @@
 		A.client.eye = A.eyeobj
 		return 1
 
-	if (!C.can_use() || user.stat || (get_dist(user, src) > 1 || user.machine != src || user.blinded || !( user.canmove ) && !istype(user, /mob/living/silicon)))
+	if (user.stat || user.blinded || inoperable())
 		return 0
 	set_current(C)
 	if(ishuman(user))
@@ -213,17 +202,6 @@
 	if(istype(usr.machine,/obj/machinery/computer/security))
 		var/obj/machinery/computer/security/console = usr.machine
 		console.jump_on_click(usr,src)
-
-//Camera control: arrow keys.
-/mob/living/Move(n,direct)
-	if(istype(machine,/obj/machinery/computer/security))
-		var/obj/machinery/computer/security/console = machine
-		var/turf/T = get_turf(console.current_camera)
-		for(var/i;i<10;i++)
-			T = get_step(T,direct)
-		console.jump_on_click(src,T)
-		return
-	return ..(n,direct)
 
 /obj/machinery/computer/security/telescreen
 	name = "Telescreen"

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -26,6 +26,11 @@
 	power_change()
 	update_icon()
 
+/obj/machinery/computer/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = TRUE)
+	if(inoperable() || isNotStationLevel(z) || user.stat)
+		user.unset_machine()
+		return
+
 /obj/machinery/computer/emp_act(severity)
 	if(prob(20/severity)) set_broken()
 	..()

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -258,150 +258,145 @@
 /obj/machinery/computer/message_monitor/Topic(href, href_list)
 	if(..())
 		return 1
-	if(stat & (NOPOWER|BROKEN))
-		return
-	if(!istype(usr, /mob/living))
-		return
-	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
-		//Authenticate
-		if (href_list["auth"])
+	//Authenticate
+	if (href_list["auth"])
+		if(auth)
+			auth = 0
+			screen = 0
+		else
+			var/dkey = trim(input(usr, "Please enter the decryption key.") as text|null)
+			if(dkey && dkey != "")
+				if(src.linkedServer.decryptkey == dkey)
+					auth = 1
+				else
+					message = incorrectkey
+
+	//Turn the server on/off.
+	if (href_list["active"])
+		if(auth) linkedServer.active = !linkedServer.active
+	//Find a server
+	if (href_list["find"])
+		if(message_servers && message_servers.len > 1)
+			src.linkedServer = input(usr,"Please select a server.", "Select a server.", null) as null|anything in message_servers
+			message = "<span class='alert'>NOTICE: Server selected.</span>"
+		else if(message_servers && message_servers.len > 0)
+			linkedServer = message_servers[1]
+			message =  "<span class='notice'>NOTICE: Only Single Server Detected - Server selected.</span>"
+		else
+			message = noserver
+
+	//View the logs - KEY REQUIRED
+	if (href_list["view"])
+		if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
+			message = noserver
+		else
 			if(auth)
-				auth = 0
-				screen = 0
-			else
+				src.screen = 1
+
+	//Clears the logs - KEY REQUIRED
+	if (href_list["clear"])
+		if(!linkedServer || (src.linkedServer.stat & (NOPOWER|BROKEN)))
+			message = noserver
+		else
+			if(auth)
+				src.linkedServer.pda_msgs = list()
+				message = "<span class='notice'>NOTICE: Logs cleared.</span>"
+	//Clears the requests console logs - KEY REQUIRED
+	if (href_list["clearr"])
+		if(!linkedServer || (src.linkedServer.stat & (NOPOWER|BROKEN)))
+			message = noserver
+		else
+			if(auth)
+				src.linkedServer.rc_msgs = list()
+				message = "<span class='notice'>NOTICE: Logs cleared.</span>"
+	//Change the password - KEY REQUIRED
+	if (href_list["pass"])
+		if(!linkedServer || (src.linkedServer.stat & (NOPOWER|BROKEN)))
+			message = noserver
+		else
+			if(auth)
 				var/dkey = trim(input(usr, "Please enter the decryption key.") as text|null)
 				if(dkey && dkey != "")
 					if(src.linkedServer.decryptkey == dkey)
-						auth = 1
+						var/newkey = trim(input(usr,"Please enter the new key (3 - 16 characters max):"))
+						if(length(newkey) <= 3)
+							message = "<span class='notice'>NOTICE: Decryption key too short!</span>"
+						else if(length(newkey) > 16)
+							message = "<span class='notice'>NOTICE: Decryption key too long!</span>"
+						else if(newkey && newkey != "")
+							src.linkedServer.decryptkey = newkey
+						message = "<span class='notice'>NOTICE: Decryption key set.</span>"
 					else
 						message = incorrectkey
 
-		//Turn the server on/off.
-		if (href_list["active"])
-			if(auth) linkedServer.active = !linkedServer.active
-		//Find a server
-		if (href_list["find"])
-			if(message_servers && message_servers.len > 1)
-				src.linkedServer = input(usr,"Please select a server.", "Select a server.", null) as null|anything in message_servers
-				message = "<span class='alert'>NOTICE: Server selected.</span>"
-			else if(message_servers && message_servers.len > 0)
-				linkedServer = message_servers[1]
-				message =  "<span class='notice'>NOTICE: Only Single Server Detected - Server selected.</span>"
-			else
-				message = noserver
-
-		//View the logs - KEY REQUIRED
-		if (href_list["view"])
-			if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
-				message = noserver
-			else
-				if(auth)
-					src.screen = 1
-
-		//Clears the logs - KEY REQUIRED
-		if (href_list["clear"])
+	//Hack the Console to get the password
+	if (href_list["hack"])
+		if((istype(usr, /mob/living/silicon/ai) || istype(usr, /mob/living/silicon/robot)) && (usr.mind.special_role && usr.mind.original == usr))
+			src.hacking = 1
+			src.screen = 2
+			update_icon()
+			//Time it takes to bruteforce is dependant on the password length.
+			spawn(100*length(src.linkedServer.decryptkey))
+				if(src && src.linkedServer && usr)
+					BruteForce(usr)
+	//Delete the log.
+	if (href_list["delete"])
+		//Are they on the view logs screen?
+		if(screen == 1)
 			if(!linkedServer || (src.linkedServer.stat & (NOPOWER|BROKEN)))
 				message = noserver
-			else
-				if(auth)
-					src.linkedServer.pda_msgs = list()
-					message = "<span class='notice'>NOTICE: Logs cleared.</span>"
-		//Clears the requests console logs - KEY REQUIRED
-		if (href_list["clearr"])
+			else //if(istype(href_list["delete"], /datum/data_pda_msg))
+				src.linkedServer.pda_msgs -= locate(href_list["delete"])
+				message = "<span class='notice'>NOTICE: Log Deleted!</span>"
+	//Delete the requests console log.
+	if (href_list["deleter"])
+		//Are they on the view logs screen?
+		if(screen == 4)
 			if(!linkedServer || (src.linkedServer.stat & (NOPOWER|BROKEN)))
 				message = noserver
-			else
-				if(auth)
-					src.linkedServer.rc_msgs = list()
-					message = "<span class='notice'>NOTICE: Logs cleared.</span>"
-		//Change the password - KEY REQUIRED
-		if (href_list["pass"])
-			if(!linkedServer || (src.linkedServer.stat & (NOPOWER|BROKEN)))
-				message = noserver
-			else
-				if(auth)
-					var/dkey = trim(input(usr, "Please enter the decryption key.") as text|null)
-					if(dkey && dkey != "")
-						if(src.linkedServer.decryptkey == dkey)
-							var/newkey = trim(input(usr,"Please enter the new key (3 - 16 characters max):"))
-							if(length(newkey) <= 3)
-								message = "<span class='notice'>NOTICE: Decryption key too short!</span>"
-							else if(length(newkey) > 16)
-								message = "<span class='notice'>NOTICE: Decryption key too long!</span>"
-							else if(newkey && newkey != "")
-								src.linkedServer.decryptkey = newkey
-							message = "<span class='notice'>NOTICE: Decryption key set.</span>"
-						else
-							message = incorrectkey
+			else //if(istype(href_list["delete"], /datum/data_pda_msg))
+				src.linkedServer.rc_msgs -= locate(href_list["deleter"])
+				message = "<span class='notice'>NOTICE: Log Deleted!</span>"
+	//Create a custom message
+	if (href_list["msg"])
+		if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
+			message = noserver
+		else
+			if(auth)
+				src.screen = 3
 
-		//Hack the Console to get the password
-		if (href_list["hack"])
-			if((istype(usr, /mob/living/silicon/ai) || istype(usr, /mob/living/silicon/robot)) && (usr.mind.special_role && usr.mind.original == usr))
-				src.hacking = 1
-				src.screen = 2
-				update_icon()
-				//Time it takes to bruteforce is dependant on the password length.
-				spawn(100*length(src.linkedServer.decryptkey))
-					if(src && src.linkedServer && usr)
-						BruteForce(usr)
-		//Delete the log.
-		if (href_list["delete"])
-			//Are they on the view logs screen?
-			if(screen == 1)
-				if(!linkedServer || (src.linkedServer.stat & (NOPOWER|BROKEN)))
-					message = noserver
-				else //if(istype(href_list["delete"], /datum/data_pda_msg))
-					src.linkedServer.pda_msgs -= locate(href_list["delete"])
-					message = "<span class='notice'>NOTICE: Log Deleted!</span>"
-		//Delete the requests console log.
-		if (href_list["deleter"])
-			//Are they on the view logs screen?
-			if(screen == 4)
-				if(!linkedServer || (src.linkedServer.stat & (NOPOWER|BROKEN)))
-					message = noserver
-				else //if(istype(href_list["delete"], /datum/data_pda_msg))
-					src.linkedServer.rc_msgs -= locate(href_list["deleter"])
-					message = "<span class='notice'>NOTICE: Log Deleted!</span>"
-		//Create a custom message
-		if (href_list["msg"])
-			if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
-				message = noserver
-			else
-				if(auth)
-					src.screen = 3
+	//Requests Console Logs - KEY REQUIRED
+	if(href_list["viewr"])
+		if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
+			message = noserver
+		else
+			if(auth)
+				src.screen = 4
 
-		//Requests Console Logs - KEY REQUIRED
-		if(href_list["viewr"])
-			if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
-				message = noserver
-			else
-				if(auth)
-					src.screen = 4
+		//to_chat(usr, href_list["select"])
 
-			//to_chat(usr, href_list["select"])
+	if(href_list["spam"])
+		if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
+			message = noserver
+		else
+			if(auth)
+				src.screen = 5
 
-		if(href_list["spam"])
-			if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
-				message = noserver
-			else
-				if(auth)
-					src.screen = 5
+	if(href_list["addtoken"])
+		if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
+			message = noserver
+		else
+			src.linkedServer.spamfilter += input(usr,"Enter text you want to be filtered out","Token creation") as text|null
 
-		if(href_list["addtoken"])
-			if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
-				message = noserver
-			else
-				src.linkedServer.spamfilter += input(usr,"Enter text you want to be filtered out","Token creation") as text|null
+	if(href_list["deltoken"])
+		if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
+			message = noserver
+		else
+			var/tokennum = text2num(href_list["deltoken"])
+			src.linkedServer.spamfilter.Cut(tokennum,tokennum+1)
 
-		if(href_list["deltoken"])
-			if(src.linkedServer == null || (src.linkedServer.stat & (NOPOWER|BROKEN)))
-				message = noserver
-			else
-				var/tokennum = text2num(href_list["deltoken"])
-				src.linkedServer.spamfilter.Cut(tokennum,tokennum+1)
-
-		if (href_list["back"])
-			src.screen = 0
+	if (href_list["back"])
+		src.screen = 0
 
 	return src.attack_hand(usr)
 

--- a/code/game/machinery/computer/pod.dm
+++ b/code/game/machinery/computer/pod.dm
@@ -105,35 +105,33 @@
 /obj/machinery/computer/pod/Topic(href, href_list)
 	if(..())
 		return 1
-	if((usr.contents.Find(src) || (in_range(src, usr) && istype(loc, /turf))) || (istype(usr, /mob/living/silicon)))
-		usr.set_machine(src)
-		if(href_list["power"])
-			var/t = text2num(href_list["power"])
-			t = min(max(0.25, t), 16)
-			if(connected)
-				connected.power = t
-		if(href_list["alarm"])
-			alarm()
-		if(href_list["drive"])
-			for(var/obj/machinery/mass_driver/M in SSmachinery.processing_machines)
-				if(M.id == id)
-					M.power = connected.power
-					M.drive()
+	if(href_list["power"])
+		var/t = text2num(href_list["power"])
+		t = min(max(0.25, t), 16)
+		if(connected)
+			connected.power = t
+	if(href_list["alarm"])
+		alarm()
+	if(href_list["drive"])
+		for(var/obj/machinery/mass_driver/M in SSmachinery.processing_machines)
+			if(M.id == id)
+				M.power = connected.power
+				M.drive()
 
-		if(href_list["time"])
-			timing = text2num(href_list["time"])
-		if(href_list["tp"])
-			var/tp = text2num(href_list["tp"])
-			time += tp
-			time = min(max(round(time), 0), 120)
-		if(href_list["door"])
-			for(var/obj/machinery/door/blast/M in SSmachinery.processing_machines)
-				if(M.id == id)
-					if(M.density)
-						M.open()
-					else
-						M.close()
-		updateUsrDialog()
+	if(href_list["time"])
+		timing = text2num(href_list["time"])
+	if(href_list["tp"])
+		var/tp = text2num(href_list["tp"])
+		time += tp
+		time = min(max(round(time), 0), 120)
+	if(href_list["door"])
+		for(var/obj/machinery/door/blast/M in SSmachinery.processing_machines)
+			if(M.id == id)
+				if(M.density)
+					M.open()
+				else
+					M.close()
+	updateUsrDialog()
 	return
 
 

--- a/code/game/machinery/computer/sentencing.dm
+++ b/code/game/machinery/computer/sentencing.dm
@@ -479,10 +479,6 @@
 	if(..())
 		return
 
-	if(stat & (NOPOWER|BROKEN))
-		return 0 // don't update UIs attached to this object
-
-	usr.set_machine(src)
 
 	switch(href_list["button"])
 		if( "import_incident" )

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -106,41 +106,37 @@
 	if(..())
 		return 1
 
-	if((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
+	if(locked && !allowed(usr))
+		return
 
-		if(locked && !allowed(usr))
+	if(href_list["program"])
+		var/prog = href_list["program"]
+		if(prog in current_map.holodeck_programs)
+			loadProgram(current_map.holodeck_programs[prog])
+
+	else if(href_list["AIoverride"])
+		if(!issilicon(usr))
 			return
 
-		usr.set_machine(src)
+		if(safety_disabled && emagged)
+			return //if a traitor has gone through the trouble to emag the thing, let them keep it.
 
-		if(href_list["program"])
-			var/prog = href_list["program"]
-			if(prog in current_map.holodeck_programs)
-				loadProgram(current_map.holodeck_programs[prog])
+		safety_disabled = !safety_disabled
+		update_projections()
+		if(safety_disabled)
+			message_admins("[key_name_admin(usr)] overrode the holodeck's safeties")
+			log_game("[key_name(usr)] overrided the holodeck's safeties",ckey=key_name(usr))
+		else
+			message_admins("[key_name_admin(usr)] restored the holodeck's safeties")
+			log_game("[key_name(usr)] restored the holodeck's safeties",ckey=key_name(usr))
 
-		else if(href_list["AIoverride"])
-			if(!issilicon(usr))
-				return
+	else if(href_list["gravity"])
+		toggleGravity(linkedholodeck)
 
-			if(safety_disabled && emagged)
-				return //if a traitor has gone through the trouble to emag the thing, let them keep it.
+	else if(href_list["togglehololock"])
+		togglelock(usr)
 
-			safety_disabled = !safety_disabled
-			update_projections()
-			if(safety_disabled)
-				message_admins("[key_name_admin(usr)] overrode the holodeck's safeties")
-				log_game("[key_name(usr)] overrided the holodeck's safeties",ckey=key_name(usr))
-			else
-				message_admins("[key_name_admin(usr)] restored the holodeck's safeties")
-				log_game("[key_name(usr)] restored the holodeck's safeties",ckey=key_name(usr))
-
-		else if(href_list["gravity"])
-			toggleGravity(linkedholodeck)
-
-		else if(href_list["togglehololock"])
-			togglelock(usr)
-
-		src.add_fingerprint(usr)
+	src.add_fingerprint(usr)
 	src.updateUsrDialog()
 	return
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -58,8 +58,6 @@
 		to_chat(usr, SPAN_WARNING("Access denied."))
 		return
 
-	if((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
-		usr.set_machine(src)
 
 	if(href_list["setarea"])
 		if(!call_area_names)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -227,6 +227,16 @@
 				if(item.zoom)
 					item.zoom(mob)
 					break
+		if(istype(mob.machine,/obj/machinery/computer/security))
+			// Has to be here specfically to allow WASD/arrow movement of cameras while buckled.
+			// TODO: Remove when machinery/computer finally dies.
+			var/obj/machinery/computer/security/console = mob.machine
+			if(console.current_camera)
+				var/turf/T = get_turf(console.current_camera)
+				for(var/i;i<10;i++)
+					T = get_step(T,direct)
+				console.jump_on_click(mob,T)
+				return
 
 		// Only meaningful for living mobs.
 		if(Process_Grab())

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -112,6 +112,11 @@
 	if(iscarbon(user))
 		playsound(src, 'sound/machines/pda_click.ogg', 20)
 
+/obj/item/modular_computer/CouldNotUseTopic(var/mob/user)
+	..()
+	if(user.machine == src)
+		user.unset_machine()
+
 /obj/item/modular_computer/emag_act(var/remaining_charges, var/mob/user)
 	if(computer_emagged)
 		to_chat(user, SPAN_WARNING("\The [src] has already been emagged."))

--- a/code/modules/modular_computers/file_system/programs/security/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/security/camera.dm
@@ -157,12 +157,11 @@
 	current_camera = null
 
 /datum/nano_module/camera_monitor/check_eye(var/mob/user as mob)
-	if(istype(ui_host(), /obj/machinery/computer))
-		var/obj/machinery/computer/C = ui_host()
-		if (C.use_check_and_message(user) || C.inoperable())
+	var/obj/item/modular_computer/MC = user.machine
+	if(istype(MC) && ui_host() == MC)
+		if(!MC.working || user.blinded || user.stat)
+			user.unset_machine()
 			return -1
-	if(user.blinded)
-		return -1
 	if(!current_camera)
 		return 0
 	var/viewflag = current_camera.check_eye(user)

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -36,7 +36,7 @@
 	// robots can interact with things they can see within their view range
 	if((src_object in view(src)) && get_dist(src_object, src) <= src.client.view)
 		return STATUS_INTERACTIVE	// interactive (green visibility)
-	return STATUS_DISABLED			// no updates, completely disabled (red visibility)
+	return STATUS_CLOSE			// close the UI if no longer in view
 
 /mob/living/silicon/ai/default_can_use_topic(var/src_object)
 	. = shared_nano_interaction()

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -445,6 +445,9 @@ nanoui is used to open and update nano browser uis
 	state = null
 	master_ui = null
 
+	if(istype(user))
+		user.unset_machine()
+
  /**
   * Set the UI window to call the nanoclose verb when the window is closed
   * This allows Nano to handle closed windows

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -253,29 +253,27 @@
 /obj/machinery/computer/turbine_computer/Topic(href, href_list)
 	if(..())
 		return
-	if ((usr.contents.Find(src) || (in_range(src, usr) && istype(src.loc, /turf))) || (istype(usr, /mob/living/silicon)))
-		usr.machine = src
 
-		if( href_list["view"] )
-			usr.client.eye = src.compressor
-		else if( href_list["str"] )
-			src.compressor.starter = !src.compressor.starter
-		else if (href_list["doors"])
-			for(var/obj/machinery/door/blast/D in src.doors)
-				if (door_status == 0)
-					spawn( 0 )
-						D.open()
-						door_status = 1
-				else
-					spawn( 0 )
-						D.close()
-						door_status = 0
-		else if( href_list["close"] )
-			usr << browse(null, "window=computer")
-			usr.machine = null
-			return
+	if( href_list["view"] )
+		usr.client.eye = src.compressor
+	else if( href_list["str"] )
+		src.compressor.starter = !src.compressor.starter
+	else if (href_list["doors"])
+		for(var/obj/machinery/door/blast/D in src.doors)
+			if (door_status == 0)
+				spawn( 0 )
+					D.open()
+					door_status = 1
+			else
+				spawn( 0 )
+					D.close()
+					door_status = 0
+	else if( href_list["close"] )
+		usr << browse(null, "window=computer")
+		usr.machine = null
+		return
 
-		src.add_fingerprint(usr)
+	src.add_fingerprint(usr)
 	src.updateUsrDialog()
 	return
 

--- a/code/modules/vueui/ui.dm
+++ b/code/modules/vueui/ui.dm
@@ -109,6 +109,8 @@ main ui datum.
 	SSvueui.ui_closed(src) // this stops processing and cleans up references to this UI
 	user << browse(null, "window=[windowid]")
 	status = null
+	if(istype(user))
+		user.unset_machine()
 
 /**
   * Resizes UI

--- a/html/changelogs/johnwildkins-cameraconsole.yml
+++ b/html/changelogs/johnwildkins-cameraconsole.yml
@@ -1,0 +1,7 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Camera consoles can now be used while buckled in non-office chairs, and should reset view properly when no longer in use."
+  - tweak: "Computer UIs will now close for cyborgs if they move beyond visual range. (They already disabled interaction in the past.)"


### PR DESCRIPTION
Fixes #11105
Fixes #10329
Fixes #2246

This fixes the above issues; tl;dr, that both the original `obj/machinery/computer/security` and its successor program, `datum/nano_module/camera_monitor` both had issues re: removing the machine var from mobs, which would in turn lock up their camera even after leaving the console, or spam their log as `check_eye` failed but didn't actually resolve the issue

Part of this is my own shitcode from before I really understood how these systems work (and I'm not entirely sure I do still). Other computer .dm files were touched to move some redundant code to the main computer procs

The functionality here is a band-aid fix until we finally decide to vue-ify the camera console and burn these two to the ground