### PR TITLE
Scans will show N2O as "Nitrous Oxide" instead of "Sleeping Agent"

### DIFF
--- a/code/defines/gases.dm
+++ b/code/defines/gases.dm
@@ -44,7 +44,7 @@
 
 /decl/xgm_gas/sleeping_agent
 	id = GAS_N2O
-	name = "Sleeping Agent"
+	name = "Nitrous Oxide"
 	specific_heat = 40	// J/(mol*K)
 	molar_mass = 0.044	// kg/mol. N2O
 	tile_overlay = "sleeping_agent"

--- a/html/changelogs/wickedcybs_nitrous.yml
+++ b/html/changelogs/wickedcybs_nitrous.yml
@@ -1,0 +1,6 @@
+author: Wickedcybs
+
+delete-after: True
+
+changes:
+  - tweak: "N20 will now be referred to as 'Nitrous Oxide' in all cases instead of having it appear as 'Sleeping agent' on scans but N20 in all other cases."


### PR DESCRIPTION
At the moment, N20 has its name set to "Sleeping Agent" so scans would display its presence with that name specifically. In most other places in the game and even the code though, it's labelled as N2O. From the filters to the variables.

I've just renamed it to Nitrous Oxide so it's more clear what type of gas this actually is and to keep up consistency. 