### PR TITLE
Removes the ability to print telecomms logs

### DIFF
--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -108,34 +108,6 @@
 
 					screen = 0
 
-			if("printlog")
-				var/start_point = 1
-				var/end_point = SelectedServer.log_entries.len
-				if(SelectedServer)
-					if(SelectedServer.log_entries.len)
-						start_point = input(usr, "Type the start address to print from, cancel to print full log.", "Start Address") as null|num
-						if(!isnum(start_point))
-							start_point = 1
-						else
-							end_point = input(usr, "Type the end address to print to, cancel to print full log.", "End Address") as null|num
-							if(!isnum(end_point))
-								end_point = 0
-					else
-						to_chat(usr, SPAN_WARNING("Cannot print from server that has no logs."))
-						return
-				else
-					to_chat(usr, SPAN_WARNING("Select a server before trying to print logs."))
-					return
-
-				if(!last_print_time || (last_print_time + 2 SECONDS < world.time))
-					last_print_time = world.time
-					var/obj/item/paper/P = new /obj/item/paper(get_turf(src), log_entries_to_text(SelectedServer, start_point, end_point), "[SelectedServer.id] Logs ([start_point] - [end_point])")
-					var/mob/M = usr
-					if(M)
-						M.put_in_hands(P)
-				else
-					to_chat(usr, SPAN_WARNING("Please wait before trying to print more logs."))
-
 	if(href_list["delete"])
 
 		if(!src.allowed(usr) && !emagged)

--- a/html/changelogs/revert-telecomms-logs.yml
+++ b/html/changelogs/revert-telecomms-logs.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - rscdel: "Removed telecomms logs printing feature until a better solution can be found for the lag it can cause."


### PR DESCRIPTION
Printing telecomms logs (originally added in #13422) can cause lag ( #13680 ) due to the way `strip_html_properly` works (it's extremely slow over large text). 

I implemented a much faster method with #13685 but it has some security concerns. So PRing a removal of this feature until I find a safe & faster way to do it. 

Fixes #13680