### PR TITLE
Clerical Module Radio Changes

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -693,6 +693,8 @@ var/global/list/robot_modules = list(
 
 /obj/item/robot_module/clerical/general
 	name = "clerical robot module"
+	channels = list(CHANNEL_SUPPLY = TRUE, CHANNEL_COMMAND = TRUE)
+	networks = list(NETWORK_MINE)
 
 /obj/item/robot_module/clerical/general/Initialize()
 	. = ..()

--- a/html/changelogs/Ben10083 - ClericalRadio.yml
+++ b/html/changelogs/Ben10083 - ClericalRadio.yml
@@ -1,0 +1,16 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Clerical module now uses operations radio channel."
+  - tweak: "Clerical cyborg cameras now moved to mine network."
+  - rscadd: "Clerical module now can use command radio channel."
+


### PR DESCRIPTION
Clerical module borgs "moved" to Operations department, as they are far more suited in that department than service.
They also have been given command radio since any paperwork needs head of staff for it. (If abused, command can easily just order it to stfu or turn off it's command radio network access)