### PR TITLE
Lets toolbelts hold duct tape, removes hand drills from cargo toolbelts

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -115,7 +115,8 @@
 		/obj/item/powerdrill,
 		/obj/item/device/radio,
 		/obj/item/device/debugger,
-		/obj/item/device/eftpos
+		/obj/item/device/eftpos,
+		/obj/item/tape_roll
 	)
 	content_overlays = TRUE
 
@@ -139,7 +140,6 @@
 		/obj/item/crowbar = 1,
 		/obj/item/wirecutters/toolbelt = 1,
 		/obj/item/stack/cable_coil/random = 1,
-		/obj/item/powerdrill = 1,
 		/obj/item/hammer = 1
 	)
 

--- a/html/changelogs/Forester40 - toolbelt-duct-tape.yml
+++ b/html/changelogs/Forester40 - toolbelt-duct-tape.yml
@@ -1,9 +1,0 @@
-author: Forester40
-
-
-delete-after: True
-
-
-changes:
-  - rscadd: "Utility belts can now hold rolls of duct tape."
-  - tweak: "Uility belts ordered from Operations no longer spawn with hand drills in them and therefore no longer spawn with one more item than they're supposed to hold."

--- a/html/changelogs/Forester40 - toolbelt-duct-tape.yml
+++ b/html/changelogs/Forester40 - toolbelt-duct-tape.yml
@@ -1,0 +1,9 @@
+author: Forester40
+
+
+delete-after: True
+
+
+changes:
+  - rscadd: "Utility belts can now hold rolls of duct tape."
+  - tweak: "Uility belts ordered from Operations no longer spawn with hand drills in them and therefore no longer spawn with one more item than they're supposed to hold."

--- a/html/changelogs/Forester40-PR-14541.yml
+++ b/html/changelogs/Forester40-PR-14541.yml
@@ -1,0 +1,9 @@
+author: Forester40
+
+
+delete-after: True
+
+
+changes:
+  - rscadd: "Utility belts can now hold rolls of duct tape."
+  - tweak: "Uility belts ordered from Operations no longer spawn with hand drills in them and therefore no longer spawn with one more item than they actually have storage slots for."


### PR DESCRIPTION
* Tool belts can now hold duct tape.
* Tool belts from cargo no longer spawn with a hand drill in them.

The PR that added hammers to the game, #12505, made hammers spawn in /obj/item/storage/belt/utility/full (the toolbelts you get from cargo), which made it spawn with 8 items in it when it only has 7 storage slots.
Instead of fixing this by removing the hammer from the belt, I think we should remove the hand drill instead, since I think it's weird anyway that the belt spawns with both a drill and the tools that it replaces, and that it spawns with upgraded tools instead of only the regular ones.
