### PR TITLE
Suits and Overwear Cost One Point (Down From Two)

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -4,14 +4,12 @@
 	path = /obj/item/clothing/suit/apron
 	slot = slot_wear_suit
 	sort_category = "Suits and Overwear"
-	cost = 2
+	cost = 1
 
 /datum/gear/suit/colorapron
 	display_name = "apron, multipurpose"
 	path = /obj/item/clothing/suit/apron/colored
 	slot = slot_wear_suit
-	sort_category = "Suits and Overwear"
-	cost = 2
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
 
 datum/gear/suit/colorvest

--- a/html/changelogs/wickedcybs_1point.yml
+++ b/html/changelogs/wickedcybs_1point.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Suit items only cost 1 point now. Down from 2."


### PR DESCRIPTION
Just the PR title essentially. All suit slot items in the loadout no longer cost two points. They cost one.

I think this is a pretty good compromise from not just being able to set it to zero points, like was tried in the past. It still costs something but not as much as before.