### PR TITLE
Implements beakmouth speech impediment for Skrell using auto-hiss + adds small auto-hiss functionality

### DIFF
--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -11,7 +11,7 @@
 
 /client/verb/toggle_autohiss()
 	set name = "Toggle Auto-Hiss"
-	set desc = "Toggle automatic hissing as Unathi, r-rolling as Taj, and buzzing as Vaurca"
+	set desc = "Toggle automatic hissing as Unathi, r-rolling as Taj, buzzing as Vaurca, or beakmouth-speech as Skrell."
 	set category = "OOC"
 
 	autohiss_mode = (autohiss_mode + 1) % AUTOHISS_NUM
@@ -35,6 +35,7 @@
 	var/list/autohiss_basic_extend = null
 	var/list/autohiss_extra_extend = null
 	var/autohiss_extender = "..."
+	var/ignore_subsequent = FALSE
 
 /datum/species/unathi
 	autohiss_basic_map = list(
@@ -59,6 +60,16 @@
 			LANGUAGE_YA_SSA,
 			LANGUAGE_DELVAHII
 		)
+
+/datum/species/skrell
+	autohiss_basic_map = list(
+			"s" = list("sch", "ssch")
+		)
+	autohiss_extra_map = list(
+			"x" = list("ksch", "kssch")
+		)
+	autohiss_exempt = list(LANGUAGE_SKRELLIAN)
+	ignore_subsequent = TRUE
 
 /datum/species/bug
 	autohiss_basic_map = list(
@@ -159,7 +170,10 @@
 						. += capitalize(pick(map[min_char]))
 			else
 				. += pick(map[min_char])
-			message = copytext(message, min_index + 1)
+			if(ignore_subsequent && copytext(message, min_index, min_index+1) == copytext(message, min_index+1, min_index+2))
+				message = copytext(message, min_index + 2) // If the current letter and the subsequent letter are the same, skip the subsequent letter
+			else
+				message = copytext(message, min_index + 1)
 
 	return jointext(., "")
 

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -170,7 +170,7 @@
 						. += capitalize(pick(map[min_char]))
 			else
 				. += pick(map[min_char])
-			if(ignore_subsequent && copytext(message, min_index, min_index+1) == copytext(message, min_index+1, min_index+2))
+			if(ignore_subsequent && lowertext(copytext(message, min_index, min_index+1)) == lowertext(copytext(message, min_index+1, min_index+2)))
 				message = copytext(message, min_index + 2) // If the current letter and the subsequent letter are the same, skip the subsequent letter
 			else
 				message = copytext(message, min_index + 1)

--- a/html/changelogs/llywelwyn-skrell-autohiss.yml
+++ b/html/changelogs/llywelwyn-skrell-autohiss.yml
@@ -1,0 +1,7 @@
+author: Llywelwyn
+
+delete-after: True
+
+changes:
+  - rscadd: "Adds auto-hiss for Skrell beakmouth, simulating a mouth-full sound. BASIC replaces 's' with 'sch', FULL additionally replaces 'x' with 'ksch'."
+  - backend: "Adds additional functionality to auto-hiss to allow an option for preventing doubling up of substitutions for consecutive letters."


### PR DESCRIPTION
  - rscadd: "Adds auto-hiss for Skrell beakmouth, simulating a mouth-full sound. BASIC replaces 's' with 'sch', FULL additionally replaces 'x' with 'ksch'."
  - backend: "Adds additional functionality to auto-hiss to allow an option for preventing doubling up of substitutions for consecutive letters."

![h2qOoXS](https://user-images.githubusercontent.com/82828093/167489483-14e9e851-b331-41b0-a26e-a236a08fb144.gif)

