### PR TITLE
Fixes Nico-Tine Box

### DIFF
--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -172,7 +172,10 @@
 	use_sound = 'sound/items/storage/box.ogg'
 
 /obj/item/storage/box/fancy/chewables/tobacco/update_icon()
-	icon_state = "[initial(icon_state)][contents.len]"
+	if(opened) //use the open icon.
+		icon_state = "[initial(icon_state)][contents.len]"
+	else
+		icon_state = "[initial(icon_state)]" // closed
 
 //loose leaf
 
@@ -211,4 +214,3 @@
 	starts_with = list(/obj/item/reagent_containers/food/snacks/grown/dried_tobacco/pure = 8)
 	icon_state = "roll_nico"
 	item_state = "Epacket"
-

--- a/html/changelogs/wezzy_cigboxfix.yml
+++ b/html/changelogs/wezzy_cigboxfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: WowzewoW (Wezzy)
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes Nico-Tine box sprite being unable to open and close."


### PR DESCRIPTION
  - bugfix: "Fixes Nico-Tine box sprite being unable to open and close."

* Please describe the intent of your changes in a clear fashion.
* Please make sure that, in the case of mapping changes, you include images of these changes in the PR's description.
* Please make sure to mark your PR as wip or review required by making a comment with !wip or !review required

### IC changelog
`It is possible and encouraged (for changes that will have a larger impact on players) to write a ic changelog and add it to the PR description.
This changelog will be pushed to the newscasters when the PR is merged`