### PR TITLE
Atmos map fixes

### DIFF
--- a/html/changelogs/doxxmedearly-atmosmapping.yml
+++ b/html/changelogs/doxxmedearly-atmosmapping.yml
@@ -8,3 +8,4 @@ changes:
   - bugfix: "Removed some duplicated pipes in atmos."
   - bugfix: "The pump that supplies air to the station now begins the round turned on. Seems important."
   - bugfix: "Large gas tank monitors should no longer report the gas temperature as a percentage."
+  - bugfix: "Made the gas room of the starboard-side thrusters airless, to match the port side."

--- a/html/changelogs/doxxmedearly-atmosmapping.yml
+++ b/html/changelogs/doxxmedearly-atmosmapping.yml
@@ -1,0 +1,10 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - maptweak: "In atmos, slightly remapped the area near the mix tank, to separate the Engine to Mix from the other parts of the mix line, since only the former should be going through the radiator loop."
+  - maptweak: "Removed the digital valves in atmos near the canister ports. Also added a manual valve to the Hydrogen tank pipeline."
+  - bugfix: "Removed some duplicated pipes in atmos."
+  - bugfix: "The pump that supplies air to the station now begins the round turned on. Seems important."
+  - bugfix: "Large gas tank monitors should no longer report the gas temperature as a percentage."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -3845,7 +3845,7 @@
 	id = "starboard_prop_igni";
 	pixel_x = -16
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion/starboard)
 "dDq" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -5021,7 +5021,7 @@
 	id_tag = "starboard_prop_sensor";
 	output = 31
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion/starboard)
 "eDV" = (
 /obj/effect/floor_decal/industrial/loading/yellow{
@@ -6875,7 +6875,7 @@
 /area/hangar/control)
 "gal" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion/starboard)
 "gaC" = (
 /obj/structure/window/shuttle/scc_space_ship,
@@ -8397,7 +8397,7 @@
 	id = "starboard_prop_in";
 	tag = "starboard_prop_in"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion/starboard)
 "hqV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -9684,7 +9684,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 5
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion/starboard)
 "iCZ" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -22989,7 +22989,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion/starboard)
 "uQa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23207,7 +23207,7 @@
 	frequency = 1442;
 	id_tag = "starboard_prop_out"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion/starboard)
 "vai" = (
 /obj/effect/floor_decal/industrial/outline,
@@ -23773,7 +23773,7 @@
 /obj/machinery/door/blast/regular{
 	id = "exteriorpropulsionstarboard"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion/starboard)
 "vyK" = (
 /obj/effect/floor_decal/corner_wide/purple{

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -1603,9 +1603,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "bvN" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 10
-	},
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -1788,12 +1785,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/operations)
 "bDt" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "Mix to Waste"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
@@ -2083,7 +2080,7 @@
 /turf/simulated/floor/plating,
 /area/rnd/xenoarch_atrium)
 "bOR" = (
-/obj/machinery/atmospherics/valve/digital,
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "bQh" = (
@@ -2093,9 +2090,6 @@
 /turf/simulated/floor/tiled,
 /area/hangar/operations)
 "bQj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 6
-	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/hallway/engineering)
@@ -3317,9 +3311,6 @@
 	},
 /area/maintenance/disposal)
 "cYS" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
@@ -3329,6 +3320,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "cZi" = (
@@ -3809,7 +3801,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "dAZ" = (
@@ -4069,8 +4060,11 @@
 /turf/simulated/floor/tiled,
 /area/hangar/operations)
 "dMa" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/simulated/floor/reinforced/airless,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "dMM" = (
 /obj/structure/cable/green{
@@ -4665,14 +4659,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/starboard)
 "eqa" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	name = "Engine to Mix"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "eqk" = (
@@ -5631,9 +5625,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "faE" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Mix to Waste"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
@@ -6722,9 +6715,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "fUG" = (
@@ -7292,9 +7286,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/hallway/engineering)
@@ -9340,10 +9332,8 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/binary/pump{
-	name = "Air to Distro";
-	target_pressure = 2000;
-	use_power = 1
+/obj/machinery/atmospherics/binary/pump/on{
+	name = "Air to Distro"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
@@ -10546,9 +10536,6 @@
 /area/engineering/atmos/propulsion/starboard)
 "jue" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/plating,
 /area/hallway/engineering)
@@ -11177,6 +11164,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/binary/pump{
+	name = "Mix to Connector"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "jWE" = (
@@ -11521,6 +11511,7 @@
 	name = "Atmospherics Maintenance";
 	req_access = list(12,24)
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "kqT" = (
@@ -13728,7 +13719,9 @@
 	layer = 10.1;
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos)
 "moj" = (
@@ -17899,6 +17892,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "qio" = (
@@ -18034,7 +18028,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos)
 "qoD" = (
@@ -19670,23 +19663,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"rOy" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/hallway/engineering)
 "rOz" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -20743,12 +20719,11 @@
 	},
 /area/maintenance/disposal)
 "sNH" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Mix to Connector"
-	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering - Atmospherics Control 4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
@@ -23503,11 +23478,11 @@
 /turf/simulated/floor/shuttle/dark_blue,
 /area/shuttle/escape_pod/pod1)
 "vlY" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
@@ -24304,12 +24279,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
-"wbp" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/valve/open,
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/turf/space/dynamic,
-/area/template_noop)
 "wbO" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -45577,10 +45546,10 @@ nEm
 nEm
 nEm
 bQj
-rOy
+xVg
 dAU
 qop
-dMa
+xmg
 mnQ
 dee
 sua
@@ -46390,7 +46359,7 @@ iUi
 bDt
 vlY
 jVj
-iFd
+dMa
 mGp
 arr
 qDK
@@ -46589,8 +46558,8 @@ dzi
 sta
 iPW
 sQT
-hVE
 eKb
+hVE
 bDc
 jTJ
 rNe
@@ -46988,7 +46957,7 @@ eSV
 hoV
 nto
 cnx
-kBt
+kid
 dzi
 sta
 xlr
@@ -49006,7 +48975,7 @@ wdX
 onN
 tSa
 gJa
-wbp
+kid
 dEC
 dpF
 gCN

--- a/vueui/src/components/view/console/atmocontrol/main.vue
+++ b/vueui/src/components/view/console/atmocontrol/main.vue
@@ -5,7 +5,7 @@
     <div v-else v-for="(sdata, key) in state.sensors" :key="key">
       <b>{{ sdata.name }}</b><br>
       <vui-item v-if="sdata.pressure" label="Pressure:">{{ sdata.pressure }} kPa</vui-item>
-      <vui-item v-if="sdata.temperature" label="Temperature:">{{ sdata.temperature }}% K</vui-item>
+      <vui-item v-if="sdata.temperature" label="Temperature:">{{ sdata.temperature }} K</vui-item>
       <vui-item v-if="sdata.oxygen || sdata.hydrogen || sdata.phoron || sdata.nitrogen || sdata.carbon_dioxide" label="Gas Composition:">
         <span class="complist" v-if="sdata.oxygen">{{ sdata.oxygen }}% O<sub>2</sub></span>
         <span class="complist" v-if="sdata.nitrogen">{{ sdata.nitrogen }}% N</span>


### PR DESCRIPTION
Fixes #13516
Fixes #13523
-Double-mapped pipes removed.
-Manual valve added to the hydrogen tank line for consistency with the phoron and co2 tanks.
-Removed the digital valves by the 3 canister ports, since, as stated in the issue, they're the admin logging valves, and cannot be removed. If atmos techs want to play with gas mixes, they can add whatever pumps and valves they need now.
-Uhhh the air to distro pipe didn't start the round on. It does now. Air for everyone. (It's just the shitty default pump still, atmos can upgrade it)
-The large tank consoles reported temperatures as 273% K. Removed that percent sign.
-Remapped the pipes leading into the mix tank, per the issue; basically, only stuff that comes from the Engine to Mix line is going through the cooling radiator pipes in space. Before, EVERYTHING in the mix pipes was getting shunted through the cooling pipes.