### PR TITLE
Radio key helpers

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -29,6 +29,9 @@
 		keyslot1 = new ks1type(src)
 	if(ks2type)
 		keyslot2 = new ks2type(src)
+	if(syndie)
+		desc_antag = "<u>Only while at an off-station base:</u> the ; key will talk into your antagonist channel; you can use :a to speak on the station common radio.\
+		While on station, ; will transmit to the common channel, as usual."
 	recalculateChannels(TRUE)
 
 /obj/item/device/radio/headset/Destroy()

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -159,6 +159,12 @@
 		if(client && (client.prefs.primary_radio_slot in headsets))
 			return headsets[client.prefs.primary_radio_slot]
 		return headsets[headsets[1]]
+
+	//No headsets. Check for radios in-hand
+	if(istype(r_hand, /obj/item/device/radio))
+		return r_hand
+	if(istype(l_hand, /obj/item/device/radio))
+		return l_hand
 	return null
 
 /mob/living/carbon/human/handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name, successful_radio, whisper, var/is_singing = FALSE)
@@ -176,7 +182,7 @@
 			var/obj/item/device/radio/R = get_radio()
 			if(R)
 				used_radios += R
-				if(R.talk_into(src, message, null, verb, speaking))
+				if(R.talk_into(src, message, isAdminLevel(z) ? "department" : null, verb, speaking))
 					successful_radio += R
 		if("right ear")
 			var/obj/item/device/radio/R

--- a/html/changelogs/doxxmedearly-radiohelp.yml
+++ b/html/changelogs/doxxmedearly-radiohelp.yml
@@ -1,0 +1,5 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - tweak: "Using ; to send radio messages while on an admin z-level, such as centcomm, ert, and antag bases, will send the message to your department channel, aka your :h key channel, to prevent miscomms from antags or event setup. You can still use :a to type on common."
+  - tweak: "You can use ; to talk into handheld radios instead of having to use :r and :l, provided you are not wearing a headset or wristbound, as those are given priority. It will only broadcast to the channel it's set to, as usual."


### PR DESCRIPTION
; can now be used to talk into your handheld radio, instead of using :r or :l, but only if you aren't wearing a headset/wristbound radio.

When on an admin z level, ; will send to your department headset (Response Team for ERT/CCIA, antag frequency for mercs/ninjas/burgs, etc) instead of the common frequency. Apparently it's stupidly easy to accidentally talk on common as an antag. This should help avert any disastrous faux pas. When on station, the radio is normal. 