### PR TITLE
Implements PASSRAILING as a new pass flag

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -50,6 +50,7 @@
 #define PASSDOORHATCH	0x8
 #define PASSMOB			0x10
 #define PASSTRACE       0x20 //Used by turrets in the check_trajectory proc to target mobs hiding behind certain things (such as closets)
+#define PASSRAILING     0x40
 
 // Bitmasks for the flags_inv variable. These determine when a piece of clothing hides another, i.e. a helmet hiding glasses.
 #define HIDEGLOVES      0x1

--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -31,7 +31,7 @@
 	unacidable = 1//Just to be sure.
 	var/def_zone
 	flags = PROXMOVE
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE | PASSRAILING
 
 /var/list/acting_rank_prefixes = list("acting", "temporary", "interim", "provisional")
 

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -59,7 +59,7 @@
 	icon_state = "large"
 	density = TRUE
 	anchored = TRUE
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE | PASSRAILING
 
 	var/hits = 4
 	var/hitpwr = 2 //Level of ex_act to be called on hit.
@@ -163,7 +163,7 @@
 /obj/effect/meteor/dust
 	name = "space dust"
 	icon_state = "dust"
-	pass_flags = PASSTABLE | PASSGRILLE
+	pass_flags = PASSTABLE | PASSGRILLE | PASSRAILING
 	meteor_loot = list(/obj/item/ore/glass)
 	dropamt = 1
 

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -587,9 +587,9 @@
 	if(get_dist(src, L) > 7)	//if it's too far away, why bother?
 		return TURRET_NOT_TARGET
 
-	var/flags =  PASSTABLE|PASSTRACE
+	var/flags =  PASSTABLE|PASSTRACE|PASSRAILING
 	if(ispath(projectile, /obj/item/projectile/beam) || ispath(eprojectile, /obj/item/projectile/beam))
-		flags |= PASSTABLE|PASSGLASS|PASSGRILLE
+		flags |= PASSTABLE|PASSGLASS|PASSGRILLE|PASSRAILING
 
 	if(!(L in check_trajectory(L, src, pass_flags=flags)))	//check if we have true line of sight
 		return TURRET_NOT_TARGET

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -79,7 +79,7 @@
 /obj/structure/railing/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(istype(mover,/obj/item/projectile))
 		return TRUE
-	if(!istype(mover) || mover.checkpass(PASSTABLE))
+	if(!istype(mover) || mover.checkpass(PASSRAILING))
 		return TRUE
 	if(get_dir(loc, target) == dir)
 		return !density

--- a/code/modules/heavy_vehicle/mech_construction.dm
+++ b/code/modules/heavy_vehicle/mech_construction.dm
@@ -12,6 +12,7 @@
 	if(legs)
 		frame.legs = legs
 		legs.forceMove(frame)
+		pass_flags &= PASSRAILING //if previously was hoverthrusters, need to update pass flag
 		legs = null
 	if(body)
 		frame.body = body

--- a/code/modules/heavy_vehicle/mecha.dm
+++ b/code/modules/heavy_vehicle/mecha.dm
@@ -188,6 +188,8 @@
 		if(source_frame.legs)
 			source_frame.legs.forceMove(src)
 			legs = source_frame.legs
+			if(legs.hover) //Checks here if hoverthrusters
+				pass_flags |= PASSRAILING
 		if(source_frame.head)
 			source_frame.head.forceMove(src)
 			head = source_frame.head

--- a/code/modules/heavy_vehicle/premade/_premade.dm
+++ b/code/modules/heavy_vehicle/premade/_premade.dm
@@ -190,6 +190,8 @@
 		var/list/forbidden_leg_types = list(/obj/item/mech_component/propulsion/cult, /obj/item/mech_component/propulsion/superheavy, /obj/item/mech_component/propulsion/combat)
 		var/legstype = pick(subtypesof(/obj/item/mech_component/propulsion) - forbidden_leg_types)
 		legs = new legstype(src)
+		if(legs.hover)
+			pass_flags |= PASSRAILING
 		legs.color = mech_colour ? mech_colour : pick(use_colours)
 	if(!head)
 		var/list/forbidden_head_types = list(/obj/item/mech_component/sensors/cult, /obj/item/mech_component/sensors/superheavy, /obj/item/mech_component/sensors/combat)

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -8,7 +8,7 @@
 	holder_type = /obj/item/holder/drone/mining
 	maxHealth = 45
 	health = 45
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE|PASSRAILING
 	req_access = list(access_mining, access_robotics)
 	id_card_type = /obj/item/card/id/minedrone
 	speed = -1

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -44,7 +44,7 @@
 	// Interaction
 	universal_speak = FALSE
 	universal_understand = TRUE
-	pass_flags = PASSTABLE | PASSDOORHATCH
+	pass_flags = PASSTABLE | PASSDOORHATCH | PASSRAILING
 	density = FALSE
 	possession_candidate = TRUE
 	mob_size = 4

--- a/code/modules/mob/living/simple_animal/bees.dm
+++ b/code/modules/mob/living/simple_animal/bees.dm
@@ -17,7 +17,7 @@
 	var/mob/target_mob
 	var/obj/machinery/beehive/parent
 	var/loner = 0
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE | PASSRAILING
 	turns_per_move = 6
 	var/obj/machinery/portable_atmospherics/hydroponics/my_hydrotray
 	emote_sounds = list('sound/effects/creatures/bees.ogg')

--- a/code/modules/mob/living/simple_animal/friendly/carp.dm
+++ b/code/modules/mob/living/simple_animal/friendly/carp.dm
@@ -45,7 +45,7 @@
 	stomach_size_mult = 3 //They're just baby
 
 	density = TRUE
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE | PASSRAILING
 	canbrush = TRUE
 	brush = /obj/item/reagent_containers/glass/rag
 

--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot.dm
@@ -31,7 +31,7 @@
 	flying = TRUE
 	smart_melee = FALSE
 	see_in_dark = 8
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE|PASSRAILING
 	attack_emote = "focuses on"
 	var/mob/living/simple_animal/hostile/hivebotbeacon/linked_parent = null
 	psi_pingable = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_harvester.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_harvester.dm
@@ -31,7 +31,7 @@
 	flying = 1
 	mob_size = MOB_LARGE
 	see_in_dark = 8
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE|PASSRAILING
 	attack_emote = "focuses on"
 	var/mob/living/simple_animal/hostile/hivebotbeacon/linked_parent = null
 	var/turf/last_processed_turf

--- a/code/modules/mob/living/simple_animal/hostile/spider_queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/spider_queen.dm
@@ -39,7 +39,7 @@
 	attacktext = "bit"
 	attack_sound = 'sound/weapons/bite.ogg'
 
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE|PASSRAILING
 	move_to_delay = 6
 	speed = 1
 	mob_size = 15

--- a/code/modules/mob/living/simple_animal/hostile/viscerator.dm
+++ b/code/modules/mob/living/simple_animal/hostile/viscerator.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/mob/npc/aibots.dmi'
 	icon_state = "viscerator_attack"
 	icon_living = "viscerator_attack"
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE|PASSRAILING
 	health = 15
 	maxHealth = 15
 	melee_damage_lower = 10

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -32,7 +32,7 @@
 	icon_state = "parrot_fly"
 	icon_living = "parrot_fly"
 	icon_dead = "parrot_dead"
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE | PASSRAILING
 	mob_size = MOB_TINY
 
 	speak = list("Hi","Hello!","Cracker?","BAWWWWK george mellons griffing me")

--- a/code/modules/projectiles/guns/energy/mining.dm
+++ b/code/modules/projectiles/guns/energy/mining.dm
@@ -73,7 +73,7 @@
 	damage_type = BURN
 	check_armor = "laser"
 	range = 5
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE|PASSRAILING
 
 	var/mineral_passes = 2 // amount of mineral turfs it passes through before ending
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -7,7 +7,7 @@
 	density = TRUE
 	unacidable = TRUE
 	anchored = TRUE				//There's a reason this is here, Mport. God fucking damn it -Agouri. Find&Fix by Pete. The reason this is here is to stop the curving of emitter shots.
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE|PASSRAILING
 	mouse_opacity = 0
 	animate_movement = 0	//Use SLIDE_STEPS in conjunction with legacy
 	var/projectile_type = /obj/item/projectile

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/beam
 	name = "laser"
 	icon_state = "laser"
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSRAILING
 	damage = 30
 	damage_type = BURN
 	impact_sounds = list(BULLET_IMPACT_MEAT = SOUNDS_LASER_MEAT, BULLET_IMPACT_METAL = SOUNDS_LASER_METAL)
@@ -19,7 +19,7 @@
 /obj/item/projectile/beam/practice
 	name = "laser"
 	icon_state = "laser"
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSRAILING
 	damage = 0
 	damage_type = BURN
 	no_attack_log = 1
@@ -123,7 +123,7 @@
 /obj/item/projectile/beam/laser_tag
 	name = "lasertag beam"
 	icon_state = "laser"
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSRAILING
 	damage = 0
 	no_attack_log = 1
 	damage_type = BURN
@@ -301,7 +301,7 @@
 /obj/item/projectile/beam/shotgun
 	name = "diffuse laser"
 	icon_state = "laser"
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSRAILING
 	damage = 20
 	eyeblur = 4
 
@@ -431,7 +431,7 @@
 	icon_state = "lightning"
 	damage = 10
 	damage_type = BURN
-	pass_flags = PASSTABLE | PASSGRILLE
+	pass_flags = PASSTABLE | PASSGRILLE | PASSRAILING
 	range = 40
 	eyeblur = 0
 
@@ -456,7 +456,7 @@
 /obj/item/projectile/beam/freezer
 	name = "freezing ray"
 	icon_state = "bluelaser"
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE | PASSRAILING
 	damage = 15
 	damage_type = BURN
 	check_armor = "energy"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -106,7 +106,7 @@
 	check_armor = "bomb"
 	damage = 60
 	damage_type = BRUTE
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSRAILING
 	range = 100
 	embed = 0
 	speed = 8
@@ -148,7 +148,7 @@
 	icon_state = "bluespace"
 	damage = 0
 	damage_type = BRUTE
-	pass_flags = PASSTABLE | PASSGRILLE
+	pass_flags = PASSTABLE | PASSGRILLE | PASSRAILING
 	range = 10
 	embed = 0
 	speed = 2
@@ -176,7 +176,7 @@
 	check_armor = "bio"
 	damage = 5
 	damage_type = BRUTE
-	pass_flags = PASSTABLE | PASSGRILLE
+	pass_flags = PASSTABLE | PASSGRILLE | PASSRAILING
 	embed = 0
 	weaken = 0
 
@@ -198,13 +198,13 @@
 	check_armor = "laser"
 	damage_type = BURN
 	damage_flags = DAM_LASER
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
+	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSRAILING
 	muzzle_type = /obj/effect/projectile/muzzle/bolt
 	hit_effect = /obj/effect/temp_visual/blaster_effect
 
 /obj/item/projectile/energy/blaster/disruptor
 	damage = 20
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE | PASSRAILING
 
 /obj/item/projectile/energy/disruptorstun
 	name = "disruptor bolt"
@@ -214,7 +214,7 @@
 	speed = 0.4
 	damage_type = BURN
 	eyeblur = TRUE
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE | PASSRAILING
 	muzzle_type = /obj/effect/projectile/muzzle/bolt
 
 /obj/item/projectile/energy/blaster/heavy

--- a/code/modules/projectiles/projectile/trace.dm
+++ b/code/modules/projectiles/projectile/trace.dm
@@ -1,5 +1,5 @@
 //Helper proc to check if you can hit them or not.
-/proc/check_trajectory(atom/target as mob|obj, atom/firer as mob|obj, var/pass_flags=PASSTABLE|PASSGLASS|PASSGRILLE, flags=null)
+/proc/check_trajectory(atom/target as mob|obj, atom/firer as mob|obj, var/pass_flags=PASSTABLE|PASSGLASS|PASSGRILLE|PASSRAILING, flags=null)
 	if(!istype(target) || !istype(firer))
 		return 0
 

--- a/html/changelogs/Ben10083 - PASSRAILING.yml
+++ b/html/changelogs/Ben10083 - PASSRAILING.yml
@@ -1,0 +1,14 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Mech Hoverthrusters can now pass over railings."
+  - backend: "added PASSRAILING as a pass flag."


### PR DESCRIPTION
As the name implies, seperated railings from PASSTABLE so we can clearly define what can go over railings but not other objects. This is useful for mobs like exosuits which can fly but can't go over railings.

I tested energy and ballistic projectiles and did the best I could with what should also get passrailing, and what shouldn't.