### PR TITLE
Optimize changeturf / lighting

### DIFF
--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -1,6 +1,7 @@
 var/datum/controller/subsystem/lighting/SSlighting
 
 /var/lighting_profiling = FALSE
+/var/lighting_overlays_initialized = FALSE
 
 /datum/controller/subsystem/lighting
 	name = "Lighting"
@@ -84,6 +85,8 @@ var/datum/controller/subsystem/lighting/SSlighting
 			overlaycount++
 
 			CHECK_TICK
+
+	lighting_overlays_initialized = TRUE
 
 	admin_notice(SPAN_DANGER("Created [overlaycount] lighting overlays in [(REALTIMEOFDAY - starttime)/10] seconds."), R_DEBUG)
 

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -61,23 +61,24 @@
 		regenerate_ao()
 #endif
 
-	recalc_atom_opacity()
-	lighting_overlay = old_lighting_overlay
-	if (lighting_overlay && lighting_overlay.loc != src)
-		// This is a hack, but I can't figure out why the fuck they're not on the correct turf in the first place.
-		lighting_overlay.forceMove(src, harderforce = TRUE)
+	if(lighting_overlays_initialized)
+		recalc_atom_opacity()
+		lighting_overlay = old_lighting_overlay
+		if (lighting_overlay && lighting_overlay.loc != src)
+			// This is a hack, but I can't figure out why the fuck they're not on the correct turf in the first place.
+			lighting_overlay.forceMove(src, harderforce = TRUE)
 
-	affecting_lights = old_affecting_lights
-	corners = old_corners
+		affecting_lights = old_affecting_lights
+		corners = old_corners
 
-	if ((old_opacity != opacity) || (dynamic_lighting != old_dynamic_lighting) || force_lighting_update)
-		reconsider_lights()
+		if ((old_opacity != opacity) || (dynamic_lighting != old_dynamic_lighting) || force_lighting_update)
+			reconsider_lights()
 
-	if (dynamic_lighting != old_dynamic_lighting)
-		if (dynamic_lighting)
-			lighting_build_overlay()
-		else
-			lighting_clear_overlay()
+		if (dynamic_lighting != old_dynamic_lighting)
+			if (dynamic_lighting)
+				lighting_build_overlay()
+			else
+				lighting_clear_overlay()
 
 	if (config.starlight)
 		for (var/turf/space/S in RANGE_TURFS(1, src))

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -19,28 +19,32 @@
 // The proc you should always use to set the light of this atom.
 /atom/proc/set_light(var/l_range, var/l_power, var/l_color = NONSENSICAL_VALUE, var/uv = NONSENSICAL_VALUE, var/angle = NONSENSICAL_VALUE, var/no_update = FALSE)
 	//L_PROF(src, "atom_setlight")
+	. = FALSE // don't update if nothing changed
 
 	if(l_range > 0 && l_range < MINIMUM_USEFUL_LIGHT_RANGE)
 		l_range = MINIMUM_USEFUL_LIGHT_RANGE	//Brings the range up to 1.4, which is just barely brighter than the soft lighting that surrounds players.
-	if (l_power != null)
+		. = TRUE
+	if (l_power != null && light_power != l_power)
 		light_power = l_power
-
-	if (l_range != null)
+		. = TRUE
+	if (l_range != null && light_range != l_range)
 		light_range = l_range
+		. = TRUE
 
-	if (l_color != NONSENSICAL_VALUE)
+	if (l_color != NONSENSICAL_VALUE && light_color != l_color)
 		light_color = l_color
+		. = TRUE
 
-	if (uv != NONSENSICAL_VALUE)
+	if (uv != NONSENSICAL_VALUE && uv_intensity != uv)
 		set_uv(uv, no_update = TRUE)
+		. = TRUE
 
-	if (angle != NONSENSICAL_VALUE)
+	if (angle != NONSENSICAL_VALUE && light_wedge != angle)
 		light_wedge = angle
+		. = TRUE
 
-	if (no_update)
-		return
-
-	update_light()
+	if(!no_update && .)
+		update_light()
 
 #undef NONSENSICAL_VALUE
 
@@ -59,6 +63,7 @@
 // Will update the light (duh).
 // Creates or destroys it if needed, makes it update values, makes sure it's got the correct source turf...
 /atom/proc/update_light()
+	set waitfor = FALSE
 	if (QDELING(src))
 		return
 

--- a/html/changelogs/johnwildkins-lighting.yml
+++ b/html/changelogs/johnwildkins-lighting.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - backend: "Optimized lighting updates, primarily in initialization."


### PR DESCRIPTION
Basically, make it so that `ChangeTurf()` no longer tries to update the lighting of a turf if the lighting subsystem isn't initialized yet. This is mostly important in away/exoplanet generation, where ChangeTurf is called a *lot*, and having to do a million something lighting changes that just get overwritten anyway is a tiny bit of a performance snag.

Also makes it so that set_light() doesn't update if the new values being sent are the same as the current values.