### PR TITLE
Ghosts can no longer rename monkeys

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1233,7 +1233,12 @@ mob/living/carbon/human/proc/change_monitor()
 	set src in view(1)
 
 	var/mob/living/M = usr
-	if(!M || usr == src)
+	if(!istype(M))
+		to_chat(usr, SPAN_WARNING("You aren't allowed to rename \the [src]."))
+		return
+	 
+	if(usr == src)
+		to_chat(usr, SPAN_WARNING("You're a simple creature, you can't rename yourself!"))
 		return
 
 	if(can_name(M))

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1232,7 +1232,7 @@ mob/living/carbon/human/proc/change_monitor()
 	set category = "IC"
 	set src in view(1)
 
-	var/mob/living/M = usr
+	var/mob/living/carbon/M = usr
 	if(!istype(M))
 		to_chat(usr, SPAN_WARNING("You aren't allowed to rename \the [src]."))
 		return

--- a/html/changelogs/doxxmedearly-spookymonkeyrenames.yml
+++ b/html/changelogs/doxxmedearly-spookymonkeyrenames.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Ghosts can no longer rename monkeys or their equivalents."


### PR DESCRIPTION
Fixes #13520 

When I fixed this for simple animals last year, I forgot to do it for monkeys, too. 