### PR TITLE
IV Drip Oversights

### DIFF
--- a/html/changelogs/IV_drip_cleanup.yml
+++ b/html/changelogs/IV_drip_cleanup.yml
@@ -1,0 +1,8 @@
+author: Vrow
+
+delete-after: True
+
+changes:
+  - tweak: "Tweaked the IV drip tank indicator icon to use the percentage helper instead of the exact gauge updating, and some IV drip code clean up and oversight patching."
+  - bugfix: "Fixed the IV drip not automatically retracting the installed mask if you stripped it from someone and then wearing it yourself."
+  - bugfix: "Fixed the IV drip outputting a specific message even though the installed tank gets spilled everywhere when not secured."


### PR DESCRIPTION
* Patches some oversights introduced in #13369
* List of oversights include
  * Simple mobs being able to operate the IV drip and therefore causing runtimes
  * The IV stand being unable to retract the installed mask if you stripped it from a patient and wore it yourself, causing weird shit to happen
  * The IV outputting the "rattles but remains in the stand" message when the tank wasn't, in fact, actually secured and flying off with everything else
  * The ``visible_message`` sentence for attaching the IV when upgraded past armor checks having improper spacing
* Cleans up the code a little bit and organizes it better

Code clean up and maintenance is good, and I've been itching to do this one ever since the Auto-Compressor buffs got merged with the new tank helper
Plus it's been a month or so after fiddling with the IVs so much, so it... probably shouldn't be bad that I'm touching it again.