### PR TITLE
Can apply tape to doors again & tape can cross lattices

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1252,7 +1252,7 @@ About the new airlock wires panel:
 			if(src.shock(user, 75))
 				return TRUE
 	if(istype(C, /obj/item/taperoll) || istype(C, /obj/item/rfd))
-		return TRUE
+		return
 	if(!istype(C, /obj/item/forensics))
 		src.add_fingerprint(user)
 	if (!repairing && (stat & BROKEN) && src.locked) //bolted and broken

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -138,7 +138,7 @@ var/list/tape_roll_applications = list()
 				can_place = 0
 			else
 				for(var/obj/O in cur)
-					if(!istype(O, /obj/item/tape) && O.density)
+					if(istype(O, /obj/structure/lattice) && (!istype(O, /obj/item/tape) && O.density))
 						can_place = 0
 						break
 			cur = get_step_towards(cur,end)

--- a/html/changelogs/tape-on-doors.yml
+++ b/html/changelogs/tape-on-doors.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - bugfix: "You can place tape on doors again."
+  - bugfix: "Tape can now cross lattices/gratings."

--- a/html/changelogs/tape-on-doors.yml
+++ b/html/changelogs/tape-on-doors.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "You can place tape on doors again."


### PR DESCRIPTION
Currently you can't put police/engineering tape on doors. It's due to #13571 putting in a TRUE where there shouldn't be.

Fixes #13644
Fixes #13678
Also allows tape to cross lattices/gratings.