### PR TITLE
Kills modular computer hear_talk runtimes

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -324,7 +324,7 @@
 		return card_slot.stored_card
 
 /obj/item/modular_computer/hear_talk(mob/M, text, verb, datum/language/speaking)
-	if(Adjacent(M))
+	if(Adjacent(M) && hard_drive)
 		var/datum/computer_file/program/chat_client/P = hard_drive.find_file_by_name("ntnrc_client")
 		if(!P || (P.program_state == PROGRAM_STATE_KILLED && P.service_state == PROGRAM_STATE_KILLED))
 			return


### PR DESCRIPTION
This is killing the CI because hard_drive is null. Just makes a check for that.