### PR TITLE
Cryogenic Announcement Tweaks

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -402,8 +402,8 @@ var/global/list/frozen_crew = list()
 				W.forceMove(control_computer)
 			else
 				W.forceMove(T)
-
-	global_announcer.autosay("[occupant.real_name], [occupant.mind.role_alt_title], [on_store_message] [on_store_location].", "[on_store_name]")
+	if(isStationLevel(z))
+		global_announcer.autosay("[occupant.real_name], [occupant.mind.role_alt_title], [on_store_message] [on_store_location].", "[on_store_name]")
 	visible_message(SPAN_NOTICE("\The [src] hums and hisses as it moves [occupant] to [on_store_location]."))
 	playsound(loc, on_store_sound, 25)
 	frozen_crew += occupant

--- a/code/modules/ghostroles/spawner/human/human.dm
+++ b/code/modules/ghostroles/spawner/human/human.dm
@@ -97,6 +97,7 @@
 
 	if(assigned_role)
 		M.mind.assigned_role = assigned_role
+		M.mind.role_alt_title = assigned_role
 	if(special_role)
 		M.mind.special_role = special_role
 	if(faction)

--- a/html/changelogs/doxxmedearly-cryonnouncements.yml
+++ b/html/changelogs/doxxmedearly-cryonnouncements.yml
@@ -1,0 +1,5 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Ghost roles jobs will no longer show up as a blank space when entering cryo."
+  - tweak: "The cryogenic oversight announcer will only announce when people cryo if the cryopod is on the Horizon."


### PR DESCRIPTION
Cryo announcements only happen on the Horizon Z-level. It's weird to get announcements for ghost ships. 
Cryo uses the `mind.role_alt_title` to get the job, which is not set when the mob spawned in via ghostspawner, so it would show up as "Hatsune Miku, ,has entered cryo." Now it should show their job properly.