### PR TITLE
Drone Fall Damage Reduction & Matriarch Drone Health Buff

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -144,6 +144,9 @@
 		return default_language
 	return all_languages[LANGUAGE_LOCAL_DRONE]
 
+/mob/living/silicon/robot/drone/fall_impact()
+  ..(damage_mod = 0.25) //reduces fall damage by 75%
+
 /mob/living/silicon/robot/drone/construction
 	// Look and feel
 	name = "construction drone"

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -200,6 +200,8 @@
 	module_type = /obj/item/robot_module/drone/construction/matriarch
 	law_type = /datum/ai_laws/matriarch_drone
 	can_swipe = FALSE
+	maxHealth = 50
+	health = 50
 
 	var/matrix_tag
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -483,9 +483,6 @@
 
 	return TRUE
 
-/mob/living/silicon/robot/drone/fall_impact()
-  ..(damage_mod = 0.25)
-
 /mob/living/carbon/human/fall_impact(levels_fallen, stopped_early = FALSE, var/damage_mod = 1)
 	// No gravity, stop falling into spess!
 	var/area/area = get_area(src)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -463,10 +463,6 @@
 
 	var/z_velocity = 5*(levels_fallen**2)
 
-	//Since maint drones don't have a fall_mod that can be modified, they will have a check here
-	if(isDrone(src))
-		damage_mod = 0.25
-
 	var/damage = ((60 + z_velocity) + rand(-20,20)) * damage_mod
 
 	apply_damage(damage, BRUTE)
@@ -486,6 +482,9 @@
 		playsound(src.loc, "sound/weapons/smash.ogg", 75, 1)
 
 	return TRUE
+
+/mob/living/silicon/robot/drone/fall_impact()
+  ..(damage_mod = 0.25)
 
 /mob/living/carbon/human/fall_impact(levels_fallen, stopped_early = FALSE, var/damage_mod = 1)
 	// No gravity, stop falling into spess!

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -462,6 +462,11 @@
 		"With a loud thud, you land on \the [loc]!", "You hear a thud!")
 
 	var/z_velocity = 5*(levels_fallen**2)
+
+	//Since maint drones don't have a fall_mod that can be modified, they will have a check here
+	if(isDrone(src))
+		damage_mod = 0.25
+
 	var/damage = ((60 + z_velocity) + rand(-20,20)) * damage_mod
 
 	apply_damage(damage, BRUTE)

--- a/html/changelogs/Ben10083 - Drone Fall.yml
+++ b/html/changelogs/Ben10083 - Drone Fall.yml
@@ -1,0 +1,14 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Significantly reduced the amount of fall damage drones recieve."
+  - tweak: "Increased Matriarch Drone health."


### PR DESCRIPTION
Title

Given how easy it is for drones to fall down a z-level (they go through railings), it was a bit too punishing that even with a matrix upgrade to their max health, falling down 1 z-level is guaranteed death.

Even with how much I reduced the modifier, the damage by default was so high for them that this modifier reduces their health by about half.