### PR TITLE
Red Nightshade Tweaks/Fixes/Buffs

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -131,6 +131,8 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	var/power = force
 	if(HULK in user.mutations)
 		power *= 2
+	if(user.is_berserk())
+		power *= 1.5
 	if(ishuman(user))
 		var/mob/living/carbon/human/X = user
 		if(ishuman(target))

--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -40,6 +40,11 @@
 	item_cost = 1
 	path = /obj/item/storage/box/syndie_kit/stimulants
 
+/datum/uplink_item/item/medical/berserk_injectors
+	name = "Box of Berserk Injectors"
+	item_cost = 2
+	path = /obj/item/storage/box/syndie_kit/berserk_injectors
+
 /datum/uplink_item/item/medical/sideeffectbegone
 	name = "Box of Sideeffect-Be-Gone Injectors"
 	item_cost = 1

--- a/code/datums/uplink/stealthy and inconspicuous weapons.dm
+++ b/code/datums/uplink/stealthy and inconspicuous weapons.dm
@@ -15,7 +15,8 @@
 	path = /obj/item/storage/box/syndie_kit/cigarette
 
 /datum/uplink_item/item/stealthy_weapons/random_toxin
-	name = "Random Toxin - Beaker"
+	name = "Random Toxins Kit"
+	desc = "A kit that contains 3 vials containing random toxins. Comes with a syringe!"
 	item_cost = 1
 	path = /obj/item/storage/box/syndie_kit/toxin
 

--- a/code/game/objects/items/contraband.dm
+++ b/code/game/objects/items/contraband.dm
@@ -34,6 +34,7 @@
 		list(/decl/reagent/toxin/dextrotoxin = 10)								= 1,
 		list(/decl/reagent/toxin/spectrocybin = 15)								= 1,
 		list(/decl/reagent/joy = 10, /decl/reagent/water = 20)					= 1,
+		list(/decl/reagent/toxin/berserk = 10)                                  = 1,
 		list(/decl/reagent/ammonia = 15)										= 3)
 
 /obj/item/reagent_containers/glass/beaker/vial/random/Initialize()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -179,7 +179,7 @@
 /obj/item/storage/box/syndie_kit/toxin
 	name = "toxin kit"
 	desc = "An apple will not be enough to keep the doctor away after this."
-	starts_with = list(/obj/item/reagent_containers/glass/beaker/vial/random/toxin = 1, /obj/item/reagent_containers/syringe = 1)
+	starts_with = list(/obj/item/reagent_containers/glass/beaker/vial/random/toxin = 3, /obj/item/reagent_containers/syringe = 1)
 
 /obj/item/storage/box/syndie_kit/cigarette
 	name = "tricky smokes"
@@ -260,4 +260,11 @@
 	desc = "Comes with 4x autoinjectors filled with drugs to counter chemical side-effects. Each injector has 2 uses."
 	starts_with = list(
 		/obj/item/reagent_containers/hypospray/autoinjector/sideeffectbgone = 4
+	)
+
+/obj/item/storage/box/syndie_kit/berserk_injectors
+	name = "box of berserk injectors"
+	desc = "Comes with 2x autoinjectors filled with Red Nightshade - used to induce a berserk state lasting ~2.5 minutes per injector. Using both injectors will increase time berserk, but will lead to liver failure."
+	starts_with = list(
+		/obj/item/reagent_containers/hypospray/autoinjector/berserk = 2
 	)

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -457,7 +457,8 @@
 			/decl/reagent/water,
 			/decl/reagent/woodpulp,
 			/decl/reagent/ambrosia_extract,
-			/decl/reagent/skrell_nootropic
+			/decl/reagent/skrell_nootropic,
+			/decl/reagent/toxin/berserk
 			)
 
 		for(var/x=1;x<=additional_chems;x++)

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -106,6 +106,9 @@
 	if(HULK in A.mutations)
 		real_damage *= 2 // Hulks do twice the damage
 		rand_damage *= 2
+	if(A.is_berserk())
+		real_damage *= 1.5 // Nightshade increases damage by 50%
+		rand_damage *= 1.5
 
 	real_damage = max(1, real_damage)
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -229,6 +229,10 @@
 		else if(jitteriness >= 100)
 			msg += "<span class='warning'>[get_pronoun("He")] [get_pronoun("is")] twitching ever so slightly.</span>\n"
 
+	//Red Nightshade
+	if(is_berserk())
+		msg += "<span class='warning'><B>[get_pronoun("He")] [get_pronoun("has")] engorged veins which appear a vibrant red.</span>\n"
+		
 	//splints
 	for(var/organ in list(BP_L_LEG,BP_R_LEG,BP_L_ARM,BP_R_ARM,BP_L_HAND,BP_R_HAND,BP_R_FOOT,BP_L_FOOT))
 		var/obj/item/organ/external/o = get_organ(organ)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -84,7 +84,7 @@
 				return 0
 			var/obj/item/organ/external/affecting = get_organ(ran_zone(H.zone_sel.selecting))
 
-			if(HULK in H.mutations)
+			if(HULK in H.mutations || H.is_berserk())
 				damage += 5
 
 			playsound(loc, /decl/sound_category/punch_sound, 25, 1, -1)
@@ -267,6 +267,9 @@
 			if(HULK in H.mutations)
 				real_damage *= 2 // Hulks do twice the damage
 				rand_damage *= 2
+			if(H.is_berserk())
+				real_damage *= 1.5 // Nightshade increases damage by 50%
+				rand_damage *= 1.5
 
 			real_damage = max(1, real_damage)
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -637,7 +637,7 @@
 	taste_mult = 2
 
 /mob/living/carbon/human/proc/berserk_start()
-	to_chat(src, SPAN_DANGER("An uncontrollable rage overtakes your thoughts!"))
+	to_chat(src, SPAN_DANGER("An uncontrollable rage courses through your body and overtakes your thoughts - your blood begins to boil with fury!"))
 	add_client_color(/datum/client_color/berserk)
 	shock_stage = 0
 	SetParalysis(0)
@@ -655,17 +655,18 @@
 	adjustHalLoss(-1)
 
 /mob/living/carbon/human/proc/berserk_stop()
-	to_chat(src, SPAN_DANGER("Your rage fades away, your thoughts are clear once more!"))
+	to_chat(src, SPAN_DANGER("Your rage fades away and the boiling sensation subsides, your thoughts are clear once more."))
 	remove_client_color(/datum/client_color/berserk)
 
 /decl/reagent/toxin/berserk
 	name = "Red Nightshade"
-	description = "An illegal combat performance enhancer originating from the criminal syndicates of Mars. The drug stimulates regions of the brain responsible for violence and rage, inducing a feral, berserk state in users."
+	description = "An illegal combat performance enhancer originating from the criminal syndicates of Mars. The drug stimulates regions of the brain responsible for violence and rage, inducing a feral, berserk state in users. It is incredibly hard on the liver."
 	reagent_state = LIQUID
 	color = "#AF111C"
-	strength = 5
-	taste_description = "bitterness"
-	metabolism = REM * 2
+	strength = 3
+	overdose = 10
+	taste_description = "popping candy"
+	metabolism = REM*0.3 //10u = ~5 minutes of being berserk.
 	unaffected_species = IS_DIONA | IS_MACHINE
 
 /decl/reagent/toxin/berserk/initial_effect(var/mob/living/carbon/human/H, var/alien, var/holder)
@@ -687,9 +688,14 @@
 	M.add_chemical_effect(CE_BERSERK, 1)
 	if(M.a_intent != I_HURT)
 		M.a_intent_change(I_HURT)
-	var/obj/item/organ/internal/heart = M.internal_organs_by_name[BP_HEART]
-	if(heart)
-		M.add_chemical_effect(CE_CARDIOTOXIC, removed * 0.020)
+	if(prob(3))
+		to_chat(M, SPAN_WARNING(pick("Your blood boils with rage!", "A monster stirs within you - let it out.", "You feel an overwhelming sense of rage!", "You cannot contain your anger!", "You struggle to relax - a fury stirs within you.", "You feel an electric sensation course through your body!")))
+	if(prob(5))
+		M.emote(pick("twitch_v", "grunt"))
+
+/decl/reagent/toxin/berserk/overdose(var/mob/living/carbon/M, var/datum/reagents/holder)
+	if(prob(25))
+		M.add_chemical_effect(CE_CARDIOTOXIC, 1)
 
 /decl/reagent/toxin/spectrocybin
 	name = "Spectrocybin"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -754,7 +754,7 @@
 	name = "Red Nightshade"
 	id = "berserk"
 	result = /decl/reagent/toxin/berserk
-	required_reagents = list(/decl/reagent/psilocybin = 1, /decl/reagent/alcohol/moonshine = 1)
+	required_reagents = list(/decl/reagent/toxin/stimm = 1, /decl/reagent/synaptizine = 1, /decl/reagent/toxin/phoron = 0.1)
 	result_amount = 1
 
 /datum/chemical_reaction/joy

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -243,6 +243,14 @@
 
 	reagents_to_add = list(/decl/reagent/tricordrazine = 15, /decl/reagent/inaprovaline = 5, /decl/reagent/dexalin/plus = 5, /decl/reagent/oxycomorphine = 3, /decl/reagent/synaptizine = 2, /decl/reagent/mental/corophenidate = 5)
 
+/obj/item/reagent_containers/hypospray/autoinjector/berserk
+	name_label = "berserk injector"
+	desc = "An injector containing Red Nightshade. Used before fights to induce a berserk state - lasts ~2.5 minutes."
+	volume = 5
+	amount_per_transfer_from_this = 5
+
+	reagents_to_add = list(/decl/reagent/toxin/berserk = 5)
+
 /obj/item/reagent_containers/hypospray/autoinjector/trauma
 	name = "trauma hypo-injector"
 	desc = "A special hypospray made to combat most forms of physical trauma."

--- a/html/changelogs/rednightshade-stuff.yml
+++ b/html/changelogs/rednightshade-stuff.yml
@@ -1,0 +1,50 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: kermit
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Red Nightshade induced berserk state now increases your melee damage by 50%."
+  - rsctweak: "Red Nightshade's metabolisation speed has been decreased, so the berserk state lasts a lot longer. This also prevents all the toxins immediately destroying your liver in 30 seconds."
+  - rscadd: "An examine message makes it obvious when someone is using Nightshade, in addition to the jitters already present."
+  - rscadd: "Adds flavour messages which appear when using Red Nightshhade."
+  - rsctweak: "Moves Nightshade's cardiotoxicity to OD only. The liver damage will still be severe regardless of ODing."
+  - rsctweak: "Changes Nightshade's recipe to something more sensical and in-line with it's effects (now 1u Stimm, 1u Synaptizine, 0.1u Phoron)."    
+  - rscadd: "Adds Red Nightshade to the Random Toxin Kit uplink purchase, maintenance contraband spawn and xenobotany plant chemicals pool."
+  - rscadd: "Adds a Box of Berserk Injectors to the Uplink for 2 TC, containing 2 doses of Red Nightshade lasting 2.5 minutes each."
+  - rsctweak: "The Random Toxins Kit comes with 3 random toxins instead of just the 1."
+


### PR DESCRIPTION
-  Red Nightshade's been tweaked so that it's actually viable for use ingame. It's always been a weird drug that just instantly kills you, whether by nuking your brain or liver. This has been fixed by slightly reducing it's toxicity and slowing it's metabolism. 10 units of Red Nightshade will still overpower your liver, so it remains a dangerous chemical if not used carefully.
- The berserk state induced by Nightshade has been buffed. In addition to breaking windows, you now get 50% increased melee damage. The berserk state also lasts much longer as Nightshade's metabolisation has been reduced. Berserked people are still vulnerable to flashes, can't break walls, etc., so remain a lot weaker than proper hulks.
- Flavour messages have been added.
- Examine text now makes it obvious when someone is on Nightshade or not. If someone's being observant, they can steer clear of someone going berserk.
- The recipe has been changed to something more in-line with the effects of Nightshade. The recipe is now 1u Stimm, 1u Synaptizine, 0.1u Phoron. The makes it somewhat harder to obtain given the damage buff to the berserk state.

Now it can actually be used safely, I added it to the Traitor Uplink via a Box of Berserk Injectors. It can now also spawn in xenobotany mutations and maintenance spawns.

Additionally:
- The Random Toxin Kit has been renamed and now spawns with 3x Random Toxin Vials just to provide more options for someone buying the kit.