### PR TITLE
Re-adds the missing Quikpay to the kitchen

### DIFF
--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -32330,6 +32330,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
+/obj/item/device/nanoquikpay,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen/freezer)
 "tvM" = (


### PR DESCRIPTION
I thought the Quikpay spawns with the /chefcloset, it does not. This fixes this. 

No changelog because bugfix.