### PR TITLE
Fixes infestation spawns happening outside the Horizon

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -442,6 +442,8 @@ var/list/mob/living/forced_ambiance_list = new
 			continue
 		if (istype(A, /area/mine))
 			continue
+		if (istype(A, /area/horizonexterior))
+			continue
 
 		//Although hostile mobs instadying to turrets is fun
 		//If there's no AI they'll just be hit with stunbeams all day and spam the attack logs.

--- a/html/changelogs/doxxmedearly-eventspawn_inside.yml
+++ b/html/changelogs/doxxmedearly-eventspawn_inside.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - rscdel: "Killed innocent kittens."

--- a/html/changelogs/doxxmedearly-eventspawn_inside.yml
+++ b/html/changelogs/doxxmedearly-eventspawn_inside.yml
@@ -1,42 +1,4 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes:
-#   bugfix
-#   wip (For works in progress)
-#   tweak
-#   soundadd
-#   sounddel
-#   rscadd (general adding of nice things)
-#   rscdel (general deleting of nice things)
-#   imageadd
-#   imagedel
-#   maptweak
-#   spellcheck (typo fixes)
-#   experiment
-#   balance
-#   admin
-#   backend
-#   security
-#   refactor
-#################################
-
-# Your name.
-author: ChangeMe
-
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+author: Doxxmedearly
 delete-after: True
-
-# Any changes you've made.  See valid prefix list above.
-# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-# SCREW THIS UP AND IT WON'T WORK.
-# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
-# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - bugfix: "Random event spawns (Such as rats and crates) should now only spawn on the inside of the Horizon."


### PR DESCRIPTION
Fixes #13440

The space outside the ship specified in the linked issue is a station area, and `get_random_area()` was marking it as a valid spawnpoint. Fixed that. 

The other outside areas all seem to be fine (They are not marked as station areas, so will not be chosen)