### PR TITLE
Fixes Library Machines being unable to be unsecured and moved

### DIFF
--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -413,8 +413,16 @@ datum/borrowbook // Datum used to keep track of who has borrowed what when and f
 			return	
 		user.drop_from_inventory(O,src)
 	if(O.iswrench())
+		playsound(get_turf(src), O.usesound, 75, TRUE)
+		if(anchored)
+			user.visible_message(SPAN_NOTICE("\The [user] unsecures \the [src] from the floor."), \
+				SPAN_NOTICE("You unsecure \the [src] from the floor."), \
+				SPAN_WARNING("You hear a ratcheting noise."))
+		else
+			user.visible_message(SPAN_NOTICE("\The [user] secures \the [src] to the floor."), \
+				SPAN_NOTICE("You secure \the [src] to the floor."), \
+				SPAN_WARNING("You hear a ratcheting noise."))
 		anchored = !anchored
-		to_chat(user, SPAN_NOTICE("You [anchored ? "secure" : "unsecure"] the bolts holding \the [src] to the floor."))
 
 /obj/machinery/libraryscanner/attack_hand(var/mob/user as mob)
 	usr.set_machine(src)
@@ -494,6 +502,13 @@ datum/borrowbook // Datum used to keep track of who has borrowed what when and f
 		qdel(O)
 		return
 	if(O.iswrench())
+		playsound(get_turf(src), O.usesound, 75, TRUE)
+		if(anchored)
+			user.visible_message(SPAN_NOTICE("\The [user] unsecures \the [src] from the floor."), \
+				SPAN_NOTICE("You unsecure \the [src] from the floor."), \
+				SPAN_WARNING("You hear a ratcheting noise."))
+		else
+			user.visible_message(SPAN_NOTICE("\The [user] secures \the [src] to the floor."), \
+				SPAN_NOTICE("You secure \the [src] to the floor."), \
+				SPAN_WARNING("You hear a ratcheting noise."))
 		anchored = !anchored
-		to_chat(user, SPAN_NOTICE("You [anchored ? "secure" : "unsecure"] the bolts holding \the [src] to the floor."))
-		return

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -210,9 +210,10 @@ datum/borrowbook // Datum used to keep track of who has borrowed what when and f
 			dat += "<H3>Upload a New Title</H3>"
 			if(!scanner)
 				for(var/obj/machinery/libraryscanner/S in range(9))
-					scanner = S
-					break
-			if(!scanner)
+					if(S.anchored)
+						scanner = S
+						break
+			if(!(scanner?.anchored))
 				dat += "<FONT color=red>No scanner found within wireless network range.</FONT><BR>"
 			else if(!scanner.cache)
 				dat += "<FONT color=red>No data found in scanner memory.</FONT><BR>"
@@ -240,7 +241,7 @@ datum/borrowbook // Datum used to keep track of who has borrowed what when and f
 		src.emagged = 1
 		return 1
 
-/obj/machinery/librarycomp/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/librarycomp/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/barcodescanner))
 		var/obj/item/barcodescanner/scanner = W
 		scanner.computer = src
@@ -325,7 +326,7 @@ datum/borrowbook // Datum used to keep track of who has borrowed what when and f
 		if(newcategory)
 			upload_category = newcategory
 	if(href_list["upload"])
-		if(scanner)
+		if(scanner?.anchored)
 			if(scanner.cache)
 				var/choice = input("Are you certain you wish to upload this title to the Archive?") in list("Confirm", "Abort")
 				if(choice == "Confirm")
@@ -396,17 +397,24 @@ datum/borrowbook // Datum used to keep track of who has borrowed what when and f
  * Library Scanner
  */
 /obj/machinery/libraryscanner
-	name = "scanner"
+	name = "upload scanner"
+	desc = "A machine that scans books for upload to the library database."
 	icon = 'icons/obj/library.dmi'
 	icon_state = "bigscanner"
 	var/insert_anim = "bigscanner1"
-	anchored = 1
-	density = 1
+	anchored = TRUE
+	density = TRUE
 	var/obj/item/book/cache		// Last scanned book
 
-/obj/machinery/libraryscanner/attackby(var/obj/O as obj, var/mob/user as mob)
+/obj/machinery/libraryscanner/attackby(obj/item/O, mob/user)
 	if(istype(O, /obj/item/book))
+		if(!anchored)
+			to_chat(user, SPAN_WARNING("\The [src] must be secured to the floor first!"))
+			return	
 		user.drop_from_inventory(O,src)
+	if(O.iswrench())
+		anchored = !anchored
+		to_chat(user, SPAN_NOTICE("You [anchored ? "secure" : "unsecure"] the bolts holding \the [src] to the floor."))
 
 /obj/machinery/libraryscanner/attack_hand(var/mob/user as mob)
 	usr.set_machine(src)
@@ -449,25 +457,43 @@ datum/borrowbook // Datum used to keep track of who has borrowed what when and f
  * Book binder
  */
 /obj/machinery/bookbinder
-	name = "Book Binder"
+	name = "book binder"
+	desc = "A machine that takes paper and binds them into books. Fascinating!"
 	icon = 'icons/obj/library.dmi'
 	icon_state = "binder"
-	anchored = 1
-	density = 1
+	anchored = TRUE
+	density = TRUE
+	var/binding = FALSE
 
-/obj/machinery/bookbinder/attackby(var/obj/O as obj, var/mob/user as mob)
+/obj/machinery/bookbinder/attackby(var/obj/O, mob/user)
 	if(istype(O, /obj/item/paper))
+		if(!anchored)
+			to_chat(user, SPAN_WARNING("\The [src] must be secured to the floor first!"))
+			return
+		if(binding)
+			to_chat(user, SPAN_WARNING("You must wait for \the [src] to finish its current operation!"))
+			return
+		var/turf/T = get_turf(src)
 		user.drop_from_inventory(O,src)
-		user.visible_message("[user] loads some paper into [src].", "You load some paper into [src].")
-		src.visible_message("[src] begins to hum as it warms up its printing drums.")
-		playsound(src.loc, 'sound/bureaucracy/binder.ogg', 75, 1)
+		user.visible_message(SPAN_NOTICE("\The [user] loads some paper into \the [src]."), SPAN_NOTICE("You load some paper into \the [src]."))
+		visible_message(SPAN_NOTICE("\The [src] begins to hum as it warms up its printing drums."))
+		playsound(T, 'sound/bureaucracy/binder.ogg', 75, 1)
+		binding = TRUE
 		sleep(rand(200,400))
-		src.visible_message("[src] whirs as it prints and binds a new book.")
-		playsound(src.loc, 'sound/bureaucracy/print.ogg', 75, 1)
-		var/obj/item/book/b = new(src.loc)
+		binding = FALSE
+		if(!anchored)
+			visible_message(SPAN_WARNING("\The [src] buzzes and flashes an error light."))
+			O.forceMove(T)
+			return
+		visible_message(SPAN_NOTICE("\The [src] whirs as it prints and binds a new book."))
+		playsound(T, 'sound/bureaucracy/print.ogg', 75, 1)
+		var/obj/item/book/b = new(T)
 		b.dat = O:info
 		b.name = "Print Job #" + "[rand(100, 999)]"
 		b.icon_state = "book[rand(1,7)]"
 		qdel(O)
-	else
-		..()
+		return
+	if(O.iswrench())
+		anchored = !anchored
+		to_chat(user, SPAN_NOTICE("You [anchored ? "secure" : "unsecure"] the bolts holding \the [src] to the floor."))
+		return

--- a/html/changelogs/doxxmedearly-libraryunanchor.yml
+++ b/html/changelogs/doxxmedearly-libraryunanchor.yml
@@ -1,4 +1,4 @@
-author: Doxxmedearly
+author: Doxxmedearly, MattAtlas
 delete-after: True
 changes:
   - bugfix: "The library book upload scanner and book binder can now be anchored and unanchored."

--- a/html/changelogs/doxxmedearly-libraryunanchor.yml
+++ b/html/changelogs/doxxmedearly-libraryunanchor.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "The library book upload scanner and book binder can now be anchored and unanchored."
+  - bugfix: "You are no longer able to put a paper in the book binder while it is already binding a book."
+  - tweak: "Adjusted some visible messages relating to some library machines."


### PR DESCRIPTION
Yes I know Matt just put a PR up for this. This one also allows the book binder to be moved, and adds interactions for unanchored objects (Namely, they cannot be used). Putting this up for his review. He is credited in the CL as his unanchor/anchor messages were better. 

Also fixes a bug where you could just queue up endless books in the binder, and updates some visible messages.