### PR TITLE
Horizon: The Re-Emergency Shuttering

### DIFF
--- a/html/changelogs/emergencyshutter_wickedcybs.yml
+++ b/html/changelogs/emergencyshutter_wickedcybs.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Adds in the missing emergency shutters and air alarms to all three decks of the Horizon."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -5053,6 +5053,7 @@
 	name = "Morgue Maintenance";
 	req_one_access = list(12,66)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/medical/morgue/lower)
 "eyI" = (
@@ -15138,6 +15139,10 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid)
+"ndp" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/wall,
+/area/maintenance/operations)
 "ndN" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -18563,9 +18568,22 @@
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion)
 "qns" = (
-/obj/effect/map_effect/wingrille_spawn/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/operations/lower/machinist)
+/area/maintenance/operations)
 "qnt" = (
 /obj/effect/floor_decal/corner/black/full,
 /turf/simulated/floor/tiled,
@@ -19395,6 +19413,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
+"qXU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/operations)
 "qXZ" = (
 /obj/structure/morgue,
 /turf/simulated/floor/tiled,
@@ -23871,6 +23894,7 @@
 	icon_state = "cobweb1"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/operations)
 "uZk" = (
@@ -25247,6 +25271,7 @@
 /area/operations/storage)
 "wmD" = (
 /obj/effect/map_effect/wingrille_spawn/reinforced/firedoor,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/morgue/lower)
 "wmL" = (
@@ -43712,7 +43737,7 @@ nPN
 emF
 usP
 usP
-usP
+qns
 mVX
 usP
 xRP
@@ -43914,7 +43939,7 @@ dgl
 nnw
 tJg
 aUC
-wqj
+qXU
 xrE
 nyY
 eBw
@@ -44116,7 +44141,7 @@ vqW
 nnw
 nnw
 nnw
-nnw
+ndp
 teb
 nyY
 uQa
@@ -44519,7 +44544,7 @@ gtS
 rtJ
 bdY
 nnw
-nnw
+ndp
 xhE
 jak
 nyY
@@ -44923,8 +44948,8 @@ arr
 vrm
 iDw
 iDw
-qns
-qns
+uWW
+uWW
 iDw
 iDw
 rgo

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -103,6 +103,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
+"aiG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port/deck1)
 "ajF" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -688,6 +704,24 @@
 	},
 /turf/simulated/floor/shuttle/dark_blue,
 /area/shuttle/escape_pod/pod4)
+"aHr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/research_port)
 "aHu" = (
 /obj/structure/shuttle_part{
 	icon = 'icons/turf/shuttles_unique/scc_shuttle_pieces.dmi';
@@ -984,6 +1018,7 @@
 	name = "Atmospherics Maintenance";
 	req_access = list(12,24)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "aUk" = (
@@ -1643,6 +1678,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
+"bwp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "bwN" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -2136,6 +2191,16 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
+"bQb" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos/propulsion)
 "bQh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -3419,6 +3484,16 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/control)
+"cZG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port/deck1)
 "dae" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -3917,6 +3992,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "dCe" = (
@@ -4355,6 +4433,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
+"dZQ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos/propulsion)
 "dZT" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/computer/cryopod{
@@ -4695,6 +4783,7 @@
 /obj/item/storage/briefcase,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/engineering/storage/lower)
 "emF" = (
@@ -5279,6 +5368,9 @@
 	dir = 4
 	},
 /obj/machinery/meter,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "eKi" = (
@@ -5534,9 +5626,16 @@
 /turf/space,
 /area/template_noop)
 "eTi" = (
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/tiled,
-/area/maintenance/wing/port/deck1)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28;
+	req_one_access = list(24,11,55)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos/propulsion/starboard)
 "eTJ" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -5677,6 +5776,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28;
+	req_one_access = list(24,11,55)
 	},
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
@@ -6096,6 +6200,7 @@
 	req_access = list(10)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "fox" = (
@@ -7059,6 +7164,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenoarch_atrium)
+"gbY" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28;
+	req_one_access = list(24,11,55)
+	},
+/turf/simulated/floor/plating,
+/area/engineering/storage/lower)
 "gcZ" = (
 /obj/machinery/button/remote/blast_door{
 	id = "shutters_custodialdesk";
@@ -7452,6 +7566,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "gsc" = (
@@ -7717,6 +7832,9 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/light/small/emergency{
 	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 28
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
@@ -8888,6 +9006,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
+"hIf" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port/deck1)
 "hIl" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/structure/railing/mapped{
@@ -9331,6 +9454,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "ibH" = (
@@ -9926,6 +10052,9 @@
 	dir = 6
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/deck1)
 "iFd" = (
@@ -11261,6 +11390,16 @@
 "jPp" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/isolation_c)
+"jQh" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos/propulsion/starboard)
 "jQQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -12300,6 +12439,18 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/starboard)
+"kLG" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28;
+	req_one_access = list(24,11,55)
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/gravity_gen)
 "kLR" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -12800,6 +12951,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/eva)
+"lkx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/wing/port/deck1)
 "llk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 9
@@ -13632,6 +13802,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/lattice/catwalk/indoor/grate/damaged,
 /obj/effect/decal/cleanable/greenglow,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/deck1)
 "lWd" = (
@@ -14385,6 +14556,10 @@
 "mGO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -15874,6 +16049,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28;
+	req_one_access = list(24,11,55)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/gravity_gen)
 "nTh" = (
@@ -16173,6 +16353,10 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/deck1)
+"ofy" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/wall,
+/area/maintenance/wing/port/deck1)
 "ohl" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small,
@@ -16314,6 +16498,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
+"oqO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port/deck1)
 "orq" = (
 /obj/structure/cable/green{
 	icon_state = "0-8"
@@ -18178,6 +18372,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/cobweb,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "qeY" = (
@@ -18675,6 +18872,7 @@
 	dir = 1;
 	name = "Excess Waste to Mix"
 	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "qBv" = (
@@ -19451,6 +19649,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/deck1)
 "riI" = (
@@ -20372,6 +20571,7 @@
 /area/rnd/test_range)
 "scW" = (
 /obj/effect/map_effect/wingrille_spawn/reinforced/firedoor,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/deck1)
 "sdP" = (
@@ -20563,6 +20763,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access = list(12,61)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "sll" = (
@@ -20661,6 +20862,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "srC" = (
@@ -24675,6 +24877,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/eva)
+"vUe" = (
+/obj/structure/railing/mapped,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port/deck1)
 "vUo" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -25048,6 +25258,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/deck1)
 "wnc" = (
@@ -25272,6 +25485,9 @@
 /obj/structure/closet/crate/bin,
 /obj/random/loot,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled{
 	dir = 5;
 	icon_state = "vault"
@@ -25297,6 +25513,9 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 8
+	},
+/obj/machinery/alarm{
+	pixel_y = 28
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion/starboard)
@@ -25929,6 +26148,9 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/light/small/emergency{
 	dir = 8
+	},
+/obj/machinery/alarm{
+	pixel_y = 28
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
@@ -36436,7 +36658,7 @@ hoV
 eSV
 eSV
 hTk
-pLU
+oqO
 xGF
 noz
 eSV
@@ -36824,7 +37046,7 @@ noz
 noz
 hTk
 hTk
-eTi
+aTR
 hTk
 hTk
 hTk
@@ -37030,7 +37252,7 @@ lEq
 gBl
 gBl
 gBl
-gBl
+cZG
 gBl
 gBl
 gBl
@@ -37430,7 +37652,7 @@ wtB
 phO
 phO
 wVV
-qBU
+aiG
 hdK
 bmx
 fif
@@ -38840,9 +39062,9 @@ eSV
 eSV
 eSV
 hTk
-wVV
+ofy
 dTe
-fif
+hIf
 scW
 qBU
 qdE
@@ -40859,7 +41081,7 @@ eSV
 eSV
 hTk
 hTk
-ePk
+lkx
 vjl
 lIg
 ege
@@ -42050,7 +42272,7 @@ mNU
 szM
 szM
 xQU
-nFs
+jQh
 sfF
 awJ
 uZU
@@ -42070,7 +42292,7 @@ kqk
 gBw
 idS
 jdP
-nBK
+bwp
 gtS
 mTZ
 wYE
@@ -42464,7 +42686,7 @@ awJ
 jZo
 uwB
 beF
-oAi
+gbY
 pfQ
 ldW
 dKB
@@ -43681,7 +43903,7 @@ nSt
 hAY
 pTT
 qyK
-lAU
+kLG
 qWf
 lAU
 aJA
@@ -44474,7 +44696,7 @@ mNU
 szM
 szM
 xQU
-vUo
+eTi
 sfF
 awJ
 cwa
@@ -51769,7 +51991,7 @@ juK
 bfA
 jOJ
 cxA
-pwd
+aHr
 fTy
 mVU
 wRE
@@ -52353,7 +52575,7 @@ dip
 uVL
 uVL
 gGE
-fCd
+dZQ
 uVL
 xtY
 tkS
@@ -53160,7 +53382,7 @@ wjY
 fWs
 fWs
 qxV
-fQk
+bQb
 hRF
 uVL
 eBj
@@ -56232,7 +56454,7 @@ rBp
 iTD
 pJx
 jPp
-aOv
+vUe
 ikm
 aYu
 lPW

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -16354,10 +16354,6 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/deck1)
-"ofy" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/wall,
-/area/maintenance/wing/port/deck1)
 "ohl" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small,
@@ -17096,23 +17092,6 @@
 "pdC" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_upload_foyer)
-"pdJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/operations)
 "pdL" = (
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 8
@@ -18581,8 +18560,21 @@
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion)
 "qns" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
-/turf/simulated/wall,
+/turf/simulated/floor/plating,
 /area/maintenance/operations)
 "qnt" = (
 /obj/effect/floor_decal/corner/black/full,
@@ -23888,7 +23880,6 @@
 	icon_state = "cobweb1"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/operations)
 "uZk" = (
@@ -39080,7 +39071,7 @@ eSV
 eSV
 eSV
 hTk
-ofy
+wVV
 dTe
 hIf
 scW
@@ -43730,7 +43721,7 @@ nPN
 emF
 usP
 usP
-pdJ
+qns
 mVX
 usP
 xRP
@@ -44537,7 +44528,7 @@ gtS
 rtJ
 bdY
 nnw
-qns
+nnw
 xhE
 jak
 nyY

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -15139,10 +15139,6 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid)
-"ndp" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/wall,
-/area/maintenance/operations)
 "ndN" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -17100,6 +17096,23 @@
 "pdC" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_upload_foyer)
+"pdJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/operations)
 "pdL" = (
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 8
@@ -18568,21 +18581,8 @@
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion)
 "qns" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/maintenance/operations)
 "qnt" = (
 /obj/effect/floor_decal/corner/black/full,
@@ -19413,11 +19413,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
-"qXU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/operations)
 "qXZ" = (
 /obj/structure/morgue,
 /turf/simulated/floor/tiled,
@@ -20594,7 +20589,6 @@
 /area/rnd/test_range)
 "scW" = (
 /obj/effect/map_effect/wingrille_spawn/reinforced/firedoor,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/deck1)
 "sdP" = (
@@ -25271,7 +25265,6 @@
 /area/operations/storage)
 "wmD" = (
 /obj/effect/map_effect/wingrille_spawn/reinforced/firedoor,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/morgue/lower)
 "wmL" = (
@@ -43737,7 +43730,7 @@ nPN
 emF
 usP
 usP
-qns
+pdJ
 mVX
 usP
 xRP
@@ -43939,7 +43932,7 @@ dgl
 nnw
 tJg
 aUC
-qXU
+wqj
 xrE
 nyY
 eBw
@@ -44141,7 +44134,7 @@ vqW
 nnw
 nnw
 nnw
-ndp
+nnw
 teb
 nyY
 uQa
@@ -44544,7 +44537,7 @@ gtS
 rtJ
 bdY
 nnw
-ndp
+qns
 xhE
 jak
 nyY

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -285,6 +285,7 @@
 	name = "Engineering Substation";
 	req_one_access = list(11,24)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
 "ahG" = (
@@ -1590,6 +1591,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/operations/storage)
 "aSO" = (
@@ -1860,6 +1862,7 @@
 	req_access = list(12)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/aux_atmospherics/deck_2/starboard)
 "aYf" = (
@@ -2353,6 +2356,7 @@
 /obj/item/material/shard{
 	icon_state = "medium"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/aux_atmospherics/deck_2/starboard)
 "boR" = (
@@ -2436,6 +2440,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port/far)
 "bpY" = (
@@ -2621,6 +2626,7 @@
 	name = "Engineering Substation";
 	req_one_access = list(11,24)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/wing_port)
 "bwR" = (
@@ -2963,6 +2969,16 @@
 "bHe" = (
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
+"bHm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aux_atmospherics/deck_2/starboard)
 "bHs" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/disposalpipe/segment{
@@ -4147,6 +4163,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(66)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/icu)
 "cxO" = (
@@ -4350,6 +4367,9 @@
 "cGd" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/window/reinforced,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "cGJ" = (
@@ -4870,6 +4890,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/aux_atmospherics/deck_2/starboard)
 "cYy" = (
@@ -6107,6 +6128,7 @@
 /area/security/lobby)
 "dLD" = (
 /obj/effect/map_effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/operations/break_room)
 "dLO" = (
@@ -6285,6 +6307,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port)
 "dUw" = (
@@ -6505,6 +6528,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_room)
+"ebQ" = (
+/obj/structure/lattice/catwalk/indoor/grate/damaged,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port/far)
 "ebR" = (
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck - Hallway 4";
@@ -6714,6 +6744,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "elh" = (
@@ -7064,6 +7095,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 2
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "evU" = (
@@ -7401,11 +7435,11 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/machinery/light/small/emergency{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	pixel_y = 28
+	},
+/obj/machinery/light/small/emergency{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/wing_port)
@@ -7803,6 +7837,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port/far)
 "eUY" = (
@@ -8486,10 +8521,24 @@
 "fnn" = (
 /turf/simulated/wall,
 /area/engineering/atmos/storage)
+"fns" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "fnB" = (
 /obj/machinery/computer/slot_machine,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
+"fnP" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/wing/port/far)
 "foc" = (
 /obj/effect/map_effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled,
@@ -8716,6 +8765,7 @@
 /area/medical/psych)
 "fuJ" = (
 /obj/effect/map_effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "fuX" = (
@@ -9399,6 +9449,7 @@
 	req_access = list(11)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "fQM" = (
@@ -9521,6 +9572,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/starboard)
 "fTZ" = (
@@ -10364,6 +10416,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "gsz" = (
@@ -10594,6 +10647,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28;
+	req_one_access = list(24,11,55)
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "gzg" = (
@@ -11009,6 +11067,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/wing/starboard)
+"gKh" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/wing/starboard/far)
 "gKt" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -11451,6 +11516,13 @@
 "gZt" = (
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
+"gZY" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/simulated/wall,
+/area/maintenance/wing/port/far)
 "hal" = (
 /obj/effect/floor_decal/corner_wide/yellow/full,
 /obj/machinery/button/remote/blast_door{
@@ -11883,6 +11955,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port/far)
 "hnP" = (
@@ -12092,6 +12165,7 @@
 	name = "Security Maintenance";
 	req_access = list(63)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/brig)
 "hsH" = (
@@ -17204,6 +17278,7 @@
 	name = "Engineering Substation";
 	req_one_access = list(11,24)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/wing_starboard)
 "kHS" = (
@@ -17397,6 +17472,13 @@
 "kPA" = (
 /turf/simulated/wall,
 /area/rnd/xenobiology/xenoflora)
+"kQA" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/ramp{
+	dir = 8
+	},
+/area/maintenance/wing/port/far)
 "kQS" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
@@ -17608,6 +17690,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(31)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/operations/storage)
 "kXU" = (
@@ -17894,6 +17977,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/medical)
+"lfF" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/starboard)
 "lga" = (
 /obj/machinery/door/window/eastright,
 /obj/machinery/light/small/emergency,
@@ -19205,6 +19295,14 @@
 	},
 /turf/simulated/wall,
 /area/maintenance/wing/port)
+"lVn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/wing/port/far)
 "lVG" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/tiled/dark,
@@ -19257,6 +19355,7 @@
 /area/rnd/research)
 "lXo" = (
 /obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "lXt" = (
@@ -19702,6 +19801,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "mjl" = (
@@ -20271,6 +20371,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(45)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/or1)
 "mEc" = (
@@ -20558,6 +20659,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port/far)
 "mMz" = (
@@ -20589,6 +20691,7 @@
 	name = "Medbay Substation";
 	req_one_access = list(11,24)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "mOp" = (
@@ -21605,6 +21708,7 @@
 	req_access = list(66);
 	req_one_access = null
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "noS" = (
@@ -21668,6 +21772,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "nqy" = (
@@ -21994,6 +22099,7 @@
 	name = "Engineering Substation";
 	req_one_access = list(11,24)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/wing_starboard)
 "nBD" = (
@@ -22105,6 +22211,7 @@
 /obj/effect/map_effect/wingrille_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/aux_atmospherics/deck_2/starboard)
 "nEx" = (
@@ -22212,6 +22319,7 @@
 /area/hallway/medical)
 "nJq" = (
 /obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "nJs" = (
@@ -22254,6 +22362,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "nLC" = (
@@ -23333,6 +23442,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port)
 "oyq" = (
@@ -23670,6 +23780,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(45)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/medical/or2)
 "oGp" = (
@@ -25115,6 +25226,7 @@
 	name = "Engineering Substation";
 	req_one_access = list(11,24)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
 "pAo" = (
@@ -26495,6 +26607,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port)
 "qsj" = (
@@ -26733,6 +26846,7 @@
 "qxK" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "qyh" = (
@@ -27174,6 +27288,7 @@
 /area/storage/primary)
 "qOt" = (
 /obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port/far)
 "qOM" = (
@@ -29072,13 +29187,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
 "rPp" = (
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/ramp{
-	dir = 8
-	},
-/area/maintenance/wing/port/far)
+/obj/effect/map_effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/starboard/far)
 "rPY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -29147,6 +29259,12 @@
 /obj/item/paper_bin,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
+"rRe" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/ramp{
+	dir = 8
+	},
+/area/maintenance/wing/port/far)
 "rSv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29650,6 +29768,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/aux_atmospherics/deck_2/starboard)
 "shi" = (
@@ -31367,6 +31486,7 @@
 	name = "Engineering Substation";
 	req_one_access = list(11,24)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/wing_port)
 "tlh" = (
@@ -31384,6 +31504,22 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/assembly/chargebay)
+"tmb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "tmG" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -32287,6 +32423,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "tOS" = (
@@ -33174,6 +33313,16 @@
 /obj/structure/lattice,
 /turf/simulated/open/airless,
 /area/horizonexterior)
+"upl" = (
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port/far)
 "upm" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -34093,6 +34242,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/tcommsat/mainlvl_tcomms__relay/second)
 "uNs" = (
@@ -34841,6 +34991,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port/far)
 "vpj" = (
@@ -35555,6 +35706,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(66)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/hallway/medical)
 "vLu" = (
@@ -35655,6 +35807,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/wing_starboard)
+"vOd" = (
+/obj/effect/map_effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port/far)
 "vOm" = (
 /obj/machinery/flasher{
 	id = "permflash";
@@ -37961,6 +38118,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "wTb" = (
@@ -37969,6 +38127,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
+"wTd" = (
+/obj/effect/floor_decal/corner/brown/diagonal,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/wing/starboard)
 "wTU" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -39550,6 +39716,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access = list(12,47)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
 "xSU" = (
@@ -39598,6 +39765,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/hallway/engineering)
 "xUW" = (
@@ -45649,7 +45817,7 @@ nox
 nox
 nox
 nox
-nox
+gKh
 atB
 nox
 nox
@@ -45845,15 +46013,15 @@ vcH
 vcH
 vcH
 wSG
-tGP
+rPp
 dEz
 dEz
-tGP
-tGP
-tGP
+rPp
+rPp
+rPp
 dEz
 dEz
-tGP
+rPp
 dEz
 dEz
 dEz
@@ -47879,7 +48047,7 @@ dEz
 uEg
 oKR
 fdF
-qxy
+bHm
 tND
 lVG
 fdF
@@ -50279,7 +50447,7 @@ qgN
 aOj
 ugZ
 oIL
-pGp
+wTd
 bmS
 aob
 xoW
@@ -55938,7 +56106,7 @@ rns
 gsX
 pfp
 jvV
-fsf
+lfF
 dIZ
 tSC
 nMp
@@ -66256,7 +66424,7 @@ uTr
 kGX
 wsW
 wsW
-kaT
+fns
 vNG
 xMV
 fpj
@@ -71312,7 +71480,7 @@ aUQ
 qsw
 fLi
 iwo
-ryu
+tmb
 tgp
 pXp
 kaT
@@ -72707,9 +72875,9 @@ mAO
 mAO
 mAO
 mAO
-kZj
-kZj
-dXB
+kQA
+rRe
+vOd
 iwo
 iwo
 iwo
@@ -72729,7 +72897,7 @@ pbM
 fuu
 lBd
 xpX
-jIj
+lVn
 svf
 mfN
 qgN
@@ -72930,7 +73098,7 @@ lBd
 pbM
 fuu
 fuu
-fuu
+gZY
 fuu
 agG
 kmx
@@ -73514,7 +73682,7 @@ qgN
 vnz
 lUA
 fuu
-qQs
+ebQ
 aIx
 rLg
 lBd
@@ -73934,7 +74102,7 @@ jpc
 eFS
 ueH
 fuu
-rPp
+kZj
 vYQ
 pcJ
 wId
@@ -74128,15 +74296,15 @@ eUX
 fuu
 fuu
 fuu
-dXB
+vOd
 fuu
-dXB
+vOd
 fuu
-dXB
+vOd
 fuu
-dXB
+vOd
 fuu
-oWu
+upl
 oWu
 pcJ
 wId
@@ -74937,9 +75105,9 @@ dXB
 tmO
 fKG
 xDA
+fnP
 ueH
-ueH
-dXB
+vOd
 lBd
 lBd
 lBd
@@ -75143,9 +75311,9 @@ ueH
 ueH
 fuu
 fuu
-dXB
-dXB
-dXB
+vOd
+vOd
+vOd
 fuu
 hnN
 fuu

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -3779,6 +3779,10 @@
 /obj/effect/landmark/engine_setup/filter,
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
+"cgw" = (
+/obj/effect/map_effect/wingrille_spawn/reinforced/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/starboard)
 "cgP" = (
 /turf/simulated/floor/tiled/freezer,
 /area/operations/break_room)
@@ -6134,8 +6138,7 @@
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "dLD" = (
-/obj/effect/map_effect/wingrille_spawn/reinforced,
-/obj/machinery/door/firedoor,
+/obj/effect/map_effect/wingrille_spawn/reinforced/firedoor,
 /turf/simulated/floor/tiled,
 /area/operations/break_room)
 "dLO" = (
@@ -8781,8 +8784,7 @@
 /turf/simulated/floor/carpet,
 /area/medical/psych)
 "fuJ" = (
-/obj/effect/map_effect/wingrille_spawn/reinforced,
-/obj/machinery/door/firedoor,
+/obj/effect/map_effect/wingrille_spawn/reinforced/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "fuX" = (
@@ -11686,7 +11688,7 @@
 /turf/simulated/floor/tiled,
 /area/teleporter)
 "hfh" = (
-/obj/effect/map_effect/wingrille_spawn/reinforced,
+/obj/effect/map_effect/wingrille_spawn/reinforced/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/locker_room)
 "hfm" = (
@@ -22224,10 +22226,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/engineering)
 "nDK" = (
-/obj/effect/map_effect/wingrille_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
+/obj/effect/map_effect/wingrille_spawn/reinforced/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/aux_atmospherics/deck_2/starboard)
 "nEx" = (
@@ -29204,8 +29205,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
 "rPp" = (
-/obj/effect/map_effect/wingrille_spawn/reinforced,
-/obj/machinery/door/firedoor,
+/obj/effect/map_effect/wingrille_spawn/reinforced/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "rPY" = (
@@ -35825,8 +35825,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/wing_starboard)
 "vOd" = (
-/obj/effect/map_effect/wingrille_spawn/reinforced,
-/obj/machinery/door/firedoor,
+/obj/effect/map_effect/wingrille_spawn/reinforced/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "vOm" = (
@@ -47240,7 +47239,7 @@ oIL
 fQn
 fsf
 oAL
-tGP
+rPp
 uOq
 uOq
 nsx
@@ -53697,7 +53696,7 @@ nlr
 sjT
 wOd
 oIL
-uRo
+cgw
 oIL
 nKK
 dKR
@@ -75118,7 +75117,7 @@ eED
 dFG
 xPm
 iZt
-dXB
+vOd
 tmO
 fKG
 xDA

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -5729,6 +5729,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
+"dzI" = (
+/obj/structure/railing/mapped,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "dzL" = (
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d3-1-f"
@@ -8695,6 +8702,16 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/engineering/tesla)
+"fsF" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port/far)
 "fsL" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -16016,13 +16033,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
-"jOC" = (
-/obj/structure/railing/mapped,
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
 "jOK" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -16722,11 +16732,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/conference)
-"kpm" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
 "kpC" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/aft)
@@ -17486,12 +17491,10 @@
 /turf/simulated/wall,
 /area/rnd/xenobiology/xenoflora)
 "kQA" = (
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/ramp{
-	dir = 8
-	},
-/area/maintenance/wing/port/far)
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "kQS" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
@@ -25471,16 +25474,6 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"pGP" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port/far)
 "pGX" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/floor_decal/industrial/loading/yellow{
@@ -67657,7 +67650,7 @@ uDd
 fqa
 uon
 cjX
-jOC
+dzI
 kaT
 kaT
 kaT
@@ -68870,7 +68863,7 @@ wlF
 vVL
 cjX
 bzh
-kpm
+kQA
 sYc
 sYc
 sYc
@@ -72899,7 +72892,7 @@ mAO
 mAO
 mAO
 mAO
-kQA
+rRe
 rRe
 vOd
 iwo
@@ -73715,7 +73708,7 @@ wBF
 iTh
 kPu
 wBF
-pGP
+fsF
 lBd
 lGm
 ulr

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -16016,6 +16016,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
+"jOC" = (
+/obj/structure/railing/mapped,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "jOK" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -16715,6 +16722,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/conference)
+"kpm" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "kpC" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/aft)
@@ -16875,6 +16887,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/conference)
 "kuG" = (
@@ -25458,6 +25471,16 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"pGP" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port/far)
 "pGX" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/floor_decal/industrial/loading/yellow{
@@ -26437,6 +26460,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port)
 "qkF" = (
@@ -67633,7 +67657,7 @@ uDd
 fqa
 uon
 cjX
-pXp
+jOC
 kaT
 kaT
 kaT
@@ -68846,7 +68870,7 @@ wlF
 vVL
 cjX
 bzh
-kaT
+kpm
 sYc
 sYc
 sYc
@@ -73691,7 +73715,7 @@ wBF
 iTh
 kPu
 wBF
-jVc
+pGP
 lBd
 lGm
 ulr

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -19216,6 +19216,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 2
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)
 "Tz" = (

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -43,6 +43,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access = list(12,61)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "ah" = (
@@ -2858,6 +2859,7 @@
 	req_access = list(66)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/hallway/medical/upper)
 "gw" = (
@@ -8655,6 +8657,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/maintenance/aux_atmospherics/deck_3)
 "tG" = (
@@ -13354,6 +13357,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/locker)
+"FV" = (
+/obj/effect/map_effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/maintenance/engineering_ladder)
 "FX" = (
 /obj/structure/bed/stool/chair/padded/brown,
 /obj/machinery/status_display{
@@ -14152,6 +14160,7 @@
 	req_one_access = list(12,61)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "HW" = (
@@ -15638,6 +15647,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access = list(12,61)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "Lk" = (
@@ -17444,6 +17454,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
 /turf/simulated/floor,
 /area/maintenance/aux_atmospherics/deck_3)
 "Pq" = (
@@ -20413,6 +20427,7 @@
 	req_one_access = list(12,61)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/maintenance/aux_atmospherics/deck_3)
 "WH" = (
@@ -42736,7 +42751,7 @@ Ol
 Ai
 hf
 lK
-lV
+FV
 El
 fJ
 fJ
@@ -43140,7 +43155,7 @@ qK
 Ai
 BM
 hn
-lV
+FV
 El
 fJ
 fJ


### PR DESCRIPTION
There's a critical lack of air alarms and emergency shutters on every deck, mostly in the Horizon's maintenance areas but in some public places too. It was concluded this couldn't really be an intentional design choice, as areas with the shutters and alarms were seemingly random, with some departments having doors with emergency shutters leading to maint contrasted to others with no such thing. It has to led to very catastrophic venting on a few rounds at this point.

To name an example. this open airlock here has no emergency shutter mapped in, so we had a round where deck one vented, which vented part of deck two, then someone had opened that airlock, and it stayed open and vented the rest of the area including the larger part of deck three due to the open floor plan.

![image](https://user-images.githubusercontent.com/52309324/164649009-e8f21917-1015-4e45-b4a8-f86728e80948.png)

This PR should add most everything that's missing.