### PR TITLE
Srom no longer crashes you on death

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -102,9 +102,10 @@
 	return
 
 /mob/proc/exit_vr()
-	// If we have a remotely controlled mob, we come back to our body to die properly
-	if(vr_mob)
-		vr_mob.body_return()
-	// Alternatively, if we are the remotely controlled mob, just kick our controller out
-	if(old_mob)
-		body_return()
+	if(!bg) // If brainghost exists, let handle_shared_dreaming handle the wake up
+		// If we have a remotely controlled mob, we come back to our body to die properly
+		if(vr_mob)
+			vr_mob.body_return()
+		// Alternatively, if we are the remotely controlled mob, just kick our controller out
+		if(old_mob)
+			body_return()

--- a/code/modules/shareddream/brainghost.dm
+++ b/code/modules/shareddream/brainghost.dm
@@ -37,11 +37,12 @@
 /mob/living/brain_ghost/proc/awaken_impl(var/force_awaken = FALSE)
 
 	if(body.willfully_sleeping)
-		body.sleeping = max(body.sleeping - 5, 0)
 		body.willfully_sleeping = FALSE
 		if(force_awaken)
+			body.sleeping = 0
 			to_chat(src, "<span class='notice'>You suddenly feel like your connection to the dream is breaking up by the outside force.</span>")
 		else
+			body.sleeping = max(body.sleeping - 5, 0)
 			to_chat(src, "<span class='notice'>You release your concentration on sleep, allowing yourself to wake up.</span>")
 	else
 		to_chat(src, "<span class='warning'>You've already released concentration. Wait to wake up naturally.</span>")

--- a/code/modules/shareddream/brainghost.dm
+++ b/code/modules/shareddream/brainghost.dm
@@ -56,7 +56,8 @@
 		return
 
 	if(body.stat == DEAD) // Body is dead, and won't get a life tick.
-		body.handle_shared_dreaming()
+		awaken_impl(TRUE)
+		body.handle_shared_dreaming(TRUE)
 
 /mob/living/brain_ghost/say(var/message, var/datum/language/speaking = null, var/verb="says", var/alt_name="", var/ghost_hearing = GHOSTS_ALL_HEAR, var/whisper = FALSE)
 	if(!istype(body) || body.stat!=UNCONSCIOUS)

--- a/code/modules/shareddream/dream_entry.dm
+++ b/code/modules/shareddream/dream_entry.dm
@@ -1,7 +1,9 @@
 var/list/dream_entries = list()
 
-/mob/living/carbon/human
+/mob
 	var/mob/living/brain_ghost/bg
+
+/mob/living/carbon/human
 	var/datum/weakref/srom_pulled_by
 	var/datum/weakref/srom_pulling
 
@@ -82,6 +84,9 @@ var/list/dream_entries = list()
 			if(B?.host_brain)
 				return_mob = B.host_brain
 				return_text = "You are ripped from the Srom as you return to the captivity of your own mind."
+
+			if(body.stat == DEAD)
+				return_text = "You are ripped from the Srom." // You're dead - ensures there's no message about feeling weird or waking up.
 
 			return_mob.ckey = old_bg.ckey
 			old_bg.visible_message("<span class='notice'>[old_bg] begins to fade as they depart from the dream...</span>")

--- a/code/modules/shareddream/dream_entry.dm
+++ b/code/modules/shareddream/dream_entry.dm
@@ -85,7 +85,7 @@ var/list/dream_entries = list()
 				return_mob = B.host_brain
 				return_text = "You are ripped from the Srom as you return to the captivity of your own mind."
 
-			if(body.stat == DEAD)
+			if(stat == DEAD)
 				return_text = "You are ripped from the Srom." // You're dead - ensures there's no message about feeling weird or waking up.
 
 			return_mob.ckey = old_bg.ckey

--- a/html/changelogs/llywelwyn-srom-bugfix.yml
+++ b/html/changelogs/llywelwyn-srom-bugfix.yml
@@ -1,0 +1,6 @@
+author: Llywelwyn
+
+delete-after: True
+
+changes:
+  - bugfix: "People in Srom will no longer crash when they die."


### PR DESCRIPTION
fixes #12541

bugfix: "People in Srom will no longer crash when they die."

zany race condition

exit_vr called on mob death and handle_shared_dreaming both attempted to handle the return to old body. majority of the time the player would crash and reconnect to the main menu, without the ability to return to their body. occasionally you'd be woken up by handle_shared_dreaming first and exit_vr would get called without a cinch, but it was super rare

fixed by adding a check to exit_vr. if mob has a brainghost (is dreaming), let the dream handle the exit and ckey transfer.

also fixed force_wakeups to now give the appropriate message when forced awake

testing was pretty thorough but there might be a better way to implement this fix