### PR TITLE
Updating sprite_accessories.dm to include previously unused markings + minor bug fix

### DIFF
--- a/code/modules/mob/abstract/new_player/sprite_accessories.dm
+++ b/code/modules/mob/abstract/new_player/sprite_accessories.dm
@@ -1005,19 +1005,19 @@ Follow by example and make good judgement based on length which list to include 
 		icon_state = "hair_ponytail_short"
 		length = 2
 		chatname = "short ponytail"
-			
+
 	ponytail_short2
 		name = "Ponytail, Short 2"
 		icon_state = "hair_ponytail_short2"
 		length = 2
 		chatname = "short ponytail"
-			
+
 	ponytail_short3
 		name = "Ponytail, Short 3"
 		icon_state = "hair_ponytail_short3"
 		length = 2
 		chatname = "short ponytail"
-			
+
 	ponytail_short4
 		name = "Ponytail, Short 4"
 		icon_state = "hair_ponytail_short4"
@@ -2380,7 +2380,7 @@ Follow by example and make good judgement based on length which list to include 
 			icon_state = "skrell_excited"
 			length = 6
 			chatname = "headtails"
-		
+
 		skr_tentacle_insulted
 			name = "Expressive Headtails, insulted"
 			icon_state = "skrell_insulted"
@@ -3708,7 +3708,7 @@ Follow by example and make good judgement based on length which list to include 
 		tuux_chops
 			name = "Tuux Chops"
 			icon_state = "Tuux_Chops"
-			
+
 		tuux_chops_big
 			name = "Tuux Chops (Big)"
 			icon_state = "Tuux_Chops_Big"
@@ -3736,19 +3736,19 @@ Follow by example and make good judgement based on length which list to include 
 		tuux_mustache
 			name = "Tuux Stache"
 			icon_state = "Tuux_Mustache"
-			
+
 		tuux_overgrown
 			name = "Tuux Overgrown"
 			icon_state = "Tuux_Overgrown"
-			
+
 		tuux_braided
 			name = "Tuux Braided"
 			icon_state = "Tuux_Braided"
-			
+
 		tuux_braided_long
 			name = "Tuux Braided (Long)"
 			icon_state = "Tuux_Braided_Long"
-			
+
 		tuux_braided_double
 			name = "Tuux Braided (Double)"
 			icon_state = "Tuux_Braided_Double"
@@ -4116,6 +4116,24 @@ Follow by example and make good judgement based on length which list to include 
 		icon_state = "aug_abdomenports"
 		body_parts = list(BP_CHEST)
 		species_allowed = list(/datum/species/human, /datum/species/human/offworlder, /datum/species/machine/shell, /datum/species/diona, /datum/species/diona/coeu, /datum/species/skrell,/datum/species/skrell/axiori, /datum/species/tajaran, /datum/species/tajaran/zhan_khazan, /datum/species/tajaran/m_sai, /datum/species/unathi, /datum/species/bug, /datum/species/bug/type_b)
+
+	aug_lowerjaw
+		name = "Augment (Lower Jaw)"
+		icon_state = "aug_lowerjaw"
+		body_parts = list(BP_HEAD)
+		species_allowed = list(/datum/species/human, /datum/species/human/offworlder, /datum/species/machine/shell, /datum/species/skrell,/datum/species/skrell/axiori,/datum/species/unathi)
+
+	aug_headcase
+		name = "Augment (Headcase)"
+		icon_state = "aug_headcase"
+		body_parts = list(BP_HEAD)
+		species_allowed = list(/datum/species/human, /datum/species/human/offworlder, /datum/species/machine/shell, /datum/species/skrell,/datum/species/skrell/axiori, /datum/species/tajaran, /datum/species/tajaran/zhan_khazan, /datum/species/tajaran/m_sai, /datum/species/unathi)
+
+	aug_headcaselight
+		name = "Augment (Headcase, Light)"
+		icon_state = "aug_headcaselight"
+		body_parts = list(BP_HEAD)
+		species_allowed = list(/datum/species/human, /datum/species/human/offworlder, /datum/species/machine/shell, /datum/species/skrell,/datum/species/skrell/axiori, /datum/species/tajaran, /datum/species/tajaran/zhan_khazan, /datum/species/tajaran/m_sai, /datum/species/unathi)
 
 	vaurca_augs
 		name = "Mecha Chest"

--- a/code/modules/mob/abstract/new_player/sprite_accessories.dm
+++ b/code/modules/mob/abstract/new_player/sprite_accessories.dm
@@ -4395,7 +4395,7 @@ Follow by example and make good judgement based on length which list to include 
 		body_parts = list(BP_HEAD)
 		species_allowed = list(/datum/species/human, /datum/species/human/offworlder, /datum/species/diona, /datum/species/diona/coeu, /datum/species/machine/shell, /datum/species/skrell, /datum/species/skrell/axiori)
 
-	lowercheek_left
+	lowercheek_right
 		name = "Lower Cheek Right"
 		icon_state = "lowercheek_r"
 		body_parts = list(BP_HEAD)

--- a/html/changelogs/sinfulbehaviors-AddUnusedMarks.yml
+++ b/html/changelogs/sinfulbehaviors-AddUnusedMarks.yml
@@ -1,0 +1,7 @@
+author: SinfulBehaviors
+
+delete-after: True
+
+changes:
+  - rscadd: "Added three previously unused body markings."
+  - bugfix: "Fixed Lower Cheek Right not being available in the markings list."


### PR DESCRIPTION
While trawling through the files to see how I could perfect a character's look with markings, I found exactly what I needed.

Unfortunately, it was unused content.

In fact, I found three markings that have as yet gone unused. Specifically aug_lowerjaw, aug_headcase, and aug_headcaselight. I've set up some code that places them into the list of available markings for most races. Diona and Vaurca have been excluded from all three, and Tajara have been excluded from aug_lowerjaw, considering it wasn't designed with a muzzle in mind and doesn't look great on them. 

I also made an edit to another line, fixing the Lower Cheek Right marking to be selectable, as it previously wasn't appearing in the list.
![image](https://user-images.githubusercontent.com/63945373/171308442-46d61dda-6bdd-4b18-b4d7-37effbf70f8f.png) ![image](https://user-images.githubusercontent.com/63945373/171308486-251f689d-aeb5-4404-9249-788180821eee.png) ![image](https://user-images.githubusercontent.com/63945373/171308532-22434f9e-d9cb-498a-8bfe-70917d662df2.png) ![image](https://user-images.githubusercontent.com/63945373/171308603-35964fce-0a68-45b6-ad3c-bb125af39486.png)
