### PR TITLE
Add orbital minecart droppers

### DIFF
--- a/code/game/objects/items/devices/drop_targeter/orbital_drops.dm
+++ b/code/game/objects/items/devices/drop_targeter/orbital_drops.dm
@@ -2,10 +2,20 @@
 	name = "drill dropper"
 	desc = "A device used to paint a target, which will then promptly orbitally drop the requested items. This drill literally pierces the heavens."
 
-	drop_message = "Stand by for drillfall, ETA ten seconds, clear the targetted area."
+	drop_message = "Stand by for drillfall, ETA ten seconds, clear the targeted area."
 	drop_message_emagged = "St%n^ b* for dr$llfa#l, ETA t@n s*c%&ds, RUN."
 
 	map = new /datum/map_template/drill
+
+/obj/item/device/orbital_dropper/minecart
+	name = "minecart train dropper"
+	desc = "A device used to paint a target, which will then promptly orbitally drop the requested items. This one is configured to deliver an exoplanet-ready minecart train. Rails not included."
+
+	drop_message = "Stand by for trainfall, ETA ten seconds. Clear the targeted area."
+	drop_message_emagged = "St%n^ b* for tr$infa#l, ETA t@n s*c%&ds, CHOO CHOO!"
+
+	drop_amount = 1
+	map = new /datum/map_template/minecart
 
 /obj/item/device/orbital_dropper/mecha
 	name = "mecha dropper"

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -55,6 +55,7 @@ var/global/list/minevendor_list = list( //keep in order of price
 	new /datum/data/mining_equipment("Industrial Drill Head",		/obj/machinery/mining/drill,								-1,					1000,	1),
 	new /datum/data/mining_equipment("Super Resonator",				/obj/item/resonator/upgraded,								10,					1250),
 	new /datum/data/mining_equipment("Diamond Pickaxe",				/obj/item/pickaxe/diamond,									10,					1500),
+	new /datum/data/mining_equipment("Orbital Minecart Dropper",	/obj/item/device/orbital_dropper/minecart,					5,					2000),
 	new /datum/data/mining_equipment("Orbital Drill Dropper",		/obj/item/device/orbital_dropper/drill,						10,					3250),
 	new /datum/data/mining_equipment("Thermal Drill",				/obj/item/gun/energy/vaurca/thermaldrill,					5,					3750)
 	)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -598,7 +598,7 @@
 /obj/vehicle/train/cargo/engine/mining/Initialize()
 	. = ..()
 	cell = new /obj/item/cell/high(src)
-	key = null
+	key = new /obj/item/key/minecarts(src)
 	var/image/I = new(icon = 'icons/obj/cart.dmi', icon_state = "[icon_state]_overlay", layer = src.layer + 0.2) //over mobs
 	add_overlay(I)
 	turn_off()
@@ -612,7 +612,19 @@
 	..()
 
 /obj/vehicle/train/cargo/engine/mining/Move(var/turf/destination)
-	return ((locate(/obj/structure/track) in destination)) ? ..() : FALSE
+	if((locate(/obj/structure/track) in destination))
+		move_delay = initial(move_delay)
+	else if(!(locate(/obj/structure/track) in loc) && on) // Allow minecarts to off-track move, albeit slowly and only if not on a track already
+		if(move_delay == initial(move_delay))
+			move_delay = 10
+			visible_message(SPAN_WARNING("\The [src]'s rollers struggle to move without a track to follow!"), SPAN_WARNING("You hear a horrible grinding noise!"))
+			playsound(loc, 'sound/mecha/tanktread.ogg', 50, 1)
+		else if(prob(50))
+			playsound(loc, 'sound/mecha/tanktread.ogg', 50, 1)
+	else
+		return FALSE
+
+	. = ..()
 
 /obj/vehicle/train/cargo/engine/mining/update_car(var/train_length, var/active_engines)
 	return
@@ -635,9 +647,6 @@
 	light_range = 3
 	light_wedge = LIGHT_OMNI
 	light_color = LIGHT_COLOR_FIRE
-
-/obj/vehicle/train/cargo/trolley/mining/Move(var/turf/destination)
-	return ((locate(/obj/structure/track) in destination)) ? ..() : FALSE
 
 /obj/item/key/minecarts
 	name = "key"
@@ -1450,4 +1459,3 @@ var/list/total_extraction_beacons = list()
 	for(var/turf/simulated/mineral/M in range(7,drill_loc))
 		if(prob(75))
 			M.GetDrilled(1)
-

--- a/code/modules/vehicles/cargo_train.dm
+++ b/code/modules/vehicles/cargo_train.dm
@@ -16,7 +16,7 @@
 
 	var/car_limit = 3		//how many cars an engine can pull before performance degrades
 	active_engines = 1
-	var/obj/item/key/cargo_train/key
+	var/obj/item/key/key
 
 /obj/item/key/cargo_train
 	name = "key"
@@ -48,7 +48,7 @@
 
 /obj/vehicle/train/cargo/engine/proc/setup_engine()
 	cell = new /obj/item/cell/high(src)
-	key = new(src)
+	key = new /obj/item/key/cargo_train(src)
 	var/image/I = new(icon = icon, icon_state = "[icon_state]_overlay", layer = src.layer + 0.2) //over mobs
 	add_overlay(I)
 	turn_off()

--- a/html/changelogs/johnwildkins-orbitaltrain.yml
+++ b/html/changelogs/johnwildkins-orbitaltrain.yml
@@ -1,0 +1,8 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - tweak: "Mining cart engines now start with a key inside."
+  - rscadd: "Adds a minecart orbital dropper, available from mining vendors for 2000pts. Comes with an engine and two carts."
+  - tweak: "Mining carts can now travel off-tracks very slowly, so long as they aren't already on a track."

--- a/maps/templates/orbital/minecart.dmm
+++ b/maps/templates/orbital/minecart.dmm
@@ -1,0 +1,28 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"b" = (
+/obj/vehicle/train/cargo/trolley/mining,
+/turf/template_noop,
+/area/template_noop)
+"F" = (
+/obj/vehicle/train/cargo/engine/mining,
+/turf/template_noop,
+/area/template_noop)
+
+(1,1,1) = {"
+a
+b
+a
+"}
+(2,1,1) = {"
+a
+b
+a
+"}
+(3,1,1) = {"
+a
+F
+a
+"}

--- a/maps/templates/orbital/orbital_templates.dm
+++ b/maps/templates/orbital/orbital_templates.dm
@@ -21,3 +21,7 @@
 /datum/map_template/drill
 	name = "Drill Drop"
 	mappath = 'maps/templates/orbital/drill.dmm'
+
+/datum/map_template/minecart
+	name = "Minecart Drop"
+	mappath = 'maps/templates/orbital/minecart.dmm'


### PR DESCRIPTION
changes:
  - tweak: "Mining cart engines now start with a key inside."
  - rscadd: "Adds a minecart orbital dropper, available from mining vendors for 2000pts. Comes with an engine and two carts."
  - tweak: "Mining carts can now travel off-tracks very slowly, so long as they aren't already on a track."