### PR TITLE
ZAS code oversight

### DIFF
--- a/code/ZAS/Zone.dm
+++ b/code/ZAS/Zone.dm
@@ -53,9 +53,6 @@ Class Procs:
 
 	var/datum/gas_mixture/air = new
 
-	var/list/graphic_add
-	var/list/graphic_remove
-
 /zone/New()
 	SSair.add_zone(src)
 	air.temperature = TCMB
@@ -156,16 +153,11 @@ Class Procs:
 		if(istype(T))
 			T.create_fire(vsc.fire_firelevel_multiplier)
 
-	LAZYINITLIST(graphic_add)
-	LAZYINITLIST(graphic_remove)
+	var/list/graphic_add = list()
+	var/list/graphic_remove = list()
 	if(air.check_tile_graphic(graphic_add, graphic_remove))
 		for(var/turf/simulated/T in contents)
 			T.update_graphic(graphic_add, graphic_remove)
-
-		LAZYCLEARLIST(graphic_add)
-		LAZYCLEARLIST(graphic_remove)
-		UNSETEMPTY(graphic_add)
-		UNSETEMPTY(graphic_remove)
 
 	for(var/connection_edge/E in edges)
 		if(E.sleeping)


### PR DESCRIPTION
I was doing a bit of ZAS optimization over on Daedalus, as I usually do, and when comparing to Aurora I realized y'all have a misuse of lazylists going on here so I threw together a webedit to fix it.

Basically, these dont need to be held on `/zone`, are actively worse because this list cannot be lazy, and it doesnt even work properly because there will never be a situation where the list cleans itself up and doesn't immediately re-add itself to memory afterwards as-is.

This list can't be lazy because it's effectively used as a pointer to pass the list transmutations from `check_tile_graphic()` into `update_graphic()`, and `null` doesn't pass a reference, it passes a value. The change also makes it slightly faster because it skips the datum var access overhead. Woo, nano-second opts!