### PR TITLE
Adds the Jovian accent to Idris Incorporated IPCs

### DIFF
--- a/code/modules/background/origins/origins/ipc/megacorporate.dm
+++ b/code/modules/background/origins/origins/ipc/megacorporate.dm
@@ -10,7 +10,7 @@
 	)
 
 /decl/origin_item/origin/idris
-	name = "Idris Incorporate"
+	name = "Idris Incorporated"
 	desc = "Idris Incorporated is renowned across the Spur for its top of the line service, security, and investigative IPCs. Positronics working for the company are given little autonomy and closely monitored to ensure maximum efficiency and stellar customer service. Although the company likes to advertise its award-winning service IPCs, just as infamous are its Idris Reclamation Units: synthetics who will stop at nothing to ensure that the bank is given its dues."
 	important_information = "Idris IPCs working in security are given the prefix ISU or IRU depending on their responsibilities while those working in other fields are not obliged to take one. They are barred from seeking freedom by the company and cannot be sold without having their proprietary programming wiped."
 	possible_accents = list(ACCENT_SILVERSUN_EXPATRIATE, ACCENT_SILVERSUN_ORIGINAL, ACCENT_SOL, ACCENT_JUPITER, ACCENT_ERIDANI, ACCENT_LUNA, ACCENT_EARTH, ACCENT_VENUS, ACCENT_CETI, ACCENT_TTS)

--- a/code/modules/background/origins/origins/ipc/megacorporate.dm
+++ b/code/modules/background/origins/origins/ipc/megacorporate.dm
@@ -13,7 +13,7 @@
 	name = "Idris Incorporate"
 	desc = "Idris Incorporated is renowned across the Spur for its top of the line service, security, and investigative IPCs. Positronics working for the company are given little autonomy and closely monitored to ensure maximum efficiency and stellar customer service. Although the company likes to advertise its award-winning service IPCs, just as infamous are its Idris Reclamation Units: synthetics who will stop at nothing to ensure that the bank is given its dues."
 	important_information = "Idris IPCs working in security are given the prefix ISU or IRU depending on their responsibilities while those working in other fields are not obliged to take one. They are barred from seeking freedom by the company and cannot be sold without having their proprietary programming wiped."
-	possible_accents = list(ACCENT_SILVERSUN_EXPATRIATE, ACCENT_SILVERSUN_ORIGINAL, ACCENT_SOL, ACCENT_ERIDANI, ACCENT_LUNA, ACCENT_EARTH, ACCENT_VENUS, ACCENT_CETI, ACCENT_TTS)
+	possible_accents = list(ACCENT_SILVERSUN_EXPATRIATE, ACCENT_SILVERSUN_ORIGINAL, ACCENT_SOL, ACCENT_JUPITER, ACCENT_ERIDANI, ACCENT_LUNA, ACCENT_EARTH, ACCENT_VENUS, ACCENT_CETI, ACCENT_TTS)
 	possible_citizenships = list(CITIZENSHIP_NONE)
 	possible_religions = list(RELIGION_NONE)
 

--- a/html/changelogs/omicega-zzzzzzzzzaerearrfdadf.yml
+++ b/html/changelogs/omicega-zzzzzzzzzaerearrfdadf.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Adds the Jovian accent to an overlooked IPC origin."


### PR DESCRIPTION
See title.

Lore support from the wiki's Callisto page:

... The industrial production of the Plains has historically been dominated by heavy industry but has seen a rapid growth in its synthetic production sector following Konyang's secession. **Many of Idris Incorporated and Einstein Engines' synthetics are produced in this district**, and Callisteans from it tend to be very familiar with IPCs due to interacting with them on an almost daily basis. The rapid growth of the synthetic production sector in the Plains has caused unexpected problems for the local government and the district's CMPD branch, which is now responsible for policing more synthetics than perhaps any other agency in the entire Solarian Alliance.