### PR TITLE
Maint-drone hat fix

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -584,8 +584,6 @@
 
 	if(!success)
 		return FALSE
-	else if(success == ALREADY_WEARING_HAT)
-		to_chat(user, SPAN_WARNING("You are already wearing a hat."))
 	else if(success == WEAR_HAT)
 		to_chat(user, SPAN_NOTICE("You crawl under \the [src]."))
 	return TRUE

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -4,12 +4,17 @@
 	if(hat.item_state_slots && hat.item_state_slots[slot_head_str])
 		t_state = hat.item_state_slots[slot_head_str]
 	else if(hat.item_state)
-		t_state = hat.item_state
+		if(hat.contained_sprite)
+			t_state = "[hat.item_state][WORN_HEAD]"
+		else
+			t_state = hat.item_state
 	var/key = "[t_state]_[offset_x]_[offset_y]"
 	if(!mob_hat_cache[key])            // Not ideal as there's no guarantee all hat icon_states
 		var/t_icon = INV_HEAD_DEF_ICON // are unique across multiple dmis, but whatever.
 		if(hat.icon_override)
 			t_icon = hat.icon_override
+		else if (hat.contained_sprite)
+			t_icon = hat.icon
 		else if(hat.item_icons && (slot_head_str in hat.item_icons))
 			t_icon = hat.item_icons[slot_head_str]
 		var/image/I = image(icon = t_icon, icon_state = t_state)
@@ -78,7 +83,7 @@
 	var/obj/item/hat
 	var/image/hat_overlay
 	var/hat_x_offset = 0
-	var/hat_y_offset = -13
+	var/hat_y_offset = -14
 
 	var/can_swipe = TRUE
 	var/rebooting = FALSE
@@ -165,7 +170,7 @@
 	holder_type = /obj/item/holder/drone/heavy
 
 	// Hats!!
-	hat_x_offset = 1
+	hat_x_offset = 0
 	hat_y_offset = -12
 
 	standard_drone = FALSE
@@ -572,12 +577,6 @@
 
 /mob/living/silicon/robot/drone/examine(mob/user)
 	..()
-	var/msg
-	if(emagged)
-		msg += "Their eye glows red."
-	else
-		msg += "Their eye glows green."
-	to_chat(user, msg)
 
 /mob/living/silicon/robot/drone/self_diagnosis()
 	if(!is_component_functioning("diagnosis unit"))

--- a/html/changelogs/wezzy_dronehatfix.yml
+++ b/html/changelogs/wezzy_dronehatfix.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Wowzewow (Wezzy)
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes hats for maintenance drones not working with contained sprites. Makes it so hats fit better on maintenace drones."
+  - rscdel: "Removes superfluous examine text from maintenance drones."


### PR DESCRIPTION
  - bugfix: "Fixes hats for maintenance drones not working with contained sprites. Makes it so hats fit better on maintenace drones."
  - rscdel: "Removes superfluous examine text from maintenance drones."