### PR TITLE
The Rumbling: Removal of Security's Black Glove Roundstart Spawn

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -61,16 +61,6 @@
 	dufflebag = /obj/item/storage/backpack/duffel/sec
 	messengerbag = /obj/item/storage/backpack/messenger/sec
 
-/datum/outfit/job/hos/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	. = ..()
-	if(istajara(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/tajara(H), slot_gloves)
-	else if(isunathi(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/unathi(H), slot_gloves)
-	else
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
-
-
 /datum/job/warden
 	title = "Warden"
 	flag = WARDEN
@@ -119,15 +109,6 @@
 		/obj/item/handcuffs = 1
 	)
 
-/datum/outfit/job/warden/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	. = ..()
-	if(istajara(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/tajara(H), slot_gloves)
-	else if(isunathi(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/unathi(H), slot_gloves)
-	else
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
-
 /datum/job/investigator
 	title = "Investigator"
 	flag = FORENSICS
@@ -172,15 +153,6 @@
 	backpack_contents = list(
 		/obj/item/storage/box/evidence = 1
 	)
-
-/datum/outfit/job/forensics/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	. = ..()
-	if(istajara(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/tajara(H), slot_gloves)
-	else if(isunathi(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/unathi(H), slot_gloves)
-	else
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
 
 /datum/job/officer
 	title = "Security Officer"
@@ -228,15 +200,6 @@
 	backpack_contents = list(
 		/obj/item/handcuffs = 1
 	)
-
-/datum/outfit/job/officer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	. = ..()
-	if(istajara(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/tajara(H), slot_gloves)
-	else if(isunathi(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black/unathi(H), slot_gloves)
-	else
-		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black(H), slot_gloves)
 
 /datum/job/intern_sec
 	title = "Security Cadet"

--- a/html/changelogs/wickedcybs_gloves.yml
+++ b/html/changelogs/wickedcybs_gloves.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - rscdel: "No security role will spawn with the off colour black gloves anymore. If you want gloves, look through your department or grab some in the loadout."


### PR DESCRIPTION
Most of the security roles spawn with off colour black gloves. The amount of people who I see trash or throw those away far outnumbers those who keep them.

I would have swapped it for the black leather gloves, but decided it would be best not to force this on anyone. They can instead loadout it or grab some from the sec uniform locker.