### PR TITLE
Energy sword nerfs/tweaks.

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -5,7 +5,7 @@
 	var/active_w_class
 	sharp = 0
 	edge = FALSE
-	armor_penetration = 10
+	armor_penetration = 20
 	flags = NOBLOODY
 	can_embed = 0//No embedding pls
 	var/base_reflectchance = 40
@@ -79,15 +79,14 @@
 		var/bad_arc = reverse_direction(user.dir) //arc of directions from which we cannot block
 		if(check_shield_arc(user, bad_arc, damage_source, attacker))
 
-			if(prob(base_block_chance))
+			if(prob(base_block_chance) && shield_power)
 				spark(src, 5)
 				playsound(user.loc, 'sound/weapons/blade.ogg', 50, 1)
-				shield_power -= round(damage/4)
+				shield_power -= round(damage * 0.75)
 
 				if(shield_power <= 0)
-					visible_message("<span class='danger'>\The [user]'s [src.name] overloads!</span>")
-					deactivate()
-					shield_power = initial(shield_power)
+					to_chat(user, SPAN_DANGER("\The [src]'s integrated shield goes out! It will no longer assist in parrying."))
+					shield_power = 0
 					return FALSE
 
 				if(istype(damage_source, /obj/item/projectile/energy) || istype(damage_source, /obj/item/projectile/beam))
@@ -136,8 +135,9 @@
 	active_force = 40
 	active_throwforce = 60
 	active_w_class = ITEMSIZE_HUGE
-	force = 20
-	throwforce = 30
+	force = 30
+	throwforce = 40
+	armor_penetration = 20 
 	throw_speed = 5
 	throw_range = 10
 	w_class = ITEMSIZE_HUGE
@@ -151,7 +151,6 @@
 	base_block_chance = 0 //cannot be used to block guns
 	shield_power = 0
 	can_block_bullets = 0
-	armor_penetration = 20
 
 /obj/item/melee/energy/glaive/activate(mob/living/user)
 	..()
@@ -373,8 +372,7 @@
 	icon_state = "blade"
 	force = 40
 	active_force = 40 //Normal attacks deal very high damage - about the same as wielded fire axe
-	armor_penetration = 100
-	sharp = 1
+	sharp = TRUE
 	edge = TRUE
 	anchored = 1    // Never spawned outside of inventory, should be fine.
 	throwforce = 1  //Throwing or dropping the item deletes it.
@@ -384,11 +382,10 @@
 	flags = NOBLOODY
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	var/mob/living/creator
-	base_reflectchance = 140
+	base_reflectchance = 75
 	base_block_chance = 75
-	shield_power = 150
-	can_block_bullets = 1
-	active = 1
+	can_block_bullets = TRUE
+	active = TRUE
 	var/datum/effect_system/sparks/spark_system
 
 /obj/item/melee/energy/blade/Initialize()

--- a/html/changelogs/mattatlas-ancientcode.yml
+++ b/html/changelogs/mattatlas-ancientcode.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "The ninja esword no longer has 100 armor piercing for no reason at all."
+  - tweak: "The ninja esword no longer has a 100 percent guaranteed deflection rate on projectiles. It is now closer to 65 percent when shot with a laser rifle."
+  - tweak: "Energy sword parrying now functions off of the integrated shield power. If the shield power falls to below zero, parrying is no longer possible. Energy swords have 100 shield power, while the Ninja energy sword has 150. Shield power receives three fourths of the damage parried."
+  - tweak: "The energy glaive now does 30 damage 10 AP 40 throw damage, instead of 20 damage 10 AP 40 throw damage."


### PR DESCRIPTION
-  The ninja esword no longer has 100 armor piercing for no reason at all.
- The ninja esword no longer has a 100 percent guaranteed deflection rate on projectiles. It is now closer to 65 percent when shot with a laser rifle.
- Energy sword parrying now functions off of the integrated shield power. If the shield power falls to below zero, parrying is no longer possible. Energy swords have 100 shield power, while the Ninja energy sword has 150. Shield power receives three fourths of the damage parried.
- The energy glaive now does 30 damage 10 AP 40 throw damage, instead of 20 damage 10 AP 40 throw damage.