### PR TITLE
Animal Control

### DIFF
--- a/html/changelogs/dansemacabre-animalcontrol.yml
+++ b/html/changelogs/dansemacabre-animalcontrol.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheDanseMacabre
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "All ship animals have been demapped."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -14093,18 +14093,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/operations/mail_room)
-"hCo" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/westleft{
-	name = "Pun Pun's Cage Access";
-	req_access = list(57)
-	},
-/mob/living/carbon/human/monkey/punpun,
-/turf/simulated/floor/carpet,
-/area/horizon/bar)
 "hCF" = (
 /obj/effect/floor_decal/spline/plain/corner{
 	dir = 1
@@ -63991,7 +63979,7 @@ qyA
 pjQ
 qlX
 nxI
-hCo
+wZF
 ayT
 nxI
 ePg

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -8394,24 +8394,10 @@
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "eEr" = (
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 2;
-	req_access = list(58)
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = 32
 	},
-/mob/living/simple_animal/hostile/commanded/dog/columbo,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hos)
 "eEx" = (
@@ -11352,18 +11338,10 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "gho" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/brigdoor/southright{
-	req_access = list(56)
-	},
-/obj/effect/decal/warning_stripes,
-/mob/living/simple_animal/carp/fluff/ginny,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
 "ghq" = (
 /obj/structure/ladder{

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -11331,18 +11331,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
-"uW" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/mob/living/simple_animal/corgi/Ian,
-/obj/machinery/door/window/westleft{
-	name = "Ian's Cage Access";
-	req_access = list(57)
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/hop/xo)
 "uX" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -17808,7 +17796,6 @@
 /turf/simulated/floor,
 /area/crew_quarters/heads/hop/xo)
 "Hj" = (
-/mob/living/simple_animal/corgi/fox/Chauncey,
 /obj/effect/floor_decal/spline/fancy/wood/full,
 /obj/effect/floor_decal/plaque{
 	desc = "The Stellar Corporate Conglomerate Logo Engraved in bronze." ;
@@ -48713,7 +48700,7 @@ Uq
 YU
 Hi
 Bk
-uW
+Dd
 Bl
 bJ
 og


### PR DESCRIPTION
Removes all station pets except Crusher, infirmary cat. A ship's cat is fine. The rest are mostly just stupid. Columbo is genuinely broken. Ginny is hostile wildlife. Foxes are not pets. Ian is ugly. They are constantly killed by airlocks or minor changes in the atmosphere or being clicked with the wrong item.