### PR TITLE
Dracula Feeding Tweak

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -9,7 +9,7 @@
 	var/datum/vampire/vampire = vampire_power(0, 0)
 	vampire.stealth = !vampire.stealth
 	if(vampire.stealth)
-		to_chat(src, SPAN_NOTICE("Your victims will now forget your interactions, and get paralyzed when you do them."))
+		to_chat(src, SPAN_NOTICE("Your victims will now forget your interactions, and get paralyzed when you do them. After feeding on them, you can also tell them what to believe what happened to them."))
 	else
 		to_chat(src, SPAN_NOTICE("Your victims will now remember your interactions."))
 
@@ -76,7 +76,7 @@
 	admin_attack_log(src, T, "drained blood from [key_name(T)], who [remembrance] the encounter.", "had their blood drained by [key_name(src)] and [remembrance] the encounter.", "is draining blood from")
 
 	if(vampire.stealth)
-		to_chat(T, SPAN_WARNING("You are unable to resist or even move. Your mind blanks as you're being fed upon."))
+		to_chat(T, SPAN_WARNING("You are unable to resist or even move. Your mind blanks completely as you're being fed upon."))
 		T.paralysis = 3400
 	else
 		to_chat(T, SPAN_WARNING("You are unable to resist or even move. Your mind is acutely aware of what's occuring."))
@@ -143,14 +143,14 @@
 
 	var/endsuckmsg = "You extract your fangs from \the [T]'s neck and stop draining them of blood."
 	if(vampire.stealth)
-		endsuckmsg += " They will remember nothing of this occurance, provided they survived."
+		endsuckmsg += " They will only remember about this encounter what you tell them now. If you don't tell them now, then they will forget the previous few minutes entirely, all provided they survived."
 	visible_message(SPAN_DANGER("[src] stops biting \the [T]'s neck!"), SPAN_NOTICE(endsuckmsg))
 	if(target_aware)
 		T.paralysis = 0
 		T.stunned = 0
 		if(T.stat != DEAD)
 			if(vampire.stealth)
-				to_chat(T.find_mob_consciousness(), SPAN_WARNING("You remember nothing about being fed upon. Instead, you simply remember having a pleasant encounter with [src]."))
+				to_chat(T.find_mob_consciousness(), SPAN_WARNING("You remember nothing about being fed upon. Instead, you simply remember whatever [src] told you after it was over. If you heard nothing, then you forgot the entire ordeal and the few minutes leading up to it."))
 			else
 				to_chat(T.find_mob_consciousness(), SPAN_WARNING("You remember everything about being fed upon. How you react to [src]'s actions is up to you."))
 
@@ -361,7 +361,7 @@
 			T.Stun(5)
 		T.stuttering = 20
 		T.adjustEarDamage(10, 20, TRUE)
-		
+
 		victims += T
 
 	for(var/obj/structure/window/W in view(7))

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -150,7 +150,7 @@
 		T.stunned = 0
 		if(T.stat != DEAD)
 			if(vampire.stealth)
-				to_chat(T.find_mob_consciousness(), SPAN_WARNING("You remember nothing about being fed upon. Instead, you simply remember whatever [src] told you after it was over. If you heard nothing, then you forgot the entire ordeal and the few minutes leading up to it."))
+				to_chat(T.find_mob_consciousness(), SPAN_WARNING("You remember nothing about being fed upon. Instead, you remember whatever \the [src] told you after it was over. If \the [src] said nothing, then you have forgotten the entire interaction and the few minutes leading up to it."))
 			else
 				to_chat(T.find_mob_consciousness(), SPAN_WARNING("You remember everything about being fed upon. How you react to [src]'s actions is up to you."))
 

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -143,7 +143,7 @@
 
 	var/endsuckmsg = "You extract your fangs from \the [T]'s neck and stop draining them of blood."
 	if(vampire.stealth)
-		endsuckmsg += " They will only remember about this encounter what you tell them now. If you don't tell them now, then they will forget the previous few minutes entirely, all provided they survived."
+		endsuckmsg += " They will only remember about this encounter by what you tell them now. If you don't tell them anything, then they will forget the previous few minutes entirely, provided they survived."
 	visible_message(SPAN_DANGER("[src] stops biting \the [T]'s neck!"), SPAN_NOTICE(endsuckmsg))
 	if(target_aware)
 		T.paralysis = 0

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -9,7 +9,7 @@
 	var/datum/vampire/vampire = vampire_power(0, 0)
 	vampire.stealth = !vampire.stealth
 	if(vampire.stealth)
-		to_chat(src, SPAN_NOTICE("Your victims will now forget your interactions, and get paralyzed when you do them. After feeding on them, you can also tell them what to believe what happened to them."))
+		to_chat(src, SPAN_NOTICE("Your victims will now forget your interactions and become paralyzed. After feeding on them, you can tell them what they should believe happened to them."))
 	else
 		to_chat(src, SPAN_NOTICE("Your victims will now remember your interactions."))
 

--- a/html/changelogs/KingOfThePing - amogus.yml
+++ b/html/changelogs/KingOfThePing - amogus.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: KingOfThePing
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Tweaks the message victims of stealth vampire feeding get, to allow the vampire more freedom in how to frame it."
+


### PR DESCRIPTION
This PR simply tweaks the "ooooh, I forgor I got fed on message" to give the vampire more freedom on how to veil their sucking rampage, as suggested in this thread:

https://forums.aurorastation.org/topic/16959-alternative-vampire-victim-alertness-mode/#comment-157991

This means, as a vampire you can now tell the victim what happened to them. If you dont tell them anything, then they just completely forget about the feeding and a few minutes up to it. The victim gets told about this fact, as well.