### PR TITLE
Miscellaneous Organ Fixes

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -330,7 +330,7 @@
 /atom/proc/add_fingerprint(mob/living/M, ignoregloves = 0)
 	if(isnull(M)) return
 	if(!istype(M, /mob)) return
-	if(isAI(M)) return
+	if(issilicon(M)) return
 	if(isnull(M.key)) return
 	if (ishuman(M))
 		//Add the list if it does not exist.

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -292,7 +292,7 @@
 				continue
 			var/thin_covering = (skipbody & body_part) ? TRUE : FALSE
 			if((temp.status & ORGAN_ASSISTED) && !thin_covering)
-				if(!(temp.brute_dam + temp.burn_dam))
+				if(!(temp.brute_dam + temp.burn_dam) && !(temp.open))
 					continue
 				else
 					wound_flavor_text["[temp.name]"] = "<span class='warning'>[get_pronoun("He")] [get_pronoun("has")] [temp.get_wounds_desc()] on [get_pronoun("his")] [temp.name].</span><br>"

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -232,7 +232,8 @@
 /decl/surgery_step/robotics/repair_burn
 	name = "Repair burns"
 	allowed_tools = list(
-		/obj/item/stack/cable_coil = 100
+		/obj/item/stack/cable_coil = 100,
+		/obj/item/stack/cable_coil/cyborg = 100
 	)
 
 	min_duration = 50

--- a/html/changelogs/organs_misc.yml
+++ b/html/changelogs/organs_misc.yml
@@ -1,0 +1,8 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed Medical Grippers being able to duplicate organs."
+  - bugfix: "Fixed Cable Synthesizers being unable to repair robotic limbs."
+  - bugfix: "Fixed being unable to see whether a robotic limb has their screws/panel off if it's not damaged."


### PR DESCRIPTION
* Fixes #12788
Medical grippers caused the organ to runtime since stationbounds don't have fingerprints.
* Fixes #13415
Pretty much what Myazaki mentioned in the bug report. ``cable_coil/cyborg`` wasn't in the approved surgery tool list.
* Fixed being unable to tell when a robotic limb has their screws unscrewed/panel open
