### PR TITLE
Cut down on z-level generation for shuttles

### DIFF
--- a/code/modules/overmap/ships/landable.dm
+++ b/code/modules/overmap/ships/landable.dm
@@ -7,6 +7,7 @@
 	var/obj/effect/shuttle_landmark/ship/landmark       // Record our open space landmark for easy reference.
 	var/multiz = 0										// Index of multi-z levels, starts at 0
 	var/status = SHIP_STATUS_LANDED
+	var/subshuttle = FALSE								// TRUE/FALSE: Is this a ship that starts docked to another ship?
 	icon_state = "shuttle"
 	moving_state = "shuttle_moving"
 
@@ -34,8 +35,12 @@
 
 // We autobuild our z levels.
 /obj/effect/overmap/visitable/ship/landable/find_z_levels()
-	for(var/i = 0 to multiz)
-		world.maxz++
+	if(isStationLevel(z) || multiz || subshuttle)
+		// If we're not on station and not multi-z or inside an existing ship, then we already had a z-level generated for us; let's use that
+		for(var/i = 0 to multiz)
+			world.maxz++
+			map_z += world.maxz
+	else
 		map_z += world.maxz
 
 	var/turf/center_loc = locate(round(world.maxx/2), round(world.maxy/2), world.maxz)

--- a/html/changelogs/johnwildkins-budgeting.yml
+++ b/html/changelogs/johnwildkins-budgeting.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - refactor: "Cut down on extraneous z-level generation for off-map shuttles."

--- a/maps/away/ships/biesel.dm
+++ b/maps/away/ships/biesel.dm
@@ -7,6 +7,7 @@
 	spawn_cost = 1
 	id = "tcfl_peacekeeper_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/tcfl_peacekeeper_ship, /datum/shuttle/autodock/overmap/tcfl_shuttle)
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 /obj/effect/overmap/visitable/sector/tcfl_peacekeeper_ship
 	name = "faint ship activity"
@@ -92,6 +93,7 @@
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY
+	subshuttle = TRUE
 
 /obj/machinery/computer/shuttle_control/explore/tcfl_shuttle
 	name = "shuttle control console"

--- a/maps/away/ships/corporate.dm
+++ b/maps/away/ships/corporate.dm
@@ -92,6 +92,7 @@
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY
+	subshuttle = TRUE
 
 /obj/machinery/computer/shuttle_control/explore/orion_express_shuttle
 	name = "shuttle control console"
@@ -220,6 +221,7 @@
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY
+	subshuttle = TRUE
 
 /obj/machinery/computer/shuttle_control/explore/ee_shuttle
 	name = "shuttle control console"

--- a/maps/away/ships/sol.dm
+++ b/maps/away/ships/sol.dm
@@ -92,6 +92,7 @@
 	vessel_mass = 3000 //very inefficient pod
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY
+	subshuttle = TRUE
 
 /obj/machinery/computer/shuttle_control/explore/sfa_shuttle
 	name = "shuttle control console"

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -126,7 +126,3 @@
 	allow_borgs_to_leave = TRUE
 
 	warehouse_basearea = /area/operations/storage
-
-/datum/map/sccv_horizon/finalize_load()
-	// generate an empty space Z
-	world.maxz++


### PR DESCRIPTION
title
essentially adds a check for if a shuttle is off-station and not inside a mothership, which means that it's added by an away site, and thus already has a z-level made

also removes an extraneous z-level generation on map init