### PR TITLE
Shitcurity Typos

### DIFF
--- a/html/changelogs/ben10083-typos.yml
+++ b/html/changelogs/ben10083-typos.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - spellcheck: "Fixed typos in some airlocks in Security"

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -2104,7 +2104,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "prisonexit";
-	name = "Brig Exit";
+	name = "Brig Exterior";
 	req_access = list(2)
 	},
 /obj/machinery/door/firedoor,
@@ -14108,7 +14108,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "prisonentry";
-	name = "Brig Entry";
+	name = "Brig Interior";
 	req_access = list(2)
 	},
 /obj/machinery/door/blast/regular{
@@ -32666,10 +32666,6 @@
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "ucq" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Eqiuipment Room";
-	req_access = list(63)
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -32683,6 +32679,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Security Equipment Room";
+	req_access = list(63)
+	},
 /turf/simulated/floor/tiled,
 /area/security/main)
 "ucI" = (

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -10357,7 +10357,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
-	name = "Theorethical Training";
+	name = "Theoretical Training";
 	req_access = list(1)
 	},
 /turf/simulated/floor/tiled,


### PR DESCRIPTION
Fixed typos in Equipment room and Security Spawn Area, and while I was there, I renamed brig exit and entry to brig exterior and interior respectively 