### PR TITLE
Fix uplinks not working off-station (for real this time)

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -173,8 +173,7 @@
 			if((!computer.registered_id && !computer.register_account(src)))
 				return
 	if(service_state == PROGRAM_STATE_DISABLED)
-		if(!computer.enable_service(null, user, src))
-			return
+		computer.enable_service(null, user, src)
 	return ..(user)
 
 /datum/computer_file/program/chat_client/event_registered()

--- a/html/changelogs/johnwildkins-uplinkbruh.yml
+++ b/html/changelogs/johnwildkins-uplinkbruh.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed antag uplinks not working off-station (for real this time). Chat clients on PDAs can now be opened off-Horizon, but with limited functionality."

--- a/vueui/src/components/view/mcomputer/chat/index.vue
+++ b/vueui/src/components/view/mcomputer/chat/index.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
-    <h2 v-if="!s.service" class="red">Chat service is not enabled, please enable it from main menu.</h2>
-    <h2 v-else-if="!s.registered" class="red">No registered user detected.</h2>
+    <h2 v-if="!s.registered" class="red">No registered user detected.</h2>
     <template v-else>
       <div>
         <vui-button v-if="s.can_netadmin_mode || s.netadmin_mode" :class="{ on: s.netadmin_mode }" :params="{toggleadmin: 1}">Admin Mode</vui-button>


### PR DESCRIPTION
I forgor that chat clients have a service they rely on, and the service shuts down and won't boot up if you're off z-level
This removes that requirement so you can have the window open (and only access ringtone settings)