### PR TITLE
Fixes several typos in the character setup screen

### DIFF
--- a/code/game/jobs/faction/nanotrasen.dm
+++ b/code/game/jobs/faction/nanotrasen.dm
@@ -8,7 +8,7 @@
 	Nonetheless, NanoTrasen has managed to secure itself as a crucial member of the newly-founded Stellar Corporate Conglomerate
 	allowing themselves to remain as a dominant corporate presence within the Orion Spur.
 	</p>"}
-	departments = {"Medicalbr>Science<br>Service"}
+	departments = {"Medical<br>Science<br>Service"}
 	title_suffix = "NT"
 
 	is_default = TRUE

--- a/code/game/jobs/faction/zavodskoi.dm
+++ b/code/game/jobs/faction/zavodskoi.dm
@@ -3,7 +3,7 @@
 	description = {"<p>
 	The largest weapons producer in human space, Zavodskoi Interstellar initially
 	found its place with the invention of a militarized voidsuit for use in the Interstellar War.
-	With many extraordinarily weapons contracts thanks to the Sol Alliance, as well as acquisitions of
+	With many lucrative weapon contracts thanks to the Sol Alliance, as well as acquisitions of
 	other major armaments companies, Zavodskoi weapons can be found in the hands of nearly every
 	military force across the Orion Spur. They are the main corporation found in the Empire of
 	Dominia, and are at the forefront of weapons development technology.

--- a/code/modules/background/origins/origins/human/elyra.dm
+++ b/code/modules/background/origins/origins/human/elyra.dm
@@ -29,14 +29,14 @@
 
 /decl/origin_item/origin/medina
 	name = "Medina"
-	desc = "A planet rich in phorn, Medina is known for two things: its prolific art scene, and the Phoron Bulletin. The environment outside of Medina's floating cities is extremely hazardous due to unpredictable tectonic activity, which has led to bounties being placed for phoron extraction and presented to non-Elyran citizens in order to ensure that Elyran citizens do not end up dead. The Phoron Bulletin is an immensely hazardous, yet potentially immensely profitable, line of work in which a Non-Citizen Person in Elyra can become rich. Assuming they survive."
+	desc = "A planet rich in phoron, Medina is known for two things: its prolific art scene, and the Phoron Bulletin. The environment outside of Medina's floating cities is extremely hazardous due to unpredictable tectonic activity, which has led to bounties being placed for phoron extraction and presented to non-Elyran citizens in order to ensure that Elyran citizens do not end up dead. The Phoron Bulletin is an immensely hazardous, yet potentially immensely profitable, line of work in which a Non-Citizen Person in Elyra can become rich. Assuming they survive."
 	possible_accents = list(ACCENT_MEDINA)
 	possible_citizenships = list(CITIZENSHIP_ELYRA)
 	possible_religions = RELIGIONS_ELYRA
 
 /decl/origin_item/origin/aemaq
 	name = "Aemaq"
-	desc = "An Elyran frontier world that is home to the majority of the Republic's chemical industry, Aemaq is most well-known for its chemical seas and the unusual creatures that reside in them known as leviathans. The cities of Aemaq float above its chemical oceans on complicated magpulse-based platforms designed by the Republic, and are centered around harvesting chemicals from the Aemaqii Ocean. Many of the Non-Citizen Person on Aemaq are refugees from the Empire of Dominia's frontier conquests who have nowhere else to go, and must work in Aemaq's chemical industry to make ends meet."
+	desc = "An Elyran frontier world that is home to the majority of the Republic's chemical industry, Aemaq is most well-known for its chemical seas and the unusual creatures that reside in them known as leviathans. The cities of Aemaq float above its chemical oceans on complicated magpulse-based platforms designed by the Republic, and are centered around harvesting chemicals from the Aemaqii Ocean. Many of the Non-Citizen Persons on Aemaq are refugees from the Empire of Dominia's frontier conquests who have nowhere else to go, and must work in Aemaq's chemical industry to make ends meet."
 	possible_accents = list(ACCENT_AEMAQ)
 	possible_citizenships = list(CITIZENSHIP_ELYRA)
 	possible_religions = RELIGIONS_ELYRA

--- a/html/changelogs/Forester40-zv-nt-elyra-typo-fix.yml
+++ b/html/changelogs/Forester40-zv-nt-elyra-typo-fix.yml
@@ -1,0 +1,6 @@
+author: Forester40
+
+delete-after: True
+
+changes:
+  - spellcheck: "Fixed some typos in the Nanotrasen, Zavodskoi, Aemaq and Medina descriptions in the character setup screen."


### PR DESCRIPTION
* Fixes the missing < in the line break formatting tag (< br > without the spaces) in the Nanotrasen playable department list
* Changes "With many extraordinarily weapons contracts thanks to the Sol Alliance" to "With many lucrative weapon contracts thanks to the Sol Alliance" in the Zavodskoi description. 
I don't know what word was supposed to follow "extraordinarily" so I kind of paraphrased it a bit so I guess it's *technically* not only a typo fix but it's easier to just list it as one
* Changes "Many of the Non-Citizen Person" to "Many of the Non-Citizen Persons" in the Aemaq description. (persons is a real word, honest)
* Fixes "phoron" being mispelled as "phorn" in the Medina description.