### PR TITLE
Fixes away map selection not checking if the away site could spawn in that sector

### DIFF
--- a/maps/_common/mapsystem/map.dm
+++ b/maps/_common/mapsystem/map.dm
@@ -222,7 +222,7 @@
 		var/datum/map_template/ruin/away_site/site = SSmapping.away_sites_templates[site_name]
 		if (site.template_flags & TEMPLATE_FLAG_SPAWN_GUARANTEED)
 			guaranteed += site
-			if ((site.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES) && !(site.template_flags & TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED))
+			if ((site.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES) && !(site.template_flags & TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED) && (!(SSatlas.current_sector.name in site.sectors)))
 				available[site] = site.spawn_weight
 		else if (!(site.template_flags & TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED))
 			available[site] = site.spawn_weight

--- a/maps/_common/mapsystem/map.dm
+++ b/maps/_common/mapsystem/map.dm
@@ -222,9 +222,9 @@
 		var/datum/map_template/ruin/away_site/site = SSmapping.away_sites_templates[site_name]
 		if (site.template_flags & TEMPLATE_FLAG_SPAWN_GUARANTEED)
 			guaranteed += site
-			if ((site.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES) && !(site.template_flags & TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED) && (SSatlas.current_sector.name in site.sectors))
+			if ((site.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES) && !(site.template_flags & TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED))
 				available[site] = site.spawn_weight
-		else if (!(site.template_flags & TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED))
+		else if (!(site.template_flags & TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED) && (SSatlas.current_sector.name in site.sectors))
 			available[site] = site.spawn_weight
 		by_type[site.type] = site
 

--- a/maps/_common/mapsystem/map.dm
+++ b/maps/_common/mapsystem/map.dm
@@ -222,7 +222,7 @@
 		var/datum/map_template/ruin/away_site/site = SSmapping.away_sites_templates[site_name]
 		if (site.template_flags & TEMPLATE_FLAG_SPAWN_GUARANTEED)
 			guaranteed += site
-			if ((site.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES) && !(site.template_flags & TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED) && (!(SSatlas.current_sector.name in site.sectors)))
+			if ((site.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES) && !(site.template_flags & TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED) && (SSatlas.current_sector.name in site.sectors))
 				available[site] = site.spawn_weight
 		else if (!(site.template_flags & TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED))
 			available[site] = site.spawn_weight


### PR DESCRIPTION
This makes sure that away sites only spawns in the sectors they are meant to.