### PR TITLE
Vampire screech affects windoors

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -367,6 +367,12 @@
 	for(var/obj/structure/window/W in view(7))
 		W.shatter()
 
+	for(var/obj/machinery/door/window/WD in view(7))
+		if(get_dist(src, WD) > 5) //Windoors are strong, may only take damage instead of break if far away.
+			WD.take_damage(rand(12, 16) * 10)
+		else
+			WD.shatter()
+
 	for(var/obj/machinery/light/L in view(7))
 		L.broken()
 

--- a/html/changelogs/doxxmedearly-vampscreech.yml
+++ b/html/changelogs/doxxmedearly-vampscreech.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Vampire's Screech ability will now shatter or, if far away, damage windoors."


### PR DESCRIPTION
Fixes #13739

At the very edges of the screech range, it will damage instead of auto-shattering. The damage may be enough to break regular windoors, and halfway damage reinforced ones (AKA brig doors)