### PR TITLE
Small Hallucinations Bugfixes

### DIFF
--- a/code/controllers/subsystems/hallucinations.dm
+++ b/code/controllers/subsystems/hallucinations.dm
@@ -10,7 +10,7 @@
 	var/static/list/hal_emote = list("mutters quietly.", "stares.", "grunts.", "looks around.", "twitches.", "shivers.", "swats at the air.", "wobbles.", "gasps!", "blinks rapidly.", "murmurs.",
 				"dry heaves!", "twitches violently.", "giggles.", "drools.", "scratches all over.", "grinds their teeth.", "whispers something quietly.")
 	var/static/list/message_sender = list("Mom", "Dad", "Captain", "Captain(as Captain)", "help", "Home", "MaxBet Online Casino", "IDrist Corp", "Dr. Maxman",
-			"www.wetskrell.nt", "You are our lucky grand prize winner!",  "Officer Beepsky", "Ginny", "Ian",
+			"www.wetskrell.nt", "You are our lucky grand prize winner!",  "Matriarch Drone", "Ginny", "Human Resources",
 			"what have you DONE?", "Miranda Trasen", "Central Command", "AI", "maintenance drone", "Unknown", "I don't want to die")
 	var/list/all_hallucinations = list()
 

--- a/code/modules/hallucinations/hallucinations.dm
+++ b/code/modules/hallucinations/hallucinations.dm
@@ -60,15 +60,6 @@
 			for(var/mob/M in oviewers(world.view, holder))	//Only shows to others, not you; you're not aware of what you're doing. Could prompt others to ask if you're okay, and lead to confusion.
 				to_chat(M, "<B>[holder]</B> [chosen_emote]")
 
-//For adding accent tags when you imagine people talking to you
-/datum/hallucination/proc/get_hallucinated_accent(var/mob/living/talker, var/mob/hearer)
-	var/hal_accent
-	if(ishuman(talker))
-		var/mob/living/carbon/human/T = talker
-		hal_accent = T.accent ? T.accent : pick(SSrecords.accents)
-	else
-		hal_accent = pick(SSrecords.accents)
-	var/datum/accent/a = SSrecords.accents[hal_accent]
-
-	var/final_icon = a.tag_icon
-	return "<img src=\"[final_icon].png\">"
+//For adding accent tags when you imagine people talking to you. This will be a forced accent. If there is no accent (simplemobs), give them a random one from a list
+/datum/hallucination/proc/get_hallucinated_accent(var/mob/living/talker)
+	return talker.accent ? talker.accent : pick(ACCENTS_ALL_IPC)

--- a/code/modules/hallucinations/types/basic.dm
+++ b/code/modules/hallucinations/types/basic.dm
@@ -6,7 +6,7 @@
 /datum/hallucination/announcement/start()
 	var/list/hal_sender = SShallucinations.message_sender
 	for(var/mob/living/carbon/human/H in living_mob_list)
-		if(H.client && !player_is_antag(H, only_offstation_roles = TRUE))	//We're not going to add ninjas, mercs, borers, etc to prevent meta.
+		if(H.client && !player_is_antag(H, only_offstation_roles = TRUE) && isStationLevel(H.z))	//We're not going to add ninjas, mercs, borers, etc to prevent meta. No people off-station, either
 			hal_sender += H
 	switch(rand(1,15))
 		if(1)
@@ -17,7 +17,7 @@
 		if(2)
 			sound_to(holder, 'sound/AI/strangeobject.ogg')
 			to_chat(holder, "<h2 class='alert'>Welcome Object</h2>")
-			to_chat(holder, SPAN_ALERT("Transport signature of [pick(adjectives)] origin detected in your path, an object appears to have been nesting aboard NSS Upsilon. [pick(SShallucinations.hallucinated_phrases)]"))
+			to_chat(holder, SPAN_ALERT("Transport signature of [pick(adjectives)] origin detected in your path, an object appears to have been nesting aboard the Intrepid. [pick(SShallucinations.hallucinated_phrases)]"))
 
 		if(3)
 			sound_to(holder, 'sound/AI/scrubbers.ogg')
@@ -27,7 +27,7 @@
 		if(4)
 			sound_to(holder, 'sound/AI/emergency_shuttle_leaving_dock.ogg')
 			to_chat(holder, "<h2 class='alert'>Emergency Departure</h2>")
-			to_chat(holder, SPAN_ALERT("The emergency evacuation shuttle has arrived. It will depart in approximately two minutes. Please do not allow [holder] to board."))
+			to_chat(holder, SPAN_ALERT("An emergency evacuation shuttle has arrived in the hangar to extract the crew of [current_map.station_name]. It will depart in approximately two minutes. Please do not allow [holder] to board."))
 
 		if(5)
 			sound_to(holder, 'sound/AI/vermin.ogg')
@@ -42,7 +42,7 @@
 		if(7)
 			sound_to(holder, 'sound/AI/meteors_detected_message.ogg')
 			to_chat(holder, "<h2 class='alert'>Meteor Alarm</h2>")
-			to_chat(holder, SPAN_ALERT("A [pick(adjectives)] meteor storm has been authorized for a destruction course with your station. Less than three minutes until impact, shields cannot help you; seek shelter in the upper level."))
+			to_chat(holder, SPAN_ALERT("A [pick(adjectives)] meteor storm has been authorized for a destruction course with your station. Less than three minutes until impact, shields cannot help you; seek shelter in the central ring."))
 
 		if(8)
 			sound_to(holder,'sound/AI/fungi.ogg')
@@ -57,13 +57,13 @@
 
 		if(10 to 15)    //Announcements that would be made by a player instead of random event
 			var/list/body = list(
-                        "Please avoid [pick("medical", "security", "the bar", "engineering", "cargo")] at this time due to [pick("a k'ois outbreak.", "a hostage situation.", "hostile boarders.", "[holder].")]",
+                        "Please avoid [pick("medical", "security", "the bar", "engineering", "operations", "the hangar")] at this time due to [pick("a k'ois outbreak.", "a hostage situation.", "hostile boarders.", "[holder].")]",
 						"Due to various complaints about [holder], we have conducted an investigation and due to the findings, we will [pick("arrest them. Please turn yourself in, [holder]", "terminate their employment with us.", "inform their family of their shortcomings.", "cyborgify them immediately.")]. Thank you.",
 						"[pick("Boarders have", "The AI has", "Intruders have")] demanded we sacrifice a crewmember to them. After [pick("much", "little", "quick")] deliberation, we have chosen [holder]. Please turn yourself over, or [pick("we", "your family", "all of us", "those you love")] will die.",
-						"Central Command has chosen [holder] as the NanoTrasen employee of the month! Everyone please congratulate them.",
+						"Central Command has chosen [holder] as the SCC employee of the month! Everyone please congratulate them.",
 						"Everything is fine.",
 						"The tesla may or may not be loose.",
-						"This is your directive 11. [pick("Spiders have killed several crew.", "Boarders have taken a hostage.", "[holder] is armed and dangerous. Avoid them at all costs.", "Two black-suited individuals have taken items from the vault and armory.")]",
+						"This is your directive 11. [pick("Greimorians have killed several crew.", "Boarders have taken a hostage.", "[holder] is armed and dangerous. Avoid them at all costs.", "Two black-suited individuals have taken items from the armory.")]",
 						"Please stop [pick("drawing in blood. It's unsanitary.", "killing your fellow crew. It's rude.", "[holder] at all costs.", "falling down holes.")]",
 						"[holder] disappoints us all once again.")
 			sound_to(holder, 'sound/misc/announcements/notice.ogg')
@@ -75,16 +75,15 @@
 /datum/hallucination/announcement/proc/delam_call()
 	var/list/people = list()
 	for(var/mob/living/carbon/human/M in living_mob_list)
-		if(!M.isMonkey() && !player_is_antag(M, only_offstation_roles = TRUE))	//Antag check prevents meta
+		if(!M.isMonkey() && !player_is_antag(M, only_offstation_roles = TRUE) && isStationLevel(M.z))	//Antag check prevents meta, isStationLevel prevents people offsite doing it
 			people += M
 	people -= holder
-	if(!people.len)
+	if(!length(people))
 		return
 	var/radio_exclaim = pick("Oh SHIT!", "Oh fuck.", "Uhhh!", "That's not good!", "FUCK.", "Engineering?", "It's under control!", "We're fucked!", "Ohhhh boy.", "What?!", "Um, <b>what?!</b>")
-	var/mob/living/caller = pick(people)
-	var/caller_accent = get_hallucinated_accent(caller, holder)
+	var/mob/living/carbon/human/caller = pick(people)
 
-	to_chat(holder, "[caller_accent] <span class='radio'><b>[pick(people)]</b> says, \"[radio_exclaim]\"</span>")
+	to_chat(holder, "[caller.get_accent_icon(null, holder)] <span class='radio'><b>[caller]</b> says, \"[radio_exclaim]\"</span>")
 
 
 /datum/hallucination/pda	//fake PDA messages. this only plays the beep and sends something to chat; it won't show up in the PDA.
@@ -110,7 +109,7 @@
 	for(var/mob/living/M in oview(C))
 		if(!M.stat)
 			hal_target += M
-	if(hal_target.len)
+	if(length(hal_target))
 		return TRUE
 
 /datum/hallucination/paranoia/start()
@@ -123,7 +122,7 @@
 	max_power = 60
 
 /datum/hallucination/skitter/start()
-	to_chat(holder, "The spiderling skitters around.")
+	to_chat(holder, "The greimorian larva skitters around.")
 
 
 /datum/hallucination/prick
@@ -243,7 +242,7 @@
 					to_chat(holder, SPAN_DANGER("You feel a horrible burning sensation on your [O.name]!"))
 				if(HAL_POWER_MED to INFINITY)
 					to_chat(holder, SPAN_DANGER("It feels like your [O.name] is being burnt to the bone!"))
-					holder.emote("esweat")
+					holder.emote(pick("whimper", "twitch_v", "gasp"))
 
 //sort of like the vampire friend messages.
 /datum/hallucination/friendly
@@ -254,7 +253,7 @@
 	var/list/halpal = list()
 	for(var/mob/living/L in oview(holder))
 		halpal += L
-	if(halpal.len)
+	if(length(halpal))
 		var/pal = pick(halpal)
 		var/list/halpal_emotes = list("[pal] looks trustworthy.",
 			"You feel as if [pal] is a relatively friendly individual.",
@@ -348,7 +347,7 @@
 	for(var/mob/living/M in oview(C,1))
 		if(!M.stat)
 			attacker_candidates += M
-	if(attacker_candidates.len)
+	if(length(attacker_candidates))
 		return TRUE
 
 /datum/hallucination/fakeattack/start()
@@ -362,7 +361,7 @@
 		sound_to(holder, 'sound/weapons/push.ogg')
 
 	//If we are hallucinating particularly hard and there's another person adjacent to us, we imagine they attack us, too.
-	if(holder.hallucination >= 70 && attacker_candidates.len)
+	if(holder.hallucination >= 70 && length(attacker_candidates))
 		attacker = pick(attacker_candidates)
 		if(prob(50))
 			to_chat(holder, SPAN_DANGER("[attacker] has hit [holder]!"))
@@ -409,13 +408,13 @@
 				if(ishuman(M))
 					candidates += M
 
-	if(!candidates.len)	//No candidates, no effect.
+	if(!length(candidates))	//No candidates, no effect.
 		end()
 		return
 
 	var/mob/living/talker = pick(candidates)	//Who is talking to us?
 	var/message		//What will they say?
-	var/accent_tag = get_hallucinated_accent(talker, holder) //Can't forget the accent
+	var/forced_accent_tag = get_hallucinated_accent(talker) //Can't forget the accent
 
 	//Name selection. This gives us variety. Sometimes it will be your last name, sometimes your first.
 	var/list/names = list()
@@ -425,7 +424,7 @@
 		names += lastname
 	if(firstname)
 		names += firstname
-	if(!names.len)
+	if(!length(names))
 		names += holder.real_name
 
 	switch(rand(1,8))	//Deciding how we're going to manifest this hallucinated conversation.
@@ -441,14 +440,14 @@
 				phrases += list("What did you come here for[add]?","Don't touch me[add].","You're not getting out of here[add].", "You're a failure, [pick(names)].","Just kill yourself already, [pick(names)].","Put on some clothes[add].","You're a horrible person[add].","You know nobody wants you here, right[add]?")
 
 			message = pick(phrases)
-			to_chat(holder,"<span class='game say'>[accent_tag] <B>[talker]</B> [talker.say_quote(message)], <span class='message'><span class='body'>\"[message]\"</span></span></span>")
+			to_chat(holder,"<span class='game say'>[talker.get_accent_icon(null, holder, forced_accent_tag)] <B>[talker]</B> [talker.say_quote(message)], <span class='message'><span class='body'>\"[message]\"</span></span></span>")
 		else	//More varied messages using text list and different speech prefixes
 			//message prep
 			var/speak_prefix = pick("Hey", "Uh", "Um", "Oh", "Ah")		//For variety, we have a different greeting. This one has a chance of picking a starter....
 			speak_prefix = "[speak_prefix], [pick(names)][pick(".","!","?")]"		//...then adds the name, and ends it randomly with ., !, or ? ("Hey, name?" "Oh, name!" "Ah, name." "Name!"") etc.
 
 			message = prob(70) ? "[speak_prefix] [pick(SShallucinations.hallucinated_phrases)]" : pick(SShallucinations.hallucinated_phrases) //Here's the message that uses the hallucinated_phrases text list. Won't always apply the speak_prefix; sometimes they say weird shit without addressing you.
-			to_chat(holder,"<span class='game say'>[accent_tag] <B>[talker]</B> [talker.say_quote(message)], <span class='message'><span class='body'>\"[message]\"</span></span></span>")
+			to_chat(holder,"<span class='game say'>[talker.get_accent_icon(null, holder, forced_accent_tag)] <B>[talker]</B> [talker.say_quote(message)], <span class='message'><span class='body'>\"[message]\"</span></span></span>")
 
 	repeats -= 1
 	if(repeats)	//And we do it all over again, one or two more times.
@@ -472,11 +471,11 @@
 	for(var/mob/living/M in oview(holder, 1))
 		if(!M.stat)
 			whisper_candidates += M
-	if(whisper_candidates.len)
+	if(length(whisper_candidates))
 		var/mob/living/whisperer = pick(whisper_candidates)
-		var/whisper_accent = get_hallucinated_accent(whisperer, holder)
+		var/whisper_accent_tag = get_hallucinated_accent(whisperer)
 		if(prob(70))
-			to_chat(holder, "[whisper_accent] <B>[whisperer]</B> whispers, <I>\"[pick(SShallucinations.hallucinated_phrases)]\"</I>")
+			to_chat(holder, "[whisperer.get_accent_icon(null, holder, whisper_accent_tag)] <B>[whisperer]</B> whispers, <I>\"[pick(SShallucinations.hallucinated_phrases)]\"</I>")
 		else
 			to_chat(holder, "<B>[whisperer]</B> [pick("gently nudges", "pokes at", "taps", "looks at", "pats")] [holder], trying to get their attention.")
 

--- a/html/changelogs/doxxmedearly-hallucinationsfixes.yml
+++ b/html/changelogs/doxxmedearly-hallucinationsfixes.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Accents now appear properly during hallucinated messages."
+  - bugfix: "Removed an invalid emote from a pain hallucination."
+  - bugfix: "Hallucinated announcements can now only come from people actually on station."
+  - tweak: "Tweaked some text in hallucinated messages to better fit the current setting."


### PR DESCRIPTION
-Removes my stupidly janky hallucination accent stuff and actually uses `get_accent_icon()`. Uses the IPC_ALL_ACCENTS list because it's huge and good enough for giving simple mobs random accents.
-Replaces some Aurora-specific stuff in text with Horizon stuff (Cargo -> Operations, Spiders -> Greimorians, using `current_map.station_name`, etc.)
-Replaces multiple instances of .len with length()
-Replaces an invalid emote with valid ones during the pain hallucination. 
-Checks that offstation folks don't accidentally get added to some station-specific hallucinations. 

Fixes #14351