### PR TITLE
Fixes HoS Fax Machine Name

### DIFF
--- a/html/changelogs/hos_fax.yml
+++ b/html/changelogs/hos_fax.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the HoS fax being named as \"Unknown\"."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -31264,7 +31264,9 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "sHm" = (
-/obj/machinery/photocopier/faxmachine,
+/obj/machinery/photocopier/faxmachine{
+	department = "Head of Security's Office"
+	},
 /obj/structure/table/standard,
 /obj/machinery/light{
 	dir = 1


### PR DESCRIPTION
this PR fixes the HoS' fax machine not having a name when faxing it. fixes #13812.