### PR TITLE
Fixes Unsimulated Steel Walls Not Smoothing

### DIFF
--- a/code/game/turfs/unsimulated/walls.dm
+++ b/code/game/turfs/unsimulated/walls.dm
@@ -44,7 +44,10 @@
 	color = "#666666"
 	smooth = SMOOTH_TRUE
 	canSmoothWith = list(
-		/turf/unsimulated/wall/steel
+		/turf/unsimulated/wall/steel,
+		/obj/structure/window_frame,
+		/obj/structure/window_frame/unanchored,
+		/obj/structure/window_frame/empty
 	)
 
 /turf/unsimulated/wall/darkshuttlewall

--- a/html/changelogs/cent_smoothing_fixes.yml
+++ b/html/changelogs/cent_smoothing_fixes.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes unsimulated steel walls not smoothing with simulated steel window frames."


### PR DESCRIPTION
this PR fixes the unsimulated steel walls on the centcomm z-level not smoothing with simulated steel window frames.