### PR TITLE
Body Scanner VueUI Damage Readout Tweak

### DIFF
--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -490,9 +490,9 @@
 	var/organs = list()
 	for (var/obj/item/organ/external/O in H.organs)
 		var/list/data = list()
-		var/burn_damage = get_wound_severity(O.burn_ratio, TRUE)
+		var/burn_damage = get_severity(O.burn_dam, TRUE)
 		data["burnDmg"] = burn_damage
-		var/brute_damage = get_wound_severity(O.brute_ratio, TRUE)
+		var/brute_damage = get_severity(O.brute_dam, TRUE)
 		data["bruteDmg"] = brute_damage
 		data["name"] = capitalize_first_letters(O.name)
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -34,16 +34,18 @@ BREATH ANALYZER
 	var/degree = "none"
 
 	switch(damage_ratio)
-		if(0.05 to 0.1)
+		if(0.001 to 0.1)
 			degree = "minor"
-		if(0.1 to 0.25)
+		if(0.1 to 0.2)
 			degree = "moderate"
-		if(0.25 to 0.5)
+		if(0.2 to 0.4)
 			degree = "significant"
-		if(0.5 to 0.75)
+		if(0.4 to 0.6)
 			degree = "severe"
-		if(0.75 to 1)
-			degree = "extreme"
+		if(0.6 to 0.8)
+			degree = "critical"
+		if(0.8 to 1)
+			degree = "fatal"
 
 	if(uppercase)
 		degree = capitalize(degree)

--- a/html/changelogs/damage_readout_bodyscanner.yml
+++ b/html/changelogs/damage_readout_bodyscanner.yml
@@ -1,0 +1,7 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - tweak: "Body Scanner VueUI will now show the additional damage readouts of Critical and Fatal, and accurately as well in accordance to how the health analyzers/medscans do it."
+  - bugfix: "Fixed the Body Scanner VueUI damage readouts not being colored."

--- a/vueui/src/components/view/medical/bodyscanner.vue
+++ b/vueui/src/components/view/medical/bodyscanner.vue
@@ -184,19 +184,22 @@
         }
       },
     damageLabel(value) {
-      if(value == "extreme" || value < 20) {
+      if(value == "Fatal" || value < 10) {
         return "Crimson"
       }
-      else if(value == "severe" || value < 40) {
+      if(value == "Critical" || value < 20) {
+        return "Crimson"
+      }
+      else if(value == "Severe" || value < 40) {
         return "OrangeRed"
       }
-      else if(value == "significant" || value < 60) {
+      else if(value == "Significant" || value < 60) {
         return "Tomato"
       }
-      else if(value == "moderate" || value < 80) {
+      else if(value == "Moderate" || value < 80) {
         return "Orange"
       }
-      else if(value == "minor" || value < 100) {
+      else if(value == "Minor" || value < 100) {
         return "LawnGreen"
       }
       else {


### PR DESCRIPTION
* Body Scanners finally also get the new Critical and Fatal damage readouts in their fancy VueUI (as promised in #14121 )
* Adjusts the ``get_wound_severity`` proc a bit and also adds the Critical and Fatal reading outputs to it.
* Fixes the Body Scanner VueUI damage readouts not being colored

Basically, the Body Scanner VueUI used a damage ratio readout which depends on the external organ ``max_damage`` and the actual damage it has.
This means that if a Foot (max_damage of 55) had 100 brute damage, the Body Scanner VueUI would get the calculated brute ratio value and call the damage "Severe", while if a Head (max_damage of 125) had 100 brute damage, the calculated output would pin it as "Significant".

So instead of making everyone's lives even more confusing, I've tweaked the Body Scanner VueUI damage readout in accordance to the straight damage reading (so if it's 100 Brute/Burn, it'll always be called Fatal regardless of the limb max health).  **This is only for the External Limbs**

I've decided to use the straight damage readouts instead of the opposite (as in: make everything else use the relative damage ratio readout) to make it less confusing since then hands/feet would get Fatal incredibly often, but not the head/chest/groin.

**Body Scanner VueUI with new Damage Readouts** (and the colors fix)
![](https://i.imgur.com/T5Pt4hY.png)