### PR TITLE
Throw-Intent Placing, the Refixening

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -381,8 +381,18 @@ var/list/slot_equipment_priority = list( \
 			return TRUE
 
 		var/turf/T = get_turf(target)
-		if(T.contains_dense_objects() && !istype(target, /obj/structure/table)) //Stop at dense objects, like walls and windows. Allow placing on tables.
+		if(T.density) //Don't put the item in dense turfs
 			return TRUE //Takes off throw mode
+		if(T.contains_dense_objects())
+			for(var/obj/O in T)
+				if(!O.density) //We don't care about you.
+					continue
+				if(O.CanPass(item, T)) //Items have CANPASS for tables/railings, allows placement. Also checks windows. 
+					continue
+				if(istype(O, /obj/structure/closet/crate)) //Placing on/in crates is fine.
+					continue
+				return TRUE //Something is stopping us. Takes off throw mode.
+				
 		remove_from_mob(I)
 		make_item_drop_sound(I)
 		I.forceMove(T)

--- a/html/changelogs/doxxmedearly-throwplacefixes_TWO.yml
+++ b/html/changelogs/doxxmedearly-throwplacefixes_TWO.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "You can now throw-intent place items on crates and tables consistently again."


### PR DESCRIPTION
Contains_dense_objects was too strict, exceptions were too inconsistent (You'd have to be clicking on the item itself)

Now, if we have dense objects, we'll check to make sure we can place on or past them. CanPass check catches everything EXCEPT crates, so that needed its own special exception.

Tested to ensure it goes on the tile no matter what you click, as ease of placing was the intended purpose of this feature in the first place. Doesn't go through windows/walls/closed doors. Goes onto tables, onto crates, and past railings just fine.