### PR TITLE
Adjusts phoron scarcity bounties

### DIFF
--- a/code/modules/cargo/bounties/special.dm
+++ b/code/modules/cargo/bounties/special.dm
@@ -19,6 +19,52 @@
 		for(var/i = 0; i < reward; ++i)
 			SScargo.try_add_bounty(SScargo.random_bounty())
 
+//Part of the Horizon's operations is to secure phoron, so high priority.
+
+/datum/bounty/item/phoron_sheet
+	name = "Phoron Sheets"
+	description = "Shipment of Phoron is considered to be a key part of the SCCV Horizon's operations within the CRZ. This bounty should always be prioritized."
+	reward_low = 2600
+	reward_high = 3750
+	required_count = 40
+	random_count = 10
+	wanted_types = list(/obj/item/stack/material/phoron)
+	high_priority = TRUE
+
+/datum/bounty/item/phoron_sheet/New()
+	..()
+	required_count = round(required_count, 10)
+	//Overwrite the normal price randomization because the random_count is so high. There would be absolutely nuts price fluctuation. 
+	reward = round(rand(reward_low, reward_high), 100)
+
+/datum/bounty/item/phoron_sheet/ship(var/obj/item/stack/material/phoron/O)
+	if(!applies_to(O))
+		return
+	shipped_count += O.amount
+
+/datum/bounty/item/phoron_canister
+	name = "Phoron Canisters"
+	description = "Shipment of Phoron is considered to be a key part of the SCCV Horizon's operations within the CRZ. This bounty should always be prioritized. Canisters must contain a minimum of 2000 moles."
+	reward_low = 6000
+	reward_high = 8000
+	required_count = 2
+	random_count = 1 // 1 to 3
+	wanted_types = list(/obj/machinery/portable_atmospherics/canister)
+	high_priority = TRUE
+	var/moles_required = 2000 //Roundstart total_moles for a FULL tank is about 1871 per tank.
+
+/datum/bounty/item/phoron_canister/applies_to(var/obj/machinery/portable_atmospherics/canister/O)
+	if(!..())
+		return FALSE
+	if(!istype(O))
+		return FALSE
+
+	var/datum/gas_mixture/environment = O.return_air()
+	if(!environment || !O.air_contents.gas["phoron"])
+		return FALSE
+
+	return O.air_contents.gas["phoron"] >= moles_required
+
 /datum/bounty/item/solar_array
 	name = "Assembled Solar Panels"
 	description = "Owing to the phoron shortage continuing for over a year, longer than projected, we have decided to use solar arrays to power various facilities across our region of influence."

--- a/code/modules/cargo/bounties/special.dm
+++ b/code/modules/cargo/bounties/special.dm
@@ -19,52 +19,6 @@
 		for(var/i = 0; i < reward; ++i)
 			SScargo.try_add_bounty(SScargo.random_bounty())
 
-//during phoron scarcity lore arc. remove when lore permits.
-
-/datum/bounty/item/phoron_sheet
-	name = "Phoron Sheets"
-	description = "Always prioritize this bounty. Failure to meet this quota may result in adverse impact upon your status in the NanoTrasen Corporation."
-	reward_low = 2600
-	reward_high = 3750
-	required_count = 40
-	random_count = 10
-	wanted_types = list(/obj/item/stack/material/phoron)
-	high_priority = TRUE
-
-/datum/bounty/item/phoron_sheet/New()
-	..()
-	required_count = round(required_count, 10)
-	//Temporarily overwrite the normal price randomization because the random_count is so high. There would be absolutely nuts price fluctuation. It's a temporary bounty anyway.
-	reward = round(rand(reward_low, reward_high), 100)
-
-/datum/bounty/item/phoron_sheet/ship(var/obj/item/stack/material/phoron/O)
-	if(!applies_to(O))
-		return
-	shipped_count += O.amount
-
-/datum/bounty/item/phoron_canister
-	name = "Phoron Canisters"
-	description = "Updated requirement: Canisters must now be filled to a minimum of 2000 moles. Always prioritize this bounty. Failure to meet this quota may result in adverse impact upon your status in the NanoTrasen Corporation."
-	reward_low = 8000
-	reward_high = 10000
-	required_count = 3
-	random_count = 1 // 2 to 4
-	wanted_types = list(/obj/machinery/portable_atmospherics/canister)
-	high_priority = TRUE
-	var/moles_required = 2000 //Roundstart total_moles for a FULL tank is about 1871 per tank. However during the arc this bounty is relevant, tanks are half full.
-
-/datum/bounty/item/phoron_canister/applies_to(var/obj/machinery/portable_atmospherics/canister/O)
-	if(!..())
-		return FALSE
-	if(!istype(O))
-		return FALSE
-
-	var/datum/gas_mixture/environment = O.return_air()
-	if(!environment || !O.air_contents.gas["phoron"])
-		return FALSE
-
-	return O.air_contents.gas["phoron"] >= moles_required
-
 /datum/bounty/item/solar_array
 	name = "Assembled Solar Panels"
 	description = "Owing to the phoron shortage continuing for over a year, longer than projected, we have decided to use solar arrays to power various facilities across our region of influence."

--- a/code/modules/cargo/bounties/special.dm
+++ b/code/modules/cargo/bounties/special.dm
@@ -42,29 +42,6 @@
 		return
 	shipped_count += O.amount
 
-/datum/bounty/item/phoron_canister
-	name = "Phoron Canisters"
-	description = "Shipment of Phoron is considered to be a key part of the SCCV Horizon's operations within the CRZ. This bounty should always be prioritized. Canisters must contain a minimum of 2000 moles."
-	reward_low = 6000
-	reward_high = 8000
-	required_count = 2
-	random_count = 1 // 1 to 3
-	wanted_types = list(/obj/machinery/portable_atmospherics/canister)
-	high_priority = TRUE
-	var/moles_required = 2000 //Roundstart total_moles for a FULL tank is about 1871 per tank.
-
-/datum/bounty/item/phoron_canister/applies_to(var/obj/machinery/portable_atmospherics/canister/O)
-	if(!..())
-		return FALSE
-	if(!istype(O))
-		return FALSE
-
-	var/datum/gas_mixture/environment = O.return_air()
-	if(!environment || !O.air_contents.gas["phoron"])
-		return FALSE
-
-	return O.air_contents.gas["phoron"] >= moles_required
-
 /datum/bounty/item/solar_array
 	name = "Assembled Solar Panels"
 	description = "Owing to the phoron shortage continuing for over a year, longer than projected, we have decided to use solar arrays to power various facilities across our region of influence."

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -209,8 +209,13 @@
 	var/datum/bounty/r_subtype = pick(subtypesof(/datum/bounty/reagent))
 	try_add_bounty(new r_subtype)
 
-	var/datum/bounty/B = pick(bounties_list)
-	B.mark_high_priority()
+	if(prob(60))
+		//phoron bounties
+		var/datum/bounty/item/phoron_bounty = pick(/datum/bounty/item/phoron_sheet, /datum/bounty/item/solar_array)
+		try_add_bounty(new phoron_bounty)
+	else
+		var/datum/bounty/B = pick(bounties_list)
+		B.mark_high_priority()
 
 	// Generate these last so they can't be high priority.
 	try_add_bounty(new /datum/bounty/more_bounties)

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -209,13 +209,8 @@
 	var/datum/bounty/r_subtype = pick(subtypesof(/datum/bounty/reagent))
 	try_add_bounty(new r_subtype)
 
-	if(prob(60))
-		//phoron arc bounties. remove when arc is done.
-		var/datum/bounty/item/phoron_bounty = pick(/datum/bounty/item/phoron_sheet, /datum/bounty/item/solar_array)
-		try_add_bounty(new phoron_bounty)
-	else
-		var/datum/bounty/B = pick(bounties_list)
-		B.mark_high_priority()
+	var/datum/bounty/B = pick(bounties_list)
+	B.mark_high_priority()
 
 	// Generate these last so they can't be high priority.
 	try_add_bounty(new /datum/bounty/more_bounties)

--- a/html/changelogs/doxxmedearly-phoronbounty.yml
+++ b/html/changelogs/doxxmedearly-phoronbounty.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - tweak: "Edited the wording of the phoron-related bounties to more accurately represent current lore."
-  - tweak: "The amount of canisters required for the related phoron bounty has been reduced. The reward matches this reduction."
+  - rscdel: "Removes the phoron canister bounty."

--- a/html/changelogs/doxxmedearly-phoronbounty.yml
+++ b/html/changelogs/doxxmedearly-phoronbounty.yml
@@ -3,4 +3,5 @@ author: Doxxmedearly
 delete-after: True
 
 changes:
-  - rscdel: "Removed the high-priority phoron bounties, as they were meant to be temporary for the Aurora station during the phoron scarcity arc."
+  - tweak: "Edited the wording of the phoron-related bounties to more accurately represent current lore."
+  - tweak: "The amount of canisters required for the related phoron bounty has been reduced. The reward matches this reduction."

--- a/html/changelogs/doxxmedearly-phoronbounty.yml
+++ b/html/changelogs/doxxmedearly-phoronbounty.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - rscdel: "Removed the high-priority phoron bounties, as they were meant to be temporary for the Aurora station during the phoron scarcity arc."


### PR DESCRIPTION
Updated 4/23:
Reworded bounties to reflect current lore.
Removed the canister bounty since it was replaced at some point by the solar array bounty. Also it's... kinda weird for the exploration vessel that needs phoron to ship its fuel supply out. 

Old:
I'm sure this will need approval from lore and maintainers. 

Basically, when I made these bounties, they were only meant for the Aurora during the scarcity arc leading up to the NBT, to put pressure on them and really drive the shortage home. 

Now that we're on the SCCV Horizon, these bounties should be removed, as the vessel does not fulfill the same role as the Aurora. 

They can also be edited as lore/maintainers see fit, will make those changes if requested. But it was not meant to carry over to NBT. 