### PR TITLE
KA Cost Tweaking

### DIFF
--- a/code/modules/research/designs/protolathe/mining_designs.dm
+++ b/code/modules/research/designs/protolathe/mining_designs.dm
@@ -110,64 +110,64 @@
 
 /datum/design/item/mining/ka_cell05
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 6, TECH_MAGNET = 5, TECH_POWER = 5, TECH_PHORON = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, MATERIAL_GLASS = 3000, MATERIAL_SILVER = 3000, MATERIAL_GOLD = 1000, MATERIAL_PHORON = 5000)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, MATERIAL_GLASS = 3000, MATERIAL_SILVER = 3000, MATERIAL_GOLD = 1000, MATERIAL_URANIUM = 5000)
 	build_path = /obj/item/custom_ka_upgrade/cells/cell05
 
 /datum/design/item/mining/ka_cellinertia
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 6, TECH_MAGNET = 5, TECH_POWER = 5, TECH_PHORON = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 6000, MATERIAL_GLASS = 4000, MATERIAL_SILVER = 4000, MATERIAL_GOLD = 2000, MATERIAL_PHORON = 5000)
+	materials = list(DEFAULT_WALL_MATERIAL = 6000, MATERIAL_GLASS = 4000, MATERIAL_SILVER = 4000, MATERIAL_GOLD = 4000, MATERIAL_URANIUM = 5000)
 	build_path = /obj/item/custom_ka_upgrade/cells/inertia_charging
 
 /datum/design/item/mining/ka_cellphoron
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 6, TECH_MAGNET = 5, TECH_POWER = 5, TECH_PHORON = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 6000, MATERIAL_GLASS = 4000, MATERIAL_SILVER = 5000, MATERIAL_GOLD = 2000, MATERIAL_PHORON = 4000)
+	materials = list(DEFAULT_WALL_MATERIAL = 6000, MATERIAL_GLASS = 4000, MATERIAL_SILVER = 5000, MATERIAL_GOLD = 5000, MATERIAL_PHORON = 4000)
 	build_path = /obj/item/custom_ka_upgrade/cells/loader
 
 /datum/design/item/mining/ka_celluranium
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 6, TECH_MAGNET = 5, TECH_POWER = 5, TECH_PHORON = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 6000, MATERIAL_GLASS = 4000, MATERIAL_SILVER = 4000, MATERIAL_GOLD = 2000, MATERIAL_PHORON = 3000)
+	materials = list(DEFAULT_WALL_MATERIAL = 6000, MATERIAL_GLASS = 4000, MATERIAL_SILVER = 7000, MATERIAL_GOLD = 7000, MATERIAL_URANIUM = 3000)
 	build_path = /obj/item/custom_ka_upgrade/cells/loader/uranium
 
 /datum/design/item/mining/ka_cellhydrogen
 	req_tech = list(TECH_MATERIAL = 5, TECH_ENGINEERING = 6, TECH_MAGNET = 5, TECH_POWER = 5, TECH_PHORON = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 6000, MATERIAL_GLASS = 4000, MATERIAL_SILVER = 4000, MATERIAL_GOLD = 2000, MATERIAL_PHORON = 2000)
+	materials = list(DEFAULT_WALL_MATERIAL = 6000, MATERIAL_GLASS = 4000, MATERIAL_SILVER = 4000, MATERIAL_GOLD = 4000, MATERIAL_URANIUM = 2000)
 	build_path = /obj/item/custom_ka_upgrade/cells/loader/hydrogen
 
 
 //Barrels
 /datum/design/item/mining/ka_barrel01
 	req_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1, TECH_MAGNET = 1, TECH_PHORON = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 2000, MATERIAL_GLASS = 2000, MATERIAL_PHORON = 500)
+	materials = list(DEFAULT_WALL_MATERIAL = 2000, MATERIAL_GLASS = 2000, MATERIAL_URANIUM = 500)
 	build_path = /obj/item/custom_ka_upgrade/barrels/barrel01
 
 /datum/design/item/mining/ka_barrel02
 	req_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1, TECH_MAGNET = 3, TECH_PHORON = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 3000, MATERIAL_GLASS = 2000, MATERIAL_PHORON = 500)
+	materials = list(DEFAULT_WALL_MATERIAL = 3000, MATERIAL_GLASS = 2000, MATERIAL_URANIUM = 500)
 	build_path = /obj/item/custom_ka_upgrade/barrels/barrel02
 
 /datum/design/item/mining/ka_barrel03
 	req_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3, TECH_MAGNET = 3, TECH_PHORON = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, MATERIAL_GLASS = 2000, MATERIAL_GOLD = 2000, MATERIAL_PHORON = 1000)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000, MATERIAL_GLASS = 2000, MATERIAL_GOLD = 2000, MATERIAL_URANIUM = 1000)
 	build_path = /obj/item/custom_ka_upgrade/barrels/barrel03
 
 /datum/design/item/mining/ka_barrel04
 	req_tech = list(TECH_MATERIAL = 6, TECH_ENGINEERING = 3, TECH_MAGNET = 5, TECH_PHORON = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 5000, MATERIAL_GLASS = 3000, MATERIAL_GOLD = 3000, MATERIAL_PHORON = 3000, MATERIAL_DIAMOND = 1000)
+	materials = list(DEFAULT_WALL_MATERIAL = 5000, MATERIAL_GLASS = 3000, MATERIAL_GOLD = 3000, MATERIAL_URANIUM = 3000, MATERIAL_DIAMOND = 1000)
 	build_path = /obj/item/custom_ka_upgrade/barrels/barrel04
 
 /datum/design/item/mining/ka_barrel05
 	req_tech = list(TECH_MATERIAL = 6, TECH_ENGINEERING = 5, TECH_MAGNET = 6, TECH_PHORON = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 6000, MATERIAL_GLASS = 4000, MATERIAL_GOLD = 4000, MATERIAL_PHORON = 4000, MATERIAL_DIAMOND = 2000)
+	materials = list(DEFAULT_WALL_MATERIAL = 6000, MATERIAL_GLASS = 4000, MATERIAL_GOLD = 4000, MATERIAL_URANIUM = 4000, MATERIAL_DIAMOND = 2000)
 	build_path = /obj/item/custom_ka_upgrade/barrels/barrel05
 
 /datum/design/item/mining/ka_barrel02_alt
 	req_tech = list(TECH_MATERIAL = 1,TECH_ENGINEERING = 1,TECH_MAGNET = 3, TECH_PHORON = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, MATERIAL_GLASS = 3000, MATERIAL_PHORON = 600)
+	materials = list(DEFAULT_WALL_MATERIAL = 4000, MATERIAL_GLASS = 3000, MATERIAL_URANIUM = 600)
 	build_path = /obj/item/custom_ka_upgrade/barrels/barrel02_alt
 
 /datum/design/item/mining/ka_barrelphoron
 	req_tech = list(TECH_MATERIAL = 6, TECH_ENGINEERING = 5, TECH_MAGNET = 6, TECH_PHORON = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 8000, MATERIAL_GLASS = 6000, MATERIAL_GOLD = 6000, MATERIAL_PHORON = 6000, MATERIAL_DIAMOND = 3000)
+	materials = list(DEFAULT_WALL_MATERIAL = 8000, MATERIAL_GLASS = 6000, MATERIAL_GOLD = 6000, MATERIAL_PHORON= 6000, MATERIAL_DIAMOND = 3000)
 	build_path = /obj/item/custom_ka_upgrade/barrels/phoron
 
 //Upgrades

--- a/html/changelogs/Ben10083 - KACosts.yml
+++ b/html/changelogs/Ben10083 - KACosts.yml
@@ -1,0 +1,14 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Most KA barrels now cost Uranium instead of Phoron."
+  - balance: "KA cell costs have been tweaked."


### PR DESCRIPTION
With phoron no longer available for miners, it was a bit too hard that mining basically couldnt get KAs from science, as even basic ones requires phoron. The barrel and cells have had their phoron cost replaced with uranium (with exceptions to phoron variants ofc).