### PR TITLE
Allows mining drones to go mining

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -15,6 +15,7 @@
 	hat_x_offset = 1
 	hat_y_offset = -12
 	standard_drone = FALSE
+	var/list/allowed_areas = list(/area/exoplanet, /area/shuttle/mining, /area/shuttle/intrepid) //Needed for the bot to go mining
 	var/seeking_player = FALSE
 	var/health_upgrade
 	var/ranged_upgrade
@@ -117,6 +118,8 @@
 	//Check if they are not on a station level -> else abort
 	var/turf/T = get_turf(src)
 	if (!T || isStationLevel(T.z))
+		return FALSE
+	if(is_type_in_list(get_area(T), allowed_areas))
 		return FALSE
 	if(!self_destructing)
 		to_chat(src, SPAN_DANGER("WARNING: Removal from [current_map.company_name] property detected. Anti-Theft mode activated."))

--- a/html/changelogs/doxxmedearly-minebots_befree.yml
+++ b/html/changelogs/doxxmedearly-minebots_befree.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Mining drones can now actually go mining without exploding."


### PR DESCRIPTION
Drone anti-theft only checked station Z, so when arriving at a planet, since the Z is no longer a station Z, they explode.

Fixes that by allowing some areas.

Fixes #14235