### PR TITLE
Mining Shuttle APC Access Tweak

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -89,7 +89,7 @@
 /obj/machinery/power/apc/intrepid
 	cell_type = /obj/item/cell/high
 	req_access = null
-	req_one_access = list(access_intrepid,access_heads,access_engine_equip)
+	req_one_access = list(access_intrepid,access_engine_equip)
 
 /obj/machinery/power/apc/mining_pod
 	cell_type = /obj/item/cell/high

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -88,10 +88,12 @@
 
 /obj/machinery/power/apc/intrepid
 	cell_type = /obj/item/cell/high
+	req_access = null
 	req_one_access = list(access_intrepid,access_engine_equip)
 
 /obj/machinery/power/apc/mining_pod
 	cell_type = /obj/item/cell/high
+	req_access = null
 	req_one_access = list(access_mining,access_engine_equip)
 
 // Construction site APC, starts turned off

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -89,7 +89,7 @@
 /obj/machinery/power/apc/intrepid
 	cell_type = /obj/item/cell/high
 	req_access = null
-	req_one_access = list(access_intrepid,access_engine_equip)
+	req_one_access = list(access_intrepid,access_heads,access_engine_equip)
 
 /obj/machinery/power/apc/mining_pod
 	cell_type = /obj/item/cell/high

--- a/html/changelogs/Ben10083 - MiningAPC.yml
+++ b/html/changelogs/Ben10083 - MiningAPC.yml
@@ -11,3 +11,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - maptweak: "Mining now has access to mining shuttle APC and Intrepid APC."
+  - maptweak: "Intrepid APC can now be also unlocked with IDs that have bridge access."

--- a/html/changelogs/Ben10083 - MiningAPC.yml
+++ b/html/changelogs/Ben10083 - MiningAPC.yml
@@ -10,4 +10,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - maptweak: "Mining now has access to mining shuttle APC."
+  - maptweak: "Mining now has access to mining shuttle APC and Intrepid APC."

--- a/html/changelogs/Ben10083 - MiningAPC.yml
+++ b/html/changelogs/Ben10083 - MiningAPC.yml
@@ -11,4 +11,3 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - maptweak: "Mining now has access to mining shuttle APC and Intrepid APC."
-  - maptweak: "Intrepid APC can now be also unlocked with IDs that have bridge access."

--- a/html/changelogs/Ben10083 - MiningAPC.yml
+++ b/html/changelogs/Ben10083 - MiningAPC.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Mining now has access to mining shuttle APC."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -22696,7 +22696,8 @@
 	},
 /obj/machinery/power/apc/mining_pod{
 	dir = 8;
-	pixel_x = -30
+	pixel_x = -30;
+	req_access = null
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark,

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -22696,8 +22696,7 @@
 	},
 /obj/machinery/power/apc/mining_pod{
 	dir = 8;
-	pixel_x = -30;
-	req_access = null
+	pixel_x = -30
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark,


### PR DESCRIPTION
Fixes #14070 

Turns out miners were supposed to have access but req_access wasn't set to null.