### PR TITLE
Explosion Performance

### DIFF
--- a/code/controllers/subsystems/explosives.dm
+++ b/code/controllers/subsystems/explosives.dm
@@ -218,6 +218,9 @@ var/datum/controller/subsystem/explosives/SSexplosives
 			for(var/atom_movable in T.contents)	//bypass type checking since only atom/movable can be contained by turfs anyway
 				var/atom/movable/AM = atom_movable
 				if(!QDELETED(AM) && AM.simulated)
+					var/obj/O = AM
+					if(istype(O) && O.hides_under_flooring() && !T.is_plating())
+						continue
 					AM.ex_act(dist)
 
 				CHECK_TICK
@@ -396,6 +399,9 @@ var/datum/controller/subsystem/explosives/SSexplosives
 			for (var/subthing in T)
 				var/atom/movable/AM = subthing
 				if (AM.simulated)
+					var/obj/O = AM
+					if(istype(O) && O.hides_under_flooring() && !T.is_plating())
+						continue
 					AM.ex_act(severity)
 					movable_tally++
 				CHECK_TICK

--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -52,8 +52,10 @@ var/datum/controller/subsystem/lighting/SSlighting
 
 /datum/controller/subsystem/lighting/ExplosionStart()
 	force_queued = TRUE
+	suspend()
 
 /datum/controller/subsystem/lighting/ExplosionEnd()
+	wake()
 	if (!force_override)
 		force_queued = FALSE
 

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -141,13 +141,11 @@ for reference:
 /obj/structure/barricade/ex_act(severity)
 	switch(severity)
 		if(1.0)
-			visible_message(SPAN_DANGER("\The [src] is blown apart!"))
 			qdel(src)
 			return
 		if(2.0)
 			src.health -= 25
 			if (src.health <= 0)
-				visible_message(SPAN_DANGER("\The [src] is blown apart!"))
 				dismantle()
 			return
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -391,17 +391,18 @@
 		open(1)
 		return 1
 
-/obj/machinery/door/proc/take_damage(var/damage)
+/obj/machinery/door/proc/take_damage(var/damage, message = TRUE)
 	var/initialhealth = src.health
 	src.health = max(0, src.health - damage)
 	if(src.health <= 0 && initialhealth > 0)
 		src.set_broken()
-	else if(src.health < src.maxhealth / 4 && initialhealth >= src.maxhealth / 4)
-		visible_message(SPAN_WARNING("\The [src] looks like it's about to break!"))
-	else if(src.health < src.maxhealth / 2 && initialhealth >= src.maxhealth / 2)
-		visible_message(SPAN_WARNING("\The [src] looks seriously damaged!"))
-	else if(src.health < src.maxhealth * 3/4 && initialhealth >= src.maxhealth * 3/4)
-		visible_message(SPAN_WARNING("\The [src] shows signs of damage!"))
+	else if(message)
+		if(src.health < src.maxhealth / 4 && initialhealth >= src.maxhealth / 4)
+			visible_message(SPAN_WARNING("\The [src] looks like it's about to break!"))
+		else if(src.health < src.maxhealth / 2 && initialhealth >= src.maxhealth / 2)
+			visible_message(SPAN_WARNING("\The [src] looks seriously damaged!"))
+		else if(src.health < src.maxhealth * 3/4 && initialhealth >= src.maxhealth * 3/4)
+			visible_message(SPAN_WARNING("\The [src] shows signs of damage!"))
 	update_icon()
 	return
 
@@ -442,7 +443,7 @@
 				var/damage = rand(300,600)
 				if (bolted)
 					damage *= 0.8 //Bolted doors are a bit tougher
-				take_damage(damage)
+				take_damage(damage, FALSE)
 		if(2.0)
 			if((!bolted && prob(25)) || prob(20))
 				qdel(src)
@@ -450,14 +451,14 @@
 				var/damage = rand(150,300)
 				if (bolted)
 					damage *= 0.8 //Bolted doors are a bit tougher
-				take_damage(damage)
+				take_damage(damage, FALSE)
 		if(3.0)
 			if(prob(80))
 				spark(src, 2, alldirs)
 			var/damage = rand(100,150)
 			if (bolted)
 				damage *= 0.8
-			take_damage(damage)
+			take_damage(damage, FALSE)
 
 	if (health <= 0)
 		qdel(src)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -79,11 +79,11 @@
 			qdel(src)
 			return
 		if(2.0)
-			deflate(TRUE)
+			deflate(TRUE, FALSE)
 			return
 		if(3.0)
 			if(prob(50))
-				deflate(TRUE)
+				deflate(TRUE, FALSE)
 				return
 
 /obj/structure/inflatable/attack_hand(mob/user)
@@ -113,7 +113,7 @@
 /obj/structure/inflatable/CtrlClick()
 	hand_deflate()
 
-/obj/structure/inflatable/proc/deflate(var/violent = FALSE)
+/obj/structure/inflatable/proc/deflate(var/violent = FALSE, msg = TRUE)
 	if(deflating)
 		return
 	playsound(loc, 'sound/machines/hiss.ogg', 75, TRUE)
@@ -121,7 +121,8 @@
 		if(!torn_path)
 			return
 		deflating = TRUE
-		visible_message(SPAN_WARNING("\The [src] rapidly deflates!"))
+		if(msg)
+			visible_message(SPAN_WARNING("\The [src] rapidly deflates!"))
 		var/matrix/M = new
 		M.Scale(0.6)
 		M.Turn(pick(-40, 40))
@@ -131,7 +132,8 @@
 		if(!undeploy_path)
 			return
 		deflating = TRUE
-		visible_message(SPAN_NOTICE("\The [src] slowly deflates."))
+		if(msg)
+			visible_message(SPAN_NOTICE("\The [src] slowly deflates."))
 		var/matrix/M = new
 		M.Scale(0.6)
 		animate(src, 2.6 SECONDS, transform = M)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -52,7 +52,7 @@
 /obj/structure/window/update_icon()
 	queue_smooth(src)
 
-/obj/structure/window/proc/take_damage(var/damage = 0,  var/sound_effect = 1, message = TRUE)
+/obj/structure/window/proc/take_damage(var/damage = 0,  var/sound_effect = 1, var/message = TRUE)
 	var/initialhealth = health
 
 	if(silicate)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -52,7 +52,7 @@
 /obj/structure/window/update_icon()
 	queue_smooth(src)
 
-/obj/structure/window/proc/take_damage(var/damage = 0,  var/sound_effect = 1)
+/obj/structure/window/proc/take_damage(var/damage = 0,  var/sound_effect = 1, message = TRUE)
 	var/initialhealth = health
 
 	if(silicate)
@@ -61,18 +61,21 @@
 	health = max(0, health - damage)
 
 	if(health <= 0)
-		shatter()
+		shatter(message)
 	else
 		if(sound_effect)
 			playsound(loc, 'sound/effects/glass_hit.ogg', 100, 1)
 		if(health < maxhealth / 4 && initialhealth >= maxhealth / 4)
-			visible_message(SPAN_DANGER("[src] looks like it's about to shatter!"))
+			if(message)
+				visible_message(SPAN_DANGER("[src] looks like it's about to shatter!"))
 			playsound(loc, /decl/sound_category/glasscrack_sound, 100, 1)
 		else if(health < maxhealth / 2 && initialhealth >= maxhealth / 2)
-			visible_message(SPAN_WARNING("[src] looks seriously damaged!"))
+			if(message)
+				visible_message(SPAN_WARNING("[src] looks seriously damaged!"))
 			playsound(loc, /decl/sound_category/glasscrack_sound, 100, 1)
 		else if(health < maxhealth * 3/4 && initialhealth >= maxhealth * 3/4)
-			visible_message(SPAN_WARNING("Cracks begin to appear in [src]!"))
+			if(message)
+				visible_message(SPAN_WARNING("Cracks begin to appear in [src]!"))
 			playsound(loc, /decl/sound_category/glasscrack_sound, 100, 1)
 	return
 
@@ -143,7 +146,7 @@
 				shatter(0)
 				return
 			else
-				take_damage(rand(10,30))
+				take_damage(rand(10,30), message=FALSE)
 
 //TODO: Make full windows a separate type of window.
 //Once a full window, it will always be a full window, so there's no point

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -52,7 +52,7 @@
 /obj/structure/window/update_icon()
 	queue_smooth(src)
 
-/obj/structure/window/proc/take_damage(var/damage = 0,  var/sound_effect = 1, var/message = TRUE)
+/obj/structure/window/proc/take_damage(var/damage = 0,  var/sound_effect = 1, message = TRUE)
 	var/initialhealth = health
 
 	if(silicate)
@@ -146,7 +146,7 @@
 				shatter(0)
 				return
 			else
-				take_damage(rand(10,30), message=FALSE)
+				take_damage(rand(10,30), TRUE, FALSE)
 
 //TODO: Make full windows a separate type of window.
 //Once a full window, it will always be a full window, so there's no point

--- a/code/modules/modular_computers/computers/modular_computer/damage.dm
+++ b/code/modules/modular_computers/computers/modular_computer/damage.dm
@@ -9,8 +9,9 @@
 	else if(damage)
 		to_chat(user, SPAN_WARNING("It is damaged."))
 
-/obj/item/modular_computer/proc/break_apart()
-	visible_message(SPAN_WARNING("\The [src] breaks apart!"))
+/obj/item/modular_computer/proc/break_apart(msg = TRUE)
+	if(msg)
+		visible_message(SPAN_WARNING("\The [src] breaks apart!"))
 	new /obj/item/stack/material/steel(get_turf(src), round(steel_sheet_cost/2))
 	for(var/obj/item/computer_hardware/H in get_all_components())
 		uninstall_component(null, H)
@@ -19,7 +20,7 @@
 			H.take_damage(rand(10, 30))
 	qdel(src)
 
-/obj/item/modular_computer/proc/take_damage(var/amount, var/component_probability, var/damage_casing = TRUE, var/randomize = TRUE)
+/obj/item/modular_computer/proc/take_damage(var/amount, var/component_probability, var/damage_casing = TRUE, var/randomize = TRUE, msg=TRUE)
 	if(randomize)
 		// 75%-125%, rand() works with integers, apparently.
 		amount *= (rand(75, 125) / 100.0)
@@ -34,13 +35,13 @@
 				H.take_damage(round(amount / 2))
 
 	if(damage >= max_damage)
-		break_apart()
+		break_apart(msg)
 	update_icon()
 
 // Stronger explosions cause serious damage to internal components
 // Minor explosions are mostly mitigitated by casing.
 /obj/item/modular_computer/ex_act(var/severity)
-	take_damage(rand(125, 200) / severity, 30 / severity)
+	take_damage(rand(125, 200) / severity, 30 / severity, msg = FALSE)
 
 // EMPs are similar to explosions, but don't cause physical damage to the casing. Instead they screw up the components
 /obj/item/modular_computer/emp_act(var/severity)

--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -150,7 +150,6 @@
 			if(prob(50))
 				qdel(src)
 			else
-				visible_message("\The [src] shakes violently, and neatly collapses as its damage sensors go off.")
 				collapse_kit()
 			return
 		if(3.0)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -405,6 +405,11 @@ obj/structure/cable/proc/cableColor(var/colorC)
 			if(C.powernet)
 				. -= C
 
+/obj/structure/cable/proc/auto_propagate_cut_cable(obj/O)
+	if(O && !QDELETED(O))
+		var/datum/powernet/newPN = new()// creates a new powernet...
+		propagate_network(O, newPN)//... and propagates it to the other side of the cable
+
 //should be called after placing a cable which extends another cable, creating a "smooth" cable that no longer terminates in the centre of a turf.
 //needed as this can, unlike other placements, disconnect cables
 /obj/structure/cable/proc/denode()
@@ -443,8 +448,13 @@ obj/structure/cable/proc/cableColor(var/colorC)
 	loc = null
 	powernet.remove_cable(src) //remove the cut cable from its powernet
 
-	var/datum/powernet/newPN = new()// creates a new powernet...
-	propagate_network(P_list[1], newPN)//... and propagates it to the other side of the cable
+	var/first = TRUE
+	for(var/obj/O in P_list)
+		if(first)
+			first = FALSE
+			continue
+		addtimer(CALLBACK(O, .proc/auto_propagate_cut_cable, O), 0)
+		// prevents rebuilding the powernet X times when an explosion cuts X cables
 
 	// Disconnect machines connected to nodes
 	if(d1 == 0) // if we cut a node (O-X) cable

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -36,7 +36,6 @@
 
 /obj/structure/reagent_dispensers/ex_act(severity)
 	reagents.splash_turf(get_turf(src), reagents.total_volume)
-	visible_message(SPAN_DANGER("\The [src] bursts open, spreading reagents all over the area!"))
 	qdel(src)
 
 /obj/structure/reagent_dispensers/attackby(obj/item/O as obj, mob/user as mob)

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -37,7 +37,7 @@
 
 	health += maxhealth - old_maxhealth
 
-/obj/structure/table/proc/take_damage(amount)
+/obj/structure/table/proc/take_damage(amount, msg = TRUE)
 	// If the table is made of a brittle material, and is *not* reinforced with a non-brittle material, damage is multiplied by TABLE_BRITTLE_MATERIAL_MULTIPLIER
 	if(material && material.is_brittle())
 		if(reinforced)
@@ -47,7 +47,8 @@
 			amount *= TABLE_BRITTLE_MATERIAL_MULTIPLIER
 	health -= amount
 	if(health <= 0)
-		visible_message(SPAN_WARNING("\The [src] breaks down!"), intent_message = THUNK_SOUND)
+		if(msg)
+			visible_message(SPAN_WARNING("\The [src] breaks down!"), intent_message = THUNK_SOUND)
 		return break_to_parts() // if we break and form shards, return them to the caller to do !FUN! things with
 
 
@@ -57,9 +58,9 @@
 			qdel(src)
 			return
 		if(2.0)
-			take_damage(rand(100,400))
+			take_damage(rand(100,400), FALSE)
 		if(3.0)
-			take_damage(rand(50,150))
+			take_damage(rand(50,150), FALSE)
 
 
 /obj/structure/table/Initialize()

--- a/html/changelogs/johnwildkins-explodefaster.yml
+++ b/html/changelogs/johnwildkins-explodefaster.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - tweak: "Removed several visible_messages for objects being damaged in explosions, deferred powernet regeneration until after explosions completed. Explosions should now process significantly faster."
+  - bugfix: "Cables, pipes, and other objects hidden beneath floor tiles should no longer be damaged by explosions, unless the tile itself is blown off first."

--- a/html/changelogs/johnwildkins-explodefaster.yml
+++ b/html/changelogs/johnwildkins-explodefaster.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - tweak: "Removed several visible_messages for objects being damaged in explosions, deferred powernet regeneration until after explosions completed. Explosions should now process significantly faster."


### PR DESCRIPTION
tl;dr: Explosions should now process up to 50% faster

Removes several visible_message procs fired on ex_act (i.e., when something explodes), and changed cable/powernet code to only begin rebuilding powernets after all the exploding is completed

Also avoids damaging any objects that hide under flooring (cables, pipes, etc.) unless the flooring above them is destroyed first; not only does this cut down on objects to interact with, it also prevents cables/pipes from being blown up through intact flooring

Tested by exploding two different areas in the main concourse of Deck 2;

Before (Test #1): 1.475 seconds, 204 turfs, 367 movables
Before (Test #2): 2.15 seconds, 245 turfs, 504 movables

After (Test #1): 0.675 seconds, 204 turfs, 310 movables
After (Test #2): 0.8 seconds, 245 turfs, 384 movables