### PR TITLE
Security no longer has access to non-Security cameras on code green.

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -117,9 +117,18 @@
 	if (user.stat || user.blinded || inoperable())
 		return 0
 	set_current(C)
+
 	if(!is_contact_area(get_area(C)))
 		to_chat(user, SPAN_NOTICE("This camera is too far away to connect to!"))
 		return FALSE
+
+	var/access_granted = FALSE
+	for(var/network in C.network)
+		if(can_access_network(user, network))
+			access_granted = TRUE //We only need access to one of the networks.
+	if(!access_granted)
+		to_chat(user, SPAN_WARNING("Access unauthorized."))
+
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.reset_view(current_camera)

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -128,6 +128,7 @@
 			access_granted = TRUE //We only need access to one of the networks.
 	if(!access_granted)
 		to_chat(user, SPAN_WARNING("Access unauthorized."))
+		return
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -43,7 +43,7 @@
 	for(var/nw in network)
 		all_networks.Add(list(list(
 							"tag" = nw,
-							"has_access" = can_access_network(nw)
+							"has_access" = can_access_network(user, nw)
 							)))
 
 	data["networks"] = all_networks
@@ -63,10 +63,12 @@
 		ui.set_initial_data(data)
 		ui.open()
 
-/obj/machinery/computer/security/proc/can_access_network(var/nw)
-	if(nw in network)
-		return 1
-	return 0
+/obj/machinery/computer/security/proc/can_access_network(var/mob/user, var/network_access)
+	// No access passed, or 0 which is considered no access requirement. Allow it.
+	if(!network_access)
+		return TRUE
+
+	return (check_access(user, access_security) && security_level >= SEC_LEVEL_BLUE) || check_access(user, network_access)
 
 /obj/machinery/computer/security/Topic(href, href_list)
 	if(..())

--- a/code/modules/modular_computers/file_system/programs/security/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/security/camera.dm
@@ -131,6 +131,14 @@
 		to_chat(user, SPAN_NOTICE("This camera is too far away to connect to!"))
 		return FALSE
 
+	var/access_granted = FALSE
+	for(var/network in C.network)
+		if(can_access_network(user, get_camera_access(network)))
+			access_granted = TRUE //We only need access to one of the networks.
+	if(!access_granted)
+		to_chat(user, SPAN_WARNING("Access unauthorized."))
+		return
+
 	set_current(C)
 	user.machine = ui_host()
 	user.reset_view(current_camera)

--- a/code/modules/modular_computers/file_system/programs/security/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/security/camera.dm
@@ -14,6 +14,8 @@
 			return access_engine
 		if(NETWORK_MEDICAL)
 			return access_medical
+		if(NETWORK_SECURITY)
+			return access_security
 		if(NETWORK_RESEARCH,NETWORK_RESEARCH_OUTPOST)
 			return access_research
 		if(NETWORK_MINE,NETWORK_SUPPLY,NETWORK_CIVILIAN_WEST,NETWORK_EXPEDITION,NETWORK_CALYPSO,NETWORK_POD)
@@ -84,7 +86,7 @@
 	if(!network_access)
 		return TRUE
 
-	return check_access(user, access_security) || check_access(user, network_access)
+	return (check_access(user, access_security) && security_level >= SEC_LEVEL_BLUE) || check_access(user, network_access)
 
 /datum/nano_module/camera_monitor/Topic(href, href_list)
 	if(..())

--- a/html/changelogs/mattatlas-IPCmainsdidthis.yml
+++ b/html/changelogs/mattatlas-IPCmainsdidthis.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Security no longer has access to non-Security cameras on code green."


### PR DESCRIPTION
As per title. Security now only has full camera access on code blue and above.

This is to stop idle validhunting with people randomly browsing cameras and just so happening to call out some shit happening in the chef's freezer at 00:10.