### PR TITLE
Fixes shuttle walls interactions, renames shuttle alloy to plastitanium.

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -185,7 +185,7 @@
 		if(reinf_material)
 			weaken += reinf_material.integrity * 3 //Since girders don't have a secondary material, buff 'em up a bit.
 		weaken /= 100
-		do_attack_animation(src)
+		user.do_attack_animation(src)
 		playsound(src, 'sound/weapons/smash.ogg', 50)
 		if(damage_to_deal > weaken && (damage_to_deal > MIN_DAMAGE_TO_HIT))
 			damage_to_deal -= weaken

--- a/code/game/turfs/simulated/shuttle_turfs.dm
+++ b/code/game/turfs/simulated/shuttle_turfs.dm
@@ -17,54 +17,6 @@
 /turf/simulated/wall/shuttle/Initialize(mapload)
 	. = ..(mapload,"shuttle")
 
-/turf/simulated/wall/shuttle/attackby(obj/item/W as obj, mob/user as mob)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	if (!user)
-		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return
-
-	if(!istype(user.loc, /turf))
-		return
-
-	if(locate(/obj/effect/overlay/wallrot) in src)
-		if(W.iswelder() )
-			var/obj/item/weldingtool/WT = W
-			if( WT.use(0,user) )
-				to_chat(user, "<span class='notice'>You burn away the fungi with \the [WT].</span>")
-				playsound(src, 'sound/items/welder.ogg', 10, 1)
-				for(var/obj/effect/overlay/wallrot/WR in src)
-					qdel(WR)
-				return
-		else if(!is_sharp(W) && W.force >= 10 || W.force >= 20)
-			to_chat(user, "<span class='notice'>\The [src] crumbles away under the force of your [W.name].</span>")
-			src.dismantle_wall(1)
-			return
-
-	if(thermite)
-		if(W.iswelder() )
-			var/obj/item/weldingtool/WT = W
-			if( WT.use(0,user) )
-				thermitemelt(user)
-				return
-
-		else if(istype(W, /obj/item/gun/energy/plasmacutter))
-			thermitemelt(user)
-			return
-
-		else if( istype(W, /obj/item/melee/energy/blade) )
-			var/obj/item/melee/energy/blade/EB = W
-
-			spark(EB, 5)
-			to_chat(user, "<span class='notice'>You slash \the [src] with \the [EB]; the thermite ignites!</span>")
-			playsound(src, /decl/sound_category/spark_sound, 50, 1)
-			playsound(src, 'sound/weapons/blade.ogg', 50, 1)
-
-			thermitemelt(user)
-			return
-
-	if(!istype(W, /obj/item/reagent_containers))
-		return attack_hand(user)
-
 /turf/simulated/wall/shuttle/cardinal
 	smooth = SMOOTH_TRUE
 

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -106,7 +106,6 @@
 /turf/simulated/wall/attackby(obj/item/W, mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(!user)
-		to_chat(user, SPAN_WARNING("You don't have the dexterity to do this!"))
 		return
 
 	//get the user's location
@@ -188,7 +187,7 @@
 	// Basic dismantling.
 	if(isnull(construction_stage) || !reinf_material)
 
-		var/cut_delay = 60 - material.cut_delay
+		var/cut_delay = 60 + material.cut_delay
 		var/dismantle_verb
 		var/dismantle_sound
 

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -290,6 +290,18 @@
 	amount = max_amount
 	update_icon()
 
+/obj/item/stack/material/shuttle
+	name = "plastitanium"
+	icon_state = "sheet-plastitanium"
+	item_state = "sheet-metal"
+	default_type = MATERIAL_SHUTTLE
+	icon_has_variants = TRUE
+
+/obj/item/stack/material/shuttle/full/Initialize()
+	. = ..()
+	amount = max_amount
+	update_icon()
+
 /obj/item/stack/material/wood
 	name = "wooden plank"
 	icon_state = "sheet-wood"

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -986,7 +986,7 @@
 
 /material/shuttle
 	name = MATERIAL_SHUTTLE
-	display_name = "spaceship alloy"
+	display_name = "plastitanium alloy"
 	stack_type = null
 	icon_base = "shuttle"
 	integrity = 1200
@@ -995,6 +995,7 @@
 	hardness = 500
 	weight = 500
 	protectiveness = 80 // 80%
+	cut_delay = 20 SECONDS
 
 /material/shuttle/skrell
 	name = MATERIAL_SHUTTLE_SKRELL

--- a/html/changelogs/mattatlas-armstrongwalls.yml
+++ b/html/changelogs/mattatlas-armstrongwalls.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Shuttle walls can now properly be interacted with, just like normal walls. This means you can break them with weapons, put APC frames on them, etc."
+  - bugfix: "Material cut delays now work properly. Since the shuttle walls can now be cut open through welding, there is an extra 20 second delay to it for them."

--- a/html/changelogs/mattatlas-armstrongwalls.yml
+++ b/html/changelogs/mattatlas-armstrongwalls.yml
@@ -40,3 +40,4 @@ delete-after: True
 changes:
   - bugfix: "Shuttle walls can now properly be interacted with, just like normal walls. This means you can break them with weapons, put APC frames on them, etc."
   - bugfix: "Material cut delays now work properly. Since the shuttle walls can now be cut open through welding, there is an extra 20 second delay to it for them."
+  - bugfix: "Fixes girder attack animation."


### PR DESCRIPTION
As per title. Shuttle walls, for some reason, completely overrode the normal wall attackby so a whole bunch of shit didn't work. With this PR you can take them apart with girders, add APC frames, etc. Since you can also take them apart by welding them, I made cut_delay work properly and now it takes an extra 20 seconds to tear shuttle alloy walls apart.

Also renamed shuttle alloy to something more sensible as in the future it won't be an OOC material.

Fixes #14350 