### PR TITLE
Removes a Leftover DNA Injector

### DIFF
--- a/html/changelogs/genetics_oversight.yml
+++ b/html/changelogs/genetics_oversight.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Removes a human-to-monkey DNA injector from the NSS Aurora I map."

--- a/maps/away/romanovich/first_aurora.dmm
+++ b/maps/away/romanovich/first_aurora.dmm
@@ -4180,12 +4180,6 @@
 /obj/structure/girder,
 /turf/template_noop,
 /area/derelict/hallway/southwest)
-"nQ" = (
-/obj/structure/table/standard,
-/obj/item/dnainjector/h2m,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/derelict/hallway/southeast)
 "nR" = (
 /obj/item/device/flashlight/pen,
 /turf/simulated/floor/tiled/white,
@@ -46090,7 +46084,7 @@ mM
 jl
 jl
 jl
-nQ
+jn
 jx
 ij
 ij


### PR DESCRIPTION
title. removes a leftover DNA injector on the old NSS Aurora I map, as it was likely forgotten as an oversight, since genetics isn't part of the game anymore.