### PR TITLE
Replaces supermatter on overgrown mining station away site

### DIFF
--- a/html/changelogs/doxxmedearly-dontpanic.yml
+++ b/html/changelogs/doxxmedearly-dontpanic.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - maptweak: "Replaces the supermatter on the overgrown mining station with a shard, so there won't be any false delamination announcements."

--- a/maps/away/generic/overgrown_mining_station.dmm
+++ b/maps/away/generic/overgrown_mining_station.dmm
@@ -344,7 +344,7 @@
 /turf/simulated/floor/tiled/steel/airless,
 /area/overgrown_mining_station)
 "ny" = (
-/obj/machinery/power/supermatter,
+/obj/machinery/power/supermatter/shard,
 /turf/simulated/floor/diona/airless,
 /area/overgrown_mining_station)
 "nP" = (


### PR DESCRIPTION
Having a FULL SUPERMATTER on the away site causes the Horizon to get delamination warnings, which I should not have to explain how bad that is. 

Replaces with a shard. 