### PR TITLE
Deck 1 Security Checkpoint and Pilot Room QoL and Fixes Remap

### DIFF
--- a/html/changelogs/hangar_checkpoint_remap.yml
+++ b/html/changelogs/hangar_checkpoint_remap.yml
@@ -1,0 +1,7 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - maptweak: "Remaps the deck 1 security checkpoint."
+  - maptweak: "Remaps the deck 1 pilot room."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -32,16 +32,12 @@
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid)
 "acp" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline,
-/obj/structure/closet/secure_closet/pilot,
+/obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "acY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "adj" = (
 /obj/machinery/vending/vendors,
@@ -92,9 +88,8 @@
 /turf/simulated/floor/tiled,
 /area/hangar/auxiliary)
 "ahw" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/firealarm/west,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/eva)
 "aix" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -153,19 +148,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
 "akx" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/black{
-	dir = 9
+/obj/machinery/door/airlock/glass{
+	name = "Hangar Access";
+	req_one_access = list(12, 29, 31, 47, 67)
 	},
-/obj/effect/floor_decal/industrial/loading/yellow{
-	dir = 1
+/obj/machinery/door/blast/regular/open{
+	dir = 8;
+	id = "hangarlockdown";
+	name = "Hangar Lockdown"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
@@ -271,9 +266,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid)
 "apf" = (
-/obj/effect/floor_decal/industrial/loading/yellow{
-	dir = 1
-	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "aph" = (
@@ -417,16 +410,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "awf" = (
-/obj/structure/window/reinforced,
-/obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/ramp/bottom{
-	dir = 4
+/obj/effect/floor_decal/spline/plain{
+	dir = 5
 	},
+/turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "awo" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -438,6 +427,9 @@
 	},
 /obj/effect/floor_decal/corner/black{
 	dir = 9
+	},
+/obj/effect/floor_decal/industrial/loading/yellow{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
@@ -555,12 +547,14 @@
 /turf/simulated/floor/tiled,
 /area/hangar/auxiliary)
 "aCu" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
-	layer = 5
+	layer = 5;
+	id = "shutters_evarecharging";
+	name = "E.V.A. Recharging Shutter"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/eva)
 "aDj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -597,11 +591,12 @@
 /area/maintenance/operations)
 "aEl" = (
 /obj/effect/map_effect/wingrille_spawn/reinforced,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "hangarlockdown";
-	name = "Hangar Lockdown"
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "shutters_hangarseccp";
+	name = "Security Checkpoint Shutter"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/security/checkpoint)
 "aEn" = (
@@ -775,6 +770,16 @@
 "aJB" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
+"aKj" = (
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "shutters_hangarseccp";
+	name = "Security Checkpoint Shutter"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/map_effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/security/checkpoint)
 "aKn" = (
 /obj/effect/floor_decal/corner_wide/purple/diagonal,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -795,10 +800,12 @@
 /obj/machinery/alarm{
 	pixel_y = 28
 	},
-/obj/effect/floor_decal/corner/black{
-	dir = 4
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "shutters_hangardeskcpport";
+	name = "Security Checkpoint Shutter"
 	},
-/obj/item/device/radio/beacon,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "aLu" = (
@@ -919,13 +926,22 @@
 /turf/simulated/floor/tiled/white,
 /area/operations/lower/machinist)
 "aPY" = (
-/obj/structure/railing/mapped{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/railing/mapped,
-/obj/effect/floor_decal/corner/black/full,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "researchhangar";
+	name = "E.V.A. Recharging Shutters";
+	req_access = list(18);
+	dir = 1;
+	pixel_y = -25;
+	pixel_x = -7
+	},
 /turf/simulated/floor/tiled/dark,
-/area/hangar/intrepid)
+/area/rnd/eva)
 "aQr" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -1005,11 +1021,10 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/wing/port/deck1)
 "aUg" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
+/obj/structure/table/standard,
+/obj/item/material/ashtray/bronze,
 /turf/simulated/floor/tiled/dark,
-/area/hangar/control)
+/area/hangar/intrepid)
 "aUi" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -1359,6 +1374,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
+"bfL" = (
+/obj/effect/floor_decal/corner/black{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hangar/intrepid)
 "bfX" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
@@ -1656,7 +1686,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "bvL" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1756,6 +1786,7 @@
 	name = "E.V.A.";
 	req_one_access = list(18)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "bzv" = (
@@ -1763,7 +1794,8 @@
 /obj/effect/floor_decal/corner/black{
 	dir = 9
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/firealarm/east,
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "bAq" = (
@@ -1939,14 +1971,16 @@
 /area/operations/loading)
 "bEJ" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/power/apc/low{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
@@ -1983,8 +2017,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "bGQ" = (
 /obj/structure/cable{
@@ -2040,7 +2073,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access = list(73)
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "bIe" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2065,10 +2098,40 @@
 /turf/simulated/floor/plating,
 /area/hangar/auxiliary)
 "bKx" = (
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/steel,
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "shutters_hangardeskcpstarboard";
+	name = "Starboard Security Checkpoint Access Shutters";
+	pixel_y = -1;
+	pixel_x = -6;
+	req_access = list(63)
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "shutters_hangardeskcpport";
+	name = "Port Security Checkpoint Access Shutters";
+	pixel_y = -1;
+	pixel_x = 5;
+	req_access = list(63)
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "shutters_hangarseccpdesk";
+	name = "Desk Shutter";
+	dir = 4;
+	pixel_y = 10;
+	req_access = list(63);
+	pixel_x = -6
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "shutters_hangarseccpexternal";
+	name = "External Security Checkpoint Shutters";
+	dir = 4;
+	pixel_x = 5;
+	pixel_y = 10;
+	req_access = list(63)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
 "bKC" = (
@@ -2142,10 +2205,19 @@
 /turf/simulated/floor/tiled,
 /area/janitor)
 "bMO" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/camera/network/first_deck{
 	c_tag = "First Deck - Hangar 2";
 	dir = 4
+	},
+/obj/structure/bed/stool/chair{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_x = -28;
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
@@ -2682,6 +2754,12 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
+"coF" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hangar/intrepid)
 "cpf" = (
 /turf/simulated/floor/tiled,
 /area/operations/loading)
@@ -2737,13 +2815,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/loading/yellow{
-	dir = 4
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "shutters_hangardeskcpstarboard";
+	name = "Security Checkpoint Shutter"
 	},
-/obj/machinery/door/blast/regular/open{
-	id = "hangarlockdown";
-	name = "Hangar Lockdown"
-	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "crh" = (
@@ -2782,11 +2859,14 @@
 	},
 /area/crew_quarters/kitchen/freezer)
 "ctI" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
+/obj/effect/map_effect/wingrille_spawn/reinforced,
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "shutters_hangarseccpexternal";
+	name = "Security Checkpoint External Shutter"
 	},
-/turf/simulated/floor/tiled,
-/area/storage/eva)
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "ctM" = (
 /obj/effect/floor_decal/industrial/loading/yellow,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3209,9 +3289,10 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/ramp{
-	dir = 8
+/obj/effect/floor_decal/corner/black{
+	dir = 6
 	},
+/turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid/interstitial)
 "cOy" = (
 /obj/structure/cable/green{
@@ -3499,9 +3580,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "cZw" = (
-/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
-/area/hangar/control)
+/area/storage/eva)
 "cZG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3550,7 +3630,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "dee" = (
 /obj/structure/tank_wall{
@@ -3634,7 +3714,9 @@
 /obj/effect/floor_decal/corner/black{
 	dir = 10
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "dhX" = (
@@ -3752,6 +3834,7 @@
 	name = "E.V.A.";
 	req_one_access = list(18)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "dnJ" = (
@@ -3871,7 +3954,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "dsI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -3938,9 +4021,6 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenoarch_atrium)
 "dxv" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -4642,14 +4722,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "eeD" = (
 /obj/machinery/vending/wallmed1{
@@ -4728,20 +4807,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/hangar/port)
 "ejc" = (
-/obj/structure/table/reinforced/steel,
-/obj/machinery/door/window/brigdoor/westleft,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/door/blast/shutters/open{
-	dir = 2;
-	id = "1";
-	name = "shutter"
-	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor/eastleft{
-	name = "Arrivals Processing Desk"
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "shutters_hangarseccp";
+	name = "Security Checkpoint Shutter"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/map_effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
 /area/security/checkpoint)
 "ejL" = (
 /obj/machinery/power/smes/buildable{
@@ -5938,12 +6011,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
 "fbL" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/eva)
 "fcc" = (
 /obj/structure/table/standard,
@@ -6643,8 +6715,11 @@
 	dir = 4
 	},
 /obj/machinery/door/window/southright{
-	name = "Engineering Voidsuit";
-	req_one_access = list(11,24)
+	name = "Atmospherics Voidsuit";
+	req_access = list(24)
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/storage/eva)
@@ -7053,10 +7128,9 @@
 /turf/simulated/floor/tiled,
 /area/janitor)
 "fVD" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/eva)
 "fWp" = (
 /obj/structure/cable/green{
@@ -7151,7 +7225,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -7164,7 +7237,8 @@
 	name = "Hangar Lockdoor";
 	pixel_y = -32
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/photocopier,
+/turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "gal" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
@@ -7484,12 +7558,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/glass_command{
 	name = "Pilot Room";
 	req_one_access = list(73)
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "gnP" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
@@ -7624,7 +7697,6 @@
 /obj/structure/bed/stool/chair/office/bridge{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "gtE" = (
@@ -7903,8 +7975,10 @@
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid)
 "gDC" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate,
+/obj/structure/bed/stool/chair{
+	dir = 1
+	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "gDV" = (
@@ -7934,7 +8008,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "gEv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8073,7 +8147,7 @@
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "gKG" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -8112,6 +8186,9 @@
 /area/rnd/eva)
 "gOa" = (
 /obj/effect/floor_decal/corner/black{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -8618,7 +8695,10 @@
 	},
 /obj/machinery/door/window/southleft{
 	name = "Engineering Voidsuit";
-	req_one_access = list(11,24)
+	req_access = list(11)
+	},
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/storage/eva)
@@ -8835,7 +8915,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "hxh" = (
 /obj/structure/cable/green{
@@ -9113,14 +9193,13 @@
 	},
 /area/hangar/auxiliary)
 "hJx" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/eva)
 "hLq" = (
 /obj/structure/window/reinforced,
@@ -9283,11 +9362,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
 "hTa" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hangar/control)
+/obj/machinery/door/firedoor,
+/obj/effect/map_effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/storage/eva)
 "hTd" = (
 /obj/machinery/power/apc/super{
 	dir = 4;
@@ -9321,13 +9399,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/storage/lower)
 "hUk" = (
-/obj/structure/railing/mapped{
-	dir = 4
+/obj/effect/floor_decal/corner/black{
+	dir = 6
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/ramp/bottom,
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "hUt" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
@@ -9803,7 +9879,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "ipW" = (
 /obj/machinery/door/airlock/external{
@@ -9859,7 +9935,7 @@
 /obj/machinery/alarm{
 	pixel_y = 28
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "isL" = (
 /obj/machinery/computer/ship/sensors{
@@ -10015,9 +10091,6 @@
 /turf/simulated/floor/plating,
 /area/rnd/xenoarch_atrium)
 "iCI" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -10187,6 +10260,11 @@
 "iJM" = (
 /obj/effect/map_effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "shutters_hangarseccp";
+	name = "Security Checkpoint Shutter"
+	},
 /turf/simulated/floor/plating,
 /area/security/checkpoint)
 "iJR" = (
@@ -10594,15 +10672,10 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
-/obj/structure/closet/secure_closet/security,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/power/apc/low{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
@@ -10667,8 +10740,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/firealarm/north,
+/obj/effect/floor_decal/industrial/loading/yellow{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "jiS" = (
@@ -11701,7 +11778,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "kho" = (
 /obj/structure/cable/green{
@@ -11941,14 +12018,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "kru" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/black{
-	dir = 6
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
@@ -12501,6 +12575,11 @@
 	req_access = null;
 	req_one_access = list(31,48,26,67)
 	},
+/obj/machinery/door/blast/regular/open{
+	dir = 8;
+	id = "hangarlockdown";
+	name = "Hangar Lockdown"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "kMl" = (
@@ -12883,14 +12962,13 @@
 /turf/simulated/floor/plating,
 /area/hangar/auxiliary)
 "lfj" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/eva)
 "lfw" = (
 /obj/structure/cable/green{
@@ -12910,6 +12988,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/steel,
+/obj/item/device/flashlight/lamp,
+/obj/item/device/hand_labeler,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
 "lho" = (
@@ -13047,13 +13128,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/railing/mapped,
-/obj/structure/railing/mapped{
-	dir = 1
+/obj/effect/floor_decal/corner/black{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/ramp{
-	dir = 4
-	},
+/turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid/interstitial)
 "lnG" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -13782,7 +13860,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "lUT" = (
 /obj/structure/cable{
@@ -13852,9 +13930,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "lWu" = (
-/obj/structure/railing/mapped,
-/obj/structure/closet/crate/bin,
-/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "lWM" = (
@@ -13890,21 +13966,20 @@
 "lXZ" = (
 /obj/machinery/recharger/wallcharger{
 	layer = 3.3;
-	pixel_x = -1;
-	pixel_y = 24
+	pixel_y = 24;
+	pixel_x = 4
 	},
 /obj/machinery/recharger/wallcharger{
 	layer = 3.3;
-	pixel_x = -1;
-	pixel_y = 32
+	pixel_x = 4;
+	pixel_y = 33
 	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
@@ -14365,22 +14440,24 @@
 /area/hangar/auxiliary)
 "mvq" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_mining{
-	name = "Cargo Bay";
-	req_access = null;
-	req_one_access = list(31,48,26,67)
+/obj/machinery/door/airlock/glass{
+	name = "Hangar"
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 8;
+	id = "hangarlockdown";
+	name = "Hangar Lockdown"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "mwo" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/eva)
 "mwu" = (
 /obj/structure/window/reinforced,
@@ -14722,6 +14799,24 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
+"mMQ" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/loading/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hangar/intrepid)
 "mMR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15283,7 +15378,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "niw" = (
 /obj/structure/railing/mapped{
@@ -15389,11 +15484,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "nmQ" = (
 /obj/effect/floor_decal/corner/green{
@@ -15577,14 +15671,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/eva)
 "nup" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline,
 /obj/machinery/newscaster{
 	pixel_y = 30
 	},
-/obj/structure/closet/secure_closet/pilot,
+/obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "nvV" = (
@@ -15915,7 +16005,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "nMA" = (
 /obj/structure/cable/green{
@@ -16321,10 +16411,10 @@
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "ocy" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/device/flashlight/lamp,
-/obj/item/device/hand_labeler,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/item/modular_computer/console/preset/security{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
 "ocJ" = (
@@ -16492,9 +16582,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access = null
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
@@ -16638,9 +16725,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/closet/secure_closet/pilot,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "owP" = (
@@ -16651,10 +16737,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/operations)
 "owZ" = (
-/obj/effect/floor_decal/corner/black{
-	dir = 9
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "oxp" = (
@@ -17532,9 +17629,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/starboard)
 "pth" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
+/obj/effect/floor_decal/industrial/loading/yellow,
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "pvn" = (
@@ -17751,13 +17846,14 @@
 /obj/effect/floor_decal/corner/black{
 	dir = 6
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "pEl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "pEE" = (
 /obj/structure/cable/green{
@@ -18003,9 +18099,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/closet/secure_closet/pilot,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "pNN" = (
@@ -18202,11 +18297,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "pYy" = (
 /obj/machinery/washing_machine,
@@ -18400,9 +18494,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "qeD" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/structure/bed/stool/chair{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "qeG" = (
@@ -18549,20 +18646,19 @@
 /turf/simulated/wall,
 /area/maintenance/substation/supply)
 "qkk" = (
-/obj/effect/floor_decal/industrial/loading/yellow{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 2
-	},
-/obj/machinery/door/blast/regular/open{
-	id = "hangarlockdown";
-	name = "Hangar Lockdown"
 	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
 	name = "Hangar"
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "shutters_hangardeskcpstarboard";
+	name = "Security Checkpoint Shutter"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "qks" = (
@@ -19096,10 +19192,13 @@
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "qFy" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
+/obj/effect/floor_decal/corner/black{
+	dir = 9
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "qGG" = (
 /obj/structure/cable{
@@ -19346,6 +19445,13 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/button/remote/blast_door{
+	id = "shutters_hangarseccp";
+	name = "Security Checkpoint Shutters";
+	dir = 8;
+	pixel_x = 32;
+	req_access = list(63)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
 "qTC" = (
@@ -19576,14 +19682,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/deck1)
 "rbx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/storage/eva)
+/turf/simulated/floor/tiled/dark,
+/area/hangar/intrepid)
 "rbK" = (
 /obj/structure/tank_wall/nitrous_oxide{
 	density = 0;
@@ -20205,13 +20308,7 @@
 /turf/space/dynamic,
 /area/template_noop)
 "rEl" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/outline,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 22
@@ -20386,9 +20483,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "rPN" = (
-/obj/structure/railing/mapped,
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/floor_decal/industrial/outline/red,
+/obj/effect/map_effect/wingrille_spawn/reinforced,
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "shutters_hangarseccpexternal";
+	name = "Security Checkpoint External Shutter"
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "rPO" = (
@@ -21290,6 +21391,7 @@
 /obj/effect/floor_decal/corner/black{
 	dir = 6
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "sId" = (
@@ -21410,6 +21512,17 @@
 	},
 /obj/effect/floor_decal/corner/black{
 	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "researchhangar";
+	name = "E.V.A. Recharging Shutters";
+	pixel_x = 25;
+	req_access = list(18);
+	dir = 8;
+	pixel_y = 7
 	},
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
@@ -21722,7 +21835,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "tbP" = (
-/obj/effect/floor_decal/industrial/warning/corner,
 /obj/item/modular_computer/console/preset/civilian{
 	dir = 4
 	},
@@ -22150,20 +22262,21 @@
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/maintenance/hangar/port)
 "ttc" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
 /obj/item/modular_computer/console/preset/command{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "ttK" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/effect/map_effect/wingrille_spawn/reinforced,
+/obj/machinery/door/blast/shutters/open{
+	dir = 4;
+	id = "shutters_hangarseccp";
+	name = "Security Checkpoint Shutter"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/hangar/control)
+/turf/simulated/floor/plating,
+/area/security/checkpoint)
 "ttV" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -22229,7 +22342,9 @@
 /obj/effect/floor_decal/corner/black{
 	dir = 9
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "txk" = (
@@ -22491,8 +22606,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "tKE" = (
 /obj/effect/floor_decal/corner/green{
@@ -22693,9 +22807,7 @@
 	name = "Security Checkpoint";
 	req_access = list(63)
 	},
-/turf/simulated/floor/tiled/ramp{
-	dir = 4
-	},
+/turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
 "tTg" = (
 /obj/structure/cable/green{
@@ -22979,13 +23091,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
 "ufp" = (
-/obj/structure/table/reinforced/steel,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/security,
+/obj/machinery/alarm{
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
@@ -24002,9 +24114,6 @@
 /area/engineering/atmos/propulsion/starboard)
 "vai" = (
 /obj/effect/floor_decal/industrial/outline,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/structure/closet/secure_closet/pilot,
 /obj/machinery/power/apc/low{
 	dir = 1;
@@ -24060,8 +24169,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "vcF" = (
 /obj/structure/cable{
@@ -24121,7 +24229,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/storage/lower)
 "veU" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -24131,7 +24238,7 @@
 /obj/machinery/alarm{
 	pixel_y = 28
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/eva)
 "vfc" = (
 /obj/structure/table/rack,
@@ -24722,7 +24829,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -24740,7 +24846,7 @@
 	pixel_x = -8;
 	pixel_y = -24
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "vJy" = (
 /obj/machinery/artifact_analyser,
@@ -25219,6 +25325,22 @@
 /obj/structure/lattice/catwalk/indoor/grate/damaged,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/deck1)
+"wif" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2;
+	name = "Hangar"
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 2
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 8;
+	id = "shutters_hangardeskcpport";
+	name = "Security Checkpoint Shutter"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/hangar/intrepid)
 "wjp" = (
 /obj/machinery/door/window/eastright,
 /obj/structure/window/reinforced{
@@ -25559,7 +25681,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "wtB" = (
 /obj/structure/closet/crate/bin,
@@ -25624,10 +25746,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
 "wxC" = (
-/obj/item/modular_computer/console/preset/security{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/bed/stool/chair/office/dark,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
 "wzl" = (
@@ -25906,11 +26026,25 @@
 /turf/simulated/wall,
 /area/storage/eva)
 "wSd" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced/steel,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/door/window/brigdoor/northleft{
+	name = "Arrivals Checkpoint Processing Desk";
+	req_access = list(63)
+	},
+/obj/machinery/door/window/brigdoor/southleft{
+	name = "Arrivals Checkpoint Processing Desk";
+	req_access = list(63)
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "shutters_hangarseccpdesk";
+	name = "Security Checkpoint Desk Shutter"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/hangar/control)
+/area/security/checkpoint)
 "wSr" = (
 /obj/structure/tank_wall/carbon_dioxide{
 	density = 0;
@@ -26215,12 +26349,13 @@
 /turf/simulated/floor/tiled,
 /area/hangar/auxiliary)
 "xdE" = (
-/obj/structure/window/reinforced,
-/obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/ramp{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_command{
+	name = "E.V.A.";
+	req_one_access = list(18)
 	},
-/area/hangar/intrepid)
+/turf/simulated/floor/tiled/dark,
+/area/rnd/eva)
 "xdF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -26341,7 +26476,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenoarch_atrium)
 "xiQ" = (
-/obj/structure/bed/stool/chair/office/dark,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
@@ -26972,12 +27106,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/starboard)
 "xFo" = (
+/obj/effect/floor_decal/corner/black{
+	dir = 9
+	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/ramp/bottom,
+/turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "xFB" = (
 /obj/structure/table/steel,
@@ -27128,7 +27265,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/operations)
 "xLY" = (
-/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "xMa" = (
@@ -46033,8 +46174,8 @@ gTx
 jeS
 wuD
 omo
-kru
-hUk
+xVU
+xVU
 xVU
 pEO
 xVU
@@ -46234,7 +46375,7 @@ uCH
 uCH
 hId
 lCX
-xdE
+aHY
 lBY
 kEJ
 kEJ
@@ -46436,7 +46577,7 @@ uCH
 uCH
 pIf
 lCX
-awf
+aHY
 aUk
 iRC
 iRC
@@ -47040,7 +47181,7 @@ uqn
 gYZ
 voa
 bMO
-qtm
+aUg
 wuD
 aHY
 aUk
@@ -47241,7 +47382,7 @@ uqE
 yau
 mXP
 gkE
-mNH
+coF
 gDC
 wuD
 aHY
@@ -47443,7 +47584,7 @@ uWW
 iDw
 gFI
 gkE
-mNH
+awf
 qeD
 wuD
 mvq
@@ -47648,7 +47789,7 @@ rkQ
 pjy
 pjy
 pjy
-pjy
+hUk
 cFq
 oFN
 aRG
@@ -48250,11 +48391,11 @@ vDj
 cNp
 wuD
 jcZ
-owZ
+jqE
 bzv
 txa
-jqE
-jqE
+qFy
+bfL
 cFq
 ifJ
 rmT
@@ -48456,7 +48597,7 @@ ejc
 hdi
 crb
 qkk
-cFq
+wuD
 wuD
 aUk
 dFQ
@@ -48655,10 +48796,10 @@ bEJ
 gmL
 lgf
 bKx
-hdi
+aKj
 jgk
-uCH
-lWu
+rbx
+rPN
 aEn
 blb
 uKX
@@ -48857,7 +48998,7 @@ lXZ
 wKh
 xiQ
 wxC
-aEl
+wSd
 kLb
 uCH
 rPN
@@ -49062,7 +49203,7 @@ ocy
 aEl
 kLb
 uCH
-aHY
+rPN
 aUk
 iRC
 iRC
@@ -49262,9 +49403,9 @@ pSH
 qTf
 bpL
 aEl
-kLb
-uCH
-aHY
+mMQ
+cfg
+rPN
 aUk
 iRC
 iRC
@@ -49462,18 +49603,18 @@ wRE
 hdi
 tSX
 hdi
-hdi
+ttK
 hdi
 aKo
-uCH
-aHY
+wif
+wuD
 lBY
 jgf
 iRC
 nyl
-iRC
-iRC
 kMl
+uRt
+uRt
 uRt
 uRt
 jgf
@@ -49659,23 +49800,23 @@ oQa
 lWd
 cMq
 bOs
-wRE
+hTa
 ahw
 qDN
 hJx
-aCu
-pth
+xdE
+hYy
 xLY
-mXD
-uCH
-gOa
-aPY
-oFN
-uRt
-uRt
-uRt
-uRt
-qFy
+owZ
+rbx
+wuD
+wuD
+ctI
+ctI
+ctI
+ctI
+wuD
+wuD
 jKc
 vvU
 lBY
@@ -49869,13 +50010,13 @@ aCu
 pth
 xLY
 mXD
-uCH
+lWu
 kSq
 gOa
-esD
-esD
-wPD
-esD
+jqE
+jqE
+kru
+jqE
 awo
 akx
 ihC
@@ -50265,10 +50406,10 @@ gJN
 wtl
 nhw
 iph
-wRE
+hTa
 xNz
 gyj
-lfj
+aPY
 fQC
 qDq
 qpA
@@ -50464,10 +50605,10 @@ fTy
 als
 wRE
 gEb
-dlM
-rbx
+cZw
+gzQ
 lUu
-wRE
+hTa
 ocJ
 ocJ
 lfj
@@ -50485,8 +50626,8 @@ fox
 aWP
 acp
 gOe
+oEp
 rdU
-cZw
 nmF
 bHV
 wcz
@@ -50665,9 +50806,9 @@ pwd
 fTy
 fzA
 hzK
-ctI
-dlM
-rbx
+sOG
+cZw
+gzQ
 cPm
 wRE
 fQC
@@ -50687,8 +50828,8 @@ cBF
 aWP
 vai
 dxv
-ttK
-hTa
+oEp
+oEp
 vJe
 aWP
 htq
@@ -51070,7 +51211,7 @@ lvP
 mVU
 wRE
 hmn
-dlM
+cZw
 ded
 hwy
 rBI
@@ -51091,8 +51232,8 @@ weO
 aWP
 rEl
 iCI
-aUg
-wSd
+oEp
+oEp
 vcp
 aWP
 ksI
@@ -51272,7 +51413,7 @@ lvP
 mVU
 wRE
 fHn
-dlM
+cZw
 pEl
 hwy
 uHA
@@ -51292,8 +51433,8 @@ jcT
 kBF
 aWP
 nup
-oEp
 gua
+oEp
 gtt
 bGM
 lXa
@@ -51474,8 +51615,8 @@ lvP
 aNR
 wRE
 nMp
-dlM
-dlM
+cZw
+cZw
 dsG
 haj
 lvq


### PR DESCRIPTION
this PR remaps the deck 1 research E.V.A. and xenoarcheology area. this is part three of a three-part previous PR.

changes:
- remaps the deck 1 security checkpoint so it's actually usable as a checkpoint.
- the path from the auxiliary hangar to the checkpoint is now secure.
- access fixes and visual polish in E.V.A.
- makes the "mech bay" room next to the checkpoint's shutter actually openable.