### PR TITLE
Adjusts limb max_damage to allow for laser rifle delimbs.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -896,10 +896,12 @@
 
 /mob/living/carbon/human/proc/check_has_mouth()
 	// Todo, check stomach organ when implemented.
-	var/obj/item/organ/external/head/H = get_organ(BP_HEAD)
-	if(!H || !H.can_intake_reagents)
-		return 0
-	return 1
+	var/obj/item/organ/external/E = get_organ(BP_HEAD)
+	if(E && !E.is_stump())
+		var/obj/item/organ/external/head/H = E
+		if(!H.can_intake_reagents)
+			return FALSE
+	return TRUE
 
 /mob/living/proc/empty_stomach()
 	return

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -390,7 +390,7 @@
 		victim.take_internal_damage(damage_amt)
 		return TRUE
 
-/obj/item/organ/external/proc/handle_limb_gibbing(var/used_weapon,var/brute,var/burn)
+/obj/item/organ/external/proc/handle_limb_gibbing(var/used_weapon, var/brute, var/burn)
 	//If limb took enough damage, try to cut or tear it off
 	if(owner && loc == owner && !is_stump())
 		if((limb_flags & ORGAN_CAN_AMPUTATE) && config.limbs_can_break)
@@ -412,7 +412,7 @@
 					if(W.w_class >= w_class && (dam_flags & DAM_EDGE))
 						edge_eligible = TRUE
 
-				if(!blunt_eligible && edge_eligible && brute >= max_damage / (DROPLIMB_THRESHOLD_EDGE + maim_bonus))
+				if(!blunt_eligible && edge_eligible && (brute >= max_damage / (DROPLIMB_THRESHOLD_EDGE + maim_bonus)))
 					droplimb(0, DROPLIMB_EDGE)
 				else if(burn >= max_damage / (DROPLIMB_THRESHOLD_DESTROY + maim_bonus))
 					droplimb(0, DROPLIMB_BURN)
@@ -1468,7 +1468,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	pain = max(0, min(pain + amount, species.total_health * 2))
 	if(owner && ((amount > 15 && prob(20)) || (amount > 30 && prob(60))))
 		owner.emote("scream")
-	if(amount > 5)
+	if(amount > 5 && owner)
 		owner.undo_srom_pull()
 	return pain-last_pain
 

--- a/code/modules/organs/subtypes/standard.dm
+++ b/code/modules/organs/subtypes/standard.dm
@@ -53,7 +53,7 @@
 	limb_name = BP_L_ARM
 	name = "left arm"
 	icon_name = "l_arm"
-	max_damage = 75
+	max_damage = 65
 	min_broken_damage = 30
 	w_class = ITEMSIZE_NORMAL
 	body_part = ARM_LEFT
@@ -86,7 +86,7 @@
 	limb_name = BP_L_LEG
 	name = "left leg"
 	icon_name = "l_leg"
-	max_damage = 75
+	max_damage = 65
 	min_broken_damage = 30
 	w_class = ITEMSIZE_NORMAL
 	body_part = LEG_LEFT
@@ -119,7 +119,7 @@
 	limb_name = BP_L_FOOT
 	name = "left foot"
 	icon_name = "l_foot"
-	max_damage = 55
+	max_damage = 50
 	min_broken_damage = 15
 	w_class = ITEMSIZE_SMALL
 	body_part = FOOT_LEFT
@@ -156,7 +156,7 @@
 	limb_name = BP_L_HAND
 	name = "left hand"
 	icon_name = "l_hand"
-	max_damage = 55
+	max_damage = 50
 	min_broken_damage = 15
 	w_class = ITEMSIZE_SMALL
 	body_part = HAND_LEFT
@@ -200,7 +200,7 @@
 	limb_name = BP_HEAD
 	icon_name = "head"
 	name = BP_HEAD
-	max_damage = 125
+	max_damage = 75
 	min_broken_damage = 35
 	w_class = ITEMSIZE_NORMAL
 	body_part = HEAD | FACE

--- a/html/changelogs/mattatlas-laserdecap.yml
+++ b/html/changelogs/mattatlas-laserdecap.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "The head and the human limbs now have a lower max damage, which means that they should now be delimbable by laser rifles and similarly-damaging weapons."


### PR DESCRIPTION
Technically an unintended consequence of my earlier PR that addressed limb meta, but I won't mark this one as a bugfix for further discussion. Nothing should behave _too_ differently. As it remains, most guns in the game cannot delimb arms/hands without a red grab PB unless they do more than 50/65 damage respectively.

In short, the issue is that laser rifles (and most weapons) cannot exceed the DESTROY_LIMB threshold even with a red grab PB/attack because the max_damage of the head is way too high. It's been lowered to allow for it again. I also lowered other limb thresholds because they were a bit ridiculous.
