### PR TITLE
Kitchen Freezer and Deck 1 Cameras Bugfix

### DIFF
--- a/html/changelogs/kitchen_bugfix.yml
+++ b/html/changelogs/kitchen_bugfix.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes tiles in freezer having the wrong temperature. Removes a duplicate APC in the old freezer. Fixes missing door access."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -3054,10 +3054,9 @@
 /area/outpost/mining_main/refinery)
 "ctz" = (
 /obj/structure/table/stone/marble,
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/obj/machinery/light/small/emergency,
+/obj/item/material/kitchen/utensil/knife/plastic,
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "ctI" = (
 /obj/effect/map_effect/wingrille_spawn/reinforced,
@@ -4419,10 +4418,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "dEe" = (
 /obj/machinery/recharge_station,
@@ -4797,13 +4793,9 @@
 /area/shuttle/intrepid/cargo_bay)
 "dWw" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/freezer_maint{
-	name = "Freezer"
-	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/cobweb2,
-/obj/structure/plasticflaps/airtight,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "dWC" = (
 /obj/effect/shuttle_landmark/lift/cargo_bottom,
@@ -5985,10 +5977,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "eMK" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -6936,10 +6925,7 @@
 /area/engineering/atmos/propulsion/starboard)
 "fyR" = (
 /obj/machinery/icecream_vat,
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "fzA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7246,6 +7232,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
+"fKB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
+/area/maintenance/hangar/port)
 "fKD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -7616,10 +7606,7 @@
 /area/maintenance/wing/port/deck1)
 "fXy" = (
 /obj/structure/trash_pile,
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "fXF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10511,6 +10498,21 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/port)
+"iqk" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/hangar/port)
 "irA" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
@@ -11312,15 +11314,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green,
-/obj/machinery/power/apc/low{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "jeS" = (
 /obj/machinery/light,
@@ -11924,11 +11919,12 @@
 /turf/simulated/floor/plating,
 /area/hangar/operations)
 "jCl" = (
-/obj/structure/table,
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+/obj/effect/decal/cleanable/blood/drip/oil,
+/obj/effect/decal/cleanable/blood/drip/oil{
+	pixel_y = 8;
+	pixel_x = -8
 	},
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "jCK" = (
 /turf/simulated/wall,
@@ -12658,6 +12654,14 @@
 /obj/effect/decal/fake_object/light_source/invisible,
 /turf/simulated/floor/reinforced/n20,
 /area/engineering/atmos/air)
+"kov" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/maintenance/hangar/port)
 "koz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -13743,7 +13747,6 @@
 /area/hangar/auxiliary)
 "kZl" = (
 /obj/structure/sink/kitchen{
-	pixel_x = -2;
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -13752,10 +13755,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/obj/item/frame/apc,
+/obj/item/cell/apc,
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "laL" = (
 /obj/effect/floor_decal/corner/blue/full,
@@ -14999,6 +15001,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/hangar/auxiliary)
 "mdL" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/maintenance/hangar/port)
 "mdZ" = (
@@ -16843,10 +16846,8 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "nyz" = (
 /obj/structure/lattice/catwalk/indoor,
@@ -16883,13 +16884,18 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "nzz" = (
-/obj/machinery/light/small/red{
+/obj/machinery/light/small/emergency{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+/obj/random/loot,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/shuttle_control/lift/wall{
+	shuttle_tag = "Kitchen Lift";
+	pixel_y = -24;
+	pixel_x = 6;
+	dir = 1
 	},
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "nAS" = (
 /obj/structure/cable/green{
@@ -17084,6 +17090,12 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
+"nLh" = (
+/obj/structure/stairs/south,
+/turf/simulated/floor/tiled/ramp{
+	dir = 1
+	},
+/area/maintenance/hangar/port)
 "nLL" = (
 /obj/effect/floor_decal/corner_wide/purple/full{
 	dir = 8
@@ -17684,10 +17696,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "oma" = (
 /obj/structure/window/shuttle/scc_space_ship,
@@ -21807,6 +21816,7 @@
 	req_access = list(28);
 	name = "Freezer Maintenance"
 	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/tiled/freezer{
 	name = "cold storage tiles";
 	temperature = 278
@@ -22351,10 +22361,8 @@
 /area/horizon/stairwell/central)
 "spL" = (
 /obj/effect/decal/cleanable/blood/drip/oil,
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/obj/random/junk,
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "spQ" = (
 /obj/structure/bed/stool/chair/shuttle{
@@ -23364,10 +23372,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/eva)
 "tfB" = (
-/obj/machinery/light{
-	dir = 8
+/turf/simulated/floor/tiled/ramp/bottom{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
 /area/maintenance/hangar/port)
 "tfR" = (
 /turf/simulated/floor/tiled,
@@ -24006,6 +24013,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
+"tHH" = (
+/obj/random/junk,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
+/area/maintenance/hangar/port)
 "tIz" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -26230,13 +26242,11 @@
 	dir = 1
 	},
 /obj/machinery/door/window/northright,
-/obj/machinery/light/small/red{
+/obj/structure/table,
+/obj/machinery/light/small/emergency{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "vxw" = (
 /obj/structure/railing/mapped,
@@ -27072,10 +27082,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/mucus,
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "wlh" = (
 /obj/machinery/conveyor{
@@ -27596,8 +27603,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
 "wKq" = (
-/obj/structure/stairs/south,
-/turf/simulated/floor/tiled,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "wKW" = (
 /obj/structure/cable/green{
@@ -28578,18 +28585,17 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenoarch_atrium)
 "xtj" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -29
-	},
 /obj/machinery/camera/network/service{
 	c_tag = "Dinner - Kitchen Freezer Bottom";
 	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/securearea{
+	name = "\improper DANGER: AUTOMATIC EQUIPMENT - CRUSH HAZARD sign";
+	desc = "A warning sign which reads 'DANGER: AUTOMATIC EQUIPMENT STARTS AND STOPS AUTOMATICALLY' and 'CRUSH HAZARD'.";
+	pixel_y = -32
 	},
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "xtn" = (
 /obj/structure/closet/radiation,
@@ -28707,18 +28713,12 @@
 /turf/simulated/floor/tiled,
 /area/rnd/eva)
 "xyG" = (
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "xzd" = (
 /obj/structure/table/stone/marble,
 /obj/random/loot,
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/turf/simulated/floor/tiled/freezer,
 /area/maintenance/hangar/port)
 "xAr" = (
 /obj/machinery/power/apc{
@@ -52364,14 +52364,14 @@ byS
 kcE
 snA
 dMS
-dMS
+iqk
 rRi
 jeF
 olu
 eMc
 dWw
 tfB
-wKq
+nLh
 tsD
 kVe
 eSV
@@ -52571,9 +52571,9 @@ bCi
 kZl
 dDV
 xtj
-tsD
-tsD
-tsD
+bCi
+bCi
+bCi
 tsD
 kVe
 eSV
@@ -52773,8 +52773,8 @@ bCi
 uYo
 nyp
 spL
-xyG
-xyG
+fKB
+kov
 fXy
 tsD
 kVe
@@ -52976,9 +52976,9 @@ mdL
 wlf
 xyG
 jCl
+xyG
 xzd
-tsD
-tsD
+drU
 kVe
 eSV
 eSV
@@ -53176,11 +53176,11 @@ ehP
 bCi
 pdL
 vuG
-xyG
+fKB
+wKq
+tHH
 ctz
-tsD
-tsD
-kVe
+hob
 kVe
 eSV
 eSV
@@ -53372,18 +53372,18 @@ bCi
 bCi
 bCi
 bCi
-tsD
-tsD
+bCi
+bCi
+bCi
 tsD
 tsD
 tsD
 drU
-tsD
 drU
 tsD
+hob
+hob
 kVe
-kVe
-eSV
 eSV
 eSV
 eSV
@@ -53584,8 +53584,8 @@ kVe
 kVe
 kVe
 kVe
-eSV
-eSV
+kVe
+kVe
 eSV
 eSV
 eSV

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -9765,7 +9765,7 @@
 /area/operations/storage)
 "hMj" = (
 /obj/machinery/camera/network/supply{
-	c_tag = Operations - Mining Shuttle Dock Fore Port;
+	c_tag = "Operations - Mining Shuttle Dock Fore Port";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/brown/full{
@@ -13897,7 +13897,7 @@
 /area/shuttle/mining)
 "lig" = (
 /obj/machinery/camera/network/supply{
-	c_tag = Operations - Mining Shuttle Dock Fore Starboard;
+	c_tag = "Operations - Mining Shuttle Dock Fore Starboard";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/brown/full,
@@ -27437,7 +27437,7 @@
 	dir = 9
 	},
 /obj/machinery/camera/network/supply{
-	c_tag = Operations - Mining Shuttle Dock Starboard;
+	c_tag = "Operations - Mining Shuttle Dock Starboard";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -1751,8 +1751,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "aSj" = (
@@ -2328,8 +2328,8 @@
 /obj/item/reagent_containers/food/snacks/fish/fishfillet,
 /obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "bee" = (
@@ -5552,8 +5552,8 @@
 "ddX" = (
 /obj/structure/reagent_dispensers/cookingoil,
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "dec" = (
@@ -13369,10 +13369,7 @@
 /turf/simulated/open/airless,
 /area/horizonexterior)
 "htd" = (
-/obj/machinery/door/blast/shutters/open{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/ramp/bottom,
+/turf/simulated/floor/holofloor/tiled/ramp/bottom,
 /area/bridge/third_deck_stairs)
 "hte" = (
 /obj/structure/railing/mapped{
@@ -14114,7 +14111,10 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled/freezer{
+	name = "cooled tiles";
+	temperature = 253.15
+	},
 /area/crew_quarters/kitchen/freezer)
 "hPH" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -15384,7 +15384,7 @@
 /area/storage/secure)
 "iGG" = (
 /obj/structure/stairs/north,
-/turf/simulated/floor/tiled/ramp,
+/turf/simulated/floor/holofloor/tiled/ramp,
 /area/bridge/third_deck_stairs)
 "iGY" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -15825,7 +15825,7 @@
 	c_tag = "Dinner - Kitchen Stairwell";
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/bridge/third_deck_stairs)
 "iRl" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -17108,8 +17108,8 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "jDb" = (
@@ -19027,8 +19027,8 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "kPA" = (
@@ -20119,8 +20119,8 @@
 "lzC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "lzI" = (
@@ -21112,7 +21112,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/bridge/third_deck_stairs)
 "lZp" = (
 /obj/structure/toilet{
@@ -21809,8 +21809,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "mue" = (
@@ -22017,8 +22017,8 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "myE" = (
@@ -29859,7 +29859,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/bridge/third_deck_stairs)
 "qPC" = (
 /obj/structure/disposalpipe/segment,
@@ -31606,7 +31606,10 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled/freezer{
+	name = "cooled tiles";
+	temperature = 253.15
+	},
 /area/crew_quarters/kitchen/freezer)
 "rHw" = (
 /obj/structure/disposalpipe/segment,
@@ -32903,7 +32906,10 @@
 	dir = 1
 	},
 /obj/structure/largecrate/animal/cow,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/tiled/freezer{
+	name = "cooled tiles";
+	temperature = 253.15
+	},
 /area/crew_quarters/kitchen/freezer)
 "ssK" = (
 /obj/structure/cable,
@@ -33655,8 +33661,8 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "sTu" = (
@@ -34597,7 +34603,10 @@
 	pixel_y = 24
 	},
 /obj/item/device/nanoquikpay,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/freezer{
+	name = "cooled tiles";
+	temperature = 253.15
+	},
 /area/crew_quarters/kitchen/freezer)
 "tvM" = (
 /obj/structure/shuttle_part/scc_space_ship{
@@ -35484,8 +35493,8 @@
 /obj/structure/table/stone/marble,
 /obj/item/material/hook,
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "tWt" = (
@@ -36160,8 +36169,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "uma" = (
@@ -36379,8 +36388,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "upP" = (
@@ -37256,8 +37265,8 @@
 "uNs" = (
 /obj/structure/kitchenspike,
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "uNK" = (
@@ -37498,7 +37507,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/plasticflaps/airtight,
-/obj/machinery/door/airlock/freezer_maint,
+/obj/machinery/door/airlock/freezer{
+	req_access = list(28);
+	name = "Freezer"
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen/freezer)
 "uUz" = (
@@ -37929,7 +37941,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/bridge/third_deck_stairs)
 "vkq" = (
 /obj/structure/table/wood,
@@ -38813,11 +38825,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/sink/kitchen{
-	layer = 3.3;
-	pixel_y = 26
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/bridge/third_deck_stairs)
 "vKg" = (
 /obj/structure/bed/stool/chair,
@@ -39645,8 +39653,8 @@
 /area/hallway/engineering)
 "waI" = (
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "wbC" = (
@@ -40061,8 +40069,8 @@
 "wmc" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
+	name = "cooled tiles";
+	temperature = 253.15
 	},
 /area/crew_quarters/kitchen/freezer)
 "wme" = (
@@ -42036,7 +42044,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/bridge/third_deck_stairs)
 "xmw" = (
 /obj/machinery/alarm{
@@ -42454,15 +42462,15 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/freezer,
+/obj/machinery/door/airlock/freezer{
+	req_access = list(28);
+	name = "Freezer"
+	},
 /obj/structure/plasticflaps/airtight,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer{
-	name = "cold storage tiles";
-	temperature = 278
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/kitchen/freezer)
 "xzK" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -8123,6 +8123,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/third_deck_stairs)
 "pe" = (
@@ -11445,6 +11448,9 @@
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
+	},
+/obj/structure/railing/mapped{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/third_deck_stairs)
@@ -16295,10 +16301,6 @@
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Kitchen Stairwell";
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/third_deck_stairs)
@@ -21540,12 +21542,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
-"Ob" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/turf/simulated/open,
-/area/bridge/third_deck_stairs)
 "Oc" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -21881,6 +21877,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/blue/full,
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - Kitchen Stairwell";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/third_deck_stairs)
 "OI" = (
@@ -22942,6 +22942,9 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/white,
 /area/security/forensics_morgue)
+"Qw" = (
+/turf/simulated/open,
+/area/bridge/third_deck_stairs)
 "Qx" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -51218,8 +51221,8 @@ za
 LA
 ED
 hs
-Ob
-Ob
+Qw
+Qw
 iF
 hR
 hR
@@ -51417,11 +51420,11 @@ Zj
 Zj
 xx
 iF
-uu
 iF
 uu
-iF
 uu
+uu
+iF
 iF
 Tr
 Tr


### PR DESCRIPTION
fixes the freezer tiles not starting at -20 celsius. also fixes missing access on the doors. removes a duplicate APC in the old freezer. fixes unsanitized camera ctags in the mining shuttle dock.