### PR TITLE
Painkiller Pills Last Longer

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -259,7 +259,7 @@
 	od_minimum_dose = 2
 	scannable = TRUE
 	metabolism = REM/10 // same as before when in blood, 0.02 units per tick
-	ingest_met = REM * 2 // .4 units per tick
+	ingest_met = REM / 3 // Should be 0.06 units per tick
 	breathe_met = REM * 4 // .8 units per tick
 	taste_description = "sickness"
 	metabolism_min = 0.005
@@ -288,7 +288,7 @@
 	scannable = TRUE
 	od_minimum_dose = 2
 	metabolism = REM / 3.33 // 0.06ish units per tick
-	ingest_met = REM * 2 // .4 units per tick
+	ingest_met = REM / 2.3 // Should be 0.08 units per tick
 	breathe_met = REM * 4 // .8 units per tick
 	taste_description = "sourness"
 	metabolism_min = 0.005
@@ -354,7 +354,7 @@
 	od_minimum_dose = 2
 	scannable = TRUE
 	metabolism = REM / 3.33 // 0.06ish units per tick
-	ingest_met = REM * 2 // .4 units per tick
+	ingest_met = REM / 1.5 // Should be 0.13 units per tick
 	breathe_met = REM * 4 // .8 units per tick
 	taste_description = "bitterness"
 	metabolism_min = 0.005

--- a/html/changelogs/wickedcybs_pilleat.yml
+++ b/html/changelogs/wickedcybs_pilleat.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Painkillers in pill form should last far longer than it did before now. It won't be as long as injecting it, but it should be at least triple the amount of time it used to when ingested. "


### PR DESCRIPTION
Painkillers in pill form were essentially rubbish and not worthwhile to use due to how fast they processed. The amount processed per tick was actually being multiplied so the reason the painkilling effects didn't really get over a minute is because (using the old metab rate as an example) you would use up 0.4 of a reagent per tick 1.2, so in just thirteen ticks the effects of your painkiller would be over. A tick is about two or three seconds each.

What I've done is give the painkillers a big buff if in ingested in pill form. Injecting is still the superior option in terms of duration but they'll still last a few minutes if taken orally.