### PR TITLE
Reduces the item size of comic books

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -301,6 +301,7 @@
 /obj/item/toy/comic
 	name = "comic book"
 	desc = "A magazine presenting a fictional story through a sequence of images. Perfect for those long, boring shifts."
+	w_class = ITEMSIZE_SMALL
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "comic"
 	item_state = "comic"

--- a/html/changelogs/omicega-coisadcidsfcimosdifomdsf.yml
+++ b/html/changelogs/omicega-coisadcidsfcimosdifomdsf.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Reduces the item size of comic books and manga. Now they can fit in your pockets!"


### PR DESCRIPTION
See title. Comic books are `ITEMSIZE_NORMAL` right now, which is a bit stupid considering they're just flavour items. This change lets you stuff them in your overwear pockets or something, so you can actually carry them around more feasibly.