### PR TITLE
"Tactical" Loadout Selection - For Security and Command

### DIFF
--- a/html/changelogs/wickedcybs_tacticool.yml
+++ b/html/changelogs/wickedcybs_tacticool.yml
@@ -1,0 +1,7 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a 'Tactical' submenu to the loadout selections. It will contain the usual holsters and flash proof sunglasses you know and love, everything security related essentially. Command will want to look inside too though, since they're privileged enough to recieve things like flash proof sunglasses or holsters."
+  - rscadd: "Moved a lot of security gear in various loadout selections into the tactical selection."


### PR DESCRIPTION
This is a WIP and I just opened it to get that bit out of the way. There's nothing significant in the PR yet, other than the changelog.

Also there is a poll, since the name for this loadout selection isn't set in stone. It can be seen in the code dungeon on the Aurora discord. Currently, deciding between "Tactical" or "Duty Gear"

We're adding more things to security lately and considering the added customization to plate carriers (and more if we force clem to slave away at stuff) a new menu specifically for this gear and the more combat-related stuff in the loadout like holsters or flash-proof sunglasses would do wonders I think. It will reduce the amount of stuff in the menus it is spread in (accessories especially) and also open a more fitting place for future additions to go to without being out of place. 

Command would have access to a lot of what would be in the selection too, since they're afforded sidearms and flash protection, among other things.

I would be open to changing the name of this menu, I just can't think of anything better to describe it since It's not _specifically_ a security submenu still.