### PR TITLE
Medical Grippers and Organ Transplant Fix

### DIFF
--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -71,7 +71,6 @@
 
 /obj/item/organ/internal/liver/handle_regeneration()
 	if(..())
-		testing("Liver regenerating!")
 		if(!owner.total_radiation && damage > 0)
 			if(damage < min_broken_damage)
 				heal_damage(0.2)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -135,7 +135,7 @@ proc/spread_germs_to_organ(var/obj/item/organ/external/E, var/mob/living/carbon/
 		return TRUE
 
 	// Otherwise we can make a start on surgery!
-	else if(istype(M) && !QDELETED(M) && user.get_active_hand() == tool)
+	else if(istype(M) && !QDELETED(M) && tool)
 		// Double-check this in case it changed between initial check and now.
 		if(zone in M.op_stage.in_progress)
 			to_chat(user, SPAN_WARNING("You can't operate on this area while surgery is already in progress."))

--- a/html/changelogs/medical_cyborg_organ_transplant.yml
+++ b/html/changelogs/medical_cyborg_organ_transplant.yml
@@ -1,0 +1,7 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed Medical Stationbounds being unable to perform organ transplants."
+  - bugfix: "Removed a debug message as liver regenerates"


### PR DESCRIPTION
* Fixes #13497
Basically, in ``proc/do_surgery`` had a check to make sure the active hand was equal to the tool, but for Medical Stationbounds, it returned the gripper instead of the tool (as a result from another gripper fix).
* Removes leftover debug message when the liver regenerates