### PR TITLE
Civilian station hotfixes

### DIFF
--- a/html/changelogs/dansemacabre-hotfix.yml
+++ b/html/changelogs/dansemacabre-hotfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheDanseMacabre
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed a few oversights on the civilian station. First being that it had no overmap site, second being it had no holopads, and the last being no price scanners."

--- a/html/changelogs/dansemacabre-hotfix.yml
+++ b/html/changelogs/dansemacabre-hotfix.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "Fixed a few oversights on the civilian station. First being that it had no overmap site, second being it had no holopads, and the last being no price scanners."
+  - bugfix: "Fixed a few oversights on the civilian station. First being that it had no overmap site, second being it had no holopads, third being food court money, and the last being no price scanners."

--- a/html/changelogs/dansemacabre-hotfix.yml
+++ b/html/changelogs/dansemacabre-hotfix.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "Fixed a few oversights on the civilian station. First being that it had no overmap site, second being it had no holopads, third being food court money, and the last being no price scanners."
+  - bugfix: "Fixed a few oversights on the civilian station. First being that it had no overmap site, second being it had no holopads, and lastly a number of missing items, from clothing to first aid to ammo."

--- a/maps/away/generic/civilian_station.dmm
+++ b/maps/away/generic/civilian_station.dmm
@@ -397,6 +397,11 @@
 	},
 /turf/simulated/floor/lino/grey,
 /area/civilian_station)
+"bms" = (
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/obj/effect/overmap/visitable/sector/civilian_station,
+/turf/simulated/floor/tiled/white,
+/area/civilian_station)
 "bnS" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/appliance/cooker/fryer,
@@ -1402,6 +1407,11 @@
 /obj/effect/shuttle_landmark/automatic,
 /turf/simulated/floor/tiled/steel,
 /area/civilian_station/hangar)
+"mao" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/hologram/holopad/long_range,
+/turf/simulated/floor/tiled/white,
+/area/civilian_station)
 "mhC" = (
 /obj/effect/floor_decal/corner_wide/blue/diagonal,
 /obj/structure/bed/stool/chair/office/dark,
@@ -1793,6 +1803,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/civilian_station/hangar)
+"qHN" = (
+/obj/machinery/hologram/holopad/long_range,
+/turf/simulated/floor/lino/grey,
+/area/civilian_station)
 "qRl" = (
 /obj/structure/window/basic,
 /obj/structure/window/basic{
@@ -31534,7 +31548,7 @@ wji
 ygr
 xFU
 xYB
-xYB
+bms
 xYB
 xYB
 xYB
@@ -32299,7 +32313,7 @@ wji
 wji
 cqJ
 wji
-wji
+mao
 wji
 dkB
 ygr
@@ -34869,7 +34883,7 @@ wZf
 wZf
 ctQ
 wZf
-wZf
+qHN
 wZf
 dqB
 ygr

--- a/maps/away/generic/civilian_station.dmm
+++ b/maps/away/generic/civilian_station.dmm
@@ -397,11 +397,6 @@
 	},
 /turf/simulated/floor/lino/grey,
 /area/civilian_station)
-"bms" = (
-/obj/effect/floor_decal/corner_wide/blue/diagonal,
-/obj/effect/overmap/visitable/sector/civilian_station,
-/turf/simulated/floor/tiled/white,
-/area/civilian_station)
 "bnS" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/appliance/cooker/fryer,
@@ -495,6 +490,10 @@
 /obj/structure/table/steel,
 /obj/random/lavalamp,
 /turf/simulated/floor/wood,
+/area/civilian_station)
+"ceJ" = (
+/obj/machinery/hologram/holopad/long_range,
+/turf/simulated/floor/lino/grey,
 /area/civilian_station)
 "cqJ" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -821,6 +820,11 @@
 	pixel_x = -5
 	},
 /turf/simulated/floor/lino/grey,
+/area/civilian_station)
+"glu" = (
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/obj/effect/overmap/visitable/sector/civilian_station,
+/turf/simulated/floor/tiled/white,
 /area/civilian_station)
 "gmi" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1407,11 +1411,6 @@
 /obj/effect/shuttle_landmark/automatic,
 /turf/simulated/floor/tiled/steel,
 /area/civilian_station/hangar)
-"mao" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/hologram/holopad/long_range,
-/turf/simulated/floor/tiled/white,
-/area/civilian_station)
 "mhC" = (
 /obj/effect/floor_decal/corner_wide/blue/diagonal,
 /obj/structure/bed/stool/chair/office/dark,
@@ -1521,9 +1520,9 @@
 /turf/simulated/floor/tiled/white,
 /area/civilian_station)
 "oeF" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/hologram/holopad/long_range,
+/turf/simulated/floor/tiled/white,
 /area/civilian_station)
 "ofl" = (
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -1803,10 +1802,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/civilian_station/hangar)
-"qHN" = (
-/obj/machinery/hologram/holopad/long_range,
-/turf/simulated/floor/lino/grey,
-/area/civilian_station)
 "qRl" = (
 /obj/structure/window/basic,
 /obj/structure/window/basic{
@@ -31022,7 +31017,7 @@ xRX
 xRX
 xRX
 xRX
-oeF
+frn
 frn
 frn
 frn
@@ -31548,7 +31543,7 @@ wji
 ygr
 xFU
 xYB
-bms
+glu
 xYB
 xYB
 xYB
@@ -32313,7 +32308,7 @@ wji
 wji
 cqJ
 wji
-mao
+oeF
 wji
 dkB
 ygr
@@ -34883,7 +34878,7 @@ wZf
 wZf
 ctQ
 wZf
-qHN
+ceJ
 wZf
 dqB
 ygr

--- a/maps/away/generic/civilian_station.dmm
+++ b/maps/away/generic/civilian_station.dmm
@@ -495,6 +495,62 @@
 /obj/machinery/hologram/holopad/long_range,
 /turf/simulated/floor/lino/grey,
 /area/civilian_station)
+"chG" = (
+/obj/structure/closet/cabinet,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c100,
+/obj/item/spacecash/c100,
+/obj/item/spacecash/c100,
+/obj/item/spacecash/c100,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c20,
+/obj/item/spacecash/c20,
+/obj/item/spacecash/c20,
+/obj/item/spacecash/c20,
+/obj/item/spacecash/c20,
+/obj/item/spacecash/c20,
+/obj/item/spacecash/c200,
+/obj/item/spacecash/c200,
+/obj/item/spacecash/c200,
+/obj/item/spacecash/c200,
+/obj/item/spacecash/c200,
+/obj/item/spacecash/c200,
+/obj/item/spacecash/c50,
+/obj/item/spacecash/c50,
+/obj/item/spacecash/c50,
+/obj/item/spacecash/c50,
+/obj/item/spacecash/c500,
+/obj/item/spacecash/c500,
+/obj/item/spacecash/c10,
+/obj/item/spacecash/c10,
+/obj/item/spacecash/c10,
+/obj/item/spacecash/c10,
+/obj/item/spacecash/c10,
+/obj/item/spacecash/c10,
+/obj/item/spacecash/c10,
+/obj/item/spacecash/c10,
+/obj/item/spacecash/c10,
+/obj/item/spacecash/c1,
+/obj/item/spacecash/c1,
+/obj/item/spacecash/c1,
+/obj/item/spacecash/c1,
+/obj/item/spacecash/c1,
+/obj/item/spacecash/c1,
+/obj/item/spacecash/c1,
+/obj/item/spacecash/c1,
+/obj/item/spacecash/c1,
+/obj/item/spacecash/c1,
+/obj/item/spacecash/c1,
+/obj/item/spacecash/c1,
+/obj/item/device/price_scanner,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/civilian_station)
 "cqJ" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/table/rack,
@@ -1362,6 +1418,7 @@
 /obj/item/spacecash/c1,
 /obj/item/spacecash/c1,
 /obj/item/spacecash/c1,
+/obj/item/device/price_scanner,
 /turf/simulated/floor/marble/dark,
 /area/civilian_station)
 "lev" = (
@@ -1696,6 +1753,7 @@
 /obj/item/spacecash/c1,
 /obj/item/spacecash/c1,
 /obj/item/gun/projectile/leyon,
+/obj/item/device/price_scanner,
 /turf/simulated/floor/marble/dark,
 /area/civilian_station)
 "pJZ" = (
@@ -36929,7 +36987,7 @@ xRX
 xRX
 xRX
 ygr
-xto
+chG
 xto
 ygr
 bwR

--- a/maps/away/generic/civilian_station.dmm
+++ b/maps/away/generic/civilian_station.dmm
@@ -320,6 +320,16 @@
 /obj/item/lipstick/random,
 /turf/simulated/floor/tiled/white,
 /area/civilian_station)
+"aJb" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/obj/structure/closet/wardrobe/mixed,
+/turf/simulated/floor/tiled/white,
+/area/civilian_station)
 "aJd" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/table/rack,
@@ -369,6 +379,15 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/civilian_station/hangar)
+"bbT" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1";
+	pixel_x = 0
+	},
+/obj/structure/closet/wardrobe/suit,
+/turf/simulated/floor/lino/grey,
+/area/civilian_station)
 "bdA" = (
 /obj/structure/window/basic,
 /obj/structure/window/basic{
@@ -454,6 +473,8 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
+/obj/item/clothing/accessory/holster/thigh,
+/obj/item/clothing/accessory/holster/thigh,
 /turf/simulated/floor/tiled/dark,
 /area/civilian_station)
 "bKn" = (
@@ -820,6 +841,18 @@
 /obj/random/hoodie{
 	pixel_x = 5
 	},
+/obj/item/clothing/suit/storage/toggle/bomber{
+	pixel_y = 5
+	},
+/obj/item/clothing/suit/storage/toggle/leather_jacket/designer/black{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/suit/storage/toggle/leather_jacket/designer/red{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/clothing/suit/storage/toggle/leather_jacket/flight/green,
 /turf/simulated/floor/tiled/white,
 /area/civilian_station)
 "fWG" = (
@@ -1141,6 +1174,7 @@
 /obj/structure/closet/walllocker/medical{
 	pixel_y = 30
 	},
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/tiled/dark,
 /area/civilian_station)
 "iVQ" = (
@@ -1419,6 +1453,7 @@
 /obj/item/spacecash/c1,
 /obj/item/spacecash/c1,
 /obj/item/device/price_scanner,
+/obj/item/ammo_magazine/mc10mm/leyon,
 /turf/simulated/floor/marble/dark,
 /area/civilian_station)
 "lev" = (
@@ -1754,6 +1789,7 @@
 /obj/item/spacecash/c1,
 /obj/item/gun/projectile/leyon,
 /obj/item/device/price_scanner,
+/obj/item/ammo_magazine/mc10mm/leyon,
 /turf/simulated/floor/marble/dark,
 /area/civilian_station)
 "pJZ" = (
@@ -33396,7 +33432,7 @@ riA
 wji
 cJe
 wji
-cJe
+aJb
 ygr
 hON
 xYB
@@ -35966,7 +36002,7 @@ rtf
 wZf
 dcL
 wZf
-dcL
+bbT
 ygr
 gHC
 xYB


### PR DESCRIPTION
Fixes one minor (but important) oversight - the civilian station has no overmap site. Also adds holopads. Fixes a number of items missing that really should be there.