### PR TITLE
Damage Readout Tweak

### DIFF
--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -751,7 +751,7 @@
 		if(!AN && !open && !infected && !imp)
 			AN = "None:"
 		if(!e.is_stump())
-			dat += "<td>[e.name]</td><td>[e.burn_dam]</td><td>[get_severity(e.brute_dam, TRUE)]</td><td>[robot][bled][AN][splint][open][infected][imp][dislocated][internal_bleeding][severed_tendon][lung_ruptured]</td>"
+			dat += "<td>[e.name]</td><td>[get_severity(e.burn_dam, TRUE)]</td><td>[get_severity(e.brute_dam, TRUE)]</td><td>[robot][bled][AN][splint][open][infected][imp][dislocated][internal_bleeding][severed_tendon][lung_ruptured]</td>"
 		else
 			dat += "<td>[e.name]</td><td>-</td><td>-</td><td>Not [e.is_stump() ? "Found" : "Attached Completely"]</td>"
 		dat += "</tr>"

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -317,7 +317,7 @@
 		if(!AN && !open && !infected && !imp)
 			AN = "None:"
 		if(!e.is_stump())
-			dat += "<td>[e.name]</td><td>[e.burn_dam]</td><td>[get_severity(e.brute_dam, TRUE)]</td><td>[robot][bled][AN][splint][open][infected][imp][dislocated][internal_bleeding][severed_tendon][lung_ruptured]</td>"
+			dat += "<td>[e.name]</td><td>[get_severity(e.burn_dam, TRUE)]</td><td>[get_severity(e.brute_dam, TRUE)]</td><td>[robot][bled][AN][splint][open][infected][imp][dislocated][internal_bleeding][severed_tendon][lung_ruptured]</td>"
 		else
 			dat += "<td>[e.name]</td><td>-</td><td>-</td><td>Not [e.is_stump() ? "Found" : "Attached Completely"]</td>"
 		dat += "</tr>"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -53,6 +53,10 @@ BREATH ANALYZER
 	var/output = "none"
 	if(!amount)
 		output = "none"
+	else if(amount > 100)
+		output = "fatal"
+	else if(amount > 75)
+		output = "critical"
 	else if(amount > 50)
 		output = "severe"
 	else if(amount > 25)

--- a/html/changelogs/more_damage_readouts.yml
+++ b/html/changelogs/more_damage_readouts.yml
@@ -1,0 +1,7 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - rscadd: "Added two more reading outputs for damage. The cap for damage readout now is Fatal (over 100 damage), in contrast to Severe (over 50 damage)."
+  - bugfix: "Fixed the Burn Severity reading from being hard numbers to the minor/moderate/significant/severe/critical/fatal."


### PR DESCRIPTION
* Adds two damage reading outputs: Critical (over 75 damage), and Fatal (over 100 damage).
* Fixes the Burn Severity reading being hard numbers, intead being like how Physical Trauma does it (minor/moderate/significant/... etc)

To note:
This isn't updated for the Body Scanners yet since I'm scared of VueUI and I'll touch it carefully in a separate PR

**Critical, Fatal and No More Burn Hard Numbers**
![](https://i.imgur.com/hD6bCS6.png)