### PR TITLE
Zeng-Hu & Zavod xenobiologists are now xenobiologists not scientists

### DIFF
--- a/code/game/jobs/faction/zavodskoi.dm
+++ b/code/game/jobs/faction/zavodskoi.dm
@@ -70,7 +70,7 @@
 		"Security Cadet" = /datum/outfit/job/intern_sec/zavodskoi,
 		"Investigator" =/datum/outfit/job/forensics/zavodskoi,
 		"Scientist" = /datum/outfit/job/scientist/zavodskoi,
-		"Xenobiologist" = /datum/outfit/job/scientist/zavodskoi/xenobio,
+		"Xenobiologist" = /datum/outfit/job/scientist/xenobiologist/zavodskoi,
 		"Xenobotanist" = /datum/outfit/job/scientist/zavodskoi,
 		"Lab Assistant" = /datum/outfit/job/intern_sci/zavodskoi,
 		"Xenoarcheologist"= /datum/outfit/job/scientist/xenoarcheologist/zavodskoi,
@@ -118,7 +118,7 @@
 	id = /obj/item/card/id/zavodskoi
 	suit = null
 
-/datum/outfit/job/scientist/zavodskoi/xenobio
+/datum/outfit/job/scientist/xenobiologist/zavodskoi
 	name = "Xenobiologist - Zavodskoi Interstellar"
 
 	uniform = /obj/item/clothing/under/rank/scientist/xenobio/zavod

--- a/code/game/jobs/faction/zeng_hu.dm
+++ b/code/game/jobs/faction/zeng_hu.dm
@@ -53,8 +53,7 @@
 		"First Responder" = /datum/outfit/job/med_tech/zeng_hu,
 		"Medical Intern" = /datum/outfit/job/intern_med/zeng_hu,
 		"Scientist" = /datum/outfit/job/scientist/zeng_hu,
-		"Xenobiologist" = /datum/outfit/job/scientist/zeng_hu/xenobio,
-		"Xenobotanist" = /datum/outfit/job/scientist/zeng_hu,
+		"Xenobiologist" = /datum/outfit/job/scientist/xenobiologist/zeng_hu,
 		"Xenobotanist" = /datum/outfit/job/scientist/zeng_hu,
 		"Lab Assistant" = /datum/outfit/job/intern_sci/zeng_hu,
 		"Xenoarcheologist"= /datum/outfit/job/scientist/xenoarcheologist/zeng_hu,
@@ -112,12 +111,12 @@
 	id = /obj/item/card/id/zeng_hu
 	suit = null
 
-/datum/outfit/job/scientist/zeng_hu/xenobio
+/datum/outfit/job/scientist/xenobiologist/zeng_hu
 	name = "Xenobiologist - Zeng-Hu"
 
 	uniform = /obj/item/clothing/under/rank/scientist/xenobio/zeng
-	suit = /obj/item/clothing/suit/storage/toggle/labcoat/zavodskoi
-	id = /obj/item/card/id/zavodskoi
+	suit = /obj/item/clothing/suit/storage/toggle/labcoat/zeng/alt
+	id = /obj/item/card/id/zeng_hu
 	suit = null
 
 

--- a/html/changelogs/faction-xenobiologists.yml
+++ b/html/changelogs/faction-xenobiologists.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Zeng-hu and Zavodskoi Xenobiologists now have the proper access instead of Scientist access."


### PR DESCRIPTION
Fixes their access. They were a scientist subtype not an xenobiologist subtype.

Also the zeng-hu one had zavod gear.

Also zeng-hu had xenobotanist twice.