### PR TITLE
Pneumalin for Shuttles

### DIFF
--- a/html/changelogs/KingOfThePing - peridaxon_my_beloved.yml
+++ b/html/changelogs/KingOfThePing - peridaxon_my_beloved.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: KingOfThePing
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds 2 Peridaxon autoinhalers to the Intrepid's, the mining shuttle's and the Medbay's stabilization locker."
+

--- a/html/changelogs/KingOfThePing - peridaxon_my_beloved.yml
+++ b/html/changelogs/KingOfThePing - peridaxon_my_beloved.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Adds 2 Peridaxon autoinhalers to the Intrepid's, the mining shuttle's and the Medbay's stabilization locker."
+  - rscadd: "Adds 2 Pneumalin autoinhalers to the Intrepid's, the mining shuttle's and the Medbay's stabilization locker."
 

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -903,8 +903,8 @@
 /obj/machinery/camera/network/mining{
 	c_tag = "Mining - Shuttle"
 	},
-/obj/item/reagent_containers/inhaler/peridaxon,
-/obj/item/reagent_containers/inhaler/peridaxon,
+/obj/item/reagent_containers/inhaler/pneumalin,
+/obj/item/reagent_containers/inhaler/pneumalin,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
 "aNR" = (
@@ -19024,8 +19024,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lime/diagonal,
-/obj/item/reagent_containers/inhaler/peridaxon,
-/obj/item/reagent_containers/inhaler/peridaxon,
+/obj/item/reagent_containers/inhaler/pneumalin,
+/obj/item/reagent_containers/inhaler/pneumalin,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/intrepid/medical_compartment)
 "pEb" = (

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -903,6 +903,8 @@
 /obj/machinery/camera/network/mining{
 	c_tag = "Mining - Shuttle"
 	},
+/obj/item/reagent_containers/inhaler/peridaxon,
+/obj/item/reagent_containers/inhaler/peridaxon,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
 "aNR" = (
@@ -19022,6 +19024,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lime/diagonal,
+/obj/item/reagent_containers/inhaler/peridaxon,
+/obj/item/reagent_containers/inhaler/peridaxon,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/intrepid/medical_compartment)
 "pEb" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -23886,8 +23886,8 @@
 /obj/item/clothing/mask/breath/medical,
 /obj/item/clothing/mask/breath/medical,
 /obj/item/clothing/mask/breath/medical,
-/obj/item/reagent_containers/inhaler/peridaxon,
-/obj/item/reagent_containers/inhaler/peridaxon,
+/obj/item/reagent_containers/inhaler/pneumalin,
+/obj/item/reagent_containers/inhaler/pneumalin,
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
 "nbJ" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -23886,6 +23886,8 @@
 /obj/item/clothing/mask/breath/medical,
 /obj/item/clothing/mask/breath/medical,
 /obj/item/clothing/mask/breath/medical,
+/obj/item/reagent_containers/inhaler/peridaxon,
+/obj/item/reagent_containers/inhaler/peridaxon,
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
 "nbJ" = (


### PR DESCRIPTION
Adds 2 Peridaxon inhalers to, as requested by this thread:

https://forums.aurorastation.org/topic/17376-load-peridaxon-auto-inhalers-onto-our-ships/#comment-158093

- the Medbay stabilization wall locker
- to the Intrepid's medical room med locker
- to the mining shuttle's emergency wall locker

This totals to 10 units Peridaxon each. Good for up to two patients, so they dont die. A reasonable amount, without being too overpowered I hope.
