### PR TITLE
Fix yield declarations and the Racer away site

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -226,16 +226,16 @@
 
 	printing = TRUE
 
-	var/obj/item/paper/P = new /obj/item/paper(user.loc)
+	var/obj/item/paper/P = new /obj/item/paper(get_turf(src))
 	var/date_string = worlddate2text()
 	idx++
 
 	var/form_title = "Form 0600 - Mining Yield Declaration"
-	var/dat = "<small><center><b>NanoTrasen Inc.<br>"
-	dat += "Civilian Branch of Operation</b><br><br>"
+	var/dat = "<small><center><b>Stellar Corporate Conglomerate<br>"
+	dat += "Operations Department</b><br><br>"
 
 	dat += "Form 0600<br> Mining Yield Declaration</center><hr>"
-	dat += "Facility: NSS Aurora<br>"
+	dat += "Facility: [current_map.station_name]<br>"
 	dat += "Date: [date_string]<br>"
 	dat += "Index: [idx]<br><br>"
 
@@ -292,7 +292,7 @@
 	P.ico += "paper_stamp-cent"
 	P.stamped += /obj/item/stamp
 	P.add_overlay(stampoverlay)
-	P.stamps += "<HR><i>This paper has been stamped by the NT Ore Processing System.</i>"
+	P.stamps += "<HR><i>This paper has been stamped by the SCC Ore Processing System.</i>"
 
 	user.visible_message("\The [src] rattles and prints out a sheet of paper.")
 	playsound(get_turf(src), "sound/bureaucracy/print_short.ogg", 50, 1)
@@ -302,7 +302,8 @@
 	input_mats = list()
 	waste = 0
 
-	user.put_in_hands(P)
+	if(user.Adjacent(src))
+		user.put_in_hands(P)
 
 	printing = FALSE
 	return

--- a/html/changelogs/johnwildkins-minerace.yml
+++ b/html/changelogs/johnwildkins-minerace.yml
@@ -1,0 +1,8 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed invalid objects causing runtimes on the Racers away station."
+  - bugfix: "Fixed cyborgs being able to teleport yield declarations infinitely far away. They will now dispense at the console unless you are adjacent."
+  - tweak: "Yield Declaration paperwork updated to comply with current lore and map."

--- a/maps/away/generic/racers.dmm
+++ b/maps/away/generic/racers.dmm
@@ -474,7 +474,7 @@
 /turf/simulated/floor/lino/grey,
 /area/racers)
 "bwf" = (
-/obj/structure/closet/medical_wall{
+/obj/structure/closet/walllocker/medical{
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -3520,7 +3520,7 @@
 /turf/simulated/floor/plating,
 /area/racers)
 "rtf" = (
-/obj/structure/closet/secure_closet/bar,
+/obj/structure/closet/secure_closet/cabinet/bar,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/gun/energy/taser,
 /obj/item/reagent_containers/inhaler/hyperzine,
@@ -4231,7 +4231,7 @@
 /area/racers)
 "uTr" = (
 /obj/machinery/optable,
-/obj/item/clothing/head/surgery/blue,
+/obj/item/clothing/head/surgery,
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/gloves/latex/nitrile,
 /turf/simulated/floor/tiled/white,
@@ -4401,7 +4401,7 @@
 "vDH" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/beakers,
-/obj/item/reagent_containers/dropper/industrial,
+/obj/item/reagent_containers/dropper,
 /turf/simulated/floor/plating,
 /area/racers)
 "vDS" = (


### PR DESCRIPTION
title
fixes yield declarations teleporting, changes NT -> SCC where applicable, and additionally fixes some runtimes related to outdated paths on the Racer away site

Fixes #13794