### PR TITLE
IV Drip Breath Mask Following and Crashing Removal

### DIFF
--- a/html/changelogs/ultimate_breath_mask_fix.yml
+++ b/html/changelogs/ultimate_breath_mask_fix.yml
@@ -1,0 +1,7 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - rscdel: "IV Drip no longer follows or crashes people with breath masks aren't adjacent to it. It instead retracts their breath mask without changing the wearer's location."
+  - tweak: "Rounded the IV Drip's tank pressure output when examined."


### PR DESCRIPTION
* Removes the IV Drip's ability to follow after people wearing the breath mask.
* Removes the IV Drip crashing when the person wearing the breath mask isn't adjacent to the IV Drip.
* Functionality replaced by the IV Drip simply retracting the breath mask back into itself.

The concept idea for that functionality was fundamentally flawed, and simply unsalvageable considering how bloated the code became when I tried to keep it in.

So that is being fully removed, and is getting replaced by the breath mask going back into the IV drip if the wearer isn't adjacent to it.