### PR TITLE
Changes TCFL active service card to reservist in loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -446,13 +446,13 @@
 
 /datum/gear/accessory/TCFLcard
 	display_name = "TCFL service cards"
-	description = "Identification cards given to active and former members of the Tau Ceti Foreign Legion."
+	description = "Identification cards given to reservists and former members of the Tau Ceti Foreign Legion."
 	path = /obj/item/clothing/accessory/badge/tcfl_papers
 
 /datum/gear/accessory/TCFLcard/New()
 	..()
 	var/list/TCFLcard = list()
-	TCFLcard["active service"] = /obj/item/clothing/accessory/badge/tcfl_papers/service
+	TCFLcard["reservist"] = /obj/item/clothing/accessory/badge/tcfl_papers/service/reservist
 	TCFLcard["veteran"] = /obj/item/clothing/accessory/badge/tcfl_papers/service/veteran
 	gear_tweaks += new /datum/gear_tweak/path(TCFLcard)
 

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -212,6 +212,12 @@
 	Republic shops. Go Biesel!"
 	badge_string = "Tau Ceti Foreign Legion Veteran"
 
+/obj/item/clothing/accessory/badge/tcfl_papers/service/reservist
+	name = "\improper TCFL reservist's service card"
+	desc = "A small card identifying one as a current reservist of the Tau Ceti Foreign Legion. Often used to secure discounts in \
+	Republic shops. Go Biesel!"
+	badge_string = "Tau Ceti Foreign Legion Reservist"
+
 /obj/item/clothing/accessory/badge/sheriff
 	name = "sheriff badge"
 	desc = "A star-shaped brass badge denoting who the law is around these parts."

--- a/html/changelogs/FearTheBlackout-thereserve.yml
+++ b/html/changelogs/FearTheBlackout-thereserve.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: SimpleMaroon
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: Adds a reservist version of the TCFL service card.
+  - tweak: Swaps the active service card in loadout with the reservist card.


### PR DESCRIPTION
As discussed in the relay, anyone traveling abroad on the Horizon would be a reservist, not active duty. This adds a reservist card and makes it the default in loadout.