### PR TITLE
Allows you to take butanol in loadout flasks/thermos etc

### DIFF
--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -113,7 +113,6 @@ var/list/lunchables_drink_reagents_ = list(
 // This default list is a bit different, it contains items we don't want
 var/list/lunchables_alcohol_reagents_ = list(
 	/decl/reagent/alcohol,
-	/decl/reagent/alcohol/butanol,
 	/decl/reagent/alcohol/acid_spit,
 	/decl/reagent/alcohol/atomicbomb,
 	/decl/reagent/alcohol/beepsky_smash,

--- a/html/changelogs/anconfuzedrock-butanolflask.yml
+++ b/html/changelogs/anconfuzedrock-butanolflask.yml
@@ -1,0 +1,6 @@
+author: anconfuzedrock
+
+delete-after: True
+
+changes:
+  - tweak: "You can now take butanol in your loadout flask, just like yummy toothpaste or ethanol."


### PR DESCRIPTION
you can take a wide variety of drinks in loadout snax, including raw ethanol and toothpaste. Why not butanol? Adds butanol to the list, by removing it from the list of things to not allow in loadout snax.
Soorta an Unathi thing so asked petrichor, they're cool with it.