### PR TITLE
Vaurca Projector frequency tweak.

### DIFF
--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -76,7 +76,7 @@
                                         "Distant chattering can be heard coming from the fortress including what sounds almost like jovial laughter.",
                                         "The turquoise water emits a jubilant smell of freshly cut lemons which lasts for only for a moment.",
                                         "You see the gas giant Sedantis dominating a starry sky.",
-										"For a moment the Golden Fortress towering above starts to glimmer majestically catching the light from the imposing gas giant in the sky")
+										"For a moment the Golden Fortress towering above starts to glimmer majestically catching the light from the imposing gas giant in the sky.")
 
 			if("City of New Sedantis")
 				hologram_message = pick("A towering cavernous city takes up the viewfinder, great buildings of stone jutting out of the ground and twisting towards the ceiling.",

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -71,7 +71,7 @@
 
 			if("Celestial Landing Ground")
 				hologram_message = pick("An awe inspiring fortress of gold dominates the landscape and bathes the surrounding area in yellow luminescence.",
-										"A loud hymn is chanted in an unknown language accompanied by a smell of morning Dew in the countryside.",
+										"A loud hymn is chanted in an unknown language accompanied by a smell of morning dew in the countryside.",
 										"Unbound workers moving through the realm stop to gaze up in awe at the distant structure before returning to previous activities.",
                                         "Distant chattering can be heard coming from the fortress including what sounds almost like jovial laughter.",
                                         "The turquoise water emits a jubilant smell of freshly cut lemons which lasts for only for a moment.",

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -76,7 +76,7 @@
                                         "Distant chattering can be heard coming from the fortress including what sounds almost like jovial laughter.",
                                         "The turquoise water emits a jubilant smell of freshly cut lemons which lasts for only for a moment.",
                                         "You see the gas giant Sedantis dominating a starry sky.",
-										"For a moment the Golden Fortress towering above starts to glimmer majestically catching the light from the imposing gas giant in the sky.")
+										"For a moment the Golden Fortress towering above starts to glimmer majestically, catching the light from the imposing gas giant in the sky.")
 
 			if("City of New Sedantis")
 				hologram_message = pick("A towering cavernous city takes up the viewfinder, great buildings of stone jutting out of the ground and twisting towards the ceiling.",

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/vaurca_items.dmi'
 	icon_state = "zora_projector"
 	worlds_selection = list("Ocean", "Hive War Exhibition", "Celestial Landing Ground", "City of New Sedantis", "Titan Prime")
-	message_frequency = 9
+	message_frequency = 10
 
 /obj/item/skrell_projector/vaurca_projector/attack_self(mob/user as mob)
 	working = !working

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -27,7 +27,7 @@
 	switch(choice)
 		if("Ocean")
 			light_color = "#1122c2"
-		if("Hive War exhibition")
+		if("Hive War Exhibition")
 			light_color = "#83290b"
 		if("Celestial Landing Ground")
 			light_color = "#f5e61d"
@@ -64,7 +64,7 @@
                                         "You can hear a quiet celestial chanting the source of which feels just beyond sight.",
                                         "The turquoise water emits a jubilant smell of freshly cut lemons which lasts for only for a moment.",
                                         "You see the gas giant Sedantis dominating a starry sky.")
-			if("Hive War exhibition")
+			if("Hive War Exhibition")
 				hologram_message = pick("You see a carefully crafted exhibition detailing the Great Hive War. It explains in brief the details of the event through paintings and dioramas.",
 										"You smell burning and rusted metal. An exhibition showcases the Battle of a Thousand Titans.",
 										"You see a  memorial to the lives lost, a sad hymn flowing in the background.")

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -27,7 +27,7 @@
 	switch(choice)
 		if("Ocean")
 			light_color = "#1122c2"
-		if("Hive War Exhibition")
+		if("Hive War exhibition")
 			light_color = "#83290b"
 		if("Celestial Landing Ground")
 			light_color = "#f5e61d"

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -61,7 +61,7 @@
 				hologram_message = pick("You see a golden fortress floating majestically above an ocean of sapphire.",
 										"A euphoric smell of the ocean fills your senses as the water gently ebbs and flows.",
 										"You hear the faint humming of a hymn as a gentle wave envelops the viewfinder.",
-                                        "You can hear a quiet celestial chanting the source of which feels just beyond sight",
+                                        "You can hear a quiet celestial chanting the source of which feels just beyond sight.",
                                         "The turquoise water emits a jubilant smell of freshly cut lemons which lasts for only for a moment.",
                                         "You see the gas giant Sedantis dominating a starry sky.")
 			if("Hive War exhibition")

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - rscdel: "Killed innocent kittens."

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -39,4 +39,6 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - tweak: "Changed Vaurca Projector frequency to prevent multiple minute long gaps where it won't project anything."
+  - bugfix: "Fixed some missing fullstops in the Vaurca Projector."
+
   

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: Connorjg1
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -39,6 +39,6 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - tweak: "Changed Vaurca Projector frequency to prevent multiple minute long gaps where it won't project anything."
-  - bugfix: "Fixed some missing fullstops in the Vaurca Projector."
+  - bugfix: "Fixed some missing fullstops in the Vaurca Projector and adjusted some grammar."
 
   

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - tweak: "Changed Vaurca Projector frequency to prevent multiple minute long gaps where it won't project anything."
+  


### PR DESCRIPTION
The Vaurca projector now projects messages slightly more frequently. Should help prevent the sometimes occurring multi-minute large gaps where it looks bugged and won't project anything at all due to bad RNG.

It also adds a handful of missing full-stops/incorrect spelling.