### PR TITLE
Magboot Fixes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -103,7 +103,7 @@
 	return prob_slip
 
 /mob/living/carbon/human/Check_Shoegrip(checkSpecies = TRUE)
-	if(shoes && (shoes.item_flags & NOSLIP) && istype(shoes, /obj/item/clothing/shoes/magboots) && !lying && !buckled_to && !grabbed_by)  //magboots + dense_object = no floating. Doesn't work if lying. Grabbedby and buckled_to are for mob carrying, wheelchairs, roller beds, etc.
+	if(shoes && (shoes.item_flags & NOSLIP) && istype(shoes, /obj/item/clothing/shoes/magboots) && !lying && !buckled_to && !length(grabbed_by))  //magboots + dense_object = no floating. Doesn't work if lying. Grabbedby and buckled_to are for mob carrying, wheelchairs, roller beds, etc.
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -472,7 +472,7 @@
 	return -1
 
 //Checks if a mob has solid ground to stand on
-//If there's no gravity then there's no up or down so naturally you can't stand on anything.
+//If there's no gravity then there's no up or down so naturally you can't stand on anything, unless you have grip.
 //For the same reason lattices in space don't count - those are things you grip, presumably.
 /mob/proc/check_solid_ground()
 	var/turf/T = get_turf(src)
@@ -484,7 +484,7 @@
 
 	var/area/A = T.loc
 
-	if (!A.has_gravity())
+	if (!A.has_gravity() && !Check_Shoegrip())
 		return 0
 
 	return 1

--- a/html/changelogs/doxxmedearly-bootsaremadeforwalking.yml
+++ b/html/changelogs/doxxmedearly-bootsaremadeforwalking.yml
@@ -1,0 +1,5 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Magboots should once more prevent you from being flung about during shuttle launches."
+  - bugfix: "Magboots should now always function if there's solid ground beneath you, including at away sites, and newly built floors in space."


### PR DESCRIPTION
Only one of these was caused by me!
grabbed_by is a list, not a var. Oops. Checks length properly, now.

Magboots not working at some sites and when building tiles in space is due to `check_solid_ground()` returning FALSE if the AREA was set to no_gravity (Lattices overrode this). The sol bunker site outside is area/space, and obviously building tiles in space is.... area/space. So that explains the slipping. The fix? Just check_shoegrip(). It already fails if there's open space on your tile, this just allows powered magboots to grip in areas that don't have gravity IF they have actual floor below them. 

Sadly this means people will no longer careen into landmines on the sol bunker site. Oh well. 

Fixes #14304
Fixes #13723