### PR TITLE
Evacuation should no longer stall

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -43,7 +43,6 @@ var/list/gamemode_cache = list()
 	var/traitor_scaling = 0 			//if amount of traitors scales based on amount of players
 	var/objectives_disabled = 0 			//if objectives are disabled or not
 	var/protect_roles_from_antagonist = 0// If security and such can be traitor/cult/other
-	var/continous_rounds = 0			// Gamemodes which end instantly will instead keep on going until the round ends by escape shuttle or nuke.
 	var/allow_Metadata = 0				// Metadata is supported.
 	var/popup_admin_pm = 0				//adminPMs to non-admins show in a pop-up 'reply' window when set to 1.
 	var/Ticklag = 0.4
@@ -710,9 +709,6 @@ var/list/gamemode_cache = list()
 
 				if("gateway_delay")
 					config.gateway_delay = text2num(value)
-
-				if("continuous_rounds")
-					config.continous_rounds = 1
 
 				if("ghost_interaction")
 					config.ghost_interaction = 1

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -174,12 +174,9 @@ var/datum/controller/subsystem/ticker/SSticker
 	if(force_end)
 		game_finished = TRUE
 		mode_finished = TRUE
-	else if(config.continous_rounds)
+	else
 		game_finished = (evacuation_controller.round_over() || mode.station_was_nuked)
 		mode_finished = (!post_game && mode.check_finished())
-	else
-		game_finished = (mode.check_finished() || (evacuation_controller.round_over() && evacuation_controller.emergency_evacuation)) || universe_has_ended
-		mode_finished = game_finished
 
 	if(!mode.explosion_in_progress && game_finished && (mode_finished || post_game))
 		current_state = GAME_STATE_FINISHED
@@ -227,19 +224,6 @@ var/datum/controller/subsystem/ticker/SSticker
 					to_world("<span class='notice'><b>An admin has delayed the round end</b></span>")
 			else if(!delay_notified)
 				to_world("<span class='notice'><b>An admin has delayed the round end</b></span>")
-
-	else if (mode_finished)
-		post_game = 1
-
-		mode.cleanup()
-
-		//call a transfer shuttle vote
-		spawn(50)
-			if(!round_end_announced && !config.continous_rounds) // Spam Prevention. Now it should announce only once.
-				to_world("<span class='danger'>The round has ended!</span>")
-				round_end_announced = 1
-				SSvote.autotransfer()
-
 	return 1
 
 /datum/controller/subsystem/ticker/proc/declare_completion()

--- a/code/game/gamemodes/borer/borer.dm
+++ b/code/game/gamemodes/borer/borer.dm
@@ -5,6 +5,5 @@
 	config_tag = "borer"
 	required_players = 15
 	required_enemies = 2
-	end_on_antag_death = FALSE
 	antag_tags = list(MODE_BORER)
 	votable = TRUE

--- a/code/game/gamemodes/burglars/burglars.dm
+++ b/code/game/gamemodes/burglars/burglars.dm
@@ -8,5 +8,4 @@
 	required_players = 4
 	round_description = "Something tiny is on the horizon! Is it the distance, or...?"
 	extended_round_description = "Two of the Orion Spur's best and brightest (or so they were told) have been tasked with burglarizing a station that will change the way capitalism grips this galaxy forever (or so they were told). It is up to the crew to repel them, and up to them to survive and possibly thrive."
-	end_on_antag_death = FALSE
 	antag_tags = list(MODE_BURGLAR)

--- a/code/game/gamemodes/changeling/helpers/changeling.dm
+++ b/code/game/gamemodes/changeling/helpers/changeling.dm
@@ -13,6 +13,5 @@
 	config_tag = "changeling"
 	required_players = 10
 	required_enemies = 1
-	end_on_antag_death = 1
 	antag_scaling_coeff = 8
 	antag_tags = list(MODE_CHANGELING)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -5,5 +5,4 @@
 	config_tag = "cult"
 	required_players = 9
 	required_enemies = 4
-	end_on_antag_death = FALSE
 	antag_tags = list(MODE_CULTIST)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -13,7 +13,6 @@ var/global/list/additional_antag_types = list()
 	var/max_players = 0			 			// Maximum players for round to start for secret voting. 0 means "doesn't matter"
 	var/required_enemies = 0                 // Minimum antagonists for round to start.
 	var/newscaster_announcements = null
-	var/end_on_antag_death = 0               // Round will end when all antagonists are dead.
 	var/ert_disabled = 0                     // ERT cannot be called.
 	var/deny_respawn = 0	                 // Disable respawn during this round.
 
@@ -335,17 +334,7 @@ var/global/list/additional_antag_types = list()
 	command_announcement.Announce("The presence of [pick(reasons)] in the region is tying up all available local emergency resources; emergency response teams cannot be called at this time, and post-evacuation recovery efforts will be substantially delayed.","Emergency Transmission")
 
 /datum/game_mode/proc/check_finished()
-	if(evacuation_controller.round_over() || station_was_nuked)
-		return 1
-	if(end_on_antag_death && antag_templates && antag_templates.len)
-		for(var/datum/antagonist/antag in antag_templates)
-			if(!antag.antags_are_dead())
-				return 0
-		if(config.continous_rounds)
-			evacuation_controller.auto_recall(1)
-			return 0
-		return 1
-	return 0
+	return evacuation_controller.round_over() || station_was_nuked
 
 /datum/game_mode/proc/cleanup()	//This is called when the round has ended but not the game, if any cleanup would be necessary in that case.
 	return

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -7,7 +7,6 @@
 	extended_round_description = "The galaxy is a place full of dangers, even the inner colonies are not free of such scourges. \
 	Raiders and pirates are a well-know threat in the inhabited space, and places such as space stations are easy targets \
 	for their greedy plans."
-	end_on_antag_death = 1
 	antag_tags = list(MODE_RAIDER)
 
 /datum/game_mode/heist/apprentices

--- a/code/game/gamemodes/loner/loner.dm
+++ b/code/game/gamemodes/loner/loner.dm
@@ -6,5 +6,4 @@
 	required_players = 5
 	round_description = "Does anyone else hear a whistling noise...?"
 	extended_round_description = "A lone operative with a very large brain plans on dropping in and paying the crew a visit."
-	end_on_antag_death = FALSE
 	antag_tags = list(MODE_LONER)

--- a/code/game/gamemodes/meme/meme.dm
+++ b/code/game/gamemodes/meme/meme.dm
@@ -7,7 +7,6 @@
 	config_tag = "meme"
 	required_players = 3
 	votable = 0 // temporarily disable this mode for voting
-	end_on_antag_death = 1
 
 	var/var/list/datum/mind/first_hosts = list()
 	var/var/list/assigned_hosts = list()

--- a/code/game/gamemodes/mixed/acolytes.dm
+++ b/code/game/gamemodes/mixed/acolytes.dm
@@ -5,6 +5,5 @@
 	config_tag = "acolytes"
 	required_players = 20
 	required_enemies = 6
-	end_on_antag_death = 0
 	antag_tags = list(MODE_BORER, MODE_CULTIST)
 	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/bughunt.dm
+++ b/code/game/gamemodes/mixed/bughunt.dm
@@ -5,7 +5,6 @@
 	config_tag = "bughunt"
 	required_players = 20
 	required_enemies = 6
-	end_on_antag_death = FALSE
 	antag_tags = list(MODE_BORER, MODE_MERCENARY)
 	require_all_templates = TRUE
 	votable = TRUE

--- a/code/game/gamemodes/mixed/crossfire.dm
+++ b/code/game/gamemodes/mixed/crossfire.dm
@@ -7,6 +7,5 @@
 	config_tag = "crossfire"
 	required_players = 25
 	required_enemies = 8
-	end_on_antag_death = 0
 	antag_tags = list(MODE_RAIDER, MODE_MERCENARY)
 	require_all_templates = 1

--- a/code/game/gamemodes/mixed/feeding.dm
+++ b/code/game/gamemodes/mixed/feeding.dm
@@ -5,7 +5,6 @@
 	config_tag = "feeding"
 	required_players = 20
 	required_enemies = 2
-	end_on_antag_death = 0
 	require_all_templates = 1
 	votable = 1
 	antag_tags = list(MODE_VAMPIRE, MODE_CHANGELING)

--- a/code/game/gamemodes/mixed/incursion.dm
+++ b/code/game/gamemodes/mixed/incursion.dm
@@ -5,6 +5,5 @@
 	extended_round_description = "Nanotrasen has been playing with fire, maybe a little visit will teach them a lesson."
 	required_players = 20
 	required_enemies = 6
-	end_on_antag_death = FALSE
 	antag_tags = list(MODE_MERCENARY, MODE_NINJA)
 	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/infestation.dm
+++ b/code/game/gamemodes/mixed/infestation.dm
@@ -5,7 +5,6 @@
 	config_tag = "infestation"
 	required_players = 15
 	required_enemies = 3
-	end_on_antag_death = 1
 	antag_tags = list(MODE_BORER, MODE_CHANGELING)
 	require_all_templates = 1
 	votable = 0

--- a/code/game/gamemodes/mixed/intrigue.dm
+++ b/code/game/gamemodes/mixed/intrigue.dm
@@ -5,6 +5,5 @@
 	config_tag = "intrigue"
 	required_players = 20
 	required_enemies = 3
-	end_on_antag_death = 0
 	antag_tags = list(MODE_NINJA, MODE_TRAITOR)
 	require_all_templates = 1

--- a/code/game/gamemodes/mixed/siege.dm
+++ b/code/game/gamemodes/mixed/siege.dm
@@ -5,6 +5,5 @@
 	extended_round_description = "Getting stuck between a rock and a hard place, maybe the nice visitors can help with your internal security problem?"
 	required_players = 25
 	required_enemies = 10
-	end_on_antag_death = 0
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST, MODE_MERCENARY)
 	require_all_templates = 1

--- a/code/game/gamemodes/mixed/towerdefense.dm
+++ b/code/game/gamemodes/mixed/towerdefense.dm
@@ -5,6 +5,5 @@
 	extended_round_description = "Nanotrasen has been playing with fire, maybe a big visit will teach them a lesson."
 	required_players = 30
 	required_enemies = 10
-	end_on_antag_death = FALSE
 	antag_tags = list(MODE_MERCENARY, MODE_RAIDER, MODE_NINJA)
 	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/traitorling.dm
+++ b/code/game/gamemodes/mixed/traitorling.dm
@@ -5,6 +5,5 @@
 	config_tag = "traitorling"
 	required_players = 10
 	required_enemies = 2
-	end_on_antag_death = 1
 	require_all_templates = 1
 	antag_tags = list(MODE_CHANGELING, MODE_TRAITOR)

--- a/code/game/gamemodes/mixed/veilparty.dm
+++ b/code/game/gamemodes/mixed/veilparty.dm
@@ -5,7 +5,6 @@
 	config_tag = "veilparty"
 	required_players = 15
 	required_enemies = 5
-	end_on_antag_death = 0
 	require_all_templates = 1
 	votable = 1
 	antag_tags = list(MODE_VAMPIRE, MODE_CULTIST)

--- a/code/game/gamemodes/mixed/visitors.dm
+++ b/code/game/gamemodes/mixed/visitors.dm
@@ -5,6 +5,5 @@
 	config_tag = "visitors"
 	required_players = 20
 	required_enemies = 3
-	end_on_antag_death = 0
 	antag_tags = list(MODE_TECHNOMANCER, MODE_NINJA)
 	require_all_templates = 1

--- a/code/game/gamemodes/ninja/ninja.dm
+++ b/code/game/gamemodes/ninja/ninja.dm
@@ -12,5 +12,4 @@
 	required_players = 15
 	max_players = 30
 	required_enemies = 2
-	end_on_antag_death = 0
 	antag_tags = list(MODE_NINJA)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -13,7 +13,6 @@ var/list/nuke_disks = list()
 	config_tag = "mercenary"
 	required_players = 15
 	required_enemies = 4
-	end_on_antag_death = 1
 	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station
 	var/syndies_didnt_escape = 0 //Used for tracking if the syndies got the shuttle off of the z-level
 	antag_tags = list(MODE_MERCENARY)

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -5,8 +5,6 @@
 	extended_round_description = "A revolution is in the early stages of formation, and a group of loyalists are rallying to oppose them."
 	required_players = 15
 	required_enemies = 6
-	auto_recall_shuttle = 0
-	end_on_antag_death = 0
 	antag_tags = list(MODE_REVOLUTIONARY, MODE_LOYALIST)
 	require_all_templates = 1
 	ert_disabled = TRUE

--- a/code/game/gamemodes/technomancer/technomancer.dm
+++ b/code/game/gamemodes/technomancer/technomancer.dm
@@ -10,5 +10,4 @@
 	max_players = 15
 	required_players = 5
 	required_enemies = 1
-	end_on_antag_death = 0
 	antag_tags = list(MODE_TECHNOMANCER)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -13,7 +13,6 @@
 	config_tag = "traitor"
 	required_players = 1
 	required_enemies = 1
-	end_on_antag_death = 1
 	antag_tags = list(MODE_TRAITOR)
 	antag_scaling_coeff = 8
 

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -7,6 +7,5 @@
 	config_tag = "vampire"
 	required_players = 2
 	required_enemies = 1
-	end_on_antag_death = 0
 	antag_scaling_coeff = 8
 	antag_tags = list(MODE_VAMPIRE)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -323,10 +323,6 @@ GATEWAY_DELAY 18000
 ## Remove the # to give assistants maint access.
 #ASSISTANT_MAINT
 
-## Remove the # to make rounds which end instantly (Rev, Wizard, Malf) to continue until the shuttle is called or the station is nuked.
-## Malf and Rev will let the shuttle be called when the antags/protags are dead.
-#CONTINUOUS_ROUNDS
-
 ## Uncomment to restrict non-admins from using humanoid alien races
 USEALIENWHITELIST
 

--- a/config/ut/config-db.txt
+++ b/config/ut/config-db.txt
@@ -318,10 +318,6 @@ GATEWAY_DELAY 18000
 ## Remove the # to give assistants maint access.
 #ASSISTANT_MAINT
 
-## Remove the # to make rounds which end instantly (Rev, Wizard, Malf) to continue until the shuttle is called or the station is nuked.
-## Malf and Rev will let the shuttle be called when the antags/protags are dead.
-#CONTINUOUS_ROUNDS
-
 ## Uncomment to restrict non-admins from using humanoid alien races
 USEALIENWHITELIST
 

--- a/config/ut/config-nodb.txt
+++ b/config/ut/config-nodb.txt
@@ -318,10 +318,6 @@ GATEWAY_DELAY 18000
 ## Remove the # to give assistants maint access.
 #ASSISTANT_MAINT
 
-## Remove the # to make rounds which end instantly (Rev, Wizard, Malf) to continue until the shuttle is called or the station is nuked.
-## Malf and Rev will let the shuttle be called when the antags/protags are dead.
-#CONTINUOUS_ROUNDS
-
 ## Uncomment to restrict non-admins from using humanoid alien races
 USEALIENWHITELIST
 

--- a/html/changelogs/no-continuous-rounds.yml
+++ b/html/changelogs/no-continuous-rounds.yml
@@ -1,0 +1,7 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Evacuations should no longer stall at the ends of certain round-types."
+  - tweak: "Removed continous rounds config option."


### PR DESCRIPTION
Evacuations were stalling on certain roundtypes where `end_on_antag_death` was `TRUE`. The evacuation was cancelling itself due to the victory conditions not being met.

This PR removes everything related to continuous rounds and antagonist death ending a round. Rounds should now only end if:

- Evacuation successfully happens.
- Ship is nuked.
- Admin makes it happen.

Should be accompanied by a config change to remove the `CONTINUOUS_ROUNDS` option.