### PR TITLE
Hydro&Garden 1.0

### DIFF
--- a/html/changelogs/Huntime-HydryoImprovements.yml
+++ b/html/changelogs/Huntime-HydryoImprovements.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Huntime
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Hydroponics & Garden QOL changes for access/tray count."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -1636,6 +1636,8 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
+/obj/structure/window/reinforced,
+/obj/structure/railing/mapped,
 /turf/simulated/floor/grass/alt,
 /area/maintenance/hangar/port)
 "bqi" = (
@@ -1942,12 +1944,16 @@
 /turf/simulated/wall,
 /area/maintenance/hangar/port)
 "bCN" = (
-/obj/structure/railing/mapped{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/structure/railing/mapped,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/grass/alt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
 /area/maintenance/hangar/port)
 "bCU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4889,8 +4895,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/fancy/wood/corner{
-	dir = 4
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/hangar/port)
@@ -7249,9 +7255,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "fWH" = (
-/obj/structure/railing/mapped,
-/obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/window/reinforced,
+/obj/structure/railing/mapped,
 /turf/simulated/floor/grass/alt,
 /area/maintenance/hangar/port)
 "fXy" = (
@@ -11908,13 +11913,17 @@
 /turf/simulated/floor/plating,
 /area/hangar/auxiliary)
 "kcE" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/railing/mapped{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/grass/alt,
 /area/maintenance/hangar/port)
 "kcL" = (
 /obj/structure/shuttle/engine/propulsion/burst/right{
@@ -13946,10 +13955,16 @@
 /turf/simulated/wall,
 /area/hangar/auxiliary)
 "lQE" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
 /area/maintenance/hangar/port)
 "lQI" = (
 /obj/structure/cable/green{
@@ -22625,6 +22640,15 @@
 /area/maintenance/engineering)
 "tsD" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
+/area/maintenance/hangar/port)
+"ttb" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/turf/simulated/floor/grass/alt,
 /area/maintenance/hangar/port)
 "ttc" = (
 /obj/item/modular_computer/console/preset/command{
@@ -51091,9 +51115,9 @@ tVl
 yff
 ucG
 byS
-kcE
 snA
-dMS
+lQE
+bCN
 dMS
 rRi
 jeF
@@ -51295,8 +51319,8 @@ goQ
 mqy
 qTO
 bqb
-bCN
 dcZ
+kcE
 bCi
 kZl
 dDV
@@ -51496,9 +51520,9 @@ iqf
 cnV
 bZn
 eZX
-vpB
 fWH
 fxh
+ttb
 bCi
 uYo
 nyp
@@ -51700,7 +51724,7 @@ lPF
 eTW
 qfU
 vpB
-lQE
+vpB
 bCi
 mdL
 wlf

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -172,11 +172,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora_hazard)
 "acH" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
@@ -187,14 +187,16 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "aec" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/effect/floor_decal/corner/green{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "aem" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -253,19 +255,26 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "agY" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
+/obj/effect/floor_decal/corner/green{
+	dir = 5
 	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/small/south,
 /obj/structure/cable/green{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/obj/structure/table/standard,
-/obj/machinery/reagentgrinder{
-	pixel_y = 7
+/obj/machinery/requests_console{
+	department = "Hydroponics";
+	departmentType = 2;
+	name = "Hydroponics Requests Console";
+	pixel_y = 30
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "ahu" = (
 /obj/structure/cable{
@@ -684,19 +693,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
 "asG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/corner/green{
+	dir = 5
 	},
-/obj/effect/landmark/start{
-	name = "Gardener"
+/obj/effect/floor_decal/corner/green{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "asO" = (
+/obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
 /turf/simulated/floor/grass/alt,
 /area/hydroponics/garden)
 "ati" = (
@@ -922,14 +933,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
-"ayo" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
 "ayv" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -1009,11 +1012,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/storage)
 "azB" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "azO" = (
@@ -1714,10 +1721,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
-"aTO" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
 "aUh" = (
 /obj/machinery/chemical_dispenser/full{
 	dir = 1
@@ -2515,10 +2518,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/hallway/primary/central_two)
 "bpF" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/seed_extractor,
-/turf/simulated/floor/tiled,
+/obj/machinery/vending/hydronutrients,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics)
 "bpN" = (
 /obj/structure/cable{
@@ -2669,16 +2671,18 @@
 /area/maintenance/hangar/port)
 "buz" = (
 /obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/device/radio/intercom{
-	pixel_y = 25
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/obj/machinery/light_switch{
-	pixel_x = 10;
-	pixel_y = 40
+/obj/effect/floor_decal/corner/green/full{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/item/material/hatchet,
+/obj/item/material/minihoe,
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "bve" = (
 /obj/structure/window/reinforced{
@@ -2745,12 +2749,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/kitchen)
 "byq" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/newscaster{
-	pixel_y = 30
+/obj/effect/floor_decal/corner/green{
+	dir = 5
 	},
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/bed/stool/chair/office/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "byv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3213,19 +3221,25 @@
 	},
 /area/server)
 "bOA" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/green{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics/garden)
 "bOI" = (
 /obj/structure/cable/green{
@@ -3338,9 +3352,22 @@
 /turf/simulated/floor/plating,
 /area/engineering/storage/tech)
 "bQt" = (
-/obj/effect/map_effect/airlock/w_to_e,
-/turf/simulated/wall,
-/area/hydroponics)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
+/area/maintenance/hangar/port)
 "bQv" = (
 /obj/machinery/door/airlock/freezer{
 	id_tag = "arrivals_unit_1";
@@ -3442,24 +3469,19 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "bTz" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/requests_console{
-	department = "Hydroponics";
-	departmentType = 2;
-	name = "Hydroponics Requests Console";
-	pixel_y = 30
+/obj/structure/table/stone/marble,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/dark,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/hydroponics/garden)
 "bTM" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/seed_storage/garden,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/dark,
-/area/hydroponics)
+/turf/simulated/floor/wood,
+/area/hydroponics/garden)
 "bUk" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3567,10 +3589,23 @@
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "bXR" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/effect/floor_decal/corner/green{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "bXS" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
@@ -4499,9 +4534,13 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical)
 "cIN" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "cJu" = (
 /obj/effect/floor_decal/corner_wide/yellow{
@@ -4563,8 +4602,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/port)
 "cKg" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics/garden)
 "cKn" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -4685,23 +4727,24 @@
 /turf/simulated/floor/tiled,
 /area/operations/break_room)
 "cNz" = (
-/obj/structure/table/stone/marble,
-/obj/machinery/reagentgrinder,
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/hydroponics/garden)
+/obj/machinery/smartfridge/secure,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
 "cNU" = (
 /turf/simulated/wall,
 /area/rnd/research)
 "cNX" = (
-/obj/structure/table/standard,
-/obj/machinery/door/window{
-	dir = 4;
-	layer = 2.85;
-	name = "hydroponics desk";
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/effect/floor_decal/corner/green/diagonal{
+	dir = 8
+	},
+/obj/machinery/door/airlock/glass_service{
+	name = "Hydroponics";
 	req_access = list(35)
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "cOj" = (
 /obj/machinery/vending/security,
@@ -4711,10 +4754,12 @@
 /turf/simulated/floor/tiled,
 /area/security/main)
 "cOk" = (
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 8
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/corner/green/full,
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "cOn" = (
 /obj/effect/floor_decal/corner/green{
@@ -4947,13 +4992,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "cWf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "cWx" = (
 /obj/effect/floor_decal/industrial/outline/red,
@@ -5435,18 +5493,22 @@
 /turf/simulated/floor/tiled/dark/airless,
 /area/maintenance/wing/starboard)
 "dlG" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/bee_smoker,
-/obj/item/beehive_assembly,
-/obj/item/bee_pack,
-/obj/item/bee_net,
-/obj/item/honey_frame,
-/obj/item/honey_frame,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/light,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/turf/simulated/floor/grass/alt,
+/obj/effect/floor_decal/corner/green/full{
+	dir = 1
+	},
+/obj/structure/sink/kitchen{
+	dir = 8;
+	name = "Hydroponics sink";
+	pixel_x = 21
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "dlQ" = (
 /obj/machinery/door/airlock/glass_mining{
@@ -5510,13 +5572,13 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/port)
 "dnJ" = (
@@ -5970,18 +6032,17 @@
 /area/rnd/hallway)
 "dDo" = (
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 1;
+	is_critical = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/random/junk,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/maintenance/hangar/port)
+/obj/structure/railing/mapped,
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
 "dDp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -6171,16 +6232,14 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/port)
 "dKB" = (
@@ -7193,14 +7252,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
-"euT" = (
-/obj/structure/sink/kitchen{
-	dir = 4;
-	name = "hydroponics sink";
-	pixel_x = -20
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hydroponics)
 "euX" = (
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d2-1"
@@ -7248,10 +7299,27 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "evU" = (
-/obj/structure/window/reinforced,
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/grass/alt,
-/area/hydroponics)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
+/area/maintenance/hangar/port)
 "ewb" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -7438,7 +7506,11 @@
 /turf/simulated/open,
 /area/maintenance/wing/starboard)
 "eAX" = (
+/obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/grass/alt,
 /area/hydroponics/garden)
 "eBc" = (
@@ -8146,23 +8218,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/storage_eva)
-"eZm" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/maintenance/hangar/port)
 "eZo" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8363,19 +8418,28 @@
 /turf/simulated/open,
 /area/hallway/primary/central_two)
 "fdZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_service{
-	name = "Hydroponics";
-	req_access = list(35)
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/map_effect/wingrille_spawn/reinforced/firedoor,
+/turf/simulated/floor/plating,
 /area/hydroponics)
 "fei" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/effect/floor_decal/corner/green{
+	dir = 5
 	},
-/obj/machinery/firealarm/west,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/structure/sink/kitchen{
+	dir = 4;
+	name = "hydroponics sink";
+	pixel_x = -20
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "fek" = (
 /obj/structure/cable{
@@ -8450,11 +8514,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "fgd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/green/diagonal,
-/turf/simulated/floor/tiled,
+/obj/machinery/seed_extractor,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics)
 "fgZ" = (
 /obj/machinery/light/small{
@@ -8563,17 +8625,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
-	},
-/obj/random/junk,
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/port)
 "fkF" = (
@@ -8944,10 +9005,14 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
 "fwE" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/green{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "fwK" = (
 /obj/structure/bed/stool/chair/padded/black{
@@ -9135,14 +9200,13 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "fEI" = (
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck - Garden";
-	dir = 8
-	},
-/obj/structure/sink/kitchen{
+/obj/machinery/alarm{
 	dir = 8;
-	name = "sink";
-	pixel_x = 20
+	pixel_x = 28;
+	req_one_access = list(24,11,55)
+	},
+/obj/machinery/firealarm{
+	pixel_y = -32
 	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
@@ -9204,8 +9268,17 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "fGT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
+/obj/structure/cable/green{
+	icon_state = "11-8"
+	},
+/obj/structure/lattice,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/turf/simulated/open,
 /area/maintenance/hangar/port)
 "fHo" = (
 /obj/effect/floor_decal/corner/green/full,
@@ -9836,14 +9909,15 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "fWh" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/structure/window/reinforced{
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/item/watertank,
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/grass/alt,
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "fWp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -9909,9 +9983,22 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/hor)
 "fZr" = (
-/obj/machinery/chem_master,
-/turf/simulated/floor/tiled/dark,
-/area/hydroponics)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/hydroponics/garden)
 "fZz" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -10389,10 +10476,12 @@
 /turf/template_noop,
 /area/horizonexterior)
 "gmt" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/chemical_dispenser,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/grass/alt,
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics)
 "gmE" = (
 /obj/structure/table/standard,
@@ -10591,11 +10680,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/aux_atmospherics/deck_2/starboard)
-"gsh" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
 "gst" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11110,10 +11194,14 @@
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "gEf" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/seed_storage/garden,
-/turf/simulated/floor/tiled,
+/obj/structure/table/standard,
+/obj/machinery/reagentgrinder{
+	pixel_y = 7
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics)
 "gEB" = (
 /obj/structure/cable{
@@ -11134,12 +11222,22 @@
 /turf/simulated/floor/grass/alt,
 /area/rnd/hallway)
 "gFc" = (
-/obj/machinery/disposal,
-/obj/machinery/light{
-	dir = 1
+/obj/effect/floor_decal/corner/green{
+	dir = 9
 	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics/garden)
 "gFs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -11483,17 +11581,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"gQD" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/hydroponics/garden)
 "gRh" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -11507,12 +11594,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "gRr" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/biogenerator{
-	icon_state = "biogen-empty"
-	},
-/turf/simulated/floor/tiled,
+/obj/machinery/seed_storage/garden,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics)
 "gRU" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -11676,9 +11760,10 @@
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/telesci)
 "gXb" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
+/obj/machinery/seed_extractor,
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "gXu" = (
@@ -11712,10 +11797,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armory)
 "gYj" = (
-/obj/structure/window/reinforced,
-/obj/machinery/light,
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/grass/alt,
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/effect/landmark/start{
+	name = "Gardener"
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "gYm" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
@@ -11749,7 +11843,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "gZt" = (
-/turf/simulated/floor/wood,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/grass/alt,
 /area/hydroponics/garden)
 "gZY" = (
 /obj/machinery/alarm{
@@ -11951,7 +12047,15 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "hfD" = (
-/obj/machinery/seed_storage/garden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "hfI" = (
@@ -12628,17 +12732,17 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/or1)
 "hBz" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/hydroponics/garden)
+/obj/structure/table/standard,
+/obj/item/reagent_containers/chem_disp_cartridge,
+/obj/item/reagent_containers/chem_disp_cartridge,
+/obj/item/reagent_containers/chem_disp_cartridge,
+/obj/item/reagent_containers/chem_disp_cartridge,
+/obj/item/reagent_containers/chem_disp_cartridge,
+/obj/item/reagent_containers/chem_disp_cartridge,
+/obj/item/reagent_containers/chem_disp_cartridge,
+/obj/item/reagent_containers/chem_disp_cartridge,
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
 "hBJ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -13058,10 +13162,14 @@
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
 "hMX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "hNC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -13200,8 +13308,11 @@
 /turf/simulated/floor/reinforced,
 /area/turret_protected/ai)
 "hSp" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/machinery/light,
 /turf/simulated/floor/grass/alt,
-/area/hydroponics)
+/area/hydroponics/garden)
 "hSr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13483,12 +13594,18 @@
 /turf/simulated/floor/plating,
 /area/rnd/hallway)
 "idL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/structure/disposalpipe/sortjunction/flipped{
-	name = "Hydroponics";
-	sortType = "Hydroponics"
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
@@ -13840,9 +13957,14 @@
 /turf/simulated/floor/tiled,
 /area/engineering/storage_eva)
 "inB" = (
-/obj/machinery/seed_extractor,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/small/west,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
@@ -14164,6 +14286,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/floor_decal/corner/green/full{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hydroponics/garden)
 "iCz" = (
@@ -15039,7 +15164,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/starboard)
 "jaK" = (
-/obj/machinery/smartfridge/drying_rack,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "jaR" = (
@@ -16140,11 +16278,19 @@
 	},
 /area/crew_quarters/bar)
 "jHK" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_service{
+	name = "Hydroponics";
+	req_access = list(35)
 	},
-/turf/simulated/floor/wood,
-/area/hydroponics/garden)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
 "jHX" = (
 /obj/structure/bed/stool/chair/padded/brown{
 	dir = 8
@@ -17221,17 +17367,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/conference)
 "kuG" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/bed/stool/bar/padded/green,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
@@ -18408,13 +18558,11 @@
 /turf/simulated/floor/wood,
 /area/operations/qm)
 "lgB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/effect/floor_decal/corner/green{
+	dir = 10
 	},
-/obj/effect/landmark/start{
-	name = "Gardener"
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "lgC" = (
 /obj/machinery/door/firedoor,
@@ -18766,8 +18914,10 @@
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "ltv" = (
-/obj/machinery/chemical_dispenser,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "ltG" = (
 /obj/effect/floor_decal/corner_wide/yellow{
@@ -18970,9 +19120,12 @@
 /turf/simulated/floor/plating,
 /area/chapel/office)
 "lBS" = (
-/obj/machinery/light/small/red,
-/turf/simulated/floor/plating,
-/area/maintenance/hangar/port)
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(35)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics)
 "lBV" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
 /turf/simulated/open/airless,
@@ -19548,12 +19701,14 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
 "lRq" = (
-/obj/structure/disposalpipe/trunk{
+/obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
-/obj/machinery/disposal/small/west,
-/turf/simulated/floor/tiled/dark,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/hydroponics/garden)
 "lRx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20092,6 +20247,8 @@
 /obj/machinery/door/window{
 	req_one_access = list(28)
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen)
 "mgs" = (
@@ -20238,11 +20395,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "mjl" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/grass/alt,
+/obj/machinery/light_switch{
+	pixel_y = 25;
+	pixel_x = 25
+	},
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics)
 "mjx" = (
 /obj/machinery/atmospherics/unary/freezer{
@@ -20553,15 +20716,12 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "muz" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/structure/window/reinforced{
+/obj/structure/lattice,
+/obj/structure/railing/mapped{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/grass/alt,
-/area/hydroponics)
+/turf/space,
+/area/maintenance/hangar/port)
 "muK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -20720,12 +20880,17 @@
 	},
 /area/crew_quarters/kitchen/freezer)
 "myE" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/floor_decal/corner/green{
+	dir = 5
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/grass/alt,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "myG" = (
 /obj/structure/table/standard,
@@ -20752,8 +20917,16 @@
 /turf/simulated/wall,
 /area/rnd/xenobiology/xenoflora_hazard)
 "mBk" = (
-/obj/structure/bed/stool/padded/red,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/corner/green{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics/garden)
 "mBB" = (
 /turf/simulated/wall/r_wall,
@@ -21313,15 +21486,12 @@
 /turf/simulated/floor/tiled/white,
 /area/operations/break_room)
 "mQR" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/effect/floor_decal/corner/green,
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "mQW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -21514,10 +21684,19 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "mXh" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/effect/floor_decal/industrial/outline,
-/obj/item/watertank,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "mXw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -21841,13 +22020,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "nfN" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/item/watertank,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/green/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "nfW" = (
 /obj/effect/floor_decal/corner/mauve{
@@ -22254,10 +22438,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armory)
 "npD" = (
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 4
+/obj/effect/floor_decal/corner/green{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "npF" = (
 /obj/effect/floor_decal/corner_wide/yellow{
@@ -22446,13 +22636,11 @@
 /turf/simulated/floor/carpet,
 /area/medical/psych)
 "nxk" = (
+/obj/structure/cable/green,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
 	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
 	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
@@ -22581,18 +22769,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "nAM" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/maintenance/hangar/port)
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/corner/green/full,
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics/garden)
 "nAO" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -22660,22 +22840,7 @@
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "nCt" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/structure/bed/stool/bar/padded/green,
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "nCD" = (
@@ -22693,11 +22858,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/engineering/tesla)
 "nCX" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/tiled,
+/obj/machinery/chem_master,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics)
 "nDd" = (
 /obj/effect/floor_decal/corner/blue{
@@ -22842,11 +23005,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "nJs" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/biogenerator{
+	icon_state = "biogen-empty"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics)
 "nKc" = (
 /obj/effect/floor_decal/industrial/loading/yellow{
@@ -23439,11 +23602,17 @@
 /turf/simulated/floor/carpet,
 /area/chapel/office)
 "ogu" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood,
+/area/hydroponics/garden)
 "ogR" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -23760,7 +23929,9 @@
 /area/maintenance/research_port)
 "oqN" = (
 /obj/structure/table/stone/marble,
-/obj/item/wirecutters/clippers,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "oqW" = (
@@ -24233,16 +24404,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"oBV" = (
-/obj/structure/cable/green{
-	icon_state = "11-8"
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/turf/simulated/open,
-/area/maintenance/hangar/port)
 "oBZ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -24771,11 +24932,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/port)
 "oTR" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/grass/alt,
-/area/hydroponics)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/hydroponics/garden)
 "oUt" = (
 /turf/simulated/wall,
 /area/medical/first_responder)
@@ -26825,6 +26991,16 @@
 /obj/structure/table/stone/marble,
 /obj/item/material/hatchet,
 /obj/item/material/minihoe,
+/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "qbq" = (
@@ -27135,13 +27311,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small/red,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/port)
 "qnE" = (
@@ -27311,7 +27489,15 @@
 /area/turret_protected/ai_upload_foyer)
 "quh" = (
 /obj/structure/table/stone/marble,
-/obj/item/reagent_containers/glass/bucket,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 7
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "quD" = (
@@ -28354,9 +28540,15 @@
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "qZb" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/reagent_dispensers/watertank,
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "qZi" = (
@@ -29393,13 +29585,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
 "rAn" = (
-/obj/structure/table/wood,
-/obj/item/storage/pill_bottle/dice/gaming,
-/obj/item/storage/pill_bottle/dice,
-/obj/machinery/newscaster{
-	pixel_y = -32
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = -26
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/library)
 "rAw" = (
 /obj/structure/cable/green{
@@ -31351,12 +31542,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
-"sKo" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/vending/hydronutrients,
-/turf/simulated/floor/tiled,
-/area/hydroponics)
 "sKz" = (
 /obj/structure/closet/secure_closet/security,
 /obj/effect/floor_decal/corner/blue{
@@ -31510,6 +31695,11 @@
 "sOu" = (
 /obj/machinery/recharger,
 /obj/structure/table/wood,
+/obj/item/storage/pill_bottle/dice,
+/obj/item/storage/pill_bottle/dice/gaming,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
 /turf/simulated/floor/wood,
 /area/library)
 "sPp" = (
@@ -31783,12 +31973,20 @@
 /turf/simulated/wall,
 /area/engineering/lobby)
 "sYq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/machinery/door/window/westleft,
-/turf/simulated/floor/grass/alt,
-/area/hydroponics)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hydroponics/garden)
 "sYA" = (
 /obj/structure/lattice,
 /obj/structure/cable/green{
@@ -32152,12 +32350,13 @@
 /area/operations/storage)
 "tiF" = (
 /obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/light,
-/obj/machinery/camera/network/service{
-	c_tag = "Dinner - Hydroponics 1";
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hydroponics)
 "tiJ" = (
@@ -32179,9 +32378,14 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/hor)
 "tje" = (
-/obj/effect/map_effect/wingrille_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/obj/machinery/honey_extractor{
+	density = 1
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics)
 "tjk" = (
 /obj/machinery/light{
@@ -32363,20 +32567,28 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/pharmacy)
 "tpc" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/green{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics/garden)
 "tpy" = (
 /obj/structure/sink/kitchen{
@@ -33548,11 +33760,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "tZR" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/rack,
-/obj/item/crowbar/red,
-/obj/item/crowbar/red,
+/obj/effect/floor_decal/corner/green{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "uaM" = (
@@ -33645,16 +33865,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/or1)
 "ucY" = (
-/obj/structure/table/standard,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
 /obj/machinery/light,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/obj/item/reagent_containers/chem_disp_cartridge,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "udv" = (
 /obj/structure/disposalpipe/segment{
@@ -33953,11 +34168,22 @@
 /turf/simulated/floor/plating,
 /area/rnd/research)
 "ulS" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/structure/sink/kitchen{
-	name = "sink";
-	pixel_y = 26
+/obj/effect/floor_decal/corner/green{
+	dir = 5
 	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/table/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/crowbar,
+/obj/item/crowbar,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "ulV" = (
@@ -33982,6 +34208,7 @@
 	},
 /area/crew_quarters/kitchen/freezer)
 "uma" = (
+/obj/effect/map_effect/airlock,
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/hydroponics)
 "umH" = (
@@ -34917,10 +35144,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
 "uLh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/corner/green{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/effect/landmark/start{
+	name = "Gardener"
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "uLw" = (
 /obj/structure/bed/stool/chair{
@@ -35497,19 +35734,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
-"veO" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/maintenance/hangar/port)
 "veP" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -35650,17 +35874,17 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
 "vkw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 2;
 	icon_state = "pipe-j2"
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
 "vlr" = (
@@ -36211,9 +36435,9 @@
 /turf/simulated/floor/plating,
 /area/rnd/hallway)
 "vCa" = (
-/obj/effect/map_effect/wingrille_spawn/reinforced,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/turf/simulated/floor/grass/alt,
 /area/hydroponics/garden)
 "vCl" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -37190,10 +37414,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "vZJ" = (
-/obj/structure/table/standard,
-/obj/structure/closet/crate/hydroponics/prespawned,
-/turf/simulated/floor/wood,
-/area/hydroponics/garden)
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/sortjunction/flipped{
+	name = "Hydroponics";
+	sortType = "Hydroponics"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/hydroponics)
 "vZY" = (
 /obj/structure/bed/stool/chair/office/dark,
 /obj/machinery/light{
@@ -37501,13 +37738,14 @@
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
 "wiz" = (
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/structure/table/standard,
-/obj/item/storage/box/fancy/vials,
-/obj/item/storage/box/spraybottles,
-/obj/item/storage/box/pillbottles,
-/obj/machinery/camera/network/service{
-	c_tag = "Dinner - Hydroponics 2"
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
@@ -38121,17 +38359,28 @@
 /turf/simulated/floor/tiled/ramp,
 /area/maintenance/wing/starboard)
 "wBq" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/bed/stool/bar/padded/green,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "wBF" = (
@@ -38701,10 +38950,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "wOo" = (
-/obj/machinery/honey_extractor{
-	density = 1
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/corner/green/full{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/sink/kitchen{
+	dir = 8;
+	name = "Hydroponics sink";
+	pixel_x = 21
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "wOV" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -39404,6 +39662,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/port)
@@ -39548,12 +39809,7 @@
 /turf/simulated/open,
 /area/maintenance/wing/starboard)
 "xoL" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/hydroponics/garden)
 "xoW" = (
@@ -39754,10 +40010,6 @@
 "xwo" = (
 /turf/simulated/floor/reinforced,
 /area/engineering/storage/tech)
-"xwU" = (
-/obj/structure/lattice/catwalk,
-/turf/simulated/floor/plating,
-/area/template_noop)
 "xxa" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -39899,8 +40151,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/armory)
 "xBv" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/map_effect/wingrille_spawn/reinforced/firedoor,
+/turf/simulated/floor/plating,
 /area/hydroponics/garden)
 "xBN" = (
 /obj/machinery/light{
@@ -40666,18 +40918,15 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engine_airlock)
 "xXi" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_service{
-	name = "Hydroponics";
-	req_access = list(35)
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/bee_net,
+/obj/item/bee_pack,
+/obj/item/beehive_assembly,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/bee_smoker,
+/turf/simulated/floor/tiled/dark,
 /area/hydroponics)
 "xXM" = (
 /obj/machinery/requests_console{
@@ -40796,16 +41045,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
 "yaJ" = (
-/obj/structure/bed/stool/chair/padded/black{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = -26
 	},
 /turf/simulated/floor/carpet,
 /area/library)
@@ -41079,8 +41320,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "yfo" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "yfL" = (
 /obj/structure/table/standard,
@@ -61808,15 +62058,15 @@ rOx
 rQh
 pWx
 xOo
-vCa
+xBv
 iCx
+nAM
 xBv
-xBv
-vCa
 dvw
-tje
+dvw
+fdZ
 cNX
-tje
+fdZ
 fdZ
 txq
 txq
@@ -62010,16 +62260,16 @@ hGj
 nVX
 cSi
 xOo
-eAX
-kuG
+vCa
+bOA
+cKg
 gZt
-gZt
-eAX
 dvw
+gEf
 buz
 cOk
-euT
-cOE
+maV
+maV
 fei
 maV
 pED
@@ -62214,15 +62464,15 @@ uZs
 xOo
 eAX
 bOA
-gXb
-gZt
-eAX
-dvw
+cKg
+hSp
+fdZ
+hBz
 byq
-cOE
-aTO
-gsh
-uLh
+lgB
+maV
+maV
+asG
 maV
 pED
 pFU
@@ -62415,15 +62665,15 @@ nVX
 sOu
 xOo
 asO
-kuG
+bOA
 cKg
-gZt
-eAX
-dvw
-bTz
-cOE
-sKo
-tZR
+vCa
+fdZ
+gmt
+cIN
+lgB
+maV
+maV
 uLh
 tiF
 pED
@@ -62614,18 +62864,18 @@ oNS
 lnr
 tPJ
 pea
-rAn
+pWx
 xOo
 gFc
 tpc
 mBk
-mBk
-mBk
-dvw
-bTM
+sYq
+fdZ
+nCX
+cIN
 lgB
-gEf
-ayo
+maV
+maV
 asG
 maV
 pED
@@ -62817,18 +63067,18 @@ pWx
 ewk
 pWx
 pWx
-xOo
-sdd
+gXb
+lRq
 kuG
 oqN
 quh
 cNz
-dvw
+cOE
 cIN
 hMX
 gRr
 bpF
-uLh
+idL
 maV
 pED
 vxK
@@ -63014,21 +63264,21 @@ pWx
 gjl
 laV
 pWx
-mHh
+vyP
 rtI
 axG
-pWx
-veO
-hBz
+mHh
+xOo
+sdd
 azB
 wBq
 qbp
-gZt
+oTR
 jHK
-tje
-mXh
-hMX
-nCX
+mjl
+vZJ
+tZR
+qZb
 qZb
 cWf
 bXR
@@ -63219,18 +63469,18 @@ pWx
 vyP
 aYP
 yaJ
-pWx
-nAM
+rAn
 xOo
+bTM
 hfD
 nCt
+bTz
 xoL
-xoL
-gQD
+dvw
 xXi
-nfN
+mXh
 mQR
-idL
+acH
 acH
 aec
 yfo
@@ -63421,14 +63671,14 @@ pWx
 vyP
 fmz
 hpO
-pWx
-dDo
+fmz
 xOo
+ogu
 jaK
 nxk
 inB
 fEI
-vZJ
+dvw
 tje
 mXh
 fwE
@@ -63624,19 +63874,19 @@ pWx
 pWx
 pWx
 pWx
-nAM
 xOo
-xOo
+fZr
 xOo
 xOo
 xOo
 xOo
 dvw
+dvw
 agY
-ogu
-lRq
-uLh
-fZr
+lgB
+maV
+maV
+cIN
 ltv
 pED
 sPK
@@ -63826,18 +64076,18 @@ buh
 buh
 tSa
 buh
-eZm
-hUC
+kyO
+bQt
 hUC
 hUC
 dnn
-bFA
 rxb
-dvw
-wiz
+lBS
 cOE
-muz
-sYq
+wiz
+lgB
+maV
+maV
 myE
 pED
 pED
@@ -64034,12 +64284,12 @@ mJJ
 urP
 fkr
 fGT
-oBV
 dvw
+dDo
 ulS
-cOE
-mjl
-oTR
+lgB
+maV
+maV
 gYj
 cam
 sGn
@@ -64235,14 +64485,14 @@ wdj
 mJJ
 cKJ
 dKA
-gOL
-qOM
-bQt
+muz
+dvw
 ntu
-cOE
-mjl
-hSp
-evU
+fWh
+lgB
+maV
+maV
+cIN
 lAx
 lAx
 lAx
@@ -64437,13 +64687,13 @@ wwd
 mJJ
 vTN
 qnl
-gOL
-lBS
+muz
 dvw
 tRz
+nfN
 wOo
-fWh
-gmt
+maV
+maV
 dlG
 lAx
 iGG
@@ -64640,7 +64890,7 @@ mJJ
 hmX
 xjN
 gOL
-qOM
+dvw
 uma
 idX
 idX
@@ -64840,10 +65090,10 @@ jpR
 pjK
 mJJ
 cLD
-xjN
-gOL
-xwU
-xwU
+evU
+qOM
+qOM
+qOM
 hUK
 hUK
 hUK


### PR DESCRIPTION
- Adds more trays per hydroponics player request by 4x additional trays.
- Removal of the garden pen, since they have a garden down the stairs with grass for use/gives more space for the 4x additional trays.
- QOL layout changes for easy maneuvers and farmbot sink access.
- Moved the stairwell and modified d1 hydro garden.
![19da90f9581375d2d2ec17c52eb1dc13](https://user-images.githubusercontent.com/29168551/167415792-2038ca15-1fd4-4ca4-8af4-73c28c3d5aa7.png)

