### PR TITLE
Removes one blast door from security

### DIFF
--- a/html/changelogs/remove-sec-blastdoor.yml
+++ b/html/changelogs/remove-sec-blastdoor.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - tweak: "Maintenance door by the Investigator's Office no longer has a blast-door, to allow access to security if the lockdown is triggered and no one is available to lift it."

--- a/html/changelogs/remove-sec-blastdoor.yml
+++ b/html/changelogs/remove-sec-blastdoor.yml
@@ -3,4 +3,4 @@ author: mikomyazaki
 delete-after: True
 
 changes:
-  - tweak: "Maintenance door by the Investigator's Office no longer has a blast-door, to allow access to security if the lockdown is triggered and no one is available to lift it."
+  - maptweak: "Maintenance door by the Investigator's Office no longer has a blast-door, to allow access to security if the lockdown is triggered and no one is available to lift it."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -3283,13 +3283,6 @@
 	name = "Security Maintenance";
 	req_access = list(63)
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "Security Lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
 /turf/simulated/floor,
 /area/security/investigations)
 "hu" = (


### PR DESCRIPTION
Requested by Mel. 
Removes the blast door to maintenance next to the Investigator's office. This seemed like the least important one.

Now the department is accessible during a lockdown (like medical is in a similar situation), which is apparently a problem during lowpop/medpop when there is no AI or HoS to lift the lockdown.