### PR TITLE
Ghostrole ID and Citizenship

### DIFF
--- a/code/game/antagonist/antagonist_update.dm
+++ b/code/game/antagonist/antagonist_update.dm
@@ -16,7 +16,7 @@
 		spawn(3)
 			var/mob/living/carbon/human/H = player.current
 			if(istype(H))
-				H.change_appearance(APPEARANCE_ALL, H, valid_species)
+				H.change_appearance(APPEARANCE_ALL, H, valid_species, update_id = TRUE)
 				H.rejuvenate() //So that things like disabilities and stuff get cleared.
 	if((flags & ANTAG_NO_FLAVORTEXT) && ishuman(player.current))
 		var/mob/living/carbon/human/H = player.current

--- a/code/modules/acting/acting_items.dm
+++ b/code/modules/acting/acting_items.dm
@@ -28,7 +28,7 @@
 	if(!istype(H))
 		return
 
-	H.change_appearance(APPEARANCE_ALL, H, TRUE, H.generate_valid_species(), null, default_state, src)
+	H.change_appearance(APPEARANCE_ALL, H, TRUE, H.generate_valid_species(), null, default_state, src, update_id = TRUE)
 	var/getName = sanitizeName(sanitize_readd_odd_symbols(sanitize(input(H, "Would you like to change your name to something else?", "Name change") as null|text)))
 	if(getName)
 		H.real_name = getName

--- a/code/modules/ghostroles/spawner/human/human.dm
+++ b/code/modules/ghostroles/spawner/human/human.dm
@@ -106,12 +106,6 @@
 	M.forceMove(T)
 	M.lastarea = get_area(M.loc) //So gravity doesnt fuck them.
 
-	//Setup the appearance
-	if(allow_appearance_change)
-		M.change_appearance(allow_appearance_change, M)
-	else //otherwise randomize
-		M.client.prefs.randomize_appearance_for(M, FALSE)
-
 	//Setup the mob age and name
 	if(!mname)
 		mname = random_name(M.gender, M.species.name)
@@ -133,6 +127,12 @@
 	else if(outfit)
 		M.preEquipOutfit(outfit, FALSE)
 		M.equipOutfit(outfit, FALSE)
+
+	//Setup the appearance
+	if(allow_appearance_change)
+		M.change_appearance(allow_appearance_change, M, update_id = TRUE)
+	else //otherwise randomize
+		M.client.prefs.randomize_appearance_for(M, FALSE)
 
 	for(var/language in extra_languages)
 		M.add_language(language)

--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -1,5 +1,5 @@
-/mob/living/carbon/human/proc/change_appearance(var/flags = APPEARANCE_ALL_HAIR, var/mob/user = src, var/check_species_whitelist = TRUE, var/list/species_whitelist = list(), var/list/species_blacklist = list(), var/datum/topic_state/ui_state = interactive_state, var/datum/state_object = src)
-	var/datum/vueui_module/appearance_changer/AC = new /datum/vueui_module/appearance_changer(src, check_species_whitelist, species_whitelist, species_blacklist, ui_state, state_object)
+/mob/living/carbon/human/proc/change_appearance(var/flags = APPEARANCE_ALL_HAIR, var/mob/user = src, var/check_species_whitelist = TRUE, var/list/species_whitelist = list(), var/list/species_blacklist = list(), var/datum/topic_state/ui_state = interactive_state, var/datum/state_object = src, var/update_id = FALSE)
+	var/datum/vueui_module/appearance_changer/AC = new /datum/vueui_module/appearance_changer(src, check_species_whitelist, species_whitelist, species_blacklist, ui_state, state_object, update_id)
 	AC.flags = flags
 	AC.ui_interact(user)
 

--- a/html/changelogs/doxxmedearly-appearance_changer_additions.yml
+++ b/html/changelogs/doxxmedearly-appearance_changer_additions.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Ghostspawner roles will now have their ID card updated after they close the character setup window, so that it displays the correct information."
+  - rscadd: "Ghostspawner roles will now be able to select their citizenship, based on standard origin and culture selections."
+  - rscadd: "Citizenship selection and ID card updates will also apply to any mob using the plastic surgeon machine, assuming they have an ID equipped before using it."

--- a/vueui/src/components/view/misc/appearancechanger.vue
+++ b/vueui/src/components/view/misc/appearancechanger.vue
@@ -41,6 +41,12 @@
           <vui-button v-for="origin in valid_origins" :class="{'button' : 1, 'selected' : owner_origin == origin}" :params="{ origin: origin }" :key="origin">{{ origin }}</vui-button>
         </div>
         <div class="itemLabelNarrow">
+          Citizenships:
+        </div>
+        <div class="itemContentWide">
+          <vui-button v-for="citizenship in valid_citizenships" :class="{'button' : 1, 'selected' : owner_citizenship == citizenship}" :params="{ citizenship: citizenship }" :key="citizenship">{{ citizenship }}</vui-button>
+        </div>
+        <div class="itemLabelNarrow">
           Accents:
         </div>
         <div class="itemContentWide">


### PR DESCRIPTION
Fixes #13506
Ghost role IDs were imprinted at the time the mob's outfit was equipped. However, the player hasn't had a chance to update their appearance or origin by this time, so the ID would always display the randomly generated info. 

Now the ID updates upon the appearance editor's window closing. Also added this functionality to the plastic surgeon machine, which should make antag and event setup less of a hassle (Don't need to distribute syndie IDs, for example). 

I made sure that the ID does NOT update when doing things like changing your hair with synth hair extensions or a mirror. 

Additionally, I put a citizenship selection in for the appearance editor, mainly so the ID reflects the right citizenship information. Based on origin/culture the same way character setup is normally. 