### PR TITLE
Shuttle unit test + bugfix

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -3022,6 +3022,7 @@
 #include "code\unit_tests\observation_tests.dm"
 #include "code\unit_tests\overmap_tests.dm"
 #include "code\unit_tests\recipe_tests.dm"
+#include "code\unit_tests\shuttle_tests.dm"
 #include "code\unit_tests\spawner_tests.dm"
 #include "code\unit_tests\species_tests.dm"
 #include "code\unit_tests\sql_tests.dm"

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -99,6 +99,14 @@
 			fuel_to_consume -= fuel_available
 			FT.remove_air_by_flag(XGM_GAS_FUEL, fuel_available)
 
+/datum/shuttle/autodock/overmap/on_move_interim()
+	..()
+	for(var/obj/machinery/computer/shuttle_control/explore/E in shuttle_computers)
+		var/obj/effect/overmap/visitable/ship/S = E.linked
+		if(S)
+			S.halt()
+			S.unhalt()
+
 /obj/structure/fuel_port
 	name = "fuel port"
 	desc = "The fuel input port of the shuttle. Holds one fuel tank. Use a crowbar to open and close it."

--- a/code/modules/overmap/ships/computers/shuttle.dm
+++ b/code/modules/overmap/ships/computers/shuttle.dm
@@ -3,6 +3,17 @@
 	name = "general shuttle control console"
 	ui_template = "shuttle_control_console_exploration.tmpl"
 
+/obj/machinery/computer/shuttle_control/explore/attempt_hook_up(obj/effect/overmap/visitable/ship/sector)
+	. = ..()
+
+	if(.)
+		LAZYSET(linked.consoles, src, TRUE)
+
+/obj/machinery/computer/shuttle_control/explore/Destroy()
+	if(linked)
+		LAZYREMOVE(linked.consoles, src)
+	. = ..()
+
 /obj/machinery/computer/shuttle_control/explore/get_ui_data(var/datum/shuttle/autodock/overmap/shuttle)
 	. = ..()
 	if(istype(shuttle))

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -49,6 +49,9 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 	for(var/obj/machinery/computer/ship/S in SSmachinery.all_machines)
 		if(S.linked == src)
 			S.linked = null
+	for(var/obj/machinery/computer/shuttle_control/explore/C in SSmachinery.all_machines)
+		if(C.linked == src)
+			C.linked = null
 	for(var/obj/machinery/hologram/holopad/H as anything in SSmachinery.all_holopads)
 		if(H.linked == src)
 			H.linked = null
@@ -241,6 +244,8 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 	..()
 	for(var/obj/machinery/computer/ship/S in SSmachinery.all_machines)
 		S.attempt_hook_up(src)
+	for(var/obj/machinery/computer/shuttle_control/explore/C in SSmachinery.all_machines)
+		C.attempt_hook_up(src)
 	for(var/obj/machinery/hologram/holopad/H as anything in SSmachinery.all_holopads)
 		H.attempt_hook_up(src)
 	for(var/datum/ship_engine/E in ship_engines)

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -126,6 +126,7 @@
 		arrive_time = world.time + travel_time*10
 		moving_status = SHUTTLE_INTRANSIT
 		if(attempt_move(interim))
+			on_move_interim()
 			var/fwooshed = 0
 			while (world.time < arrive_time)
 				if(!fwooshed && (arrive_time - world.time) < 100)
@@ -299,3 +300,6 @@
 	process_state = new_state
 	for(var/obj/machinery/computer/shuttle_control/SC as anything in shuttle_computers)
 		SC.update_helmets(src)
+
+/datum/shuttle/proc/on_move_interim()
+	return

--- a/code/unit_tests/shuttle_tests.dm
+++ b/code/unit_tests/shuttle_tests.dm
@@ -6,7 +6,6 @@
 
 	for(var/A in subtypesof(/datum/shuttle/autodock))
 		var/datum/shuttle/autodock/shuttle = A
-		testing("Checking shuttle type [A]")
 		// Check start location and transition locations exist
 		var/found_current_location = FALSE
 		var/found_transition_location = FALSE

--- a/code/unit_tests/shuttle_tests.dm
+++ b/code/unit_tests/shuttle_tests.dm
@@ -10,18 +10,24 @@
 		// Check start location and transition locations exist
 		var/found_current_location = FALSE
 		var/found_transition_location = FALSE
+		var/found_logging_home_location = FALSE
 		for(var/L in subtypesof(/obj/effect/shuttle_landmark))
 			var/obj/effect/shuttle_landmark/landmark = L
 			if(initial(landmark.landmark_tag) == initial(shuttle.current_location))
 				found_current_location = TRUE
 			if(initial(landmark.landmark_tag) == initial(shuttle.landmark_transition))
 				found_transition_location = TRUE
+			if(initial(landmark.landmark_tag) == initial(shuttle.logging_home_tag))
+				found_logging_home_location = TRUE
 
 		if(initial(shuttle.current_location) && !found_current_location)
 			log_unit_test("Failed to find 'current_location' landmark for [shuttle].")
 			failed++
 		if(initial(shuttle.landmark_transition) && !found_transition_location)
 			log_unit_test("Failed to find 'landmark_transition' landmark for [shuttle].")
+			failed++
+		if(initial(shuttle.logging_home_tag) && !found_logging_home_location)
+			log_unit_test("Failed to find 'logging_home_tag' landmark for [shuttle].")
 			failed++
 
 	if(failed)

--- a/code/unit_tests/shuttle_tests.dm
+++ b/code/unit_tests/shuttle_tests.dm
@@ -1,0 +1,31 @@
+/datum/unit_test/shuttle_landmarks_shall_exist
+	name = "SHUTTLE: Defined shuttle landmarks shall exist."
+
+/datum/unit_test/shuttle_landmarks_shall_exist/start_test()
+	var/failed = 0
+
+	for(var/A in subtypesof(/datum/shuttle/autodock))
+		var/datum/shuttle/autodock/shuttle = A
+		testing("Checking shuttle type [A]")
+		// Check start location and transition locations exist
+		var/found_current_location = FALSE
+		var/found_transition_location = FALSE
+		for(var/L in subtypesof(/obj/effect/shuttle_landmark))
+			var/obj/effect/shuttle_landmark/landmark = L
+			if(initial(landmark.landmark_tag) == initial(shuttle.current_location))
+				found_current_location = TRUE
+			if(initial(landmark.landmark_tag) == initial(shuttle.landmark_transition))
+				found_transition_location = TRUE
+
+		if(initial(shuttle.current_location) && !found_current_location)
+			log_unit_test("Failed to find 'current_location' landmark for [shuttle].")
+			failed++
+		if(initial(shuttle.landmark_transition) && !found_transition_location)
+			log_unit_test("Failed to find 'landmark_transition' landmark for [shuttle].")
+			failed++
+
+	if(failed)
+		fail("[failed] shuttle transition and start location landmarks were not found.")
+	else
+		pass("All shuttle transition and start location landmarks were found.")
+	return TRUE

--- a/html/changelogs/shuttle-move-times.yml
+++ b/html/changelogs/shuttle-move-times.yml
@@ -1,0 +1,7 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - tweak: "Reduced the dock/undock time of all small shuttles to 20s rather than 90s."
+  - bugfix: "Ships will stop moving across the overmap when they launch to dock/move to an away site."

--- a/maps/away/ships/biesel.dm
+++ b/maps/away/ships/biesel.dm
@@ -103,7 +103,7 @@
 	move_time = 90
 	shuttle_area = list(/area/shuttle/tcfl_shuttle)
 	current_location = "nav_hangar_tcfl"
-	landmark_transition = "nav_transit_tcfl"
+	landmark_transition = "nav_transit_tcfl_shuttle"
 	range = 1
 	fuel_consumption = 2
 	logging_home_tag = "nav_hangar_tcfl"

--- a/maps/away/ships/corporate.dm
+++ b/maps/away/ships/corporate.dm
@@ -230,7 +230,7 @@
 	move_time = 90
 	shuttle_area = list(/area/shuttle/ee_shuttle)
 	current_location = "nav_hangar_ee"
-	landmark_transition = "nav_transit_ee"
+	landmark_transition = "nav_transit_ee_shuttle"
 	range = 1
 	fuel_consumption = 2
 	logging_home_tag = "nav_hangar_ee"

--- a/maps/away/ships/sol.dm
+++ b/maps/away/ships/sol.dm
@@ -103,7 +103,7 @@
 	move_time = 90
 	shuttle_area = list(/area/shuttle/sfa_shuttle)
 	current_location = "nav_hangar_sfa"
-	landmark_transition = "nav_transit_sfa"
+	landmark_transition = "nav_transit_sfa_shuttle"
 	range = 1
 	fuel_consumption = 2
 	logging_home_tag = "nav_hangar_sfa"


### PR DESCRIPTION
Fixes #13572

- Adds a unit test that checks for some shuttle mapping mistakes, like those fixed in #13563
- When you launch to dock/move to an away-site, your ship's speed will go to zero so you're not moving across the overmap for the 20s until you actually dock.