### PR TITLE
Re-added cook as chef alt-title

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -51,6 +51,7 @@
 
 	access = list(access_hydroponics, access_bar, access_kitchen)
 	minimal_access = list(access_kitchen)
+	alt_titles = list("Cook")
 	outfit = /datum/outfit/job/chef
 	blacklisted_species = list(SPECIES_VAURCA_BREEDER)
 

--- a/html/changelogs/KingOfThePing - 13535.yml
+++ b/html/changelogs/KingOfThePing - 13535.yml
@@ -1,0 +1,16 @@
+
+
+# Your name.
+author: KingOfThePing
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Re-added the cook alt title for chefs."
+ 


### PR DESCRIPTION
Re-added the lost and probably just forgotten alt-title of cook per player request. Not all cooks are chefs. They are (at least where I live) two different qualifications, with cook being the lower one. 
Re-adding this allows for players to let their low-income character to be even less qualified with what they are doing.