### PR TITLE
Increased economic modifier for Consulars and Reps

### DIFF
--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -8,7 +8,7 @@
 	spawn_positions = 1
 	supervisors = "company officials"
 	selection_color = "#6186cf"
-	economic_modifier = 7
+	economic_modifier = 15
 
 	minimum_character_age = 30
 
@@ -92,7 +92,7 @@
 	spawn_positions = 1
 	supervisors = "your embassy"
 	selection_color = "#6186cf"
-	economic_modifier = 7
+	economic_modifier = 15
 
 	minimum_character_age = 30
 

--- a/html/changelogs/Ben10083 - ILoveMoney.yml
+++ b/html/changelogs/Ben10083 - ILoveMoney.yml
@@ -10,4 +10,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Consulars and Representatives have had their allowances increased to allow them to spend more credits in pursuit of their superior's interests."
+  - tweak: "Consulars and Representatives have had their allowances increased to allow them to spend more credits in pursuit of their superior's interests."

--- a/html/changelogs/Ben10083 - ILoveMoney.yml
+++ b/html/changelogs/Ben10083 - ILoveMoney.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Consulars and Representatives have had their allowances increased to allow them to spend more credits in pursuit of their superior's interests."


### PR DESCRIPTION
Title

This was done with [this suggestion](https://forums.aurorastation.org/topic/17093-consular-officers-and-corporate-liasons-need) in mind, by increasing their modifier to encourage these roles to use their credits for RP purposes. (It was raised to around RD level)

![image](https://user-images.githubusercontent.com/91219575/165865707-bf718876-fc4c-41b7-a320-9b5498270e0b.png)
