### PR TITLE
Bar Lounge Air Alarm Placement Fix

### DIFF
--- a/html/changelogs/wickedcybs_barfix.yml
+++ b/html/changelogs/wickedcybs_barfix.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - bugfix: "Changed the position of an air alarm in the bar lounge that was in the position of a closing emergency shutter. That leads to odd behaviour with the alarm not being able to properly check room atmosphere."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -2143,6 +2143,10 @@
 /area/security/prison)
 "bfB" = (
 /obj/machinery/light/small,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "bgN" = (
@@ -15897,10 +15901,6 @@
 /obj/structure/curtain/black{
 	icon_state = "open";
 	opacity = 0
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 28
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)


### PR DESCRIPTION
I mapped an air alarm into a position where an emergency shutter would close on it, which meant it can't really read the atmos of the room it's intended to be in. This PR moves it to a different location in the same area