### PR TITLE
Merc Shuttle Has Windows at the Cockpit Again + Inflatables

### DIFF
--- a/html/changelogs/wickedcybs_mercwindow.yml
+++ b/html/changelogs/wickedcybs_mercwindow.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - tweak: "The mercenary ship has windows at the cockpit area again."
+  - rscadd: "Adds one inflatables box to the merc ship."

--- a/html/changelogs/wickedcybs_mercwindow.yml
+++ b/html/changelogs/wickedcybs_mercwindow.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "The mercenary ship has windows at the cockpit area again."

--- a/maps/sccv_horizon/sccv_horizon-4_centcomm.dmm
+++ b/maps/sccv_horizon/sccv_horizon-4_centcomm.dmm
@@ -2024,7 +2024,8 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /obj/item/ammo_magazine/assault_shotgun,
 /obj/item/ammo_magazine/assault_shotgun,
@@ -6725,7 +6726,8 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station)
@@ -6811,7 +6813,8 @@
 "apn" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -7300,7 +7303,8 @@
 "aqR" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -7311,7 +7315,8 @@
 "aqS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -7319,7 +7324,8 @@
 "aqT" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -7519,7 +7525,8 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station)
@@ -7527,7 +7534,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station)
@@ -7899,7 +7907,8 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station/warehouse)
@@ -7946,7 +7955,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station/warehouse)
@@ -7957,7 +7967,8 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station/warehouse)
@@ -8445,7 +8456,8 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /turf/simulated/floor/plating,
 /area/merchant_station/warehouse)
@@ -10083,7 +10095,8 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /obj/item/paper_bin{
 	pixel_x = -2;
@@ -10404,7 +10417,8 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -19955,7 +19969,8 @@
 /area/centcom/legion)
 "aWj" = (
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -19991,7 +20006,8 @@
 /area/centcom/legion)
 "aWm" = (
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -21848,7 +21864,8 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /turf/unsimulated/floor{
 	icon_state = "new_reinforced"
@@ -22820,7 +22837,8 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /turf/unsimulated/floor/plating,
 /area/centcom/legion/hangar5)
@@ -22828,7 +22846,8 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -23885,7 +23904,8 @@
 /area/centcom/legion/hangar5)
 "bdY" = (
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -23925,7 +23945,8 @@
 /area/centcom/legion/hangar5)
 "beb" = (
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -23979,7 +24000,8 @@
 /area/centcom/legion/hangar5)
 "bee" = (
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -29550,7 +29572,8 @@
 /area/shuttle/mercenary)
 "bqq" = (
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -34850,13 +34873,15 @@
 "bGp" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /turf/unsimulated/wall/riveted,
 /area/template_noop)
 "bGq" = (
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /obj/structure/window/reinforced,
 /turf/unsimulated/wall/riveted,
@@ -37242,6 +37267,21 @@
 	},
 /turf/simulated/floor/holofloor/grass,
 /area/horizon/holodeck/source_dininghall)
+"duV" = (
+/obj/structure/window/reinforced{
+	maxhealth = 140
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	maxhealth = 140
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	maxhealth = 140
+	},
+/obj/structure/grille,
+/turf/simulated/floor/shuttle/advanced,
+/area/shuttle/mercenary)
 "dwR" = (
 /obj/structure/flora/grass/green,
 /turf/simulated/floor/holofloor/snow,
@@ -37318,6 +37358,17 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/holofloor/grass,
 /area/horizon/holodeck/source_dininghall)
+"fPY" = (
+/obj/structure/window/reinforced{
+	maxhealth = 140
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	maxhealth = 140
+	},
+/obj/structure/grille,
+/turf/simulated/floor/shuttle/advanced,
+/area/shuttle/mercenary)
 "fQK" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -37365,6 +37416,15 @@
 /turf/simulated/floor/holofloor/reinforced,
 /area/horizon/holodeck/source_battlemonsters)
 "hTO" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	maxhealth = 140
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	maxhealth = 140
+	},
+/obj/structure/grille,
 /turf/simulated/floor/shuttle/advanced,
 /area/shuttle/mercenary)
 "hYO" = (
@@ -37438,6 +37498,22 @@
 	},
 /turf/simulated/floor/holofloor/wood,
 /area/horizon/holodeck/source_battlemonsters)
+"nCh" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	maxhealth = 140
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	maxhealth = 140
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	maxhealth = 140
+	},
+/obj/structure/grille,
+/turf/simulated/floor/shuttle/advanced,
+/area/shuttle/mercenary)
 "olV" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -37478,7 +37554,8 @@
 /area/template_noop)
 "rlY" = (
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 1;
+	maxhealth = 140
 	},
 /turf/unsimulated/wall/riveted,
 /area/template_noop)
@@ -37510,10 +37587,40 @@
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/horizon/holodeck/source_boxingcourt)
+"sPP" = (
+/obj/structure/window/reinforced{
+	maxhealth = 140
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	maxhealth = 140
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	maxhealth = 140
+	},
+/obj/structure/grille,
+/turf/simulated/floor/shuttle/advanced,
+/area/shuttle/mercenary)
 "tIz" = (
 /obj/structure/flora/grass/brown,
 /turf/simulated/floor/holofloor/snow,
 /area/horizon/holodeck/source_snowfield)
+"url" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	maxhealth = 140
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	maxhealth = 140
+	},
+/obj/structure/window/reinforced{
+	maxhealth = 140
+	},
+/obj/structure/grille,
+/turf/simulated/floor/shuttle/advanced,
+/area/shuttle/mercenary)
 "vMz" = (
 /obj/structure/dueling_table/no_collide{
 	icon_state = "bottom_right"
@@ -42647,9 +42754,9 @@ aaa
 aaa
 aaa
 bxw
+nCh
 hTO
-hTO
-hTO
+url
 bxw
 bxw
 bjG
@@ -42903,7 +43010,7 @@ aaa
 aaa
 aaa
 aaa
-hTO
+duV
 bfX
 bgO
 bhB
@@ -43160,7 +43267,7 @@ aaa
 aaa
 aaa
 aaa
-hTO
+fPY
 bfY
 bgP
 bhC
@@ -43417,7 +43524,7 @@ aaa
 aaa
 aaa
 aaa
-hTO
+sPP
 bfZ
 bgQ
 bhD
@@ -43675,9 +43782,9 @@ aaa
 aaa
 aaa
 bxw
+nCh
 hTO
-hTO
-hTO
+url
 bxw
 bxw
 bjK

--- a/maps/sccv_horizon/sccv_horizon-4_centcomm.dmm
+++ b/maps/sccv_horizon/sccv_horizon-4_centcomm.dmm
@@ -26816,8 +26816,15 @@
 /area/shuttle/mercenary)
 "bkr" = (
 /obj/structure/table/reinforced,
-/obj/item/airbubble/syndie,
-/obj/item/airbubble/syndie,
+/obj/item/airbubble/syndie{
+	pixel_y = 4
+	},
+/obj/item/airbubble/syndie{
+	pixel_y = 4
+	},
+/obj/item/storage/bag/inflatable{
+	pixel_y = -5
+	},
 /turf/simulated/floor/shuttle/black,
 /area/shuttle/mercenary)
 "bkt" = (

--- a/maps/sccv_horizon/sccv_horizon-4_centcomm.dmm
+++ b/maps/sccv_horizon/sccv_horizon-4_centcomm.dmm
@@ -37358,10 +37358,6 @@
 /turf/simulated/floor/holofloor/reinforced,
 /area/horizon/holodeck/source_battlemonsters)
 "hTO" = (
-/obj/structure/window/full{
-	maxhealth = 100
-	},
-/obj/structure/grille,
 /turf/simulated/floor/shuttle/advanced,
 /area/shuttle/mercenary)
 "hYO" = (
@@ -42643,7 +42639,7 @@ aaa
 aaa
 aaa
 aaa
-hTO
+bxw
 hTO
 hTO
 hTO
@@ -43671,7 +43667,7 @@ aaa
 aaa
 aaa
 aaa
-hTO
+bxw
 hTO
 hTO
 hTO

--- a/maps/sccv_horizon/sccv_horizon-4_centcomm.dmm
+++ b/maps/sccv_horizon/sccv_horizon-4_centcomm.dmm
@@ -37357,6 +37357,13 @@
 	},
 /turf/simulated/floor/holofloor/reinforced,
 /area/horizon/holodeck/source_battlemonsters)
+"hTO" = (
+/obj/structure/window/full{
+	maxhealth = 100
+	},
+/obj/structure/grille,
+/turf/simulated/floor/shuttle/advanced,
+/area/shuttle/mercenary)
 "hYO" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -42636,10 +42643,10 @@ aaa
 aaa
 aaa
 aaa
-bxw
-bxw
-bxw
-bxw
+hTO
+hTO
+hTO
+hTO
 bxw
 bxw
 bjG
@@ -42893,7 +42900,7 @@ aaa
 aaa
 aaa
 aaa
-bxw
+hTO
 bfX
 bgO
 bhB
@@ -43150,7 +43157,7 @@ aaa
 aaa
 aaa
 aaa
-bxw
+hTO
 bfY
 bgP
 bhC
@@ -43407,7 +43414,7 @@ aaa
 aaa
 aaa
 aaa
-bxw
+hTO
 bfZ
 bgQ
 bhD
@@ -43664,10 +43671,10 @@ aaa
 aaa
 aaa
 aaa
-bxw
-bxw
-bxw
-bxw
+hTO
+hTO
+hTO
+hTO
 bxw
 bxw
 bjK


### PR DESCRIPTION
The change to the Horizon had the Merc ship changed a bit, and one of those changes was essentially making it so the entirety of the ship is only surrounded by un-interactable walls that can only be blown open. The only entrance would be the dock. The windows were an important part of the balance and aesthetics, giving people options. So I've added those back.

![image](https://user-images.githubusercontent.com/52309324/171068193-f15720a6-cd1f-474b-b3d6-9c1a45be710c.png)

The reinforced windows have had their health buffed compared to the usual.



