### PR TITLE
Fix windoors, powernets, and the Schlorrgo Columbo Dimension

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -26,6 +26,12 @@
 		icon_state = "[icon_state]"
 		base_state = icon_state
 
+/obj/machinery/door/window/update_icon()
+	if(!density != !operating) //XOR, baby
+		icon_state = base_state
+	else
+		icon_state = "[base_state]open"
+
 /obj/machinery/door/window/proc/shatter(var/display_message = 1)
 	new /obj/item/trash/broken_electronics(loc)
 	new /obj/item/material/shard(loc)
@@ -43,34 +49,19 @@
 	return ..()
 
 /obj/machinery/door/window/CollidedWith(atom/movable/AM as mob|obj)
-	if(istype(AM, /mob/living/heavy_vehicle))
-		var/mob/living/heavy_vehicle/HV = AM
-		for(var/user in HV.pilots)
-			AM = user
-			break
-	if (istype(AM, /mob/living/bot))
-		var/mob/living/bot/bot = AM
-		if(istype(bot))
-			if(density && src.check_access(bot.botcard))
+	var/mob/M = AM
+	if (!( ROUND_IS_STARTED ) || operating || !density || !istype(M) || !allowed(M))
+		return
+
+	if(ishuman(M) || isrobot(M) || isbot(M) || istype(M, /mob/living/simple_animal/spiderbot) || ismech(M))
+		if(inoperable())
+			if(do_after(M, 1 SECOND, TRUE, src))
+				// The VM here is before open and the wording is backwards because density gets set after a background sleep in open
+				visible_message("\The [user] [density ? "pushes" : "pulls"] \the [src] [density ? "open" : "closed"].")
 				open()
-				addtimer(CALLBACK(src, .proc/close), 50)
-		return
-	if(istype(AM, /mob/living/simple_animal/spiderbot))
-		var/mob/living/simple_animal/spiderbot/bot = AM
-		if(istype(bot))
-			if(density && src.check_access(bot.internal_id))
-				open()
-				addtimer(CALLBACK(src, .proc/close), 50)
-		return
-	if (!( ROUND_IS_STARTED ))
-		return
-	if (src.operating)
-		return
-	if (src.density && (ishuman(AM) || isrobot(AM)) && src.allowed(AM))
-		open()
-		//secure doors close faster
-		var/time = check_access(null) ? 50 : 20
-		addtimer(CALLBACK(src, .proc/close), time)
+		else
+			open()
+			addtimer(CALLBACK(src, .proc/close), check_access(null) ? 5 SECONDS : 2 SECONDS)
 
 /obj/machinery/door/window/allowed(mob/M)
 	. = ..()
@@ -105,7 +96,7 @@
 	operating = TRUE
 	flick("[base_state]opening", src)
 	playsound(src.loc, 'sound/machines/windowdoor.ogg', 100, 1)
-	icon_state = "[base_state]open"
+	update_icon()
 	sleep(1 SECOND)
 
 	explosion_resistance = 0
@@ -122,7 +113,7 @@
 	operating = TRUE
 	flick("[base_state]closing", src)
 	playsound(src.loc, 'sound/machines/windowdoor.ogg', 100, 1)
-	icon_state = base_state
+	update_icon()
 
 	density = TRUE
 	explosion_resistance = initial(explosion_resistance)
@@ -147,7 +138,7 @@
 		user.visible_message("<span class='danger'>[user] smashes against [src].</span>", "<span class='danger'>You smash against [src]!</span>")
 		take_damage(25)
 		return
-	else if(operable())
+	else
 		return attackby(user, user)
 
 /obj/machinery/door/window/emag_act(var/remaining_charges, var/mob/user)
@@ -187,16 +178,15 @@
 			qdel(src)
 		return TRUE
 
-	if(!isliving(I))
-		if(I.iscrowbar() && user.a_intent == I_HELP)
-			if(inoperable())
-				visible_message("\The [user] forces \the [src] [density ? "open" : "closed"].")
-				if(density)
-					open(1)
-				else
-					close(1)
+	if(isobj(I) && I.iscrowbar() && user.a_intent == I_HELP)
+		if(inoperable())
+			visible_message("\The [user] forces \the [src] [density ? "open" : "closed"].")
+			if(density)
+				open(TRUE)
 			else
-				to_chat(user, SPAN_NOTICE("The windoor's motors resist your efforts to force it."))
+				close(TRUE)
+		else
+			to_chat(user, SPAN_NOTICE("\The [src]'s motors resist your efforts to force it."))
 		return TRUE
 
 	//If it's a weapon, smash windoor. Unless it's an id card, agent card, ect.. then ignore it (Cards really shouldnt damage a door anyway)
@@ -214,11 +204,9 @@
 
 	if(allowed(user))
 		if(inoperable())
-			user.visible_message("\The [user] begins to manually [density ? "push" : "pull"] \the [src] [density ? "open" : "closed"]!",
-				"You begin to manually [density ? "push" : "pull"] \the [src] [density ? "open" : "closed"]!", "You hear the sound of a glass door [density ? "opening" : "closing"].")
 			if(!do_after(user, 1 SECOND, TRUE, src))
 				return TRUE
-			visible_message("\The [user] [density ? "pulls" : "pushes"] \the [src] [density ? "closed" : "open"].")
+			visible_message("\The [user] [density ? "pushes" : "pulls"] \the [src] [density ? "open" : "closed"].")
 		if (src.density)
 			open()
 		else

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -57,7 +57,7 @@
 		if(inoperable())
 			if(do_after(M, 1 SECOND, TRUE, src))
 				// The VM here is before open and the wording is backwards because density gets set after a background sleep in open
-				visible_message("\The [user] [density ? "pushes" : "pulls"] \the [src] [density ? "open" : "closed"].")
+				visible_message("\The [M] [density ? "pushes" : "pulls"] \the [src] [density ? "open" : "closed"].")
 				open()
 		else
 			open()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -81,8 +81,8 @@ default behaviour is:
 				return
 
 			if(can_swap_with(tmob)) // mutual brohugs all around!
-				var/turf/tmob_oldloc = tmob.loc
-				var/turf/src_oldloc = loc
+				var/turf/tmob_oldloc = get_turf(tmob)
+				var/turf/src_oldloc = get_turf(src)
 				if(pulling?.density)
 					tmob.forceMove(pulling.loc)
 					forceMove(tmob_oldloc)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1311,6 +1311,8 @@
 	if (dest != loc && istype(dest, /atom/movable))
 		AM = dest
 		LAZYADD(AM.contained_mobs, src)
+		if(pulledby)
+			pulledby.stop_pulling()
 
 	if (istype(loc, /atom/movable))
 		AM = loc

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -427,22 +427,24 @@ obj/structure/cable/proc/cableColor(var/colorC)
 // cut the cable's powernet at this cable and updates the powergrid
 /obj/structure/cable/proc/cut_cable_from_powernet()
 	var/turf/T1 = loc
+	var/turf/T2
 	var/list/P_list
 	if(!T1)	return
-	for(var/obj/machinery/power/P in T1)
-		if(!P.connect_to_network()) //can't find a node cable on a the turf to connect to
-			P.disconnect_from_network() //remove from current network
 
 	for(var/check_dir in list(d1, d2))
 		if(check_dir)
-			T1 = get_step(loc, check_dir)
-			P_list += power_list(T1, src, turn(check_dir,180),0,cable_only = 1)	// what adjacently joins on to cut cable...
+			T2 = get_step(loc, check_dir)
+			P_list += power_list(T2, src, turn(check_dir,180),0,cable_only = 1)	// what adjacently joins on to cut cable...
 
 	P_list += power_list(loc, src, d1, 0, cable_only = 1)//... and on turf
 
 	// remove the cut cable from its turf and powernet, so that it doesn't get count in propagate_network worklist
 	loc = null
 	powernet.remove_cable(src) //remove the cut cable from its powernet
+
+	for(var/obj/machinery/power/P in T1)
+		if(!P.connect_to_network()) //can't find a node cable on a the turf to connect to
+			P.disconnect_from_network() //remove from current network
 
 	var/first = TRUE
 	for(var/obj/O in P_list)

--- a/html/changelogs/johnwildkins-miscfixes.yml
+++ b/html/changelogs/johnwildkins-miscfixes.yml
@@ -1,0 +1,10 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Fix machinery not being disconnected from powernets when node cables (O-X) are cut."
+  - bugfix: "Fix windoors turning invisible when power is cut."
+  - bugfix: "Fix interacting with windoors with objects (i.e. hitting them)."
+  - tweak: "Colliding with unpowered windoors now pushes them open as if you clicked on them, rather than opening instantly."
+  - bugfix: "Fix colliding with a pulled simple-mob being picked up sending players into another player's columbo dimension."


### PR DESCRIPTION
stops the horrifying race condition between pulling a simplemob and picking it up while colliding with another player sending that player into the Columbo Dimension
node cables (O-X) when cut will now disconnect machines on their tile again
fixed up a bunch of handling for windoor interaction, as well as overriding update_icon so they don't become invisible due to power_change

Fixes #14193
Fixes #14037