### PR TITLE
Removal of Autodrobes from the Horizon and Aurora + Spawn locker buffs

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -500,7 +500,7 @@
 			Debug("EP/([H]): Abort, H is AI.")
 			return EquipRank(H, rank, 1)
 
-	if(!current_map.command_spawn_enabled || spawning_at != "Arrivals Shuttle" && spawning_at != "Cryogenic Storage"  && spawning_at != "Living Quarters Lift")
+	if(!current_map.command_spawn_enabled || spawning_at != "Arrivals Shuttle" && spawning_at != "Cryogenic Storage")
 		return EquipRank(H, rank, 1)
 
 	if("Arrivals Shuttle" in current_map.allowed_spawns)
@@ -510,7 +510,7 @@
 
 	H.job = rank
 
-	if(spawning_at != "Arrivals Shuttle" && spawning_at != "Cryogenic Storage" && spawning_at != "Living Quarters Lift" || job.latejoin_at_spawnpoints)
+	if(spawning_at != "Arrivals Shuttle" && spawning_at != "Cryogenic Storage" || job.latejoin_at_spawnpoints)
 		return EquipRank(H, rank, 1)
 
 	var/list/spawn_in_storage = list()

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -500,7 +500,7 @@
 			Debug("EP/([H]): Abort, H is AI.")
 			return EquipRank(H, rank, 1)
 
-	if(!current_map.command_spawn_enabled || spawning_at != "Arrivals Shuttle" && spawning_at != "Cryogenic Storage")
+	if(!current_map.command_spawn_enabled || spawning_at != "Arrivals Shuttle")
 		return EquipRank(H, rank, 1)
 
 	if("Arrivals Shuttle" in current_map.allowed_spawns)
@@ -510,7 +510,7 @@
 
 	H.job = rank
 
-	if(spawning_at != "Arrivals Shuttle" && spawning_at != "Cryogenic Storage" || job.latejoin_at_spawnpoints)
+	if(spawning_at != "Arrivals Shuttle" || job.latejoin_at_spawnpoints)
 		return EquipRank(H, rank, 1)
 
 	var/list/spawn_in_storage = list()

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -76,5 +76,4 @@
 		if(!C.occupant)
 			C.set_occupant(victim, 1)
 			to_chat(victim, SPAN_NOTICE("You have arrived from the living quarters aboard the [current_map.full_name]."))
-			to_chat(victim, FONT_LARGE("<b>Your workplace attire is waiting for you at the nearest autodrobe vendor.</b>"))
 			return

--- a/html/changelogs/wickedcybs_nodrobe.yml
+++ b/html/changelogs/wickedcybs_nodrobe.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: WickedCybs
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "People using the living quarters lift don't need to use an autodrobe anymore. They've mastered the art of putting on their uniforms at home."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -24958,9 +24958,6 @@
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 1
 	},
-/obj/machinery/megavendor/vendor{
-	pixel_y = 16
-	},
 /obj/machinery/disposal/small/west{
 	pixel_y = -6
 	},

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -3783,7 +3783,9 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/machinery/megavendor/vendor,
+/obj/structure/closet/emcloset,
+/obj/item/crowbar/red,
+/obj/item/crowbar/red,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/cryo)
 "is" = (


### PR DESCRIPTION
The autodrobes have proven to be pretty unpopular and very confusing for players new to the server. They remain in the code, but I've done away with them on the Horizon and Aurora maps. If total removal from those maps isn't desired, I will instead opt for at least having the living quarter lifts not require it at the least.

I also put emergency toolboxes into the oxygen lockers at each spawn point. It was like this on the Aurora, but they lost these on the Horizon. It can be handy, as they contain radios and other emergency tools that can be useful if cryo for whatever reason is near a dangerous area.