### PR TITLE
Workshop APC Cell Buff

### DIFF
--- a/html/changelogs/Ben10083 - Powercreep.yml
+++ b/html/changelogs/Ben10083 - Powercreep.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Workshop APC now starts with a better cell."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -19060,13 +19060,13 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
 /obj/effect/floor_decal/corner/white{
 	dir = 9
+	},
+/obj/machinery/power/apc/super{
+	dir = 8;
+	pixel_x = -24;
+	name = "west bump"
 	},
 /turf/simulated/floor/tiled/white,
 /area/operations/lower/machinist)


### PR DESCRIPTION
Workshop APC now starts with a super-cap.

Their massive power draw is an issue, and their standard APC cell almost never can handle a workshop's normal operations unless engineering really works on it.