### PR TITLE
Combustion Chamber Expansions

### DIFF
--- a/html/changelogs/wickedcybs_nacelle.yml
+++ b/html/changelogs/wickedcybs_nacelle.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - maptweak: "The port and starboard propulsion chambers have been made safer via being extended out and getting a small airlock area before the combustion chamber itself. It's an extra line of insurance and should help properly using the area. Cameras were also added inside these areas for better observation."

--- a/html/changelogs/wickedcybs_nacelle.yml
+++ b/html/changelogs/wickedcybs_nacelle.yml
@@ -3,4 +3,4 @@ author: WickedCybs
 delete-after: True
 
 changes:
-  - maptweak: "The port and starboard propulsion chambers have been made safer via being extended out and getting a small airlock area before the combustion chamber itself. It's an extra line of insurance and should help properly using the area. Cameras were also added inside these areas for better observation."
+  - maptweak: "The port and starboard propulsion chambers have been made safer via being extended out and getting a small airlock area before the combustion chamber itself. It's an extra line of insurance and should help properly using the area. Cameras were also added inside these areas for better observation during gameplay."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -234,7 +234,15 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "port_propulsion_interior";
+	locked = 1;
+	name = "Combustion Chamber";
+	req_access = list(13)
+	},
+/obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
 	id = "portpropulsioninterior"
 	},
@@ -7202,9 +7210,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "gal" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/black,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "port_propulsion_exterior";
+	locked = 1;
+	name = "Combustion Chamber ;
+	req_access = list(13)
+	},
+/obj/machinery/door/blast/regular{
+	id = "portpropulsioninterior"
+	},
 /turf/simulated/floor/reinforced/airless,
-/area/engineering/atmos/propulsion/starboard)
+/area/engineering/atmos/propulsion)
 "gaC" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
@@ -8141,6 +8162,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/control)
+"gPg" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 4;
+	frequency = 1442;
+	id = "starboard_prop_in";
+	tag = "starboard_prop_in"
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Starboard Combustion Chamber";
+	dir = 1;
+	pixel_x = -11
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/atmos/propulsion/starboard)
 "gPv" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/structure/window/reinforced,
@@ -8683,6 +8718,12 @@
 /obj/structure/lattice,
 /turf/space/dynamic,
 /area/template_noop)
+"hoZ" = (
+/obj/machinery/door/blast/regular{
+	id = "portpropulsionairlockvent"
+	},
+/turf/space,
+/area/engineering/atmos/propulsion)
 "hpA" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -8759,11 +8800,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
 "hqH" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 4;
-	frequency = 1442;
-	id = "starboard_prop_in";
-	tag = "starboard_prop_in"
+/obj/machinery/atmospherics/pipe/manifold/visible/black,
+/obj/machinery/access_button/airlock_exterior{
+	pixel_x = 22;
+	pixel_y = -21;
+	req_one_access = list(10);
+	master_tag = "starboard_propulsion_control"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion/starboard)
@@ -9501,6 +9543,20 @@
 "hYy" = (
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
+"hYI" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	frequency = 1442;
+	id = "port_prop_in";
+	tag = "port_prop_in"
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Port Combustion chamber";
+	dir = 1;
+	pixel_x = -11
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/atmos/propulsion)
 "hZr" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -12165,6 +12221,12 @@
 	dir = 8
 	},
 /obj/machinery/meter,
+/obj/machinery/access_button/airlock_interior{
+	pixel_x = -24;
+	pixel_y = -20;
+	req_one_access = list(10);
+	master_tag = "starboard_propulsion_control"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "kzH" = (
@@ -12663,6 +12725,21 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "starboardpropulsionairlockvent";
+	name = "Combustion Airlock Purge";
+	pixel_x = -5;
+	pixel_y = 25
+	},
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	id_tag = "starboard_propulsion_control";
+	name = "Starboard Propulsion Combustion Chamber";
+	pixel_x = -37;
+	pixel_y = 3;
+	req_access = null;
+	tag_exterior_door = "starboard_propulsion_exterior";
+	tag_interior_door = "starboard_propulsion_interior"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
@@ -18092,6 +18169,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/disposal)
+"pRg" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/reinforced/airless,
+/area/engineering/atmos/propulsion)
 "pSk" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	input_tag = null;
@@ -19760,14 +19844,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/hangar)
 "rhI" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 8;
-	frequency = 1442;
-	id = "port_prop_in";
-	tag = "port_prop_in"
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/engineering/atmos/propulsion)
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "starboard_propulsion_exterior";
+	locked = 1;
+	name = "Combustion Chamber ;
+	req_access = list(13)
+	},
+/obj/machinery/door/blast/regular{
+	id = "interiorpropulsionstarboard"
+	},
+/turf/simulated/floor/reinforced,
+/area/engineering/atmos/propulsion/starboard)
 "riF" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -22001,6 +22093,12 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/machinery/access_button/airlock_interior{
+	pixel_x = 21;
+	pixel_y = -20;
+	req_one_access = list(10);
+	master_tag = "port_propulsion_control"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "tkX" = (
@@ -23239,14 +23337,21 @@
 /turf/simulated/floor/tiled,
 /area/hangar/operations)
 "uob" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "starboard_propulsion_exterior";
+	locked = 1;
+	name = "Combustion Chamber ;
+	req_access = list(13)
 	},
-/obj/machinery/door/airlock/external,
 /obj/machinery/door/blast/regular{
 	id = "interiorpropulsionstarboard"
 	},
-/turf/simulated/floor/reinforced,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion/starboard)
 "uoF" = (
 /obj/structure/cable/green{
@@ -24812,6 +24917,12 @@
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/reinforced,
 /area/rnd/isolation_a)
+"vKX" = (
+/obj/machinery/door/blast/regular{
+	id = "starboardpropulsionairlockvent"
+	},
+/turf/space,
+/area/engineering/atmos/propulsion/starboard)
 "vMd" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -25560,6 +25671,12 @@
 /area/operations/storage)
 "wsF" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
+/obj/machinery/access_button/airlock_exterior{
+	pixel_x = -23;
+	pixel_y = -21;
+	req_one_access = list(10);
+	master_tag = "port_propulsion_control"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion)
 "wsO" = (
@@ -26841,6 +26958,21 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
+	},
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	id_tag = "port_propulsion_control";
+	name = "Port Propulsion Combustion Chamber";
+	pixel_x = 37;
+	pixel_y = 3;
+	req_access = null;
+	tag_exterior_door = "port_propulsion_exterior";
+	tag_interior_door = "port_propulsion_interior"
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "portpropulsionairlockvent";
+	name = "Combustion Airlock Purge";
+	pixel_x = 4;
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -41409,11 +41541,11 @@ eSV
 eSV
 eSV
 eSV
+awJ
 eSV
 eSV
 eSV
-eSV
-eSV
+awJ
 eSV
 eSV
 eSV
@@ -41611,11 +41743,11 @@ eSV
 eSV
 eSV
 eSV
+awJ
+awJ
 eSV
-eSV
-eSV
-eSV
-eSV
+awJ
+awJ
 tuP
 tuP
 tuP
@@ -41813,10 +41945,10 @@ eSV
 eSV
 eSV
 eSV
-eSV
-eSV
-eSV
-eSV
+awJ
+awJ
+vyG
+awJ
 awJ
 tuP
 cCg
@@ -42016,9 +42148,9 @@ awJ
 awJ
 awJ
 awJ
-awJ
-eSV
-awJ
+uZU
+iCX
+dCC
 awJ
 oAi
 pxH
@@ -42218,9 +42350,9 @@ awJ
 awJ
 awJ
 awJ
-awJ
-vyG
-awJ
+uZU
+eDE
+gPg
 awJ
 hUh
 wCf
@@ -42421,8 +42553,8 @@ jQh
 sfF
 awJ
 uZU
-iCX
-dCC
+hqH
+uPX
 awJ
 nmV
 ver
@@ -42622,9 +42754,9 @@ fBs
 mqI
 eBf
 awJ
-uZU
-eDE
-hqH
+awJ
+rhI
+fyz
 awJ
 gWp
 uwB
@@ -42824,8 +42956,8 @@ xQU
 dgC
 ekt
 awJ
-uZU
-gal
+vKX
+uPX
 uPX
 awJ
 jZo
@@ -53126,9 +53258,9 @@ qxV
 fvq
 fCd
 uVL
-eBj
-wsF
+hoZ
 qnr
+pRg
 uVL
 gyD
 eKc
@@ -53328,9 +53460,9 @@ jFb
 gwg
 cIU
 uVL
-eBj
-lBi
-rhI
+uVL
+gal
+uPx
 uVL
 tnb
 eKc
@@ -53531,9 +53663,9 @@ bQb
 hRF
 uVL
 eBj
-moj
-cne
-uVL
+wsF
+qnr
+rsL
 rsL
 vil
 rsL
@@ -53732,10 +53864,10 @@ uVL
 uVL
 uVL
 uVL
-uVL
-dLn
-uVL
-uVL
+eBj
+lBi
+hYI
+rsL
 vil
 vil
 vil
@@ -53934,9 +54066,9 @@ uVL
 uVL
 uVL
 uVL
-uVL
-eSV
-rsL
+eBj
+moj
+cne
 rsL
 oTX
 vil
@@ -54135,10 +54267,10 @@ eSV
 eSV
 eSV
 eSV
-eSV
-eSV
-eSV
-eSV
+uVL
+uVL
+dLn
+uVL
 rsL
 rsL
 vil
@@ -54337,11 +54469,11 @@ eSV
 eSV
 eSV
 eSV
+uVL
+uVL
 eSV
-eSV
-eSV
-eSV
-eSV
+uVL
+uVL
 eSV
 eSV
 eSV
@@ -54539,11 +54671,11 @@ eSV
 eSV
 eSV
 eSV
+uVL
 eSV
 eSV
 eSV
-eSV
-eSV
+uVL
 eSV
 eSV
 eSV


### PR DESCRIPTION
At the moment, the combustion chambers look like this.

![image](https://user-images.githubusercontent.com/52309324/166411511-26833496-686d-4854-90aa-d736df5b9b37.png)

The problem as I saw it is that you have only a single airlock/blast door combo between you and a potentially firey doom. It's actually quite easy for something to go wrong there. We've had plenty of propulsion accidents with it being set on fire or just getting vented. My solution was adding an airlock in-between the actual combustion chamber if for whatever reason it needed to be accessed to remove some of the risk. If you really wanted to sabotage it or use it in some way, it's still easy to do that. This change should just hopefully have people be able to do these things without fear, and it's also just a lot more sensible in my opinion.

![image](https://user-images.githubusercontent.com/52309324/166411816-effc1da0-3146-4ab7-9456-fe196b7bc7b2.png)

Something in particular that I'll note is that the blast door within the airlock itself is covering an exposed space tile. It's so the airlock itself can be purged after use without compromising the main combustion chamber. There's an added camera in the chambers to monitor progress too.