### PR TITLE
Optimize playsound, starlight, and visualnet generation

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -245,7 +245,7 @@
 
 #define ECONOMIC_POSITIONS		list(ECONOMICALLY_WEALTHY, ECONOMICALLY_WELLOFF, ECONOMICALLY_AVERAGE, ECONOMICALLY_UNDERPAID, ECONOMICALLY_POOR)
 
-// Defines the argument used for get_mobs_and_objs_in_view_fast
+// Defines the argument used for get_mobs_or_objs_in_view
 #define GHOSTS_ALL_HEAR 1
 #define ONLY_GHOSTS_IN_VIEW 0
 

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -156,31 +156,6 @@
 
 // Returns a list of mobs and/or objects in range of R from source. Used in radio and say code.
 
-/proc/get_mobs_or_objects_in_view(var/R, var/atom/source, var/include_mobs = 1, var/include_objects = 1)
-
-	var/turf/T = get_turf(source)
-	var/list/hear = list()
-
-	if(!T)
-		return hear
-
-	var/list/range = hear(R, T)
-
-	for(var/I in range)
-		if(ismob(I))
-			recursive_content_check(I, hear, 3, 1, 0, include_mobs, include_objects)
-			if(include_mobs)
-				var/mob/M = I
-				if(M.client)
-					hear += M
-		else if(istype(I, /obj/))
-			recursive_content_check(I, hear, 3, 1, 0, include_mobs, include_objects)
-			if(include_objects)
-				hear += I
-
-	return hear
-
-
 /proc/get_mobs_in_radio_ranges(var/list/obj/item/device/radio/radios)
 
 	set background = 1
@@ -215,7 +190,7 @@
 		if(M.can_hear_radio(speaker_coverage))
 			. += M
 
-/proc/get_mobs_and_objs_in_view_fast(turf/T, range, list/mobs, list/objs, checkghosts = GHOSTS_ALL_HEAR)
+/proc/get_mobs_or_objs_in_view(turf/T, range, list/mobs, list/objs, checkghosts = GHOSTS_ALL_HEAR)
 	var/list/hear = list()
 	DVIEW(hear, range, T, INVISIBILITY_MAXIMUM)
 	var/list/hearturfs = list()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -590,7 +590,10 @@
 
 /atom/proc/intent_message(var/message, var/range = 7)
 	if(air_sound(src))
-		var/list/mobs = get_mobs_or_objects_in_view(range, src, include_objects = FALSE)
+		var/turf/T = get_turf(src)
+		var/list/mobs = list()
+		var/list/objs = list()
+		get_mobs_and_objs_in_view_fast(T, range, mobs, objs, ONLY_GHOSTS_IN_VIEW)
 		for(var/mob/living/carbon/human/H as anything in intent_listener)
 			if(!(H in mobs))
 				if(src.z == H.z && get_dist(src, H) <= range)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -547,7 +547,7 @@
 	var/turf/T = get_turf(src)
 	var/list/mobs = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(T,range, mobs, objs, ONLY_GHOSTS_IN_VIEW)
+	get_mobs_or_objs_in_view(T,range, mobs, objs, ONLY_GHOSTS_IN_VIEW)
 
 	for(var/o in objs)
 		var/obj/O = o
@@ -576,7 +576,7 @@
 	var/turf/T = get_turf(src)
 	var/list/mobs = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(T,range, mobs, objs, ONLY_GHOSTS_IN_VIEW)
+	get_mobs_or_objs_in_view(T,range, mobs, objs, ONLY_GHOSTS_IN_VIEW)
 
 	for(var/m in mobs)
 		var/mob/M = m
@@ -593,7 +593,7 @@
 		var/turf/T = get_turf(src)
 		var/list/mobs = list()
 		var/list/objs = list()
-		get_mobs_and_objs_in_view_fast(T, range, mobs, objs, ONLY_GHOSTS_IN_VIEW)
+		get_mobs_or_objs_in_view(T, range, mobs, objs, ONLY_GHOSTS_IN_VIEW)
 		for(var/mob/living/carbon/human/H as anything in intent_listener)
 			if(!(H in mobs))
 				if(src.z == H.z && get_dist(src, H) <= range)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -578,7 +578,10 @@ var/global/list/default_medbay_channels = list(
 
 	var/range = receive_range(freq, level)
 	if(range > -1)
-		return get_mobs_or_objects_in_view(canhear_range, src)
+		var/list/mobs = list()
+		var/list/objs = list()
+		get_mobs_or_objs_in_view(get_turf(src), canhear_range, mobs, objs)
+		return mobs
 
 
 /obj/item/device/radio/examine(mob/user)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -120,9 +120,10 @@
 			M.playsound_to(source_turf, S, use_random_freq = use_random_freq, use_pressure = use_pressure, modify_environment = modify_environment)
 
 /proc/playsound_lineofsight(atom/source, sound/S, use_random_freq = FALSE, use_pressure = TRUE, modify_environment = TRUE, required_preferences = 0, required_asfx_toggles = 0)
-	var/list/mobs = get_mobs_or_objects_in_view(world.view, source, include_objects = FALSE)
-
 	var/turf/source_turf = get_turf(source)
+	var/list/mobs = list()
+	var/list/objs = list()
+	get_mobs_and_objs_in_view_fast(source_turf, world.view, mobs, objs, ONLY_GHOSTS_IN_VIEW)
 
 	for (var/MM in mobs)
 		var/mob/M = MM

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -123,7 +123,7 @@
 	var/turf/source_turf = get_turf(source)
 	var/list/mobs = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(source_turf, world.view, mobs, objs, ONLY_GHOSTS_IN_VIEW)
+	get_mobs_or_objs_in_view(source_turf, world.view, mobs, objs, ONLY_GHOSTS_IN_VIEW)
 
 	for (var/MM in mobs)
 		var/mob/M = MM

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -62,17 +62,15 @@
 
 	return 0
 
-/turf/space/proc/update_starlight()
-	if(config.starlight)
-		for (var/T in RANGE_TURFS(1, src))
-			if (istype(T, /turf/space))
-				continue
-
-			set_light(config.starlight)
-			return
-
-		if (light_range)
-			set_light(0)
+/turf/space/proc/update_starlight(var/validate = TRUE)
+	if(!config.starlight)
+		return
+	if(!validate) // basically a hack for places where the check was already done for us
+		set_light(1, config.starlight)
+	else if(locate(/turf/simulated) in RANGE_TURFS(1, src))
+		set_light(1, config.starlight)
+	else
+		set_light(0)
 
 /turf/space/attackby(obj/item/C as obj, mob/user as mob)
 

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -81,7 +81,7 @@
 
 	if (config.starlight)
 		for (var/turf/space/S in RANGE_TURFS(1, src))
-			S.update_starlight()
+			S.update_starlight(FALSE)
 
 	W.above = old_above
 

--- a/code/modules/balloon_alert/balloon_alert.dm
+++ b/code/modules/balloon_alert/balloon_alert.dm
@@ -17,7 +17,7 @@
 
 	var/list/hearers = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(get_turf(src), vision_distance, hearers, objs, ONLY_GHOSTS_IN_VIEW)
+	get_mobs_or_objs_in_view(get_turf(src), vision_distance, hearers, objs, ONLY_GHOSTS_IN_VIEW)
 	hearers -= ignored_mobs
 
 	for(var/mob/hearer as anything in hearers - src)

--- a/code/modules/effects/map_effects/portal.dm
+++ b/code/modules/effects/map_effects/portal.dm
@@ -234,7 +234,7 @@ when portals are shortly lived, or when portals are made to be obvious with spec
 	var/turf/T = counterpart.get_focused_turf()
 	var/list/mobs_to_relay = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(T, world.view, mobs_to_relay, objs)
+	get_mobs_or_objs_in_view(T, world.view, mobs_to_relay, objs)
 
 	for(var/thing in mobs_to_relay)
 		var/mob/mob = thing
@@ -251,7 +251,7 @@ when portals are shortly lived, or when portals are made to be obvious with spec
 	var/turf/T = counterpart.get_focused_turf()
 	var/list/mobs_to_relay = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(T, world.view, mobs_to_relay, objs)
+	get_mobs_or_objs_in_view(T, world.view, mobs_to_relay, objs)
 
 	for(var/thing in mobs_to_relay)
 		var/mob/mob = thing
@@ -266,7 +266,7 @@ when portals are shortly lived, or when portals are made to be obvious with spec
 	var/turf/T = counterpart.get_focused_turf()
 	var/list/mobs_to_relay = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(T, world.view, mobs_to_relay, objs)
+	get_mobs_or_objs_in_view(T, world.view, mobs_to_relay, objs)
 
 	for(var/thing in mobs_to_relay)
 		var/mob/mob = thing

--- a/code/modules/mob/abstract/freelook/update_triggers.dm
+++ b/code/modules/mob/abstract/freelook/update_triggers.dm
@@ -1,7 +1,7 @@
 //UPDATE TRIGGERS, when the chunk (and the surrounding chunks) should update.
 
 /proc/updateVisibility(atom/A, var/opacity_check = TRUE)
-	if(SSticker)
+	if(SSticker.current_state >= GAME_STATE_PLAYING)
 		for(var/datum/visualnet/VN in visual_nets)
 			VN.update_visibility(A, opacity_check)
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -293,7 +293,7 @@ proc/get_radio_key_from_channel(var/channel)
 				italics = 1
 				sound_vol *= 0.5 //muffle the sound a bit, so it's like we're actually talking through contact
 
-		get_mobs_and_objs_in_view_fast(T, message_range, listening, listening_obj, ghost_hearing)
+		get_mobs_or_objs_in_view(T, message_range, listening, listening_obj, ghost_hearing)
 
 	var/list/hear_clients = list()
 	for(var/m in listening)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -199,7 +199,7 @@
 
 	var/list/mobs = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(T, range, mobs, objs, ghost_hearing)
+	get_mobs_or_objs_in_view(T, range, mobs, objs, ghost_hearing)
 
 
 	for(var/m in mobs)

--- a/html/changelogs/johnwildkins-optimize2.yml
+++ b/html/changelogs/johnwildkins-optimize2.yml
@@ -1,0 +1,8 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Starlight module no longer attempts to generate lights on turfs that haven't initialized."
+  - refactor: "Sounds and messages via sensitive hearing were optimized to no longer rely on expensive recursive checks."
+  - refactor: "Visualnets no longer attempt to update their visibility chunks prior to game start."


### PR DESCRIPTION
should maybe possibly help init time and also maybe possibly kill some lag maybe???
changes:
  - bugfix: "Starlight module no longer attempts to generate lights on turfs that haven't initialized."
  - refactor: "Sounds and messages via sensitive hearing were optimized to no longer rely on expensive recursive checks."
  - refactor: "Visualnets no longer attempt to update their visibility chunks prior to game start."