### PR TITLE
Tech storage buffs, engineering wood plus pipe wrenches in lockers.

### DIFF
--- a/html/changelogs/mattatlas-engibuffs.yml
+++ b/html/changelogs/mattatlas-engibuffs.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Engineering now gets a stack of wood in their locker room."
+  - maptweak: "Added some pipe wrenches to Engineering lockers."
+  - maptweak: "Added more spare parts to tech storage."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -6329,6 +6329,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage/tech)
 "dsw" = (
@@ -17043,6 +17045,7 @@
 /obj/item/storage/belt/utility,
 /obj/item/device/gps/engineering,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/pipewrench,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "jlQ" = (
@@ -27019,6 +27022,7 @@
 /obj/item/stack/material/glass/phoronrglass{
 	amount = 20
 	},
+/obj/item/stack/material/wood/full,
 /turf/simulated/floor/tiled,
 /area/engineering/storage_eva)
 "oPE" = (
@@ -36139,6 +36143,8 @@
 /obj/structure/table/steel,
 /obj/item/circuitboard/arcade/orion_trail,
 /obj/item/circuitboard/arcade/battle,
+/obj/item/stock_parts/console_screen,
+/obj/item/stock_parts/console_screen,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage/tech)
 "tKs" = (
@@ -39110,6 +39116,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/scanning_module,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage/tech)
 "voX" = (
@@ -41428,6 +41437,7 @@
 /obj/item/storage/belt/utility,
 /obj/item/device/gps/engineering,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/pipewrench,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "wrK" = (


### PR DESCRIPTION
  - Engineering now gets a stack of wood in their locker room.
  - Added some pipe wrenches to Engineering lockers.
  - Added more spare parts to tech storage.

Tech storage is currently far worse than the Aurora counterpart and you can't even make an autolathe with the parts in there.
Wood is not present in Engineering, so outside of using cargo the chapel or the library cannot be fixed.
Pipewrenches are once again available to everyone, as they are vital for dismantling pipes after buffing distro.