### PR TITLE
Silicons can un-electrify doors; fix 

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1193,7 +1193,7 @@ About the new airlock wires panel:
 			else
 				electrify(30 * activate, 1)
 		if("electrify_permanently")
-			if(!isAdmin && issilicon(usr) && !antag)
+			if(!isAdmin && issilicon(usr) && !antag && (electrified_until == 0))
 				to_chat(usr, SPAN_WARNING("Your programming prevents you from electrifying the door."))
 			else
 				electrify(-1 * activate, 1)

--- a/html/changelogs/DreamySkrell-PR-14444.yml
+++ b/html/changelogs/DreamySkrell-PR-14444.yml
@@ -1,0 +1,6 @@
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - bugfix: "Silicons can un-electrify doors."


### PR DESCRIPTION
fixes #12201

ai and borgs can un-electrify doors again, if electrified by antag/wires/whatever
they can't electrify doors unless antag