### PR TITLE
New and Improved Survival Box for Antags, Admins, CCIA and Engineering

### DIFF
--- a/code/datums/outfits/event/outfit_nanotrasen.dm
+++ b/code/datums/outfits/event/outfit_nanotrasen.dm
@@ -10,7 +10,7 @@
 	id = /obj/item/card/id
 
 	backpack_contents = list(
-		/obj/item/storage/box/engineer = 1
+		/obj/item/storage/box/survival/engineer = 1
 	)
 
 	id_icon = "centcom"
@@ -50,7 +50,7 @@
 	belt = /obj/item/storage/belt/security
 
 	backpack_contents = list(
-		/obj/item/storage/box/engineer = 1,
+		/obj/item/storage/box/survival/engineer = 1,
 		/obj/item/clothing/head/helmet/swat/peacekeeper = 1,
 		/obj/item/clothing/accessory/holster/hip = 1,
 		/obj/item/gun/energy/disruptorpistol/magnum = 1
@@ -204,7 +204,7 @@
 	accessory_contents = list(/obj/item/gun/projectile/sec/lethal = 1)
 
 	backpack_contents = list(
-		/obj/item/storage/box/engineer = 1,
+		/obj/item/storage/box/survival/engineer = 1, 
 		/obj/item/device/flash = 1,
 		/obj/item/handcuffs = 1
 	)
@@ -227,7 +227,7 @@
 	)
 
 	backpack_contents = list(
-		/obj/item/storage/box/engineer = 1,
+		/obj/item/storage/box/survival/engineer = 1,
 		/obj/item/storage/box/zipties = 1,
 		/obj/item/clothing/head/helmet = 1
 	)

--- a/code/datums/outfits/event/outfit_nanotrasen.dm
+++ b/code/datums/outfits/event/outfit_nanotrasen.dm
@@ -204,7 +204,7 @@
 	accessory_contents = list(/obj/item/gun/projectile/sec/lethal = 1)
 
 	backpack_contents = list(
-		/obj/item/storage/box/survival/engineer = 1, 
+		/obj/item/storage/box/survival/engineer = 1,
 		/obj/item/device/flash = 1,
 		/obj/item/handcuffs = 1
 	)

--- a/code/datums/outfits/event/outfit_scc.dm
+++ b/code/datums/outfits/event/outfit_scc.dm
@@ -14,7 +14,7 @@
 	id = /obj/item/card/id
 
 	backpack_contents = list(
-		/obj/item/storage/box/engineer = 1
+		/obj/item/storage/box/survival/engineer = 1
 	)
 
 	id_icon = "centcom"
@@ -46,7 +46,7 @@
 	accessory_contents = list(/obj/item/gun/energy/repeater)
 
 	backpack_contents = list(
-		/obj/item/storage/box/engineer = 1,
+		/obj/item/storage/box/survival/engineer = 1,
 		/obj/item/reagent_containers/spray/pepper = 1,
 		/obj/item/melee/baton/loaded = 1,
 		/obj/item/grenade/chem_grenade/gas = 1,

--- a/code/datums/outfits/outfit_antag.dm
+++ b/code/datums/outfits/outfit_antag.dm
@@ -18,7 +18,7 @@
 	id = /obj/item/card/id/syndicate
 	r_pocket = /obj/item/device/radio/uplink
 	backpack_contents = list(
-		/obj/item/storage/box/engineer = 1,
+		/obj/item/storage/box/survival/engineer = 1,
 		/obj/item/device/flashlight = 1,
 		/obj/item/card/emag = 1,
 		/obj/item/reagent_containers/food/snacks/donkpocket/sinpocket = 1,
@@ -59,7 +59,7 @@
 	l_hand = /obj/item/tank/jetpack/void
 
 	backpack_contents = list(
-		/obj/item/storage/box/engineer = 1,
+		/obj/item/storage/box/survival/engineer = 1,
 		/obj/item/reagent_containers/pill/cyanide = 1,
 		/obj/item/gun/projectile/automatic/x9 = 1,
 		/obj/item/ammo_magazine/c45m/auto = 1,
@@ -81,7 +81,7 @@
 	r_pocket = null // stop them getting a radio uplink, they get an implant instead
 
 	backpack_contents = list(
-		/obj/item/storage/box/engineer = 1,
+		/obj/item/storage/box/survival/engineer = 1,
 		/obj/item/device/flashlight = 1,
 		/obj/item/reagent_containers/pill/cyanide = 1,
 		/obj/item/reagent_containers/food/snacks/donkpocket/sinpocket = 1,
@@ -153,7 +153,7 @@
 	pda = /obj/item/modular_computer/handheld/pda/syndicate
 
 	backpack_contents = list(
-		/obj/item/storage/box/engineer = 1,
+		/obj/item/storage/box/survival/engineer = 1,
 		/obj/item/reagent_containers/pill/cyanide = 1
 	)
 

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -40,6 +40,7 @@
 /datum/outfit/job/chief_engineer
 	name = "Chief Engineer"
 	jobtype = /datum/job/chief_engineer
+	box = /obj/item/storage/box/survival/engineer
 
 	uniform = /obj/item/clothing/under/rank/chief_engineer
 	head = /obj/item/clothing/head/hardhat/white
@@ -98,6 +99,7 @@
 /datum/outfit/job/engineer
 	name = "Engineer"
 	jobtype = /datum/job/engineer
+	box = /obj/item/storage/box/survival/engineer
 
 	uniform = /obj/item/clothing/under/rank/engineer
 	head = /obj/item/clothing/head/hardhat
@@ -155,6 +157,7 @@
 /datum/outfit/job/atmos
 	name = "Atmospheric Technician"
 	jobtype = /datum/job/atmos
+	box = /obj/item/storage/box/survival/engineer
 
 	uniform = /obj/item/clothing/under/rank/atmospheric_technician
 	belt = /obj/item/storage/belt/utility
@@ -210,6 +213,7 @@
 /datum/outfit/job/intern_eng
 	name = "Engineering Apprentice"
 	jobtype = /datum/job/intern_eng
+	box = /obj/item/storage/box/survival/engineer
 
 	uniform = /obj/item/clothing/under/rank/engineer/apprentice
 	shoes = /obj/item/clothing/shoes/orange

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -130,7 +130,7 @@
 	can_hold = list(
 				/obj/item/clothing/mask,
 				/obj/item/tank/emergency_oxygen,
-				/obj/item/device/flashlight/flare/glowstick,
+				/obj/item/device/flashlight/flare,
 				/obj/item/stack/medical,
 				/obj/item/reagent_containers/hypospray/autoinjector,
 				/obj/item/reagent_containers/inhaler,
@@ -154,8 +154,15 @@
 					/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline = 1
 					)
 
-/obj/item/storage/box/engineer
-	starts_with = list(/obj/item/clothing/mask/breath = 1, /obj/item/tank/emergency_oxygen/engi = 1)
+/obj/item/storage/box/survival/engineer
+		starts_with = list(
+					/obj/item/clothing/mask/breath = 1,
+					/obj/item/tank/emergency_oxygen/engi = 1,
+					/obj/item/device/oxycandle = 1,
+					/obj/item/device/flashlight/flare = 1,
+					/obj/item/stack/medical/bruise_pack = 1,
+					/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline = 1
+					)
 
 /obj/item/storage/box/vaurca
 	starts_with = list(/obj/item/clothing/mask/breath = 1, /obj/item/reagent_containers/inhaler/phoron_special = 1)

--- a/html/changelogs/wickedcybs_ebox.yml
+++ b/html/changelogs/wickedcybs_ebox.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - balance: "The engineer survival box that most antags and a lot of admin or ccia ghost spawners start with now has what survival boxes usually get. Main difference is that their oxygen tank is upgraded to an expanded capacity variant and the glowstick is replaced with a flare. Horizon engineering department members get it too now, it is an engineering box after all."


### PR DESCRIPTION
Most admin spawns, ccia spawns and a lot of antags used a variant of the survival box labelled "engineer" in the code. The main difference it had with the survival box the crew had, is that it had an extended capacity oxygen tank vs the normal blue oxygen tank.

Eventually the survival box got buffed but the engineer variant never was, so antags and CCIA were spawning with the old variants that only had a mask and tank instead of getting new additions like having some gauze or a autoinjector. So what I have done in this PR is made the engineering survival box a subtype of the survival box, filled it with the usual useful stuff and then upgraded the glowstick to a flare and the oxy tank to an extended capacity oxy tank.

Engineering also spawns with the engineer variant of the survival box too now.