### PR TITLE
Bridge Camera Fix

### DIFF
--- a/html/changelogs/Huntime - BridgeCameraFix.yml
+++ b/html/changelogs/Huntime - BridgeCameraFix.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "I am an idiot and forgot that cameras are personally defined in var not by area."
+  - bugfix: "Bridge cameras are now properly defined."

--- a/html/changelogs/Huntime - BridgeCameraFix.yml
+++ b/html/changelogs/Huntime - BridgeCameraFix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Huntime
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "I am an idiot and forgot that cameras are personally defined in var not by area."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -296,7 +296,7 @@
 	dir = 9
 	},
 /obj/machinery/camera/network/command{
-	c_tag = "AI Core - Third Deck Chamber Aft";
+	c_tag = "Bridge - Starboard 2";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -6082,6 +6082,9 @@
 	pixel_y = 30
 	},
 /obj/item/storage/secure/briefcase,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/crew_quarters/captain)
 "nA" = (
@@ -6571,6 +6574,10 @@
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
+/obj/machinery/camera/network/command{
+	dir = 1;
+	c_tag = "Bridge - Crewman Lockeroom"
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/bridge_crew)
 "oE" = (
@@ -6651,8 +6658,8 @@
 	dir = 8
 	},
 /obj/machinery/camera/network/command{
-	c_tag = "AI Core - Third Deck Chamber Port";
-	dir = 8
+	dir = 8;
+	c_tag = "Bridge - Center 1"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/ramp/bottom{
@@ -9147,7 +9154,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/network/command{
-	c_tag = "Bridge - Corridor Camera 2";
+	c_tag = "Bridge - Starboard 1";
 	dir = 4;
 	network = list("Command","Capt_Office")
 	},
@@ -9408,7 +9415,7 @@
 	},
 /obj/structure/flora/pottedplant/random,
 /obj/machinery/camera/network/command{
-	c_tag = "Bridge - Executive Officer's Quarters"
+	c_tag = "Bridge - Port 1"
 	},
 /obj/machinery/status_display{
 	layer = 4;
@@ -10748,8 +10755,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/network/command{
-	c_tag = "AI Core - Third Deck Chamber Aft";
-	dir = 1
+	dir = 1;
+	c_tag = "Bridge - Port 2"
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
@@ -11676,7 +11683,7 @@
 	},
 /obj/structure/flora/pottedplant/random,
 /obj/machinery/camera/network/command{
-	c_tag = "Bridge - Corridor Camera 1"
+	c_tag = "Bridge - Breakroom"
 	},
 /turf/simulated/floor/wood,
 /area/bridge/minibar)
@@ -13055,7 +13062,7 @@
 /area/security/vacantoffice)
 "Es" = (
 /obj/machinery/camera/network/command{
-	c_tag = "Bridge - Captain's Quarters"
+	c_tag = "Bridge - Captain's Office Aft"
 	},
 /obj/structure/bed/stool/chair/padded/beige{
 	dir = 4
@@ -13804,8 +13811,8 @@
 /obj/item/tape_roll,
 /obj/item/storage/toolbox/mechanical,
 /obj/machinery/camera/network/command{
-	c_tag = "AI Core - Third Deck Chamber Starboard";
-	dir = 4
+	dir = 4;
+	c_tag = "Bridge - Cockpit"
 	},
 /obj/item/device/multitool,
 /turf/simulated/floor/carpet/rubber,
@@ -13914,6 +13921,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -14183,8 +14193,8 @@
 	dir = 4
 	},
 /obj/machinery/camera/network/command{
-	c_tag = "AI Core - Third Deck Chamber Starboard";
-	dir = 4
+	dir = 4;
+	c_tag = "Bridge - Center 2"
 	},
 /turf/simulated/floor/tiled/ramp/bottom{
 	dir = 1
@@ -15126,8 +15136,8 @@
 	dir = 8
 	},
 /obj/machinery/camera/network/command{
-	c_tag = "AI Core - Third Deck Chamber Aft";
-	dir = 1
+	dir = 1;
+	c_tag = "Bridge - Captain's Office Fore"
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/structure/cable/green{
@@ -16839,6 +16849,10 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/machinery/camera/network/command{
+	dir = 1;
+	c_tag = "Bridge - Backroom"
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/aibunker)
 "MY" = (
@@ -16861,7 +16875,7 @@
 	dir = 9
 	},
 /obj/machinery/camera/network/command{
-	c_tag = "Bridge - Corridor Camera 1"
+	c_tag = "Bridge - Captain's Private Office 1"
 	},
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/wood,
@@ -17416,8 +17430,8 @@
 "Ok" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/machinery/camera/network/command{
-	c_tag = "AI Core - Third Deck Chamber Aft";
-	dir = 1
+	dir = 1;
+	c_tag = "Bridge - Captain's Private Office 2"
 	},
 /obj/structure/table/reinforced/wood,
 /obj/machinery/photocopier/faxmachine{
@@ -17714,6 +17728,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/ramp/bottom{
 	dir = 4
 	},
@@ -19797,9 +19812,6 @@
 "TA" = (
 /obj/structure/bed/stool/chair/office/bridge{
 	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /obj/machinery/button/remote/airlock{
 	desc = "A remote control-switch for the office door.";

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -19483,17 +19483,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
-"SF" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/door/airlock/glass_command{
-	id_tag = "";
-	name = "Bridge";
-	req_one_access = list(19,38)
-	},
-/turf/simulated/floor/tiled,
-/area/bridge)
 "SG" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
@@ -43886,7 +43875,7 @@ Qz
 HO
 Cg
 Ns
-SF
+tE
 uY
 tE
 GW


### PR DESCRIPTION
I am an idiot.
When the first PR broke, I added/changed camera locations, and forgot that each variable had to be defined and cameras were not organized per area. This has been fixed, all cameras have been given unique/proper names. I knew I would have forgotten something. This also fixes the darkness in the COs office.

- I am dumb
- It should be fixed
- Shoot me?