### PR TITLE
Fixes the Impoverished Economic Status Not Saving Properly

### DIFF
--- a/SQL/migrate/V072__economic_status_fix.sql
+++ b/SQL/migrate/V072__economic_status_fix.sql
@@ -1,0 +1,6 @@
+--
+-- Implemented in PR #???
+-- Adds the impoverished option to the economic status in the database so it saves correctly.
+--
+
+ALTER TABLE `ss13_characters` CHANGE COLUMN `economic_status` ENUM('Wealthy', 'Well-off', 'Average', 'Underpaid', 'Poor', 'Impoverished');

--- a/SQL/migrate/V072__economic_status_fix.sql
+++ b/SQL/migrate/V072__economic_status_fix.sql
@@ -1,6 +1,6 @@
 --
--- Implemented in PR #???
+-- Implemented in PR #14329.
 -- Adds the impoverished option to the economic status in the database so it saves correctly.
 --
 
-ALTER TABLE `ss13_characters` CHANGE COLUMN `economic_status` ENUM('Wealthy', 'Well-off', 'Average', 'Underpaid', 'Poor', 'Impoverished');
+ALTER TABLE `ss13_characters` MODIFY COLUMN `economic_status` ENUM('Wealthy', 'Well-off', 'Average', 'Underpaid', 'Poor', 'Impoverished');

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -580,14 +580,15 @@ proc/display_logout_report()
 		return
 	to_chat(src,get_logout_report())
 
-/datum/game_mode/proc/get_poor()
+proc/get_poor()
 	var/list/characters = list()
 
 	for(var/mob/living/carbon/human/character in player_list)
 		if(character.client)
-			if(character.client.prefs.economic_status == (ECONOMICALLY_POOR || ECONOMICALLY_DESTITUTE))
+			if(character.client.prefs.economic_status == ECONOMICALLY_DESTITUTE) // Discrimination.
 				characters += character
-
+			else if(character.client.prefs.economic_status == ECONOMICALLY_POOR && prob(50)) // 50% discrimination.
+				characters += character
 	if(characters.len == 0)
 		return null
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -589,6 +589,7 @@ proc/get_poor()
 				characters += character
 			else if(character.client.prefs.economic_status == ECONOMICALLY_POOR && prob(50)) // 50% discrimination.
 				characters += character
+
 	if(characters.len == 0)
 		return null
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -580,16 +580,18 @@ proc/display_logout_report()
 		return
 	to_chat(src,get_logout_report())
 
-proc/get_poor()
-	var/list/dudes = list()
-	for(var/mob/living/carbon/human/man in player_list)
-		if(man.client)
-			if(man.client.prefs.economic_status == (ECONOMICALLY_POOR || ECONOMICALLY_DESTITUTE))
-				dudes += man
-			else if(man.client.prefs.economic_status == (ECONOMICALLY_POOR || ECONOMICALLY_DESTITUTE) && prob(50))
-				dudes += man
-	if(dudes.len == 0) return null
-	return pick(dudes)
+/datum/game_mode/proc/get_poor()
+	var/list/characters = list()
+
+	for(var/mob/living/carbon/human/character in player_list)
+		if(character.client)
+			if(character.client.prefs.economic_status == (ECONOMICALLY_POOR || ECONOMICALLY_DESTITUTE))
+				characters += character
+
+	if(characters.len == 0)
+		return null
+
+	return pick(characters)
 
 //Announces objectives/generic antag text.
 /proc/show_generic_antag_text(var/datum/mind/player)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -584,9 +584,9 @@ proc/get_poor()
 	var/list/dudes = list()
 	for(var/mob/living/carbon/human/man in player_list)
 		if(man.client)
-			if(man.client.prefs.economic_status == ECONOMICALLY_POOR)
+			if(man.client.prefs.economic_status == (ECONOMICALLY_POOR || ECONOMICALLY_DESTITUTE))
 				dudes += man
-			else if(man.client.prefs.economic_status == ECONOMICALLY_POOR && prob(50))
+			else if(man.client.prefs.economic_status == (ECONOMICALLY_POOR || ECONOMICALLY_DESTITUTE) && prob(50))
 				dudes += man
 	if(dudes.len == 0) return null
 	return pick(dudes)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -590,8 +590,8 @@ proc/get_poor()
 			else if(character.client.prefs.economic_status == ECONOMICALLY_POOR && prob(50)) // 50% discrimination.
 				characters += character
 
-	if(characters.len == 0)
-		return null
+	if(!length(characters))
+		return
 
 	return pick(characters)
 

--- a/html/changelogs/sql_impoverished_fix.yml
+++ b/html/changelogs/sql_impoverished_fix.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - backend: "Adds the impoverished economic status as an option in the SQL database, so it can save properly."


### PR DESCRIPTION
this PR fixes the impoverished economic status not saving properly, which was caused due to the SQL database not having it as an option. fixes #14328.

**needs to be reviewed by Arrow768 before being merged.**