### PR TITLE
Reduces bridge crew income, increases ops manager income.

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -155,7 +155,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	supervisors = "the executive officer and the captain"
 	selection_color = "#2b5bb5"
 	minimal_player_age = 20
-	economic_modifier = 10
+	economic_modifier = 5
 	ideal_character_age = list(
 		SPECIES_HUMAN = 30,
 		SPECIES_SKRELL = 75,

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -360,7 +360,7 @@
 	spawn_positions = 1
 	supervisors = "the captain"
 	selection_color = "#967032"
-	economic_modifier = 5
+	economic_modifier = 10
 
 	minimum_character_age = list(
 		SPECIES_HUMAN = 30,

--- a/html/changelogs/anconfuzedrock-bridgeandopsecon.yml
+++ b/html/changelogs/anconfuzedrock-bridgeandopsecon.yml
@@ -2,4 +2,5 @@ author: anconfuzedrock
 
 delete-after: True
 
+changes:
   - tweak: "Operations managers now make more money (same as other heads) and bridge crew make less (same as miners and engineers)."

--- a/html/changelogs/anconfuzedrock-bridgeandopsecon.yml
+++ b/html/changelogs/anconfuzedrock-bridgeandopsecon.yml
@@ -1,0 +1,5 @@
+author: anconfuzedrock
+
+delete-after: True
+
+  - tweak: "Operations managers now make more money (same as other heads) and bridge crew make less (same as miners and engineers)."


### PR DESCRIPTION
These are two jobs which have incomes that I think are oversights:
Operations manager has an econ modifier of 5, which is the same as their underling miners and machinists. Considering ops managers are head staff and all the others have econ 10, this gives the OM econ 10.

Bridge crew has econ 10. This is almost definitely an oversight; it's the same as most heads of staff, it's more than surgeons, etc. Bridge crew have no real qualifications other than piloting, and so this gives them an econ modifier of 5, same as most moderately skilled jobs.