### PR TITLE
Removes some duplicate clothing items from roundstart job uniforms

### DIFF
--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -57,7 +57,6 @@
 /datum/outfit/job/officer/idris
 	name = "Security Officer - Idris"
 
-	head = /obj/item/clothing/head/beret/security/idris/alt
 	uniform = /obj/item/clothing/under/rank/security/idris
 	id = /obj/item/card/id/idris/sec
 
@@ -81,7 +80,6 @@
 	uniform = /obj/item/clothing/under/rank/cadet/idris
 	id = /obj/item/card/id/idris/sec
 	suit = null
-	head = /obj/item/clothing/head/beret/security/idris/alt
 
 /datum/outfit/job/bartender/idris
 	name = "Bartender - Idris"

--- a/code/game/jobs/faction/zavodskoi.dm
+++ b/code/game/jobs/faction/zavodskoi.dm
@@ -85,7 +85,6 @@
 
 	uniform = /obj/item/clothing/under/rank/security/zavod
 	id = /obj/item/card/id/zavodskoi/sec
-	head = /obj/item/clothing/head/beret/security/zavodskoi/alt
 
 /datum/outfit/job/warden/zavodskoi
 	name = "Warden - Zavodskoi Interstellar"
@@ -100,7 +99,6 @@
 	uniform = /obj/item/clothing/under/rank/cadet/zavod
 	id = /obj/item/card/id/zavodskoi/sec
 	suit = null
-	head = /obj/item/clothing/head/beret/security/zavodskoi/alt
 
 /datum/outfit/job/forensics/zavodskoi
 	name = "Investigator - Zavodskoi Interstellar"

--- a/html/changelogs/omicega-fds9fds90fsdfsd.yml
+++ b/html/changelogs/omicega-fds9fds90fsdfsd.yml
@@ -1,0 +1,14 @@
+
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Removed redundant faction berets from certain job spawns. They still exist (and have always existed) in the faction section of the loadout as optional extras."


### PR DESCRIPTION
See title. For now, this is just some security berets, since those are the most obvious ones that I've kept noticing. I'm sick of spawning with two berets every round, and I don't want to give up the one with a custom name and description from my loadout panel either.