### PR TITLE
fixes(?) being unable to reattach nymph hands and feet.

### DIFF
--- a/code/modules/organs/subtypes/nymph_limbs.dm
+++ b/code/modules/organs/subtypes/nymph_limbs.dm
@@ -96,7 +96,7 @@
 
 /datum/component/nymph_limb
 	var/list/valid_species = list(SPECIES_UNATHI, SPECIES_SKRELL)
-	var/list/valid_organs_to_replace = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG)
+	var/list/valid_organs_to_replace = list(BP_L_ARM, BP_L_HAND, BP_R_ARM, BP_R_HAND, BP_L_LEG, BP_L_FOOT, BP_R_LEG, BP_R_FOOT)
 	// Main limb where the Nymph mob lives
 	var/list/nymph_limb_types = list(
 		/obj/item/organ/external/arm/nymph,

--- a/html/changelogs/anconfuzedrock-nymphhands.yml
+++ b/html/changelogs/anconfuzedrock-nymphhands.yml
@@ -1,0 +1,6 @@
+author: anconfuzedrock
+
+delete-after: True
+
+changes:
+  - bugfix: "Diona Nymph Limbs can now be reattached to hands and feet, rather than just arms and legs."


### PR DESCRIPTION
Currently it's possible to get nymph arms, legs, hands and feet in loadout, but you can't re-attach hands and feet if detached, only arms and legs. Seems like a bug to me, this adds hands and feet to the list of re-attachables.