### PR TITLE
Fixes ship-console linking runtime

### DIFF
--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -120,8 +120,9 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 	. = ..()
 
 	if(.)
-		connected = linked
-		LAZYSET(connected.consoles, src, TRUE)
+		if(istype(linked, /obj/effect/overmap/visitable/ship)) //Only ships get ship computers
+			connected = linked
+			LAZYSET(connected.consoles, src, TRUE)
 
 /obj/machinery/computer/ship/Initialize()
 	. = ..()


### PR DESCRIPTION
Small oversight when moving the bulk of attempt_hookup to `visitable` from `visitable/ship` where the consoles attempt to link to a non-ship.

This is in part due to the fact that away ships have their own sectors as well as ships, but I am currently working on that. This is just to stop the runtime for now (And it should only ever attempt to hook up ship consoles to ships anyway)