### PR TITLE
Timed PlaySound Proc

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -232,6 +232,9 @@
 	var/sound/S = playsound_get_sound(soundin, volume, falloff, frequency)
 	return playsound_to(source ? get_turf(source) : null, S, use_random_freq, use_pressure = use_pressure, required_preferences = required_preferences, required_asfx_toggles = required_asfx_toggles)
 
+/proc/playsound_in(atom/source, soundin, vol, vary, extrarange, falloff, is_global, usepressure = 1, environment = -1, required_preferences = 0, required_asfx_toggles = 0, frequency = 0, time)
+	addtimer(CALLBACK(src, /atom/.proc/playsound, source, soundin, vol, vary, extrarange, falloff, is_global, usepressure, environment, required_preferences, required_asfx_toggles, frequency), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)
+
 /client/proc/playtitlemusic()
 	if(!SSticker.login_music)
 		return

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -233,7 +233,7 @@
 	return playsound_to(source ? get_turf(source) : null, S, use_random_freq, use_pressure = use_pressure, required_preferences = required_preferences, required_asfx_toggles = required_asfx_toggles)
 
 /proc/playsound_in(atom/source, soundin, vol, vary, extrarange, falloff, is_global, usepressure = 1, environment = -1, required_preferences = 0, required_asfx_toggles = 0, frequency = 0, time)
-	addtimer(CALLBACK(source, /atom/.proc/playsound, source, soundin, vol, vary, extrarange, falloff, is_global, usepressure, environment, required_preferences, required_asfx_toggles, frequency), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)
+	addtimer(CALLBACK(GLOBAL_PROC, /proc/playsound, source, soundin, vol, vary, extrarange, falloff, is_global, usepressure, environment, required_preferences, required_asfx_toggles, frequency), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)
 
 /client/proc/playtitlemusic()
 	if(!SSticker.login_music)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -233,7 +233,7 @@
 	return playsound_to(source ? get_turf(source) : null, S, use_random_freq, use_pressure = use_pressure, required_preferences = required_preferences, required_asfx_toggles = required_asfx_toggles)
 
 /proc/playsound_in(atom/source, soundin, vol, vary, extrarange, falloff, is_global, usepressure = 1, environment = -1, required_preferences = 0, required_asfx_toggles = 0, frequency = 0, time)
-	addtimer(CALLBACK(src, /atom/.proc/playsound, source, soundin, vol, vary, extrarange, falloff, is_global, usepressure, environment, required_preferences, required_asfx_toggles, frequency), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)
+	addtimer(CALLBACK(source, /atom/.proc/playsound, source, soundin, vol, vary, extrarange, falloff, is_global, usepressure, environment, required_preferences, required_asfx_toggles, frequency), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)
 
 /client/proc/playtitlemusic()
 	if(!SSticker.login_music)

--- a/html/changelogs/playsound_in_proc.yml
+++ b/html/changelogs/playsound_in_proc.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - backend: "Adds a \"playsound_in\" proc that lets one play a sound after a set time has passed."


### PR DESCRIPTION
this PR adds a timed playsound proc named "playsound_in" which lets you use the playsound proc after a set amount of time has passed.

example usage:
`playsound_in(src, 'sound/example.ogg', 50, FALSE, time = 1 SECOND)`