### PR TITLE
Rescue pods now work again and land on an asteroid in the Overmap.

### DIFF
--- a/code/modules/events/rescue_pod.dm
+++ b/code/modules/events/rescue_pod.dm
@@ -5,7 +5,7 @@
 
 /datum/event/rescue_pod/announce()
     if(prob(66))
-        command_announcement.Announce("Ship sensors indicate an escape pod inbound to the [station_name()]. Investigate and attend to the situation in accordance with SCC corporate regulations.", new_title="SCCV Horizon Sensor Suite", new_sound = 'sound/AI/commandreport.ogg')
+        command_announcement.Announce("Ship sensors indicate an escape pod inbound to a nearby celestial body. Investigate the situation if necessary and hand off the survivors, if any, to a third party vessel.", new_title="SCCV Horizon Sensor Suite", new_sound = 'sound/AI/commandreport.ogg')
 
 /datum/event/rescue_pod/setup()
     for(var/datum/event/E in typesof(src))

--- a/code/modules/events/rescue_pod.dm
+++ b/code/modules/events/rescue_pod.dm
@@ -5,7 +5,7 @@
 
 /datum/event/rescue_pod/announce()
     if(prob(66))
-        command_announcement.Announce("The NDV Icarus reports an escape pod inbound to the [station_name()]. Investigate and attend to the situation in accordance with SCC corporate regulations.", new_title="NDV Icarus", new_sound='sound/AI/escapepod.ogg')
+        command_announcement.Announce("Ship sensors indicate an escape pod inbound to the [station_name()]. Investigate and attend to the situation in accordance with SCC corporate regulations.", new_title="SCCV Horizon Sensor Suite", new_sound = 'sound/AI/commandreport.ogg')
 
 /datum/event/rescue_pod/setup()
     for(var/datum/event/E in typesof(src))

--- a/code/modules/ghostroles/spawner/human/emergencypod.dm
+++ b/code/modules/ghostroles/spawner/human/emergencypod.dm
@@ -1,7 +1,7 @@
 /datum/ghostspawner/human/rescuepodsurv
 	short_name = "rescuepodsurv"
 	name = "Rescue Pod Survivor"
-	desc = "You managed to get into a rescue pod and landed somewhere on an asteroid."
+	desc = "You managed to get into a rescue pod and landed somewhere on an asteroid in the sector."
 	tags = list("External")
 
 	enabled = FALSE
@@ -68,8 +68,8 @@
 		possible_species = list(SPECIES_HUMAN,SPECIES_SKRELL, SPECIES_SKRELL_AXIORI,SPECIES_UNATHI)
 
 /datum/ghostspawner/human/rescuepodsurv/select_spawnlocation(var/use=TRUE)
-	//Randomly select a Turf on the asteroid.
-	var/turf/T = pick_area_turf(/area/mine/unexplored)
+	var/list/possible_areas = list(/area/exoplanet/barren/asteroid) 
+	var/turf/T = pick_area_turf(pick(possible_areas))
 	if(!use) //If we are just checking if we can get one, return the turf we found
 		return T
 

--- a/code/modules/random_map/drop/droppod_doors.dm
+++ b/code/modules/random_map/drop/droppod_doors.dm
@@ -29,6 +29,28 @@
 	sleep(30)
 	deploy()
 
+/obj/structure/droppod_door/attackby(obj/item/W, mob/user)
+	. = ..()
+	if(W.iswelder())
+		var/obj/item/weldingtool/WT = W
+		if(WT.isOn())
+			user.visible_message(
+				SPAN_NOTICE("[user] begins cutting \the [src]'s safety bolts."),
+				SPAN_NOTICE("You begin welding \the [src]'s safety bolts."),
+				SPAN_NOTICE("You hear a welding torch on metal.")
+			)
+			if(!WT.use_tool(src, user, 50, volume = 50))
+				return
+			if(!WT.use(1, user))
+				to_chat(user, SPAN_NOTICE("You need more welding fuel to complete this task."))
+				return
+			user.visible_message(
+				SPAN_NOTICE("[user] cuts \the [src]'s safety bolts and removes the plating."),
+				SPAN_NOTICE("You cut \the [src]'s safety bolts and remove the plating.")
+			)
+			new /obj/item/stack/material/steel(get_turf(src), 5)
+			qdel(src)
+
 /obj/structure/droppod_door/proc/deploy()
 	if(deployed)
 		return

--- a/html/changelogs/mattatlas-rescuepod.yml
+++ b/html/changelogs/mattatlas-rescuepod.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Rescue pods now work again. Instead of spawning on the ship, they spawn on an asteroid in the sector. Good luck surviving!"
+  - bugfix: "Drop pod doors can now be dismantled for metal. Survival."


### PR DESCRIPTION
There's no real space for them to land on in the Horizon so I made them spawn on an asteroid, which mining SHOULD get to basically every round. Since it's a ghost role, the players can be sure before spawning.

Also made pod doors deconstructible for the extra Minecraft Survival Single Player feel.