### PR TITLE
Fix mining equipment orders and orbital drills

### DIFF
--- a/code/controllers/subsystems/cargo.dm
+++ b/code/controllers/subsystems/cargo.dm
@@ -16,6 +16,7 @@ var/datum/controller/subsystem/cargo/SScargo
 	var/shipmentnum
 	var/list/cargo_shipments = list() //List of the shipments to the station
 	var/datum/cargo_shipment/current_shipment = null //The current cargo shipment
+	var/list/queued_mining_equipment = list()
 
 	//order stuff
 	var/ordernum
@@ -630,6 +631,13 @@ var/datum/controller/subsystem/cargo/SScargo
 	current_shipment.generate_invoice()
 	current_shipment = null //Null the current shipment because its completed
 
+/datum/controller/subsystem/cargo/proc/order_mining(var/equip_path)
+	if(!ispath(equip_path))
+		return FALSE
+
+	queued_mining_equipment += equip_path
+	return TRUE
+
 //Buys the item and places them on the shuttle
 //Returns 0 if unsuccessful returns 1 if the shuttle can be sent
 /datum/controller/subsystem/cargo/proc/buy()
@@ -655,6 +663,19 @@ var/datum/controller/subsystem/cargo/SScargo
 			if(contcount)
 				continue
 			clear_turfs += T
+
+	for(var/E in queued_mining_equipment)
+		if(!ispath(E))
+			continue
+
+		var/i = rand(1,clear_turfs.len)
+		var/turf/pickedloc = clear_turfs[i]
+		clear_turfs.Cut(i,i+1)
+
+		if(isturf(pickedloc))
+			new E(pickedloc)
+
+	queued_mining_equipment.Cut()
 
 	for(var/datum/cargo_order/co in approved_orders)
 		if(!co)

--- a/code/controllers/subsystems/cargo.dm
+++ b/code/controllers/subsystems/cargo.dm
@@ -675,7 +675,7 @@ var/datum/controller/subsystem/cargo/SScargo
 		if(isturf(pickedloc))
 			new E(pickedloc)
 
-	queued_mining_equipment.Cut()
+		queued_mining_equipment -= E
 
 	for(var/datum/cargo_order/co in approved_orders)
 		if(!co)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -130,7 +130,7 @@ var/global/list/minevendor_list = list( //keep in order of price
 /obj/machinery/mineral/equipment_vendor/interact(mob/user)
 	var/dat
 	dat +="<div class='statusDisplay'>"
-	var/obj/item/card/id/ID = scanned_id.resolve()
+	var/obj/item/card/id/ID = scanned_id?.resolve()
 	if(ID)
 		dat += "You have [ID.mining_points ? ID.mining_points : 0] mining points collected. <A href='?src=\ref[src];choice=eject'>Eject ID.</A><br>"
 	else
@@ -174,42 +174,11 @@ var/global/list/minevendor_list = list( //keep in order of price
 			if(prize.cost > ID.mining_points)
 			else
 				if(prize.shuttle)
-					var/datum/shuttle/autodock/ferry/supply/shuttle = SScargo.shuttle
-					if(shuttle)
-						if(!shuttle.shuttle_area) //This really should never happen, but, oh well.
-							to_chat(usr, SPAN_DANGER("{ERR Code: NO_SHUTTLE} Order failed! Please try again."))
-							return
-						var/list/clear_turfs = list()
-						for(var/area/subarea in shuttle.shuttle_area)
-							for(var/turf/T in subarea)
-								if(T.density)
-									continue
-								var/contcount
-								for(var/atom/A in T.contents)
-									if(!A.simulated)
-										continue
-									contcount++
-								if(contcount)
-									continue
-								clear_turfs += T
-
-						if(!length(clear_turfs))
-							to_chat(usr, SPAN_DANGER("{ERR Code: NO_SHUTTLE_SPACE} Order failed! Please try again."))
-							return
-
-						var/i = rand(1, length(clear_turfs))
-						var/turf/pickedloc = clear_turfs[i]
-
-						if(pickedloc)
-							ID.mining_points -= prize.cost
-							new prize.equipment_path(pickedloc)
-							to_chat(usr, SPAN_NOTICE("Order passed. Your order has been placed on the next available supply shuttle."))
-						else
-							to_chat(usr, SPAN_DANGER("{ERR Code: NO_SHUTTLE_SPACE} Order failed! Please try again."))
-							return
+					if(SScargo.order_mining(prize.equipment_path))
+						ID.mining_points -= prize.cost
+						to_chat(usr, SPAN_NOTICE("Order passed. Your order has been placed on the next available supply shuttle."))
 					else
-						to_chat(usr, SPAN_DANGER("{ERR Code: NO_SHUTTLE} Order failed! Please try again."))
-						return
+						to_chat(usr, SPAN_DANGER("{ERR Code: NO_SHUTTLE_SPACE} Order failed! Please try again."))
 				else
 					ID.mining_points -= prize.cost
 					if(prize.amount != -1)

--- a/html/changelogs/johnwildkins-cargofix.yml
+++ b/html/changelogs/johnwildkins-cargofix.yml
@@ -1,0 +1,7 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Shuttle-shipped mining supplies now properly queue for the next shuttle delivery, rather than being lost in nullspace."
+  - bugfix: "Orbital drills no longer create their own turfs/areas, which should permit them to drill where dropped."

--- a/maps/templates/orbital/drill.dmm
+++ b/maps/templates/orbital/drill.dmm
@@ -1,15 +1,15 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/simulated/floor/reinforced/airless,
-/area/mine/explored)
+/turf/template_noop,
+/area/template_noop)
 "b" = (
 /obj/machinery/mining/brace,
-/turf/simulated/floor/reinforced/airless,
-/area/mine/explored)
+/turf/template_noop,
+/area/template_noop)
 "c" = (
 /obj/machinery/mining/drill,
-/turf/simulated/floor/reinforced/airless,
-/area/mine/explored)
+/turf/template_noop,
+/area/template_noop)
 
 (1,1,1) = {"
 a


### PR DESCRIPTION
changes:
  - bugfix: "Shuttle-shipped mining supplies now properly queue for the next shuttle delivery, rather than being lost in nullspace."
  - bugfix: "Orbital drills no longer create their own turfs/areas, which should permit them to drill where dropped."

Fixes #3785