### PR TITLE
Improvised Crossbow Nerfs

### DIFF
--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -45,7 +45,7 @@
 	icon_state = "metal-rod"
 
 /obj/item/arrow/rod/removed(mob/user)
-	if(throwforce == 10) // The rod has been superheated - we don't want it to be useable when removed from the bow.
+	if(throwforce == 20) // The rod has been superheated - we don't want it to be useable when removed from the bow.
 		to_chat(user, SPAN_WARNING("\The [src] shatters into a scattering of unusable overstressed metal shards as it leaves the crossbow."))
 		qdel(src)
 
@@ -189,13 +189,13 @@
 		return
 	if(cell.charge < 500)
 		return
-	if(bolt.throwforce >= 10)
+	if(bolt.throwforce >= 20)
 		return
 	if(!istype(bolt,/obj/item/arrow/rod))
 		return
 
 	to_chat(user, SPAN_WARNING("\The [bolt] plinks and crackles as it begins to glow red-hot."))
-	bolt.throwforce = 10
+	bolt.throwforce = 20
 	bolt.icon_state = "metal-rod-superheated"
 	cell.use(500)
 

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -45,7 +45,7 @@
 	icon_state = "metal-rod"
 
 /obj/item/arrow/rod/removed(mob/user)
-	if(throwforce == 15) // The rod has been superheated - we don't want it to be useable when removed from the bow.
+	if(throwforce == 10) // The rod has been superheated - we don't want it to be useable when removed from the bow.
 		to_chat(user, SPAN_WARNING("\The [src] shatters into a scattering of unusable overstressed metal shards as it leaves the crossbow."))
 		qdel(src)
 
@@ -64,8 +64,8 @@
 
 	var/obj/item/bolt
 	var/tension = 0                         // Current draw on the bow.
-	var/max_tension = 5                     // Highest possible tension.
-	var/release_speed = 5                   // Speed per unit of tension.
+	var/max_tension = 3                     // Highest possible tension.
+	var/release_speed = 3                   // Speed per unit of tension.
 	var/obj/item/cell/cell = null    // Used for firing superheated rods.
 	var/current_user                        // Used to check if the crossbow has changed hands since being drawn.
 	var/draw_time = 20						// How long it takes to increase the draw on the bow by one "tension"
@@ -189,13 +189,13 @@
 		return
 	if(cell.charge < 500)
 		return
-	if(bolt.throwforce >= 15)
+	if(bolt.throwforce >= 10)
 		return
 	if(!istype(bolt,/obj/item/arrow/rod))
 		return
 
 	to_chat(user, SPAN_WARNING("\The [bolt] plinks and crackles as it begins to glow red-hot."))
-	bolt.throwforce = 15
+	bolt.throwforce = 10
 	bolt.icon_state = "metal-rod-superheated"
 	cell.use(500)
 

--- a/html/changelogs/KingOfThePing - crossbow_nerfs.yml
+++ b/html/changelogs/KingOfThePing - crossbow_nerfs.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: KingOfThePing
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Nerfed the improvised (powered) crossbow in damage. It does not pin you to walls anymore either."


### PR DESCRIPTION
This nerfs the improvised (powered) crossbow. 

- reduces (superheated) rod throwforce to 10 from 15
- reduces maximum tension to 3 from 5
- reduces speed increase per tension to 3 from 5

This means the weapon still does a considerable amount of damage + the bolt sticking into the victim, but prevents it from pinning people to walls.

Pinning people to walls is basically a game ender and while it's cool its very overpowered for an easily buildable, improvised weapon. People can run up to enemies, point blank (unmissable) pin people to walls and do considerable internal damage initially and potentially arterial bleeding when the rod is yanked out. Too strong, thus the nerf.
