### PR TITLE
Zombie tweaks/buffs/nerfs.

### DIFF
--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -98,6 +98,7 @@
 	var/real_damage = rand_damage
 	var/hit_dam_type = attack.damage_type
 	var/damage_flags = attack.damage_flags()
+	var/armor_penetration = attack.armor_penetration
 
 	real_damage += attack.get_unarmed_damage(A)
 	real_damage *= D.damage_multiplier
@@ -132,7 +133,7 @@
 
 	attack.apply_effects(A, D, rand_damage, hit_zone)
 
-	D.apply_damage(real_damage, hit_dam_type, hit_zone, damage_flags = damage_flags)
+	D.apply_damage(real_damage, hit_dam_type, hit_zone, damage_flags = damage_flags, armor_pen = armor_penetration)
 
 	return 1
 

--- a/code/modules/martial_arts/zombie.dm
+++ b/code/modules/martial_arts/zombie.dm
@@ -34,8 +34,8 @@
 	A.do_attack_animation(D)
 	var/atk_verb = pick("chomps", "bites")
 	D.visible_message(SPAN_DANGER("[A] [atk_verb] down hard on [D]!"), SPAN_DANGER("[A] [atk_verb] down hard on you!"))
-	D.apply_damage(rand(5, 10), BRUTE, damage_flags = DAM_SHARP)
-	playsound(get_turf(D), 'sound/weapons/slash.ogg', 25, 1, -1)
+	D.apply_damage(rand(5, 10), BRUTE, damage_flags = DAM_SHARP, armor_pen = 100)
+	playsound(get_turf(D), 'sound/weapons/bloodyslice.ogg', 25, 1, -1)
 	return TRUE
 
 /datum/martial_art/zombie/proc/zombie_help()
@@ -44,7 +44,8 @@
 	set category = "Abilities"
 
 	to_chat(usr, "<b><i>You moan inside yourself, grasping knowledge unknown to the living...</i></b>")
-	to_chat(usr, "<span class='notice'>Strong Bite</span>: Harm Harm Harm. Delivers a strong bite to your foe, piercing through any armor they may have.")
+	to_chat(usr, "<span class='notice'>Strong Bite</span>: Harm Harm Harm. Delivers a strong bite to your foe. This bite does 5 to 10 damage but pierces through all armour.")
 	to_chat(usr, "<span class='notice'>Strong Grip</span>: Grab. While weak, your ravenous lust for living flesh allows you to instantly get an aggressive grab on anyone you catch.")
+	to_chat(usr, SPAN_NOTICE("Press the Check Attacks verb in the IC tab! Your bite infects, but it is less powerful than your claws."))
 
 #undef STRONG_BITE

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -289,7 +289,7 @@
 			attack.apply_effects(H, src, rand_damage, hit_zone)
 
 			// Finally, apply damage to target
-			apply_damage(real_damage, hit_dam_type, hit_zone, damage_flags = damage_flags)
+			apply_damage(real_damage, hit_dam_type, hit_zone, damage_flags = damage_flags, armor_pen = attack.armor_penetration)
 
 
 			if(M.resting && src.help_up_offer)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -921,7 +921,8 @@
 
 				var/no_damage = 1
 				var/trauma_val = 0 // Used in calculating softcrit/hardcrit indicators.
-				trauma_val = max(shock_stage,get_shock())/(species.total_health-100)
+				if(can_feel_pain())
+					trauma_val = max(shock_stage,get_shock())/(species.total_health-100)
 				// Collect and apply the images all at once to avoid appearance churn.
 				var/list/health_images = list()
 				for(var/obj/item/organ/external/E in organs)

--- a/code/modules/mob/living/carbon/human/species/outsider/undead.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/undead.dm
@@ -156,6 +156,9 @@
 	icobase = 'icons/mob/human_races/zombie/r_zombie.dmi'
 	deform = 'icons/mob/human_races/zombie/r_zombie.dmi'
 
+	brute_mod = 0.5
+	burn_mod = 0.5
+
 	hide_name = TRUE
 
 	name_language = null // Use the first-name last-name generator rather than a language scrambler
@@ -163,7 +166,7 @@
 	language = null
 	default_language = LANGUAGE_GIBBERING
 
-	unarmed_types = list(/datum/unarmed_attack/bite/infectious, /datum/unarmed_attack/claws/strong)
+	unarmed_types = list(/datum/unarmed_attack/bite/infectious, /datum/unarmed_attack/claws/strong/zombie)
 	darksight = 8
 
 	has_fine_manipulation = FALSE
@@ -177,12 +180,11 @@
 
 	has_organ = list(
 		BP_ZOMBIE_PARASITE = /obj/item/organ/internal/parasite/zombie,
-		BP_BRAIN =           /obj/item/organ/internal/brain,
+		BP_BRAIN =           /obj/item/organ/internal/brain/zombie,
 		BP_STOMACH =         /obj/item/organ/internal/stomach
 		)
 
-	brute_mod = 0.5
-	burn_mod = 0.5
+	total_health = 100
 
 	slowdown = 3
 
@@ -219,6 +221,7 @@
 	H.mutations.Add(CLUMSY)
 	var/datum/martial_art/zombie/Z = new /datum/martial_art/zombie()
 	Z.teach(H)
+	to_chat(H, FONT_SIZE_LARGE(SPAN_NOTICE("Use the Check Attacks verb in your IC tab for information on your attacks! They are important! Your bite infects, but is worse at getting through armour than your claws, which have great damage and are armor piercing!")))
 	return ..()
 
 /datum/species/zombie/tajara

--- a/code/modules/mob/living/carbon/human/species/outsider/undead.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/undead.dm
@@ -221,7 +221,7 @@
 	H.mutations.Add(CLUMSY)
 	var/datum/martial_art/zombie/Z = new /datum/martial_art/zombie()
 	Z.teach(H)
-	to_chat(H, FONT_SIZE_LARGE("<span class='notice'>Use the Check Attacks verb in your IC tab for information on your attacks! They are important! Your bite infects, but is worse at getting through armour than your claws, which have great damage and are armor piercing!</span>"))
+	to_chat(H, "<font size=4><span class='notice'>Use the Check Attacks verb in your IC tab for information on your attacks! They are important! Your bite infects, but is worse at getting through armour than your claws, which have great damage and are armor piercing!</font></span>")
 	return ..()
 
 /datum/species/zombie/tajara

--- a/code/modules/mob/living/carbon/human/species/outsider/undead.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/undead.dm
@@ -221,7 +221,7 @@
 	H.mutations.Add(CLUMSY)
 	var/datum/martial_art/zombie/Z = new /datum/martial_art/zombie()
 	Z.teach(H)
-	to_chat(H, FONT_SIZE_LARGE(SPAN_NOTICE("Use the Check Attacks verb in your IC tab for information on your attacks! They are important! Your bite infects, but is worse at getting through armour than your claws, which have great damage and are armor piercing!")))
+	to_chat(H, FONT_SIZE_LARGE("<span class='notice'>Use the Check Attacks verb in your IC tab for information on your attacks! They are important! Your bite infects, but is worse at getting through armour than your claws, which have great damage and are armor piercing!</span>"))
 	return ..()
 
 /datum/species/zombie/tajara

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -74,6 +74,12 @@
 	shredding = TRUE
 	attack_name = "strong claws"
 
+/datum/unarmed_attack/claws/strong/zombie
+	attack_verb = list("mauled", "slashed", "gored", "stabbed")
+	desc = "These claws are armor-piercing and do a good amount of damage, but do not infect! Use these if you need to take someone with heavy armor down."
+	damage = 25
+	armor_penetration = 35
+
 /datum/unarmed_attack/bite/strong
 	attack_verb = list("mauled")
 	damage = 10
@@ -182,12 +188,16 @@
 	attack_verb = list("mauled","gored","perforated")
 	attack_noun = list("mandibles")
 	damage = 35
+	armor_penetration = 25
 	shredding = TRUE
 	sharp = TRUE
 	edge = TRUE
 	attack_name = "mandibles"
 
 /datum/unarmed_attack/bite/infectious
+	desc = "This attack infects those you bite, but it is chance-based and depends on their armour. It is not very strong against armoured foes, compared to your claws."
+	damage = 20
+	armor_penetration = 15
 	shredding = TRUE
 
 /datum/unarmed_attack/bite/infectious/apply_effects(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/armor,var/attack_damage,var/zone)

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -6,6 +6,7 @@ var/global/list/sparring_attack_cache = list()
 	var/attack_noun = list("fist")
 	var/desc = "A simple unarmed attack."
 	var/damage = 0						// Extra empty hand attack damage.
+	var/armor_penetration = 0
 	var/attack_sound = /decl/sound_category/punch_sound
 	var/miss_sound = /decl/sound_category/punchmiss_sound
 	var/shredding = 0 // Calls the old attack_alien() behavior on objects/mobs when on harm intent.
@@ -52,7 +53,7 @@ var/global/list/sparring_attack_cache = list()
 		return
 
 	var/stun_chance = rand(0, 100)
-	var/armor = target.get_blocked_ratio(zone, BRUTE)
+	var/armor = target.get_blocked_ratio(zone, BRUTE, damage_flags(), armor_penetration, damage)
 	var/pain_message = TRUE
 
 	if(!target.can_feel_pain())

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -226,3 +226,6 @@
 			to_chat(user, SPAN_WARNING("The brain has already been prepared!"))
 		return
 	return ..()
+
+/obj/item/organ/internal/brain/zombie
+	relative_size = 100

--- a/html/changelogs/mattatlas-zomboid.yml
+++ b/html/changelogs/mattatlas-zomboid.yml
@@ -1,0 +1,47 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Zombie attacks now have armor piercing."
+  - bugfix: "The armor piercing Zombie martial art now actually has armor piercing. It does 5 to 10 damage, but pierces through all armor."
+  - tweak: "Zombies now only have 70 brain health and the brain is much easier to hit. If you're a survivor, aim for the head!"
+  - tweak: "Zombie bite now has some armor piercing. Zombie claws are now far stronger for damage output, however, since they have more AP and damage."
+  - rscadd: "Added useful information for zombies in their attack descriptions."
+  - tweak: "Martial arts and unarmed attacks can now have armor piercing. Martial arts effects depend on unarmed attack armor piercing."
+  - tweak: "Unarmed attack special effects (such as dropping people) now consider the actual damage dealt in the chance calculation."


### PR DESCRIPTION
  - Zombie attacks now have armor piercing.
  - The armor piercing Zombie martial art now actually has armor piercing. It does 5 to 10 damage, but pierces through all armor.
  - Zombies now only have 70 brain health and the brain is much easier to hit. If you're a survivor, aim for the head!
  - Zombie bite now has some armor piercing. Zombie claws are now far stronger for damage output, however, since they have more AP and damage.
  - Added useful information for zombies in their attack descriptions.
  - Martial arts and unarmed attacks can now have armor piercing. Martial arts effects depend on unarmed attack armor piercing.
  - Unarmed attack special effects (such as dropping people) now consider the actual damage dealt in the chance calculation.