### PR TITLE
Lower Zhan Resist Mod to more normal levels.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/tajara/tajaran_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/tajara/tajaran_subspecies.dm
@@ -18,7 +18,7 @@
 	ethanol_resistance = 1 // Default value
 	climb_coeff = 1.1
 
-	resist_mod = 2 // ZHAN POWERRRRRR
+	resist_mod = 1.5 // ZHAN POWERRRRRR
 
 	cold_level_1 = 160 //RaceDefault 200 Default 260
 	cold_level_2 = 100 //RaceDefault 140 Default 200

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Connorjg1/Talion
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Tajara Zhan subspecies have a slightly lower grab resist mod bringing them more in line with the other species."
+  


### PR DESCRIPTION
Zhan grab resist mod is reduced from 2 to 1.5 with Tajara lore team recommendation. This brings them more in line with the other species and no longer means they're equally as powerful as a base IPC or nearly as strong as a Unathi in a straight wrestling match.