### PR TITLE
Adds new var to APCs that determines if they will trigger power alarms or not

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -137,6 +137,7 @@
 	var/cellused = 0
 	var/start_charge = 90				// initial cell charge %
 	var/cell_type = /obj/item/cell/apc
+	var/trip_alarm = TRUE
 	var/opened = COVER_CLOSED
 	var/shorted = FALSE
 	var/night_mode = FALSE// Determines if the light level is set to dimmed or not
@@ -1249,7 +1250,8 @@
 		equipment = autoset(equipment, CHANNEL_OFF)
 		lighting = autoset(lighting, CHANNEL_OFF)
 		environ = autoset(environ, CHANNEL_OFF)
-		power_alarm.triggerAlarm(loc, src)
+		if(trip_alarm)
+			power_alarm.triggerAlarm(loc, src)
 		autoflag = AUTOFLAG_OFF
 
 	// update icon & area power if anything changed
@@ -1279,21 +1281,24 @@
 			equipment = autoset(equipment, CHANNEL_ON)
 			lighting = autoset(lighting, CHANNEL_OFF_AUTO)
 			environ = autoset(environ, CHANNEL_OFF_AUTO)
-			power_alarm.triggerAlarm(loc, src)
+			if(trip_alarm)
+				power_alarm.triggerAlarm(loc, src)
 			autoflag = AUTOFLAG_ENVIRON_LIGHTS_ON
 	else if(cell.percent() <= 15)        // <15%, turn off lighting & equipment
 		if((autoflag > AUTOFLAG_ENVIRON_ON && longtermpower < 0) || (autoflag > AUTOFLAG_ENVIRON_ON && longtermpower >= 0))
 			equipment = autoset(equipment, CHANNEL_ON)
 			lighting = autoset(lighting, CHANNEL_ON)
 			environ = autoset(environ, CHANNEL_OFF_AUTO)
-			power_alarm.triggerAlarm(loc, src)
+			if(trip_alarm)
+				power_alarm.triggerAlarm(loc, src)
 			autoflag = AUTOFLAG_ENVIRON_ON
 	else                                   // zero charge, turn all off
 		if(autoflag != AUTOFLAG_OFF)
 			equipment = autoset(equipment, CHANNEL_OFF)
 			lighting = autoset(lighting, CHANNEL_OFF)
 			environ = autoset(environ, CHANNEL_OFF)
-			power_alarm.triggerAlarm(loc, src)
+			if(trip_alarm)
+				power_alarm.triggerAlarm(loc, src)
 			autoflag = AUTOFLAG_OFF
 
 /obj/machinery/power/apc/proc/autoset(var/val, var/on)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -137,7 +137,7 @@
 	var/cellused = 0
 	var/start_charge = 90				// initial cell charge %
 	var/cell_type = /obj/item/cell/apc
-	var/trip_alarm = TRUE
+	var/trip_alarm = TRUE // Determines if this APC will trip power alarms or not
 	var/opened = COVER_CLOSED
 	var/shorted = FALSE
 	var/night_mode = FALSE// Determines if the light level is set to dimmed or not

--- a/html/changelogs/llywelwyn-apc-tripalarm-var.yml
+++ b/html/changelogs/llywelwyn-apc-tripalarm-var.yml
@@ -1,0 +1,6 @@
+author: Llywelwyn
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a new var to APCs, trip_power, that determines if they will trigger power alarms or not - primarily made to allow powered away sites that could lose power."

--- a/html/changelogs/llywelwyn-apc-tripalarm-var.yml
+++ b/html/changelogs/llywelwyn-apc-tripalarm-var.yml
@@ -3,4 +3,4 @@ author: Llywelwyn
 delete-after: True
 
 changes:
-  - rscadd: "Added a new var to APCs, trip_power, that determines if they will trigger power alarms or not - primarily made to allow powered away sites that could lose power."
+  - rscadd: "Added a new var to APCs that determines if they will trigger power alarms or not."


### PR DESCRIPTION
rscadd: "Added a new var to APCs that determines if they will trigger power alarms or not."

var/trip_alarm = TRUE // Determines if this APC will trip power alarms or not

made primarily for use in derelict away sites that will lose power, but have a network that can be powered by crew once they arrive - as it stands, away sites with an APC that has lost power will always appear on the power alarm monitor