### PR TITLE
Fixes some badly mapped tank dispensers. Adds some phoron tanks to Ops Secure Storage.

### DIFF
--- a/html/changelogs/phoron-tanks.yml
+++ b/html/changelogs/phoron-tanks.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - maptweak: "Adds empty handheld phoron tanks to the dispenser in mining. There is another dispenser like that in atmospherics storage!"

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -65,10 +65,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "aau" = (
-/obj/structure/dispenser/oxygen{
-	phorontanks = 10
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/dispenser,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/storage)
 "aax" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -5897,6 +5897,8 @@
 	},
 /obj/item/stack/material/phoron,
 /obj/item/stack/material/phoron,
+/obj/item/tank/phoron,
+/obj/item/tank/phoron,
 /turf/simulated/floor/reinforced,
 /area/storage/secure)
 "dCa" = (

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -17284,12 +17284,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/vacantoffice2)
 "NX" = (
-/obj/structure/dispenser/oxygen{
-	phorontanks = 10
-	},
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
+/obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/aux_atmospherics/deck_3)
 "NY" = (


### PR DESCRIPTION
Some of the `/obj/structure/dispenser/oxygen` were map-var-edited to have phoron tanks like their parent `/obj/structure/dispenser` rather than just mapping the parent `/obj/structure/dispenser` so I fixed that and just replaced them with `/obj/structure/dispenser` or `/obj/structure/dispenser/oxygen` where appropriate.

Also added a couple of spare handheld phoron tanks to the Ops Secure Storage so they can use those phoron canisters they spawn with, and make it less likely someone can ground all the shuttles by stealing the phoron tanks.
