### PR TITLE
Lung Rescue Surgery Fixes

### DIFF
--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -45,7 +45,7 @@
 		icon_state = dead_icon
 
 /obj/item/organ/internal/proc/surgical_fix(mob/user)
-	if(damage > min_broken_damage)
+	if(damage > min_broken_damage && !(status & ORGAN_ROBOT))
 		var/scarring = damage / max_damage
 		scarring = 1 - 0.5 * scarring ** 2 // Between ~15 and 50 percent loss.
 		var/new_max_dam = Floor(scarring * max_damage)
@@ -71,7 +71,10 @@
 		return ..() && !is_broken()
 
 /obj/item/organ/internal/proc/is_damaged()
-	return damage > 0
+	return damage > 0 || special_condition()
+
+/obj/item/organ/internal/proc/special_condition() // For unique conditions
+	return
 
 /obj/item/organ/internal/robotize(var/company = "Unbranded")
 	..()

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -370,6 +370,9 @@
 
 	return english_list(.)
 
+/obj/item/organ/internal/lungs/special_condition()
+	return rescued
+
 /obj/item/organ/internal/lungs/surgical_fix(mob/user)
 	..()
 	rescued = FALSE

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -34,8 +34,8 @@
 		return FALSE
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/is_organ_damaged = FALSE
-	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I.damage > 0)
+	for(var/obj/item/organ/internal/I in affected.internal_organs)
+		if(I.is_damaged())
 			is_organ_damaged = TRUE
 			break
 	return is_organ_damaged
@@ -52,7 +52,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
-		if(I && I.damage > 0 && !BP_IS_ROBOTIC(I) && (~I.status & ORGAN_DEAD || I.can_recover()))
+		if(I && I.is_damaged() && !BP_IS_ROBOTIC(I) && (~I.status & ORGAN_DEAD || I.can_recover()))
 			user.visible_message("[user] starts treating damage to [target]'s [I.name] with [tool_name].", \
 			"You start treating damage to [target]'s [I.name] with [tool_name]." )
 	target.custom_pain("The pain in your [affected.name] is living hell!",100, affecting = affected)
@@ -71,7 +71,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
-		if(I && I.damage > 0 && !BP_IS_ROBOTIC(I))
+		if(I && I.is_damaged() && !BP_IS_ROBOTIC(I))
 			if(I.status & ORGAN_DEAD && I.can_recover())
 				user.visible_message("<span class='notice'>\The [user] treats damage to [target]'s [I.name] with [tool_name], though it needs to be recovered further.</span>", \
 				"<span class='notice'>You treat damage to [target]'s [I.name] with [tool_name], though it needs to be recovered further.</span>" )
@@ -101,8 +101,8 @@
 		target.adjustToxLoss(10)
 		target.apply_damage(5, BRUTE, target_zone, 0, tool)
 
-	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I && I.damage > 0)
+	for(var/obj/item/organ/internal/I in affected.internal_organs)
+		if(I && I.is_damaged())
 			I.take_damage(dam_amt,0)
 
 /decl/surgery_step/internal/fix_organ_robotic //For artificial organs
@@ -122,8 +122,8 @@
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/is_organ_damaged = 0
-	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I.damage > 0 && I.robotic >= 2)
+	for(var/obj/item/organ/internal/I in affected.internal_organs)
+		if(I.is_damaged() && I.robotic >= 2)
 			is_organ_damaged = TRUE
 			break
 	return is_organ_damaged && IS_ORGAN_FULLY_OPEN
@@ -133,8 +133,8 @@
 		return
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
-	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I && I.damage > 0)
+	for(var/obj/item/organ/internal/I in affected.internal_organs)
+		if(I && I.is_damaged())
 			if(I.robotic >= 2)
 				user.visible_message("<b>[user]</b> starts mending the damage to [target]'s [I.name]'s mechanisms.", \
 					SPAN_NOTICE("You start mending the damage to [target]'s [I.name]'s mechanisms." ))
@@ -147,12 +147,12 @@
 		return
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 
-	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I && I.damage > 0)
+	for(var/obj/item/organ/internal/I in affected.internal_organs)
+		if(I && I.is_damaged())
 			if(I.robotic >= 2)
 				user.visible_message("<b>[user]</b> repairs [target]'s [I.name] with [tool].", \
 					SPAN_NOTICE("You repair [target]'s [I.name] with [tool].") )
-				I.damage = 0
+				I.surgical_fix(user)
 				if(istype(tool, /obj/item/stack/nanopaste))
 					var/obj/item/stack/nanopaste/nanopaste = tool
 					nanopaste.use(1)
@@ -169,7 +169,7 @@
 	target.adjustToxLoss(5)
 	target.apply_damage(5, BRUTE, target_zone, 0, tool, damage_flags = tool.damage_flags())
 
-	for(var/obj/item/organ/I in affected.internal_organs)
+	for(var/obj/item/organ/internal/I in affected.internal_organs)
 		if(I)
 			I.take_damage(rand(3,5),0)
 

--- a/html/changelogs/lung_rescue_surgery.yml
+++ b/html/changelogs/lung_rescue_surgery.yml
@@ -1,0 +1,7 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed being unable to fix rescued lungs surgically if they don't have any damage."
+  - bugfix: "Fixed being unable to fix rescued mechanical lungs at all."


### PR DESCRIPTION
* Fixes #13705
* Fixes being COMPLETELY unable to repair rescued mechanical lungs, therefore being forced to print another pair of lungs to replace the other.

Also, to note:
 * Organic and ASSISTED lungs are fixed with the Advanced Trauma Kit
 * Only FULLY MECHANICAL lungs need the nanopaste to fix