### PR TITLE
Fixes grab intent injury inspection not working on a surgery table.

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -103,7 +103,7 @@ proc/spread_germs_to_organ(var/obj/item/organ/external/E, var/mob/living/carbon/
 		/obj/item/device/breath_analyzer,
 		/obj/item/personal_inhaler,
 		/obj/item/clothing/accessory/stethoscope,
-		/obj/item/autopsy_scanner
+		/obj/item/autopsy_scanner,
 		/obj/item/grab
 		)
 	// Check for multi-surgery drifting.

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -104,6 +104,7 @@ proc/spread_germs_to_organ(var/obj/item/organ/external/E, var/mob/living/carbon/
 		/obj/item/personal_inhaler,
 		/obj/item/clothing/accessory/stethoscope,
 		/obj/item/autopsy_scanner
+		/obj/item/grab
 		)
 	// Check for multi-surgery drifting.
 	var/zone = user.zone_sel.selecting

--- a/html/changelogs/omicega-bugfixsaoidsaiomdsaiodf4.yml
+++ b/html/changelogs/omicega-bugfixsaoidsaiomdsaiodf4.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes injury inspection via grab not working on surgery tables."


### PR DESCRIPTION
See title. For reference, what I'm talking about is the little 'inspection' mechanic where you grab someone and click them with the grab on help intent. Ordinarily, this lets you check for broken bones and stuff, but the proc was being overridden (or whatever, I don't know the terminology) by the surgery code. That's fixed now.