### PR TITLE
Crew Armoury Maint Window Fix

### DIFF
--- a/html/changelogs/wickedcybs_wallfix.yml
+++ b/html/changelogs/wickedcybs_wallfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: WickedCybs
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Some walls in the maintenance behind the crew armoury were mapped inside of windows, so those were removed and replaced with emergency shutters as they had none. The passage also had a missing air alarm mapped in."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -338,7 +338,8 @@
 "aK" = (
 /obj/structure/grille,
 /obj/structure/window/shuttle/scc_space_ship,
-/turf/simulated/wall/shuttle/scc_space_ship/cardinal,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "aL" = (
 /obj/structure/railing/mapped{
@@ -12337,6 +12338,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "Cz" = (
@@ -13081,6 +13085,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/washroom)
+"Eu" = (
+/obj/structure/trash_pile,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor,
+/area/maintenance/engineering_ladder)
 "Ev" = (
 /turf/simulated/floor/reinforced,
 /area/hallway/crew_area)
@@ -13769,6 +13780,16 @@
 	},
 /turf/simulated/floor/marble/dark,
 /area/bridge/minibar)
+"Gn" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28;
+	req_one_access = list(24,11,55)
+	},
+/turf/simulated/floor,
+/area/maintenance/engineering_ladder)
 "Go" = (
 /obj/effect/floor_decal/corner_wide/blue{
 	dir = 10
@@ -45229,7 +45250,7 @@ DQ
 bQ
 Ho
 FH
-Lv
+Eu
 tX
 FH
 QM
@@ -45823,7 +45844,7 @@ at
 at
 at
 at
-em
+aK
 EG
 DQ
 Rb
@@ -46025,7 +46046,7 @@ at
 at
 at
 at
-em
+aK
 EG
 DQ
 Fx
@@ -46227,7 +46248,7 @@ at
 at
 at
 at
-em
+aK
 Vl
 DQ
 XO
@@ -46429,7 +46450,7 @@ at
 at
 at
 at
-em
+aK
 EG
 DQ
 CJ
@@ -46835,7 +46856,7 @@ at
 at
 em
 Fq
-DJ
+Gn
 rH
 DJ
 DJ
@@ -47039,7 +47060,7 @@ em
 em
 em
 em
-em
+aK
 aK
 aK
 aK


### PR DESCRIPTION
The windows in the maintenance connected to the crew armoury had walls mapped inside their windows. The passage also had no air alarm. I mapped out the walls, moved the windows a little and set emergency shutters and an air alarm in there. You'll be able to see out those now.