### PR TITLE
Emergency softsuit and air for emergency pod survivors; fix for #14384

### DIFF
--- a/code/modules/ghostroles/spawner/human/emergencypod.dm
+++ b/code/modules/ghostroles/spawner/human/emergencypod.dm
@@ -105,6 +105,9 @@
 	new /obj/item/pickaxe/drill(H.loc)
 	new /obj/item/device/gps(H.loc)
 	new /obj/item/device/flashlight/flare/mech(H.loc) // spawns an active flare
+	new /obj/item/clothing/suit/space/emergency(H.loc)        // weak softsuit, so if for whatever reason 
+	new /obj/item/clothing/head/helmet/space/emergency(H.loc) // the survivor spawns with no EVA gear,
+	new /obj/item/tank/emergency_oxygen/double(H.loc)         // they can use this, and not just die in space
 
 /datum/outfit/admin/pod/star
 	name = "RescuePod - Star"

--- a/html/changelogs/DreamySkrell-PR-14441.yml
+++ b/html/changelogs/DreamySkrell-PR-14441.yml
@@ -1,0 +1,5 @@
+author: DreamySkrell
+delete-after: True
+changes:
+  - rscadd: "Emergency softsuit and air for emergency pod survivors."
+  - bugfix: "Some emergency pod survivors no longer spawn with no EVA gear."


### PR DESCRIPTION
fix for https://github.com/Aurorastation/Aurora.3/issues/14384
fixes #14384

All pod survivors get these spawned on their feet:
```
new /obj/item/clothing/suit/space/emergency(H.loc)
new /obj/item/clothing/head/helmet/space/emergency(H.loc)
new /obj/item/tank/emergency_oxygen/double(H.loc)
```