### PR TITLE
Fixes Three Mapping Bugs

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -387,6 +387,8 @@ var/list/mob/living/forced_ambiance_list = new
 			continue
 		if (istype(A, /area/mine))
 			continue
+		if (istype(A, /area/horizon/exterior))
+			continue
 
 		//Although hostile mobs instadying to turrets is fun
 		//If there's no AI they'll just be hit with stunbeams all day and spam the attack logs.

--- a/code/modules/shieldgen/shield_diffuser.dm
+++ b/code/modules/shieldgen/shield_diffuser.dm
@@ -14,7 +14,7 @@
 	level = 1
 
 	var/enabled = TRUE
-	var/diffuser_range = 1 // 1 tile, including the tile its on.
+	var/diffuser_range = 1 // 1x1 tiles, including the tile its on.
 
 /obj/machinery/shield_diffuser/process()
 	if(stat & BROKEN)

--- a/code/modules/shieldgen/shield_diffuser.dm
+++ b/code/modules/shieldgen/shield_diffuser.dm
@@ -2,7 +2,6 @@
 // Shield Diffusers
 //
 
-
 /obj/machinery/shield_diffuser
 	name = "shield diffuser"
 	desc = "A small underfloor device specifically designed to disrupt energy barriers."

--- a/code/modules/shieldgen/shield_diffuser.dm
+++ b/code/modules/shieldgen/shield_diffuser.dm
@@ -1,3 +1,6 @@
+//
+// Shield Diffusers
+//
 /obj/machinery/shield_diffuser
 	name = "shield diffuser"
 	desc = "A small underfloor device specifically designed to disrupt energy barriers."
@@ -11,6 +14,7 @@
 	level = 1
 
 	var/enabled = TRUE
+	var/diffuser_range = 1 // 1 tile, including the tile its on.
 
 /obj/machinery/shield_diffuser/process()
 	if(stat & BROKEN)
@@ -19,7 +23,7 @@
 	if(!enabled || stat & NOPOWER)
 		return
 
-	for(var/obj/effect/energy_field/S in range(1, src))
+	for(var/obj/effect/energy_field/S in range((diffuser_range - 1), src)) // Range - 1 because of how the BYOND proc works, i.e. excluding the source object.
 		S.diffuse(5)
 
 /obj/machinery/shield_diffuser/update_icon()
@@ -51,3 +55,7 @@
 /obj/machinery/shield_diffuser/power_change()
 	..()
 	update_icon()
+
+// 3x3 Range Shield Diffuser
+/obj/machinery/shield_diffuser/3x3
+	diffuser_range = 3

--- a/code/modules/shieldgen/shield_diffuser.dm
+++ b/code/modules/shieldgen/shield_diffuser.dm
@@ -15,7 +15,7 @@
 	level = 1
 
 	var/diffuser_enabled = TRUE
-	var/diffuser_range = 1 // 1x1 tiles, including the tile its on.
+	var/diffuser_range = 0 // 1x1 tiles, including the tile its on.
 
 /obj/machinery/shield_diffuser/process()
 	if(stat & BROKEN)
@@ -24,7 +24,7 @@
 	if(!diffuser_enabled || stat & NOPOWER)
 		return
 
-	for(var/obj/effect/energy_field/S in range((diffuser_range - 1), src)) // "Range - 1" because of how the BYOND proc works, i.e. excluding the source object.
+	for(var/obj/effect/energy_field/S in range(diffuser_range, src))
 		S.diffuse(5)
 
 /obj/machinery/shield_diffuser/update_icon()
@@ -63,4 +63,4 @@
 
 // 3x3 Range Shield Diffuser
 /obj/machinery/shield_diffuser/threebythree
-	diffuser_range = 3
+	diffuser_range = 1 // 3x3 tiles, including the tile its on.

--- a/code/modules/shieldgen/shield_diffuser.dm
+++ b/code/modules/shieldgen/shield_diffuser.dm
@@ -62,5 +62,5 @@
 //
 
 // 3x3 Range Shield Diffuser
-/obj/machinery/shield_diffuser/3x3
+/obj/machinery/shield_diffuser/threebythree
 	diffuser_range = 3

--- a/code/modules/shieldgen/shield_diffuser.dm
+++ b/code/modules/shieldgen/shield_diffuser.dm
@@ -23,7 +23,7 @@
 	if(!enabled || stat & NOPOWER)
 		return
 
-	for(var/obj/effect/energy_field/S in range((diffuser_range - 1), src)) // Range - 1 because of how the BYOND proc works, i.e. excluding the source object.
+	for(var/obj/effect/energy_field/S in range((diffuser_range - 1), src)) // "Range - 1" because of how the BYOND proc works, i.e. excluding the source object.
 		S.diffuse(5)
 
 /obj/machinery/shield_diffuser/update_icon()

--- a/code/modules/shieldgen/shield_diffuser.dm
+++ b/code/modules/shieldgen/shield_diffuser.dm
@@ -2,6 +2,7 @@
 // Shield Diffusers
 //
 
+
 /obj/machinery/shield_diffuser
 	name = "shield diffuser"
 	desc = "A small underfloor device specifically designed to disrupt energy barriers."

--- a/code/modules/shieldgen/shield_diffuser.dm
+++ b/code/modules/shieldgen/shield_diffuser.dm
@@ -1,6 +1,7 @@
 //
 // Shield Diffusers
 //
+
 /obj/machinery/shield_diffuser
 	name = "shield diffuser"
 	desc = "A small underfloor device specifically designed to disrupt energy barriers."

--- a/code/modules/shieldgen/shield_diffuser.dm
+++ b/code/modules/shieldgen/shield_diffuser.dm
@@ -14,21 +14,21 @@
 	density = FALSE
 	level = 1
 
-	var/enabled = TRUE
+	var/diffuser_enabled = TRUE
 	var/diffuser_range = 1 // 1x1 tiles, including the tile its on.
 
 /obj/machinery/shield_diffuser/process()
 	if(stat & BROKEN)
 		return PROCESS_KILL
 
-	if(!enabled || stat & NOPOWER)
+	if(!diffuser_enabled || stat & NOPOWER)
 		return
 
 	for(var/obj/effect/energy_field/S in range((diffuser_range - 1), src)) // "Range - 1" because of how the BYOND proc works, i.e. excluding the source object.
 		S.diffuse(5)
 
 /obj/machinery/shield_diffuser/update_icon()
-	if(stat & NOPOWER || stat & BROKEN || !enabled)
+	if(stat & NOPOWER || stat & BROKEN || !diffuser_enabled)
 		icon_state = "fdiffuser_off"
 	else
 		icon_state = "fdiffuser_on"
@@ -44,14 +44,14 @@
 	interact(user)
 
 /obj/machinery/shield_diffuser/interact(mob/user)
-	enabled = !enabled
+	diffuser_enabled = !diffuser_enabled
 
 	update_icon()
-	to_chat(user, "You turn \the [src] [enabled ? "on" : "off"].")
+	to_chat(user, "You turn \the [src] [diffuser_enabled ? "on" : "off"].")
 
 /obj/machinery/shield_diffuser/examine(mob/user)
 	. = ..()
-	to_chat(user, "It is [enabled ? "enabled" : "disabled"].")
+	to_chat(user, "It is [diffuser_enabled ? "diffuser_enabled" : "disabled"].")
 
 /obj/machinery/shield_diffuser/power_change()
 	..()

--- a/code/modules/shieldgen/shield_diffuser.dm
+++ b/code/modules/shieldgen/shield_diffuser.dm
@@ -57,7 +57,9 @@
 	update_icon()
 
 //
-// 3x3 Range Shield Diffuser
+// Shield Diffuser Variants
 //
+
+// 3x3 Range Shield Diffuser
 /obj/machinery/shield_diffuser/3x3
 	diffuser_range = 3

--- a/code/modules/shieldgen/shield_diffuser.dm
+++ b/code/modules/shieldgen/shield_diffuser.dm
@@ -56,6 +56,8 @@
 	..()
 	update_icon()
 
+//
 // 3x3 Range Shield Diffuser
+//
 /obj/machinery/shield_diffuser/3x3
 	diffuser_range = 3

--- a/html/changelogs/xenobot_airalarm.yml
+++ b/html/changelogs/xenobot_airalarm.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes:
   - bugfix: "Fixes the xenobotanist not having access to the hazardous specimens air alarm."
   - bugfix: "Fixes the chaplain's shield diffusers leaving the bar exposed to meteors."
+  - bugfix: "Fixes the SM colliding with the shields when ejected."

--- a/html/changelogs/xenobot_airalarm.yml
+++ b/html/changelogs/xenobot_airalarm.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the xenobotanist not having access to the hazardous specimens air alarm."

--- a/html/changelogs/xenobot_airalarm.yml
+++ b/html/changelogs/xenobot_airalarm.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - bugfix: "Fixes the xenobotanist not having access to the hazardous specimens air alarm."
+  - bugfix: "Fixes the chaplain's shield diffusers leaving the bar exposed to meteors."

--- a/maps/sccv_horizon/code/sccv_horizon_areas.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_areas.dm
@@ -309,6 +309,17 @@
 	icon_state = "unknown"
 	station_area = TRUE
 
+// Exterior
+/area/horizon/exterior
+	name = "Horizon - Exterior"
+	icon_state = "exterior"
+	base_turf = /turf/space
+	dynamic_lighting = TRUE
+	requires_power = FALSE
+	has_gravity = FALSE
+	no_light_control = TRUE
+	allow_nightmode = FALSE
+
 /********** Maintenance Start **********/
 // Maintenance
 /area/horizon/maintenance

--- a/maps/sccv_horizon/code/sccv_horizon_unittest.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_unittest.dm
@@ -11,7 +11,8 @@
 		/area/supply/dock,
 		/area/turbolift,
 		/area/mine,
-		/area/construction
+		/area/construction,
+		/area/horizon/exterior
 	)
 
 	ut_apc_exempt_areas = list()

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -2901,9 +2901,15 @@
 /turf/space/dynamic,
 /area/template_noop)
 "cnE" = (
+/obj/structure/lattice/catwalk,
 /obj/machinery/shield_diffuser,
-/turf/simulated/wall/shuttle/scc_space_ship/cardinal,
-/area/maintenance/disposal)
+/obj/item/hullbeacon/red,
+/obj/structure/sign/drop{
+	desc = "A warning sign which reads 'DANGER: MASS EJECTOR PATH ON THIS SIGN'.";
+	name = "\improper DANGER: MASS EJECTOR PATH sign"
+	},
+/turf/space/dynamic,
+/area/template_noop)
 "cnV" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -47389,7 +47395,7 @@ eSV
 eSV
 eSV
 eSV
-eSV
+cnE
 uza
 hEZ
 aZP
@@ -47592,7 +47598,7 @@ eSV
 eSV
 eSV
 eSV
-cnE
+nEm
 cYs
 rOV
 fzU

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -24,7 +24,7 @@
 	dir = 4
 	},
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "abQ" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -1392,7 +1392,7 @@
 	dir = 6
 	},
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "beF" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -1617,11 +1617,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "boH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "boN" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/porta_turret,
@@ -2847,7 +2847,7 @@
 	dir = 4
 	},
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "ckB" = (
 /turf/simulated/floor/reinforced/phoron,
 /area/engineering/atmos)
@@ -2875,7 +2875,7 @@
 "clT" = (
 /obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "cnb" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -2899,7 +2899,7 @@
 	dir = 4
 	},
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "cnE" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/shield_diffuser,
@@ -2975,7 +2975,7 @@
 "cpF" = (
 /obj/structure/grille/diagonal,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "cpU" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -4198,7 +4198,7 @@
 	dir = 9
 	},
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "dpK" = (
 /obj/structure/lattice/catwalk/indoor/grate/damaged,
 /turf/simulated/floor/plating,
@@ -4690,7 +4690,7 @@
 	dir = 8
 	},
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "dPt" = (
 /obj/machinery/light/small/emergency{
 	dir = 4
@@ -5572,7 +5572,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "eyW" = (
 /obj/machinery/camera/network/intrepid{
 	c_tag = "Intrepid - Airlock Starboard"
@@ -5756,7 +5756,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "eGE" = (
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 8
@@ -6115,7 +6115,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "eRF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -6881,7 +6881,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "fwA" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -7735,7 +7735,7 @@
 	dir = 1
 	},
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "gdR" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -12562,7 +12562,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/valve/open,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "kiw" = (
 /obj/structure/sign/securearea{
 	pixel_y = 32
@@ -13113,7 +13113,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/lattice,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "kBF" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -13168,7 +13168,7 @@
 	},
 /obj/structure/lattice,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "kDf" = (
 /obj/structure/railing/mapped,
 /obj/effect/decal/cleanable/dirt,
@@ -15517,7 +15517,7 @@
 "mBc" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/black,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "mBx" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 1;
@@ -16694,7 +16694,7 @@
 	},
 /obj/structure/lattice,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "ntJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 9
@@ -17439,12 +17439,12 @@
 	},
 /obj/structure/lattice,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "oap" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "oaZ" = (
 /obj/machinery/door/window/westright,
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -17686,7 +17686,7 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/black,
 /obj/structure/lattice,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "oos" = (
 /obj/machinery/door/blast/regular/open{
 	id = "hangarlockdown";
@@ -19544,6 +19544,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hangar/auxiliary)
+"pYB" = (
+/obj/structure/lattice,
+/turf/space/dynamic,
+/area/horizon/exterior)
 "pYD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19807,7 +19811,7 @@
 "qgu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "qhz" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/black,
 /obj/machinery/meter,
@@ -20089,7 +20093,7 @@
 	dir = 4
 	},
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "qsq" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/effect/decal/fake_object{
@@ -20114,7 +20118,7 @@
 	},
 /obj/structure/lattice,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "qtm" = (
 /obj/machinery/papershredder,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -20447,7 +20451,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/lattice,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "qEK" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
@@ -20863,7 +20867,7 @@
 	dir = 4
 	},
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "qZj" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -21573,7 +21577,7 @@
 	dir = 4
 	},
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "rEl" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -22207,7 +22211,7 @@
 	dir = 4
 	},
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "sfh" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -23110,7 +23114,7 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "sPQ" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -24060,7 +24064,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "tFO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25682,7 +25686,7 @@
 	},
 /obj/structure/lattice,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "uVF" = (
 /obj/structure/shuttle_part{
 	icon = 'icons/turf/shuttles_unique/scc_shuttle_pieces.dmi';
@@ -27531,7 +27535,7 @@
 	dir = 4
 	},
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "wuD" = (
 /turf/simulated/wall,
 /area/hangar/intrepid)
@@ -27585,7 +27589,7 @@
 	},
 /obj/structure/lattice,
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "wxs" = (
 /obj/machinery/camera/network/supply{
 	c_tag = "Operations - Mining Shuttle Dock Starboard";
@@ -27660,6 +27664,9 @@
 /mob/living/silicon/robot/drone/construction/matriarch,
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
+"wEY" = (
+/turf/space/dynamic,
+/area/horizon/exterior)
 "wGn" = (
 /obj/structure/bed/stool/chair/shuttle,
 /turf/simulated/floor/tiled,
@@ -27951,7 +27958,7 @@
 	dir = 6
 	},
 /turf/space/dynamic,
-/area/template_noop)
+/area/horizon/exterior)
 "wUz" = (
 /obj/effect/floor_decal/corner_wide/purple/diagonal,
 /obj/machinery/door/window/westright{
@@ -48608,8 +48615,8 @@ eSV
 eSV
 oam
 cpF
-dEC
-hoV
+wEY
+pYB
 onU
 qEq
 oap
@@ -48809,8 +48816,8 @@ eSV
 eSV
 eSV
 sPo
-hoV
-hoV
+pYB
+pYB
 oDB
 bID
 fOC
@@ -49011,8 +49018,8 @@ eSV
 eSV
 eSV
 sPo
-dEC
-dEC
+wEY
+wEY
 jvE
 lPP
 xHW
@@ -49213,14 +49220,14 @@ eSV
 eSV
 eSV
 sPo
-dEC
-dEC
+wEY
+wEY
 twq
 dBA
 pMX
 dBA
 ipg
-dEC
+wEY
 wup
 ckd
 hWb
@@ -49415,8 +49422,8 @@ eSV
 eSV
 eSV
 sPo
-dEC
-dEC
+wEY
+wEY
 foN
 htn
 nnh
@@ -49617,8 +49624,8 @@ eSV
 eSV
 eSV
 sPo
-hoV
-hoV
+pYB
+pYB
 oDB
 nAX
 vWL
@@ -49626,7 +49633,7 @@ mnL
 oDB
 ckd
 wup
-dEC
+wEY
 gaC
 lqh
 rNy
@@ -49819,13 +49826,13 @@ eSV
 eSV
 eSV
 sPo
-dEC
-dEC
-hoV
-dEC
-dEC
-dEC
-hoV
+wEY
+wEY
+pYB
+wEY
+wEY
+wEY
+pYB
 nto
 cnx
 kid
@@ -50021,16 +50028,16 @@ eSV
 eSV
 eSV
 sPo
-hoV
-hoV
+pYB
+pYB
 oDB
 kna
 uAi
 wVU
 oDB
-dEC
+wEY
 wup
-dEC
+wEY
 hWb
 aph
 sXy
@@ -50223,8 +50230,8 @@ eSV
 eSV
 eSV
 sPo
-dEC
-dEC
+wEY
+wEY
 xJv
 ebN
 sEE
@@ -50425,16 +50432,16 @@ eSV
 eSV
 eSV
 sPo
-dEC
-dEC
+wEY
+wEY
 tBT
 dKY
 nRZ
 dKY
 fFm
-dEC
+wEY
 wup
-dEC
+wEY
 gaC
 keQ
 eIS
@@ -50627,8 +50634,8 @@ eSV
 eSV
 eSV
 sPo
-dEC
-dEC
+wEY
+wEY
 wnz
 bGf
 enn
@@ -50829,8 +50836,8 @@ eSV
 eSV
 eSV
 sPo
-hoV
-hoV
+pYB
+pYB
 oDB
 eMK
 lzc
@@ -50838,7 +50845,7 @@ iMg
 oDB
 tFM
 wup
-dEC
+wEY
 hWb
 aph
 btw
@@ -51031,13 +51038,13 @@ eSV
 eSV
 eSV
 sPo
-dEC
-dEC
-hoV
-dEC
+wEY
+wEY
+pYB
+wEY
 mBc
-dEC
-hoV
+wEY
+pYB
 wUo
 qsn
 eRb
@@ -51233,8 +51240,8 @@ eSV
 eSV
 eSV
 sPo
-hoV
-hoV
+pYB
+pYB
 oDB
 vbv
 dEU
@@ -51242,7 +51249,7 @@ bFw
 oDB
 qZc
 wup
-dEC
+wEY
 gaC
 bBR
 uPe
@@ -51435,8 +51442,8 @@ eSV
 eSV
 eSV
 sPo
-dEC
-dEC
+wEY
+wEY
 uKu
 vuB
 jpI
@@ -51637,14 +51644,14 @@ eSV
 eSV
 eSV
 sPo
-dEC
-dEC
+wEY
+wEY
 lJK
 ckB
 pTj
 ckB
 xki
-dEC
+wEY
 wup
 qZc
 hWb
@@ -51839,8 +51846,8 @@ eSV
 eSV
 eSV
 sPo
-dEC
-dEC
+wEY
+wEY
 fQZ
 wdX
 onN
@@ -52041,16 +52048,16 @@ eSV
 eSV
 eSV
 sPo
-hoV
-hoV
+pYB
+pYB
 oDB
 ukl
 eeb
 iES
 oDB
-dEC
+wEY
 wup
-dEC
+wEY
 gCN
 aYt
 pAp
@@ -52244,15 +52251,15 @@ eSV
 eSV
 wxd
 abr
-dEC
-hoV
+wEY
+pYB
 clT
 eyU
 boC
 boC
 fvy
 wup
-dEC
+wEY
 gCN
 kzi
 heH

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -921,7 +921,7 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "avy" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/light{
@@ -2422,7 +2422,7 @@
 "beY" = (
 /obj/structure/grille,
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "bff" = (
 /obj/machinery/camera/network/command{
 	c_tag = "AI Core - External";
@@ -2669,7 +2669,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/sign/emerg_exitZ,
 /turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "bmM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3022,6 +3022,10 @@
 "bwU" = (
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
+"bxp" = (
+/obj/structure/lattice/catwalk,
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "bxZ" = (
 /obj/structure/sink{
 	pixel_y = 21
@@ -3852,6 +3856,9 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/rnd/conference)
+"bSK" = (
+/turf/simulated/floor/reinforced/airless,
+/area/horizon/exterior)
 "bTg" = (
 /turf/simulated/floor/plating,
 /area/engineering/smes/tesla)
@@ -4300,6 +4307,12 @@
 /obj/effect/landmark/engine_setup/filter,
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
+"cgI" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/horizon/exterior)
 "cgP" = (
 /obj/effect/floor_decal/corner_wide/grey/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6223,9 +6236,14 @@
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
 "dpj" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/template_noop,
+/obj/structure/lattice/catwalk,
+/obj/machinery/shield_diffuser,
+/obj/item/hullbeacon/red,
+/obj/structure/sign/drop{
+	desc = "A warning sign which reads 'DANGER: MASS EJECTOR PATH ON THIS SIGN'.";
+	name = "\improper DANGER: MASS EJECTOR PATH sign"
+	},
+/turf/simulated/open/airless,
 /area/template_noop)
 "dpE" = (
 /obj/structure/cable{
@@ -7517,6 +7535,9 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/operations/office)
+"ecA" = (
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "ecV" = (
 /turf/simulated/floor/plating,
 /area/engineering/engine_monitoring/tesla)
@@ -7724,7 +7745,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "elh" = (
 /obj/structure/stairs/north,
 /turf/simulated/floor/tiled/ramp,
@@ -9898,7 +9919,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "fxe" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 10
@@ -10072,6 +10093,12 @@
 	},
 /turf/simulated/floor/lino/grey,
 /area/horizon/kitchen/hallway)
+"fDv" = (
+/obj/structure/ladder{
+	pixel_y = 16
+	},
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "fDA" = (
 /obj/machinery/porta_turret,
 /obj/effect/floor_decal/industrial/warning/full,
@@ -10299,7 +10326,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "fJX" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 10
@@ -11528,8 +11555,8 @@
 "gmo" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "gmt" = (
 /obj/structure/table/standard,
 /obj/machinery/light_switch{
@@ -12641,6 +12668,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"gNm" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/horizon/exterior)
 "gNn" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -13810,7 +13843,7 @@
 	dir = 5
 	},
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "htd" = (
 /turf/simulated/floor/holofloor/tiled/ramp/bottom,
 /area/horizon/stairwell/bridge)
@@ -13897,7 +13930,7 @@
 	},
 /obj/structure/lattice,
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "hww" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -14091,7 +14124,7 @@
 "hBN" = (
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "hBQ" = (
 /obj/machinery/alarm{
 	pixel_y = 28
@@ -14212,7 +14245,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "hEd" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 1
@@ -17055,8 +17088,8 @@
 	},
 /obj/structure/lattice,
 /obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "jmp" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/snack{
@@ -17658,6 +17691,10 @@
 /obj/effect/floor_decal/corner/green/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_quarters/cryo/living_quarters_lift)
+"jCY" = (
+/obj/structure/lattice,
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "jDa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -19395,6 +19432,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/armory)
+"kHg" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/drop{
+	desc = "A warning sign which reads 'DANGER: MASS EJECTOR PATH ON THIS SIGN'.";
+	name = "\improper DANGER: MASS EJECTOR PATH sign"
+	},
+/obj/item/hullbeacon/red,
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "kHj" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -19445,8 +19491,8 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/lattice,
 /obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "kIp" = (
 /turf/simulated/floor/tiled,
 /area/operations/break_room)
@@ -19946,6 +19992,16 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/horizon/maintenance/deck_two/fore/starboard)
+"kYF" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/drop{
+	desc = "A warning sign which reads 'DANGER: MASS EJECTOR PATH ON THIS SIGN'.";
+	name = "\improper DANGER: MASS EJECTOR PATH sign"
+	},
+/obj/machinery/shield_diffuser,
+/obj/item/hullbeacon/red,
+/turf/simulated/open/airless,
+/area/template_noop)
 "kYK" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -20116,14 +20172,8 @@
 "lcu" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/industrial/warning,
-/obj/machinery/shield_diffuser,
-/obj/structure/sign/drop{
-	desc = "A warning sign which reads 'DANGER: MASS EJECTOR PATH ON THIS SIGN'.";
-	name = "\improper DANGER: MASS EJECTOR PATH sign"
-	},
-/obj/item/hullbeacon/red,
 /turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "lcy" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
@@ -20557,8 +20607,8 @@
 	dir = 8
 	},
 /obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "lqJ" = (
 /obj/effect/floor_decal/corner/lime/full{
 	dir = 8
@@ -20800,6 +20850,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/conference)
+"lzM" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/horizon/exterior)
 "lAx" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -20880,7 +20936,7 @@
 "lBV" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "lBW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
@@ -21649,8 +21705,8 @@
 	dir = 6
 	},
 /obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "lVe" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
 /obj/machinery/hologram/holopad,
@@ -22870,8 +22926,8 @@
 	},
 /obj/structure/lattice,
 /obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "mFD" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
@@ -25193,7 +25249,7 @@
 	dir = 1
 	},
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "nNv" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 6
@@ -25243,7 +25299,7 @@
 "nPG" = (
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "nQm" = (
 /turf/simulated/wall,
 /area/maintenance/substation/medical)
@@ -27113,11 +27169,16 @@
 	dir = 4
 	},
 /obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "oTa" = (
 /turf/simulated/floor/tiled,
 /area/maintenance/aux_atmospherics/deck_2/starboard/wing)
+"oTg" = (
+/obj/item/hullbeacon/red,
+/obj/structure/lattice/catwalk,
+/turf/simulated/open/airless,
+/area/template_noop)
 "oTr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -28932,8 +28993,8 @@
 	},
 /obj/structure/lattice,
 /obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "pQj" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -29333,7 +29394,7 @@
 	dir = 1
 	},
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "qav" = (
 /turf/simulated/wall,
 /area/assembly/chargebay)
@@ -29464,10 +29525,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "qeZ" = (
-/obj/structure/lattice,
-/obj/machinery/shield_diffuser,
-/turf/template_noop,
-/area/template_noop)
+/obj/item/hullbeacon/red,
+/obj/structure/sign/drop{
+	desc = "A warning sign which reads 'DANGER: MASS EJECTOR PATH ON THIS SIGN'.";
+	name = "\improper DANGER: MASS EJECTOR PATH sign"
+	},
+/turf/simulated/floor/airless,
+/area/horizon/exterior)
 "qff" = (
 /obj/machinery/light{
 	dir = 4
@@ -31005,7 +31069,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "qXx" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 1
@@ -31706,7 +31770,7 @@
 	dir = 10
 	},
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "roP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31884,8 +31948,8 @@
 	dir = 5
 	},
 /obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "rsp" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -32201,7 +32265,7 @@
 	dir = 6
 	},
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "rBi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32617,8 +32681,8 @@
 	dir = 10
 	},
 /obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "rNe" = (
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d2-1-f"
@@ -33047,7 +33111,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "rWp" = (
 /obj/structure/foamedmetal,
 /obj/structure/shuttle_part/scc_space_ship{
@@ -33191,8 +33255,8 @@
 /obj/structure/lattice,
 /obj/structure/lattice,
 /obj/structure/grille,
-/turf/template_noop,
-/area/template_noop)
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "saJ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
@@ -34677,7 +34741,7 @@
 	dir = 1
 	},
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "sXb" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -36851,6 +36915,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/horizon/bar)
+"ugx" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/horizon/exterior)
 "ugC" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -37286,7 +37356,7 @@
 	},
 /obj/structure/lattice,
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "upl" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -38724,7 +38794,7 @@
 	dir = 4
 	},
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "vbe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -38771,7 +38841,7 @@
 /area/maintenance/substation/wing_starboard)
 "vcM" = (
 /turf/simulated/floor/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "vdy" = (
 /obj/machinery/door/firedoor,
 /obj/effect/map_effect/wingrille_spawn/reinforced/polarized{
@@ -38822,7 +38892,7 @@
 	pixel_y = 16
 	},
 /turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "veO" = (
 /obj/structure/bed/stool/chair/padded/black{
 	dir = 1
@@ -39184,8 +39254,8 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /obj/structure/grille,
-/turf/template_noop,
-/area/template_noop)
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "vrC" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -41071,7 +41141,7 @@
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "wkN" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -43388,7 +43458,7 @@
 	dir = 9
 	},
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "xsY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -44125,8 +44195,8 @@
 	dir = 9
 	},
 /obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
+/turf/simulated/open/airless,
+/area/horizon/exterior)
 "xPm" = (
 /turf/simulated/wall,
 /area/maintenance/substation/wing_port)
@@ -44346,6 +44416,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"xVu" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced/airless,
+/area/horizon/exterior)
 "xVz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -44471,6 +44545,12 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora_hazard)
+"xXW" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/horizon/exterior)
 "xYK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44771,7 +44851,7 @@
 	dir = 4
 	},
 /turf/simulated/open/airless,
-/area/template_noop)
+/area/horizon/exterior)
 "ydL" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 6
@@ -56866,12 +56946,12 @@ qgN
 qgN
 qgN
 qgN
-dpj
-dpj
-dpj
-dpj
-dpj
-dpj
+avu
+avu
+avu
+avu
+avu
+avu
 qgN
 qgN
 qgN
@@ -57062,18 +57142,18 @@ qgN
 qgN
 qgN
 qgN
-dpj
-dpj
-dpj
-dpj
-dpj
-dpj
+avu
+avu
+avu
+avu
+avu
+avu
 sau
-lJE
-lJE
-lJE
-lJE
-dpj
+bxp
+bxp
+bxp
+bxp
+avu
 qgN
 qgN
 qgN
@@ -57264,14 +57344,14 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
-lJE
-lJE
-lJE
-lJE
-lJE
-lJE
+avu
+bxp
+bxp
+bxp
+bxp
+bxp
+bxp
+bxp
 lVd
 gmo
 gmo
@@ -57466,8 +57546,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 lVd
 gmo
 gmo
@@ -57663,13 +57743,13 @@ qgN
 qgN
 qgN
 qgN
-dpj
-dpj
-dpj
-dpj
-dpj
+avu
+avu
+avu
+avu
+avu
 sau
-lJE
+bxp
 pQg
 jmm
 gmo
@@ -57864,17 +57944,17 @@ qgN
 qgN
 qgN
 qgN
-dpj
-dpj
-lJE
-lJE
-lJE
-lJE
-lJE
-lJE
+avu
+avu
+bxp
+bxp
+bxp
+bxp
+bxp
+bxp
 oSQ
 oSQ
-lJE
+bxp
 wcr
 wcr
 wcr
@@ -58066,9 +58146,9 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
-lJE
+avu
+bxp
+bxp
 lVd
 gmo
 gmo
@@ -58076,7 +58156,7 @@ gmo
 gmo
 mFz
 oSQ
-lJE
+bxp
 sSY
 sSY
 aVo
@@ -58267,9 +58347,9 @@ qgN
 qgN
 qgN
 qgN
-dpj
-dpj
-lJE
+avu
+avu
+bxp
 lVd
 xPj
 lVd
@@ -58278,7 +58358,7 @@ gmo
 gmo
 kHS
 xPj
-lJE
+bxp
 sSY
 sSY
 sSY
@@ -58469,9 +58549,9 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
-lJE
+avu
+bxp
+bxp
 oSQ
 lVd
 xPj
@@ -58670,9 +58750,9 @@ qgN
 qgN
 qgN
 qgN
-dpj
-dpj
-lJE
+avu
+avu
+bxp
 lVd
 xPj
 oSQ
@@ -58871,10 +58951,10 @@ qgN
 qgN
 qgN
 qgN
-dpj
-dpj
-lJE
-lJE
+avu
+avu
+bxp
+bxp
 oSQ
 lVd
 xPj
@@ -59072,10 +59152,10 @@ qgN
 qgN
 qgN
 qgN
-dpj
-dpj
-lJE
-lJE
+avu
+avu
+bxp
+bxp
 lVd
 xPj
 oSQ
@@ -59274,9 +59354,9 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
-lJE
+avu
+bxp
+bxp
 lVd
 xPj
 lVd
@@ -59476,8 +59556,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 lVd
 xPj
 lVd
@@ -59678,8 +59758,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 oSQ
 lVd
 xPj
@@ -59880,8 +59960,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 oSQ
 oSQ
 wcr
@@ -60082,8 +60162,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 oSQ
 oSQ
 wcr
@@ -60157,8 +60237,8 @@ bGI
 hwM
 spn
 lNQ
-xer
-ghq
+xVu
+fDv
 qgN
 qgN
 qgN
@@ -60284,8 +60364,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 oSQ
 oSQ
 wcr
@@ -60359,7 +60439,7 @@ mOS
 kOW
 eyu
 lCF
-xer
+xVu
 qgN
 qgN
 qgN
@@ -60486,8 +60566,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 oSQ
 oSQ
 wcr
@@ -60561,7 +60641,7 @@ jEL
 jEL
 oWC
 lCF
-xer
+xVu
 qgN
 qgN
 qgN
@@ -60688,8 +60768,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 oSQ
 oSQ
 wcr
@@ -60763,7 +60843,7 @@ off
 bCD
 vKF
 lCF
-xer
+xVu
 qgN
 qgN
 qgN
@@ -60889,12 +60969,12 @@ qgN
 qgN
 qgN
 qgN
-qgN
+dpj
+jCY
+kHg
+oSQ
+oSQ
 qeZ
-lJE
-oSQ
-oSQ
-qgN
 vcM
 gWf
 dAN
@@ -60965,7 +61045,7 @@ oKE
 jpf
 vYI
 lCF
-xer
+xVu
 qgN
 qgN
 qgN
@@ -61092,8 +61172,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 oSQ
 oSQ
 wcr
@@ -61167,7 +61247,7 @@ fol
 fol
 pgi
 lNQ
-xer
+xVu
 qgN
 qgN
 qgN
@@ -61294,8 +61374,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 oSQ
 oSQ
 wcr
@@ -61370,6 +61450,7 @@ fol
 aCS
 fRc
 lcu
+kYF
 qgN
 qgN
 mpN
@@ -61378,11 +61459,10 @@ qgN
 slk
 qgN
 qgN
-mpN
+oTg
 qgN
 qgN
 slk
-qgN
 qgN
 qgN
 qgN
@@ -61496,8 +61576,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 oSQ
 oSQ
 wcr
@@ -61571,7 +61651,7 @@ axL
 fol
 fol
 lNQ
-xer
+xVu
 qgN
 fRg
 mLU
@@ -61583,8 +61663,8 @@ mLU
 mLU
 mLU
 eTQ
-dUw
 qgN
+dUw
 qgN
 qgN
 qgN
@@ -61698,8 +61778,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 oSQ
 oSQ
 wcr
@@ -61900,8 +61980,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 oSQ
 oSQ
 wcr
@@ -62102,8 +62182,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 oSQ
 rMw
 rrN
@@ -62304,8 +62384,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 rMw
 rrN
 rMw
@@ -62506,9 +62586,9 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
-lJE
+avu
+bxp
+bxp
 rMw
 rrN
 rMw
@@ -62708,10 +62788,10 @@ qgN
 qgN
 qgN
 qgN
-dpj
-dpj
-lJE
-lJE
+avu
+avu
+bxp
+bxp
 rMw
 rrN
 oSQ
@@ -62911,10 +62991,10 @@ qgN
 qgN
 qgN
 qgN
-dpj
-dpj
-lJE
-lJE
+avu
+avu
+bxp
+bxp
 oSQ
 oSQ
 tNa
@@ -63114,9 +63194,9 @@ qgN
 qgN
 qgN
 qgN
-dpj
-dpj
-lJE
+avu
+avu
+bxp
 oSQ
 oSQ
 tNa
@@ -63317,8 +63397,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 oSQ
 rMw
 rrN
@@ -63519,8 +63599,8 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
+avu
+bxp
 rMw
 rrN
 oSQ
@@ -63721,9 +63801,9 @@ qgN
 qgN
 qgN
 qgN
-dpj
-lJE
-lJE
+avu
+bxp
+bxp
 oSQ
 rMw
 rrN
@@ -63923,14 +64003,14 @@ qgN
 qgN
 qgN
 qgN
-dpj
-dpj
-lJE
+avu
+avu
+bxp
 rMw
 gmo
 xPj
 beY
-kUf
+bxp
 rBh
 nNe
 hvU
@@ -64127,18 +64207,18 @@ qgN
 qgN
 qgN
 vrk
-lJE
-lJE
-lJE
-lJE
+bxp
+bxp
+bxp
+bxp
 beY
-kUf
+bxp
 ydI
-fRg
-mLU
+lzM
+xXW
 hBN
-mLU
-eTQ
+xXW
+gNm
 ydI
 dSU
 lGx
@@ -64328,19 +64408,19 @@ qgN
 qgN
 qgN
 qgN
-dpj
-dpj
-dpj
-dpj
-dpj
 avu
-kUf
+avu
+avu
+avu
+avu
+avu
+bxp
 vbc
 qWJ
-kgp
+bSK
 hBN
-kgp
-xer
+bSK
+xVu
 vbc
 kQS
 lOf
@@ -64536,13 +64616,13 @@ qgN
 qgN
 qgN
 beY
-kUf
+bxp
 rWg
 hBN
 hBN
 hBN
-kgp
-xer
+bSK
+xVu
 vbc
 lMD
 sMn
@@ -64738,13 +64818,13 @@ qgN
 qgN
 qgN
 beY
-kUf
+bxp
 vbc
 qWJ
-kgp
+bSK
 hBN
-kgp
-xer
+bSK
+xVu
 vbc
 inD
 lZP
@@ -64940,13 +65020,13 @@ qgN
 qgN
 qgN
 beY
-kUf
+bxp
 ydI
 hDE
-rVv
+ugx
 hBN
-rVv
-uhP
+ugx
+cgI
 ydI
 lMD
 qMd
@@ -65142,13 +65222,13 @@ qgN
 qgN
 qgN
 beY
-kUf
+bxp
 vbc
-dUw
-kuh
+jCY
+ecA
 nPG
-kuh
-dUw
+ecA
+jCY
 vbc
 inD
 lnv
@@ -65344,13 +65424,13 @@ qgN
 qgN
 qgN
 beY
-kUf
+bxp
 ydI
-fRg
-mLU
+lzM
+xXW
 hBN
-mLU
-eTQ
+xXW
+gNm
 ydI
 lMD
 hwH
@@ -65546,13 +65626,13 @@ qgN
 qgN
 qgN
 beY
-kUf
+bxp
 vbc
 qWJ
-kgp
+bSK
 hBN
-kgp
-xer
+bSK
+xVu
 vbc
 inD
 nCJ
@@ -65748,13 +65828,13 @@ qgN
 qgN
 qgN
 wkw
-kUf
+bxp
 rWg
 hBN
 hBN
 hBN
-kgp
-xer
+bSK
+xVu
 vbc
 lMD
 fsA
@@ -65950,12 +66030,12 @@ qgN
 qgN
 qgN
 beY
-kUf
+bxp
 vbc
 qWJ
-kgp
+bSK
 hBN
-kgp
+bSK
 bmH
 vbc
 lMD
@@ -66152,7 +66232,7 @@ qgN
 qgN
 qgN
 beY
-kUf
+bxp
 ydI
 veu
 hBN
@@ -66354,7 +66434,7 @@ qgN
 qgN
 qgN
 beY
-kUf
+bxp
 rou
 qar
 sWS

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -22324,7 +22324,6 @@
 /turf/simulated/floor/tiled,
 /area/engineering/storage_hard)
 "mpN" = (
-/obj/machinery/shield_diffuser,
 /obj/structure/lattice/catwalk,
 /obj/item/hullbeacon/red,
 /turf/simulated/open/airless,
@@ -33530,13 +33529,12 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/aux_atmospherics/deck_2/starboard/wing)
 "slk" = (
-/obj/machinery/shield_diffuser,
 /obj/structure/lattice/catwalk,
+/obj/item/hullbeacon/red,
 /obj/structure/sign/drop{
 	desc = "A warning sign which reads 'DANGER: MASS EJECTOR PATH ON THIS SIGN'.";
 	name = "\improper DANGER: MASS EJECTOR PATH sign"
 	},
-/obj/item/hullbeacon/red,
 /turf/simulated/open/airless,
 /area/template_noop)
 "slm" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -147,9 +147,8 @@
 /obj/machinery/alarm{
 	alarm_id = 1601;
 	dir = 8;
-	name = "Hazardous Specimens";
 	pixel_x = 28;
-	req_one_access = list(24,11,55)
+	req_one_access = list(11, 24, 52)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora_hazard)

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -1218,8 +1218,7 @@
 /area/turbolift/scc_ship/cargo_lift)
 "aBr" = (
 /obj/effect/floor_decal/corner/mauve{
-	dir = 5;
-	color = s
+	dir = 5
 	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -35035,15 +35034,6 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
 /area/security/brig/processing_secondary)
-"tdD" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 5
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/research)
 "tdM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/mauve,
@@ -68885,7 +68875,7 @@ bGh
 ljp
 tDc
 oGR
-tdD
+aBr
 lWQ
 bGj
 cNU


### PR DESCRIPTION
title. this PR also tweaks an oversight with shield diffusers where their range wasn't customizable.

**changes**
-

fixes #14290.
fixes the chaplain shield diffusers leaving the bar lounge exposed to meteors.
fixes the SM slamming into the shields during the ejection process, if they're enabled.