### PR TITLE
XenoBot QOL 1.0

### DIFF
--- a/html/changelogs/Huntime - XenoBot QOL.yml
+++ b/html/changelogs/Huntime - XenoBot QOL.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Huntime
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Quality of life improvements to Xenobotany"

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -11532,6 +11532,7 @@
 	pixel_x = -8;
 	pixel_y = -6
 	},
+/obj/item/device/hand_labeler,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "gSb" = (
@@ -29453,6 +29454,10 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/hydroponics,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "rFn" = (
@@ -36556,6 +36561,15 @@
 "vPj" = (
 /turf/simulated/wall/r_wall,
 /area/security/armory)
+"vPk" = (
+/obj/structure/window/phoronreinforced,
+/obj/structure/lattice,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/deliveryChute{
+	dir = 1
+	},
+/turf/space,
+/area/rnd/xenobiology/xenoflora)
 "vPt" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -39323,6 +39337,12 @@
 /obj/structure/window/phoronreinforced{
 	dir = 1
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/small/south{
+	pixel_y = 12
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "xjN" = (
@@ -40029,6 +40049,9 @@
 /obj/item/material/hatchet,
 /obj/item/reagent_containers/spray/plantbgone,
 /obj/item/device/analyzer/plant_analyzer,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "xHB" = (
@@ -40383,6 +40406,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/starboard)
+"xRv" = (
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/xenobiology/xenoflora)
 "xSq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -71767,7 +71799,7 @@ qgN
 qgN
 qgN
 qgN
-vTP
+vPk
 rFi
 oLT
 puj
@@ -71970,7 +72002,7 @@ qgN
 qgN
 qgN
 rkk
-xjK
+xRv
 xhf
 oDz
 pMT

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -3105,6 +3105,10 @@
 /obj/effect/floor_decal/corner/mauve/full{
 	dir = 8
 	},
+/obj/machinery/camera/network/research{
+	c_tag = "Research - XenoBotanical Decom";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "bJp" = (
@@ -8682,6 +8686,10 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/camera/network/research{
+	c_tag = "Research - Xenobotanical Greenhouse 2";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
@@ -15988,6 +15996,14 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
+"jFf" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/camera/network/research{
+	c_tag = "Research - XenoBotanical Hazardous Specimens"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/xenobiology/xenoflora_hazard)
 "jFi" = (
 /obj/machinery/door/airlock/glass_command{
 	id_tag = "server_door_lock";
@@ -17050,6 +17066,10 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/camera/network/research{
+	c_tag = "Research - XenoBotanical Lab";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -18244,6 +18264,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/research{
+	c_tag = "Research - XenoBotanical Greenhouse";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "ldT" = (
@@ -73164,7 +73188,7 @@ qgN
 qgN
 fpm
 mue
-pMq
+jFf
 uvo
 xXP
 mAO

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -156,7 +156,12 @@
 /turf/simulated/floor/plating,
 /area/security/lobby)
 "acA" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/machinery/alarm{
 	alarm_id = 1601;
 	dir = 8;
@@ -164,10 +169,7 @@
 	pixel_x = 28;
 	req_one_access = list(24,11,55)
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora_hazard)
 "acH" = (
 /obj/structure/disposalpipe/segment,
@@ -316,6 +318,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/or1)
 "ais" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora_hazard)
@@ -385,16 +390,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "ajV" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/grass/alt,
-/area/rnd/xenobiology/xenoflora)
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary,
+/turf/simulated/floor/tiled/dark,
+/area/rnd/xenobiology/xenoflora_hazard)
 "akl" = (
 /obj/effect/floor_decal/corner_wide/lime{
 	dir = 9
@@ -585,10 +583,17 @@
 /turf/simulated/open,
 /area/maintenance/wing/starboard)
 "aqg" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/mauve/full,
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/shower{
+	dir = 1;
+	pixel_y = -2
+	},
+/obj/structure/curtain/open/shower,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "aql" = (
 /obj/structure/cable{
@@ -714,8 +719,25 @@
 /turf/simulated/open,
 /area/maintenance/wing/starboard)
 "atQ" = (
-/obj/machinery/chem_master,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "auc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -1014,10 +1036,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "aAx" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/shuttle_part/scc_space_ship{
+	icon_state = "d3-1"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/space,
 /area/rnd/xenobiology/xenoflora)
 "aAC" = (
 /obj/effect/floor_decal/spline/plain,
@@ -2537,20 +2559,13 @@
 /turf/simulated/floor/plating,
 /area/security/prison)
 "bsj" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/obj/machinery/meter,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	icon_state = "map_on";
+	name = "Distro to Trays";
+	use_power = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/mob/living/bot/farmbot,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "bsG" = (
@@ -2911,22 +2926,13 @@
 /turf/simulated/wall,
 /area/security/lobby)
 "bDv" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 5
-	},
 /obj/machinery/camera/network/research{
 	c_tag = "Research - Corridor Camera 3"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/railing/mapped,
+/turf/simulated/floor/tiled/ramp/bottom{
+	dir = 8
+	},
 /area/rnd/hallway)
 "bDV" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -3095,20 +3101,12 @@
 /turf/simulated/floor/wood,
 /area/library)
 "bIK" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/closet/secure_closet/xenobotany,
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/hallway)
+/turf/simulated/floor/tiled/white,
+/area/rnd/xenobiology/xenoflora)
 "bJp" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -3888,19 +3886,26 @@
 "ciP" = (
 /turf/simulated/wall,
 /area/operations/storage)
-"cjD" = (
+"cjg" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/machinery/door/airlock/glass_research{
+	req_access = list(55);
+	name = "XenoBotanical Lab"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
+"cjD" = (
+/turf/simulated/wall/r_wall,
+/area/rnd/xenobiology/xenoflora_hazard)
 "cjX" = (
 /turf/simulated/wall,
 /area/rnd/strongroom)
@@ -4264,14 +4269,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "czr" = (
-/obj/machinery/atmospherics/unary/heater,
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/corner/mauve{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "czJ" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -4369,26 +4380,11 @@
 /turf/simulated/floor/tiled,
 /area/security/security_office)
 "cBY" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/effect/floor_decal/corner/grey{
-	dir = 8
+/obj/machinery/botany/extractor,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/white{
-	dir = 4
-	},
-/obj/structure/table/standard,
-/obj/item/disk/botany,
-/obj/item/disk/botany,
-/obj/item/disk/botany,
-/obj/item/disk/botany,
-/obj/item/disk/botany,
-/obj/item/disk/botany,
-/obj/item/disk/botany,
-/obj/item/disk/botany,
-/obj/item/disk/botany,
-/obj/item/disk/botany,
-/obj/item/disk/botany,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "cCy" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -4862,8 +4858,7 @@
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d3-6"
 	},
-/obj/structure/girder,
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/rnd/xenobiology/xenoflora_hazard)
 "cTn" = (
 /obj/machinery/firealarm/north,
@@ -5076,9 +5071,6 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -5086,9 +5078,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
 "dbd" = (
@@ -5801,8 +5790,7 @@
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d3-5"
 	},
-/obj/structure/girder,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/maintenance/research_port)
 "dxH" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
@@ -6868,13 +6856,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
 "ekM" = (
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 4
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10;
+	req_access = list(55)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "ekS" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -6920,6 +6906,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)
+"ema" = (
+/obj/structure/shuttle_part/scc_space_ship{
+	icon_state = "d3-6"
+	},
+/turf/simulated/wall/r_wall,
+/area/maintenance/research_port)
 "emN" = (
 /turf/simulated/wall,
 /area/maintenance/research_port)
@@ -8687,17 +8679,11 @@
 /turf/simulated/floor/lino/grey,
 /area/crew_quarters/cafeteria)
 "fpb" = (
-/obj/structure/sink{
-	pixel_y = 28
-	},
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "fpj" = (
 /obj/structure/bed/stool/chair{
@@ -8710,20 +8696,11 @@
 /turf/simulated/floor/tiled,
 /area/security/brig/processing_secondary)
 "fpm" = (
-/obj/structure/railing/mapped,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/shuttle_part/scc_space_ship{
+	icon_state = "d3-1"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/ramp/bottom{
-	dir = 4
-	},
-/area/rnd/hallway)
+/turf/space,
+/area/template_noop)
 "fqa" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
 /obj/structure/cable/green{
@@ -8808,18 +8785,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "fsy" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "fsA" = (
 /obj/machinery/door/firedoor,
@@ -8860,13 +8841,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/port)
 "fti" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/reagentgrinder,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "ftj" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -9240,10 +9225,20 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/or1)
 "fHr" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/xenobiology/xenoflora_hazard)
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/xenobiology/xenoflora)
 "fHt" = (
 /obj/structure/railing/mapped,
 /obj/machinery/light/small/emergency{
@@ -9590,14 +9585,15 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "fQM" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/floor_decal/corner/lime{
+	dir = 5
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/turf/space/dynamic,
-/area/template_noop)
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "fQS" = (
 /obj/structure/bookcase/libraryspawn/religion,
 /turf/simulated/floor/wood,
@@ -9691,6 +9687,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
+"fTc" = (
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/hallway)
 "fTd" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/structure/window/reinforced{
@@ -11127,20 +11142,26 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "gGv" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "conpipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "gGB" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
@@ -11274,9 +11295,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/starboard)
 "gLH" = (
-/obj/structure/girder,
-/turf/simulated/floor/plating,
-/area/maintenance/research_port)
+/obj/structure/closet/secure_closet/xenobotany,
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/tiled/white,
+/area/rnd/xenobiology/xenoflora)
 "gLL" = (
 /obj/machinery/light/small/emergency{
 	dir = 4
@@ -11466,15 +11491,40 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "gRY" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/effect/floor_decal/corner/grey{
-	dir = 8
+/obj/effect/floor_decal/corner/mauve{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/white{
-	dir = 4
+/obj/structure/table/standard,
+/obj/item/storage/box/botanydisk{
+	pixel_x = 2;
+	pixel_y = 8
 	},
-/obj/machinery/botany/editor,
-/turf/simulated/floor/tiled/white,
+/obj/item/disk/botany,
+/obj/item/disk/botany{
+	pixel_y = -2
+	},
+/obj/item/disk/botany{
+	pixel_y = -4
+	},
+/obj/item/disk/botany{
+	pixel_y = -6
+	},
+/obj/item/disk/botany{
+	pixel_x = -8
+	},
+/obj/item/disk/botany{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/item/disk/botany{
+	pixel_x = -8;
+	pixel_y = -4
+	},
+/obj/item/disk/botany{
+	pixel_x = -8;
+	pixel_y = -6
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "gSb" = (
 /obj/structure/table/standard,
@@ -11786,12 +11836,18 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/conference)
 "hep" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Hazardous Specimens Outlet"
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/xenobiology/xenoflora_hazard)
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/small/north,
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "het" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -12115,16 +12171,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port/far)
 "hnP" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/smartfridge,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "hnY" = (
 /obj/effect/floor_decal/corner/white{
@@ -12626,23 +12675,25 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "hCF" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	icon_state = "map_on";
-	name = "Hazardous Specimens Inlet";
-	use_power = 1
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/xenobiology/xenoflora_hazard)
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "hCW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -12782,16 +12833,13 @@
 /turf/simulated/floor/wood,
 /area/library)
 "hGx" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/floor_decal/corner/mauve/full,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/structure/window/reinforced,
-/obj/structure/table/standard,
-/obj/machinery/recharger{
-	pixel_x = 1;
-	pixel_y = 2
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/firealarm/south,
+/obj/structure/closet/l3closet/scientist,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "hGC" = (
 /obj/structure/cable/green{
@@ -13028,6 +13076,7 @@
 	req_access = list(55);
 	req_one_access = null
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "hPM" = (
@@ -13786,10 +13835,12 @@
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "ipy" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/effect/floor_decal/corner/mauve/full,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/flora/pottedplant,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "ipL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14343,12 +14394,22 @@
 /turf/simulated/floor/tiled,
 /area/security/investigations)
 "iJq" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/research{
+	name = "XenoBotanical Contaiment";
+	req_access = list(55)
 	},
-/obj/machinery/vending/hydronutrients/xenobotany,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "iJx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15240,10 +15301,6 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
 "jlp" = (
@@ -15504,11 +15561,25 @@
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_upload_foyer)
 "jrr" = (
-/obj/machinery/chemical_dispenser,
-/obj/machinery/alarm{
-	pixel_y = 28
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "jrz" = (
 /turf/simulated/floor/tiled,
@@ -16118,10 +16189,23 @@
 /turf/simulated/floor/tiled,
 /area/engineering/storage_hard)
 "jMk" = (
-/obj/structure/window/reinforced,
-/obj/machinery/seed_storage/xenobotany,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/power/apc/high{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/obj/machinery/light_switch{
+	pixel_x = -26;
+	pixel_y = -6
+	},
 /turf/simulated/floor/tiled/dark,
-/area/rnd/xenobiology/xenoflora)
+/area/rnd/xenobiology/xenoflora_hazard)
 "jMp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16206,10 +16290,26 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/cafeteria)
 "jPX" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "jQg" = (
 /obj/structure/flora/pottedplant/random,
@@ -16936,24 +17036,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
 "krL" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/structure/closet/secure_closet/xenobotany,
-/obj/machinery/requests_console{
-	department = "Xenobotany";
-	departmentType = 2;
-	name = "Xenobotany Requests Console";
-	pixel_y = 30
+/obj/structure/table/standard,
+/obj/item/storage/box/fancy/vials{
+	pixel_x = -4;
+	pixel_y = 10
 	},
-/obj/effect/floor_decal/corner/grey{
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/beakers{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/effect/floor_decal/corner/mauve/full{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/white{
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "ksC" = (
 /obj/effect/map_effect/wingrille_spawn/reinforced,
@@ -17314,8 +17413,11 @@
 /turf/simulated/open,
 /area/maintenance/wing/port/far)
 "kDx" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/vending/hydronutrients/xenobotany,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "kDC" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
@@ -17688,24 +17790,26 @@
 /turf/simulated/floor/tiled/freezer,
 /area/security/prison)
 "kRz" = (
-/obj/structure/table/standard,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/storage/box/pillbottles{
-	pixel_x = 2
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/storage/box/spraybottles{
-	pixel_x = 2;
-	pixel_y = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/airlock/research{
+	name = "XenoBotanical Contaiment";
+	req_access = list(55)
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "kRA" = (
 /obj/structure/railing/mapped{
@@ -17973,19 +18077,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
 "kZZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/table/standard,
+/obj/machinery/reagentgrinder{
+	pixel_x = 3;
+	pixel_y = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/item/reagent_containers/chem_disp_cartridge,
+/obj/item/reagent_containers/chem_disp_cartridge,
+/obj/item/reagent_containers/chem_disp_cartridge,
+/obj/item/reagent_containers/chem_disp_cartridge,
+/obj/item/reagent_containers/chem_disp_cartridge,
+/obj/item/reagent_containers/chem_disp_cartridge,
+/obj/item/reagent_containers/chem_disp_cartridge,
+/obj/effect/floor_decal/corner/mauve/full{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/firealarm/south,
-/obj/machinery/camera/network/research{
-	c_tag = "Research - Xenobotany Laboratory 1";
-	dir = 1
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "lau" = (
 /obj/structure/cable/green{
@@ -18121,21 +18229,22 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "ldu" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/mauve{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/ramp{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "ldT" = (
 /obj/structure/cable/green{
@@ -18469,11 +18578,13 @@
 /turf/template_noop,
 /area/horizonexterior)
 "lqJ" = (
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/corner/lime/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "lrh" = (
 /obj/structure/railing/mapped,
@@ -18504,20 +18615,23 @@
 /turf/simulated/floor/tiled/freezer,
 /area/security/prison)
 "lrS" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/computer/atmoscontrol/laptop{
+	monitored_alarm_ids = list("1601");
+	name = "Hazardous Specimens Atmospheric Controls";
+	req_access = null;
+	req_one_access = list(55,24,11);
+	pixel_x = 1;
+	pixel_y = 4
 	},
-/obj/structure/closet/l3closet/scientist,
-/obj/item/clothing/mask/gas/alt,
-/obj/item/clothing/mask/gas/alt,
-/obj/item/tank/oxygen,
-/obj/item/tank/oxygen,
-/turf/simulated/floor/plating,
-/area/rnd/xenobiology/xenoflora_hazard)
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "lrW" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -18604,9 +18718,11 @@
 /turf/simulated/open,
 /area/hallway/primary/central_two)
 "lvl" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Trays to Scrubbers"
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
@@ -18843,13 +18959,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "lDs" = (
-/obj/machinery/atmospherics/unary/freezer{
-	icon_state = "freezer"
+/obj/structure/railing/mapped{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "lDQ" = (
 /obj/structure/closet/secure_closet/brig{
@@ -18995,16 +19115,7 @@
 	},
 /area/maintenance/wing/starboard/far)
 "lHs" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
+/obj/machinery/seed_storage/xenobotany,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "lHx" = (
@@ -19323,14 +19434,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/port)
 "lQo" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
+/obj/structure/window/phoronreinforced{
 	dir = 1
 	},
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
 /obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/grass/alt,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "lRe" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -20315,15 +20426,13 @@
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d3-4"
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/rnd/xenobiology/xenoflora_hazard)
 "muo" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/window/phoronreinforced{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/space,
 /area/rnd/xenobiology/xenoflora)
 "muy" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -20734,10 +20843,23 @@
 /turf/simulated/floor/carpet,
 /area/library)
 "mHj" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
-/area/rnd/xenobiology/xenoflora)
+/obj/structure/railing/mapped,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/ramp/bottom{
+	dir = 4
+	},
+/area/rnd/hallway)
 "mHG" = (
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -20936,17 +21058,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "mOp" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/effect/floor_decal/corner/grey{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white{
-	dir = 4
-	},
 /obj/structure/bed/stool/chair/office/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/mauve/full,
+/obj/effect/floor_decal/corner/white{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "mOt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -21023,23 +21142,22 @@
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/crew_quarters/kitchen)
 "mPn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/table/standard,
+/obj/item/storage/box/pillbottles{
+	pixel_x = 2
 	},
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/item/storage/box/spraybottles{
+	pixel_x = 2;
+	pixel_y = 4
 	},
-/obj/effect/floor_decal/corner/grey{
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/white{
-	dir = 4
-	},
-/obj/machinery/biogenerator{
-	icon_state = "biogen-empty"
-	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "mPo" = (
 /obj/structure/table/standard,
@@ -21366,7 +21484,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "mYL" = (
-/obj/machinery/smartfridge,
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "mZI" = (
@@ -21582,21 +21711,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "nfK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/structure/window/reinforced{
+/obj/structure/bed/stool/chair/office/light{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 8
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/white{
-	dir = 4
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "nfL" = (
 /obj/structure/cable/green,
@@ -21616,19 +21743,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/hydroponics)
 "nfW" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/window/westleft,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/mauve{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 5
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "nge" = (
 /turf/simulated/wall/r_wall,
@@ -21690,20 +21812,8 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "ngG" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/seed_extractor,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "nhE" = (
 /obj/structure/shuttle_part/scc_space_ship{
@@ -21722,21 +21832,28 @@
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/research)
 "nir" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/valve/digital/open{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/rnd/xenobiology/xenoflora_hazard)
+/obj/machinery/door/airlock/research{
+	name = "Hazardous Specimens";
+	req_access = list(55)
+	},
+/obj/structure/plasticflaps/airtight,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/xenobiology/xenoflora)
 "niC" = (
 /obj/item/modular_computer/console/preset/security/armory{
 	dir = 4
@@ -21942,14 +22059,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
 "nnt" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "nnu" = (
 /obj/item/module/power_control,
@@ -21997,8 +22117,13 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "noW" = (
-/turf/space/dynamic,
-/area/template_noop)
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/xenobiology/xenoflora)
 "noZ" = (
 /turf/simulated/floor/tiled/dark,
 /area/security/armory)
@@ -22610,11 +22735,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/aux_atmospherics/deck_2/starboard)
 "nKt" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 22
+/obj/effect/floor_decal/corner/mauve{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "nKK" = (
 /obj/structure/cable/green{
@@ -22796,38 +22920,27 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "nSO" = (
-/obj/machinery/door/airlock/research{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "xenobotany_airlock_interior";
-	locked = 1;
-	name = "Hazardous Specimens Interior Airlock";
-	req_access = list(55)
+/obj/effect/floor_decal/corner/lime{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "hazardous_airlock_control";
-	name = "Interior Access Button";
-	pixel_x = -1;
-	pixel_y = -25;
-	req_access = list(55)
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/xenobiology/xenoflora_hazard)
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "nSV" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -23049,20 +23162,28 @@
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "oaQ" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 8
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
 	},
 /obj/effect/floor_decal/corner/white{
-	dir = 4
+	dir = 10
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction/yjunction,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "obi" = (
 /obj/machinery/door/airlock/glass{
@@ -23382,7 +23503,7 @@
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d3-5"
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/rnd/xenobiology/xenoflora_hazard)
 "omf" = (
 /obj/structure/cable{
@@ -23917,15 +24038,24 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "oBe" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/effect/floor_decal/corner/grey{
-	dir = 8
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10;
+	req_access = list(55)
 	},
 /obj/effect/floor_decal/corner/white{
-	dir = 4
+	dir = 5
 	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "oBl" = (
 /obj/structure/cable/green{
@@ -24049,18 +24179,17 @@
 /turf/simulated/open,
 /area/maintenance/wing/starboard)
 "oDz" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "oEr" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
@@ -24283,15 +24412,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "oLT" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Xenoflora Lab";
-	req_access = list(55)
+/obj/structure/window/phoronreinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "oNy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24891,9 +25016,20 @@
 /turf/simulated/floor/tiled/dark/airless,
 /area/maintenance/wing/starboard)
 "pev" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "pew" = (
 /obj/structure/disposalpipe/segment{
@@ -25008,11 +25144,14 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "piq" = (
-/obj/structure/window/reinforced{
+/obj/structure/shuttle_part/scc_space_ship{
+	icon_state = "d3-2"
+	},
+/obj/structure/window/phoronreinforced{
 	dir = 4
 	},
-/turf/space/dynamic,
-/area/template_noop)
+/turf/space,
+/area/rnd/xenobiology/xenoflora)
 "piz" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -25066,11 +25205,11 @@
 /turf/simulated/floor/tiled/freezer,
 /area/hallway/primary/central_two)
 "pkf" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/chem_master,
+/obj/effect/floor_decal/corner/mauve{
 	dir = 6
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "pkH" = (
 /obj/machinery/door/airlock{
@@ -25094,12 +25233,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload)
 "pkV" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora_hazard)
 "plb" = (
 /obj/structure/bed/stool/chair/office/dark{
@@ -25177,14 +25326,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/storage/tech)
 "plL" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/grass/alt,
+/turf/space,
 /area/rnd/xenobiology/xenoflora)
 "pmb" = (
 /obj/machinery/button/remote/blast_door{
@@ -25359,10 +25501,11 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "puj" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "puO" = (
 /obj/effect/map_effect/wingrille_spawn/reinforced,
@@ -25971,11 +26114,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "pMq" = (
-/obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora_hazard)
 "pMB" = (
@@ -26049,13 +26189,17 @@
 	},
 /area/server)
 "pMT" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/light{
+/obj/effect/floor_decal/corner/lime{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/machinery/disposal/small/south,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "pNw" = (
 /obj/machinery/autolathe,
@@ -26546,14 +26690,21 @@
 /turf/simulated/floor/tiled,
 /area/security/warden)
 "qbl" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/effect/floor_decal/corner/grey{
-	dir = 8
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/white{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "qbp" = (
 /obj/structure/table/stone/marble,
@@ -26624,16 +26775,15 @@
 /turf/simulated/floor/tiled,
 /area/engineering/storage_eva)
 "qen" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/effect/floor_decal/corner/grey{
-	dir = 8
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/white{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/light_switch{
+	pixel_x = 6;
+	pixel_y = -25
 	},
-/obj/machinery/light,
-/obj/machinery/botany/extractor,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "qeZ" = (
 /obj/structure/lattice,
@@ -26953,11 +27103,21 @@
 /turf/simulated/floor/tiled,
 /area/engineering/storage_eva)
 "qsf" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/standard,
-/obj/item/folder/purple,
-/obj/item/taperoll/science,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/closet/l3closet/scientist,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "qsg" = (
 /obj/structure/disposalpipe/segment{
@@ -27640,10 +27800,17 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/structure/disposalpipe/junction/yjunction,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
 "qNo" = (
@@ -28026,11 +28193,17 @@
 /turf/simulated/floor/tiled,
 /area/teleporter)
 "qXJ" = (
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/corner/lime/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain/corner{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/grass/alt,
+/obj/effect/floor_decal/spline/plain{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "qYF" = (
 /obj/structure/cable/orange{
@@ -28458,11 +28631,8 @@
 /turf/simulated/floor/wood,
 /area/chapel/main)
 "rkk" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/grass/alt,
+/obj/structure/window/phoronreinforced,
+/turf/space,
 /area/rnd/xenobiology/xenoflora)
 "rkO" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -28743,12 +28913,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "rqs" = (
-/obj/machinery/camera/network/research{
-	c_tag = "Research - Xenobotany Laboratory 3";
-	dir = 1
+/obj/structure/window/phoronreinforced{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/turf/simulated/floor/tiled/white,
+/turf/space,
 /area/rnd/xenobiology/xenoflora)
 "rqu" = (
 /obj/machinery/power/emitter{
@@ -28938,15 +29106,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/storage)
 "rvJ" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/effect/floor_decal/corner/grey{
-	dir = 8
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/white{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/seed_extractor,
-/turf/simulated/floor/tiled/white,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "rvT" = (
 /obj/structure/disposalpipe/segment,
@@ -29199,6 +29371,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
+"rDR" = (
+/obj/structure/shuttle_part/scc_space_ship{
+	icon_state = "d3-2"
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/turf/space,
+/area/rnd/xenobiology/xenoflora)
 "rEk" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
@@ -29241,10 +29422,14 @@
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "rFi" = (
-/obj/structure/shuttle_part/scc_space_ship{
-	icon_state = "d3-5"
+/obj/structure/window/phoronreinforced{
+	dir = 8
 	},
-/turf/simulated/wall,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "rFn" = (
 /turf/simulated/wall/r_wall,
@@ -29388,9 +29573,24 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "rKj" = (
-/obj/structure/window/reinforced,
-/turf/space/dynamic,
-/area/template_noop)
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/xenobiology/xenoflora)
 "rKv" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
@@ -29702,15 +29902,15 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
@@ -29949,20 +30149,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/sleep/cryo/living_quarters_lift)
 "rYW" = (
-/obj/machinery/power/apc/low{
-	name = "south bump";
-	pixel_y = -24
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
 	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "rZh" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -30058,12 +30248,16 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/exam)
 "scH" = (
-/obj/effect/map_effect/wingrille_spawn/reinforced,
+/obj/effect/floor_decal/corner/lime/full,
 /obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/rnd/xenobiology/xenoflora_hazard)
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "scN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30865,22 +31059,29 @@
 /turf/simulated/floor/reinforced,
 /area/assembly/chargebay)
 "sGR" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
+/obj/effect/floor_decal/corner/lime/full{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/rnd/xenobiology/xenoflora_hazard)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "sHm" = (
 /obj/machinery/photocopier/faxmachine,
 /obj/structure/table/standard,
@@ -31249,38 +31450,27 @@
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "sUa" = (
-/obj/machinery/door/airlock/research{
-	frequency = 1379;
-	icon_state = "door_locked";
-	id_tag = "xenobotany_airlock_exterior";
-	locked = 1;
-	name = "Hazardous Specimens Exterior Airlock";
-	req_access = list(55)
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 5
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "hazardous_airlock_control";
-	name = "Exterior Access Button";
-	pixel_x = -1;
-	pixel_y = 25;
-	req_access = list(55)
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/xenobiology/xenoflora_hazard)
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "sUi" = (
 /obj/structure/bed/stool/chair/office/dark{
 	dir = 1
@@ -31335,7 +31525,7 @@
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d3-6"
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/rnd/xenobiology/xenoflora)
 "sVO" = (
 /obj/structure/bed/stool/chair/padded/red,
@@ -31561,13 +31751,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "tbi" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/camera/network/research{
-	c_tag = "Research - Xenobotany Laboratory 2";
-	dir = 1
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet/xenobotany,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "tbu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31886,21 +32074,23 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "tkB" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/rnd/xenobiology/xenoflora_hazard)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "tkN" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Substation";
@@ -32171,15 +32361,11 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "tvM" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/shuttle_part/scc_space_ship{
+	icon_state = "d3-2"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/grass/alt,
-/area/rnd/xenobiology/xenoflora)
+/turf/space,
+/area/template_noop)
 "tvX" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -33635,11 +33821,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
 "umW" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
 	},
-/turf/space/dynamic,
-/area/template_noop)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/xenobiology/xenoflora)
 "unn" = (
 /obj/structure/table/stone/marble,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -33894,11 +34084,11 @@
 /turf/simulated/floor/tiled,
 /area/operations/mail_room)
 "use" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/window/phoronreinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "usj" = (
 /obj/structure/cable{
@@ -34020,15 +34210,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port/far)
 "uvo" = (
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/low{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora_hazard)
 "uvM" = (
@@ -34091,20 +34273,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
 "uxp" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/heater{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	icon_state = "map_on";
-	name = "Distro to Trays";
-	use_power = 1
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "uxE" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -34469,24 +34645,13 @@
 /turf/simulated/floor/tiled,
 /area/engineering/storage_hard)
 "uIa" = (
-/obj/structure/railing/mapped,
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/effect/floor_decal/corner/mauve{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -34765,9 +34930,24 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_monitoring/tesla)
 "uQS" = (
-/turf/simulated/floor/tiled/ramp{
-	dir = 4
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
 	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/biogenerator{
+	icon_state = "biogen-empty"
+	},
+/obj/machinery/power/apc/high{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "uRe" = (
 /obj/machinery/disposal/small/south,
@@ -35780,17 +35960,24 @@
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/telesci)
 "vzO" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "vAh" = (
 /obj/effect/floor_decal/corner_wide/yellow{
@@ -35961,7 +36148,24 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "vFz" = (
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10;
+	req_access = list(55)
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "vFN" = (
 /obj/structure/disposalpipe/segment,
@@ -36032,9 +36236,11 @@
 /turf/simulated/floor/wood,
 /area/chapel/main)
 "vId" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/machinery/chemical_dispenser,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "vIt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -36460,23 +36666,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/starboard/far)
 "vSA" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/map_effect/wingrille_spawn/reinforced_phoron/firedoor,
+/turf/simulated/floor/plating,
 /area/rnd/xenobiology/xenoflora)
 "vSJ" = (
 /obj/machinery/computer/general_air_control/supermatter_core{
@@ -36551,16 +36742,10 @@
 /turf/simulated/open,
 /area/maintenance/hangar/port)
 "vTP" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/machinery/camera/network/research{
-	c_tag = "Research - Xenoflora Hazardous Specimen";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/xenobiology/xenoflora_hazard)
+/obj/structure/window/phoronreinforced,
+/obj/structure/lattice,
+/turf/space,
+/area/rnd/xenobiology/xenoflora)
 "vTY" = (
 /obj/effect/floor_decal/corner_wide/lime{
 	dir = 5
@@ -36653,10 +36838,7 @@
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d3-3"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/space/dynamic,
+/turf/space,
 /area/template_noop)
 "vXn" = (
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -36794,14 +36976,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "vYV" = (
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 5
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
@@ -37072,9 +37262,8 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room/tesla)
 "wfi" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/structure/closet/secure_closet/xenobotany,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/exoplanet/grass,
 /area/rnd/xenobiology/xenoflora)
 "wfy" = (
 /obj/effect/floor_decal/corner/green{
@@ -37637,18 +37826,23 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/exam)
 "wuL" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Xenoflora Lab";
-	req_access = list(55)
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "wvn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -37768,27 +37962,25 @@
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "wzN" = (
-/obj/machinery/atmospherics/binary/pump,
-/obj/effect/floor_decal/industrial/warning{
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/structure/railing/mapped,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/embedded_controller/radio/airlock/access_controller{
-	id_tag = "hazardous_airlock_control";
-	name = "Hazardous Specimens Access Controller";
-	pixel_x = 27;
-	pixel_y = 6;
-	req_access = null;
-	tag_exterior_door = "xenobotany_airlock_exterior";
-	tag_interior_door = "xenobotany_airlock_interior"
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/ramp/bottom{
+	dir = 4
+	},
 /area/rnd/xenobiology/xenoflora)
 "wAa" = (
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
@@ -38166,19 +38358,9 @@
 /turf/simulated/floor/carpet/rubber,
 /area/engineering/engine_monitoring)
 "wKP" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/sign/biohazard{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/tiled/dark,
-/area/rnd/xenobiology/xenoflora_hazard)
+/area/rnd/xenobiology/xenoflora)
 "wKS" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -38655,7 +38837,7 @@
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d3-4"
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/rnd/xenobiology/xenoflora)
 "wXp" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
@@ -39018,14 +39200,15 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room/tesla)
 "xhf" = (
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/corner/lime/full{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
 	},
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/grass/alt,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "xhj" = (
 /turf/simulated/wall,
@@ -39069,21 +39252,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "xio" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/embedded_controller/radio/airlock/access_controller{
-	id_tag = "hazardous_airlock_control";
-	name = "Hazardous Specimens Access Controller";
-	pixel_x = -28;
-	pixel_y = -5;
-	req_access = null;
-	tag_exterior_door = "xenobotany_airlock_exterior";
-	tag_interior_door = "xenobotany_airlock_interior"
-	},
-/obj/machinery/atmospherics/portables_connector{
+/obj/machinery/atmospherics/unary/freezer{
+	icon_state = "freezer";
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/xenobiology/xenoflora_hazard)
+/obj/effect/floor_decal/corner/lime/full{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "xiu" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -39116,14 +39296,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "xjK" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/window/phoronreinforced{
+	dir = 1
 	},
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/grass/alt,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "xjN" = (
 /obj/structure/cable/green{
@@ -39236,11 +39412,25 @@
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
 "xnz" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "xnG" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -39304,25 +39494,10 @@
 /turf/simulated/floor/tiled/ramp,
 /area/maintenance/wing/port/far)
 "xqe" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -25
-	},
-/obj/effect/floor_decal/corner/grey{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white{
-	dir = 4
-	},
-/obj/item/device/flashlight/lamp{
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/botany/editor,
+/obj/effect/floor_decal/corner/mauve/full,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "xqk" = (
 /obj/structure/disposaloutlet{
@@ -39822,12 +39997,15 @@
 /turf/simulated/floor/plating,
 /area/engineering/smes/tesla)
 "xHv" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/obj/machinery/camera/network/research{
-	c_tag = "Research - Xenobotany Laboratory 4";
+/obj/structure/window/phoronreinforced{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/table/reinforced,
+/obj/item/material/minihoe,
+/obj/item/material/hatchet,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/device/analyzer/plant_analyzer,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "xHB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -39866,6 +40044,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"xIN" = (
+/obj/structure/shuttle_part/scc_space_ship{
+	icon_state = "d3-6"
+	},
+/turf/simulated/wall/r_wall,
+/area/rnd/xenobiology/xenoflora_hazard)
 "xIW" = (
 /obj/structure/curtain/black,
 /obj/structure/closet/crate/coffin,
@@ -40043,8 +40227,7 @@
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d3-4"
 	},
-/obj/structure/girder,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/maintenance/research_port)
 "xNJ" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -40093,10 +40276,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/engineering/tesla)
 "xPz" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/window/westright,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "xPY" = (
 /obj/structure/curtain/black{
@@ -40367,9 +40563,17 @@
 /turf/simulated/floor/wood,
 /area/hydroponics)
 "xXM" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
+/obj/machinery/requests_console{
+	department = "Xenobotany";
+	departmentType = 2;
+	name = "Xenobotany Requests Console";
+	pixel_y = 30
 	},
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/small/south,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "xXP" = (
@@ -40377,7 +40581,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora_hazard)
 "xYK" = (
@@ -40746,24 +40950,14 @@
 /turf/simulated/floor/tiled,
 /area/security/armory)
 "yeY" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	name = "Trays to Scrubbers"
 	},
-/obj/structure/window/reinforced,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/structure/table/standard,
-/obj/structure/sign/biohazard{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/machinery/computer/atmoscontrol/laptop{
-	monitored_alarm_ids = list("1601");
-	name = "Hazardous Specimens Atmospheric Controls";
-	pixel_x = -2;
-	req_access = null;
-	req_one_access = list(55,24,11)
+/obj/structure/sink/kitchen{
+	dir = 4;
+	name = "Sterile Sink";
+	pixel_x = -20
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
@@ -40845,14 +41039,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/aft_airlock)
 "yhb" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/grass/alt,
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/wall/r_wall,
 /area/rnd/xenobiology/xenoflora)
 "yhL" = (
 /obj/structure/railing/mapped,
@@ -40878,17 +41066,25 @@
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/xenobiology)
 "yiV" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/fancy/vials{
-	pixel_x = -4;
-	pixel_y = 10
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
 	},
-/obj/item/storage/box/beakers{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
-/obj/item/storage/box/syringes,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "yjg" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -40956,11 +41152,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload)
 "yme" = (
-/obj/structure/sink{
-	pixel_y = 28
+/obj/structure/shuttle_part/scc_space_ship{
+	icon_state = "d3-5"
 	},
-/obj/effect/floor_decal/corner/mauve/diagonal,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/wall/r_wall,
 /area/rnd/xenobiology/xenoflora)
 
 (1,1,1) = {"
@@ -69534,7 +69729,7 @@ kPA
 hPH
 rFn
 rFn
-rFn
+yhb
 nvq
 nvq
 rFn
@@ -69729,19 +69924,19 @@ qgN
 qgN
 qgN
 qgN
-dmK
+vXe
 qvb
-gLH
-kPA
+cQw
+bIK
 nKt
 aqg
-kPA
+rFn
 krL
 gRY
 cBY
 xqe
 rFn
-tPq
+fTc
 rSx
 rnA
 bSD
@@ -69932,18 +70127,18 @@ qgN
 qgN
 qgN
 qgN
-vnz
+fpm
 xNu
-kPA
+umW
 jPX
 vFz
 iJq
 qbl
-qbl
+vzO
 mOp
 qen
 rFn
-tPq
+mHj
 aDA
 rnA
 dOi
@@ -70134,17 +70329,17 @@ qgN
 qgN
 qgN
 qgN
-iox
+tvM
 dxm
-kPA
+gLH
 yiV
-vFz
-jMk
+wuL
+rFn
 uQS
 oaQ
 oBe
 rvJ
-rFn
+cjg
 vYV
 qNm
 bAZ
@@ -70336,12 +70531,12 @@ qgN
 qgN
 qgN
 qgN
-dmK
-qvb
-kPA
+vXe
+ema
+rFn
 kRz
-vFz
-vFz
+rFn
+rFn
 xXM
 pev
 nfK
@@ -70539,18 +70734,18 @@ qgN
 qgN
 qgN
 qgN
-vnz
+fpm
 wWJ
 jrr
 ipy
-aAx
+rFn
 lvl
 pkf
 vId
 kZZ
 rFn
-fpm
-bIK
+tPq
+daM
 lCI
 iwo
 iwo
@@ -70741,16 +70936,16 @@ qgN
 qgN
 qgN
 qgN
-iox
-rFi
+tvM
+yme
 atQ
 ekM
-gGv
+rFn
 hnP
-uxp
 vSA
-cjD
-wuL
+vSA
+vSA
+rFn
 uIa
 jkO
 ueF
@@ -70938,14 +71133,14 @@ qgN
 qgN
 qgN
 qgN
-noW
-piq
-piq
-piq
-piq
+qgN
+qgN
+qgN
+qgN
+qgN
 vXe
 sVF
-kPA
+rKj
 fti
 ldu
 czr
@@ -71140,16 +71335,16 @@ qgN
 qgN
 qgN
 qgN
-rKj
-xhf
-qXJ
-xjK
-qXJ
-ajV
-kPA
-kPA
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+aAx
+wWJ
 mYL
-ngG
+fHr
 lDs
 xnz
 fsy
@@ -71342,13 +71537,13 @@ qgN
 qgN
 qgN
 qgN
-rKj
-lqJ
-kDx
-kDx
-use
+qgN
+qgN
+qgN
+qgN
+plL
 rqs
-kPA
+piq
 yme
 kDx
 ngG
@@ -71544,18 +71739,18 @@ qgN
 qgN
 qgN
 qgN
-rKj
-lqJ
-kDx
-mHj
-muo
-puj
+qgN
+qgN
+qgN
+qgN
+vTP
+rFi
 oLT
 puj
-puj
+lqJ
 rYW
-kPA
-mAO
+rYW
+gGv
 sUa
 scH
 rNx
@@ -71746,18 +71941,18 @@ qgN
 qgN
 qgN
 qgN
-rKj
-lQo
+qgN
+qgN
+qgN
+qgN
 rkk
-yhb
-rkk
-rkk
-kPA
-kPA
-pMT
+xjK
+xhf
 oDz
+pMT
 tbi
-mAO
+tbi
+tbi
 hCF
 hep
 rNx
@@ -71948,18 +72143,18 @@ qgN
 qgN
 qgN
 qgN
-noW
-umW
-umW
+qgN
+qgN
+qgN
+qgN
+rkk
+xHv
 fQM
-fQM
-fQM
-fQM
-kPA
-kPA
-nnt
 wfi
-mAO
+wfi
+wfi
+wfi
+wfi
 tkB
 lrS
 rNx
@@ -72152,18 +72347,18 @@ qgN
 qgN
 qgN
 qgN
-rKj
-plL
-qXJ
+qgN
+qgN
+rkk
 xjK
 qXJ
-ajV
-kPA
 nnt
-mAO
-mAO
+nnt
+nnt
+nnt
+nnt
 nSO
-mAO
+uxp
 rNx
 pMR
 bOr
@@ -72354,15 +72549,15 @@ qgN
 qgN
 qgN
 qgN
-rKj
-lqJ
-kDx
-kDx
+qgN
+qgN
+vTP
+lQo
 use
-xHv
-kPA
+use
+use
 fpb
-mAO
+noW
 wKP
 sGR
 xio
@@ -72556,19 +72751,19 @@ qgN
 qgN
 qgN
 qgN
-rKj
-lqJ
-kDx
-mHj
+qgN
+qgN
+plL
 muo
-puj
-oLT
-vzO
-mAO
-uvo
+muo
+muo
+rDR
+yme
+rFn
+rFn
 nir
-vTP
-rNx
+rFn
+cjD
 rNx
 rNx
 rNx
@@ -72758,18 +72953,18 @@ qgN
 qgN
 qgN
 qgN
-rKj
-tvM
-rkk
-yhb
-rkk
-rkk
-kPA
-kPA
-mAO
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+vXe
+xIN
+ajV
 ais
 pkV
-oLv
+jMk
 mAO
 dHt
 hoi
@@ -72960,17 +73155,17 @@ qgN
 qgN
 qgN
 qgN
-noW
-umW
-umW
-umW
-umW
-umW
-umW
-vnz
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+fpm
 mue
 pMq
-pkV
+uvo
 xXP
 mAO
 fuu
@@ -73169,9 +73364,9 @@ qgN
 qgN
 qgN
 qgN
-iox
+tvM
 olJ
-fHr
+pMq
 acA
 oLv
 mAO


### PR DESCRIPTION
- Xenobotanical changes to layout per player request.
- Made the area more maneuverable for those working within
- Farmbot now has access to a sink, so it actually works.
- Hazard specimens still function, air-tight flaps are used instead of an airlock.
- The 'lab' and the 'greenhouse' section are split, with a decontamination room between. In case of breach or gas-based issues.
![6b9cc04a7599e6d3cbeb4f1cfc297166](https://user-images.githubusercontent.com/29168551/166505980-3692341a-1c6e-4d9a-b4b2-9bfef80c1772.png)

