### PR TITLE
Adds an automatic grenade launcher

### DIFF
--- a/code/modules/projectiles/guns/projectile/cannon.dm
+++ b/code/modules/projectiles/guns/projectile/cannon.dm
@@ -147,3 +147,27 @@
 		to_chat(user, SPAN_WARNING("You can't fire without stabilizing \the [src]!"))
 		return 0
 	return ..()
+
+/obj/item/gun/projectile/automatic_grenade_launcer
+	name = "automatic grenade launcher"
+	desc = "Zavodskoi placeholder automatic grenade launcher description."
+	desc_fluff = "placeholder about techno mumbo jumbo"
+	icon = placeholder
+	icon_state = placeholder
+	caliber = "40mm"
+	w_class = ITEMSIZE_LARGE
+	load_method = MAGAZINE
+
+	magazine_type = 
+	allowed_magazine =
+	
+	slot_flags = SLOT_BACK
+	fire_sound = 
+	ammo_type = 
+
+	fire_delay = 9
+	is_wieldable = TRUE
+	auto_eject = TRUE
+	max_shells = 6
+	recoil = 8
+

--- a/code/modules/projectiles/guns/projectile/cannon.dm
+++ b/code/modules/projectiles/guns/projectile/cannon.dm
@@ -148,7 +148,7 @@
 		return 0
 	return ..()
 
-/obj/item/gun/projectile/automatic_grenade_launcer
+/obj/item/gun/projectile/agl
 	name = "automatic grenade launcher"
 	desc = "Zavodskoi placeholder automatic grenade launcher description."
 	desc_fluff = "placeholder about techno mumbo jumbo"
@@ -160,7 +160,7 @@
 
 	magazine_type = 
 	allowed_magazine =
-	
+
 	slot_flags = SLOT_BACK
 	fire_sound = 
 	ammo_type = 

--- a/code/modules/projectiles/guns/projectile/cannon.dm
+++ b/code/modules/projectiles/guns/projectile/cannon.dm
@@ -150,13 +150,16 @@
 
 /obj/item/gun/projectile/agl
 	name = "automatic grenade launcher"
-	desc = "Zavodskoi placeholder automatic grenade launcher description."
-	desc_fluff = "placeholder about techno mumbo jumbo"
+	desc = "A belt-fed, select fire grenade launcher. Ready to dispense a lot of opinion amplifiers towards your enemies."
+	desc_fluff = "The Zavodskoi APGL-406 is an all-purpose, select fire grenade launcher. Taking a belt of six grenades and firing at 60 rounds per minute in full auto, \
+	this weapon was originally produced for riot control. A wide range of different types of ammunition types, are making this launcher a true all-rounder. \
+	The selection ranges from high explosive, over armour piercing to smoke grenades. The belt can individually be put together to maximize flexibility."
 	icon = placeholder
 	icon_state = placeholder
 	caliber = "40mm"
 	w_class = ITEMSIZE_LARGE
 	load_method = MAGAZINE
+	handle_casings = EJECT_CASINGS
 
 	magazine_type = 
 	allowed_magazine =
@@ -170,4 +173,10 @@
 	auto_eject = TRUE
 	max_shells = 6
 	recoil = 8
+
+/obj/item/gun/projectile/agl/special_check(mob/user)
+	if(!wielded)
+		to_chat(user, SPAN_WARNING("You can't fire without stabilizing \the [src]!"))
+		return 0
+	return ..()
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -434,3 +434,29 @@
 	icon_state = "peac"
 	damage = 45
 	penetrating = TRUE
+
+/obj/item/projectile/bullet/agl/40mmhe
+	name = "high explosive 40mm grenade"
+	icon_state =
+	damage = 
+
+	explosion placeholder
+
+/obj/item/projectile/bullet/agl/40mmheat
+	name = "high explosive anti tank 40m grenade"
+	icon_state =
+	damage = 
+
+	explosion placeholder
+
+/obj/item/projectile/bullet/agl/40mmsm
+	name = "smoke 40mm grenade"
+	icon_state =
+	damage = 
+
+	explosion smoke placeholder
+
+/obj/item/projectile/bullet/agl/40mmsp
+	name = "rubber 40mm grenade"
+	icon_state =
+	damage = 

--- a/html/changelogs/KingOfThePing - 14177.yml
+++ b/html/changelogs/KingOfThePing - 14177.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: KingOfThePing, Happy_Fox
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds the Zavodskoi APGL-406, a full-auto, belt-fed, all purpose grenade launcher, together with various ammo types for it. Available in the Uplink for lots of TC."


### PR DESCRIPTION
Still WIP, mostly due to missing sprites and undecided values. Sprites done by Happy_Fox.

This PR adds a Zavodskoi automatic grenade launcher, together with different types of ammunition for it, both lethal and less-lethal including:

HE = High Explosive 
HEAT = High Explosive Anti Tank
SM = Smoke
SP = Rubber Grenade

The launcher is belt fed. Reloading takes a few seconds. It has to be wielded to be shot. Costs quite the amount of TC (probably around the price of the minigun).
The grenade belt can be individually put together (e.g. 2 SM, t hen 2 HE, then 1 HEAT, then 1 SM again), if the sprites allow it.

The grenades are impact grenades, meaning they explode on impact (duh). It will NOT fire hand grenades like already in-game grenade launchers tend to do.

- [ ] Add Sprites
- [ ] Code Modular Belts
- [ ] Manage to not let it make holes into the ship everywhere