### PR TITLE
Adds notification to those with psionics when someone enters/exits Srom + animation for Srom exit

### DIFF
--- a/code/modules/shareddream/dream_entry.dm
+++ b/code/modules/shareddream/dream_entry.dm
@@ -19,10 +19,10 @@ var/list/dream_entries = list()
 			to_chat(bg, "<span class='warning'>Whilst in shared dreaming, you find it difficult to hide your secrets.</span>")
 			if(willfully_sleeping)
 				to_chat(bg, "To wake up, use the \"Awaken\" verb in the IC tab.")
-			for(var/mob/living/carbon/human/H in living_mob_list)
-				if(H.can_commune())
-					to_chat(H, SPAN_CULT("You sense an increase in the activity of Srom..."))
-					sound_to(H, sound('sound/effects/psi/power_used.ogg'))
+			for(var/thing in SSpsi.processing)
+				var/datum/psi_complexus/psi = thing
+				to_chat(psi.owner, SPAN_CULT("You sense an increase in the activity of Srom..."))
+				sound_to(psi.owner, sound('sound/effects/psi/power_used.ogg'))
 			log_and_message_admins("has entered the shared dream", bg)
 	// Does NOT
 	else
@@ -31,10 +31,10 @@ var/list/dream_entries = list()
 			if(willfully_sleeping && sleeping && stat == UNCONSCIOUS)
 				sleeping = 5
 				return
-			for(var/mob/living/carbon/human/H in living_mob_list)
-				if(H.can_commune())
-					to_chat(H, SPAN_CULT("You feel the activity of Srom decrease."))
-			log_and_message_admins("has left the shared dream",bg)
+			for(var/thing in SSpsi.processing)
+				var/datum/psi_complexus/psi = thing
+				to_chat(psi.owner, SPAN_CULT("You feel the activity of Srom decrease."))
+			log_and_message_admins("has left the shared dream", bg)
 			var/mob/living/brain_ghost/old_bg = bg
 			bg = null
 			vr_mob = null

--- a/code/modules/shareddream/dream_entry.dm
+++ b/code/modules/shareddream/dream_entry.dm
@@ -20,8 +20,8 @@ var/list/dream_entries = list()
 			if(willfully_sleeping)
 				to_chat(bg, "To wake up, use the \"Awaken\" verb in the IC tab.")
 			for(var/mob/living/carbon/human/H in living_mob_list)
-				if(H.can_commune() || H.psi)
-					to_chat(H, SPAN_CULT("You sense a presence entering Srom..."))
+				if(H.can_commune())
+					to_chat(H, SPAN_CULT("You sense an increase in the activity of Srom..."))
 					sound_to(H, sound('sound/effects/psi/power_used.ogg'))
 			log_and_message_admins("has entered the shared dream", bg)
 	// Does NOT
@@ -32,8 +32,8 @@ var/list/dream_entries = list()
 				sleeping = 5
 				return
 			for(var/mob/living/carbon/human/H in living_mob_list)
-				if(H.can_commune() || H.psi)
-					to_chat(H, SPAN_CULT("You feel a presence departing from the dream."))
+				if(H.can_commune())
+					to_chat(H, SPAN_CULT("You feel the activity of Srom decrease."))
 			log_and_message_admins("has left the shared dream",bg)
 			var/mob/living/brain_ghost/old_bg = bg
 			bg = null
@@ -47,7 +47,7 @@ var/list/dream_entries = list()
 				return_text = "You are ripped from the Srom as you return to the captivity of your own mind."
 
 			return_mob.ckey = old_bg.ckey
-			old_bg.show_message("<span class='notice'>[bg] fades as their connection is severed.</span>")
-			animate(old_bg, alpha=0, time = 200)
+			old_bg.visible_message("<span class='notice'>[old_bg] begins to fade as they depart from the dream...</span>")
+			animate(old_bg, alpha=0, time = 20)
 			QDEL_IN(old_bg, 20)
 			to_chat(return_mob, SPAN_WARNING("[return_text]"))

--- a/code/modules/shareddream/dream_entry.dm
+++ b/code/modules/shareddream/dream_entry.dm
@@ -19,6 +19,10 @@ var/list/dream_entries = list()
 			to_chat(bg, "<span class='warning'>Whilst in shared dreaming, you find it difficult to hide your secrets.</span>")
 			if(willfully_sleeping)
 				to_chat(bg, "To wake up, use the \"Awaken\" verb in the IC tab.")
+			for(var/mob/living/carbon/human/H in living_mob_list)
+				if(H.can_commune() || H.psi)
+					to_chat(H, SPAN_CULT("You sense a presence entering Srom..."))
+					sound_to(H, sound('sound/effects/psi/power_used.ogg'))
 			log_and_message_admins("has entered the shared dream", bg)
 	// Does NOT
 	else
@@ -27,6 +31,9 @@ var/list/dream_entries = list()
 			if(willfully_sleeping && sleeping && stat == UNCONSCIOUS)
 				sleeping = 5
 				return
+			for(var/mob/living/carbon/human/H in living_mob_list)
+				if(H.can_commune() || H.psi)
+					to_chat(H, SPAN_CULT("You feel a presence departing from the dream."))
 			log_and_message_admins("has left the shared dream",bg)
 			var/mob/living/brain_ghost/old_bg = bg
 			bg = null

--- a/html/changelogs/llywelwyn-srom-enterexit-announce.yml
+++ b/html/changelogs/llywelwyn-srom-enterexit-announce.yml
@@ -1,0 +1,6 @@
+author: Llywelwyn
+
+delete-after: True
+
+changes:
+  - rscadd: "Those with psionics now receive a notification when someone else enters or exits The Dream."

--- a/html/changelogs/llywelwyn-srom-enterexit-announce.yml
+++ b/html/changelogs/llywelwyn-srom-enterexit-announce.yml
@@ -3,4 +3,5 @@ author: Llywelwyn
 delete-after: True
 
 changes:
-  - rscadd: "Those with psionics now receive a notification when someone else enters or exits The Dream."
+  - rscadd: "Added notifications for Skrell/antags with psionics when someone enters or exits the dream."
+  - bugfix: "Now correctly displays a chat message and fading out animation for people exiting the dream."


### PR DESCRIPTION
rscadd: "Added notifications for Skrell/antags with psionics when someone enters or exits the dream."
bugfix: "Now correctly displays a chat message and fading out animation for people exiting the dream."

![image](https://i.imgur.com/lrqyMy9.gif)
![image](https://user-images.githubusercontent.com/82828093/164292190-4b36e34e-4b67-4638-a96a-38745237921d.png)
![image](https://user-images.githubusercontent.com/82828093/164292203-c93d2b8a-510a-4069-906b-1ac4d4a9b0de.png)

