### PR TITLE
Removes the Bubble Shield

### DIFF
--- a/html/changelogs/wickedcybs_nobubble.yml
+++ b/html/changelogs/wickedcybs_nobubble.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: WickedCybs
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "The Horizon's bubble shield has been removed."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -194,9 +194,7 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 5
 	},
-/obj/machinery/shield_gen{
-	anchored = 1
-	},
+/obj/item/modular_computer/console/preset/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/storage/shields)
 "av" = (
@@ -324,17 +322,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/storage/shields)
-"aJ" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/cyan{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/storage/shields)
 "aK" = (
 /obj/structure/grille,
 /obj/structure/window/shuttle/scc_space_ship,
@@ -379,12 +366,8 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/machinery/shield_capacitor/multiz{
-	anchored = 1;
+/obj/structure/bed/stool/chair/office/dark{
 	dir = 1
-	},
-/obj/structure/cable/cyan{
-	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/storage/shields)
@@ -14592,7 +14575,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/locker)
 "Ia" = (
-/obj/item/modular_computer/console/preset/engineering,
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
 	},
@@ -44835,7 +44817,7 @@ FH
 Eo
 bj
 RK
-aJ
+QM
 aR
 QH
 aW


### PR DESCRIPTION
Given the change to a ship, the bubble is kind of out of place and just way too strong and disruptive. Nobody can even get off any zlevel of the Horizon, mass drivers are affected, all hazards on the overmap are trivialized. The hull shield is more than strong enough vs something like meteors, so I see it as a relic of the Aurora that's better off gone. I mapped it out of the Horizon's shield room. The code is still present.