### PR TITLE
Library windoor access fix

### DIFF
--- a/html/changelogs/doxxmedearly-library_access.yml
+++ b/html/changelogs/doxxmedearly-library_access.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "The windoor to the library desk now requires the correct access to open."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -1128,7 +1128,11 @@
 /area/hallway/primary/central_two)
 "aFK" = (
 /obj/structure/table/wood,
-/obj/machinery/door/window/westright,
+/obj/machinery/door/window/southright{
+	dir = 8;
+	name = "Library Desk";
+	req_access = list(37)
+	},
 /turf/simulated/floor/wood,
 /area/library)
 "aGH" = (


### PR DESCRIPTION
I assume it's a bug that the windoor at the library desk itself has no access requirements (The one next to the desk has the correct access restrictions). Fixed that. 