### PR TITLE
Raiders Spawn With Sunglasses

### DIFF
--- a/code/datums/outfits/outfit_antag.dm
+++ b/code/datums/outfits/outfit_antag.dm
@@ -316,6 +316,7 @@
 	back = null
 	belt = null
 	gloves = null
+	glasses = /obj/item/clothing/glasses/sunglasses
 	l_ear = /obj/item/device/radio/headset/raider
 	l_pocket = /obj/item/device/contract_uplink
 	r_pocket = list(

--- a/code/datums/outfits/outfit_antag.dm
+++ b/code/datums/outfits/outfit_antag.dm
@@ -316,7 +316,12 @@
 	back = null
 	belt = null
 	gloves = null
-	glasses = /obj/item/clothing/glasses/sunglasses
+	glasses = list(
+			/obj/item/clothing/glasses/sunglasses,
+			/obj/item/clothing/glasses/sunglasses/aviator,
+			/obj/item/clothing/glasses/sunglasses/big,
+			/obj/item/clothing/glasses/sunglasses/visor
+			)
 	l_ear = /obj/item/device/radio/headset/raider
 	l_pocket = /obj/item/device/contract_uplink
 	r_pocket = list(

--- a/html/changelogs/wickedcybs_raiderglasses.yml
+++ b/html/changelogs/wickedcybs_raiderglasses.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Raiders start with sunglasses in their eye slot now."


### PR DESCRIPTION
I noticed they apparently have a good chance to lack flash protection other than their voidsuit helmets if they don't roll any in their warehouse crates. This can make them especially susceptible to flashbangs if they have a gimmick that doesn't involve wandering in the random array of voidsuits. So what I've done is have them spawn with a pair of sunglasses.

An alternate idea that was kicked around to me was having it so you can buy sunglasses in the raider uplink for 1tc. That might be a better solution if it's felt that this infringes on the low supplied feel of raider.