### PR TITLE
Magboots no longer function under certain circumstances

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -113,9 +113,9 @@
 	return prob_slip
 
 /mob/living/carbon/human/Check_Shoegrip(checkSpecies = TRUE)
-	if(shoes && (shoes.item_flags & NOSLIP) && istype(shoes, /obj/item/clothing/shoes/magboots))  //magboots + dense_object = no floating
-		return 1
-	return 0
+	if(shoes && (shoes.item_flags & NOSLIP) && istype(shoes, /obj/item/clothing/shoes/magboots) && !lying && !buckled_to && !grabbed_by)  //magboots + dense_object = no floating. Doesn't work if lying. Grabbedby and buckled_to are for mob carrying, wheelchairs, roller beds, etc.
+		return TRUE
+	return FALSE
 
 /mob/living/carbon/human/set_dir(var/new_dir, ignore_facing_dir = FALSE)
 	. = ..()

--- a/html/changelogs/doxxmedearly-magboots.yml
+++ b/html/changelogs/doxxmedearly-magboots.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - tweak: "Active magboots no longer stop you from entering open turfs if you're lying down, grabbed, or buckled to an object."


### PR DESCRIPTION
The circumstances being if you're lying down, being grabbed, or buckled to something.

This is mostly for rescue operations; if someone unconscious had magboots active, they could not be dragged down the stairs. Magboots are clearly weak enough to be able to walk in, so if someone grabs and drags you, it shouldn't stop them from bringing you down stairs.

This is put in the Check_Shoegrip() proc, rather than the turf/simulated/open/Enter() proc because for everything Check_Shoegrip() touches, it makes sense that magboots would not properly function if you weren't standing with feet firmly planted on the ground. (Floating during gravity loss being the main one). If you're lying, buckled, or being held by someone, you do not have good grip on the ground.

Fixes #13478