### PR TITLE
Self-examine now respects gender identity

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -210,7 +210,7 @@
 		if(src == M && istype(src, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = src
 			src.visible_message(
-				SPAN_NOTICE("[src] examines [src.gender==MALE?"himself":"herself"]."), \
+				SPAN_NOTICE("[src] examines [src.get_pronoun("himself")]."), \
 				SPAN_NOTICE("You check yourself for injuries.") \
 				)
 

--- a/html/changelogs/MortalRed-Examinefix.yml
+++ b/html/changelogs/MortalRed-Examinefix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ImmortalRedshirt
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Self-examine now shows a character's correct gender in chat."


### PR DESCRIPTION
The self-examine message that is shown to other players now uses the get_pronouns proc. No change for most characters, unless the Sex and Pronoun options are set differently from each other in setup, in which case it'll default to the latter, since it's the right one to use in all cases.