### PR TITLE
Fix PDA flashlights not working or installing

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/hardware.dm
+++ b/code/modules/modular_computers/computers/modular_computer/hardware.dm
@@ -72,6 +72,12 @@
 		to_chat(personal_ai.pai, SPAN_NOTICE("You gain access to \the [src]'s computronics."))
 		user.drop_from_inventory(H, src)
 		update_icon()
+	else if(istype(H, /obj/item/computer_hardware/flashlight))
+		if(flashlight)
+			to_chat(user, SPAN_WARNING("\The [src]'s flashlight slot is already occupied by \the [flashlight]."))
+			return
+		found = TRUE
+		flashlight = H
 	if(found)
 		to_chat(user, SPAN_NOTICE("You install \the [H] into \the [src]."))
 		H.parent_computer = src

--- a/code/modules/modular_computers/hardware/misc.dm
+++ b/code/modules/modular_computers/hardware/misc.dm
@@ -13,23 +13,14 @@
 /obj/item/computer_hardware/flashlight/enable()
     . = ..()
     if(parent_computer)
-        parent_computer.light_range = range
-        parent_computer.light_power = power
-        tweak_light(parent_computer)
+        parent_computer.set_light(range, power, flashlight_color)
 
 /obj/item/computer_hardware/flashlight/disable()
     . = ..()
     if(parent_computer)
-        parent_computer.light_range = initial(parent_computer.light_range)
-        parent_computer.light_power = initial(parent_computer.light_power)
-        tweak_light(parent_computer)
+        parent_computer.set_light(initial(parent_computer.light_range), initial(parent_computer.light_power), flashlight_color)
 
 /obj/item/computer_hardware/flashlight/proc/tweak_brightness(var/new_power)
     . = power = Clamp(0, new_power, 1)
-    parent_computer.light_power = power
-    tweak_light(parent_computer)
-
-/obj/item/computer_hardware/flashlight/proc/tweak_light(var/obj/item/modular_computer/C)
-    if(!istype(C))
-        return
-    C.set_light(C.light_range, C.light_power, l_color = flashlight_color)
+    if(parent_computer && enabled)
+        parent_computer.set_light(range, power, flashlight_color)

--- a/html/changelogs/johnwildkins-flashlightfix.yml
+++ b/html/changelogs/johnwildkins-flashlightfix.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - rscdel: "Killed innocent kittens."

--- a/html/changelogs/johnwildkins-flashlightfix.yml
+++ b/html/changelogs/johnwildkins-flashlightfix.yml
@@ -1,42 +1,6 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes:
-#   bugfix
-#   wip (For works in progress)
-#   tweak
-#   soundadd
-#   sounddel
-#   rscadd (general adding of nice things)
-#   rscdel (general deleting of nice things)
-#   imageadd
-#   imagedel
-#   maptweak
-#   spellcheck (typo fixes)
-#   experiment
-#   balance
-#   admin
-#   backend
-#   security
-#   refactor
-#################################
+author: JohnWildkins
 
-# Your name.
-author: ChangeMe
-
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
 
-# Any changes you've made.  See valid prefix list above.
-# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-# SCREW THIS UP AND IT WON'T WORK.
-# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
-# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - bugfix: "Fixed flashlights in PDAs not creating lighting nor being installable as components once removed."


### PR DESCRIPTION
Fixes PDA flashlights not lighting up, and not being able to be reinstalled when detached from PDAs

Fixes #13629. 