### PR TITLE
Removes negative slowdown from the loadout off-worlder RIG

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -214,6 +214,7 @@
 		bio = ARMOR_BIO_MINOR,
 		rad = ARMOR_RAD_MINOR
 	)
+	slowdown = 0
 	airtight = 0
 	seal_delay = 5
 	helm_type = /obj/item/clothing/head/lightrig/offworlder

--- a/html/changelogs/omicega-bugfixidfdsiofdsiofds.yml
+++ b/html/changelogs/omicega-bugfixidfdsiofdsiofds.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Removed negative slowdown from the loadout RIG available to off-worlders."


### PR DESCRIPTION
See title. This is an oversight introduced by #13038, I think.