### PR TITLE
Diona nymphs that grow now spawn the new mob correctly

### DIFF
--- a/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona_nymph.dm
@@ -13,7 +13,7 @@
 	name = "diona nymph"
 	voice_name = "diona nymph"
 	accent = ACCENT_ROOTSONG
-	adult_form = /mob/living/carbon/human
+	adult_form = /mob/living/carbon/human/diona/coeus
 	speak_emote = list("chirrups")
 	icon = 'icons/mob/diona.dmi'
 	icon_state = "nymph"

--- a/code/modules/mob/living/carbon/alien/diona/progression.dm
+++ b/code/modules/mob/living/carbon/alien/diona/progression.dm
@@ -8,7 +8,7 @@
 		src.forceMove(L.loc)
 		qdel(L)
 
-	return SPECIES_DIONA_COEUS
+	return TRUE
 
 /mob/living/carbon/alien/diona/proc/grow()
 	set name = "Exponential Growth"
@@ -32,8 +32,7 @@
 		return
 
 	// confirm_evolution() handles choices and other specific requirements.
-	var/new_species = confirm_evolution()
-	if(!new_species || !adult_form)
+	if(!confirm_evolution() || !adult_form)
 		return
 
 	stunned = 10 // No more moving or talking for now
@@ -45,7 +44,6 @@
 	SPAN_WARNING("All at once, we consume our stored nutrients to surge with growth, splitting into a tangle of new gestalt. We have attained a new form."))
 
 	var/mob/living/carbon/human/adult = new adult_form(get_turf(src))
-	adult.set_species(new_species)
 	show_evolution_blurb()
 
 	if(mind)

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -27,8 +27,12 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	h_style = "Unathi Horns"
 	. = ..(mapload, SPECIES_UNATHI)
 
-/mob/living/carbon/human/diona/Initialize(mapload)
-	. = ..(mapload, SPECIES_DIONA)
+/mob/living/carbon/human/diona/Initialize(mapload, new_species = null)
+	. = ..(mapload, new_species || SPECIES_DIONA)
+	src.gender = NEUTER
+
+/mob/living/carbon/human/diona/coeus/Initialize(mapload)
+	. = ..(mapload, SPECIES_DIONA_COEUS)
 	src.gender = NEUTER
 
 /mob/living/carbon/human/machine/Initialize(mapload)

--- a/html/changelogs/diona-invisible-trunk-fix.yml
+++ b/html/changelogs/diona-invisible-trunk-fix.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki2
+
+delete-after: True
+
+changes:
+  - bugfix: "Nymphs that grow into full gestalts should now always have a visible chest icon."


### PR DESCRIPTION
Fixes #13072

This PR changes the way a nymph spawns its gestalt diona body when it grows up. Instead of spawning a human then calling set_species directly, it now calls `/mob/living/carbon/human/Initialize` with the the proper `new_species` argument, which is the way it is supposed to be done -- And somehow avoids whatever is actually causing this problem (I have no idea what truly causes this problem. I ran through the debugger for ages.)

To test I spawned nymphs, gave them nutrition and grew them into full gestalts about 15 times without a problem. 