### PR TITLE
Lower the max mob size that can be crushed by airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1515,7 +1515,9 @@ About the new airlock wires panel:
 	return 0
 
 /mob/living/blocks_airlock()
-	return mob_size > MOB_SMALL
+	// if this returns false, a mob can be crushed by airlock
+	// cat is 2.5, corgi is 3.5, fox is 4, human is 9
+	return mob_size > 2.4
 
 /atom/movable/proc/airlock_crush(var/crush_damage)
 	return 0

--- a/html/changelogs/DreamySkrell-PR-14489.yml
+++ b/html/changelogs/DreamySkrell-PR-14489.yml
@@ -1,0 +1,6 @@
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - tweak: "Lower the max mob size that can be crushed by airlocks. Now crusher, ian, chauncey, or columbo, no longer get crushed."


### PR DESCRIPTION
```
/mob/living/blocks_airlock()
	// if this returns false, a mob can be crushed by airlock
	// cat is 2.5, corgi is 3.5, fox is 4, human is 9
	return mob_size > 2.4
```
used to be MOB_SMALL, which is 6

this ensure that some (small) things are still crushable, like bats or something
but the most common pets do not get crushed anymore, like crusher, ian, chauncey, or columbo
