### PR TITLE
SCC can take faction/corp items/augs

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -831,7 +831,7 @@
 
 			var/permitted = !G.allowed_roles || (rank.title in G.allowed_roles)
 			permitted = permitted && G.check_species_whitelist(H)
-			permitted = permitted && (!G.faction || (G.faction == H.employer_faction))
+			permitted = permitted && (!G.faction || (G.faction == H.employer_faction || H.employer_faction == "Stellar Corporate Conglomerate"))
 			var/decl/origin_item/culture/our_culture = decls_repository.get_decl(text2path(prefs.culture))
 			permitted = permitted && (!G.culture_restriction || (our_culture in G.culture_restriction))
 			var/decl/origin_item/origin/our_origin = decls_repository.get_decl(text2path(prefs.origin))

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -690,7 +690,7 @@
 
 			var/permitted = !G.allowed_roles || (job.title in G.allowed_roles)
 			permitted = permitted && G.check_species_whitelist(H)
-			permitted = permitted && (!G.faction || (G.faction == H.employer_faction))
+			permitted = permitted && (!G.faction || (G.faction == H.employer_faction || H.employer_faction == "Stellar Corporate Conglomerate"))
 			var/our_culture = text2path(prefs.culture)
 			permitted = permitted && (!G.culture_restriction || (our_culture in G.culture_restriction))
 			var/our_origin = text2path(prefs.origin)

--- a/html/changelogs/DreamySkrell-PR-14422.yml
+++ b/html/changelogs/DreamySkrell-PR-14422.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "SCC faction characters can now take non-SCC faction items."

--- a/html/changelogs/DreamySkrell-PR-14422.yml
+++ b/html/changelogs/DreamySkrell-PR-14422.yml
@@ -38,4 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "SCC faction characters can now take non-SCC faction items."
+  - rscadd: "SCC faction characters can now take non-SCC faction items (like a XO can now take an Idris beret)."
+  - rscadd: "SCC faction characters can now take non-SCC faction augs (like CMO can now take the Zeng faceplate)."


### PR DESCRIPTION
This allows SCC chars to take all faction items and augs. This still respects the job requirements. For example, it means that:
- HoS or XO can now take an idris beret (couldn't before)
- HoS can now take idris security hud (HoS was in `allowed_roles`, but couldn't take it anyways, because faction did not match)
- XO still can't take idris sec hud (couldn't before, can't now, because not in allowed roles)
- HoS can't take idris sec uniform (couldn't before, can't now, because not in allowed roles, and it'd be silly)
- off-duty SCC crew can take faction items (like an off-duty HoS can now take idris beret, but not an idris sec hud) (they couldn't before)
- CMO can take the zeng faceplate (couldn't before)

but also...
- CMO can now take zavod beret - but CMO is whitelisted, so can we maybe trust them to not do silly things like this ~~(but I have also asked before on the discord, if SCC hires heads only from the respective megacorps, and if there could be for example zavod CMO or whatever, and did not get any answer from the admins/mods)~~
- bridge crew can also take faction items, as they are also under the SCC faction ~~- it is unclear to me if they should, and if SCC hires bridge crew directly only, or from the megacorps also~~
**see comment below**

.

code stuff:

`permitted = permitted && (!G.faction || (G.faction == H.employer_faction))`
in file `code\controllers\subsystems\job.dm`, changes the above to the following
`permitted = permitted && (!G.faction || (G.faction == H.employer_faction || H.employer_faction == "Stellar Corporate Conglomerate"))`