### PR TITLE
Reduces Parapen Duration to 5 Minutes

### DIFF
--- a/code/datums/uplink/stealthy and inconspicuous weapons.dm
+++ b/code/datums/uplink/stealthy and inconspicuous weapons.dm
@@ -26,9 +26,10 @@
 	path = /obj/item/storage/box/syndie_kit/special_pens
 
 /datum/uplink_item/item/stealthy_weapons/parapen
-	name = "Paralysis pen"
+	name = "Paralysis Pen"
+	desc = "A kit containing: a red parapen (lasts approximately 5 minutes) and a green pen loaded with a purging chemical if you want to remove the paralytic early."
 	item_cost = 3
-	path = /obj/item/pen/reagent/paralysis
+	path = /obj/item/storage/box/syndie_kit/parapen
 
 /datum/uplink_item/item/stealthy_weapons/concealed_cane
 	name = "Concealed Cane Sword"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -146,11 +146,18 @@
 	)
 
 /obj/item/storage/box/syndie_kit/special_pens
-	name = "box (P)"
+	name = "penjector kit"
 	starts_with = list(
 		/obj/item/pen/reagent/healing = 1,
 		/obj/item/pen/reagent/pacifier = 1,
 		/obj/item/pen/reagent/hyperzine = 1
+	)
+
+/obj/item/storage/box/syndie_kit/parapen
+	name = "parapen kit"
+	starts_with = list(
+		/obj/item/pen/reagent/paralysis = 1,
+		/obj/item/pen/reagent/purge = 1
 	)
 
 /obj/item/storage/box/syndie_kit/spy

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -211,7 +211,7 @@ Pen exclusive commands
  */
 /obj/item/pen/reagent/paralysis
 	origin_tech = list(TECH_MATERIAL = 2, TECH_ILLEGAL = 5)
-	reagents_to_add = list(/decl/reagent/toxin/dextrotoxin = 10)
+	reagents_to_add = list(/decl/reagent/toxin/dextrotoxin = 10) //~~5 minutes worth of Dextrotoxin
 
 /obj/item/pen/reagent/healing
 	origin_tech = list(TECH_MATERIAL = 2, TECH_ILLEGAL = 5)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -212,7 +212,15 @@ Pen exclusive commands
 /obj/item/pen/reagent/paralysis
 	origin_tech = list(TECH_MATERIAL = 2, TECH_ILLEGAL = 5)
 	reagents_to_add = list(/decl/reagent/toxin/dextrotoxin = 10) //~~5 minutes worth of Dextrotoxin
+	icon_state = "pen_red"
+	colour = "red"
 
+/obj/item/pen/reagent/purge
+	origin_tech = list(TECH_MATERIAL = 2, TECH_ILLEGAL = 5)
+	reagents_to_add = list(/decl/reagent/fluvectionem = 5)
+	icon_state = "pen_green"
+	colour = "green"
+ 
 /obj/item/pen/reagent/healing
 	origin_tech = list(TECH_MATERIAL = 2, TECH_ILLEGAL = 5)
 	reagents_to_add = list(/decl/reagent/tricordrazine = 10, /decl/reagent/dermaline = 5, /decl/reagent/bicaridine = 5)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -774,7 +774,7 @@
 	reagent_state = LIQUID
 	color = "#002067"
 	spectro_hidden = TRUE
-	metabolism = REM * 0.2
+	metabolism = REM/3
 	strength = 0
 	taste_description = "danger"
 

--- a/html/changelogs/dextrotoxin-metabolism.yml
+++ b/html/changelogs/dextrotoxin-metabolism.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rsctweak: "Increases dextrotoxin's metabolism speed. Parapens should last ~5 minutes instead of ~8 minutes."
+  - tweak: "Increases dextrotoxin's metabolism speed. Parapens should last ~5 minutes instead of ~8 minutes."

--- a/html/changelogs/dextrotoxin-metabolism.yml
+++ b/html/changelogs/dextrotoxin-metabolism.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - tweak: "Increases dextrotoxin's metabolism speed. Parapens should last ~5 minutes instead of ~8 minutes."
+  - rscadd: "Adds a Purgepen which comes alongside the Parapen. It's used to remove the dextrotoxin and end the paralysis early."

--- a/html/changelogs/dextrotoxin-metabolism.yml
+++ b/html/changelogs/dextrotoxin-metabolism.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: kermit
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rsctweak: "Increases dextrotoxin's metabolism speed. Parapens should last ~5 minutes instead of ~8 minutes."

--- a/html/changelogs/dextrotoxin-metabolism.yml
+++ b/html/changelogs/dextrotoxin-metabolism.yml
@@ -39,4 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - tweak: "Increases dextrotoxin's metabolism speed. Parapens should last ~5 minutes instead of ~8 minutes."
-  - rscadd: "Adds a Purgepen which comes alongside the Parapen. It's used to remove the dextrotoxin and end the paralysis early."
+  - rscadd: "Adds a Purgepen which comes alongside the Parapen in a box. It's used to remove the dextrotoxin and end the paralysis early."


### PR DESCRIPTION
- Increases dextrotoxin's metabolism so that parapens last ~5 minutes instead of ~8.5 minutes.
- The parapen is now spawned inside of a Parapen Kit alongside a 'purgepen' containing fluvectionem. This will remove the dextrotoxin, ending the paralysis early.

Parapens last quite a while where the victim is unable to do anything. 5 minutes is plenty of time for an antagonist to jab, paralyse, and move a victim from a public location to a concealed location, and allows the victim to wake up and converse with or attempt to resist against an antagonist. 8.5 minutes can go on to feel like ages.