### PR TITLE
Matriarch drones are no longer locked behind a Head of Staff whitelist.

### DIFF
--- a/code/modules/ghostroles/spawner/atom/matriarchmaintdrone.dm
+++ b/code/modules/ghostroles/spawner/atom/matriarchmaintdrone.dm
@@ -5,8 +5,6 @@
 	show_on_job_select = FALSE
 	tags = list("Simple Mobs")
 
-	req_head_whitelist = TRUE // basically a chief engineer for drones
-
 	loc_type = GS_LOC_ATOM
 	atom_add_message = "A matriarch maintenance drone is now available!"
 

--- a/html/changelogs/mattatlas-matriarhc.yml
+++ b/html/changelogs/mattatlas-matriarhc.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Matriarch drones are not whitelisted anymore."


### PR DESCRIPTION
As per title. This is wholly unnecessary and unwanted by the head of staff WL team.