### PR TITLE
Vaurca Blaster buff and Vaurca merchant changes.

### DIFF
--- a/code/datums/trading/unique.dm
+++ b/code/datums/trading/unique.dm
@@ -151,7 +151,22 @@
 		/obj/item/reagent_containers/food/snacks/koisbar          = TRADER_THIS_TYPE,
 		/obj/item/reagent_containers/food/snacks/koisbar_clean    = TRADER_THIS_TYPE,
 		/obj/item/reagent_containers/food/snacks/grown/kois       = TRADER_THIS_TYPE,
-		/obj/item/stack/material/phoron                                  = TRADER_THIS_TYPE
+		/obj/item/stack/material/phoron                             = TRADER_THIS_TYPE,
+		/obj/item/reagent_containers/food/snacks/friedkois			= TRADER_THIS_TYPE,
+		/obj/item/reagent_containers/food/snacks/koiskebab1			= TRADER_THIS_TYPE,
+		/obj/item/reagent_containers/food/snacks/koiskebab2			= TRADER_THIS_TYPE,
+		/obj/item/reagent_containers/food/snacks/koiskebab3			= TRADER_THIS_TYPE,
+		/obj/item/reagent_containers/food/snacks/soup/kois			= TRADER_THIS_TYPE,
+		/obj/item/reagent_containers/food/snacks/koiswaffles		= TRADER_THIS_TYPE,
+		/obj/item/reagent_containers/food/snacks/koisjelly			= TRADER_THIS_TYPE,
+		/obj/item/reagent_containers/food/snacks/koissteak			= TRADER_THIS_TYPE,
+		/obj/item/reagent_containers/food/snacks/donut/kois			= TRADER_THIS_TYPE,
+		/obj/item/reagent_containers/food/snacks/koismuffin			= TRADER_THIS_TYPE,
+		/obj/item/reagent_containers/food/snacks/koisburger			= TRADER_THIS_TYPE,
+		/obj/item/reagent_containers/food/snacks/phoroncandy		= TRADER_THIS_TYPE,
+		/obj/item/reagent_containers/food/drinks/cans/zorasoda/jelly = TRADER_THIS_TYPE
+
+
 	)
 
 	possible_trading_items = list(
@@ -163,11 +178,11 @@
 		/obj/item/clothing/suit/space/void/vaurca        = TRADER_THIS_TYPE,
 		/obj/item/clothing/head/helmet/space/void/vaurca = TRADER_THIS_TYPE,
 		/obj/item/clothing/shoes/magboots/vaurca     = TRADER_THIS_TYPE,
-		/obj/item/gun/energy/vaurca/blaster       = TRADER_THIS_TYPE
-		/obj/item/clothing/suit/space/void/scout	= TRADER_THIS_TYPE
-		/obj/item/clothing/head/helmet/space/void/scout	= TRADER_THIS_TYPE
-		/obj/item/clothing/suit/space/void/commando	= TRADER_THIS_TYPE
-		/obj/item/clothing/head/helmet/space/void/commando = TRADER_THIS_TYPE
+		/obj/item/gun/energy/vaurca/blaster       = TRADER_THIS_TYPE,
+		/obj/item/clothing/suit/space/void/scout	= TRADER_THIS_TYPE,
+		/obj/item/clothing/head/helmet/space/void/scout	= TRADER_THIS_TYPE,
+		/obj/item/clothing/suit/space/void/commando	= TRADER_THIS_TYPE,
+		/obj/item/clothing/head/helmet/space/void/commando = TRADER_THIS_TYPE,
 		/obj/item/clothing/mask/gas/vaurca = TRADER_THIS_TYPE
 	)
 

--- a/code/datums/trading/unique.dm
+++ b/code/datums/trading/unique.dm
@@ -164,6 +164,11 @@
 		/obj/item/clothing/head/helmet/space/void/vaurca = TRADER_THIS_TYPE,
 		/obj/item/clothing/shoes/magboots/vaurca     = TRADER_THIS_TYPE,
 		/obj/item/gun/energy/vaurca/blaster       = TRADER_THIS_TYPE
+		/obj/item/clothing/suit/space/void/scout	= TRADER_THIS_TYPE
+		/obj/item/clothing/head/helmet/space/void/scout	= TRADER_THIS_TYPE
+		/obj/item/clothing/suit/space/void/commando	= TRADER_THIS_TYPE
+		/obj/item/clothing/head/helmet/space/void/commando = TRADER_THIS_TYPE
+		/obj/item/clothing/mask/gas/vaurca = TRADER_THIS_TYPE
 	)
 
 	speech = list(

--- a/code/game/objects/items/weapons/vaurca_items.dm
+++ b/code/game/objects/items/weapons/vaurca_items.dm
@@ -299,7 +299,7 @@
 	icon = 'icons/obj/vaurca_items.dmi'
 	icon_state = "commando"
 	item_state = "commando"
-	desc = "A design perfected by the Zo'ra, this helmet is commonly used  by frontline warriors of a hive. Ablative design deflects lasers away from the body while providing moderate physical protection."
+	desc = "A design perfected by the Zo'ra, this armor is commonly used  by frontline warriors of a hive. Ablative design deflects lasers away from the body while providing moderate physical protection."
 
 	species_restricted = list(BODYTYPE_VAURCA)
 	armor = list(

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -282,7 +282,7 @@
 	accuracy = 1
 	force = 10
 	projectile_type = /obj/item/projectile/energy/blaster/incendiary
-	max_shots = 6
+	max_shots = 7
 	sel_mode = 1
 	burst = 1
 	burst_delay = 1

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -223,5 +223,6 @@
 
 /obj/item/projectile/energy/blaster/incendiary
 	icon_state = "laser"
-	damage = 15
-	incinerate = 2
+	damage = 30
+	armor_penetration = 10
+	incinerate = 5

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -225,4 +225,4 @@
 	icon_state = "laser"
 	damage = 30
 	armor_penetration = 10
-	incinerate = 5
+	incinerate = 4

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Connorjg1/Talion
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Vaurca Blaster Pistol is buffed to being a good blaster."
+  - rscadd: "Vaurca merchant has new Vaurca items in the sale pool."
+  - tweak: "Vaurca merchant will now accept K'ois and Phoron in food form instead of just raw K'ois and K'ois bars."


### PR DESCRIPTION
The Vaurca Blaster (Zo'ra blaster) sold by the Vaurca merchant is no-longer one of the worst pistols in the game. It has had it's damage increased to normal blaster damage instead of 15, fire-damage slightly increased and now has one additional shot. Alongside this several already existing Vaurca items (K'lax Scout Armor, Vaurca Commando Armor, Tactical Mandible Garments) are now in the pool of items that can be sold by the Vaurca merchant. Finally the Vaurca merchant now takes K'ois and Phoron food instead of just raw K'ois as payment. 

Also fixes a spelling mistake in the Vaurca Commando voidsuit.

Done with Vaurca lore approval.