### PR TITLE
Offworlders can have human synthskin prosthetics

### DIFF
--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -111,7 +111,7 @@ var/global/datum/robolimb/basic_robolimb
 	company = PROSTHETIC_SYNTHSKIN
 	desc = "This limb is designed to mimic the Human form. It does so with moderate success."
 	icon = 'icons/mob/human_races/human/r_human.dmi'
-	species_can_use = list(SPECIES_HUMAN)
+	species_can_use = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD)
 	linked_frame = SPECIES_IPC_SHELL
 	fabricator_available = TRUE
 	paintable = TRUE

--- a/html/changelogs/doxxmedearly-offworlderprosthetics.yml
+++ b/html/changelogs/doxxmedearly-offworlderprosthetics.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Offworlders are able to have human synthskin prosthetics, and can select them in character setup."


### PR DESCRIPTION
Fixes #10969
likely an oversight with them having a separate species flag than regular humans