### PR TITLE
Research robot module QoL improvements

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -760,7 +760,9 @@ var/global/list/robot_modules = list(
 
 /obj/item/robot_module/research
 	name = "research module"
-	channels = list(CHANNEL_SCIENCE = TRUE)
+	channels = list(CHANNEL_SCIENCE = TRUE,
+					CHANNEL_SUPPLY  = TRUE
+					)
 	networks = list(NETWORK_RESEARCH)
 	sprites = list(
 			"Basic" =          list(ROBOT_CHASSIS = "robot_sci", ROBOT_PANEL = "robot", ROBOT_EYES = "robot"),
@@ -827,6 +829,13 @@ var/global/list/robot_modules = list(
 	N.charge_costs = list(1000)
 	N.synths = list(nanite)
 	modules += N
+
+	var/datum/matter_synth/metal = new /datum/matter_synth/metal(15000)
+	synths += metal
+
+	var/obj/item/stack/material/cyborg/steel/M = new /obj/item/stack/material/cyborg/steel(src)
+	M.synths = list(metal)
+	modules += M
 
 /obj/item/robot_module/syndicate
 	name = "syndicate robot module"

--- a/html/changelogs/FearTheBlackout-researchborgsupreme.yml
+++ b/html/changelogs/FearTheBlackout-researchborgsupreme.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: SimpleMaroon
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: Gives the Research Robot module access to Operations radio so they can communicate with Machinists.
+  - tweak: Gives the Research Robot module 15 steel sheets to build tech processors and other machines.


### PR DESCRIPTION
Gives the Research Robot module access to Operations radio, since they can do Robotics work and may need to communicate with Machinists, and (limited) access to the metal sheet synthesizer so they can construct tech processors on their own.