### PR TITLE
Atmospherics Map Tweaks

### DIFF
--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -160,6 +160,7 @@ obj/machinery/computer/general_air_control/Destroy()
 	icon = 'icons/obj/modular_telescreen.dmi'
 	icon_state = "telescreen"
 	icon_screen = "engi"
+	density = FALSE
 
 /obj/machinery/computer/general_air_control/large_tank_control/vueui_data_change(var/list/data, var/mob/user, var/datum/vueui/ui)
 	. = ..()

--- a/html/changelogs/atmos_airmixing_lights.yml
+++ b/html/changelogs/atmos_airmixing_lights.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - maptweak: "Adds more lights to atmospherics. Gives atmospheric technicians a pipe painter each. Gives atmospheric technicians access to the SM reactor."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -3734,6 +3734,9 @@
 "cUJ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /obj/machinery/meter,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "cVj" = (
@@ -5116,6 +5119,9 @@
 "eeV" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue,
 /obj/machinery/meter,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "efM" = (
@@ -6759,6 +6765,7 @@
 	dir = 1
 	},
 /obj/machinery/meter,
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "fqA" = (
@@ -14206,6 +14213,9 @@
 	pixel_x = -32;
 	sensors = list("n_sensor" = "Tank")
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "lvq" = (
@@ -16378,6 +16388,9 @@
 	pixel_x = 32;
 	sensors = list("air_sensor" = "Tank")
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "nfO" = (
@@ -17356,7 +17369,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/black,
-/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
 "nVO" = (
@@ -18690,6 +18702,9 @@
 	output_tag = "n2o_out";
 	pixel_x = 32;
 	sensors = list("n2o_sensor" = "Tank")
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
@@ -24594,6 +24609,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/operations)
+"uez" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos/air)
 "ufi" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -25831,6 +25853,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/auxiliary)
+"vgD" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos)
 "vgS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
@@ -26051,6 +26078,7 @@
 	dir = 1
 	},
 /obj/machinery/meter,
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "vpX" = (
@@ -26714,6 +26742,9 @@
 	output_tag = "o2_out";
 	pixel_x = -32;
 	sensors = list("o2_sensor" = "Tank")
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
@@ -51503,10 +51534,10 @@ kDF
 hVE
 hVE
 xHX
-hVE
+vgD
 nVb
 rNv
-rNv
+uez
 rNv
 rNv
 nCC

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -888,7 +888,7 @@
 	},
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Tesla Bay";
-	req_one_access = list(11,24)
+	req_access = list(11)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -933,7 +933,7 @@
 /area/engineering/engine_room)
 "avM" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos{
+/obj/machinery/door/airlock/glass_atmos{
 	name = "Atmospherics Locker Room";
 	req_access = list(24)
 	},
@@ -971,6 +971,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/operations/break_room)
+"axa" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/aft)
 "axB" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -1124,6 +1130,8 @@
 	pixel_y = 32
 	},
 /obj/structure/table/standard,
+/obj/item/device/flashlight/heavy,
+/obj/item/device/flashlight/heavy,
 /obj/item/device/flashlight/heavy,
 /obj/item/device/hand_labeler,
 /turf/simulated/floor/tiled/dark,
@@ -1313,7 +1321,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engine Monitoring Room";
-	req_access = list(11)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
@@ -1664,7 +1672,7 @@
 "aQc" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Tesla Bay";
-	req_one_access = list(11,24)
+	req_access = list(11)
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1716,7 +1724,7 @@
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "SMES Access";
-	req_access = list(11)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
@@ -2683,7 +2691,7 @@
 	id = "EngineEmitterPortWest";
 	name = "Engine Room Blast Doors";
 	pixel_x = -25;
-	req_access = list(11)
+	req_one_access = list(11, 24)
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
@@ -3859,7 +3867,7 @@
 	id_tag = "engine_electrical_maintenance";
 	locked = 1;
 	name = "Electrical Maintenance";
-	req_access = list(10)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
@@ -5013,7 +5021,7 @@
 	},
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering EVA Storage";
-	req_one_access = list(11,24)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
@@ -5841,7 +5849,7 @@
 	id_tag = "engine_airlock_exterior";
 	locked = 1;
 	name = "Engine Airlock Exterior";
-	req_access = list(11)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -5850,7 +5858,7 @@
 	name = "Engine Access Button";
 	pixel_x = 24;
 	pixel_y = -5;
-	req_access = list(11)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
@@ -7050,8 +7058,8 @@
 	id = "engine_electrical_maintenance";
 	name = "Door Bolt Control";
 	pixel_y = -25;
-	req_access = list(10);
-	specialfunctions = 4
+	specialfunctions = 4;
+	req_one_access = list(11, 24)
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/smes)
@@ -7862,7 +7870,7 @@
 	},
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Tesla Bay";
-	req_one_access = list(11,24)
+	req_access = list(11)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
@@ -10456,7 +10464,7 @@
 	id = "EngineEmitterPortWest";
 	name = "Engine Room Blast Doors";
 	pixel_x = 25;
-	req_access = list(11)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -10487,7 +10495,7 @@
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engine Waste";
-	req_access = list(11)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
@@ -13102,7 +13110,7 @@
 	id = "EngineVent";
 	name = "Engine Ventillatory Control";
 	pixel_x = -24;
-	req_access = list(11)
+	req_one_access = list(11, 24)
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
@@ -13252,7 +13260,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering Hallway";
-	req_one_access = list(10)
+	req_access = list(10)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/engineering/tesla)
@@ -13575,7 +13583,7 @@
 "hrZ" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering EVA Storage";
-	req_one_access = list(11,24)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
@@ -14484,7 +14492,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Substation";
-	req_one_access = list(11,24)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -15085,7 +15093,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Tesla Bay";
-	req_one_access = list(11,24)
+	req_access = list(11)
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_monitoring/tesla)
@@ -15729,6 +15737,7 @@
 /obj/item/storage/belt/utility,
 /obj/item/device/gps/engineering,
 /obj/item/pipewrench,
+/obj/item/device/pipe_painter,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/storage)
 "iIf" = (
@@ -15872,6 +15881,7 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/engineering/tesla)
 "iKg" = (
@@ -16977,6 +16987,7 @@
 /obj/item/storage/belt/utility,
 /obj/item/device/gps/engineering,
 /obj/item/pipewrench,
+/obj/item/device/pipe_painter,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/storage)
 "jnV" = (
@@ -17194,7 +17205,7 @@
 	id_tag = "engine_airlock_interior";
 	locked = 1;
 	name = "Engine Airlock Interior";
-	req_access = list(11)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -17203,7 +17214,7 @@
 	name = "Engine Access Button";
 	pixel_x = -24;
 	pixel_y = 5;
-	req_access = list(11)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
@@ -17718,6 +17729,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "jLM" = (
@@ -18157,7 +18169,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
-	req_one_access = list(11, 24)
+	req_access = list(11)
 	},
 /turf/simulated/floor/plating,
 /area/engineering/smes/tesla)
@@ -20128,6 +20140,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/closet/radiation,
 /turf/simulated/floor/tiled,
 /area/engineering/engine_airlock)
 "llp" = (
@@ -21068,7 +21081,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering Hallway";
-	req_one_access = list(10)
+	req_access = list(10)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/engineering)
@@ -21536,6 +21549,7 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/engineering/tesla)
 "lZQ" = (
@@ -24899,7 +24913,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering Hallway";
-	req_one_access = list(10)
+	req_access = list(10)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/engineering/tesla)
@@ -25093,7 +25107,8 @@
 	},
 /obj/machinery/door/airlock/hatch{
 	icon_state = "door_locked";
-	locked = 1
+	locked = 1;
+	req_one_access = list(11, 24)
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
@@ -27155,7 +27170,7 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Tesla Bay";
-	req_one_access = list(11,24)
+	req_access = list(11)
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -27609,7 +27624,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Substation";
-	req_one_access = list(11,24)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -28241,7 +28256,7 @@
 	},
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Tesla Bay";
-	req_one_access = list(11,24)
+	req_access = list(10)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
@@ -30466,6 +30481,7 @@
 /obj/item/storage/belt/utility,
 /obj/item/device/gps/engineering,
 /obj/item/pipewrench,
+/obj/item/device/pipe_painter,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/storage)
 "qSn" = (
@@ -31239,6 +31255,7 @@
 "rmG" = (
 /obj/machinery/door/window/brigdoor/eastleft{
 	dir = 1;
+	req_one_access = list(11, 24);
 	req_access = null
 	},
 /turf/simulated/floor/plating,
@@ -33182,7 +33199,8 @@
 /obj/machinery/button/remote/driver{
 	id = "enginecore";
 	name = "Emergency Core Eject";
-	pixel_x = 25
+	pixel_x = 25;
+	req_one_access = list(11, 24)
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
@@ -33442,7 +33460,7 @@
 /area/security/security_office)
 "sui" = (
 /obj/machinery/door/airlock/maintenance_hatch{
-	req_access = list(11)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -35397,7 +35415,6 @@
 	tag_exterior_door = "engine_airlock_exterior";
 	tag_interior_door = "engine_airlock_interior"
 	},
-/obj/structure/closet/radiation,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/engineering)
 "tEE" = (
@@ -35627,11 +35644,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/pharmacy)
 "tJB" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(24);
+	name = "Atmospherics Locker Room Maintenance"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos/storage)
 "tJP" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -36525,7 +36543,7 @@
 "uje" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Tesla Bay";
-	req_one_access = list(11,24)
+	req_access = list(11)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -37810,7 +37828,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering EVA Storage";
-	req_one_access = list(11,24)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
@@ -40125,7 +40143,7 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Tesla Bay";
-	req_one_access = list(11,24)
+	req_access = list(11)
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -40756,7 +40774,8 @@
 	},
 /obj/machinery/door/airlock/hatch{
 	icon_state = "door_locked";
-	locked = 1
+	locked = 1;
+	req_one_access = list(11, 24)
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
@@ -41512,7 +41531,7 @@
 	name = "Engine Emitter";
 	pixel_x = 6;
 	pixel_y = 7;
-	req_access = list(10)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/button/remote/blast_door{
 	desc = "A remote control-switch for the engine charging port.";
@@ -41520,14 +41539,14 @@
 	name = "Reactor Blast Doors";
 	pixel_x = -6;
 	pixel_y = 7;
-	req_access = list(10)
+	req_one_access = list(11, 24)
 	},
 /obj/machinery/button/remote/blast_door{
 	desc = "A remote control-switch for the engine control room blast doors.";
 	id = "EngineBlast";
 	name = "Engine Monitoring Room Blast Doors";
 	pixel_y = -3;
-	req_access = list(10)
+	req_one_access = list(11, 24)
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/engineering/engine_monitoring)
@@ -42391,7 +42410,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering Hallway";
-	req_one_access = list(10)
+	req_access = list(10)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/engineering)
@@ -67007,7 +67026,7 @@ nlG
 nlG
 fnn
 fnn
-fnn
+tJB
 fnn
 fnn
 nAz
@@ -67208,9 +67227,9 @@ dVN
 xHd
 jWI
 bkv
+axa
+uxE
 aUB
-tJB
-tJB
 wFh
 xpv
 nHq


### PR DESCRIPTION
this PR adds more lights to the atmos air mixing room, gives each atmos tech a pipe painter each, and gives them access to the SM reactor room. it also fixes the density of the large gas tank control wall consoles.