### PR TITLE
Cigarettes no longer cause toxins

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -610,7 +610,7 @@
 	reagent_state = SOLID
 	color = "#333300"
 	taste_description = "cheap tobacco"
-	strength = 0.004
+	strength = 0
 	taste_mult = 10
 	var/nicotine = 0.2
 
@@ -621,14 +621,12 @@
 	name = "Earth Tobacco"
 	description = "Nicknamed 'Earth Tobacco', this plant is much higher quality than its spacefaring counterpart."
 	taste_description = "luxury tobacco"
-	strength = 0.002
 	nicotine = 0.5
 
 /decl/reagent/toxin/tobacco/fake
 	name = "Cheap Tobacco"
 	description = "This actually appears to be mostly ground up leaves masquerading as tobacco. There's maybe some nicotine in there somewhere..."
 	taste_description = "acrid smoke"
-	strength = 0.008
 	nicotine = 0.1
 
 /decl/reagent/toxin/tobacco/liquid

--- a/html/changelogs/doxxmedearly-cigarettetoxins.yml
+++ b/html/changelogs/doxxmedearly-cigarettetoxins.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Tobacco will no longer cause liver damage."


### PR DESCRIPTION
Fixes #13609 
(Updated desc, now with 100% more accurate info)
Mechanical organs were never meant to regenerate, and #13420 fixed this happening with livers. However, since they do not regenerate, the very small and usually insignificant level of toxins damaged caused by smoking will apparently kill those with mechanical levels in just a handful of smokes. 

This PR removes toxins from tobacco, since smoking is a fluff thing that should not be dealing damage. See reopening post for a better explanation. 