### PR TITLE
Intellicarded AIs can no longer access the AI shell borg

### DIFF
--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -135,6 +135,10 @@
 	admin_attack_log(user, ai, "Carded with [src.name]", "Was carded with [src.name]", "used the [src.name] to card")
 	src.name = "[initial(name)] - [ai.name]"
 
+	if(ai.vr_mob) //Kick the AI out of its shell before we stuff it in a card.
+		var/mob/living/silicon/shell = ai.vr_mob
+		if(istype(shell))
+			shell.body_return()
 	ai.forceMove(src)
 	ai.destroy_eyeobj(src)
 	ai.cancel_camera()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -788,6 +788,9 @@ var/list/ai_verbs_default = list(
 	set name = "Remote Control Shell"
 	set category = "AI Commands"
 	set desc = "Remotely control any active shells on your AI shell network."
+
+	if(check_unable(AI_CHECK_WIRELESS))
+		return
 	SSvirtualreality.bound_selection(src, REMOTE_AI_ROBOT)
 
 /mob/living/silicon/ai/proc/toggle_hologram_movement()

--- a/html/changelogs/doxxmedearly-intellicardcontrol.yml
+++ b/html/changelogs/doxxmedearly-intellicardcontrol.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Intellicarded AIs can no longer remote control the AI shell. When carded, they will be kicked out of the shell, if they are in it."


### PR DESCRIPTION
Fixes #12333
Also makes sure that they're properly removed from the shell if carded while inside of it. 