### PR TITLE
Xeno Ghostrole Fixes

### DIFF
--- a/code/modules/ghostroles/spawner/human/human.dm
+++ b/code/modules/ghostroles/spawner/human/human.dm
@@ -118,6 +118,9 @@
 
 	M.fully_replace_character_name(M.real_name, mname)
 
+	M.mind.signature = mname
+	M.mind.signfont = pick("Verdana", "Times New Roman", "Courier New")
+
 	if(!age)
 		age = rand(35, 50)
 	M.age = Clamp(age, 21, 65)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -45,6 +45,13 @@
 		return 1
 	return 0
 
+/proc/isoffworlder(A)
+	if(ishuman(A))
+		var/mob/living/carbon/human/H = A
+		if(H.get_species() == SPECIES_HUMAN_OFFWORLD)
+			return TRUE
+	return FALSE
+
 /proc/isgolem(A)
 	if(ishuman(A))
 		var/mob/living/carbon/human/H = A

--- a/html/changelogs/doxxmedearly-xeno_ghostroles.yml
+++ b/html/changelogs/doxxmedearly-xeno_ghostroles.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Ghostrole vaurca and offworlders should now spawn with the things they need to survive."
+  - bugfix: "Ghostroles will now all spawn with the proper footwear."
+  - tweak: "Space bar patrons now start with a wallet containing a random amount of money."
+  - spellcheck: "Fixed a typo in the tramp freighter captain description."

--- a/html/changelogs/doxxmedearly-xeno_ghostroles.yml
+++ b/html/changelogs/doxxmedearly-xeno_ghostroles.yml
@@ -3,5 +3,6 @@ delete-after: True
 changes:
   - bugfix: "Ghostrole vaurca and offworlders should now spawn with the things they need to survive."
   - bugfix: "Ghostroles will now all spawn with the proper footwear."
+  - bugfix: "Signing papers as a ghostrole will now use the correct name."
   - tweak: "Space bar patrons now start with a wallet containing a random amount of money."
   - spellcheck: "Fixed a typo in the tramp freighter captain description."

--- a/maps/away/generic/space_bar_ghostroles.dm
+++ b/maps/away/generic/space_bar_ghostroles.dm
@@ -24,6 +24,14 @@
 	head = /obj/item/clothing/head/flatcap/bartender/idris
 	suit = /obj/item/clothing/suit/storage/bartender/idris
 	shoes = /obj/item/clothing/shoes/brown
+	species_shoes = list(
+		SPECIES_UNATHI = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_TAJARA = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_TAJARA_MSAI = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_TAJARA_ZHAN = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_VAURCA_WORKER = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_VAURCA_WARRIOR =/obj/item/clothing/shoes/workboots/toeless
+	)
 
 	back = /obj/item/storage/backpack/satchel
 
@@ -32,6 +40,17 @@
 	l_ear = /obj/item/device/radio/headset/ship
 
 	backpack_contents = list(/obj/item/storage/box/survival = 1, /obj/item/storage/wallet/random = 1, /obj/item/clothing/accessory/wcoat = 1)
+
+/datum/outfit/admin/space_bar_bartender/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(isvaurca(H))
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+		H.internal = preserve
+		H.internals.icon_state = "internal1"
+		H.equip_or_collect(new /obj/item/reagent_containers/inhaler/phoron_special, slot_in_backpack)
+	if(isoffworlder(H))
+		H.equip_or_collect(new /obj/item/storage/pill_bottle/rmt, slot_in_backpack)
 
 /datum/outfit/admin/space_bar_bartender/get_id_access()
 	return list(access_generic_away_site, access_external_airlocks)
@@ -60,6 +79,15 @@
 	suit = /obj/item/clothing/suit/chef/idris
 	head = /obj/item/clothing/head/chefhat/idris
 	shoes = /obj/item/clothing/shoes/brown
+	species_shoes = list(
+		SPECIES_UNATHI = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_TAJARA = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_TAJARA_MSAI = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_TAJARA_ZHAN = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_VAURCA_WORKER = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_VAURCA_WARRIOR =/obj/item/clothing/shoes/workboots/toeless
+	)
+
 	back = /obj/item/storage/backpack/satchel
 
 	id = /obj/item/card/id/away_site
@@ -67,6 +95,18 @@
 	l_ear = /obj/item/device/radio/headset/ship
 
 	backpack_contents = list(/obj/item/storage/box/survival = 1, /obj/item/storage/wallet/random = 1)
+
+/datum/outfit/admin/space_bar_chef/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(isvaurca(H))
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+		H.internal = preserve
+		H.internals.icon_state = "internal1"
+		H.equip_or_collect(new /obj/item/reagent_containers/inhaler/phoron_special, slot_in_backpack)
+
+	if(isoffworlder(H))
+		H.equip_or_collect(new /obj/item/storage/pill_bottle/rmt, slot_in_backpack)
 
 /datum/outfit/admin/space_bar_chef/get_id_access()
 	return list(access_generic_away_site, access_external_airlocks)
@@ -81,6 +121,9 @@
 	max_count = 3
 
 	outfit = /datum/outfit/admin/random/space_bar_patron
+	species_outfits = list(SPECIES_VAURCA_WORKER = /datum/outfit/admin/random/space_bar_patron/vaurca,
+					SPECIES_VAURCA_WARRIOR = /datum/outfit/admin/random/space_bar_patron/vaurca,
+					SPECIES_HUMAN_OFFWORLD = /datum/outfit/admin/random/space_bar_patron/offworlder)
 	possible_species = list(SPECIES_HUMAN,SPECIES_HUMAN_OFFWORLD,SPECIES_SKRELL, SPECIES_SKRELL_AXIORI,SPECIES_TAJARA,SPECIES_TAJARA_MSAI,SPECIES_TAJARA_ZHAN,SPECIES_UNATHI,SPECIES_VAURCA_WARRIOR,SPECIES_VAURCA_WORKER)
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 
@@ -90,4 +133,23 @@
 
 /datum/outfit/admin/random/space_bar_patron
 	l_ear = /obj/item/device/radio/headset/ship
-	l_pocket = /obj/item/spacecash/c500
+	l_pocket = /obj/item/storage/wallet/random
+
+/datum/outfit/admin/random/space_bar_patron/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(!H.shoes) //If they didn't get shoes, it's because they can't fit in them. Find something that works.
+		var/obj/item/clothing/shoes/S = pick(/obj/item/clothing/shoes/sandal, /obj/item/clothing/shoes/footwraps, /obj/item/clothing/shoes/workboots/toeless, /obj/item/clothing/shoes/jackboots/toeless)
+		H.equip_to_slot_or_del(new S, slot_shoes)
+
+/datum/outfit/admin/random/space_bar_patron/vaurca
+	mask = /obj/item/clothing/mask/breath/vaurca/filter
+	r_pocket = /obj/item/reagent_containers/inhaler/phoron_special
+
+/datum/outfit/admin/random/space_bar_patron/vaurca/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+	H.internal = preserve
+	H.internals.icon_state = "internal1"
+	
+/datum/outfit/admin/random/space_bar_patron/offworlder
+	r_pocket = /obj/item/storage/pill_bottle/rmt
+

--- a/maps/away/ships/biesel_ship_ghostroles.dm
+++ b/maps/away/ships/biesel_ship_ghostroles.dm
@@ -33,84 +33,73 @@
 	l_ear = /obj/item/device/radio/headset/ship
 
 	backpack_contents = list(/obj/item/storage/box/survival = 1, /obj/item/melee/energy/sword/knife = 1, /obj/item/clothing/accessory/storage/pouches/brown = 1)
+	species_shoes = list(
+		SPECIES_UNATHI = /obj/item/clothing/shoes/jackboots/toeless,
+		SPECIES_TAJARA = /obj/item/clothing/shoes/jackboots/toeless,
+		SPECIES_TAJARA_MSAI = /obj/item/clothing/shoes/jackboots/toeless,
+		SPECIES_TAJARA_ZHAN = /obj/item/clothing/shoes/jackboots/toeless,
+		SPECIES_VAURCA_WORKER = /obj/item/clothing/shoes/jackboots/toeless,
+		SPECIES_VAURCA_WARRIOR =/obj/item/clothing/shoes/jackboots/toeless
+	)
+
+/datum/outfit/admin/tcfl_peacekeeper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(isvaurca(H))
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+		H.internal = preserve
+		H.internals.icon_state = "internal1"
+		H.equip_or_collect(new /obj/item/reagent_containers/inhaler/phoron_special, slot_in_backpack)
+	if(isoffworlder(H))
+		H.equip_or_collect(new /obj/item/storage/pill_bottle/rmt, slot_in_backpack)
 
 /datum/outfit/admin/tcfl_peacekeeper/get_id_access()
 	return list(access_tcfl_peacekeeper_ship, access_external_airlocks)
 
-/datum/ghostspawner/human/tcfl_peacekeeper_prefect
+/datum/ghostspawner/human/tcfl_peacekeeper/prefect
 	short_name = "tcfl_peacekeeper_prefect"
 	name = "TCFL Peacekeeper Prefect"
 	desc = "Command the Tau Ceti Foreign Legion Peacekeeping ship. Make sure your prisoners are taken care of."
-	tags = list("External")
 	mob_name_prefix = "Pfct. "
 
 	spawnpoints = list("tcfl_peacekeeper_prefect")
 	max_count = 1
 
-	outfit = /datum/outfit/admin/tcfl_peacekeeper_prefect
-	possible_species = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_MSAI, SPECIES_TAJARA_ZHAN, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_UNATHI, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_WORKER, SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL, SPECIES_DIONA, SPECIES_DIONA_COEUS)
-	allow_appearance_change = APPEARANCE_PLASTICSURGERY
+	outfit = /datum/outfit/admin/tcfl_peacekeeper/prefect
 
 	assigned_role = "TCFL Peacekeeper Prefect"
 	special_role = "TCFL Peacekeeper Prefect"
-	respawn_flag = null
 
 
-/datum/outfit/admin/tcfl_peacekeeper_prefect
+/datum/outfit/admin/tcfl_peacekeeper/prefect
 	name = "TCFL Peacekeeper Prefect"
-
-	head = /obj/item/clothing/head/beret/legion/field
-	uniform = /obj/item/clothing/under/legion
-	shoes = /obj/item/clothing/shoes/jackboots
-	back = /obj/item/storage/backpack/legion
 	accessory = /obj/item/clothing/accessory/legion
 
-	id = /obj/item/card/id/tcfl_ship
 
-	l_ear = /obj/item/device/radio/headset/ship
-
-	backpack_contents = list(/obj/item/storage/box/survival = 1, /obj/item/melee/energy/sword/knife = 1,  /obj/item/clothing/accessory/storage/pouches/brown = 1)
-
-/datum/outfit/admin/tcfl_peacekeeper_prefect/get_id_access()
-	return list(access_tcfl_peacekeeper_ship, access_external_airlocks)
-
-/datum/ghostspawner/human/tcfl_peacekeeper_pilot
+/datum/ghostspawner/human/tcfl_peacekeeper/pilot
 	short_name = "tcfl_peacekeeper_pilot"
 	name = "TCFL Peacekeeper Pilot"
 	desc = "Pilot the Tau Ceti Foreign Legion Peacekeeping ship."
-	tags = list("External")
 	mob_name_prefix = "PL. "
 
-	spawnpoints = list("tcfl_peacekeeper")
 	max_count = 1
 
-	outfit = /datum/outfit/admin/tcfl_peacekeeper_pilot
-	possible_species = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_MSAI, SPECIES_TAJARA_ZHAN, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_UNATHI, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_WORKER, SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL, SPECIES_DIONA, SPECIES_DIONA_COEUS)
-	allow_appearance_change = APPEARANCE_PLASTICSURGERY
+	outfit = /datum/outfit/admin/tcfl_peacekeeper/pilot
 
 	assigned_role = "TCFL Peacekeeper Pilot"
 	special_role = "TCFL Peacekeeper Pilot"
-	respawn_flag = null
 
 
-/datum/outfit/admin/tcfl_peacekeeper_pilot
+/datum/outfit/admin/tcfl_peacekeeper/pilot
 	name = "TCFL Peacekeeper Pilot"
 
 	uniform = /obj/item/clothing/under/legion/pilot
 	head = /obj/item/clothing/head/helmet/pilot/legion
-	shoes = /obj/item/clothing/shoes/jackboots
 	suit = /obj/item/clothing/suit/storage/toggle/leather_jacket/flight/legion/alt
 	accessory = /obj/item/clothing/accessory/storage/webbingharness/pouches/ert
-	back = /obj/item/storage/backpack/legion
-
-	id = /obj/item/card/id/tcfl_ship
-
-	l_ear = /obj/item/device/radio/headset/ship
 
 	backpack_contents = list(/obj/item/storage/box/survival = 1, /obj/item/melee/energy/sword/knife = 1)
 
-/datum/outfit/admin/tcfl_peacekeeper_pilot/get_id_access()
-	return list(access_tcfl_peacekeeper_ship, access_external_airlocks)
 
 //items
 
@@ -141,3 +130,25 @@
 
 	uniform = /obj/item/clothing/under/color/orange
 	shoes = /obj/item/clothing/shoes/orange
+	species_shoes = list(
+		SPECIES_UNATHI = /obj/item/clothing/shoes/footwraps,
+		SPECIES_TAJARA = /obj/item/clothing/shoes/footwraps,
+		SPECIES_TAJARA_MSAI = /obj/item/clothing/shoes/footwraps,
+		SPECIES_TAJARA_ZHAN = /obj/item/clothing/shoes/footwraps,
+		SPECIES_VAURCA_WARRIOR = /obj/item/clothing/shoes/footwraps,
+		SPECIES_VAURCA_WORKER = /obj/item/clothing/shoes/footwraps
+	)
+
+/datum/outfit/admin/tcfl_detainee/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(isvaurca(H))
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+		H.internal = preserve
+		H.internals.icon_state = "internal1"
+		var/obj/item/reagent_containers/inhaler/phoron_special/PS = new /obj/item/reagent_containers/inhaler/phoron_special(get_turf(H))
+		H.put_in_hands(PS)
+
+	if(isoffworlder(H))
+		var/obj/item/storage/pill_bottle/rmt/PB = new /obj/item/storage/pill_bottle/rmt(get_turf(H))
+		H.put_in_hands(PB)

--- a/maps/away/ships/corporate_ship_ghostroles.dm
+++ b/maps/away/ships/corporate_ship_ghostroles.dm
@@ -30,6 +30,25 @@
 	l_ear = /obj/item/device/radio/headset/ship
 
 	backpack_contents = list(/obj/item/storage/box/survival = 1, /obj/item/storage/wallet/random = 1)
+	species_shoes = list(
+		SPECIES_UNATHI = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_TAJARA = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_TAJARA_MSAI = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_TAJARA_ZHAN = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_VAURCA_WORKER = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_VAURCA_WARRIOR =/obj/item/clothing/shoes/workboots/toeless
+	)
+
+/datum/outfit/admin/orion_express_courier/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(isvaurca(H))
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+		H.internal = preserve
+		H.internals.icon_state = "internal1"
+		H.equip_or_collect(new /obj/item/reagent_containers/inhaler/phoron_special, slot_in_backpack)
+	if(isoffworlder(H))
+		H.equip_or_collect(new /obj/item/storage/pill_bottle/rmt, slot_in_backpack)
 
 /datum/outfit/admin/orion_express_courier/get_id_access()
 	return list(access_orion_express_ship, access_external_airlocks)

--- a/maps/away/ships/sol_ship_ghostroles.dm
+++ b/maps/away/ships/sol_ship_ghostroles.dm
@@ -196,23 +196,17 @@
 /datum/outfit/admin/fsf_navy_officer/get_id_access()
 	return list(access_sol_ships, access_external_airlocks)
 
-/datum/ghostspawner/human/fsf_navy_senior_crewman
+/datum/ghostspawner/human/fsf_navy_crewman/senior
 	short_name = "fsf_navy_senior_crewman"
 	name = "FSF Navy Senior Crewman"
 	desc = "Serve as the second-in-command of the Free Solarian Fleets patrol corvette. Look for work, or some other source of income."
-	tags = list("External")
 	mob_name_prefix = "PO1. "
 
 	spawnpoints = list("fsf_navy_crewman")
 	max_count = 1
 
-	outfit = /datum/outfit/admin/fsf_navy_crewman
-	possible_species = list(SPECIES_HUMAN)
-	allow_appearance_change = APPEARANCE_PLASTICSURGERY
-
 	assigned_role = "FSF Navy Senior Crewman"
 	special_role = "FSF Navy Senior Crewman"
-	respawn_flag = null
 
 //items
 

--- a/maps/away/ships/wildcard_ship_ghostroles.dm
+++ b/maps/away/ships/wildcard_ship_ghostroles.dm
@@ -30,43 +30,49 @@
 	l_ear = /obj/item/device/radio/headset/ship
 
 	backpack_contents = list(/obj/item/storage/box/survival = 1)
+	species_shoes = list(
+		SPECIES_UNATHI = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_TAJARA = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_TAJARA_MSAI = /obj/item/clothing/shoes/workboots/toeless,
+		SPECIES_TAJARA_ZHAN = /obj/item/clothing/shoes/workboots/toeless
+	)
+
+/datum/outfit/admin/freighter_crew/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(isoffworlder(H))
+		H.equip_or_collect(new /obj/item/storage/pill_bottle/rmt, slot_in_backpack)
 
 /datum/outfit/admin/freighter_crew/get_id_access()
 	return list(access_external_airlocks)
 
-/datum/ghostspawner/human/freighter_crew_captain
+/datum/ghostspawner/human/freighter_crew/captain
 	short_name = "freighter_crew_captain"
 	name = "Freighter Captain"
-	desc = "Crew the tramp freighter. Be a tramp - carry cargo, do some mining, go salvaging, and try not to get into anything you can't get out of!"
-	tags = list("External")
+	desc = "Captain the tramp freighter. Be a tramp - carry cargo, do some mining, go salvaging, and try not to get into anything you can't get out of!"
 
 	spawnpoints = list("freighter_crew_captain")
 	max_count = 1
 
-	outfit = /datum/outfit/admin/freighter_crew_captain
+	outfit = /datum/outfit/admin/freighter_crew/captain
 	possible_species = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_MSAI, SPECIES_TAJARA_ZHAN, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_UNATHI)
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 
 	assigned_role = "Freighter Captain"
 	special_role = "Freighter Captain"
-	respawn_flag = null
 
 
-/datum/outfit/admin/freighter_crew_captain
+/datum/outfit/admin/freighter_crew/captain
 	name = "Freighter Captain"
 
 	uniform = /obj/item/clothing/under/tactical
 	shoes = /obj/item/clothing/shoes/workboots/grey
-	back = /obj/item/storage/backpack/satchel_norm
 
-	id = /obj/item/card/id/freighter_crew_ship
-
-	l_ear = /obj/item/device/radio/headset/ship
-
-	backpack_contents = list(/obj/item/storage/box/survival = 1)
-
-/datum/outfit/admin/freighter_crew_captain/get_id_access()
-	return list(access_external_airlocks)
+	species_shoes = list(
+		SPECIES_UNATHI = /obj/item/clothing/shoes/workboots/toeless/grey,
+		SPECIES_TAJARA = /obj/item/clothing/shoes/workboots/toeless/grey,
+		SPECIES_TAJARA_MSAI = /obj/item/clothing/shoes/workboots/toeless/grey,
+		SPECIES_TAJARA_ZHAN = /obj/item/clothing/shoes/workboots/toeless/grey
+	)
 
 /obj/item/card/id/freighter_crew_ship
 	name = "freight ship id"


### PR DESCRIPTION
Gives xenos the things they need to play ghostroles, including:
-Phoron and masks for vaurca
-RMT for offworlders
-Toeless Shoes for unathi, tajara, and vaurca

In the future, people adding these species as playable for their ghostrole ships will need to pay attention to the outfits and post_equip() procs to ensure they are able to actually play. We'll need to keep this in mind when reviewing. 

-Additionally, fixed a tiny copy+paste typo for the freighter captain, and made the space bar patrons have a bit more random cash. 
-Made it so ghostrole characters have the proper name when using [sign]. Before, it would use the character you had selected when you joined as the ghostrole. 

Non-player-facing changes:
-Added a helper for offworlder species
-Rearranged some of the ghostroles parent/child pathing in order to eliminate a lot of duplicated code. I tested each and every ghostspawn to make sure they 1) spawned properly, in the correct place, with the correct gear and prefixes, 2) Didn't runtime, and 3) Utilized the correct slot on the ghostrole pick list. 

This is also something to look out for with any new ghost role additions, to ensure tidy code standards and avoid duplication where necessary. 

Fixes #13526