### PR TITLE
Round of small bugfixes

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -14,7 +14,7 @@
 	var/storage_cost
 	var/slot_flags = 0		//This is used to determine on which slots an item can fit.
 	var/no_attack_log = 0			//If it's an item we don't want to log attack_logs with, set this to 1
-	pass_flags = PASSTABLE
+	pass_flags = PASSTABLE | PASSRAILING
 	var/obj/item/master
 
 	var/heat_protection = 0 //flags which determine which body parts are protected from heat. Use the HEAD, UPPER_TORSO, LOWER_TORSO, etc. flags. See setup.dm

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -19,15 +19,23 @@
 	drop_sound = 'sound/items/drop/gascan.ogg'
 	pickup_sound = 'sound/items/pickup/gascan.ogg'
 
-/obj/item/reagent_containers/extinguisher_refill/attackby(var/obj/O as obj, var/mob/user as mob)
+/obj/item/reagent_containers/extinguisher_refill/attackby(obj/item/O, mob/user)
+	if(O.isscrewdriver())
+		if(is_open_container())
+			flags &= ~OPENCONTAINER
+		else
+			flags |= OPENCONTAINER
+		to_chat(user, SPAN_NOTICE("Using \the [O], you [is_open_container() ? "unsecure" : "secure"] the cartridge's lid!"))
+		return TRUE
+
 	if(istype(O,/obj/item/extinguisher))
 		var/obj/item/extinguisher/E = O
-		if(src.is_open_container())
+		if(is_open_container())
 			to_chat(user,"<span class='notice'>\The [src] needs to be secured first!</span>")
-		else if(src.reagents.total_volume <= 0)
+		else if(reagents.total_volume <= 0)
 			to_chat(user,"<span class='notice'>\The [src] is empty!</span>")
 		else if(E.reagents.total_volume < E.reagents.maximum_volume)
-			src.reagents.trans_to(E, src.reagents.total_volume)
+			reagents.trans_to(E, src.reagents.total_volume)
 			user.visible_message("<span class='notice'>[user] fills \the [E] with the [src].</span>", "<span class='notice'>You fill \the [E] with the [src].</span>")
 			playsound(E.loc, 'sound/items/stimpack.ogg', 50, 1)
 		else
@@ -46,13 +54,6 @@
 	else
 		to_chat(user,"<span class='notice'>\The reagents inside [src] are already secured!</span>")
 	return
-
-/obj/item/reagent_containers/extinguisher_refill/attackby(obj/item/W, mob/user)
-	if(W.isscrewdriver() && !is_open_container())
-		to_chat(user,"<span class='notice'>Using \the [W], you unsecure the extinguisher refill cartridge's lid.</span>") // it locks shut after being secured
-		flags |= OPENCONTAINER
-		return TRUE
-	. = ..()
 
 /obj/item/reagent_containers/extinguisher_refill/examine(var/mob/user) //Copied from inhalers.
 	if(!..(user, 2))

--- a/code/game/objects/items/weapons/implants/implantfreedom.dm
+++ b/code/game/objects/items/weapons/implants/implantfreedom.dm
@@ -5,56 +5,59 @@
 	desc = "Use this to escape from those evil Red Shirts."
 	implant_color = "r"
 	var/activation_emote = "chuckle"
-	var/uses = 1.0
+	var/uses = 1
 
+/obj/item/implant/freedom/New()
+	uses = rand(1, 5)
+	..()
 
-	New()
-		src.activation_emote = pick("blink", "blink_r", "eyebrow", "chuckle", "twitch", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
-		src.uses = rand(1, 5)
-		..()
+/obj/item/implant/freedom/trigger(emote, mob/living/carbon/source)
+	if(!activation_emote)
 		return
-
-
-	trigger(emote, mob/living/carbon/source as mob)
-		if (src.uses < 1)	return 0
-		if (emote == src.activation_emote)
-			src.uses--
-			to_chat(source, "You feel a faint click.")
-			if (source.handcuffed)
-				var/obj/item/W = source.handcuffed
-				source.handcuffed = null
-				if(source.buckled_to && source.buckled_to.buckle_require_restraints)
-					source.buckled_to.unbuckle()
-				source.update_inv_handcuffed()
-				if (source.client)
-					source.client.screen -= W
-				if (W)
-					W.forceMove(source.loc)
-					dropped(source)
-					if (W)
-						W.layer = initial(W.layer)
-			if (source.legcuffed)
-				var/obj/item/W = source.legcuffed
-				source.legcuffed = null
-				source.update_inv_legcuffed()
-				if (source.client)
-					source.client.screen -= W
-				if (W)
-					W.forceMove(source.loc)
-					dropped(source)
-					if (W)
-						W.layer = initial(W.layer)
+	if(uses < 1)
+		to_chat(source, SPAN_WARNING("\The [src] gives a faint beep inside your head, indicating that it's out of uses!"))
+		activation_emote = null //Disable this to allow them to emote normally
 		return
+	if(emote == activation_emote)
+		uses--
+		to_chat(source, "You feel a faint click.")
+		if(source.handcuffed)
+			var/obj/item/W = source.handcuffed
+			source.handcuffed = null
+			if(source.buckled_to && source.buckled_to.buckle_require_restraints)
+				source.buckled_to.unbuckle()
+			source.update_inv_handcuffed()
+			if(source.client)
+				source.client.screen -= W
+			if(W)
+				W.forceMove(source.loc)
+				dropped(source)
+				if (W)
+					W.layer = initial(W.layer)
+		if(source.legcuffed)
+			var/obj/item/W = source.legcuffed
+			source.legcuffed = null
+			source.update_inv_legcuffed()
+			if(source.client)
+				source.client.screen -= W
+			if(W)
+				W.forceMove(source.loc)
+				dropped(source)
+				if(W)
+					W.layer = initial(W.layer)
+	return
 
 
-	implanted(mob/living/carbon/source)
-		source.mind.store_memory("Freedom implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.", 0, 0)
-		to_chat(source, "The implanted freedom implant can be activated by using the [src.activation_emote] emote, <B>say *[src.activation_emote]</B> to attempt to activate.")
-		return 1
+/obj/item/implant/freedom/implanted(mob/living/carbon/source)
+	activation_emote = input("Choose activation emote:") in list("blink", "blink_r", "eyebrow", "chuckle", "twitch", "frown", "nod", "blush", "giggle", "grin", "groan", "shrug", "smile", "pale", "sniff", "whimper", "wink")
+	if(source.mind)
+		source.mind.store_memory("\The [src] can be activated by using the [activation_emote] emote, <B>say *[activation_emote]</B> to attempt to activate.")
+	to_chat(source, "The implanted [src] can be activated by using the [activation_emote] emote, <B>say *[activation_emote]</B> to attempt to activate.")
+	return TRUE
 
 
-	get_data()
-		var/dat = {"
+/obj/item/implant/freedom/get_data()
+	var/dat = {"
 <b>Implant Specifications:</b><BR>
 <b>Name:</b> Freedom Beacon<BR>
 <b>Life:</b> optimum 5 uses<BR>
@@ -68,4 +71,4 @@ mechanisms<BR>
 <b>Integrity:</b> The battery is extremely weak and commonly after injection its
 life can drive down to only 1 use.<HR>
 No Implant Specifics"}
-		return dat
+	return dat

--- a/code/game/objects/structures/gore/tendrils.dm
+++ b/code/game/objects/structures/gore/tendrils.dm
@@ -5,6 +5,7 @@
 	desc = "Bloody, pulsating tendrils."
 	icon_state = "tendril"
 	maxHealth = 40
+	pass_flags = PASSTABLE | PASSMOB | PASSTRACE | PASSRAILING
 	var/being_destroyed = FALSE
 	var/is_node = FALSE
 	var/obj/structure/gore/tendrils/node/linked_node = null
@@ -113,14 +114,9 @@
 	var/D = pick(dirs_left)
 	var/turf/T = get_step(U, D)
 
-	var/obj/machinery/door/MD = locate() in T
-	if(MD?.density)
+	if(!T.Enter(src)) //Uses the pass_flags to make sure we can go under tables and things, but not walls and windows
 		return
-	var/obj/structure/simple_door/SD = locate() in T
-	if(SD?.density)
-		return
-
-	if(!isturf(T) || T.is_hole || T.is_space() || T.density || locate(/obj/structure/gore/tendrils, T))
+	if(!isturf(T) || T.is_hole || T.is_space() || locate(/obj/structure/gore/tendrils, T))
 		dirs_left -= D
 		return
 

--- a/code/modules/mob/abstract/new_player/sprite_accessories.dm
+++ b/code/modules/mob/abstract/new_player/sprite_accessories.dm
@@ -1407,11 +1407,11 @@ Follow by example and make good judgement based on length which list to include 
 			icon_state = "horny"
 
 		headtails
-			name = "Headtails"
+			name = "Head tails"
 			icon_state = "headtails"
 
 		headtails_2
-			name = "Headtails 2"
+			name = "Head tails 2"
 			icon_state = "headtails2"
 
 		tiny_eye

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -379,12 +379,13 @@ var/list/slot_equipment_priority = list( \
 				to_chat(src, SPAN_NOTICE("You offer \the [I] to \the [target]."))
 				do_give(H)
 			return TRUE
+
 		var/turf/T = get_turf(target)
-		if(T.contains_dense_objects()) //Walls, windows, etc. Can't put things inside of them!
+		if(T.contains_dense_objects() && !istype(target, /obj/structure/table)) //Stop at dense objects, like walls and windows. Allow placing on tables.
 			return TRUE //Takes off throw mode
 		remove_from_mob(I)
 		make_item_drop_sound(I)
-		I.forceMove(get_turf(target))
+		I.forceMove(T)
 		return TRUE
 
 	remove_from_mob(item)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -379,6 +379,9 @@ var/list/slot_equipment_priority = list( \
 				to_chat(src, SPAN_NOTICE("You offer \the [I] to \the [target]."))
 				do_give(H)
 			return TRUE
+		var/turf/T = get_turf(target)
+		if(T.contains_dense_objects()) //Walls, windows, etc. Can't put things inside of them!
+			return TRUE //Takes off throw mode
 		remove_from_mob(I)
 		make_item_drop_sound(I)
 		I.forceMove(get_turf(target))

--- a/code/modules/research/xenoarchaeology/tools/ano_device_battery.dm
+++ b/code/modules/research/xenoarchaeology/tools/ano_device_battery.dm
@@ -184,7 +184,7 @@
 
 /obj/item/anodevice/proc/UpdateSprite()
 	if(!inserted_battery)
-		icon_state = "anodev"
+		icon_state = initial(icon_state)
 		return
 	var/p = (inserted_battery.stored_charge/inserted_battery.capacity)*100
 	p = min(p, 100)

--- a/html/changelogs/doxxmedearly-smallfixes.yml
+++ b/html/changelogs/doxxmedearly-smallfixes.yml
@@ -5,6 +5,7 @@ changes:
   - bugfix: "Diona can now take the headtails 'hair' option again."
   - bugfix: "Anomaly power utilizers no longer go invisible when a battery is removed."
   - bugfix: "Morph turfs no longer spread through windows or doors, unless the door is open."
+  - bugfix: "You can now throw items over railing again."
   - bugfix: "Freedom implants now allow you to select a trigger emote, instead of randomly selecting one you may not be able to use."
   - tweak: "Freedom implants are now more obvious when they're out of uses."
   - tweak: "You can now secure extinguisher refill canisters with a screwdriver, giving a way for borgs and drones to refill their extinguishers."

--- a/html/changelogs/doxxmedearly-smallfixes.yml
+++ b/html/changelogs/doxxmedearly-smallfixes.yml
@@ -1,0 +1,10 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "You can no longer put items in walls by throwing on help intent."
+  - bugfix: "Diona can now take the headtails 'hair' option again."
+  - bugfix: "Anomaly power utilizers no longer go invisible when a battery is removed."
+  - bugfix: "Morph turfs no longer spread through windows or doors, unless the door is open."
+  - bugfix: "Freedom implants now allow you to select a trigger emote, instead of randomly selecting one you may not be able to use."
+  - tweak: "Freedom implants are now more obvious when they're out of uses."
+  - tweak: "You can now secure extinguisher refill canisters with a screwdriver, giving a way for borgs and drones to refill their extinguishers."


### PR DESCRIPTION
Fixes #14053
Two hairstyles having the same name eliminated one of the options. Added a space to make it unique.

Fixes #13842
Morph turfs now use pass flags so they can spread under dense items, like tables, closets, railings, computers, etc., but not through closed doors or windows. 

Fixes #9763
Drones could not use refill canisters as they had no way to secure it. Now they can secure it with a screwdriver, and thus refill. With their multipurpose grippers, they should be able to refill the canisters at the tanks.

Fixes #12216
Allows you to select an emote trigger, rather than just having one given to you.

Fixes #14129
Help intent throw-putting now checks for density, so items are no longer able to be put in walls, windows, etc.

Fixes #14028
Fixes #12259
Taking out the battery was setting to sprite to an invalid icon_state

Fixes #14161
obj/item was not given the PASSRAILING flag, so items were unable to pass railings when thrown. 
