### PR TITLE
SFA ship fix, tweak

### DIFF
--- a/html/changelogs/thedococt - sfa patrol ship tweaks.yml
+++ b/html/changelogs/thedococt - sfa patrol ship tweaks.yml
@@ -1,0 +1,6 @@
+author: Doc
+
+delete-after: True
+
+changes:
+  - maptweak: "Fixes an errant table in the SFA patrol ship, and gives their engineers webbings like its other roles."

--- a/maps/away/ships/sfa_patrol_ship.dmm
+++ b/maps/away/ships/sfa_patrol_ship.dmm
@@ -1198,6 +1198,8 @@
 /obj/item/clothing/suit/storage/hazardvest,
 /obj/item/taperoll/engineering,
 /obj/item/clothing/head/hardhat,
+/obj/item/clothing/accessory/storage/brown_vest,
+/obj/item/clothing/accessory/storage/brown_vest,
 /turf/simulated/floor/tiled/dark,
 /area/ship/sfa_patrol_ship)
 "iGK" = (
@@ -1931,12 +1933,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/sfa_shuttle)
-"oOF" = (
-/obj/structure/bed/stool,
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/table/steel,
-/turf/simulated/floor/tiled/white,
-/area/ship/sfa_patrol_ship)
 "oPL" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -32258,7 +32254,7 @@ aSm
 yjk
 eTH
 krH
-oOF
+krH
 heP
 jGx
 jGx


### PR DESCRIPTION
Removes a sporadic table in the same place as a stool in the SFA patrol ship mess, and adds two brown webbings to the engineering equipment locker, as the medical, security, and pilot lockers all already have their own respective webbings/pouches.