### PR TITLE
Fixing Cryocells kicking people out when you move sometimes

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -80,6 +80,8 @@
 	return 1
 
 /obj/machinery/atmospherics/unary/cryo_cell/relaymove(mob/user as mob)
+	if(user != occupant)
+		return
 	if(user.stat)
 		return
 	go_out()

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -80,7 +80,7 @@
 	return 1
 
 /obj/machinery/atmospherics/unary/cryo_cell/relaymove(mob/user as mob)
-	if(user != occupant) //Put this in because apparently if you open the ui and press a button, you're counted as user and can trigger relaymove, this checks if you're inside, and if you aren't it ignores you for the purposes of the relaymove.
+	if(user != occupant) //Put this in because apparently if you open the ui and press a button, you're counted as user and can trigger relaymove, this checks if you're inside, and if you aren't it ignores you for the purposes of the relaymove. - Risingvaliant
 		return
 	if(user.stat)
 		return

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -80,7 +80,7 @@
 	return 1
 
 /obj/machinery/atmospherics/unary/cryo_cell/relaymove(mob/user as mob)
-	if(user != occupant)
+	if(user != occupant) //Put this in because apparently if you open the ui and press a button, you're counted as user and can trigger relaymove, this checks if you're inside, and if you aren't it ignores you for the purposes of the relaymove.
 		return
 	if(user.stat)
 		return

--- a/html/changelogs/Cryocellfix.yml
+++ b/html/changelogs/Cryocellfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RisingValiant
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "added a check to the relaymove call in cryo.dm that checks if you're inside the cryocell before calling relaymove when you move."


### PR DESCRIPTION
Makes the cryocells check if you're inside before defining you as user and, checking your state, and calling relaymove. This means that having the ui open and turning the cryocell on doesn't mean the person inside will get kicked out if you forget to close it anymore. Fixes #14057 