### PR TITLE
Small tweak to the thruster piping.

### DIFF
--- a/html/changelogs/Leudoberct1-Nacellechanges.yml
+++ b/html/changelogs/Leudoberct1-Nacellechanges.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Leudoberct
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Alters the thruster nacelles to no longer pump cold phoron at roundstart, and predisposes the digital valves towards mixing."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -582,9 +582,9 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
+	dir = 1;
 	name = "Station Intercom (General)";
-	pixel_y = -25;
-	dir = 1
+	pixel_y = -25
 	},
 /turf/simulated/floor/tiled,
 /area/janitor)
@@ -1166,12 +1166,12 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/plasticflaps/airtight,
 /obj/machinery/door/window/southleft{
-	req_access = list(26);
-	name = "Mass Driver External Access"
+	name = "Mass Driver External Access";
+	req_access = list(26)
 	},
 /obj/machinery/door/window/northleft{
-	req_access = list(26);
-	name = "Mass Driver Internal Access"
+	name = "Mass Driver Internal Access";
+	req_access = list(26)
 	},
 /turf/simulated/floor/reinforced{
 	roof_type = null
@@ -1816,8 +1816,8 @@
 	id = "shutters_custodialgarage";
 	name = "Custodial Garage Shutters";
 	pixel_x = -25;
-	req_access = list(26);
-	pixel_y = 8
+	pixel_y = 8;
+	req_access = list(26)
 	},
 /obj/machinery/ringer_button{
 	id = "ringers_custodial";
@@ -2493,11 +2493,11 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/ringer{
-	name = "\improper Custodial ringer terminal";
-	id = "ringers_custodial";
 	department = "Custodial";
-	req_access = list(26);
-	pixel_y = -32
+	id = "ringers_custodial";
+	name = "\improper Custodial ringer terminal";
+	pixel_y = -32;
+	req_access = list(26)
 	},
 /turf/simulated/floor/tiled,
 /area/janitor)
@@ -4990,9 +4990,9 @@
 	dir = 6
 	},
 /obj/structure/sign/securearea{
+	desc = "A caution sign which reads 'DISPOSALS' and 'AUTHORIZED PERSONNEL ONLY'.";
 	name = "\improper DISPOSALS sign";
-	pixel_y = 32;
-	desc = "A caution sign which reads 'DISPOSALS' and 'AUTHORIZED PERSONNEL ONLY'."
+	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
@@ -6213,11 +6213,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/operations)
 "fnB" = (
-/obj/machinery/atmospherics/tvalve/digital{
-	dir = 4
-	},
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/tvalve/digital/bypass{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -6491,9 +6491,9 @@
 	dir = 1
 	},
 /obj/structure/sign/deathsposal{
-	pixel_y = 32;
+	desc = "A warning sign which reads 'DANGER: MASS DRIVER'.";
 	name = "\improper DANGER: MASS DRIVER sign";
-	desc = "A warning sign which reads 'DANGER: MASS DRIVER'."
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
@@ -6966,8 +6966,8 @@
 	dir = 10
 	},
 /obj/structure/sign/electricshock{
-	name = "\improper CAUTION: HEAVY MACHINERY IN USE sign";
 	desc = "A caution sign which reads 'CAUTION: HEAVY MACHINERY IN USE' and 'THIS EQUIPMENT STARTS AND STOPS AUTOMATICALLY.'.";
+	name = "\improper CAUTION: HEAVY MACHINERY IN USE sign";
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -7210,17 +7210,17 @@
 /obj/machinery/button/remote/blast_door{
 	id = "shutters_custodialdesk";
 	name = "Custodial Desk Shutter";
-	req_access = list(26);
 	pixel_x = 25;
-	pixel_y = -7
+	pixel_y = -7;
+	req_access = list(26)
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/button/remote/blast_door{
 	id = "shutters_custodialgarage";
 	name = "Custodial Garage Shutter";
-	req_access = list(26);
+	pixel_x = 25;
 	pixel_y = 8;
-	pixel_x = 25
+	req_access = list(26)
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/dark,
@@ -7390,8 +7390,8 @@
 	dir = 4
 	},
 /obj/machinery/light_switch{
-	pixel_y = -25;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = -25
 	},
 /turf/simulated/floor/tiled,
 /area/janitor)
@@ -13572,14 +13572,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/storage/eva)
 "lOi" = (
-/obj/machinery/atmospherics/tvalve/mirrored/digital{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/tvalve/mirrored/digital/bypass{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
@@ -14414,8 +14414,8 @@
 	dir = 10
 	},
 /obj/structure/sign/fire{
-	pixel_x = -32;
-	name = "\improper DANGER: COMBUSTION CHAMBER sign"
+	name = "\improper DANGER: COMBUSTION CHAMBER sign";
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
@@ -14653,8 +14653,8 @@
 	dir = 4
 	},
 /obj/structure/sign/fire{
-	pixel_x = 32;
-	name = "\improper DANGER: COMBUSTION CHAMBER sign"
+	name = "\improper DANGER: COMBUSTION CHAMBER sign";
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -15083,7 +15083,7 @@
 /turf/simulated/floor/plating,
 /area/rnd/xenoarch_atrium)
 "mYb" = (
-/obj/machinery/atmospherics/binary/passive_gate/on/output/max{
+/obj/machinery/atmospherics/binary/passive_gate{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -15322,9 +15322,9 @@
 	dir = 4
 	},
 /obj/structure/sign/fire{
-	pixel_y = 32;
+	desc = "A caution sign which reads 'PORT PROPULSION'.";
 	name = "\improper PORT PROPULSION sign";
-	desc = "A caution sign which reads 'PORT PROPULSION'."
+	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
@@ -15400,11 +15400,11 @@
 	dir = 9
 	},
 /obj/machinery/ringer{
-	name = "\improper Custodial ringer terminal";
-	id = "ringers_custodial";
 	department = "Custodial";
-	req_access = list(26);
-	pixel_x = -32
+	id = "ringers_custodial";
+	name = "\improper Custodial ringer terminal";
+	pixel_x = -32;
+	req_access = list(26)
 	},
 /obj/structure/coatrack{
 	pixel_x = -9
@@ -16224,8 +16224,8 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/shutters{
-	name = "\improper Viewing Shutter";
-	id = "shutters_disposals"
+	id = "shutters_disposals";
+	name = "\improper Viewing Shutter"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -16482,9 +16482,9 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/shutters{
-	name = "\improper Viewing Shutter";
+	dir = 4;
 	id = "shutters_disposals";
-	dir = 4
+	name = "\improper Viewing Shutter"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -17598,9 +17598,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/shutters{
-	name = "Custodial Desk Shutter";
 	dir = 4;
-	id = "shutters_custodialdesk"
+	id = "shutters_custodialdesk";
+	name = "Custodial Desk Shutter"
 	},
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -20981,15 +20981,15 @@
 /obj/machinery/button/mass_driver{
 	_wifi_id = "waste";
 	id = "waste";
-	pixel_y = 30;
 	name = "Mass Driver Activation";
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 30
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "waste";
-	pixel_y = 40;
 	name = "Mass Driver Blast Door";
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 40
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -21004,8 +21004,8 @@
 /obj/machinery/button/remote/blast_door{
 	id = "shutters_disposals";
 	name = "Viewing Shutters";
-	pixel_y = 40;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 40
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
@@ -24440,8 +24440,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access = list(29);
-	name = "Workshop Maintenance"
+	name = "Workshop Maintenance";
+	req_access = list(29)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
@@ -26097,9 +26097,9 @@
 /area/maintenance/operations)
 "wYp" = (
 /obj/structure/sign/fire{
-	pixel_y = 32;
+	desc = "A caution sign which reads 'STARBOARD PROPULSION'.";
 	name = "\improper STARBOARD PROPULSION sign";
-	desc = "A caution sign which reads 'STARBOARD PROPULSION'."
+	pixel_y = 32
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -27162,7 +27162,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "xMr" = (
-/obj/machinery/atmospherics/binary/passive_gate/on/output/max{
+/obj/machinery/atmospherics/binary/passive_gate{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,


### PR DESCRIPTION
Currently, at roundstart, the port nacelle begins with cold phoron being pumped directly into the thrusters, and the starboard nacelle starts with a regulator open to the thruster, meaning that if you mix it as if using the burn chamber (as is the normal procedure), it is being sent to the starboard thrusters before you can ignite it.

This change will deactivate both regulators on the starboard and port nacelles, and also change the valves present to be predisposed towards using the burn chamber provided for better fuelling of the thrusters.

Playtested with no issues occurring.

Pictures of the changes:

Port nacelle - https://i.imgur.com/kyTfgnw.png
Starboard nacelle - https://i.imgur.com/cxolDiO.png