### PR TITLE
Clean up runtime errors, fix VueUIs opening offscreen

### DIFF
--- a/code/controllers/subsystems/initialization/misc_early.dm
+++ b/code/controllers/subsystems/initialization/misc_early.dm
@@ -43,4 +43,6 @@
 	// Setup cargo spawn lists.
 	setup_cargo_spawn_lists()
 
+	click_catchers = create_click_catcher()
+
 	..()

--- a/code/controllers/subsystems/initialization/misc_late.dm
+++ b/code/controllers/subsystems/initialization/misc_late.dm
@@ -32,8 +32,6 @@
 	if (config.use_forumuser_api)
 		update_admins_from_api(TRUE)
 
-	click_catchers = create_click_catcher()
-
 	..(timeofday)
 
 /proc/sorted_add_area(area/A)

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -36,7 +36,7 @@ var/datum/controller/subsystem/mapping/SSmapping
 	var/list/filelist = flist(path)
 	for(var/map in filelist)
 		var/datum/map_template/T = new(path = "[path][map]", rename = "[map]")
-		map_templates[T.name] = T
+		map_templates[T.id] = T
 	preloadBlacklistableTemplates()
 
 /datum/controller/subsystem/mapping/proc/preloadBlacklistableTemplates()
@@ -62,15 +62,15 @@ var/datum/controller/subsystem/mapping/SSmapping
 			if(list_find(banned_maps, mappath))
 				continue
 
-		map_templates[MT.name] = MT
+		map_templates[MT.id] = MT
 
 		// This is nasty..
 		if(istype(MT, /datum/map_template/ruin/exoplanet))
-			exoplanet_ruins_templates[MT.name] = MT
+			exoplanet_ruins_templates[MT.id] = MT
 		else if(istype(MT, /datum/map_template/ruin/space))
-			space_ruins_templates[MT.name] = MT
+			space_ruins_templates[MT.id] = MT
 		else if(istype(MT, /datum/map_template/ruin/away_site))
-			away_sites_templates[MT.name] = MT
+			away_sites_templates[MT.id] = MT
 
 /proc/generateMapList(filename)
 	var/list/potentialMaps = list()

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -352,7 +352,7 @@ var/datum/controller/subsystem/ticker/SSticker
 	if(!istype(prefs) || force_name)
 		// trawl the whole list - we only do this on logout or job swap, aka when we can't guarantee the job datum being accurate
 		for(var/dept in ready_player_jobs)
-			if(LAZYISIN(ready_player_jobs[dept], ident))
+			if(!. && LAZYISIN(ready_player_jobs[dept], ident))
 				. = TRUE
 			ready_player_jobs[dept] -= ident
 		if(.)
@@ -361,10 +361,14 @@ var/datum/controller/subsystem/ticker/SSticker
 
 	var/datum/job/ready_job = prefs.return_chosen_high_job()
 
+	if(!istype(ready_job))
+		// literally how
+		return FALSE
+
 	for(var/dept in ready_job.departments)
-		if(ready_player_jobs[dept][prefs.real_name])
+		if(!. && ready_player_jobs[dept][prefs.real_name])
 			. = TRUE
-		LAZYREMOVE(ready_player_jobs[dept], prefs.real_name)
+		ready_player_jobs[dept] -= prefs.real_name
 
 	if(.)
 		update_ready_count()

--- a/code/game/gamemodes/vampire/vampire_helpers.dm
+++ b/code/game/gamemodes/vampire/vampire_helpers.dm
@@ -97,7 +97,7 @@
 		if (notify)
 			to_chat(src, SPAN_WARNING("You lack the power to interact with mechanical constructs."))
 		return FALSE
-	if(is_special_character(T) && (!(vampire_check.status & VAMP_ISTHRALL)))
+	if(is_special_character(T) && (!(vampire_check?.status & VAMP_ISTHRALL)))
 		if (notify)
 			to_chat(src, "<span class='warning'>\The [T]'s mind is too strong to be affected by our powers!</span>")
 		return FALSE

--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -126,7 +126,7 @@
 	return 1
 
 /obj/machinery/atmospherics/omni/mixer/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
-	usr.set_machine(src)
+	user.set_machine(src)
 
 	var/list/data = new()
 

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -139,7 +139,7 @@
 	sanitize_faction()
 
 /datum/category_item/player_setup_item/occupation/content(mob/user, limit = 16, list/splitJobs = list("Chief Engineer", "Head of Security"))
-	if (SSjobs.init_state != SS_INITSTATE_DONE && SSrecords.init_state != SS_INITSTATE_DONE)
+	if (SSjobs.init_state != SS_INITSTATE_DONE || SSrecords.init_state != SS_INITSTATE_DONE)
 		return "<center><large>Jobs controller not initialized yet. Please wait a bit and reload this section.</large></center>"
 
 	var/list/dat = list(
@@ -422,6 +422,9 @@
 	dat += factions.Join(" | ") + "</b>"
 
 	var/datum/faction/faction = SSjobs.name_factions[selected_faction]
+	if(!istype(faction))
+		to_client_chat(SPAN_DANGER("Invalid faction chosen. Resetting to default."))
+		selected_faction = SSjobs.default_faction.name
 
 	if (selected_faction == pref.faction)
 		dat += "<br>\[Faction already selected\]"

--- a/code/modules/heavy_vehicle/interface/screen_objects.dm
+++ b/code/modules/heavy_vehicle/interface/screen_objects.dm
@@ -7,7 +7,7 @@
 	maptext_y = 11
 
 /obj/screen/mecha/proc/notify_user(var/mob/user, var/text)
-	if(user.loc == owner)
+	if(user?.loc == owner)
 		to_chat(user, text)
 
 /obj/screen/mecha/radio

--- a/code/modules/heavy_vehicle/interface/screen_objects.dm
+++ b/code/modules/heavy_vehicle/interface/screen_objects.dm
@@ -7,7 +7,7 @@
 	maptext_y = 11
 
 /obj/screen/mecha/proc/notify_user(var/mob/user, var/text)
-	if(user?.loc == owner)
+	if(user && user.loc == owner)
 		to_chat(user, text)
 
 /obj/screen/mecha/radio

--- a/code/modules/mob/abstract/new_player/preferences_setup.dm
+++ b/code/modules/mob/abstract/new_player/preferences_setup.dm
@@ -225,6 +225,9 @@
 
 /datum/preferences/proc/return_chosen_high_job(var/title = FALSE)
 	var/datum/job/chosenJob
+	if(SSjobs.init_state < SS_INITSTATE_DONE)
+		return
+
 	if(job_civilian_low & ASSISTANT)
 		// Assistant is weird, has to be checked first because it overrides
 		chosenJob = SSjobs.bitflag_to_job["[SERVICE]"]["[job_civilian_low]"]

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -147,6 +147,10 @@
 		var/list/body_markings = prefs.body_markings
 		for(var/M in body_markings)
 			var/datum/sprite_accessory/marking/mark_datum = body_marking_styles_list[M]
+
+			if(!istype(mark_datum))
+				to_chat(usr, SPAN_WARNING("Invalid body marking [M] selected! Please re-save your markings, as they may have changed."))
+				continue
 			var/mark_color = "[body_markings[M]]"
 
 			for(var/BP in mark_datum.body_parts)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -143,7 +143,7 @@
 	if(pin && needspin)
 		pin = new pin(src)
 	else if(pin)
-		QDEL_NULL(pin)
+		pin = null
 
 	if(istype(loc, /obj/item/robot_module))
 		has_safety = FALSE

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -137,12 +137,11 @@
 	if(isnull(scoped_accuracy))
 		scoped_accuracy = accuracy
 
-	if (!pin && needspin)
-		pin = /obj/item/device/firing_pin
-
-	if(pin && needspin)
+	if (needspin)
+		if(!pin)
+			pin = /obj/item/device/firing_pin
 		pin = new pin(src)
-	else if(pin)
+	else
 		pin = null
 
 	if(istype(loc, /obj/item/robot_module))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -142,6 +142,8 @@
 
 	if(pin && needspin)
 		pin = new pin(src)
+	else if(pin)
+		QDEL_NULL(pin)
 
 	if(istype(loc, /obj/item/robot_module))
 		has_safety = FALSE

--- a/code/modules/vueui/ui.dm
+++ b/code/modules/vueui/ui.dm
@@ -92,9 +92,9 @@ main ui datum.
 	if(width && height)
 		var/winsize = winget(user, "mapwindow", "size")
 		var/map_size = splittext(winsize, "x")
-		var/screen_height = text2num(map_size[1])
+		var/screen_height = text2num(map_size[2])
 		if(height > screen_height)
-			params += "size=[width]x[screen_height - 100];"
+			params += "size=[width]x[max(screen_height - 100, 240)];"
 		else
 			params += "size=[width]x[height];"
 	send_resources_and_assets(user.client, load_asset)

--- a/code/modules/vueui/ui.dm
+++ b/code/modules/vueui/ui.dm
@@ -90,7 +90,13 @@ main ui datum.
 
 	var/params = "window=[windowid];file=[windowid];titlebar=0;can_resize=0;"
 	if(width && height)
-		params += "size=[width]x[height];"
+		var/winsize = winget(user, "mapwindow", "size")
+		var/map_size = splittext(winsize, "x")
+		var/screen_height = text2num(map_size[1])
+		if(height > screen_height)
+			params += "size=[width]x[screen_height - 100];"
+		else
+			params += "size=[width]x[height];"
 	send_resources_and_assets(user.client, load_asset)
 	user << browse(generate_html(load_asset?.css_tag()), params)
 	winset(user, "mapwindow.map", "focus=true")

--- a/html/changelogs/johnwildkins-runtime.yml
+++ b/html/changelogs/johnwildkins-runtime.yml
@@ -1,0 +1,8 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Cleaned up several misc. runtime errors."
+  - bugfix: "VueUI windows will now clamp to slightly less than the current BYOND window's screen height, hopefully preventing windows from being stuck open."
+  - refactor: "Away sites with the same player-facing name no longer overwrite each other in site selection."

--- a/maps/_common/mapsystem/map.dm
+++ b/maps/_common/mapsystem/map.dm
@@ -219,8 +219,8 @@
 	var/list/unavailable = list()
 	var/list/by_type = list()
 
-	for (var/site_name in SSmapping.away_sites_templates)
-		var/datum/map_template/ruin/away_site/site = SSmapping.away_sites_templates[site_name]
+	for (var/site_id in SSmapping.away_sites_templates)
+		var/datum/map_template/ruin/away_site/site = SSmapping.away_sites_templates[site_id]
 		if (site.template_flags & TEMPLATE_FLAG_SPAWN_GUARANTEED)
 			guaranteed += site
 			if ((site.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES) && !(site.template_flags & TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED))


### PR DESCRIPTION
basically fixes a bunch of minor issues from the last two days of runtime errors, plus makes VueUIs clamp to screen size and ensures that away sites with the same name don't overwrite each other

changes:
  - bugfix: "Cleaned up several misc. runtime errors."
  - bugfix: "VueUI windows will now clamp to slightly less than the current BYOND window's screen height, hopefully preventing windows from being stuck open."
  - refactor: "Away sites with the same player-facing name no longer overwrite each other in site selection."

Fixes #11274