### PR TITLE
Vaurca origin fixes

### DIFF
--- a/code/modules/background/origins/origins/vaurca/breeder/klax.dm
+++ b/code/modules/background/origins/origins/vaurca/breeder/klax.dm
@@ -14,9 +14,16 @@
 	possible_citizenships = list(CITIZENSHIP_KLAX)
 	possible_religions = list(RELIGION_PILOTDREAM)
 
+/decl/origin_item/origin/leto_b 
+	name = "Leto Brood" //jared?
+	desc = "The brood is mostly known for their archeological work and their production of k'ois in Pid, a moon near Tret."
+	possible_accents = list(ACCENT_KLAX, ACCENT_TTS)
+	possible_citizenships = list(CITIZENSHIP_KLAX)
+	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_PILOTDREAM, RELIGION_NONE)
+
 /decl/origin_item/origin/vedhra_b
 	name = "Vedhra Brood"
-	desc = "The brood is mostly known for their archeological work and their production of k'ois in Pid, a moon near Tret."
+	desc = "One of the youngest Vaurca Queens, Vedhra wishes to unite the Vaurca civilization under Preimminence. The brood is also known for their augments and fascination with the Unathi culture. As with most K'lax broods, they mainly reside in Tret."
 	possible_accents = list(ACCENT_KLAX, ACCENT_TTS)
 	possible_citizenships = list(CITIZENSHIP_KLAX)
 	possible_religions = list(RELIGION_PREIMMINENNCE)

--- a/code/modules/background/origins/origins/vaurca/cthur.dm
+++ b/code/modules/background/origins/origins/vaurca/cthur.dm
@@ -13,21 +13,21 @@
 	name = "C'thur Brood"
 	desc = "The brood of the High Queen C'thur. Due to the Queen's health, many remain near Diulszi."
 	possible_accents = list(ACCENT_CTHUR, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_JARGON, CITIZENSHIP_ERIDANI, CITIZENSHIP_CTHUR, CITIZENSHIP_NONE)
+	possible_citizenships = list(CITIZENSHIP_JARGON, CITIZENSHIP_ERIDANI, CITIZENSHIP_NONE)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)
 
 /decl/origin_item/origin/mouv
 	name = "Mouv Brood"
 	desc = "Her brood leads Vaurca scientific research in Skrellian space, and is also brokering deals with the Eridani Federation. She is also known for purchasing a portion of Einstein Engines."
 	possible_accents = list(ACCENT_CTHUR, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_JARGON, CITIZENSHIP_ERIDANI, CITIZENSHIP_CTHUR, CITIZENSHIP_NONE)
+	possible_citizenships = list(CITIZENSHIP_JARGON, CITIZENSHIP_ERIDANI, CITIZENSHIP_NONE)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)
 
 /decl/origin_item/origin/vytel
 	name = "Vytel Brood"
 	desc = "Known for upholding the law, Vytel is the Warrior brood of the C'thur. They are spread within Jargon space, the Eridani Federation, and the Corporate Reconstruction Zone."
 	possible_accents = list(ACCENT_CTHUR, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_JARGON, CITIZENSHIP_ERIDANI, CITIZENSHIP_CTHUR, CITIZENSHIP_NONE)
+	possible_citizenships = list(CITIZENSHIP_JARGON, CITIZENSHIP_ERIDANI, CITIZENSHIP_NONE)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)
 
 /decl/origin_item/origin/xetl

--- a/code/modules/background/origins/origins/vaurca/klax.dm
+++ b/code/modules/background/origins/origins/vaurca/klax.dm
@@ -15,7 +15,7 @@
 	name = "Zkaii Brood"
 	desc = "The new High Queen of the K'lax, the Zkaii Brood is often mocked for their eccentric Mother Dream religion. Many still remain within Tret and other Izweski territories."
 	possible_accents = list(ACCENT_KLAX, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_IZWESKI, CITIZENSHIP_KLAX)
+	possible_citizenships = list(CITIZENSHIP_IZWESKI)
 	possible_religions = list(RELIGION_PILOTDREAM)
 
 /decl/origin_item/origin/vetju
@@ -36,14 +36,14 @@
 	name = "Vedhra Brood"
 	desc = "One of the youngest Vaurca Queens, Vedhra wishes to unite the Vaurca civilization under Preimminence. The brood is also known for their augments and fascination with the Unathi culture. As with most K'lax broods, they mainly reside in Tret."
 	possible_accents = list(ACCENT_KLAX, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_IZWESKI, CITIZENSHIP_KLAX)
+	possible_citizenships = list(CITIZENSHIP_IZWESKI)
 	possible_religions = list(RELIGION_PREIMMINENNCE)
 
 /decl/origin_item/origin/tupii
 	name = "Tupii-K'lax Brood"
 	desc = "The old K'lax brood, reinvigorated by the newly elected Queen Tupii. While older generations retain many customs of Mother K'lax, Tupii has attempted to modernize the brood and prove their loyalty."
 	possible_accents = list(ACCENT_KLAX, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_IZWESKI, CITIZENSHIP_KLAX)
+	possible_citizenships = list(CITIZENSHIP_IZWESKI)
 	possible_religions = list(RELIGION_PREIMMINENNCE, RELIGION_HIVEPANTHEON)
 
 /decl/origin_item/origin/mikuetz

--- a/code/modules/background/origins/origins/vaurca/klax.dm
+++ b/code/modules/background/origins/origins/vaurca/klax.dm
@@ -34,7 +34,7 @@
 
 /decl/origin_item/origin/vedhra
 	name = "Vedhra Brood"
-	desc = "The brood is mostly known for their archeological work and their production of k'ois in Pid, a moon near Tret."
+	desc = "One of the youngest Vaurca Queens, Vedhra wishes to unite the Vaurca civilization under Preimminence. The brood is also known for their augments and fascination with the Unathi culture. As with most K'lax broods, they mainly reside in Tret."
 	possible_accents = list(ACCENT_KLAX, ACCENT_TTS)
 	possible_citizenships = list(CITIZENSHIP_IZWESKI, CITIZENSHIP_KLAX)
 	possible_religions = list(RELIGION_PREIMMINENNCE)
@@ -47,7 +47,7 @@
 	possible_religions = list(RELIGION_PREIMMINENNCE, RELIGION_HIVEPANTHEON)
 
 /decl/origin_item/origin/mikuetz
-	name = "Mi'kuetz Brood"
+	name = "Mi'kuetz"
 	desc = " A group of Queenless K'lax in the Moghesian Wasteland. They are known for their cheerfulness and their aid in the reconstruction of the Unathi home planet."
 	possible_accents = list(ACCENT_KLAX, ACCENT_TTS)
 	possible_citizenships = list(CITIZENSHIP_IZWESKI)

--- a/code/modules/background/origins/origins/vaurca/zora.dm
+++ b/code/modules/background/origins/origins/vaurca/zora.dm
@@ -14,35 +14,35 @@
 	name = "Zoleth Brood"
 	desc = "The Warrior brood of the Zo'ra, Zoleth is established in Caprice, Tau Ceti. Although feared as a warmonger, the Zoleth Brood is known for their diplomacy."
 	possible_accents = list(ACCENT_ZORA, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_BIESEL, CITIZENSHIP_ZORA)
+	possible_citizenships = list(CITIZENSHIP_BIESEL)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)
 
 /decl/origin_item/origin/scay
 	name = "Scay Brood"
 	desc = "The scientific brood of the Zo'ra, Scay is established in the Xerxes Biodome, New Gibson. The Queen is reluctant and eccentric, qualities shared with her brood."
 	possible_accents = list(ACCENT_ZORA, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_BIESEL, CITIZENSHIP_ZORA)
+	possible_citizenships = list(CITIZENSHIP_BIESEL)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)
 
 /decl/origin_item/origin/vaur
 	name = "Vaur Brood"
 	desc = "The brood of the current High Queen. While Queen Vaur now resides in Caprice, most of her subjects remain in Flagsdale, Mendell City."
 	possible_accents = list(ACCENT_ZORA, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_BIESEL, CITIZENSHIP_ZORA)
+	possible_citizenships = list(CITIZENSHIP_BIESEL)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)
 
 /decl/origin_item/origin/xakt
 	name = "Xakt Brood"
 	desc = "Located in Luthien, Tau Ceti, the brood is mostly Bound Workers in industrial roles."
 	possible_accents = list(ACCENT_ZORA, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_BIESEL, CITIZENSHIP_ZORA)
+	possible_citizenships = list(CITIZENSHIP_BIESEL)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)
 
 /decl/origin_item/origin/athvur
 	name = "Athvur Brood"
 	desc = "Athvur is a unique brood, as it has assimilated plenty of human customs. While the brood originally resided in Phoenixport, Biesel, they have relocated to Belle Côte."
 	possible_accents = list(ACCENT_ZORA, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_BIESEL, CITIZENSHIP_ZORA)
+	possible_citizenships = list(CITIZENSHIP_BIESEL)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)
 
 /decl/origin_item/origin/queenless

--- a/code/modules/background/origins/origins/vaurca/zora.dm
+++ b/code/modules/background/origins/origins/vaurca/zora.dm
@@ -39,7 +39,7 @@
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)
 
 /decl/origin_item/origin/athvur
-	name = "Athvur"
+	name = "Athvur Brood"
 	desc = "Athvur is a unique brood, as it has assimilated plenty of human customs. While the brood originally resided in Phoenixport, Biesel, they have relocated to Belle Côte."
 	possible_accents = list(ACCENT_ZORA, ACCENT_TTS)
 	possible_citizenships = list(CITIZENSHIP_BIESEL, CITIZENSHIP_ZORA)

--- a/html/changelogs/desven_vaurcaorfixes.yml
+++ b/html/changelogs/desven_vaurcaorfixes.yml
@@ -3,4 +3,5 @@ delete-after: True
 changes:
   - bugfix : "Fixed Vedhra's Brood description not properly showing."
   - bugfix : "Fixed some words in the Vaurca origins section."
+  - bugfix : "Fixed Leto Breeders not being able to select their citizenship."
   - rscdel : "Removed Hive citizenship for normal Vaurcae."

--- a/html/changelogs/desven_vaurcaorfixes.yml
+++ b/html/changelogs/desven_vaurcaorfixes.yml
@@ -1,0 +1,5 @@
+author: Desven
+delete-after: True
+changes:
+  - bugfix : "Fixed Vedhra's Brood description not properly showing."
+  - bugfix : "Fixed some words in the Vaurca origins section."

--- a/html/changelogs/desven_vaurcaorfixes.yml
+++ b/html/changelogs/desven_vaurcaorfixes.yml
@@ -3,3 +3,4 @@ delete-after: True
 changes:
   - bugfix : "Fixed Vedhra's Brood description not properly showing."
   - bugfix : "Fixed some words in the Vaurca origins section."
+  - rscdel : "Removed Hive citizenship for normal Vaurcae."


### PR DESCRIPTION
Some wrong description and words out of place. 

Also removed the Hive citizenship (made for Breeder consuls to spawn) from normal Vaurcae. 