### PR TITLE
Optimize lobby readied playerlist

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -38,6 +38,8 @@
 
 	ProcessSanitizationQueue()
 
+	SSticker.setup_player_ready_list()
+
 /datum/controller/subsystem/jobs/Recover()
 	occupations = SSjobs.occupations
 	unassigned = SSjobs.unassigned

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -343,7 +343,7 @@ var/datum/controller/subsystem/ticker/SSticker
 	total_players_ready = LAZYLEN(ready_player_jobs)
 
 /datum/controller/subsystem/ticker/proc/update_ready_list(var/mob/abstract/new_player/NP)
-	if(current_state >= GAME_STATE_PLAYING || !SSjobs || !istype(NP))
+	if(current_state >= GAME_STATE_PLAYING || !SSjobs)
 		return // don't bother once the game has started
 
 	if(NP.ready)

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -320,29 +320,25 @@
 	if(!job)
 		return FALSE
 
-	var/mob/abstract/new_player/NP = user
-
 	if(role == "Assistant")
 		if(pref.job_civilian_low & job.flag)
 			pref.job_civilian_low &= ~job.flag
 		else
 			pref.job_civilian_low |= job.flag
 
-		if(istype(NP) && NP.ready)
-			SSticker.update_ready_list(NP)
+		SSticker.cycle_player(user, job)
 		return TRUE
 
-	if(pref.GetJobDepartment(job, 1) & job.flag)
+	if(pref.GetJobDepartment(job, 1) & job.flag) // HIGH -> NONE
 		SetJobDepartment(job, 1)
-	else if(pref.GetJobDepartment(job, 2) & job.flag)
+		SSticker.cycle_player(user, job)
+	else if(pref.GetJobDepartment(job, 2) & job.flag) // MED -> HIGH
 		SetJobDepartment(job, 2)
-	else if(pref.GetJobDepartment(job, 3) & job.flag)
+		SSticker.cycle_player(user, job)
+	else if(pref.GetJobDepartment(job, 3) & job.flag) // LOW -> MED
 		SetJobDepartment(job, 3)
-	else//job = Never
+	else // NONE -> LOW
 		SetJobDepartment(job, 4)
-
-	if(istype(NP) && NP.ready)
-		SSticker.update_ready_list(NP)
 
 	return 1
 

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -320,11 +320,16 @@
 	if(!job)
 		return FALSE
 
+	var/mob/abstract/new_player/NP = user
+
 	if(role == "Assistant")
 		if(pref.job_civilian_low & job.flag)
 			pref.job_civilian_low &= ~job.flag
 		else
 			pref.job_civilian_low |= job.flag
+
+		if(istype(NP) && NP.ready)
+			SSticker.update_ready_list(NP)
 		return TRUE
 
 	if(pref.GetJobDepartment(job, 1) & job.flag)
@@ -335,6 +340,9 @@
 		SetJobDepartment(job, 3)
 	else//job = Never
 		SetJobDepartment(job, 4)
+
+	if(istype(NP) && NP.ready)
+		SSticker.update_ready_list(NP)
 
 	return 1
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -48,11 +48,11 @@
 
 /datum/preferences/proc/load_character(slot)
 	var/savefile/S
-	var/readied = FALSE
-	// have to do these shenanigans because the char. name is changing
-	if(SSticker && SSticker.get_readied_player(real_name))
+	var/mob/abstract/new_player/NP = src.client.mob
+	var/readied
+	if(istype(NP) && NP.ready)
 		readied = TRUE
-		SSticker.unready_player(real_name)
+		SSticker.update_ready_list(NP, force_urdy=TRUE)
 
 	if (!config.sql_saves)
 		if (!path)
@@ -81,8 +81,8 @@
 	else
 		save_preferences()
 
-	if(SSticker && readied)
-		SSticker.ready_player(src)
+	if(istype(NP) && readied)
+		SSticker.update_ready_list(NP)
 
 	return 1
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -48,6 +48,12 @@
 
 /datum/preferences/proc/load_character(slot)
 	var/savefile/S
+	var/readied = FALSE
+	// have to do these shenanigans because the char. name is changing
+	if(SSticker && SSticker.get_readied_player(real_name))
+		readied = TRUE
+		SSticker.unready_player(real_name)
+
 	if (!config.sql_saves)
 		if (!path)
 			return 0
@@ -74,6 +80,9 @@
 		loaded_character = S
 	else
 		save_preferences()
+
+	if(SSticker && readied)
+		SSticker.ready_player(src)
 
 	return 1
 

--- a/code/modules/mob/abstract/new_player/logout.dm
+++ b/code/modules/mob/abstract/new_player/logout.dm
@@ -1,5 +1,6 @@
 /mob/abstract/new_player/Logout()
-	ready = 0
+	ready = FALSE
+	SSticker.update_ready_list(src)
 
 	// see login.dm
 	if(my_client)

--- a/code/modules/mob/abstract/new_player/menu.dm
+++ b/code/modules/mob/abstract/new_player/menu.dm
@@ -234,6 +234,9 @@
 			return
 
 		ready = readying
+		if(ready)
+			last_ready_name = client.prefs.real_name
+		SSticker.update_ready_list(src)
 	else
 		ready = FALSE
 

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -41,14 +41,14 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 			stat("Game Mode:", "[master_mode]") // Old setting for showing the game mode
 
 		if(SSticker.current_state == GAME_STATE_PREGAME)
-			if (SSticker.lobby_ready)
-				stat("Time To Start:", "[SSticker.pregame_timeleft][round_progressing ? "" : " (DELAYED)"]")
-				stat("Players: [SSticker.total_players]", "Players Ready: [SSticker.total_players_ready]")
-			else
-				stat("Time To Start:", "Waiting for Server")
-				stat("Players: [player_list.len]", "Players Ready: Waiting")
-			for(var/player_name in SSticker.ready_player_jobs)
-				stat("[copytext_char(player_name, 1, 18)]", "[SSticker.ready_player_jobs[player_name]]")
+			stat("Time To Start:", "[SSticker.pregame_timeleft][round_progressing ? "" : " (DELAYED)"]")
+			stat("Players: [length(player_list)]", "Players Ready: [SSticker.total_players_ready]")
+			if(SSjobs.init_state >= SS_INITSTATE_DONE)
+				for(var/dept in SSticker.ready_player_jobs)
+					if(LAZYLEN(SSticker.ready_player_jobs[dept]))
+						stat(uppertext(dept), null)
+					for(var/char in SSticker.ready_player_jobs[dept])
+						stat("[copytext_char(char, 1, 18)]", "[SSticker.ready_player_jobs[dept][char]]")
 
 /mob/abstract/new_player/Topic(href, href_list[])
 	if(!client)	return 0

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -3,8 +3,6 @@
 /mob/abstract/new_player
 	var/ready = 0
 	var/spawning = 0 //Referenced when you want to delete the new_player later on in the code
-	var/totalPlayers = 0 //Player counts for the Lobby tab
-	var/totalPlayersReady = 0
 	var/datum/late_choices/late_choices_ui = null
 	universal_speak = 1
 
@@ -16,6 +14,8 @@
 
 	anchored = 1	//  don't get pushed around
 	simulated = FALSE
+
+	var/last_ready_name // This has to be saved because the client is nulled prior to Logout()
 
 INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 
@@ -43,17 +43,12 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 		if(SSticker.current_state == GAME_STATE_PREGAME)
 			if (SSticker.lobby_ready)
 				stat("Time To Start:", "[SSticker.pregame_timeleft][round_progressing ? "" : " (DELAYED)"]")
+				stat("Players: [SSticker.total_players]", "Players Ready: [SSticker.total_players_ready]")
 			else
 				stat("Time To Start:", "Waiting for Server")
-			stat("Players: [totalPlayers]", "Players Ready: [totalPlayersReady]")
-			totalPlayers = 0
-			totalPlayersReady = 0
-			for(var/mob/abstract/new_player/player in player_list)
-				totalPlayers++
-				if(player.ready)
-					var/job_ready = player.client.prefs.return_chosen_high_job(TRUE)
-					stat("[copytext_char(player.client.prefs.real_name, 1, 18)]", job_ready ? "[job_ready]" : "N/A")
-					totalPlayersReady++
+				stat("Players: [player_list.len]", "Players Ready: Waiting")
+			for(var/player_name in SSticker.ready_player_jobs)
+				stat("[copytext_char(player_name, 1, 18)]", "[SSticker.ready_player_jobs[player_name]]")
 
 /mob/abstract/new_player/Topic(href, href_list[])
 	if(!client)	return 0

--- a/html/changelogs/johnwildkins-fixlobby.yml
+++ b/html/changelogs/johnwildkins-fixlobby.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - refactor: "The list of readied players has been optimized, lowering pre-game server load."
+  - tweak: "The readied player list now sorts by department and name, displaying readied players by department."

--- a/html/changelogs/johnwildkins-fixlobby.yml
+++ b/html/changelogs/johnwildkins-fixlobby.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - refactor: "The list of readied players has been optimized, lowering pre-game server load."


### PR DESCRIPTION
title

essentially the original implementation iterated the entire player list for every player connected to the server, every tick, to render the ready list
now it will simply render the ready list from SSticker every tick, and the list will only be updated when a player readies/unreadies/logs out, or if the player swaps characters / job preferences while readied

probably a bit of shitcode in here because I'm tired so review carefully