### PR TITLE
Changes color of Ya'ssa

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -365,7 +365,7 @@ h1.alert, h2.alert		{color: #000080;}
 .changeling				{color: #800080;}
 .rough					{font-family: "Trebuchet MS", cursive, sans-serif;}
 .say_quote				{font-family: Georgia, Verdana, sans-serif;}
-.yassa					{color: #400987;}
+.yassa					{color: #e45aba;}
 .delvahhi				{color: #5E2612; font-weight: bold;}
 .siiktau				{color: #A52A2A;}
 .revenant				{color: #215a5c; font-style: italic;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -365,7 +365,7 @@ h1.alert, h2.alert		{color: #000080;}
 .changeling				{color: #800080;}
 .rough					{font-family: "Trebuchet MS", cursive, sans-serif;}
 .say_quote				{font-family: Georgia, Verdana, sans-serif;}
-.yassa					{color: #e45aba;}
+.yassa					{color: #801fff;}
 .delvahhi				{color: #5E2612; font-weight: bold;}
 .siiktau				{color: #A52A2A;}
 .revenant				{color: #215a5c; font-style: italic;}

--- a/html/changelogs/Afya-yassa.yml
+++ b/html/changelogs/Afya-yassa.yml
@@ -1,0 +1,6 @@
+author: Afya
+
+delete-after: True
+
+changes:
+  - tweak: "Changed color of Ya'ssa in light mode when speaking."

--- a/html/changelogs/Afya-yassa.yml
+++ b/html/changelogs/Afya-yassa.yml
@@ -3,4 +3,4 @@ author: Afya
 delete-after: True
 
 changes:
-  - tweak: "Changed color of Ya'ssa in light mode when speaking."
+  - tweak: "Changed color of Ya'ssa in light mode."


### PR DESCRIPTION
Currently with Ya'ssa in light mode, it is very difficult to differentiate it between the black of common. This update changes that.
![image](https://user-images.githubusercontent.com/54920261/170063152-5adbc61e-8e39-4062-862f-095eeacfc0f1.png)
![image](https://user-images.githubusercontent.com/54920261/170081985-03658ca7-1c2d-402c-a75e-7fd7fe3edd17.png)