### PR TITLE
Removes stunning from headshots.

### DIFF
--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -146,21 +146,6 @@
 						take_internal_damage(1)
 	..()
 
-/obj/item/organ/internal/brain/take_internal_damage(var/damage, var/silent)
-	set waitfor = 0
-	..()
-	if(damage >= (max_damage / 5)) //This probably won't be triggered by oxyloss or mercury. Probably.
-		var/damage_secondary = damage * 0.20
-		owner.eye_blurry += damage_secondary
-		owner.confused += damage_secondary * 2
-		owner.Weaken(round(damage_secondary * 3, 1))
-		if(prob(30))
-			addtimer(CALLBACK(src, .proc/brain_damage_callback, damage), rand(6, 20) SECONDS, TIMER_UNIQUE)
-
-/obj/item/organ/internal/brain/proc/brain_damage_callback(var/damage) //Confuse them as a somewhat uncommon aftershock. Side note: Only here so a spawn isn't used. Also, for the sake of a unique timer.
-	to_chat(owner, "<span class = 'notice'><font size=3><B>I can't remember which way is forward...</B></font></span>")
-	owner?.confused += damage
-
 /obj/item/organ/internal/brain/proc/handle_severe_brain_damage()
 	set waitfor = FALSE
 	healed_threshold = 0

--- a/html/changelogs/mattatlas-baycoderemnants.yml
+++ b/html/changelogs/mattatlas-baycoderemnants.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Headshots no longer stun with weapons that do equal to or over 40 damage."


### PR DESCRIPTION
Relic feature from Bay, leads to combat becoming "who can proc the weaken first" which is ass and gives antags a disproportionate advantage if someone gets a lucky headshot.

I think when I was altering the number here (default damage required on bay is 20) I had the intention making it trigger only on pointblanks, but I forgot that ARs/revolvers/etc do 40 damage. So I just got rid of it to avoid combat becoming a cheese fest of "who gets pointblanks first".