### PR TITLE
Vaurca Bulwark attacks now shred

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -243,6 +243,7 @@
 	eye_attack_text = "claws"
 	eye_attack_text_victim = "claws"
 	attack_name = "clawed fists"
+	shredding = TRUE
 
 	damage = 7.5
 	attack_door = 20

--- a/html/changelogs/Ben10083 - Bugs Life.yml
+++ b/html/changelogs/Ben10083 - Bugs Life.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Vaurca Bulwark attacks now have the shred variable, allowing them to destroy windows and other actions similar to a Industrial IPC."


### PR DESCRIPTION
As the title states, their attacks now have the shredding variable, which allows them to damage windows and other 'heavy' actions, much like a G2 can.