### PR TITLE
Level-3 Biohazard Closet Fix

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/l3closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/l3closet.dm
@@ -7,6 +7,9 @@
 	new /obj/item/clothing/suit/bio_suit/general(src)
 	new /obj/item/clothing/head/bio_hood/general(src)
 	new /obj/item/clothing/mask/gas/half(src)
+	new /obj/item/clothing/suit/bio_suit/general(src)
+	new /obj/item/clothing/head/bio_hood/general(src)
+	new /obj/item/clothing/mask/gas/half(src)
 
 /obj/structure/closet/l3closet/virology
 	icon_state = "bio_viro"

--- a/html/changelogs/l3closet_WITH_BIOSUITS.yml
+++ b/html/changelogs/l3closet_WITH_BIOSUITS.yml
@@ -1,0 +1,7 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - bugfix: "The level-3 biohazard closet in Medical's Isolation Ward is no longer empty."
+  - tweak: "Made general level-3 biohazard closets spawn with two biosuit pairs instead of just one."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -21266,7 +21266,7 @@
 /obj/effect/floor_decal/corner/red/full{
 	dir = 8
 	},
-/obj/structure/closet/l3closet,
+/obj/structure/closet/l3closet/general,
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
 	id_tag = "processing_airlock_control";
 	name = "Processing Access Controller";


### PR DESCRIPTION
* Fixes the Level-3 Biohazard Closet in Medical's Isolation Ward to not be empty
* Minor tweak so that the general Level-3 Biohazard Closet comes with two biosuits instead of one

**Proof it works**
![](https://i.imgur.com/j60Zsvw.gif)