### PR TITLE
Adds Sec Newscaster to Warden's Office

### DIFF
--- a/html/changelogs/Ben10083 - WardenOffice.yml
+++ b/html/changelogs/Ben10083 - WardenOffice.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Replaces armory camera monitor in Warden's Office with a security newscaster, to allow the Warden to utilise newscaster options such as wanted notices."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -38395,12 +38395,10 @@
 /obj/item/modular_computer/console/preset/security{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen{
-	name = "Armory Cameras";
-	network = list("Armory");
-	pixel_x = 30
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 28
+	},
 /turf/simulated/floor/tiled,
 /area/security/warden)
 "wRk" = (


### PR DESCRIPTION
Title. Replaces armory camera monitor with Sec Newscaster. Warden can simply use the camera program if it wants to see said networks. Due to lack of space in Warden office I felt this was the best option.

Fixes https://github.com/Aurorastation/Aurora.3/issues/13718