### PR TITLE
Makes orbital drill droppers work off the ship

### DIFF
--- a/code/game/objects/items/devices/drop_targeter/_droptargeter.dm
+++ b/code/game/objects/items/devices/drop_targeter/_droptargeter.dm
@@ -43,8 +43,8 @@
 	var/turf/targloc = get_turf(target)
 	if(!emagged)
 		for(var/turf/t in block(locate(targloc.x+3,targloc.y+3,targloc.z), locate(targloc.x-3,targloc.y-3,targloc.z)))
-			if (!istype(t.loc, /area/mine))
-				to_chat(user, SPAN_WARNING("You can't do this so close to the station, point the laser further into the mine!"))
+			if (isStationLevel(targloc.z))
+				to_chat(user, SPAN_WARNING("You can't request this orbital drop on the ship!"))
 				return
 			if (!isfloor(targloc))
 				to_chat(user, SPAN_WARNING("You cannot request this on unstable flooring!"))

--- a/html/changelogs/drill-drop.yml
+++ b/html/changelogs/drill-drop.yml
@@ -1,0 +1,7 @@
+author: mikomyazaki
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - bugfix: "Orbital drill droppers now work anywhere that isn't on the Horizon... unless emagged."


### PR DESCRIPTION
Previously they didn't work _anywhere_ because we don't have /area/mine anywhere.