### PR TITLE
Adjusts Deck 3 Nature Garden

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -46,11 +46,15 @@
 	icon = 'icons/obj/flora/jungletreesmall.dmi'
 
 /obj/structure/flora/tree/jungle/small/patience
+	name = "Patience"
+	desc = "A lush and healthy tree. A small golden plaque at its base reads its name, in plain text, Patience."
 	layer = 3
 	density = FALSE
 	icon_state = "patiencebottom"
 
 /obj/structure/flora/tree/jungle/small/patience_top
+	name = "Patience"
+	desc = "A lush and healthy tree. A small golden plaque at its base reads its name, in plain text, Patience."
 	pixel_y = -32
 	density = TRUE
 	icon_state = "patiencetop"

--- a/html/changelogs/doc - deck 3 garden take 2.yml
+++ b/html/changelogs/doc - deck 3 garden take 2.yml
@@ -1,0 +1,6 @@
+author: Doc
+
+delete-after: True
+
+changes:
+  - maptweak: "Changed the position of the deck 3 nature garden, replacing the unused janitorial nature display room."

--- a/maps/sccv_horizon/code/sccv_horizon_areas.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_areas.dm
@@ -554,12 +554,6 @@
 /area/horizon/deck_three/cafeteria
 	name = "Horizon - Deck 3 - Cafeteria"
 	icon_state = "cafeteria"
-
-// Nature Showcase
-/area/horizon/deck_three/nature_showcase
-	name = "Horizon - Deck 3 - Nature Showcase"
-	icon_state = "nature_showcase"
-	sound_env = SMALL_ENCLOSED
 /********** Decks End **********/
 
 /********** Unique Start **********/

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -667,11 +667,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
 "bm" = (
-/obj/effect/floor_decal/spline/fancy/wood/cee{
-	dir = 1
-	},
-/obj/structure/bed/stool/chair/padded/brown{
-	dir = 4
+/obj/structure/table/wood,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
 	},
 /turf/simulated/floor/wood,
 /area/horizon/hallway/deck_three/primary/starboard)
@@ -738,18 +736,10 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop/xo)
 "bt" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Nature Showcase Maintenance";
-	req_access = list(26)
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/horizon/deck_three/nature_showcase)
+/obj/structure/lattice,
+/obj/machinery/light,
+/turf/simulated/open,
+/area/horizon/hallway/deck_three/primary/starboard)
 "bu" = (
 /obj/effect/floor_decal/corner_wide/paleblue/full{
 	dir = 4
@@ -840,13 +830,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop/xo)
-"bC" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
 "bD" = (
 /obj/effect/floor_decal/corner/green/full{
 	dir = 4
@@ -1013,17 +996,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_armory)
 "bR" = (
+/obj/structure/table/wood,
 /obj/effect/floor_decal/spline/fancy/wood{
-	dir = 6
+	dir = 1
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/nature_showcase)
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/wood,
+/area/horizon/hallway/deck_three/primary/starboard)
 "bS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1053,12 +1032,15 @@
 /turf/simulated/floor/reinforced/airless,
 /area/template_noop)
 "bV" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 6
+/obj/structure/bed/stool/chair/wood{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/fancy/wood/cee{
+	dir = 4
 	},
 /obj/machinery/light,
-/turf/simulated/floor/beach/water/alt,
-/area/horizon/deck_three/nature_showcase)
+/turf/simulated/floor/wood,
+/area/horizon/hallway/deck_three/primary/starboard)
 "bW" = (
 /obj/structure/bed/stool/chair{
 	dir = 1
@@ -1069,9 +1051,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/vacantoffice2)
 "bX" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
-/turf/simulated/floor/tiled/dark/full,
-/area/horizon/deck_three/nature_showcase)
+/obj/structure/flora/ausbushes/leafybush,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/grass/alt,
+/area/horizon/hallway/deck_three/primary/starboard)
 "bY" = (
 /obj/machinery/alarm{
 	pixel_y = 28
@@ -1079,13 +1064,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/selfdestruct)
 "bZ" = (
-/obj/structure/railing/mapped,
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/lattice,
-/turf/simulated/open,
-/area/horizon/deck_three/cafeteria)
+/obj/structure/flora/ausbushes/pointybush,
+/turf/simulated/floor/grass/alt,
+/area/horizon/hallway/deck_three/primary/starboard)
 "ca" = (
 /obj/machinery/requests_console{
 	department = "Consular's Office";
@@ -1153,9 +1134,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "cg" = (
-/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
 /turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
+/area/horizon/hallway/deck_three/primary/starboard)
 "ch" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Deck 3 Central Stairwell"
@@ -1223,6 +1207,10 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/small/east,
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "co" = (
@@ -1271,15 +1259,13 @@
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "ct" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Nature Showcase Maintenance";
+	req_access = list(26)
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
+/area/horizon/hallway/deck_three/primary/starboard)
 "cu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
@@ -1328,13 +1314,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/horizon/crew_quarters/cryo/dormitories)
-"cy" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/nature_showcase)
 "cz" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1567,17 +1546,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_quarters/fitness/pool)
 "cV" = (
-/obj/structure/railing/mapped{
-	dir = 8
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
 	},
-/obj/structure/railing/mapped{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/structure/railing/mapped{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/lattice,
-/turf/simulated/open,
+/turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "cW" = (
 /obj/structure/flora/pottedplant{
@@ -1748,12 +1727,15 @@
 	name = "Security - Investigations Office"
 	})
 "dn" = (
-/obj/effect/floor_decal/corner/purple{
-	dir = 9
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /obj/machinery/firealarm/west,
-/turf/simulated/floor/tiled,
-/area/horizon/deck_three/nature_showcase)
+/turf/simulated/floor/wood,
+/area/horizon/hallway/deck_three/primary/starboard)
 "do" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -1994,14 +1976,17 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/equipment)
 "dG" = (
-/obj/structure/railing/mapped{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/railing/mapped{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice,
-/turf/simulated/open,
+/turf/simulated/floor/tiled/dark,
 /area/horizon/hallway/deck_three/primary/starboard)
 "dH" = (
 /obj/machinery/alarm{
@@ -2827,15 +2812,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "fj" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/railing/mapped,
-/obj/structure/railing/mapped{
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/structure/lattice,
-/turf/simulated/open,
+/turf/simulated/floor/grass/alt,
 /area/horizon/hallway/deck_three/primary/starboard)
 "fk" = (
 /obj/structure/cable/green{
@@ -3445,14 +3426,7 @@
 /area/crew_quarters/lounge)
 "gu" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_x = -32
+	dir = 6
 	},
 /turf/simulated/floor/wood,
 /area/horizon/hallway/deck_three/primary/starboard)
@@ -4242,12 +4216,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
 "hV" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/floor_decal/spline/plain{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/hallway/deck_three/primary/starboard)
 "hW" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -5140,21 +5120,12 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "jr" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/purple/full{
-	dir = 8
+/obj/structure/table/wood,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
 	},
-/obj/structure/closet/crate/hydroponics,
-/obj/item/storage/bag/plants,
-/obj/item/wirecutters/clippers,
-/obj/item/material/minihoe,
-/obj/item/material/hatchet,
-/obj/item/reagent_containers/glass/bucket,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/deck_three/nature_showcase)
+/turf/simulated/floor/wood,
+/area/horizon/hallway/deck_three/primary/starboard)
 "js" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Cryogenic Storage"
@@ -5350,14 +5321,12 @@
 /turf/simulated/floor,
 /area/maintenance/security_starboard)
 "jK" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 10
+/obj/structure/flora/ausbushes/genericbush,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
 	},
-/obj/structure/flora/pottedplant{
-	icon_state = "plant-33"
-	},
-/turf/simulated/floor/wood,
-/area/horizon/deck_three/cafeteria)
+/turf/simulated/floor/grass/alt,
+/area/horizon/hallway/deck_three/primary/starboard)
 "jL" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -5472,8 +5441,12 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "jY" = (
-/obj/effect/floor_decal/spline/fancy/wood,
-/obj/structure/table/wood,
+/obj/structure/bed/stool/chair/wood{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
+	},
 /turf/simulated/floor/wood,
 /area/horizon/deck_three/cafeteria)
 "jZ" = (
@@ -5712,14 +5685,12 @@
 /turf/simulated/open,
 /area/horizon/hallway/deck_three/primary/starboard)
 "ku" = (
-/obj/effect/floor_decal/spline/fancy/wood/corner{
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 5
-	},
-/turf/simulated/floor/wood,
-/area/horizon/deck_three/cafeteria)
+/turf/simulated/floor/grass/alt,
+/area/horizon/hallway/deck_three/primary/starboard)
 "kv" = (
 /obj/structure/table/reinforced/wood,
 /obj/item/modular_computer/laptop/preset/command/captain,
@@ -5836,11 +5807,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
-"kG" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/floor_decal/spline/plain,
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
 "kH" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
@@ -6657,18 +6623,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/stairwell/central)
-"mc" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
 "md" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/crew_quarters/captain)
 "me" = (
 /obj/structure/lattice,
-/obj/structure/railing/mapped{
-	dir = 1
-	},
+/obj/structure/lattice,
 /turf/simulated/open,
 /area/horizon/hallway/deck_three/primary/starboard)
 "mf" = (
@@ -6913,15 +6873,9 @@
 /turf/simulated/floor/tiled,
 /area/tcommsat/entrance)
 "mF" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/purple{
-	dir = 10
-	},
-/obj/machinery/vending/hydronutrients,
-/turf/simulated/floor/tiled,
-/area/horizon/deck_three/nature_showcase)
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass/alt,
+/area/horizon/hallway/deck_three/primary/starboard)
 "mG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -7305,12 +7259,10 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/obj/structure/railing/mapped{
-	dir = 8
-	},
+/obj/machinery/light,
 /obj/structure/lattice,
 /turf/simulated/open,
-/area/horizon/deck_three/cafeteria)
+/area/horizon/hallway/deck_three/primary/starboard)
 "no" = (
 /obj/machinery/firealarm/south,
 /obj/structure/table/standard,
@@ -7815,10 +7767,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/controlroom)
 "ok" = (
-/obj/structure/railing/mapped{
-	dir = 4
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
 	},
-/turf/simulated/open,
+/obj/structure/bed/stool/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
 /area/horizon/deck_three/cafeteria)
 "ol" = (
 /obj/structure/cable/green{
@@ -8375,12 +8330,12 @@
 /turf/simulated/floor/wood,
 /area/lawoffice/representative)
 "pm" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
 /obj/structure/lattice,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/open,
-/area/horizon/deck_three/cafeteria)
+/area/horizon/hallway/deck_three/primary/starboard)
 "pn" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -8916,12 +8871,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_quarters/fitness/gym)
 "qm" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
+/obj/effect/map_effect/window_spawner/full/reinforced,
+/turf/simulated/floor,
+/area/horizon/hallway/deck_three/primary/starboard)
 "qn" = (
 /turf/simulated/floor/reinforced,
 /area/bridge/selfdestruct)
@@ -8949,13 +8901,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
-"qq" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/floor_decal/spline/plain{
-	dir = 10
-	},
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
 "qr" = (
 /obj/machinery/light/small/emergency{
 	dir = 4
@@ -9062,7 +9007,12 @@
 /turf/simulated/floor/wood,
 /area/horizon/hallway/deck_three/primary/starboard)
 "qD" = (
-/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/flora/pottedplant{
+	icon_state = "plant-21"
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
+	},
 /turf/simulated/floor/wood,
 /area/horizon/deck_three/cafeteria)
 "qE" = (
@@ -9901,18 +9851,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/bridge/bridge_crew)
-"sh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/sink/kitchen{
-	dir = 8;
-	name = "water fountain";
-	pixel_x = 20
-	},
-/obj/effect/floor_decal/corner/purple{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/deck_three/nature_showcase)
 "si" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /turf/simulated/floor/tiled/dark/full,
@@ -10141,13 +10079,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
-"sD" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/turf/simulated/floor/wood,
-/area/horizon/deck_three/cafeteria)
 "sE" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -10178,10 +10109,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop/xo)
-"sI" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
 "sJ" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
@@ -11313,24 +11240,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
-"uI" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 10
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light,
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/nature_showcase)
-"uJ" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
 "uK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11899,12 +11808,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice)
-"vK" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/horizon/deck_three/cafeteria)
 "vL" = (
 /obj/structure/bed/stool/chair{
 	dir = 1
@@ -12095,15 +11998,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
-"we" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 9
-	},
-/obj/structure/flora/pottedplant{
-	icon_state = "plant-21"
-	},
-/turf/simulated/floor/wood,
-/area/horizon/deck_three/cafeteria)
 "wf" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
@@ -13322,13 +13216,13 @@
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice2)
 "yp" = (
-/obj/effect/floor_decal/corner/purple/full,
-/obj/machinery/seed_storage/garden,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
 	},
-/turf/simulated/floor/tiled,
-/area/horizon/deck_three/nature_showcase)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass/alt,
+/area/horizon/hallway/deck_three/primary/starboard)
 "yq" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/effect/floor_decal/spline/plain{
@@ -13515,7 +13409,11 @@
 /area/template_noop)
 "yJ" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
+	dir = 9
+	},
+/obj/structure/flora/pottedplant{
+	icon_state = "plant-33";
+	pixel_y = 15
 	},
 /turf/simulated/floor/wood,
 /area/horizon/deck_three/cafeteria)
@@ -14073,12 +13971,6 @@
 	},
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
-"zM" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 10
-	},
-/turf/simulated/floor/wood,
-/area/horizon/deck_three/cafeteria)
 "zN" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
@@ -14293,8 +14185,15 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "Ak" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
+/area/horizon/hallway/deck_three/primary/starboard)
 "Al" = (
 /obj/structure/table/rack,
 /obj/item/towel,
@@ -14899,17 +14798,6 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/tiled/dark/full,
 /area/tcommsat/entrance)
-"Bv" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/camera/network/service{
-	c_tag = "Third Deck - Nature Showcase";
-	dir = 4
-	},
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/nature_showcase)
 "Bw" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/cobweb,
@@ -15063,7 +14951,7 @@
 "BK" = (
 /obj/structure/bed/stool/chair/sofa/right/red,
 /obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
+	dir = 9
 	},
 /turf/simulated/floor/wood,
 /area/horizon/deck_three/cafeteria)
@@ -15462,13 +15350,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ward/isolation)
-"CB" = (
-/obj/effect/floor_decal/spline/fancy/wood,
-/obj/structure/bed/stool/chair/wood{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/horizon/deck_three/cafeteria)
 "CC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15513,13 +15394,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled,
 /area/maintenance/aux_atmospherics/deck_3)
-"CG" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/reedbush,
-/turf/simulated/floor/beach/water/alt,
-/area/horizon/deck_three/nature_showcase)
 "CH" = (
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 8
@@ -15827,16 +15701,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/security_starboard)
-"Dk" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
 "Dl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -15911,9 +15775,7 @@
 /area/maintenance/aux_atmospherics/deck_3)
 "Dt" = (
 /obj/effect/floor_decal/spline/fancy/wood,
-/obj/structure/bed/stool/chair/wood{
-	dir = 8
-	},
+/obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/horizon/deck_three/cafeteria)
 "Du" = (
@@ -16253,13 +16115,9 @@
 /turf/simulated/wall,
 /area/security/forensics_morgue)
 "Ee" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/tree/jungle/small/patience,
 /turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/nature_showcase)
+/area/horizon/hallway/deck_three/primary/starboard)
 "Ef" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -16269,11 +16127,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
-"Eg" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/floor_decal/spline/plain,
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
 "Eh" = (
 /turf/simulated/wall/r_wall,
 /area/medical/ward/isolation)
@@ -17523,9 +17376,6 @@
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_quarters/fitness/hallway)
-"Gx" = (
-/turf/simulated/open,
-/area/horizon/deck_three/cafeteria)
 "Gy" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
@@ -17705,11 +17555,6 @@
 /area/horizon/deck_three/cafeteria)
 "GN" = (
 /obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/corner/green{
@@ -17799,9 +17644,13 @@
 /turf/simulated/floor/tiled,
 /area/security/forensics_morgue)
 "GV" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
+/obj/structure/railing/mapped,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/simulated/open,
+/area/horizon/hallway/deck_three/primary/starboard)
 "GW" = (
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 1
@@ -17894,15 +17743,9 @@
 /turf/simulated/floor/wood,
 /area/bridge/minibar)
 "He" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 5
-	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/beach/water/alt,
-/area/horizon/deck_three/nature_showcase)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass/alt,
+/area/horizon/hallway/deck_three/primary/starboard)
 "Hf" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -18035,16 +17878,11 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "Hs" = (
-/obj/effect/floor_decal/spline/fancy/wood/cee,
-/obj/structure/bed/stool/chair/padded/brown{
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = -25
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/grass/alt,
 /area/horizon/hallway/deck_three/primary/starboard)
 "Ht" = (
 /obj/structure/cable/green{
@@ -18173,10 +18011,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/controlroom)
 "HD" = (
-/obj/structure/flora/ausbushes/genericbush,
-/obj/effect/floor_decal/spline/plain,
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
+/obj/structure/lattice,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/horizon/hallway/deck_three/primary/starboard)
 "HE" = (
 /obj/structure/bed/stool/chair/padded/beige{
 	dir = 8
@@ -18585,15 +18425,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
-"Io" = (
-/obj/effect/floor_decal/spline/fancy/wood/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 6
-	},
-/turf/simulated/floor/wood,
-/area/horizon/deck_three/cafeteria)
 "Ip" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18775,15 +18606,12 @@
 /turf/simulated/floor/grass/alt,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
 "IG" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/bed/stool/chair/sofa/right/red,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
 	},
-/obj/structure/bed/stool/chair,
-/obj/effect/floor_decal/corner/purple{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/deck_three/nature_showcase)
+/turf/simulated/floor/wood,
+/area/horizon/hallway/deck_three/primary/starboard)
 "IH" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 1
@@ -19085,10 +18913,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/horizon/crew_quarters/fitness/washroom)
-"Jg" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
 "Jh" = (
 /obj/machinery/door/airlock/hatch{
 	icon_state = "door_locked";
@@ -19712,18 +19536,12 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/crew_quarters/cryo)
 "Kk" = (
-/obj/effect/floor_decal/spline/fancy/wood{
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -28;
-	req_one_access = list(24,11,55)
-	},
 /turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/nature_showcase)
+/area/horizon/hallway/deck_three/primary/starboard)
 "Kl" = (
 /obj/structure/sign/emerg_exit{
 	dir = 1;
@@ -19802,13 +19620,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
-"Kt" = (
-/obj/structure/railing/mapped,
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/turf/simulated/open,
-/area/horizon/deck_three/cafeteria)
 "Ku" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -19938,9 +19749,12 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/emergency)
 "KF" = (
-/obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
+/obj/structure/lattice,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/horizon/hallway/deck_three/primary/starboard)
 "KG" = (
 /obj/effect/floor_decal/spline/plain/cee,
 /turf/simulated/floor/carpet/rubber,
@@ -20313,14 +20127,10 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/machinery/disposal/small/east,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/firealarm/west,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "Lt" = (
@@ -21154,12 +20964,6 @@
 /obj/item/hullbeacon/red,
 /turf/simulated/open/airless,
 /area/template_noop)
-"MR" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/horizon/deck_three/cafeteria)
 "MS" = (
 /obj/machinery/vending/snack,
 /obj/effect/floor_decal/corner/green{
@@ -21871,17 +21675,13 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "Oe" = (
-/obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/tiled,
-/area/horizon/deck_three/nature_showcase)
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/wood,
+/area/horizon/hallway/deck_three/primary/starboard)
 "Of" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Nature Showcase Maintenance";
-	req_access = list(26)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/horizon/deck_three/nature_showcase)
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/grass/alt,
+/area/horizon/hallway/deck_three/primary/starboard)
 "Og" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/structure/cable/green{
@@ -22038,16 +21838,9 @@
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "Ot" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/palebush,
+/obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/nature_showcase)
+/area/horizon/hallway/deck_three/primary/starboard)
 "Ou" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -22244,12 +22037,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
-"OM" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/simulated/open,
-/area/horizon/deck_three/cafeteria)
 "ON" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -22592,13 +22379,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/controlroom)
 "Pr" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 5
-	},
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/ausbushes/genericbush,
 /turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/nature_showcase)
+/area/horizon/hallway/deck_three/primary/starboard)
 "Ps" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille/diagonal,
@@ -23034,11 +22816,9 @@
 /turf/simulated/floor/wood,
 /area/bridge/minibar)
 "Qd" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/turf/simulated/floor/beach/water/alt,
-/area/horizon/deck_three/nature_showcase)
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass/alt,
+/area/horizon/hallway/deck_three/primary/starboard)
 "Qe" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -23378,13 +23158,9 @@
 /turf/simulated/floor/reinforced,
 /area/bridge/selfdestruct)
 "QK" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/pointybush,
+/obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/nature_showcase)
+/area/horizon/hallway/deck_three/primary/starboard)
 "QL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23939,10 +23715,6 @@
 /area/security/forensics_office{
 	name = "Security - Investigations Office"
 	})
-"RM" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
 "RN" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -23992,12 +23764,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
-"RQ" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/horizon/deck_three/cafeteria)
 "RR" = (
 /obj/machinery/cryopod,
 /obj/effect/floor_decal/corner/green{
@@ -24419,10 +24185,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/horizon/crew_quarters/fitness/gym)
-"SG" = (
-/obj/structure/railing/mapped,
-/turf/simulated/open,
-/area/horizon/deck_three/cafeteria)
 "SH" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -24482,15 +24244,6 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/carpet/rubber,
 /area/bridge/controlroom)
-"SO" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/simulated/open,
-/area/horizon/deck_three/cafeteria)
 "SQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/reinforced,
@@ -25064,9 +24817,9 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "TV" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/nature_showcase)
+/area/horizon/hallway/deck_three/primary/starboard)
 "TW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
@@ -25326,8 +25079,15 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
 "Uw" = (
-/turf/simulated/wall,
-/area/horizon/deck_three/nature_showcase)
+/obj/structure/bed/stool/chair/sofa/left/red,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/horizon/hallway/deck_three/primary/starboard)
 "Ux" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -25579,13 +25339,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
-"UQ" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
 "UR" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -25657,9 +25410,12 @@
 /turf/simulated/floor/tiled,
 /area/horizon/crew_quarters/fitness/changing)
 "Va" = (
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/floor_decal/spline/fancy/wood/cee{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
+/area/horizon/hallway/deck_three/primary/starboard)
 "Vb" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 1
@@ -25882,13 +25638,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"Vu" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
 "Vv" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -25955,9 +25704,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "VA" = (
-/obj/structure/flora/tree/jungle/small/patience,
+/obj/effect/floor_decal/spline/fancy/wood/cee,
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
+/area/horizon/hallway/deck_three/primary/starboard)
 "VB" = (
 /obj/machinery/door/airlock/glass_command{
 	icon_state = "door_locked";
@@ -26197,18 +25947,9 @@
 /turf/simulated/open,
 /area/hallway/medical/upper)
 "VZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/floor_decal/corner/purple/full{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/deck_three/nature_showcase)
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/grass/alt,
+/area/horizon/hallway/deck_three/primary/starboard)
 "Wa" = (
 /turf/simulated/floor/wood,
 /area/lawoffice/representative)
@@ -27191,13 +26932,15 @@
 /turf/simulated/floor/tiled,
 /area/bridge)
 "XR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/hallway/deck_three/primary/starboard)
@@ -27209,25 +26952,12 @@
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "XT" = (
-/obj/structure/cable/green,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/service{
-	c_tag = "Third Deck - Nature Showcase Maintenance";
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/purple/full{
+/obj/structure/bed/stool/chair/sofa/red,
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/horizon/deck_three/nature_showcase)
+/turf/simulated/floor/wood,
+/area/horizon/hallway/deck_three/primary/starboard)
 "XU" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/spline/plain{
@@ -27513,13 +27243,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/lawoffice/representative)
-"Ys" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/cafeteria)
 "Yt" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -27527,10 +27250,14 @@
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
 "Yu" = (
-/obj/effect/floor_decal/spline/fancy/wood,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/grass/alt,
-/area/horizon/deck_three/nature_showcase)
+/obj/structure/bed/stool/chair/wood{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy/wood/cee{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/horizon/hallway/deck_three/primary/starboard)
 "Yv" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -28245,11 +27972,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
@@ -47333,15 +47060,15 @@ Oz
 aG
 Lg
 NH
-Uw
-Uw
-Uw
-Uw
-Uw
-Of
-Uw
-Uw
-Uw
+xs
+xs
+xs
+xs
+xs
+ct
+xs
+xs
+xs
 Zm
 bY
 qn
@@ -47535,15 +47262,15 @@ Oz
 GY
 Lg
 oa
-Uw
+xs
 jr
 dn
 yp
-Uw
+Of
 Ot
-Bv
+Of
 Kk
-uI
+He
 Zm
 cj
 qn
@@ -47737,14 +47464,14 @@ xd
 Hr
 zd
 nu
-Uw
+xs
 IG
 Oe
 mF
-Uw
+He
 QK
 TV
-TV
+mF
 Yu
 Zm
 ZT
@@ -47939,14 +47666,14 @@ dZ
 ut
 ZF
 GN
-bt
+xs
 XT
-sh
+Oe
 VZ
 Of
 Pr
 Ee
-cy
+He
 bR
 Zm
 KL
@@ -48141,14 +47868,14 @@ Oz
 pb
 rY
 gN
+xs
 Uw
-Uw
-Uw
-Uw
-Uw
+Oe
+Of
+bZ
 He
 Qd
-CG
+Of
 bV
 Zm
 Zm
@@ -48347,11 +48074,11 @@ xs
 bm
 gu
 Hs
-Uw
+cg
 bX
-bX
-bX
-bX
+fj
+jK
+ku
 Zm
 Zm
 eD
@@ -48550,10 +48277,10 @@ mu
 mu
 mu
 Ls
-sC
-sC
-sC
-sC
+cV
+hV
+Ls
+Ls
 cn
 NM
 sC
@@ -48752,7 +48479,7 @@ VP
 VP
 VP
 VP
-VP
+dG
 XR
 QW
 QW
@@ -48952,13 +48679,13 @@ Ko
 kb
 KM
 xz
-dG
-fj
-MR
-RQ
-zM
-cV
-dG
+vY
+vY
+vY
+vY
+vY
+vY
+vY
 xz
 NG
 cS
@@ -49153,15 +48880,15 @@ Ie
 JJ
 iy
 UV
-OI
-hV
-uJ
-ku
-vK
-Io
-Dk
-qq
-me
+WD
+UV
+UV
+UV
+UV
+UV
+UV
+UV
+WD
 UV
 oB
 Ou
@@ -49353,19 +49080,19 @@ cb
 JS
 gl
 ag
-PM
-WD
-OI
-Vu
-sI
-Jg
-RM
-sI
-Jg
-Eg
+AG
+UV
 me
+YE
 WD
-OI
+kt
+kt
+kt
+WD
+YE
+me
+UV
+in
 TJ
 uk
 uk
@@ -49555,19 +49282,19 @@ hY
 kF
 tR
 iY
-AG
-UV
-OI
+PM
+WD
+bt
 qm
 GV
 Va
 Ak
 VA
-Va
-kG
-me
-UV
-in
+nn
+qm
+pm
+WD
+OI
 Ou
 uk
 uk
@@ -49759,13 +49486,13 @@ gl
 iY
 AG
 UV
-OI
-bC
-cg
-sI
+me
+HD
+WD
 KF
-mc
-sI
+KF
+KF
+WD
 HD
 me
 UV
@@ -49959,19 +49686,19 @@ Ei
 Vm
 GO
 Yb
-PM
+AG
+UV
 WD
-OI
-we
-zM
-Ys
-ct
-UQ
-MR
-jK
-me
+UV
+UV
+UV
+UV
+UV
+UV
+UV
 WD
-OI
+UV
+in
 Ou
 YD
 op
@@ -50163,15 +49890,15 @@ UH
 JB
 AG
 UV
-OI
-sD
-qD
-nn
-pm
-bZ
-yJ
-CB
-PM
+WD
+TN
+TN
+UV
+UV
+UV
+TN
+TN
+WD
 UV
 in
 Ou
@@ -50368,9 +50095,9 @@ UV
 OI
 BK
 qD
-OM
-Gx
-SG
+AG
+UV
+in
 yJ
 jY
 PM
@@ -50570,9 +50297,9 @@ UV
 OI
 sF
 JO
-OM
-Gx
-SG
+AG
+UV
+in
 BU
 Dt
 PM
@@ -50772,11 +50499,11 @@ TN
 GE
 cm
 Wy
-SO
-ok
-Kt
+gn
+TN
+KO
 JN
-Wy
+ok
 LR
 TN
 KO

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -3526,6 +3526,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
+"gF" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/turf/simulated/floor/grass/alt,
+/area/horizon/hallway/deck_three/primary/starboard)
 "gG" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -5687,7 +5694,7 @@
 "ku" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/floor_decal/spline/plain{
-	dir = 4
+	dir = 6
 	},
 /turf/simulated/floor/grass/alt,
 /area/horizon/hallway/deck_three/primary/starboard)
@@ -11240,6 +11247,13 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
+"uJ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
+	},
+/turf/simulated/floor/grass/alt,
+/area/horizon/hallway/deck_three/primary/starboard)
 "uK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13221,6 +13235,9 @@
 	pixel_x = -28
 	},
 /obj/structure/flora/ausbushes/ppflowers,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
 /turf/simulated/floor/grass/alt,
 /area/horizon/hallway/deck_three/primary/starboard)
 "yq" = (
@@ -19540,6 +19557,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
 /turf/simulated/floor/grass/alt,
 /area/horizon/hallway/deck_three/primary/starboard)
 "Kl" = (
@@ -21839,6 +21859,9 @@
 /area/maintenance/engineering_ladder)
 "Ot" = (
 /obj/structure/flora/ausbushes/sunnybush,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
 /turf/simulated/floor/grass/alt,
 /area/horizon/hallway/deck_three/primary/starboard)
 "Ou" = (
@@ -47266,11 +47289,11 @@ xs
 jr
 dn
 yp
-Of
+gF
 Ot
-Of
+gF
 Kk
-He
+uJ
 Zm
 cj
 qn


### PR DESCRIPTION
This restores the open space over the deck 3 atrium and moves the public nature garden into the former space of the janitorial nature display. It was never* used anyway.

![image](https://user-images.githubusercontent.com/22651198/181996832-afec74b9-f471-4e0e-be91-ebc7daaf541e.png)

![image](https://user-images.githubusercontent.com/22651198/181996838-9157cd18-935e-49b2-8f30-e41e6a748b24.png)
