### PR TITLE
Fixes Double Fuel Usage in Shuttles

### DIFF
--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -20,8 +20,8 @@
 			fuel_port_in_area.parent_shuttle = src
 			fuel_ports += fuel_port_in_area
 
-/datum/shuttle/autodock/overmap/fuel_check()
-	if(!src.try_consume_fuel()) //insufficient fuel
+/datum/shuttle/autodock/overmap/fuel_check(var/check_only = FALSE) // "check_only" lets you check the fuel levels without using any.
+	if(!src.try_consume_fuel(check_only)) //insufficient fuel
 		for(var/area/A in shuttle_area)
 			for(var/mob/living/M in A)
 				M.show_message(SPAN_WARNING("You hear the shuttle engines sputter... perhaps it doesn't have enough fuel?"), 2,
@@ -69,7 +69,7 @@
 		return "None"
 	return "[waypoint_sector(next_location)] - [next_location]"
 
-/datum/shuttle/autodock/overmap/proc/try_consume_fuel() //returns 1 if sucessful, returns 0 if error (like insufficient fuel)
+/datum/shuttle/autodock/overmap/proc/try_consume_fuel(var/check_only = FALSE) //returns 1 if sucessful, returns 0 if error (like insufficient fuel)
 	if(!fuel_consumption)
 		return 1 //shuttles with zero fuel consumption are magic and can always launch
 	if(!fuel_ports.len)
@@ -92,6 +92,8 @@
 		var/fuel_available = FT.air_contents.get_by_flag(XGM_GAS_FUEL)
 		if(!fuel_available) // Didn't even have fuel.
 			continue
+		if(check_only)
+			return 1
 		if(fuel_available >= fuel_to_consume)
 			FT.remove_air_by_flag(XGM_GAS_FUEL, fuel_to_consume)
 			return 1 //ALL REQUIRED FUEL HAS BEEN CONSUMED, GO FOR LAUNCH!

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -85,19 +85,18 @@
 
 	moving_status = SHUTTLE_WARMUP
 	callHook("shuttle_moved", list(start_location,destination))
-
-	if(!fuel_check()) //fuel error (probably out of fuel) occured, so cancel the launch
-		var/datum/shuttle/autodock/S = src
-		if(istype(S))
-			S.cancel_launch(null)
-		return
-
 	if(sound_takeoff)
-		playsound(current_location, sound_takeoff, 50, 20, is_global = TRUE)
-
+		if(!fuel_check()) return
+		playsound(current_location, sound_takeoff, 25, 20, is_global = TRUE)
 	spawn(warmup_time*10)
 		if(moving_status == SHUTTLE_IDLE)
 			return	//someone cancelled the launch
+
+		if(!fuel_check()) //fuel error (probably out of fuel) occured, so cancel the launch
+			var/datum/shuttle/autodock/S = src
+			if(istype(S))
+				S.cancel_launch(null)
+			return
 
 		moving_status = SHUTTLE_INTRANSIT //shouldn't matter but just to be safe
 		attempt_move(destination)
@@ -111,19 +110,18 @@
 
 	moving_status = SHUTTLE_WARMUP
 	callHook("shuttle_moved", list(start_location, destination))
-
-	if(!fuel_check()) //fuel error (probably out of fuel) occured, so cancel the launch
-		var/datum/shuttle/autodock/S = src
-		if(istype(S))
-			S.cancel_launch(null)
-		return
-
 	if(sound_takeoff)
+		if(!fuel_check()) return
 		playsound(current_location, sound_takeoff, 50, 20, is_global = TRUE)
-
 	spawn(warmup_time*10)
 		if(moving_status == SHUTTLE_IDLE)
 			return	//someone cancelled the launch
+
+		if(!fuel_check()) //fuel error (probably out of fuel) occured, so cancel the launch
+			var/datum/shuttle/autodock/S = src
+			if(istype(S))
+				S.cancel_launch(null)
+			return
 
 		arrive_time = world.time + travel_time*10
 		moving_status = SHUTTLE_INTRANSIT

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -85,18 +85,19 @@
 
 	moving_status = SHUTTLE_WARMUP
 	callHook("shuttle_moved", list(start_location,destination))
+
+	if(!fuel_check()) //fuel error (probably out of fuel) occured, so cancel the launch
+		var/datum/shuttle/autodock/S = src
+		if(istype(S))
+			S.cancel_launch(null)
+		return
+
 	if(sound_takeoff)
-		if(!fuel_check()) return
-		playsound(current_location, sound_takeoff, 25, 20, is_global = TRUE)
+		playsound(current_location, sound_takeoff, 50, 20, is_global = TRUE)
+
 	spawn(warmup_time*10)
 		if(moving_status == SHUTTLE_IDLE)
 			return	//someone cancelled the launch
-
-		if(!fuel_check()) //fuel error (probably out of fuel) occured, so cancel the launch
-			var/datum/shuttle/autodock/S = src
-			if(istype(S))
-				S.cancel_launch(null)
-			return
 
 		moving_status = SHUTTLE_INTRANSIT //shouldn't matter but just to be safe
 		attempt_move(destination)
@@ -110,18 +111,19 @@
 
 	moving_status = SHUTTLE_WARMUP
 	callHook("shuttle_moved", list(start_location, destination))
+
+	if(!fuel_check()) //fuel error (probably out of fuel) occured, so cancel the launch
+		var/datum/shuttle/autodock/S = src
+		if(istype(S))
+			S.cancel_launch(null)
+		return
+
 	if(sound_takeoff)
-		if(!fuel_check()) return
 		playsound(current_location, sound_takeoff, 50, 20, is_global = TRUE)
+
 	spawn(warmup_time*10)
 		if(moving_status == SHUTTLE_IDLE)
 			return	//someone cancelled the launch
-
-		if(!fuel_check()) //fuel error (probably out of fuel) occured, so cancel the launch
-			var/datum/shuttle/autodock/S = src
-			if(istype(S))
-				S.cancel_launch(null)
-			return
 
 		arrive_time = world.time + travel_time*10
 		moving_status = SHUTTLE_INTRANSIT

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -86,7 +86,8 @@
 	moving_status = SHUTTLE_WARMUP
 	callHook("shuttle_moved", list(start_location,destination))
 	if(sound_takeoff)
-		if(!fuel_check()) return
+		if(!fuel_check(check_only = TRUE)) // Check for fuel, but don't use any.
+			return
 		playsound(current_location, sound_takeoff, 25, 20, is_global = TRUE)
 	spawn(warmup_time*10)
 		if(moving_status == SHUTTLE_IDLE)
@@ -111,7 +112,8 @@
 	moving_status = SHUTTLE_WARMUP
 	callHook("shuttle_moved", list(start_location, destination))
 	if(sound_takeoff)
-		if(!fuel_check()) return
+		if(!fuel_check(check_only = TRUE)) // Check for fuel, but don't use any.
+			return
 		playsound(current_location, sound_takeoff, 50, 20, is_global = TRUE)
 	spawn(warmup_time*10)
 		if(moving_status == SHUTTLE_IDLE)

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -86,7 +86,7 @@
 	moving_status = SHUTTLE_WARMUP
 	callHook("shuttle_moved", list(start_location,destination))
 	if(sound_takeoff)
-		if(!fuel_check(check_only = TRUE)) // Check for fuel, but don't use any.
+		if(!fuel_check(TRUE)) // Check for fuel, but don't use any.
 			return
 		playsound(current_location, sound_takeoff, 25, 20, is_global = TRUE)
 	spawn(warmup_time*10)
@@ -112,7 +112,7 @@
 	moving_status = SHUTTLE_WARMUP
 	callHook("shuttle_moved", list(start_location, destination))
 	if(sound_takeoff)
-		if(!fuel_check(check_only = TRUE)) // Check for fuel, but don't use any.
+		if(!fuel_check(TRUE)) // Check for fuel, but don't use any.
 			return
 		playsound(current_location, sound_takeoff, 50, 20, is_global = TRUE)
 	spawn(warmup_time*10)

--- a/html/changelogs/fix_double_fuel_usage.yml
+++ b/html/changelogs/fix_double_fuel_usage.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes shuttles using fuel twice."

--- a/html/changelogs/fix_double_fuel_usage.yml
+++ b/html/changelogs/fix_double_fuel_usage.yml
@@ -1,6 +1,0 @@
-author: SleepyGemmy
-
-delete-after: True
-
-changes:
-  - bugfix: "Fixes shuttles using fuel twice."


### PR DESCRIPTION
this PR fixes shuttles using twice the fuel they should have, i.e. once when launching and once when arriving. fixes #13646.

playtested and everything works.