### PR TITLE
Ghostrole Whitelist Cleanup

### DIFF
--- a/code/modules/ghostroles/spawner/base.dm
+++ b/code/modules/ghostroles/spawner/base.dm
@@ -22,8 +22,6 @@
 	var/count = 0 //How ofen has this spawner been used
 	var/req_perms = null //What permission flags are required to use this spawner
 	var/req_perms_edit = R_ADMIN
-	var/req_head_whitelist = FALSE //If a head of staff whitelist is required
-	var/req_species_whitelist = null //Name/Datum of the species whitelist that is required, or null
 	var/enabled = TRUE //If the spawnpoint is enabled
 	var/enable_chance = null //If set to a value other than null, has the set chance to become enabled
 	var/enable_dmessage = TRUE //The message to send to deadchat if the ghostspawner is enabled or TRUE for a default message
@@ -63,16 +61,9 @@
 	if(loc_type == GS_LOC_ATOM && !length(spawn_atoms))
 		return "No spawn atoms available"
 
-	if(req_head_whitelist && !check_whitelist(user))
-		return "Missing Head of Staff Whitelist"
-
 	var/ban_reason = jobban_isbanned(user,jobban_job)
 	if(jobban_job && ban_reason)
 		return "[ban_reason]"
-
-	if(req_species_whitelist)
-		if(!is_alien_whitelisted(user, req_species_whitelist))
-			return "Missing Species Whitelist"
 
 	if(observers_only && !isobserver(user))
 		return "Observers Only"

--- a/code/modules/ghostroles/spawner/human/kataphract.dm
+++ b/code/modules/ghostroles/spawner/human/kataphract.dm
@@ -28,8 +28,6 @@
 	name = "Kataphract-Hopeful Klaxan"
 	desc = "Display honour in everything you do. Be an excellent person. Learn how to be a proper Kataphract by your fellow Unathi."
 	max_count = 1
-	uses_species_whitelist = TRUE
-	req_species_whitelist = SPECIES_VAURCA_WARRIOR
 
 	spawnpoints = list("kataphract_klax")
 
@@ -42,8 +40,6 @@
 	name = "Kataphract Knight"
 	desc = "Display honour in everything you do. Be an excellent person. Be a co-leader of the Kataphract Chapter, along with the other knight."
 	max_count = 2
-	uses_species_whitelist = TRUE
-	req_species_whitelist = SPECIES_UNATHI
 
 	mob_name_prefix = "Saa "
 

--- a/code/modules/ghostroles/spawner/human/pra.dm
+++ b/code/modules/ghostroles/spawner/human/pra.dm
@@ -18,7 +18,6 @@
 	special_role = "Kosmostrelki"
 	respawn_flag = null
 	extra_languages = list(LANGUAGE_SIIK_MAAS)
-	uses_species_whitelist = FALSE
 	away_site = TRUE
 
 /datum/ghostspawner/human/pra_cosmonaut/commissar
@@ -33,7 +32,6 @@
 
 	outfit = /datum/outfit/admin/pra_cosmonaut/commissar
 	possible_species = list(SPECIES_TAJARA, SPECIES_TAJARA_MSAI)
-	req_species_whitelist = SPECIES_TAJARA
 
 /datum/outfit/admin/pra_cosmonaut
 	name = "Kosmostrelki"

--- a/code/modules/ghostroles/spawner/human/responseteams/human/fsf.dm
+++ b/code/modules/ghostroles/spawner/human/responseteams/human/fsf.dm
@@ -37,7 +37,5 @@
 	max_count = 1
 	outfit = /datum/outfit/admin/ert/fsf/synth
 	mob_name_prefix = null
-	uses_species_whitelist = TRUE
-	req_species_whitelist = SPECIES_IPC
 	possible_species = list(SPECIES_IPC)
 

--- a/code/modules/ghostroles/spawner/human/responseteams/tajara/kosmostrelki.dm
+++ b/code/modules/ghostroles/spawner/human/responseteams/tajara/kosmostrelki.dm
@@ -22,10 +22,8 @@
 	mob_name_prefix = "Alm."
 
 	max_count = 1
-	uses_species_whitelist = TRUE
 	outfit = /datum/outfit/admin/ert/pra_cosmonaut/commissar
 	possible_species = list(SPECIES_TAJARA, SPECIES_TAJARA_MSAI)
-	req_species_whitelist = SPECIES_TAJARA
 
 
 /datum/ghostspawner/human/ert/pra_cosmonaut/leader

--- a/code/modules/ghostroles/spawner/human/responseteams/unathi/kataphracts.dm
+++ b/code/modules/ghostroles/spawner/human/responseteams/unathi/kataphracts.dm
@@ -20,8 +20,6 @@
 	max_count = 1
 	outfit = /datum/outfit/admin/ert/kataphract/klax
 	mob_name_prefix = "Zosaa "
-	uses_species_whitelist = TRUE
-	req_species_whitelist = SPECIES_VAURCA_WARRIOR // Kataphract K'lax would be more difficult
 	possible_species = list(SPECIES_VAURCA_WARRIOR)
 	extra_languages = list(LANGUAGE_VAURCA)
 

--- a/code/modules/ghostroles/spawner/human/zenghu.dm
+++ b/code/modules/ghostroles/spawner/human/zenghu.dm
@@ -18,7 +18,6 @@
 	assigned_role = "Zeng-Hu Survivor"
 	special_role = "Zeng-Hu Survivor"
 	respawn_flag = null
-	uses_species_whitelist = TRUE
 
 /datum/outfit/admin/zenghu_survivor
 	name = "Zeng-Hu Employee"

--- a/html/changelogs/arrow768-whitelist-cleanup.yml
+++ b/html/changelogs/arrow768-whitelist-cleanup.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Removes the \"inbuilt\ whitelist handling of the ghost roles. -> That is changed via config."

--- a/maps/away/romanovich/grand_romanovich_ghostroles.dm
+++ b/maps/away/romanovich/grand_romanovich_ghostroles.dm
@@ -15,7 +15,6 @@
 	special_role = "Grand Romanovich Host"
 	respawn_flag = null
 
-	req_species_whitelist = SPECIES_TAJARA
 	extra_languages = list(LANGUAGE_SIIK_MAAS)
 
 /datum/outfit/admin/grand_romanovich_host


### PR DESCRIPTION
Removes the inbuilt whitelist handling from the ghost roles.
That is already handled via the config and should have been removed a while ago.