### PR TITLE
Tramp freighter mapping QOL

### DIFF
--- a/html/changelogs/doxxmedearly - freighter_qol.yml
+++ b/html/changelogs/doxxmedearly - freighter_qol.yml
@@ -2,3 +2,4 @@ author: Doxxmedearly
 delete-after: True
 changes:
   - maptweak: "Made minor map tweaks to the tramp freighter. CO2 tanks split evenly between thruster rooms. Adds a suit cycler, recharging station, and cell charger."
+  - bugfix: "Added a missing console that prevented the tramp freighter cryopod from functioning."

--- a/html/changelogs/doxxmedearly - freighter_qol.yml
+++ b/html/changelogs/doxxmedearly - freighter_qol.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - maptweak: "Made minor map tweaks to the tramp freighter. CO2 tanks split evenly between thruster rooms. Adds a suit cycler, recharging station, and cell charger."

--- a/maps/away/ships/tramp_freighter.dmm
+++ b/maps/away/ships/tramp_freighter.dmm
@@ -1870,6 +1870,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/shuttle/tramp_freighter)
+"vFx" = (
+/obj/machinery/computer/cryopod{
+	pixel_y = -33
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/tramp_freighter)
 "wci" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/vending/cola,
@@ -34995,7 +35001,7 @@ gcq
 gcq
 iHx
 eyx
-eCV
+vFx
 wYA
 wYA
 xRX

--- a/maps/away/ships/tramp_freighter.dmm
+++ b/maps/away/ships/tramp_freighter.dmm
@@ -862,9 +862,7 @@
 /obj/effect/floor_decal/corner/black{
 	dir = 5
 	},
-/obj/structure/closet/crate/bin{
-	name = "trashbin"
-	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/tramp_freighter)
 "fRD" = (
@@ -1220,6 +1218,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/tramp_freighter)
+"idS" = (
+/obj/machinery/suit_cycler/mining{
+	req_access = null
+	},
+/turf/simulated/floor,
+/area/shuttle/tramp_freighter)
 "ifO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/vehicle/train/cargo/trolley,
@@ -1510,6 +1514,7 @@
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
+/obj/machinery/recharger,
 /turf/simulated/floor,
 /area/shuttle/tramp_freighter)
 "ozs" = (
@@ -1852,7 +1857,6 @@
 	icon_state = "tube1";
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor,
 /area/shuttle/tramp_freighter)
 "vwF" = (
@@ -32398,7 +32402,7 @@ xRX
 ylV
 ylV
 ylV
-wZf
+xto
 wZf
 sDF
 cVA
@@ -36000,7 +36004,7 @@ ylV
 wZf
 tGD
 biS
-biS
+idS
 uep
 dHA
 aHt


### PR DESCRIPTION
Makes some minor changes to the tramp freighter.
Adds:
-Recharging station for IPCs
-Suit cycler for non-human crew (Access requirements removed)
-Cell charger
-Cryopod console so the pod works

Tweaks:
-Moves one of the port side CO2 tanks into the starboard side, so they each have two spares in their rooms. instead of one having one spare and the other having three. 