### PR TITLE
Grippers can now be properly used on other robot module equipment

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -68,7 +68,7 @@
 	if(A == loc || (A in loc) || (A in contents))
 		// No adjacency checks
 
-		var/resolved = A.attackby(W,src)
+		var/resolved = W.resolve_attackby(A,src,params)
 		if(!resolved)
 			W.afterattack(A,src,1,params)
 		return

--- a/html/changelogs/gripper-on-contents.yml
+++ b/html/changelogs/gripper-on-contents.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - bugfix: "Mining robots can now upgrade their Kinetic Accelerators again. May also fix other gripper interactions with held robot items (e.g. Custodial Module bucket)."


### PR DESCRIPTION
Fixes #13738

Calling attackby directly like it was, meant that that line was skipping some steps that the gripper logic needed to attack properly with its wrapped item.