### PR TITLE
Fixes Various Mapping Bugs

### DIFF
--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -143,9 +143,9 @@
 
 /datum/outfit/job/scientist/xenobiologist
 	name = "Xenobiologist"
-	uniform = /obj/item/clothing/under/rank/scientist/xenobio
 	jobtype = /datum/job/xenobiologist
-	tab_pda = /obj/item/modular_computer/handheld/pda/research
+
+	uniform = /obj/item/clothing/under/rank/scientist/xenobio
 
 /datum/job/xenobotanist
 	title = "Xenobotanist"
@@ -174,9 +174,9 @@
 
 /datum/outfit/job/scientist/xenobotanist
 	name = "Xenobotanist"
-	uniform = /obj/item/clothing/under/rank/scientist/botany
 	jobtype = /datum/job/xenobotanist
-	tab_pda = /obj/item/modular_computer/handheld/pda/research
+
+	uniform = /obj/item/clothing/under/rank/scientist/botany
 
 /datum/job/intern_sci
 	title = "Lab Assistant"

--- a/html/changelogs/engi_medcloset.yml
+++ b/html/changelogs/engi_medcloset.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes Xenobotanists not spawning in the research meeting room. Fixes them not being able to choose wristbounds. Fixes engineering medical wall locker."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -2445,6 +2445,7 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "bhT" = (
@@ -6989,12 +6990,6 @@
 	},
 /turf/simulated/floor/lino/grey,
 /area/chapel/main)
-"dPV" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/locker_room)
 "dQR" = (
 /obj/structure/bed/stool/chair{
 	dir = 4
@@ -7887,14 +7882,11 @@
 /turf/simulated/floor/lino/grey,
 /area/crew_quarters/bar)
 "eui" = (
-/obj/structure/cable/green{
-	icon_state = "0-2"
+/obj/structure/closet/walllocker/medical{
+	pixel_y = 32
 	},
-/obj/machinery/power/apc/low{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
+/obj/item/storage/firstaid/regular,
+/obj/effect/floor_decal/industrial/outline/medical,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "euT" = (
@@ -16814,6 +16806,7 @@
 	},
 /obj/item/storage/belt/utility,
 /obj/item/device/gps/engineering,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "jlQ" = (
@@ -26763,6 +26756,12 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 6
 	},
+/obj/machinery/power/apc{
+	pixel_x = 24;
+	dir = 4
+	},
+/obj/structure/cable/green,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "oTK" = (
@@ -27314,9 +27313,6 @@
 /turf/space/dynamic,
 /area/rnd/xenobiology/xenoflora)
 "piz" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -29952,7 +29948,7 @@
 	dir = 9
 	},
 /obj/effect/landmark/start{
-	name = "Xenobiologist"
+	name = "Xenobotanist"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/conference)
@@ -37149,10 +37145,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
-"uyP" = (
-/obj/structure/closet/walllocker/medical,
-/turf/simulated/wall/r_wall,
-/area/engineering/storage_hard)
 "uzd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -38781,12 +38773,6 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"vxL" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/locker_room)
 "vxY" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -40774,6 +40760,7 @@
 	},
 /obj/item/storage/belt/utility,
 /obj/item/device/gps/engineering,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "wrK" = (
@@ -42117,11 +42104,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "xbv" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
@@ -58830,7 +58817,7 @@ cRu
 nlr
 nlr
 nlr
-uyP
+nlr
 laB
 mUy
 laB
@@ -59435,10 +59422,10 @@ iGY
 mKJ
 laB
 eui
-dPV
+bHe
 piz
-dPV
-vxL
+bHe
+bHe
 eIU
 laB
 kec


### PR DESCRIPTION
this PR fixes various mapping issues.

**changes**
-

- fixes the engineering locker room medical wall locker being empty and misplaced.
- fixes xenobotanists not spawning in the research meeting room.
- fixes xenobotanists not being able to spawn with wristbounds.