### PR TITLE
Bridge Shutter Fix

### DIFF
--- a/html/changelogs/Ben10083 - BridgeShutter.yml
+++ b/html/changelogs/Ben10083 - BridgeShutter.yml
@@ -1,0 +1,14 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Removed improperly placed window shutter at Bridge."
+  - maptweak: "Expanded the bridge window shutter lockdown to areas near the bridge."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -18473,6 +18473,11 @@
 /obj/structure/grille/diagonal{
 	dir = 4
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor/reinforced,
 /area/crew_quarters/captain)
 "Is" = (
@@ -22388,6 +22393,11 @@
 "Ps" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille/diagonal,
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor/reinforced,
 /area/bridge/minibar)
 "Pt" = (

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -3451,6 +3451,11 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green,
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor,
 /area/crew_quarters/captain)
 "gy" = (
@@ -3641,6 +3646,11 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -4162,6 +4172,11 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor/plating,
 /area/bridge/minibar)
 "hS" = (
@@ -4450,6 +4465,11 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
 	},
 /turf/simulated/floor,
 /area/crew_quarters/captain)
@@ -7385,6 +7405,11 @@
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor,
 /area/crew_quarters/captain)
 "nG" = (
@@ -7801,6 +7826,11 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green,
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor,
 /area/crew_quarters/captain)
 "ou" = (
@@ -8654,11 +8684,6 @@
 /area/horizon/hallway/deck_three/primary/starboard/docks)
 "qa" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/door/blast/shutters/open{
-	dir = 2;
-	name = "Safety Shutter";
-	id = "shutters_deck3_bridgesafety"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/controlroom)
 "qb" = (
@@ -8732,6 +8757,11 @@
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
 	},
 /turf/simulated/floor,
 /area/crew_quarters/captain)
@@ -10603,6 +10633,11 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "tI" = (
@@ -11015,6 +11050,11 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor/plating,
 /area/bridge/third_deck_stairs)
 "uv" = (
@@ -11599,6 +11639,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green,
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor,
 /area/crew_quarters/captain)
 "vA" = (
@@ -12416,6 +12461,11 @@
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille/diagonal{
 	dir = 8
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
 	},
 /turf/simulated/floor/wood,
 /area/bridge/minibar)
@@ -14378,6 +14428,11 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor,
 /area/crew_quarters/captain)
 "AN" = (
@@ -14924,6 +14979,11 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/structure/cable/green{
 	icon_state = "2-8"
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -16447,6 +16507,11 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor,
 /area/crew_quarters/captain)
 "ER" = (
@@ -17692,6 +17757,11 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor/wood,
 /area/bridge/minibar)
 "He" = (
@@ -18149,6 +18219,11 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "0-8"
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
 	},
 /turf/simulated/floor,
 /area/crew_quarters/captain)
@@ -20209,6 +20284,11 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor/plating,
 /area/bridge/minibar)
 "LF" = (
@@ -23786,6 +23866,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor,
 /area/crew_quarters/captain)
 "RZ" = (
@@ -26420,6 +26505,11 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor,
 /area/crew_quarters/captain)
 "Xg" = (
@@ -26779,6 +26869,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor,
 /area/crew_quarters/captain)
 "XL" = (
@@ -26917,6 +27012,11 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green,
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	name = "Safety Shutter";
+	id = "shutters_deck3_bridgesafety"
+	},
 /turf/simulated/floor,
 /area/crew_quarters/captain)
 "XW" = (


### PR DESCRIPTION
Removed the improperly placed shutter.

Also added more of those shutters so they cover captain's office and break room, as if the windows at bridge need locked down, those will as well.