### PR TITLE
Unusual Container Fixes

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -73,10 +73,11 @@
 	if(content_size > storage_capacity-5)
 		storage_capacity = content_size + 5
 
-/obj/structure/closet/Initialize(mapload)
+/obj/structure/closet/Initialize(mapload, var/no_fill)
 	. = ..()
 	update_icon()
-	fill()
+	if(!no_fill)
+		fill()
 	if(secure)
 		verbs += /obj/structure/closet/proc/verb_togglelock
 	return mapload ? INITIALIZE_HINT_LATELOAD : INITIALIZE_HINT_NORMAL

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -539,19 +539,22 @@
 		"3" = (100 - ((STOCK_RARE_PROB * rarity) + (STOCK_UNCOMMON_PROB * rarity)))
 	)
 
-	var/list/valid_loot = typesof(/obj/structure/closet/crate) - typesof(/obj/structure/closet/crate/secure/gear_loadout)
-	valid_loot -= typesof(/obj/structure/closet/crate/loot)
-	var/icontype = pick(valid_loot)
-	var/obj/structure/closet/crate/C = new icontype(get_turf(src))
+	var/icontype = pick(typesof(/obj/structure/closet/crate))
+	var/obj/structure/closet/crate/C = new icontype(get_turf(src), TRUE) //TRUE as we do not want the crate to fill(), we will fill it ourselves. 
 
 	C.name = "unusual container"
 	C.desc = "A mysterious container of unknown origins. What mysteries lie within?"
-	if(C.secure)
-		C.secure = FALSE
-	C.update_icon()
+
 	for(var/i in 1 to quantity)
 		var/newtype = get_spawntype()
 		call(newtype)(C)
+
+	if(C.secure || C.locked) //These should always be accessible
+		C.secure = FALSE
+		C.locked = FALSE
+		C.secure_lights = FALSE
+		C.req_access = null
+	C.update_icon()
 
 	qdel(src)
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -539,7 +539,8 @@
 		"3" = (100 - ((STOCK_RARE_PROB * rarity) + (STOCK_UNCOMMON_PROB * rarity)))
 	)
 
-	var/icontype = pick(typesof(/obj/structure/closet/crate))
+	var/list/crates_to_use = typesof(/obj/structure/closet/crate) - typesof(/obj/structure/closet/crate/secure/gear_loadout)
+	var/icontype = pick(crates_to_use)
 	var/obj/structure/closet/crate/C = new icontype(get_turf(src), TRUE) //TRUE as we do not want the crate to fill(), we will fill it ourselves. 
 
 	C.name = "unusual container"

--- a/html/changelogs/doxxmedearly-cratesbugfix.yml
+++ b/html/changelogs/doxxmedearly-cratesbugfix.yml
@@ -1,0 +1,5 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Unusual containers should no longer spawn locked."
+  - bugfix: "Unusual containers with certain appearances should no longer spawn with excess gear."


### PR DESCRIPTION
Fixes #13967

Unusual container spawns are the way most away sites and ghost roles get their gear (Merchants, too).

Both problems in the linked issue are related to the unusual container getting its icon from another randomly selected `typeof` crate. While it got the icon successfully, it also got the other parts of it, such as the default fill() items, and locked/access requirements.

Fill() issue resolved by just making it not fill() on Initialize. (On the plus side, this means we no longer have to exclude crates from the choice pool bc of their contents, allowing an even broader selection of icons to choose from).

Locked issue resolved by making it spawn... unlocked (It was only spawning `secure = FALSE` which has nothing to do whether or not it's locked). Also made sure it stripped any access requirements; unusual containers are open access, we ONLY want the icon and the various icon overlays and icon overwrites for the crate opening animations. 

Tested to ensure 1) The unusual containers spawn unlocked and filled only with the randomly generated crap and none of the pre-fill stuff, 2) The animations still worked on these, and 3) That I didn't fuck up every other crate on the map accidentally. 