### PR TITLE
Fixes the search warrant saying Nanotrasen Inc

### DIFF
--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -93,7 +93,7 @@
 		<HTML><HEAD><TITLE>Search Warrant: [activename]</TITLE></HEAD>
 		<BODY bgcolor='#FFFFFF'>
 		<font face="Verdana" color=black><font size = "1">
-		<center><large><b>NanoTrasen Inc.
+		<center><large><b>Stellar Corporate Conglomerate
 		<br>Civilian Branch of Operation</b></large>
 		<br>
 		<br><b>DIGITAL SEARCH WARRANT</b></center>

--- a/html/changelogs/KingOfThePing - 13615.yml
+++ b/html/changelogs/KingOfThePing - 13615.yml
@@ -1,0 +1,9 @@
+# Your name.
+author: KingOfThePing
+
+
+delete-after: True
+
+
+changes:
+  - tweak: "Tweaked the forgotten search warrant to also be in line with the current lore."


### PR DESCRIPTION
This PR also updates the search warrant to be compliant with the latest lore developments (read: scrubbing NT and Aurora from existence), since I forgor this the last time. 

Now both the search AND arrest warrant are in line with everything. 