### PR TITLE
Macro-ize some helpers, character preview optimize

### DIFF
--- a/code/__defines/_macros.dm
+++ b/code/__defines/_macros.dm
@@ -2,6 +2,8 @@
 #define CLAMP01(x) 		(Clamp(x, 0, 1))
 #define JOINTEXT(X) jointext(X, null)
 #define list_find(L, needle, LIMITS...) L.Find(needle, LIMITS)
+#define hex2num(hex) text2num(hex, 16)
+#define num2hex(num, pad) num2text(num, pad, 16)
 
 #define span(class, text) ("<span class='[class]'>" + text + "</span>")
 #define SPAN_NOTICE(X) ("<span class='notice'>" + X + "</span>")

--- a/code/_helpers/type2type.dm
+++ b/code/_helpers/type2type.dm
@@ -1,54 +1,12 @@
 /*
  * Holds procs designed to change one type of value, into another.
  * Contains:
- *			hex2num & num2hex
  *			text2list & list2text
  *			file2list
  *			angle2dir
  *			angle2text
  *			worldtime2text
  */
-
-// Returns an integer given a hexadecimal number string as input.
-/proc/hex2num(hex)
-	if (!istext(hex))
-		return
-
-	var/num   = 0
-	var/power = 1
-	var/i     = length(hex)
-
-	while (i)
-		var/char = text2ascii(hex, i)
-		switch(char)
-			if(48)                                  // 0 -- do nothing
-			if(49 to 57) num += (char - 48) * power // 1-9
-			if(97,  65)  num += power * 10          // A
-			if(98,  66)  num += power * 11          // B
-			if(99,  67)  num += power * 12          // C
-			if(100, 68)  num += power * 13          // D
-			if(101, 69)  num += power * 14          // E
-			if(102, 70)  num += power * 15          // F
-			else
-				return
-		power *= 16
-		i--
-	return num
-
-// Returns the hex value of a number given a value assumed to be a base-ten value
-/proc/num2hex(num, padlength)
-	var/global/list/hexdigits = list("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F")
-
-	. = ""
-	while(num > 0)
-		var/hexdigit = hexdigits[(num & 0xF) + 1]
-		. = "[hexdigit][.]"
-		num >>= 4 //go to the next half-byte
-
-	//pad with zeroes
-	var/left = padlength - length(.)
-	while (left-- > 0)
-		. = "0[.]"
 
 // Splits the text of a file at seperator and returns them in a list.
 /proc/file2list(filename, seperator="\n")
@@ -278,18 +236,18 @@ proc/tg_list2text(list/list, glue=",")
 	var/c
 	for(var/i = 1 to length(str))
 		c= text2ascii(str,i)
-		r+= num2hex(c)
+		r+= num2hex(c, 0)
 	return r
 
 // Decodes hex to raw byte string.
 // If safe=TRUE, returns null on incorrect input strings instead of CRASHing
-/proc/hextostr(str, safe=FALSE)
+/proc/hextostr(str)
 	if(!istext(str)||!str)
 		return
 	var/r
 	var/c
 	for(var/i = 1 to length(str)/2)
-		c = hex2num(copytext(str,i*2-1,i*2+1), safe)
+		c = hex2num(copytext(str,i*2-1,i*2+1))
 		if(isnull(c))
 			return null
 		r += ascii2text(c)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -19,9 +19,9 @@
 	var/r = hex2num(textr)
 	var/g = hex2num(textg)
 	var/b = hex2num(textb)
-	textr = num2hex(255 - r)
-	textg = num2hex(255 - g)
-	textb = num2hex(255 - b)
+	textr = num2hex(255 - r, 0)
+	textg = num2hex(255 - g, 0)
+	textb = num2hex(255 - b, 0)
 	if (length(textr) < 2)
 		textr = text("0[]", textr)
 	if (length(textg) < 2)
@@ -1020,7 +1020,7 @@ var/global/known_proc = new /proc/get_type_ref_bytes
 		colour = pick(list("FF0000","FF7F00","FFFF00","00FF00","0000FF","4B0082","8F00FF"))
 	else
 		for(var/i=1;i<=3;i++)
-			var/temp_col = "[num2hex(rand(lower,upper))]"
+			var/temp_col = "[num2hex(rand(lower,upper), 0)]"
 			if(length(temp_col )<2)
 				temp_col  = "0[temp_col]"
 			colour += temp_col

--- a/code/controllers/subsystems/plants.dm
+++ b/code/controllers/subsystems/plants.dm
@@ -58,10 +58,10 @@
 	var/list/plant_traits = ALL_GENES
 	while(plant_traits && plant_traits.len)
 		var/gene_tag = pick(plant_traits)
-		var/gene_mask = "[uppertext(num2hex(rand(0,255)))]"
+		var/gene_mask = "[uppertext(num2hex(rand(0,255), 0))]"
 
 		while(gene_mask in used_masks)
-			gene_mask = "[uppertext(num2hex(rand(0,255)))]"
+			gene_mask = "[uppertext(num2hex(rand(0,255), 0))]"
 
 		used_masks += gene_mask
 		plant_traits -= gene_tag

--- a/code/controllers/subsystems/records.dm
+++ b/code/controllers/subsystems/records.dm
@@ -294,8 +294,7 @@
 	return "[return_value][include_faction_prefix ? " ([H.mind.selected_faction.title_suffix])" : ""]"
 
 /proc/generate_record_id()
-	return add_zero(num2hex(rand(1, 65535)), 4)
-
+	return num2hex(rand(1, 65535), 4)
 
 /datum/controller/subsystem/records/proc/InitializeCitizenships()
 	for (var/type in subtypesof(/datum/citizenship))

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -357,15 +357,6 @@
 		else
 			H.equip_or_collect(I, slot_wear_id)
 
-	if(id)
-		var/obj/item/modular_computer/P = H.wear_id
-		var/obj/item/I = new id(H)
-		imprint_idcard(H,I)
-		if(istype(P) && P.card_slot)
-			addtimer(CALLBACK(src, .proc/register_pda, P, I), 2 SECOND)
-		else
-			H.equip_or_collect(I, slot_wear_id)
-
 	if(!visualsOnly) // Items in pockets or backpack don't show up on mob's icon.
 		if(l_pocket)
 			equip_item(H, l_pocket, slot_l_store)
@@ -380,6 +371,15 @@
 			var/number = belt_contents[path]
 			for(var/i in 1 to number)
 				H.equip_or_collect(new path(H), slot_in_belt)
+
+		if(id)
+			var/obj/item/modular_computer/P = H.wear_id
+			var/obj/item/I = new id(H)
+			imprint_idcard(H,I)
+			if(istype(P) && P.card_slot)
+				addtimer(CALLBACK(src, .proc/register_pda, P, I), 2 SECOND)
+			else
+				H.equip_or_collect(I, slot_wear_id)
 
 	post_equip(H, visualsOnly)
 

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -207,7 +207,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 
 // Get a hex-encoded UI block.
 /datum/dna/proc/GetUIBlock(var/block)
-	return EncodeDNABlock(GetUIValue(block))
+	return num2hex(GetUIValue(block), 3)
 
 // Do not use this unless you absolutely have to.
 // Set a block from a hex string.  This is inefficient.  If you can, use SetUIValue().
@@ -294,7 +294,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 
 // Get hex-encoded SE block.
 /datum/dna/proc/GetSEBlock(var/block)
-	return EncodeDNABlock(GetSEValue(block))
+	return num2hex(GetSEValue(block), 3)
 
 // Do not use this unless you absolutely have to.
 // Set a block from a hex string.  This is inefficient.  If you can, use SetUIValue().
@@ -323,14 +323,10 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	//testing("SetSESubBlock([block],[subBlock],[newSubBlock],[defer]): [oldBlock] -> [newBlock]")
 	SetSEBlock(block,newBlock,defer)
 
-
-/proc/EncodeDNABlock(var/value)
-	return add_zero2(num2hex(value,1), 3)
-
 /datum/dna/proc/UpdateUI()
 	src.uni_identity=""
 	for(var/block in UI)
-		uni_identity += EncodeDNABlock(block)
+		uni_identity += num2hex(block, 3)
 	//testing("New UI: [uni_identity]")
 	dirtyUI=0
 
@@ -338,7 +334,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	//var/oldse=struc_enzymes
 	struc_enzymes=""
 	for(var/block in SE)
-		struc_enzymes += EncodeDNABlock(block)
+		struc_enzymes += num2hex(block, 3)
 	//testing("Old SE: [oldse]")
 	//testing("New SE: [struc_enzymes]")
 	dirtySE=0

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -1,17 +1,6 @@
 /////////////////////////////
 // Helpers for DNA2
 /////////////////////////////
-
-// Pads 0s to t until length == u
-/proc/add_zero2(t, u)
-	var/temp1
-	while (length(t) < u)
-		t = "0[t]"
-	temp1 = t
-	if (length(t) > u)
-		temp1 = copytext(t,2,u+1)
-	return temp1
-
 // DNA Gene activation boundaries, see dna2.dm.
 // Returns a list object with 4 numbers.
 /proc/GetDNABounds(var/block)

--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -273,7 +273,7 @@
 /obj/machinery/computer/scan_consolenew/proc/all_dna_blocks(var/list/buffer)
 	var/list/arr = list()
 	for(var/i = 1, i <= buffer.len, i++)
-		arr += "[i]:[EncodeDNABlock(buffer[i])]"
+		arr += "[i]:[num2hex(buffer[i], 3)]"
 	return arr
 
 /obj/machinery/computer/scan_consolenew/proc/setInjectorBlock(var/obj/item/dnainjector/I, var/blk, var/datum/dna2/record/buffer)

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -291,6 +291,13 @@
 	l_hand = /obj/item/modular_computer/laptop/preset
 	gloves = /obj/item/modular_computer/handheld/wristbound/preset/advanced/civilian
 
+/datum/outfit/job/librarian/tech_support/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		r_hand = null
+	else
+		r_hand = initial(r_hand)
+	return ..()
+
 /datum/job/chaplain
 	title = "Chaplain"
 	flag = CHAPLAIN

--- a/code/game/objects/items/weapons/grenades/anti_photon_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/anti_photon_grenade.dm
@@ -16,7 +16,7 @@
 	spawn(extra_delay)
 		spawn(200)
 			if(prob(10+extra_delay))
-				set_light(10, 10, "#[num2hex(rand(64,255))][num2hex(rand(64,255))][num2hex(rand(64,255))]")
+				set_light(10, 10, "#[num2hex(rand(64,255), 0)][num2hex(rand(64,255), 0)][num2hex(rand(64,255), 0)]")
 		spawn(210)
 			..()
 			playsound(src.loc, 'sound/effects/bang.ogg', 50, 1, 5)

--- a/html/changelogs/johnwildkins-charsetup.yml
+++ b/html/changelogs/johnwildkins-charsetup.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - backend: "Optimized character setup mob previews; removed a source of server-crushing lag in the process."


### PR DESCRIPTION
Destroys hex2num / num2hex; they are now macros pointing to text2num / num2text, as that supports converting numbers to non-base10 number strings post-513

ID Card is no longer imprinted until spawn, which prevents colossal amounts of getFlatIcon calls during char setup

finally, tech support's circuit bag isn't spawned in-hand until he actually spawns, thereby preventing the one tech support player on the server from destroying us via 500K qdel calls