### PR TITLE
Removes human slowdown at higher hunger + thirst levels

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -26,16 +26,6 @@
 	if(species)
 		tally += species.get_species_tally(src)
 
-	if (nutrition < (max_nutrition * 0.2))
-		tally++
-		if (nutrition < (max_nutrition * 0.1))
-			tally++
-
-	if (hydration < (max_hydration * 0.2))
-		tally++
-		if (hydration < (max_hydration * 0.1))
-			tally++
-
 	tally += species.handle_movement_tally(src)
 
 	if (can_feel_pain())

--- a/html/changelogs/omicega-fdsfidsofidosfgmidogfdg.yml
+++ b/html/changelogs/omicega-fdsfidsofidosfgmidogfdg.yml
@@ -9,4 +9,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Removed human slowdown at higher hunger and thirst levels."
+  - tweak: "Removed playable species' slowdown at higher hunger and thirst levels."

--- a/html/changelogs/omicega-fdsfidsofidosfgmidogfdg.yml
+++ b/html/changelogs/omicega-fdsfidsofidosfgmidogfdg.yml
@@ -1,0 +1,12 @@
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Removed human slowdown at higher hunger and thirst levels."


### PR DESCRIPTION
See title. Yes, this is kind of a sledgehammer 'fix'.

I don't really think having to eat and drink to maintain your movement speed adds much to the game at all. People go to vending machines to try and keep their tanks full; it's not as if the mechanic really drives people towards the chef or bartender in particular. If you have to run around a lot, you're going to zero out on hunger and thirst surprisingly quickly.

The second part of why this has come to annoy me is that this mechanic impacts different species disproportionately. It hits species who have larger stamina reserves (and therefore run more) a lot harder than it does species with less run energy but a higher base movement speed, which essentially means that a human is going to have to stand at a vending machine and guzzle down chocolate bars and water 2-3 times in a particularly busy shift. A Tajara (for example) who moves around the same amount might not even need to, since they are on walk intent a much larger porportion of the time.

IPCs don't engage with this mechanic at all, either, and I don't think Diona do either?

I'm aware this is probably going to be controversial at best and get DNMed and thrown out by the maintainers at worst. I'm open to just attacking specific variables controlling the rate at which people get hungry/thirsty due to movement instead.