### PR TITLE
Medical Module Gripper Removal

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -239,7 +239,6 @@ var/global/list/robot_modules = list(
 	modules += new /obj/item/extinguisher/mini(src) // For navigating space and/or low grav, and just being useful.
 	modules += new /obj/item/device/flash(src) // Non-lethal tool that prevents any 'borg from going lethal on Crew so long as it's an option according to laws.
 	modules += new /obj/item/crowbar/robotic(src) // Base crowbar that all 'borgs should have access to.
-	modules += new /obj/item/gripper/paperwork(src)
 	emag = new /obj/item/reagent_containers/hypospray/cmo(src)
 	emag.reagents.add_reagent(/decl/reagent/wulumunusha, 30)
 	emag.name = "Wulumunusha Hypospray"

--- a/html/changelogs/Ben10083 - Gripper.yml
+++ b/html/changelogs/Ben10083 - Gripper.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Removed paperwork gripper from Medical Module."


### PR DESCRIPTION
A medical borg main pointed out to me that the medical gripper also can hold the body scans, so the paperwork gripper is not needed for the module still.

My bad, I always used the paperwork gripper and never thought to try other