### PR TITLE
Fixes the RD lacking access to the Intrepid

### DIFF
--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -17,16 +17,18 @@
 		SPECIES_SKRELL_AXIORI = 80
 	)
 
-	access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue, access_eva, access_external_airlocks,
-			            access_tox_storage, access_teleporter, access_sec_doors, access_medical, access_engine, access_construction, access_mining, access_mailsorting,
-			            access_research, access_xenobiology, access_xenobotany, access_ai_upload, access_tech_storage,
-			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network,
-			            access_maint_tunnels, access_it, access_intrepid)
-	minimal_access = list(access_rd, access_heads, access_tox, access_genetics, access_morgue, access_eva, access_external_airlocks,
-			            access_tox_storage, access_teleporter, access_sec_doors, access_medical, access_engine, access_construction, access_mining, access_mailsorting,
-			            access_research, access_xenobiology, access_xenobotany, access_ai_upload, access_tech_storage,
-			            access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network,
-			            access_maint_tunnels, access_it)
+	access = list(
+		access_rd, access_heads, access_tox, access_genetics, access_morgue, access_eva, access_external_airlocks, access_tox_storage,
+		access_teleporter, access_sec_doors, access_medical, access_engine, access_construction, access_mining, access_mailsorting, access_research,
+		access_xenobiology, access_xenobotany, access_ai_upload, access_tech_storage, access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway,
+		access_xenoarch, access_network, access_maint_tunnels, access_it, access_intrepid
+	)
+	minimal_access = list(
+		access_rd, access_heads, access_tox, access_genetics, access_morgue, access_eva, access_external_airlocks, access_tox_storage,
+		access_teleporter, access_sec_doors, access_medical, access_engine, access_construction, access_mining, access_mailsorting, access_research,
+		access_xenobiology, access_xenobotany, access_ai_upload, access_tech_storage, access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway,
+		access_xenoarch, access_network, access_maint_tunnels, access_it, access_intrepid
+	)
 	minimal_player_age = 14
 	ideal_character_age = list(
 		SPECIES_HUMAN = 50,

--- a/html/changelogs/rd_intrepid_access.yml
+++ b/html/changelogs/rd_intrepid_access.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the RD lacking access to the Intrepid cockpit."


### PR DESCRIPTION
this is a continuation of #14264.
fixes #14472.

this PR fixes an oversight regarding the RD's access to the Intrepid, as Intrepid access was intended but placed in the wrong access list.
"access_minimal" is the regular access and "access" is used on lowpop servers if set in the config. i.e. "access_minimal" is the default, not "access" as one could believe.
also cleans up the access list for the RD so it is easier to read in the code.