### PR TITLE
Vendor Outside of Investigations Density Fix

### DIFF
--- a/html/changelogs/wickedcybs_vendorfix.yml
+++ b/html/changelogs/wickedcybs_vendorfix.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - bugfix: "The vending machine outside of the investigator's office no longer blocks transit. It was odd that it did anyway, as it looked to be next to the wall and not occupying the entire tile."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -20325,7 +20325,8 @@
 "UP" = (
 /obj/machinery/vending/coffee{
 	pixel_x = 3;
-	pixel_y = 25
+	pixel_y = 25;
+	density = 0
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/starboard)


### PR DESCRIPTION
Since it's up by the wall I see a lot of people trying to walk into it and getting confused that the tile appears blocked. The fact that it does block movement is probably unintended. With this PR, you should be able to occupy the same space as this vending machine now.

![image](https://user-images.githubusercontent.com/52309324/167236912-9be44254-c95e-489b-bd36-385b95798574.png)
