### PR TITLE
Fixes Faulty Indentation in Brain Code

### DIFF
--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -177,7 +177,7 @@
 	if(is_broken())
 		if(!owner.lying && prob(5))
 			to_chat(owner, "<span class='danger'>You black out!</span>")
-		owner.Paralyse(10)
+			owner.Paralyse(10)
 
 /obj/item/organ/internal/brain/surgical_fix(mob/user)
 	var/blood_volume = owner.get_blood_oxygenation()

--- a/html/changelogs/brain_indentation.yml
+++ b/html/changelogs/brain_indentation.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes faulty indentation in the brain code, causing paralysis to proc every time instead of 5% of the time."


### PR DESCRIPTION
this PR fixes a faulty indentation in the brain code that procs every time if your brain "is_broken()" instead of 5% of the time as intended.

preferably reviewed by Matt Atlas as they have more knowledge about braincode than i do.