### PR TITLE
Holowarrant Software Update

### DIFF
--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -57,7 +57,7 @@
 		<HTML><HEAD><TITLE>Arrest Warrant: [activename]</TITLE></HEAD>
 		<BODY bgcolor='#FFFFFF'>
 		<font face="Verdana" color=black><font size = "1">
-		<center><large><b>NanoTrasen Inc.
+		<center><large><b>Stellar Corporate Conglomerate
 		<br>Civilian Branch of Operation</b></large>
 		<br>
 		<br><b>DIGITAL ARREST WARRANT</b></center>

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -62,7 +62,7 @@
 		<br>
 		<br><b>DIGITAL ARREST WARRANT</b></center>
 		<hr>
-		<b>Facility:</b>__<u>SCCV Horizon</u>__<b>Date:</b>__<u>[worlddate2text()]__</u>
+		<b>Facility:</b>__<u>[current_map.station_name]</u>__<b>Date:</b>__<u>[worlddate2text()]__</u>
 		<br>
 		<br><small><i>This document serves as a notice and permits the sanctioned arrest of
 		the denoted employee of the SCC Civilian Branch of Operation by the

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -62,11 +62,11 @@
 		<br>
 		<br><b>DIGITAL ARREST WARRANT</b></center>
 		<hr>
-		<b>Facility:</b>__<u>[current_map.station_name]</u>__<b>Date:</b>__<u>[worlddate2text()]__</u>
+		<b>Facility:</b>__<u>SCCV Horizon</u>__<b>Date:</b>__<u>[worlddate2text()]__</u>
 		<br>
 		<br><small><i>This document serves as a notice and permits the sanctioned arrest of
-		the denoted employee of the NanoTrasen Civilian Branch of Operation by the
-		Security Department of the denoted facility. </br>
+		the denoted employee of the SCC Civilian Branch of Operation by the
+		Security Department of the denoted vessel. </br>
 		In accordance with Corporate Regulations, the denoted employee must be presented with a signed and stamped or
 		digitally authorized warrant before the actions entailed can be conducted legally. </br>
 		The Suspect/Department staff are expected to offer full co-operation.</br>

--- a/html/changelogs/KingOfThePing - holowarrant_software_update.yml
+++ b/html/changelogs/KingOfThePing - holowarrant_software_update.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Removed mentions of NanoTrasen and the Aurora from the holowarrant projector, Security rejoices."

--- a/html/changelogs/KingOfThePing - holowarrant_software_update.yml
+++ b/html/changelogs/KingOfThePing - holowarrant_software_update.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: KingOfThePing
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
Changes the holowarrant's displayed warrant to be in accordance of all other paperwork. Meaning some wording was changed to scrub NanoTrasen and the Aurora from the warrant itself.

### IC changelog
sccOS (formerly ntOS) has pushed an update to the ISD's holowarrants. They now properly display all information, including the branch of operation and the current vessel properly.