### PR TITLE
Chemsmoke Runtime fix

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -51,7 +51,7 @@
 
 /obj/structure/bed/stool/chair/CanPass(atom/movable/mover, turf/target, height, air_group)
 	if(anchored && padding_material)
-		if(mover.density && isliving(mover) && (reverse_dir[dir] & angle2dir(Get_Angle(src, mover))))
+		if(mover?.density && isliving(mover) && (reverse_dir[dir] & angle2dir(Get_Angle(src, mover))))
 			return FALSE
 	return ..()
 

--- a/html/changelogs/doxxmedearly-chemsmoke_runtimes.yml
+++ b/html/changelogs/doxxmedearly-chemsmoke_runtimes.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Fixed an issue with chairs causing runtimes with the scrubbers event."


### PR DESCRIPTION
Fixes #13777

At least, it seems to? Slapped the offending type of chair around every scrubber and launched/observed three chemsmoke events with no more runtimes. 