### PR TITLE
Gives Scientists Access to the Intrepid

### DIFF
--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -80,8 +80,8 @@
 		SPECIES_SKRELL_AXIORI = 60
 	)
 
-	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch)
-	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenoarch)
+	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch, access_intrepid)
+	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenoarch, access_intrepid)
 	alt_titles = list("Xenoarcheologist", "Anomalist", "Phoron Researcher")
 
 	minimal_player_age = 14

--- a/html/changelogs/scientist_intrepid_access.yml
+++ b/html/changelogs/scientist_intrepid_access.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - tweak: "Gives scientists access to the Intrepid."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -910,6 +910,7 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
+/obj/structure/bed/handrail,
 /obj/machinery/camera/network/mining{
 	c_tag = "Mining - Shuttle"
 	},
@@ -16847,6 +16848,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 8
 	},
+/obj/structure/bed/handrail{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
 "nBK" = (
@@ -23216,6 +23220,9 @@
 	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
+	},
+/obj/structure/bed/handrail{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
@@ -45561,7 +45568,7 @@ aNO
 uNw
 rAa
 ePy
-sVu
+xpX
 tqs
 vhg
 tNp


### PR DESCRIPTION
this PR gives the scientists access to the intrepid and its cockpit, so they are able to use it for scientific expeditions.
this is also useful for when there's no bridge crew to fly it for them. the bridge crew should of course be the ones to fly it first hand, though.
also adds three hand rails to the mining shuttle, in case they want to take anyone with them.