### PR TITLE
Fix away shuttles eating the Horizon's hangar bay

### DIFF
--- a/html/changelogs/johnwildkins-hangarfix.yml
+++ b/html/changelogs/johnwildkins-hangarfix.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Fix away-ship shuttles taking parts of the Horizon with them back to space."

--- a/maps/sccv_horizon/code/sccv_horizon_overmap.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_overmap.dm
@@ -48,13 +48,13 @@
 	req_access = list(access_mining)
 
 /obj/effect/shuttle_landmark/horizon/nav1
-	name = "SCCV Horizon Navpoint #1"
+	name = "Port Hangar Bay 1"
 	landmark_tag = "nav_hangar_horizon_1"
 	base_turf = /turf/simulated/floor/plating
 	base_area = /area/hangar/auxiliary
 
 /obj/effect/shuttle_landmark/horizon/nav2
-	name = "SCCV Horizon Navpoint #2"
+	name = "Port Hangar Bay 2"
 	landmark_tag = "nav_hangar_horizon_2"
 	base_turf = /turf/simulated/floor/plating
 	base_area = /area/hangar/auxiliary

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -4151,7 +4151,7 @@
 	},
 /area/maintenance/wing/port/deck1)
 "dTk" = (
-/obj/effect/shuttle_landmark/horizon/nav1,
+/obj/effect/shuttle_landmark/horizon/nav2,
 /turf/simulated/floor/plating,
 /area/hangar/auxiliary)
 "dUK" = (
@@ -4555,7 +4555,10 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/aft)
 "ekm" = (
-/obj/effect/shuttle_landmark/horizon/nav2,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/shuttle_landmark/horizon/nav1,
 /turf/simulated/floor/plating,
 /area/hangar/auxiliary)
 "ekt" = (
@@ -51255,7 +51258,7 @@ moI
 moI
 moI
 moI
-moI
+ekm
 moI
 moI
 moI
@@ -51861,7 +51864,7 @@ bJa
 bJa
 bJa
 bJa
-dTk
+bJa
 bJa
 bJa
 lnk
@@ -53476,7 +53479,7 @@ moI
 nYD
 bJa
 bJa
-bJa
+dTk
 bJa
 bJa
 bJa
@@ -53881,10 +53884,10 @@ bJa
 bJa
 bJa
 bJa
-ekm
-bJa
 bJa
 pMP
+bJa
+bJa
 bJa
 bJa
 bJa


### PR DESCRIPTION
title
also renames the Hangar Bay landmarks to `Port Hangar Bay #` since they will have `SCCV Horizon` prepended to them by the overmap system