### PR TITLE
Deep ore scanner properly named

### DIFF
--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -1,5 +1,5 @@
 /obj/item/mining_scanner
-	name = "ore detector"
+	name = "deep ore scanner"
 	desc = "A complex device used to locate ore deep underground."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "forensic0-old" //GET A BETTER SPRITE.

--- a/html/changelogs/doxxmedearly-orescannerrename.yml
+++ b/html/changelogs/doxxmedearly-orescannerrename.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - tweak: "Updated the deep ore scanner's name to... deep ore scanner, in order to prevent confusion with other ore detectors."


### PR DESCRIPTION
Fixes #13074
Rig press was giving the wrong examine info because the deep ore scanner was named "ore detector," and we already have an item named "ore detector." Renamed. 