### PR TITLE
Fix heat exchangers not radiating properly on /turf/simulated/open

### DIFF
--- a/code/modules/atmospherics/he_pipes.dm
+++ b/code/modules/atmospherics/he_pipes.dm
@@ -58,7 +58,9 @@
 		..()
 	else
 		var/datum/gas_mixture/pipe_air = return_air()
-		if(istype(loc, /turf/simulated/))
+		if(istype(loc, /turf/space) || (isopenturf(loc) && (istype(GetBelow(loc), /turf/space) || istype(GetAbove(loc), /turf/space))))
+			parent.radiate_heat_to_space(surface, 1)
+		else if(istype(loc, /turf/simulated/))
 			var/environment_temperature = 0
 			if(loc:blocks_air)
 				environment_temperature = loc:temperature
@@ -67,8 +69,6 @@
 				environment_temperature = environment.temperature
 			if(abs(environment_temperature-pipe_air.temperature) > minimum_temperature_difference)
 				parent.temperature_interact(loc, volume, thermal_conductivity)
-		else if(istype(loc, /turf/space/))
-			parent.radiate_heat_to_space(surface, 1)
 
 		if(istype(buckled, /mob/living))
 			var/mob/living/M = buckled

--- a/html/changelogs/johnwildkins-fixsupermatter.yml
+++ b/html/changelogs/johnwildkins-fixsupermatter.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Fix heat exchangers not radiating properly on open space turfs (as opposed to space turfs). This should stop the supermatter delaminating on nominally \"safe\" setups."


### PR DESCRIPTION
see title
this was causing the supermatter to delam on normally-safe setups