### PR TITLE
Spiderbots can now be given access

### DIFF
--- a/code/modules/heavy_vehicle/mech_interaction.dm
+++ b/code/modules/heavy_vehicle/mech_interaction.dm
@@ -248,6 +248,8 @@
 	if(sync_access)
 		for(var/mob/pilot in pilots)
 			var/obj/item/card/id/pilot_id = pilot.GetIdCard()
+			if(istype(pilot, /mob/living/simple_animal/spiderbot))
+				pilot_id.access = get_all_station_access()
 			if(pilot_id && pilot_id.access) access_card.access |= pilot_id.access
 			to_chat(pilot, "<span class='notice'>Security access permissions synchronized.</span>")
 

--- a/code/modules/heavy_vehicle/mech_interaction.dm
+++ b/code/modules/heavy_vehicle/mech_interaction.dm
@@ -248,8 +248,6 @@
 	if(sync_access)
 		for(var/mob/pilot in pilots)
 			var/obj/item/card/id/pilot_id = pilot.GetIdCard()
-			if(istype(pilot, /mob/living/simple_animal/spiderbot))
-				pilot_id.access = get_all_station_access()
 			if(pilot_id && pilot_id.access) access_card.access |= pilot_id.access
 			to_chat(pilot, "<span class='notice'>Security access permissions synchronized.</span>")
 

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -143,10 +143,10 @@
 				else
 					to_chat(user, "<span class='danger'>You swipe your card with no effect.</span>")
 					return 0
-		if("Sync")
-			internal_id.access.Cut()
-			internal_id.access = id_card.access.Copy()
-			to_chat(user, SPAN_NOTICE("Access synced with [src]"))
+			if("Sync")
+				internal_id.access.Cut()
+				internal_id.access = id_card.access.Copy()
+				to_chat(user, SPAN_NOTICE("Access synced with [src]"))
 	else
 		O.attack(src, user, user.zone_sel.selecting)
 

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -133,20 +133,29 @@
 
 		switch(choice)
 			if("Eject")
-				if(access_robotics in id_card.access)
-					to_chat(user, "<span class='notice'>You swipe your access card and pop the brain out of \the [src].</span>")
-					eject_brain()
-					if(held_item)
-						held_item.forceMove(src.loc)
-						held_item = null
-					return 1
+				if(!use_check_and_message(user))
+					if(access_robotics in id_card.access)
+						to_chat(user, "<span class='notice'>You swipe your access card and pop the brain out of \the [src].</span>")
+						eject_brain()
+						if(held_item)
+							held_item.forceMove(src.loc)
+							held_item = null
+						return 1
+					else
+						to_chat(user, "<span class='danger'>You swipe your card with no effect.</span>")
+						return 0
 				else
-					to_chat(user, "<span class='danger'>You swipe your card with no effect.</span>")
+					to_chat(user, "<span class='danger'>You are unable to swipe!</span>")
 					return 0
 			if("Sync")
-				internal_id.access.Cut()
-				internal_id.access = id_card.access.Copy()
-				to_chat(user, SPAN_NOTICE("Access synced with [src]"))
+				if(!use_check_and_message(user))
+					internal_id.access.Cut()
+					internal_id.access = id_card.access.Copy()
+					to_chat(user, SPAN_NOTICE("Access synced with [src]"))
+					return 1
+				else
+					to_chat(user, "<span class='danger'>You are unable to swipe!</span>")
+					return 0
 	else
 		O.attack(src, user, user.zone_sel.selecting)
 

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -119,7 +119,7 @@
 			return
 	else if(O.GetID())
 		if (!mmi)
-			to_chat(user, "<span class='danger'>There's no reason to swipe your ID - \the [src] has no brain to remove.</span>")
+			to_chat(user, "<span class='danger'>There's no reason to swipe your ID - \the [src] has no brain.</span>")
 			return 0
 
 		var/obj/item/card/id/id_card = O.GetID()
@@ -127,17 +127,26 @@
 		if(!istype(id_card))
 			return 0
 
-		if(access_robotics in id_card.access)
-			to_chat(user, "<span class='notice'>You swipe your access card and pop the brain out of \the [src].</span>")
-			eject_brain()
-			if(held_item)
-				held_item.forceMove(src.loc)
-				held_item = null
-			return 1
-		else
-			to_chat(user, "<span class='danger'>You swipe your card with no effect.</span>")
-			return 0
+		var/choice = input(user, "Would you like to eject the brain or sync access?", "Swipe Mode") as null|anything in list("Eject", "Sync")
+		if(!choice)
+			return
 
+		switch(choice)
+			if("Eject")
+				if(access_robotics in id_card.access)
+					to_chat(user, "<span class='notice'>You swipe your access card and pop the brain out of \the [src].</span>")
+					eject_brain()
+					if(held_item)
+						held_item.forceMove(src.loc)
+						held_item = null
+					return 1
+				else
+					to_chat(user, "<span class='danger'>You swipe your card with no effect.</span>")
+					return 0
+		if("Sync")
+			internal_id.access.Cut()
+			internal_id.access = id_card.access.Copy()
+			to_chat(user, SPAN_NOTICE("Access synced with [src]"))
 	else
 		O.attack(src, user, user.zone_sel.selecting)
 

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -133,29 +133,26 @@
 
 		switch(choice)
 			if("Eject")
-				if(!use_check_and_message(user))
-					if(access_robotics in id_card.access)
-						to_chat(user, "<span class='notice'>You swipe your access card and pop the brain out of \the [src].</span>")
-						eject_brain()
-						if(held_item)
-							held_item.forceMove(src.loc)
-							held_item = null
-						return 1
-					else
-						to_chat(user, "<span class='danger'>You swipe your card with no effect.</span>")
-						return 0
-				else
-					to_chat(user, "<span class='danger'>You are unable to swipe!</span>")
+				if(use_check_and_message(user))
 					return 0
-			if("Sync")
-				if(!use_check_and_message(user))
-					internal_id.access.Cut()
-					internal_id.access = id_card.access.Copy()
-					to_chat(user, SPAN_NOTICE("Access synced with [src]"))
+				if(access_robotics in id_card.access)
+					to_chat(user, "<span class='notice'>You swipe your access card and pop the brain out of \the [src].</span>")
+					eject_brain()
+					if(held_item)
+						held_item.forceMove(src.loc)
+						held_item = null
 					return 1
 				else
-					to_chat(user, "<span class='danger'>You are unable to swipe!</span>")
+					to_chat(user, "<span class='danger'>You swipe your card with no effect.</span>")
 					return 0
+			if("Sync")
+				if(use_check_and_message(user))
+					return 0
+
+				internal_id.access.Cut()
+				internal_id.access = id_card.access.Copy()
+				to_chat(user, SPAN_NOTICE("Access synced with [src]"))
+				return 1
 	else
 		O.attack(src, user, user.zone_sel.selecting)
 

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -151,7 +151,7 @@
 
 				internal_id.access.Cut()
 				internal_id.access = id_card.access.Copy()
-				to_chat(user, SPAN_NOTICE("Access synced with [src]"))
+				to_chat(user, SPAN_NOTICE("Access synced with [src]."))
 				return 1
 	else
 		O.attack(src, user, user.zone_sel.selecting)

--- a/html/changelogs/Ben10083 - Spida.yml
+++ b/html/changelogs/Ben10083 - Spida.yml
@@ -10,4 +10,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Exosuits piloted by spiderbots now have all access (as if they were a cyborg)."
+  - tweak: "Swiping your ID card on a spiderbot can now give access."

--- a/html/changelogs/Ben10083 - Spida.yml
+++ b/html/changelogs/Ben10083 - Spida.yml
@@ -10,4 +10,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Swiping your ID card on a spiderbot can now give access."
+  - rscadd: "Swiping your ID card on a spiderbot can now give access."

--- a/html/changelogs/Ben10083 - Spida.yml
+++ b/html/changelogs/Ben10083 - Spida.yml
@@ -10,4 +10,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Swiping your ID card on a spiderbot can now give access."
+  - rscadd: "People can now give spiderbots access by swiping their ID."

--- a/html/changelogs/Ben10083 - Spida.yml
+++ b/html/changelogs/Ben10083 - Spida.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Exosuits piloted by spiderbots now have all access (as if they were a cyborg)."


### PR DESCRIPTION
OLD: Spiderbots who enter a exosuit now are able to use all airlocks, as if they were a cyborg. This change will allow spiderbots to utilize the exosuit effectively. 

NEW: People can now have their access on their ID transfer to a spiderbot by swiping.