### PR TITLE
Integrated Mining Drill for IPCs

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -147,6 +147,7 @@
 #define BP_AUG_PEN          "retractable combipen"
 #define BP_AUG_LIGHTER      "retractable lighter"
 #define BP_AUG_HEALTHSCAN   "integrated health scanner"
+#define BP_AUG_DRILL        "integrated mining drill"
 #define BP_AUG_GUSTATORIAL   "integrated gustatorial centre"
 #define BP_AUG_TESLA        "tesla spine"
 #define BP_AUG_EYE_SENSORS  "integrated eyes sensors"

--- a/code/modules/client/preference_setup/loadout/loadout_xeno/machine.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/machine.dm
@@ -161,6 +161,22 @@
 	handies["gustatorial centre (left hand)"] = /obj/item/organ/internal/augment/gustatorial/hand/left
 	gear_tweaks += new /datum/gear_tweak/path(handies)
 
+/datum/gear/augment/drill
+	display_name = "integrated drill"
+	description = "A mining drill integrated in the hand."
+	path = /obj/item/organ/internal/augment/tool/drill
+	whitelisted = list(SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION)
+	allowed_roles = list("Shaft Miner")
+	cost = 5
+	sort_category = "Xenowear - IPC"
+
+/datum/gear/augment/drill/New()
+	..()
+	var/list/augs = list()
+	augs["integrated drill, right hand"] = /obj/item/organ/internal/augment/tool/drill
+	augs["integrated drill, left hand"] = /obj/item/organ/internal/augment/tool/drill/left
+	gear_tweaks += new /datum/gear_tweak/path(augs)
+
 /datum/gear/accessory/syntheticcard
 	display_name = "synthetic residence card"
 	description = "An identification card given to free IPC residents within the Republic of Biesel."

--- a/code/modules/client/preference_setup/loadout/loadout_xeno/machine.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/machine.dm
@@ -163,7 +163,7 @@
 
 /datum/gear/augment/drill
 	display_name = "integrated drill"
-	description = "A mining drill integrated in the hand."
+	description = "A mining drill integrated in the hand. The drill is heavy, so only industrial IPCs can use it."
 	path = /obj/item/organ/internal/augment/tool/drill
 	whitelisted = list(SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION)
 	allowed_roles = list("Shaft Miner")

--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -132,6 +132,19 @@
 	parent_organ = BP_L_HAND
 	aug_slot = slot_l_hand
 
+/obj/item/organ/internal/augment/tool/drill
+	name = "integrated drill"
+	icon_state = "drill"
+	action_button_name = "Deploy Drill"
+	action_button_icon = "drill"
+	parent_organ = BP_R_HAND
+	organ_tag = BP_AUG_DRILL
+	augment_type = /obj/item/pickaxe/drill/integrated
+
+/obj/item/organ/internal/augment/tool/drill/left
+	parent_organ = BP_L_HAND
+	aug_slot = slot_l_hand
+
 /obj/item/organ/internal/augment/tool/combitool/lighter
 	name = "integrated lighter"
 	icon_state = "lighter-aug"

--- a/code/modules/organs/subtypes/autakh.dm
+++ b/code/modules/organs/subtypes/autakh.dm
@@ -320,6 +320,7 @@
 
 /obj/item/pickaxe/drill/integrated
 	name = "integrated mining drill"
+	desc = "A integrated mining drill that is installed on the hand of the user, it can retract at the user's command."
 	icon_state = "integrateddrill"
 	item_state = "integrateddrill"
 

--- a/html/changelogs/Ben10083 - Drill.yml
+++ b/html/changelogs/Ben10083 - Drill.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a integrated mining drill for industrial ipc miners in xenowear."


### PR DESCRIPTION
Adds a new augment in IPC xenowear for industrial IPC shaft miners, an integrated mining drill. 

Used autakh code for it, but if that should change I can change the icons.

Stats are same as standard mining drill.