### PR TITLE
Life improvements: Part 1

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -54,6 +54,7 @@
 #include "code\__defines\mobs.dm"
 #include "code\__defines\modular_guns.dm"
 #include "code\__defines\obj.dm"
+#include "code\__defines\organs.dm"
 #include "code\__defines\overmap.dm"
 #include "code\__defines\projectiles.dm"
 #include "code\__defines\psi.dm"

--- a/code/__defines/organs.dm
+++ b/code/__defines/organs.dm
@@ -1,0 +1,1 @@
+#define ORGAN_CAN_FEEL_PAIN(organ) !BP_IS_ROBOTIC(organ) && (!organ.species || !(organ.species.flags & NO_PAIN))

--- a/code/__defines/organs.dm
+++ b/code/__defines/organs.dm
@@ -1,1 +1,2 @@
 #define ORGAN_CAN_FEEL_PAIN(organ) !BP_IS_ROBOTIC(organ) && (!organ.species || !(organ.species.flags & NO_PAIN))
+#define ORGAN_IS_DISLOCATED(organ) (organ.dislocated > 0)

--- a/code/_onclick/hud/screen_object_types/internals.dm
+++ b/code/_onclick/hud/screen_object_types/internals.dm
@@ -37,7 +37,7 @@
 					nicename = list ("suit", "back", "belt", "right hand", "left hand", "left pocket", "right pocket")
 					tankcheck = list (H.s_store, C.back, H.belt, C.r_hand, C.l_hand, H.l_store, H.r_store)
 					if(H.species.has_organ[BP_PHORON_RESERVE])
-						var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+						var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 						if(preserve && preserve.air_contents)
 							from = "in"
 							nicename |= "sternum"
@@ -89,8 +89,8 @@
 								else
 									contents.Add(0)
 
-					if(istype(tankcheck[i], /obj/item/organ/vaurca/preserve))
-						var/obj/item/organ/vaurca/preserve/t = tankcheck[i]
+					if(istype(tankcheck[i], /obj/item/organ/internal/vaurca/preserve))
+						var/obj/item/organ/internal/vaurca/preserve/t = tankcheck[i]
 						if (!isnull(t.manipulated_by) && t.manipulated_by != C.real_name && findtext(t.desc,breathes))
 							contents.Add(t.air_contents.total_moles)	//Someone messed with the tank and put unknown gasses
 							continue					//in it, so we're going to believe the tank is what it says it is
@@ -122,7 +122,7 @@
 								else
 									contents.Add(0)
 
-					if(!(istype(tankcheck[i], /obj/item/organ/vaurca/preserve)) && !(istype(tankcheck[i], /obj/item/tank)))
+					if(!(istype(tankcheck[i], /obj/item/organ/internal/vaurca/preserve)) && !(istype(tankcheck[i], /obj/item/tank)))
 						//no tank so we set contents to 0
 						contents.Add(0)
 

--- a/code/datums/outfits/ert/kataphract.dm
+++ b/code/datums/outfits/ert/kataphract.dm
@@ -62,7 +62,7 @@
 
 /datum/outfit/admin/ert/kataphract/klax/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(H?.wear_mask && H.species.has_organ[BP_PHORON_RESERVE])
-		var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"
 
@@ -94,7 +94,7 @@
 		/obj/item/reagent_containers/glass/bottle/dexalin_plus = 1,
 		/obj/item/reagent_containers/glass/bottle/butazoline = 1,
 		/obj/item/reagent_containers/glass/bottle/dermaline = 1,
-		/obj/item/reagent_containers/glass/bottle/perconol = 1	
+		/obj/item/reagent_containers/glass/bottle/perconol = 1
 	)
 
 	backpack_contents = list(

--- a/code/datums/outfits/ert/tcfl.dm
+++ b/code/datums/outfits/ert/tcfl.dm
@@ -18,7 +18,7 @@
 	. = ..()
 	if(isvaurca(H))
 		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
-		var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"
 
@@ -67,7 +67,7 @@
 		/obj/item/handcuffs/ziptie = 3,
 		/obj/item/clothing/mask/gas/tactical = 1,
 		/obj/item/storage/firstaid/regular = 1,
-		/obj/item/clothing/gloves/swat/ert = 1, 
+		/obj/item/clothing/gloves/swat/ert = 1,
 		/obj/item/material/knife/bayonet = 1
 	)
 

--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -509,7 +509,7 @@
 			wounds += "Splinted."
 		if (O.status & ORGAN_BLEEDING)
 			wounds += "Bleeding."
-		if(O.is_dislocated())
+		if(ORGAN_IS_DISLOCATED(O))
 			wounds += "Dislocated."
 		if (O.status & ORGAN_BROKEN)
 			wounds += "[O.broken_description]."
@@ -722,7 +722,7 @@
 			lung_ruptured = "Lung ruptured."
 		if(e.status & ORGAN_SPLINTED)
 			splint = "Splinted."
-		if(e.is_dislocated())
+		if(ORGAN_IS_DISLOCATED(e))
 			dislocated = "Dislocated."
 		if(e.status & ORGAN_BLEEDING)
 			bled = "Bleeding."

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -287,7 +287,7 @@
 			lung_ruptured = "Lung ruptured."
 		if(e.status & ORGAN_SPLINTED)
 			splint = "Splinted."
-		if(e.is_dislocated())
+		if(ORGAN_IS_DISLOCATED(e))
 			dislocated = "Dislocated."
 		if(e.status & ORGAN_BLEEDING)
 			bled = "Bleeding."

--- a/code/modules/cooking/recipes/recipes_mix.dm
+++ b/code/modules/cooking/recipes/recipes_mix.dm
@@ -218,7 +218,7 @@
 
 /*
 /decl/recipe/neuralbroke
-	items = list(/obj/item/organ/vaurca/neuralsocket)
+	items = list(/obj/item/organ/internal/vaurca/neuralsocket)
 	result = /obj/item/neuralbroke
 */
 

--- a/code/modules/ghostroles/spawner/human/kataphract.dm
+++ b/code/modules/ghostroles/spawner/human/kataphract.dm
@@ -123,7 +123,7 @@
 
 /datum/outfit/admin/kataphract/klax/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(H?.wear_mask && H.species.has_organ[BP_PHORON_RESERVE])
-		var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"
 

--- a/code/modules/item_worth/worths_list.dm
+++ b/code/modules/item_worth/worths_list.dm
@@ -609,7 +609,7 @@ var/list/worths = list(
 					/obj/item/organ/internal/heart = 1200,
 					/obj/item/organ/internal/brain/golem = 3000,
 					/obj/item/organ/internal/brain = 1200,
-					/obj/item/organ/vaurca/neuralsocket = 1500,
+					/obj/item/organ/internal/vaurca/neuralsocket = 1500,
 					/obj/item/organ = 400,
 //ITEMS,
 					/obj/item/slime_extract = 200,

--- a/code/modules/martial_arts/skrell.dm
+++ b/code/modules/martial_arts/skrell.dm
@@ -43,7 +43,7 @@
 	A.do_attack_animation(D)
 	if(prob(30))
 		var/obj/item/organ/external/organ = D.get_organ(A.zone_sel.selecting)
-		if(!organ || organ.is_dislocated() || organ.dislocated == -1)
+		if(!organ || ORGAN_IS_DISLOCATED(organ) || organ.dislocated == -1)
 			return 0
 		organ.dislocate(1)
 		A.visible_message("<span class='warning'>[A] strikes [D]'s [organ.name] with their closed fist!</span>")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -398,7 +398,7 @@
 					apply_effect(5, WEAKEN)
 					forceMove(GetAbove(z_eye)) //We use GetAbove so people can't cheese it by turning their sprite.
 					return
-						
+
 			if(randn <= 25)
 				if(H.gloves && istype(H.gloves,/obj/item/clothing/gloves/force))
 					apply_effect(6, WEAKEN)
@@ -566,7 +566,7 @@
 	if(!target_zone)
 		return 0
 	var/obj/item/organ/external/organ = get_organ(check_zone(target_zone))
-	if(!organ || organ.is_dislocated() || organ.dislocated == -1)
+	if(!organ || ORGAN_IS_DISLOCATED(organ) || organ.dislocated == -1)
 		return 0
 
 	user.visible_message("<span class='warning'>[user] begins to dislocate [src]'s [organ.joint]!</span>")

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -435,7 +435,7 @@ This function restores all organs.
 	if(!damage)
 		return FALSE
 
-	if(damage > 15 && prob(damage*4) && organ.can_feel_pain())
+	if(damage > 15 && prob(damage*4) && ORGAN_CAN_FEEL_PAIN(organ))
 		if(REAGENT_VOLUME(reagents, /decl/reagent/adrenaline) < 15)
 			make_adrenaline(round(damage/10))
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -17,9 +17,9 @@
 	if(health_deficiency >= 40)
 		tally += (health_deficiency / 25)
 
-	if(can_feel_pain())
-		if(get_shock() >= 10)
-			tally += (get_shock() / 30) //pain shouldn't slow you down if you can't even feel it
+	var/shock = get_shock()
+	if(shock >= 10)
+		tally += (shock / 30) //get_shock checks if we can feel pain
 
 	tally += ClothesSlowdown()
 

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -127,7 +127,7 @@
 		if(!E || !(E.limb_flags & ORGAN_CAN_GRASP) || (E.status & ORGAN_SPLINTED))
 			continue
 
-		if(E.is_broken() || E.is_dislocated())
+		if(E.is_broken() || ORGAN_IS_DISLOCATED(E))
 			switch(E.body_part)
 				if(HAND_LEFT, ARM_LEFT)
 					if(!l_hand)

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -65,7 +65,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	// Equip mask to allow the drone to breathe
 	equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(src), slot_wear_mask)
 	// Set internals
-	var/obj/item/organ/vaurca/preserve/P = internal_organs_by_name[BP_PHORON_RESERVE]
+	var/obj/item/organ/internal/vaurca/preserve/P = internal_organs_by_name[BP_PHORON_RESERVE]
 	internal = P
 	// Set colour, default is grey, no biggie
 	var/list/hive = splittext(name, " ")

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -277,7 +277,7 @@
 					adjustCloneLoss(5 * RADIATION_SPEED_COEFFICIENT)
 					emote("gasp")
 				hallucination = max(hallucination, 20) //At this level, you're in a constant state of low-level hallucinations. As if you didn't have enough problems.
-				
+
 
 			if(damage)
 				adjustToxLoss(damage * RADIATION_SPEED_COEFFICIENT)
@@ -921,8 +921,7 @@
 
 				var/no_damage = 1
 				var/trauma_val = 0 // Used in calculating softcrit/hardcrit indicators.
-				if(can_feel_pain())
-					trauma_val = max(shock_stage,get_shock())/(species.total_health-100)
+				trauma_val = max(shock_stage,get_shock())/(species.total_health-100)
 				// Collect and apply the images all at once to avoid appearance churn.
 				var/list/health_images = list()
 				for(var/obj/item/organ/external/E in organs)
@@ -1392,7 +1391,8 @@
 	if (!exhaust_threshold) // Also quit if there's no exhaust threshold specified, because division by 0 is amazing.
 		return
 
-	if (failed_last_breath || (getOxyLoss() + get_shock()) > exhaust_threshold)//Can't catch our breath if we're suffocating
+	var/shock = get_shock() // used again later for stamina regeneration
+	if (failed_last_breath || (getOxyLoss() + shock) > exhaust_threshold)//Can't catch our breath if we're suffocating
 		flash_pain(getOxyLoss()/2)
 		return
 
@@ -1409,7 +1409,7 @@
 	if (stamina != max_stamina)
 		//Any suffocation damage slows stamina regen.
 		//This includes oxyloss from low blood levels
-		var/regen = stamina_recovery * (1 - min(((getOxyLoss()) / exhaust_threshold) + ((get_shock()) / exhaust_threshold), 1))
+		var/regen = stamina_recovery * (1 - min(((getOxyLoss()) / exhaust_threshold) + (shock / exhaust_threshold), 1))
 		if(is_drowsy())
 			regen *= 0.85
 		if (regen > 0)
@@ -1463,11 +1463,11 @@
 			bodytemperature = min(bodytemperature + fever, normal_temp)
 		else if(bodytemperature <= normal_temp + 10) //If we're hotter than max due to like, being on fire, don't keep increasing.
 			bodytemperature = normal_temp + min(fever, 10) //We use normal_temp here to maintain a steady temperature, otherwise even a small infection steadily increases bodytemp to max. This way it's easier to diagnose the intensity of an infection based on how bad the fever is.
-	//Apply side effects for having a fever. Separate from body temp changes. 
+	//Apply side effects for having a fever. Separate from body temp changes.
 	if(fever >= 2)
 		do_fever_effects(fever)
 
-		
+
 //Getting the total germ level for all infected organs, affects fever
 /mob/living/carbon/human/proc/get_infection_germ_level()
 	var/germs

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -612,17 +612,18 @@
 			H.adjustHalLoss(remainder*0.25)
 		H.adjustOxyLoss(remainder * 0.2) //Keeping oxyloss small when out of stamina to prevent old issue where running until exhausted sometimes gave you brain damage.
 
+	var/shock = H.get_shock()
 	if(!pre_move)
 		H.adjustHalLoss(remainder*0.3)
 		H.updatehealth()
-		if((H.get_shock() >= 10) && prob(H.get_shock() *2))
-			H.flash_pain(H.get_shock())
+		if((shock >= 10) && prob(shock *2))
+			H.flash_pain(shock)
 
-	if((H.get_shock() + H.getOxyLoss()*2) >= (exhaust_threshold * 0.8))
+	if((shock + H.getOxyLoss()*2) >= (exhaust_threshold * 0.8))
 		H.m_intent = M_WALK
 		H.hud_used.move_intent.update_move_icon(H)
 		to_chat(H, SPAN_DANGER("You're too exhausted to run anymore!"))
-		H.flash_pain(H.get_shock())
+		H.flash_pain(shock)
 		return 0
 
 	if(!pre_move)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -806,7 +806,7 @@
 				spark(H, 5)
 		else if (E.is_broken() || !E.is_usable())
 			stance_damage += 1
-		else if (E.is_dislocated())
+		else if (ORGAN_IS_DISLOCATED(E))
 			stance_damage += 0.5
 
 	// Canes and crutches help you stand (if the latter is ever added)

--- a/code/modules/mob/living/carbon/human/species/station/human/human.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human/human.dm
@@ -75,7 +75,7 @@
 		var/maxdam = 0
 		var/obj/item/organ/external/damaged_organ = null
 		for(var/obj/item/organ/external/E in H.organs)
-			if(!E.can_feel_pain())
+			if(!ORGAN_CAN_FEEL_PAIN(E))
 				continue
 			var/dam = E.get_damage()
 			// make the choice of the organ depend on damage,

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -101,7 +101,7 @@
 		BP_LUNGS               = /obj/item/organ/internal/lungs/vaurca,
 		BP_FILTRATION_BIT       = /obj/item/organ/vaurca/filtrationbit,
 		BP_HEART               = /obj/item/organ/internal/heart/vaurca,
-		BP_PHORON_RESERVE  = /obj/item/organ/vaurca/preserve,
+		BP_PHORON_RESERVE  = /obj/item/organ/internal/vaurca/preserve,
 		BP_LIVER               = /obj/item/organ/internal/liver/vaurca,
 		BP_KIDNEYS             = /obj/item/organ/internal/kidneys/vaurca,
 		BP_STOMACH             = /obj/item/organ/internal/stomach/vaurca,
@@ -156,7 +156,7 @@
 
 /datum/species/bug/has_psi_potential()
 	return FALSE
-	
+
 /datum/species/bug/is_naturally_insulated()
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -97,9 +97,9 @@
 	stamina_recovery = 2	//slow recovery
 
 	has_organ = list(
-		BP_NEURAL_SOCKET        = /obj/item/organ/vaurca/neuralsocket,
+		BP_NEURAL_SOCKET        = /obj/item/organ/internal/vaurca/neuralsocket,
 		BP_LUNGS               = /obj/item/organ/internal/lungs/vaurca,
-		BP_FILTRATION_BIT       = /obj/item/organ/vaurca/filtrationbit,
+		BP_FILTRATION_BIT       = /obj/item/organ/internal/vaurca/filtrationbit,
 		BP_HEART               = /obj/item/organ/internal/heart/vaurca,
 		BP_PHORON_RESERVE  = /obj/item/organ/internal/vaurca/preserve,
 		BP_LIVER               = /obj/item/organ/internal/liver/vaurca,

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
@@ -169,16 +169,16 @@
 		)
 
 	has_organ = list(
-		BP_NEURAL_SOCKET       = /obj/item/organ/vaurca/neuralsocket,
+		BP_NEURAL_SOCKET       = /obj/item/organ/internal/vaurca/neuralsocket,
 		BP_LUNGS              = /obj/item/organ/internal/lungs/vaurca,
 		BP_HEART              = /obj/item/organ/internal/heart/vaurca,
-		BP_PHORON_RESERVOIR    = /obj/item/organ/vaurca/reservoir,
+		BP_PHORON_RESERVOIR    = /obj/item/organ/internal/vaurca/reservoir,
 		BP_VAURCA_LIVER    = /obj/item/organ/internal/liver/vaurca/robo,
 		BP_VAURCA_KIDNEYS  = /obj/item/organ/internal/kidneys/vaurca/robo,
 		BP_STOMACH            = /obj/item/organ/internal/stomach,
 		BP_BRAIN              = /obj/item/organ/internal/brain/vaurca,
 		BP_EYES               = /obj/item/organ/internal/eyes/night/vaurca,
-		BP_FILTRATION_BIT      = /obj/item/organ/vaurca/filtrationbit
+		BP_FILTRATION_BIT      = /obj/item/organ/internal/vaurca/filtrationbit
 	)
 
 	default_h_style = "Bald"

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -121,7 +121,7 @@
 		if(violent_removal)
 			var/obj/item/organ/external/E = H.get_organ(pick(BP_L_ARM,BP_R_ARM))
 			var/dislocate_message = ""
-			if(E && !E.is_dislocated())
+			if(E && !ORGAN_IS_DISLOCATED(E))
 				E.dislocate(1)
 				dislocate_message = ", but dislocate your [E] in the process"
 			visible_message(

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -211,10 +211,7 @@ default behaviour is:
 		health = maxHealth
 		stat = CONSCIOUS
 	else
-		health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss() - getHalLoss()
-		//Removed Halloss from here. Halloss isn't supposed to count towards death
-
-
+		health = maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss()
 
 //This proc is used for mobs which are affected by pressure to calculate the amount of pressure that actually
 //affects them once clothing is factored in. ~Errorage

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -108,7 +108,7 @@
 		damage = between(0, src.damage + amount, max_damage)
 
 		//only show this if the organ is not robotic
-		if(owner && can_feel_pain() && parent_organ && (amount > 5 || prob(10)))
+		if(owner && ORGAN_CAN_FEEL_PAIN(src) && parent_organ && (amount > 5 || prob(10)))
 			var/obj/item/organ/external/parent = owner.get_organ(parent_organ)
 			if(parent && !silent)
 				var/degree = ""

--- a/code/modules/organs/internal/appendix.dm
+++ b/code/modules/organs/internal/appendix.dm
@@ -14,10 +14,11 @@
 
 /obj/item/organ/internal/appendix/process()
 	..()
-	if(inflamed && owner && !(status & ORGAN_ROBOT))
+	if(inflamed && owner && !BP_IS_ROBOTIC(src))
+		var/can_feel_pain = ORGAN_CAN_FEEL_PAIN(src)
 		inflamed++
 		if(prob(5))
-			if(owner.can_feel_pain())
+			if(can_feel_pain)
 				owner.custom_pain("You feel a stinging pain in your abdomen!")
 				owner.visible_message("<B>\The [owner]</B> winces slightly.")
 				var/obj/item/organ/external/O = owner.get_organ(parent_organ)
@@ -26,7 +27,7 @@
 		if(inflamed > 200)
 			if(prob(3))
 				take_internal_damage(0.1)
-				if(owner.can_feel_pain())
+				if(can_feel_pain)
 					owner.visible_message("<B>\The [owner]</B> winces painfully.")
 					var/obj/item/organ/external/O = owner.get_organ(parent_organ)
 					if(O)
@@ -38,7 +39,7 @@
 				owner.vomit()
 		if(inflamed > 600)
 			if(prob(1))
-				if(owner.can_feel_pain())
+				if(can_feel_pain)
 					owner.custom_pain("You feel a stinging pain in your abdomen!")
 					owner.Weaken(10)
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -141,9 +141,6 @@
 /obj/item/organ/proc/bruise()
 	damage = max(damage, min_bruised_damage)
 
-/obj/item/organ/proc/can_feel_pain()
-	return (!BP_IS_ROBOTIC(src) && (!species || !(species.flags & NO_PAIN)))
-
 #define ORGAN_RECOVERY_THRESHOLD (5 MINUTES)
 /obj/item/organ/proc/can_recover()
 	return (max_damage > 0) && !(status & ORGAN_DEAD) || death_time >= world.time - ORGAN_RECOVERY_THRESHOLD

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1194,7 +1194,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return FALSE
 	if(parent && (parent.tendon_status() & TENDON_CUT))
 		return FALSE
-	if(can_feel_pain() && get_pain() > pain_disability_threshold)
+	if(get_pain() > pain_disability_threshold)
 		return FALSE
 	if(brute_ratio > 1)
 		return FALSE
@@ -1444,7 +1444,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 // Pain/halloss
 /obj/item/organ/external/proc/get_pain()
-	if(!can_feel_pain() || BP_IS_ROBOTIC(src))
+	if(!ORGAN_CAN_FEEL_PAIN(src) || BP_IS_ROBOTIC(src))
 		return 0
 	. = pain + 0.7 * brute_dam + 0.8 * burn_dam + 0.5 * get_genetic_damage()
 	if(is_broken())
@@ -1455,7 +1455,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		. += 0.3 * I.getToxLoss()
 
 /obj/item/organ/external/proc/remove_pain(var/amount)
-	if(!can_feel_pain())
+	if(!ORGAN_CAN_FEEL_PAIN(src))
 		pain = 0
 		return
 	var/last_pain = pain
@@ -1463,7 +1463,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return -(pain-last_pain)
 
 /obj/item/organ/external/proc/add_pain(var/amount)
-	if(!can_feel_pain())
+	if(!ORGAN_CAN_FEEL_PAIN(src))
 		pain = 0
 		return
 	var/last_pain = pain

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1446,15 +1446,13 @@ Note that amputating the affected organ does in fact remove the infection from t
 /obj/item/organ/external/proc/get_pain()
 	if(!can_feel_pain() || BP_IS_ROBOTIC(src))
 		return 0
-	var/lasting_pain = 0
+	. = pain + 0.7 * brute_dam + 0.8 * burn_dam + 0.5 * get_genetic_damage()
 	if(is_broken())
-		lasting_pain += 10
+		. += 10
 	else if(is_dislocated())
-		lasting_pain += 5
-	var/tox_dam = 0
+		. += 5
 	for(var/obj/item/organ/internal/I in internal_organs)
-		tox_dam += I.getToxLoss()
-	return pain + lasting_pain + 0.7 * brute_dam + 0.8 * burn_dam + 0.3 * tox_dam + 0.5 * get_genetic_damage()
+		. += 0.3 * I.getToxLoss()
 
 /obj/item/organ/external/proc/remove_pain(var/amount)
 	if(!can_feel_pain())

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -186,13 +186,6 @@
 				return
 	..()
 
-/obj/item/organ/external/proc/is_dislocated()
-	if(dislocated > 0)
-		return 1
-	if(parent)
-		return parent.is_dislocated()
-	return 0
-
 /obj/item/organ/external/proc/dislocate(var/primary)
 	if(dislocated != -1)
 		if(primary)
@@ -1188,7 +1181,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 /obj/item/organ/external/is_usable()
 	if(is_stump())
 		return FALSE
-	if(is_dislocated())
+	if(ORGAN_IS_DISLOCATED(src))
 		return FALSE
 	if(tendon_status() & TENDON_CUT)
 		return FALSE
@@ -1449,7 +1442,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	. = pain + 0.7 * brute_dam + 0.8 * burn_dam + 0.5 * get_genetic_damage()
 	if(is_broken())
 		. += 10
-	else if(is_dislocated())
+	else if(ORGAN_IS_DISLOCATED(src))
 		. += 5
 	for(var/obj/item/organ/internal/I in internal_organs)
 		. += 0.3 * I.getToxLoss()

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1444,7 +1444,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		. += 10
 	else if(ORGAN_IS_DISLOCATED(src))
 		. += 5
-	for(var/obj/item/organ/internal/I in internal_organs)
+	for(var/obj/item/organ/internal/I as anything in internal_organs)
 		. += 0.3 * I.getToxLoss()
 
 /obj/item/organ/external/proc/remove_pain(var/amount)

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -48,8 +48,6 @@ mob/var/next_pain_time = 0
 	next_pain_time = world.time + 5 SECONDS
 
 /mob/living/carbon/human/proc/handle_pain()
-	if(!can_feel_pain())
-		return
 	if(stat >= DEAD)
 		return
 	if(!can_feel_pain())
@@ -60,7 +58,7 @@ mob/var/next_pain_time = 0
 	var/maxdam = 0
 	var/obj/item/organ/external/damaged_organ = null
 	for(var/obj/item/organ/external/E in organs)
-		if(E.status & (ORGAN_DEAD|ORGAN_ROBOT)) 
+		if(E.status & (ORGAN_DEAD|ORGAN_ROBOT))
 			continue
 		var/dam = E.get_damage()
 		// make the choice of the organ depend on damage,

--- a/code/modules/organs/subtypes/vaurca.dm
+++ b/code/modules/organs/subtypes/vaurca.dm
@@ -44,7 +44,7 @@
 	icon = 'icons/obj/organs/vaurca_organs.dmi'
 	can_prepare = FALSE
 
-/obj/item/organ/vaurca/reservoir
+/obj/item/organ/internal/vaurca/reservoir
 	icon = 'icons/obj/organs/vaurca_organs.dmi'
 	name = BP_PHORON_RESERVOIR
 	organ_tag = BP_PHORON_RESERVOIR
@@ -52,7 +52,7 @@
 	icon_state = "phoron_reservoir"
 	robotic = ROBOTIC_ASSISTED
 
-/obj/item/organ/vaurca/filtrationbit
+/obj/item/organ/internal/vaurca/filtrationbit
 	icon = 'icons/obj/organs/vaurca_organs.dmi'
 	name = BP_FILTRATION_BIT
 	organ_tag = BP_FILTRATION_BIT
@@ -60,7 +60,7 @@
 	icon_state = "filter"
 	robotic = ROBOTIC_MECHANICAL
 
-/obj/item/organ/vaurca/neuralsocket
+/obj/item/organ/internal/vaurca/neuralsocket
 	icon = 'icons/obj/organs/vaurca_organs.dmi'
 	name = BP_NEURAL_SOCKET
 	organ_tag = BP_NEURAL_SOCKET
@@ -80,13 +80,13 @@ obj/item/organ/vaurca/neuralsocket/process()
 			to_chat(owner, "<span class='notice'> Your mind expands, and your thoughts join the unity of the Hivenet.</span>")
 	..()
 
-/obj/item/organ/vaurca/neuralsocket/replaced(var/mob/living/carbon/human/target)
+/obj/item/organ/internal/vaurca/neuralsocket/replaced(var/mob/living/carbon/human/target)
 	if (!(all_languages[LANGUAGE_VAURCA] in owner.languages))
 		owner.add_language(LANGUAGE_VAURCA)
 		to_chat(owner, "<span class='notice'> Your mind expands, and your thoughts join the unity of the Hivenet.</span>")
 	..()
 
-/obj/item/organ/vaurca/neuralsocket/removed(var/mob/living/carbon/human/target)
+/obj/item/organ/internal/vaurca/neuralsocket/removed(var/mob/living/carbon/human/target)
 	if(all_languages[LANGUAGE_VAURCA] in target.languages)
 		target.remove_language(LANGUAGE_VAURCA)
 		to_chat(target, "<span class='warning'>Your mind suddenly grows dark as the unity of the Hive is torn from you.</span>")

--- a/code/modules/organs/subtypes/vaurca.dm
+++ b/code/modules/organs/subtypes/vaurca.dm
@@ -92,7 +92,7 @@ obj/item/organ/vaurca/neuralsocket/process()
 		to_chat(target, "<span class='warning'>Your mind suddenly grows dark as the unity of the Hive is torn from you.</span>")
 	..()
 
-/obj/item/organ/vaurca/preserve
+/obj/item/organ/internal/vaurca/preserve
 	icon = 'icons/obj/organs/vaurca_organs.dmi'
 	name = BP_PHORON_RESERVE
 	organ_tag = BP_PHORON_RESERVE
@@ -105,7 +105,7 @@ obj/item/organ/vaurca/neuralsocket/process()
 	var/volume = 50
 	var/manipulated_by = null
 
-/obj/item/organ/vaurca/preserve/Initialize()
+/obj/item/organ/internal/vaurca/preserve/Initialize()
 	. = ..()
 
 	air_contents = new /datum/gas_mixture()
@@ -122,13 +122,13 @@ obj/item/organ/vaurca/neuralsocket/process()
 
 	return
 
-/obj/item/organ/vaurca/preserve/Destroy()
+/obj/item/organ/internal/vaurca/preserve/Destroy()
 	if(air_contents)
 		QDEL_NULL(air_contents)
 
 	return ..()
 
-/obj/item/organ/vaurca/preserve/examine(mob/user)
+/obj/item/organ/internal/vaurca/preserve/examine(mob/user)
 	. = ..(user, 0)
 	if(.)
 		var/celsius_temperature = air_contents.temperature - T0C
@@ -148,7 +148,7 @@ obj/item/organ/vaurca/neuralsocket/process()
 				descriptive = "cold"
 		to_chat(user, "<span class='notice'>\The [src] feels [descriptive].</span>")
 
-/obj/item/organ/vaurca/preserve/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/organ/internal/vaurca/preserve/attackby(obj/item/W as obj, mob/user as mob)
 	..()
 	var/obj/icon = src
 
@@ -173,13 +173,13 @@ obj/item/organ/vaurca/neuralsocket/process()
 		B.blow(src)
 		src.add_fingerprint(user)
 
-/obj/item/organ/vaurca/preserve/attack_self(mob/user as mob)
+/obj/item/organ/internal/vaurca/preserve/attack_self(mob/user as mob)
 	if (!(src.air_contents))
 		return
 
 	ui_interact(user)
 
-/obj/item/organ/vaurca/preserve/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
+/obj/item/organ/internal/vaurca/preserve/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 	var/mob/living/carbon/location = null
 
 	var/using_internal
@@ -230,7 +230,7 @@ obj/item/organ/vaurca/neuralsocket/process()
 		// auto update every Master Controller tick
 		ui.set_auto_update(1)
 
-/obj/item/organ/vaurca/preserve/Topic(href, href_list)
+/obj/item/organ/internal/vaurca/preserve/Topic(href, href_list)
 	..()
 	if (usr.stat|| usr.restrained())
 		return 0
@@ -277,19 +277,19 @@ obj/item/organ/vaurca/neuralsocket/process()
 	return 1
 
 
-/obj/item/organ/vaurca/preserve/remove_air(amount)
+/obj/item/organ/internal/vaurca/preserve/remove_air(amount)
 	return air_contents.remove(amount)
 
-/obj/item/organ/vaurca/preserve/return_air()
+/obj/item/organ/internal/vaurca/preserve/return_air()
 	return air_contents
 
-/obj/item/organ/vaurca/preserve/assume_air(datum/gas_mixture/giver)
+/obj/item/organ/internal/vaurca/preserve/assume_air(datum/gas_mixture/giver)
 	air_contents.merge(giver)
 
 	check_status()
 	return 1
 
-/obj/item/organ/vaurca/preserve/proc/remove_air_volume(volume_to_return)
+/obj/item/organ/internal/vaurca/preserve/proc/remove_air_volume(volume_to_return)
 	if(!air_contents)
 		return null
 
@@ -301,14 +301,14 @@ obj/item/organ/vaurca/neuralsocket/process()
 
 	return remove_air(moles_needed)
 
-/obj/item/organ/vaurca/preserve/process()
+/obj/item/organ/internal/vaurca/preserve/process()
 	//Allow for reactions
 	air_contents.react() //cooking up air tanks - add phoron and oxygen, then heat above PHORON_MINIMUM_BURN_TEMPERATURE
 	check_status()
 	..()
 
 
-/obj/item/organ/vaurca/preserve/proc/check_status()
+/obj/item/organ/internal/vaurca/preserve/proc/check_status()
 	//Handle exploding, leaking, and rupturing of the tank
 
 	if(!air_contents)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -110,7 +110,7 @@
 			else if(F.is_broken())
 				..()
 			else if(H.species.has_organ[BP_PHORON_RESERVE])
-				var/obj/item/organ/vaurca/preserve/P = H.internal_organs_by_name[BP_PHORON_RESERVE]
+				var/obj/item/organ/internal/vaurca/preserve/P = H.internal_organs_by_name[BP_PHORON_RESERVE]
 				if(isnull(P))
 					return
 				else if(P.is_broken())
@@ -712,12 +712,12 @@
 	if(ishuman(M) && !berserked)
 		H.berserk_start()
 		berserked = TRUE
-	else if(ishuman(M) && berserked) 
+	else if(ishuman(M) && berserked)
 		H.berserk_process()
 	M.add_chemical_effect(CE_BERSERK, 1)
 	if(M.a_intent != I_HURT)
 		M.a_intent_change(I_HURT)
-		
+
 /decl/reagent/toxin/spectrocybin/final_effect(mob/living/carbon/human/H, datum/reagents/holder)
 	. = ..()
 	if(istype(H) && H.chem_doses[type] >= get_overdose(H, holder = holder))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -104,7 +104,7 @@
 
 		if(alien == IS_VAURCA && H.species.has_organ[BP_FILTRATION_BIT])
 			metabolism = REM * 20 //vaurcae metabolise phoron faster than other species - good for them if their filter isn't broken.
-			var/obj/item/organ/vaurca/filtrationbit/F = H.internal_organs_by_name[BP_FILTRATION_BIT]
+			var/obj/item/organ/internal/vaurca/filtrationbit/F = H.internal_organs_by_name[BP_FILTRATION_BIT]
 			if(isnull(F))
 				..()
 			else if(F.is_broken())

--- a/html/changelogs/life_speedups_part1.yml
+++ b/html/changelogs/life_speedups_part1.yml
@@ -1,0 +1,6 @@
+author: mikomyazaki
+
+delete-after: True
+
+changes:
+  - tweak: "Sped up code related to pain, dislocation and shock."

--- a/maps/away/generic/space_bar_ghostroles.dm
+++ b/maps/away/generic/space_bar_ghostroles.dm
@@ -45,7 +45,7 @@
 	. = ..()
 	if(isvaurca(H))
 		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
-		var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"
 		H.equip_or_collect(new /obj/item/reagent_containers/inhaler/phoron_special, slot_in_backpack)
@@ -100,7 +100,7 @@
 	. = ..()
 	if(isvaurca(H))
 		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
-		var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"
 		H.equip_or_collect(new /obj/item/reagent_containers/inhaler/phoron_special, slot_in_backpack)
@@ -146,10 +146,10 @@
 
 /datum/outfit/admin/random/space_bar_patron/vaurca/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+	var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 	H.internal = preserve
 	H.internals.icon_state = "internal1"
-	
+
 /datum/outfit/admin/random/space_bar_patron/offworlder
 	r_pocket = /obj/item/storage/pill_bottle/rmt
 

--- a/maps/away/ships/biesel_ship_ghostroles.dm
+++ b/maps/away/ships/biesel_ship_ghostroles.dm
@@ -46,7 +46,7 @@
 	. = ..()
 	if(isvaurca(H))
 		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
-		var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"
 		H.equip_or_collect(new /obj/item/reagent_containers/inhaler/phoron_special, slot_in_backpack)
@@ -143,7 +143,7 @@
 	. = ..()
 	if(isvaurca(H))
 		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
-		var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"
 		var/obj/item/reagent_containers/inhaler/phoron_special/PS = new /obj/item/reagent_containers/inhaler/phoron_special(get_turf(H))

--- a/maps/away/ships/corporate_ship_ghostroles.dm
+++ b/maps/away/ships/corporate_ship_ghostroles.dm
@@ -43,7 +43,7 @@
 	. = ..()
 	if(isvaurca(H))
 		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
-		var/obj/item/organ/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
+		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"
 		H.equip_or_collect(new /obj/item/reagent_containers/inhaler/phoron_special, slot_in_backpack)


### PR DESCRIPTION
There's quite a lot of other obvious changes to make to parts of Life() where things are called unnecessarily, but I'm going to do it in parts incase I break everything. These procs are the ones that take the most time, anyway.

- Significantly reduces the amount of times `get_shock()` is called, it is often called multiple times in one proc so it can be cached.
- Removes `getHalLoss()` from the health update checks, because it shouldn't be in there.
- Speeds up `get_pain()` _slightly_.
- Macroizes `can_feel_pain()` to reduce proc call overhead.
- Greatly reduces the amount of times `is_dislocated()` is called. If a parent organ is dislocated, then so it its child -- So there is no need for a child to check if its parents are dislocated after it checks itself.
- Macroizes `is_dislocated()` to reduce proc call overhead.
- Removes the typechecks from get_pain() (I had to make the vaurca phoron reserve into an internal organ, so that everything in the internal_organs list is internal -- but it should have been one anyway)