### PR TITLE
Removes duplicate corporate uniforms + jackets from FR job lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -88,8 +88,6 @@
 	new /obj/item/storage/backpack/medic(src)
 	new /obj/item/clothing/suit/storage/medical_chest_rig(src)
 	new /obj/item/clothing/under/rank/medical/first_responder(src)
-	new /obj/item/clothing/under/rank/medical/first_responder/zeng(src)
-	new /obj/item/clothing/under/rank/medical/first_responder/pmc(src)
 	new /obj/item/clothing/shoes/jackboots(src)
 	new /obj/item/device/flashlight/pen(src)
 	new /obj/item/clothing/accessory/stethoscope(src)
@@ -104,8 +102,6 @@
 	new /obj/item/clothing/mask/gas/half(src)
 	new /obj/item/auto_cpr(src)
 	new /obj/item/clothing/suit/storage/toggle/fr_jacket(src)
-	new /obj/item/clothing/suit/storage/toggle/fr_jacket/zeng(src)
-	new /obj/item/clothing/suit/storage/toggle/fr_jacket/pmc(src)
 
 
 /obj/structure/closet/secure_closet/CMO

--- a/html/changelogs/omicega-fdsifdsijofdsijofirew.yml
+++ b/html/changelogs/omicega-fdsifdsijofdsijofirew.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Adjusts first responder locker contents a little. Most of the duplicate jackets are gone, and now the room only has one toolbox instead of four."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -901,7 +901,7 @@
 "avl" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/table/standard,
-/obj/item/storage/toolbox,
+/obj/item/storage/toolbox/mechanical,
 /obj/item/reagent_containers/hypospray{
 	pixel_x = 5
 	},

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -825,11 +825,6 @@
 	c_tag = "Medical - First Responder Room"
 	},
 /obj/structure/closet/secure_closet/medical_fr,
-/obj/item/storage/toolbox/emergency,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -1;
-	pixel_y = 5
-	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "auG" = (
@@ -906,6 +901,7 @@
 "avl" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/table/standard,
+/obj/item/storage/toolbox,
 /obj/item/reagent_containers/hypospray{
 	pixel_x = 5
 	},
@@ -42977,11 +42973,6 @@
 	pixel_y = 32
 	},
 /obj/structure/closet/secure_closet/medical_fr,
-/obj/item/storage/toolbox/emergency,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -1;
-	pixel_y = 5
-	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "xBX" = (


### PR DESCRIPTION
See title. Also, for some reason someone mapped 4 separate toolboxes directly into the Horizon map, rather than just adding them to the responder locker's `fill()` proc. I got rid of those, and now the room only has one toolbox in it. That's all it really needs.