### PR TITLE
Decal Mapping Tweaks

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -97,8 +97,8 @@
  * Fire Closet
  */
 /obj/structure/closet/firecloset
-	name = "fire-safety closet"
-	desc = "It's a storage unit for fire-fighting supplies."
+	name = "firefighting closet"
+	desc = "It's a storage unit for firefighting supplies."
 	icon_state = "fire"
 
 /obj/structure/closet/firecloset/fill()

--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -46,8 +46,8 @@
 	dir = EAST
 
 /obj/structure/closet/walllocker/firecloset //wall mounted fire closet
-	name = "fire-safety closet"
-	desc = "It's a storage unit for fire-fighting supplies."
+	name = "firefighting closet"
+	desc = "It's a storage unit for firefighting supplies."
 	icon_state = "hydrant"
 
 /obj/structure/closet/walllocker/firecloset/fill()

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -514,6 +514,10 @@
 	name = "blue emergency closet outline"
 	color = "#618FBA"
 
+/obj/effect/floor_decal/industrial/outline/firefighting_closet
+	name = "red firefighting closet outline"
+	color = "#C82D2D"
+
 /obj/effect/floor_decal/industrial/loading
 	name = "loading area"
 	icon_state = "loadingarea"

--- a/html/changelogs/emergency_locker_outlines.yml
+++ b/html/changelogs/emergency_locker_outlines.yml
@@ -3,4 +3,5 @@ author: SleepyGemmy
 delete-after: True
 
 changes:
-  - maptweak: "Replaces old outlines around emergency lockers with their dedicated variant."
+  - maptweak: "Replaces old outlines around emergency lockers and firefighting closets with their dedicated variant."
+  - maptweak: "Adds decals around the elevators and tweaks the central ring on deck 2."

--- a/html/changelogs/emergency_locker_outlines.yml
+++ b/html/changelogs/emergency_locker_outlines.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - maptweak: "Replaces old outlines around emergency lockers with their dedicated variant."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -966,7 +966,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/hangar/operations)
 "aOD" = (
@@ -1368,6 +1368,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"bec" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/aft)
 "bek" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -2394,7 +2400,7 @@
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/blue,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
 "bOR" = (
@@ -3935,7 +3941,7 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/hangar/operations)
 "dgl" = (
@@ -7376,6 +7382,7 @@
 	dir = 4;
 	pixel_x = 32
 	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "fQU" = (
@@ -17968,7 +17975,7 @@
 /area/engineering/atmos/air)
 "oCq" = (
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/blue,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/auxiliary)
 "oCT" = (
@@ -18067,7 +18074,7 @@
 	dir = 6
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "oFI" = (
@@ -19121,7 +19128,7 @@
 	dir = 6
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "pEl" = (
@@ -22419,6 +22426,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/hangar/auxiliary)
 "sll" = (
@@ -22788,8 +22796,8 @@
 /turf/simulated/wall/shuttle/scc/cardinal,
 /area/shuttle/escape_pod/pod2)
 "syS" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/crew_compartment)
 "szM" = (
@@ -22965,6 +22973,7 @@
 	dir = 6
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "sId" = (
@@ -23667,11 +23676,11 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
+/obj/structure/closet/firecloset,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/closet/firecloset,
-/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
 "tkS" = (
@@ -26020,6 +26029,7 @@
 /area/rnd/eva)
 "vfc" = (
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/rnd/xenoarch_atrium)
 "vfk" = (
@@ -28412,6 +28422,7 @@
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/rnd/xenoarch_atrium)
 "xiQ" = (
@@ -50727,7 +50738,7 @@ gQh
 rHK
 rHK
 kuh
-fgF
+bec
 wLL
 gux
 pIy
@@ -50929,7 +50940,7 @@ rHK
 rHK
 rHK
 kuh
-fgF
+bec
 wLL
 riM
 bNT
@@ -51131,7 +51142,7 @@ qMY
 rHK
 rHK
 kuh
-fgF
+bec
 wLL
 tLM
 wRE

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -912,6 +912,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"avz" = (
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_two)
 "avM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_atmos{
@@ -5194,6 +5203,12 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/hallway/primary/central_two)
+"cMs" = (
+/obj/effect/floor_decal/spline/fancy/wood/full,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/fernybush,
+/turf/simulated/floor/grass/alt,
+/area/hallway/primary/central_two)
 "cMF" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -6216,6 +6231,15 @@
 	},
 /turf/simulated/open/airless,
 /area/template_noop)
+"dpv" = (
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_two)
 "dpE" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -16608,6 +16632,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
+"iWV" = (
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_two)
 "iXI" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -29078,6 +29111,8 @@
 /area/horizon/maintenance/deck_two/fore/starboard)
 "pQm" = (
 /obj/effect/floor_decal/spline/fancy/wood/full,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/ausbushes/palebush,
 /turf/simulated/floor/grass/alt,
 /area/hallway/primary/central_two)
 "pQq" = (
@@ -66647,7 +66682,7 @@ nkF
 hEF
 nkF
 ept
-pQm
+cMs
 fwK
 qVu
 qVu
@@ -68260,7 +68295,7 @@ pib
 nvv
 fEa
 ulB
-gzF
+dpv
 mvZ
 ukp
 ukp
@@ -68462,7 +68497,7 @@ roX
 rlp
 qTB
 rUh
-gzF
+avz
 aKr
 doI
 ejU
@@ -68664,7 +68699,7 @@ aBr
 gPM
 lFE
 ulB
-gzF
+iWV
 aNp
 qav
 qav

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -378,7 +378,7 @@
 	name = "Engineering Hallway";
 	req_one_access = null
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/full,
 /area/engineering/lobby)
 "ajO" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -460,14 +460,12 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
 "amz" = (
-/obj/structure/railing/mapped{
-	dir = 4
+/obj/effect/floor_decal/corner/mauve,
+/obj/effect/floor_decal/corner/brown{
+	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/open,
-/area/hallway/primary/central_two)
+/turf/simulated/floor/tiled/dark,
+/area/rnd/hallway)
 "amE" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -517,15 +515,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/reinforced,
 /area/engineering/storage/tech)
-"ann" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/central_two)
 "anJ" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -664,8 +653,8 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "aqZ" = (
@@ -1295,12 +1284,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/engineering)
-"aDL" = (
-/obj/effect/floor_decal/industrial/loading/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/central_two)
 "aDR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1332,8 +1315,7 @@
 /area/security/checkpoint2)
 "aFd" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "aFm" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1419,16 +1401,17 @@
 /turf/simulated/floor/tiled,
 /area/engineering/storage_eva)
 "aIj" = (
-/obj/effect/floor_decal/corner/green{
-	dir = 9
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck - Hallway 2"
+	},
+/obj/machinery/firealarm/north,
+/obj/effect/floor_decal/corner/green/full{
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 4
 	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck - Hallway 2"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "aIo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1503,7 +1486,7 @@
 /area/maintenance/wing/starboard/far)
 "aKr" = (
 /obj/effect/floor_decal/corner/mauve,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "aKv" = (
 /obj/structure/bed/stool/chair/wood{
@@ -1515,8 +1498,8 @@
 /turf/simulated/floor/wood,
 /area/chapel/main)
 "aKL" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "aKO" = (
@@ -1613,10 +1596,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "aNp" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 10
+/obj/effect/floor_decal/corner/mauve,
+/obj/effect/floor_decal/corner/brown{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "aNL" = (
 /obj/structure/disposalpipe/segment{
@@ -2229,16 +2213,16 @@
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "ban" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 4
-	},
 /obj/effect/floor_decal/spline/plain/corner{
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_two)
 "baq" = (
 /turf/simulated/floor/tiled,
@@ -2694,7 +2678,7 @@
 /obj/machinery/computer/guestpass{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "boE" = (
 /obj/structure/closet/crate,
@@ -3587,11 +3571,6 @@
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/tiled,
 /area/medical/gen_treatment)
-"bOa" = (
-/obj/effect/floor_decal/corner/mauve,
-/obj/effect/floor_decal/spline/plain/corner,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/central_two)
 "bOe" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	name = "Weaponry (En. Carbine)"
@@ -3644,10 +3623,10 @@
 /turf/simulated/floor/plating,
 /area/horizon/maintenance/deck_two/fore/starboard)
 "bOR" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "bOV" = (
 /obj/structure/cable/green{
@@ -3933,14 +3912,13 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "bVf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "bVl" = (
 /obj/structure/cable/yellow{
@@ -4251,8 +4229,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "ceD" = (
 /obj/machinery/optable,
@@ -5027,7 +5004,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/green/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "cIz" = (
 /obj/effect/floor_decal/corner_wide/green{
@@ -5073,6 +5053,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_quarters/cryo/living_quarters_lift)
 "cJU" = (
@@ -5209,12 +5190,6 @@
 	},
 /obj/structure/railing/mapped{
 	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -5359,12 +5334,10 @@
 /turf/simulated/floor/tiled,
 /area/engineering/storage_eva)
 "cQE" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 1
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 4
-	},
+/obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "cQS" = (
@@ -5446,8 +5419,8 @@
 /turf/simulated/wall,
 /area/rnd/xenobiology/xenoflora_hazard)
 "cTn" = (
-/obj/machinery/firealarm/north,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
+/turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_two)
 "cUi" = (
 /obj/item/modular_computer/console/preset/engineering{
@@ -5813,19 +5786,16 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical)
 "dex" = (
+/obj/effect/floor_decal/spline/fancy/wood/cee{
+	dir = 1
+	},
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 6
+/obj/structure/bed/stool/chair/padded/black{
+	dir = 8
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood,
 /area/hallway/primary/central_two)
 "deH" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
@@ -6221,10 +6191,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 6
+/obj/effect/floor_decal/corner/mauve,
+/obj/effect/floor_decal/corner/brown{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "doW" = (
 /obj/machinery/door/blast/shutters/open{
@@ -6575,7 +6546,19 @@
 	},
 /area/hallway/primary/central_two)
 "dza" = (
-/obj/structure/table/standard,
+/obj/structure/closet/walllocker/medical{
+	pixel_y = -32
+	},
+/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline,
+/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline,
+/obj/item/stack/medical/ointment,
+/obj/item/stack/medical/ointment,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/bruise_pack,
+/obj/effect/floor_decal/industrial/outline/medical,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "dzc" = (
@@ -7140,7 +7123,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
 "dPz" = (
-/obj/structure/bed/stool/chair/padded/black,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "dPE" = (
@@ -7694,15 +7679,16 @@
 /turf/simulated/floor/tiled,
 /area/security/lobby)
 "ejU" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 6
-	},
 /obj/item/device/radio/intercom{
 	dir = 8;
 	name = "Station Intercom (General)";
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/mauve,
+/obj/effect/floor_decal/corner/brown{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "eks" = (
 /obj/structure/disposalpipe/segment,
@@ -7738,8 +7724,7 @@
 /area/rnd/hallway)
 "ekM" = (
 /obj/effect/floor_decal/corner/mauve{
-	dir = 10;
-	req_access = list(55)
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
@@ -7880,11 +7865,10 @@
 /area/operations/lobby)
 "ept" = (
 /obj/structure/railing/mapped,
-/obj/effect/floor_decal/corner/mauve{
+/obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/obj/effect/floor_decal/spline/plain,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "epw" = (
 /obj/structure/table/standard,
@@ -7991,7 +7975,10 @@
 /area/maintenance/wing/port)
 "eqX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "erh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -8658,8 +8645,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "eNv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9143,6 +9129,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_quarters/cryo/living_quarters_lift)
 "fan" = (
@@ -9515,8 +9502,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "fkr" = (
 /obj/structure/disposalpipe/segment{
@@ -9913,8 +9899,11 @@
 /turf/simulated/floor/wood,
 /area/horizon/hydroponics/garden)
 "fwK" = (
-/obj/structure/bed/stool/chair/padded/black{
-	dir = 4
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
@@ -10166,9 +10155,10 @@
 /turf/simulated/floor/tiled,
 /area/teleporter)
 "fEQ" = (
-/obj/structure/railing/mapped,
-/obj/structure/window/reinforced,
-/turf/simulated/open,
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "fEY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -10237,7 +10227,8 @@
 "fHo" = (
 /obj/effect/floor_decal/corner/green/full,
 /obj/machinery/vending/cola,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "fHq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10427,6 +10418,7 @@
 /area/maintenance/wing/starboard/far)
 "fKZ" = (
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/lobby)
 "fLi" = (
@@ -10740,12 +10732,12 @@
 /turf/simulated/floor/plating,
 /area/tcommsat/mainlvl_tcomms__relay/second)
 "fSg" = (
-/obj/effect/floor_decal/corner/white,
 /obj/effect/floor_decal/spline/plain/corner,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 9
 	},
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/corner_wide/white,
+/turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_two)
 "fSm" = (
 /obj/structure/girder,
@@ -10955,10 +10947,10 @@
 "fWU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "fYi" = (
 /obj/effect/floor_decal/corner/mauve{
@@ -11497,15 +11489,15 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/security/checkpoint2)
 "gkM" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 10
-	},
 /obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
 /obj/structure/railing/mapped,
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_two)
 "glt" = (
 /obj/structure/grille/broken,
@@ -11808,6 +11800,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/aux_atmospherics/deck_2/starboard)
 "gsh" = (
@@ -12046,16 +12039,16 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/turret_protected/ai_upload)
 "gyn" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 8
-	},
 /obj/effect/floor_decal/spline/plain/corner{
 	dir = 8
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
 	},
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_two)
 "gyu" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -12101,10 +12094,10 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room/tesla)
 "gzF" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "gzU" = (
 /obj/machinery/computer/operating{
@@ -12192,6 +12185,9 @@
 /obj/machinery/newscaster{
 	pixel_y = 30
 	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "gBp" = (
@@ -12201,6 +12197,10 @@
 /turf/simulated/floor/reinforced,
 /area/horizon/crew_quarters/lounge/bar)
 "gBE" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "gBH" = (
@@ -12286,9 +12286,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "gDc" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 6
-	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
@@ -12298,7 +12295,10 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_two)
 "gDq" = (
 /obj/effect/floor_decal/corner_wide/lime{
@@ -12307,16 +12307,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "gDw" = (
-/obj/structure/railing/mapped,
-/obj/structure/window/reinforced{
-	layer = 5;
-	name = "adjusted reinforced window"
-	},
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/open,
+/obj/effect/floor_decal/corner/green/full,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "gDM" = (
 /obj/structure/cable/green{
@@ -12497,7 +12489,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "gGJ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -12943,19 +12935,14 @@
 	name = "Research Hallway";
 	req_one_access = null
 	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 6
-	},
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 2
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/mauve,
+/obj/effect/floor_decal/corner/brown{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/full,
 /area/rnd/hallway)
 "gUB" = (
 /obj/structure/cable/green{
@@ -13193,8 +13180,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "hcT" = (
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -13478,10 +13464,7 @@
 /area/security/armory)
 "hjG" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/bluegrid{
-	name = "cooled mainframe floor";
-	temperature = 278
-	},
+/turf/simulated/floor/bluegrid,
 /area/hallway/primary/central_two)
 "hjI" = (
 /obj/machinery/door/firedoor,
@@ -13620,9 +13603,6 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "hnY" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 9
-	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
@@ -13632,7 +13612,10 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_two)
 "hoa" = (
 /obj/machinery/mech_recharger,
@@ -13914,9 +13897,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "hvu" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_two)
 "hvH" = (
 /obj/effect/floor_decal/corner/brown{
@@ -14231,7 +14214,8 @@
 	dir = 8
 	},
 /obj/machinery/vending/snack,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "hDg" = (
 /obj/structure/disposalpipe/segment{
@@ -14870,7 +14854,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "hXN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -14954,9 +14938,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/white{
-	dir = 6
-	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
@@ -14966,7 +14947,10 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_two)
 "ibx" = (
 /obj/structure/table/rack,
@@ -15122,8 +15106,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "ifU" = (
 /turf/simulated/wall,
@@ -15629,10 +15612,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "ixR" = (
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
+/obj/effect/floor_decal/spline/fancy/wood/cee,
+/obj/structure/railing/mapped{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/bed/stool/chair/padded/black{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
 /area/hallway/primary/central_two)
 "ixU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -15788,19 +15775,13 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "iDB" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 9
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "iDE" = (
 /obj/structure/disposalpipe/junction{
@@ -16097,7 +16078,7 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/engineering/tesla)
 "iKg" = (
@@ -16529,13 +16510,17 @@
 /turf/simulated/floor/tiled,
 /area/engineering/storage_eva)
 "iVQ" = (
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
+/obj/structure/table/wood,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
 	},
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/wood,
 /area/hallway/primary/central_two)
 "iWc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -16887,9 +16872,6 @@
 	},
 /area/maintenance/wing/starboard/far)
 "jgz" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 5
-	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
@@ -16897,7 +16879,10 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_two)
 "jgZ" = (
 /obj/machinery/door/window/brigdoor/eastleft{
@@ -17529,9 +17514,6 @@
 /obj/effect/landmark{
 	name = "Observer-Start"
 	},
-/obj/effect/floor_decal/corner/white{
-	dir = 5
-	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
@@ -17539,7 +17521,10 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_two)
 "jvL" = (
 /obj/structure/cable/green{
@@ -17911,7 +17896,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "jGa" = (
 /obj/structure/bed/stool/padded/red,
@@ -17929,16 +17914,16 @@
 /turf/simulated/floor/lino/grey,
 /area/horizon/kitchen/hallway)
 "jHi" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 1
-	},
 /obj/effect/floor_decal/spline/plain/corner{
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
 	},
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_two)
 "jHp" = (
 /obj/structure/railing/mapped,
@@ -17961,8 +17946,8 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hydroponics)
 "jHX" = (
-/obj/structure/bed/stool/chair/padded/brown{
-	dir = 8
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
@@ -18117,7 +18102,7 @@
 	name = "Security Lobby"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/security/lobby)
 "jNk" = (
 /turf/simulated/wall,
@@ -18472,13 +18457,10 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/mauve{
+/obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "jWI" = (
 /obj/structure/cable{
@@ -19328,7 +19310,7 @@
 "kAJ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/corner/green/diagonal,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
 "kAM" = (
@@ -19595,15 +19577,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
-"kJN" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/central_two)
 "kJQ" = (
 /obj/machinery/door/airlock/research{
 	name = "Research storage";
@@ -20301,15 +20274,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "lcL" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
 /obj/machinery/button/remote/blast_door{
 	desc = "It controls the Mech Bay's shutters.";
 	dir = 8;
@@ -20319,7 +20283,11 @@
 	pixel_y = 7;
 	req_one_access = list(29,47)
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/brown{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "ldk" = (
 /obj/structure/cable/green{
@@ -20379,10 +20347,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
 "len" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 6
+/obj/effect/floor_decal/corner/mauve,
+/obj/effect/floor_decal/corner/brown{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "leU" = (
 /obj/structure/cable/green{
@@ -20553,8 +20522,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "ljF" = (
 /obj/effect/floor_decal/corner/green{
@@ -20657,8 +20625,7 @@
 "lng" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/junction,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "lno" = (
 /obj/machinery/door/firedoor,
@@ -20912,7 +20879,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "lwD" = (
 /turf/simulated/floor/carpet,
@@ -21072,10 +21039,6 @@
 /turf/simulated/floor/plating,
 /area/chapel/office)
 "lCI" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 10;
-	req_access = list(55)
-	},
 /obj/machinery/button/remote/blast_door{
 	desc = "A remote control-switch for shutters.";
 	dir = 1;
@@ -21095,6 +21058,9 @@
 	req_access = list(55);
 	specialfunctions = 4
 	},
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
 "lCV" = (
@@ -21113,7 +21079,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "lDs" = (
 /obj/structure/railing/mapped{
@@ -21169,12 +21135,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
-"lES" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/central_two)
 "lFn" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 6
@@ -21797,17 +21757,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/armory)
-"lUm" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/ramp{
-	dir = 1
-	},
-/area/hallway/primary/central_two)
 "lUA" = (
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d3-4"
@@ -22002,7 +21951,7 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/engineering/tesla)
 "lZQ" = (
@@ -22696,7 +22645,7 @@
 /obj/machinery/door/airlock/glass_service{
 	name = "Library"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/horizon/library)
 "muO" = (
 /obj/effect/floor_decal/corner_wide/grey/diagonal,
@@ -22763,8 +22712,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "mwv" = (
 /obj/structure/window/borosilicate/reinforced{
@@ -22937,7 +22885,7 @@
 /area/medical/pharmacy)
 "mCE" = (
 /obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "mCV" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
@@ -23022,7 +22970,7 @@
 	dir = 9
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "mFz" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -23058,7 +23006,10 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/green{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "mFX" = (
 /obj/effect/floor_decal/corner_wide/yellow,
@@ -23675,14 +23626,11 @@
 /area/hallway/engineering)
 "mUC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/mauve{
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/green{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "mUW" = (
 /obj/structure/cable/green{
@@ -23747,7 +23695,10 @@
 /obj/machinery/alarm{
 	pixel_y = 28
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "mVR" = (
 /obj/machinery/power/smes/buildable{
@@ -23826,13 +23777,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "mYp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24420,18 +24371,8 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
-"nks" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/open,
-/area/hallway/primary/central_two)
 "nkF" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "nkK" = (
 /obj/structure/stairs/west,
@@ -24726,19 +24667,6 @@
 /obj/structure/railing/mapped,
 /turf/simulated/open,
 /area/horizon/hydroponics)
-"ntN" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/open,
-/area/hallway/primary/central_two)
 "ntV" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -25223,7 +25151,7 @@
 "nJq" = (
 /obj/machinery/door/airlock/multi_tile/glass,
 /obj/machinery/door/firedoor/multi_tile,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "nJs" = (
 /obj/machinery/biogenerator{
@@ -25908,8 +25836,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "ohc" = (
 /obj/effect/floor_decal/corner/brown{
@@ -26147,8 +26074,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "ool" = (
 /obj/machinery/light{
@@ -26162,22 +26088,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
-"ooA" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/central_two)
 "opb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "opp" = (
-/obj/structure/table/standard,
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/railing/mapped{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
@@ -26685,10 +26609,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "oBe" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 10;
-	req_access = list(55)
-	},
 /obj/effect/floor_decal/corner/white{
 	dir = 5
 	},
@@ -26702,6 +26622,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "oBl" = (
@@ -28044,12 +27967,6 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /turf/simulated/open,
 /area/hallway/primary/central_two)
 "plA" = (
@@ -28718,7 +28635,7 @@
 	},
 /obj/machinery/vending/mredispenser{
 	pixel_y = 24;
-  density = 0
+	density = 0
 	},
 /turf/simulated/floor/lino/grey,
 /area/horizon/kitchen/hallway)
@@ -29160,16 +29077,8 @@
 /turf/simulated/floor/plating,
 /area/horizon/maintenance/deck_two/fore/starboard)
 "pQm" = (
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/fancy/wood/full,
+/turf/simulated/floor/grass/alt,
 /area/hallway/primary/central_two)
 "pQq" = (
 /obj/machinery/mech_recharger,
@@ -29394,10 +29303,8 @@
 /area/maintenance/substation/engineering)
 "pWR" = (
 /obj/machinery/vending/coffee,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -29733,8 +29640,8 @@
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "qgN" = (
@@ -30052,9 +29959,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "qsj" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 10
-	},
 /obj/machinery/camera/network/research{
 	c_tag = "Research - Corridor Camera 1";
 	dir = 1
@@ -30063,6 +29967,10 @@
 	desc = "A warning sign which reads 'MECH BAY AND RECHARGING STATION' and 'HIGH VOLTAGE EQUIPMENT INSIDE'.";
 	name = "\improper MECH BAY AND RECHARGING STATION sign";
 	pixel_y = -32
+	},
+/obj/effect/floor_decal/corner/mauve,
+/obj/effect/floor_decal/corner/brown{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
@@ -30819,7 +30727,7 @@
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "qMd" = (
 /obj/effect/floor_decal/corner_wide/yellow{
@@ -31174,11 +31082,10 @@
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "qVu" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "qVw" = (
 /obj/structure/disposalpipe/segment,
@@ -31394,22 +31301,8 @@
 /turf/simulated/floor/plating,
 /area/teleporter)
 "rbe" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/white{
-	dir = 10
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/green/diagonal,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "rbf" = (
 /obj/structure/railing/mapped{
@@ -31573,7 +31466,7 @@
 	dir = 9
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "rfG" = (
@@ -31591,11 +31484,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
-"rfQ" = (
-/obj/machinery/door/airlock/glass,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_two)
 "rgc" = (
 /obj/structure/flora/pottedplant/random,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -32189,12 +32077,9 @@
 /area/medical/main_storage)
 "rvf" = (
 /obj/effect/floor_decal/corner/mauve{
-	dir = 9
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/full,
 /area/rnd/hallway)
 "rvC" = (
 /obj/structure/cable/green{
@@ -32302,7 +32187,7 @@
 	},
 /obj/machinery/firealarm/south,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "ryq" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
@@ -33189,13 +33074,13 @@
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "rUT" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck - Engineering Entrance"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/green/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "rUZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -33623,10 +33508,6 @@
 /area/security/brig)
 "siL" = (
 /obj/structure/railing/mapped,
-/obj/structure/window/reinforced{
-	layer = 5;
-	name = "adjusted reinforced window"
-	},
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/hallway/primary/central_two)
@@ -33997,7 +33878,7 @@
 	c_tag = "Second Deck - Hallway 3";
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "stW" = (
 /obj/structure/cable/green{
@@ -34272,9 +34153,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/white{
-	dir = 9
-	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
@@ -34284,7 +34162,10 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_two)
 "sFk" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
@@ -34920,6 +34801,7 @@
 /area/turret_protected/ai)
 "sYY" = (
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "sZj" = (
@@ -34957,6 +34839,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 9
 	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
 "tag" = (
@@ -35124,12 +35007,6 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
 /area/security/brig/processing_secondary)
-"tdM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/mauve,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/central_two)
 "tdO" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/disposalpipe/segment{
@@ -36112,7 +35989,10 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "tHk" = (
-/obj/structure/bed/stool/padded/brown,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "tHl" = (
@@ -36418,15 +36298,7 @@
 /turf/simulated/floor/tiled,
 /area/operations/break_room)
 "tOW" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 6
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
+/obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
 "tPq" = (
@@ -36713,11 +36585,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint2)
-"tXM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
-/area/hallway/primary/central_two)
 "tXR" = (
 /turf/simulated/wall,
 /area/security/security_office)
@@ -37193,8 +37060,7 @@
 /area/horizon/kitchen)
 "ukp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "uky" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -38067,7 +37933,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "uFk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -38411,7 +38281,6 @@
 /turf/simulated/floor/wood,
 /area/horizon/crew_quarters/lounge/bar)
 "uMM" = (
-/obj/effect/floor_decal/corner/white/diagonal,
 /obj/machinery/door/airlock/glass_medical{
 	name = "First Responder Quarters";
 	req_access = list(67)
@@ -38425,7 +38294,7 @@
 	name = "MedBay Lockdown Shutters";
 	opacity = 0
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/medical/first_responder)
 "uNl" = (
 /obj/effect/floor_decal/corner/blue{
@@ -38545,7 +38414,10 @@
 "uRe" = (
 /obj/machinery/disposal/small/south,
 /obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "uRo" = (
 /obj/effect/floor_decal/corner/purple{
@@ -38773,13 +38645,10 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/mauve{
+/obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "uXV" = (
 /obj/structure/cable/green{
@@ -38943,11 +38812,10 @@
 /turf/simulated/floor/plating,
 /area/security/checkpoint2)
 "vcv" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/effect/floor_decal/corner/white{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "vcH" = (
 /turf/simulated/wall,
@@ -39337,10 +39205,6 @@
 /turf/simulated/floor/tiled/full,
 /area/medical/exam)
 "vrd" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck - Hallway 1";
 	dir = 8
@@ -39350,7 +39214,11 @@
 	name = "\improper MECH BAY AND RECHARGING STATION sign";
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/mauve,
+/obj/effect/floor_decal/corner/brown{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "vrf" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -39435,10 +39303,11 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "vtM" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/floor_decal/corner/brown{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/mauve,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "vua" = (
 /obj/effect/floor_decal/corner/brown{
@@ -39854,11 +39723,6 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "vFz" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 10;
-	req_access = list(55)
-	},
-/obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -39871,6 +39735,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "vFN" = (
@@ -39958,17 +39826,11 @@
 /area/rnd/xenobiology/xenoflora)
 "vIt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve{
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/green{
 	dir = 6
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "vIz" = (
 /obj/structure/disposalpipe/segment{
@@ -40009,11 +39871,12 @@
 "vJv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/mauve{
-	dir = 10
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/mauve,
+/obj/effect/floor_decal/corner/brown{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
@@ -40231,7 +40094,7 @@
 	pixel_x = -28
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "vOS" = (
@@ -40301,6 +40164,7 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/security/armory)
 "vQd" = (
@@ -40990,10 +40854,6 @@
 	dir = 4
 	},
 /obj/structure/railing/mapped,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
 /turf/simulated/open,
 /area/hallway/primary/central_two)
 "wdw" = (
@@ -41154,13 +41014,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
 /obj/machinery/newscaster{
 	pixel_x = 29
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/green/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "whe" = (
 /obj/structure/shuttle_part/scc_space_ship{
@@ -41306,13 +41166,6 @@
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	layer = 5;
-	name = "adjusted reinforced window"
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -41696,7 +41549,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "wtC" = (
 /obj/machinery/power/breakerbox/activated{
@@ -42564,7 +42417,7 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "wPJ" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
@@ -42701,10 +42554,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/starboard/far)
 "wTb" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_two)
 "wTd" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
@@ -42752,16 +42603,6 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/research_port)
-"wUT" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/lattice,
-/turf/simulated/open,
-/area/hallway/primary/central_two)
 "wUU" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 6
@@ -43708,7 +43549,6 @@
 /turf/simulated/floor/plating,
 /area/horizon/maintenance/deck_two/fore/port)
 "xxa" = (
-/obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -43719,6 +43559,8 @@
 	icon_state = "2-4"
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/security/armory)
 "xxc" = (
@@ -43982,7 +43824,7 @@
 /obj/machinery/door/airlock/glass_service{
 	name = "Library"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/horizon/library)
 "xFR" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
@@ -44633,7 +44475,7 @@
 "xWr" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "xWz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44752,11 +44594,9 @@
 /area/security/prison)
 "xZw" = (
 /obj/machinery/vending/cigarette,
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_two)
@@ -45029,7 +44869,8 @@
 "yea" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/green,
+/turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "yef" = (
 /obj/structure/cable/green{
@@ -65188,17 +65029,17 @@ qja
 amE
 ayF
 wTb
-nks
+pyc
 mHG
 bto
 mHG
-fEQ
+nEx
 hDd
 fHo
-ntN
-gDw
+bJp
+siL
 wPF
-cDV
+fEQ
 bnQ
 mFs
 mWs
@@ -65389,20 +65230,20 @@ ryy
 qja
 ego
 ayF
-aDL
-nks
+wTb
+pyc
 mHG
 xQj
 mHG
-fEQ
-dKH
-fqr
-wUT
+nEx
+hEF
+vXs
+bJp
 siL
-dKH
-gOH
-gOH
-rfQ
+hEF
+nkF
+nkF
+xWr
 noi
 ouK
 sZT
@@ -65591,18 +65432,18 @@ qja
 qja
 ego
 ayF
-cDV
+wTb
 pyc
 mHG
 xQj
 mHG
 nEx
-dKH
-fqr
-wUT
+hEF
+vXs
+bJp
 siL
-dKH
-gOH
+hEF
+nkF
 mCE
 xWr
 vyg
@@ -65796,15 +65637,15 @@ ayF
 hvu
 plf
 hfq
-amz
+vbk
 hfq
 wdk
 lvH
-fqr
+vXs
 cMn
 wlg
-dKH
-gOH
+hEF
+nkF
 stI
 pWx
 pWx
@@ -65991,21 +65832,21 @@ iVp
 iVp
 nUN
 rUT
-gzF
+gDw
 pyc
 bto
 ayF
 aIj
-cDV
-cDV
-cDV
-cDV
-cDV
-eQs
+fEQ
+fEQ
+fEQ
+fEQ
+fEQ
+lZX
 wtj
-cDV
-cDV
-eQs
+fEQ
+fEQ
+lZX
 bVc
 jFS
 pWx
@@ -66193,11 +66034,11 @@ iVp
 iVp
 nUN
 vcv
-bOR
+vXs
 bJp
 mHG
-ayF
 cTn
+hEF
 nkF
 nkF
 nkF
@@ -66394,18 +66235,18 @@ iVp
 iVp
 iVp
 nUN
-qVu
-bOR
+vcv
+vXs
 luT
 vbk
 ayF
 uRe
 aFd
 yea
-tXM
-tXM
-tXM
-tdM
+vIt
+vIt
+vIt
+vIt
 vIt
 vIt
 vIt
@@ -66596,22 +66437,22 @@ iVp
 iVp
 iVp
 nUN
-qVu
-bOR
-gBE
-gBE
+vcv
+wtj
+fEQ
+gDw
 nJq
-gBE
+hEF
 nkF
-bOa
+vXs
 dex
-tOW
-tOW
-rbe
-lUm
 iVQ
 ixR
-uXq
+rbe
+dex
+iVQ
+ixR
+hEF
 ifP
 lDb
 xFQ
@@ -66799,23 +66640,23 @@ iVp
 iVp
 nUN
 wgL
-ooA
-gBE
+tcE
+tcE
 cIr
-gBE
-gBE
+nkF
+hEF
 nkF
 ept
 pQm
 fwK
-gBE
-gBE
-gBE
-gBE
-kJN
+qVu
+qVu
+qVu
+cQE
+pQm
 uXq
 eNj
-fqr
+vXs
 pWx
 jUG
 aFK
@@ -67017,7 +66858,7 @@ ban
 gBE
 uXq
 eNj
-fqr
+vXs
 rQh
 ruv
 xQD
@@ -67207,7 +67048,7 @@ qJr
 rCd
 dRN
 fjc
-gBE
+gzF
 nkF
 ept
 tHk
@@ -67216,10 +67057,10 @@ hjG
 meM
 hjG
 jgz
-gBE
+tOW
 uXq
 eNj
-fqr
+vXs
 rQh
 rHd
 hYt
@@ -67409,17 +67250,17 @@ fVX
 qyh
 dki
 fjc
-gBE
+gzF
 nkF
-ept
+vXs
 dPz
 gkM
 oFp
 lTn
 ygu
 jvI
-gBE
-uXq
+tOW
+hEF
 eNj
 hWE
 pWx
@@ -67620,7 +67461,7 @@ hjG
 aST
 hjG
 jgz
-gBE
+tOW
 uXq
 ljv
 fWU
@@ -67822,10 +67663,10 @@ hnY
 sFf
 hnY
 jHi
-gBE
+tOW
 uXq
 eNj
-mFQ
+vXs
 bDo
 bDo
 bDo
@@ -68015,13 +67856,13 @@ maP
 rFF
 wGN
 ulB
-gBE
+gzF
 hcF
 ept
 ayF
 gBk
-gBE
-gBE
+jHX
+jHX
 jHX
 dza
 ayF
@@ -68217,9 +68058,9 @@ wKS
 clb
 iCz
 nRx
-gBE
+gzF
 hcF
-ann
+wtj
 jWF
 jWF
 jWF
@@ -68227,9 +68068,9 @@ iDB
 jWF
 jWF
 jWF
-cQE
+lZX
 eNj
-mFQ
+bOR
 acz
 tIQ
 ukV
@@ -68431,7 +68272,7 @@ opb
 opb
 fjX
 cev
-mFQ
+bOR
 jMO
 kqM
 rzm
@@ -68621,7 +68462,7 @@ roX
 rlp
 qTB
 rUh
-bOR
+gzF
 aKr
 doI
 ejU
@@ -68632,7 +68473,7 @@ vtM
 vtM
 lcL
 mXJ
-lES
+tcE
 mFQ
 acz
 rIK
@@ -68823,7 +68664,7 @@ aBr
 gPM
 lFE
 ulB
-ooA
+gzF
 aNp
 qav
 qav
@@ -69228,7 +69069,7 @@ oBl
 vpk
 ulB
 tPq
-rnA
+amz
 hME
 xlK
 kGl
@@ -69632,7 +69473,7 @@ soW
 rZU
 cNU
 byv
-rnA
+amz
 hME
 tlX
 kGl

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -1077,6 +1077,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "cc" = (
@@ -1386,7 +1389,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/corner/paleblue/full,
+/obj/structure/closet/firecloset,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "cF" = (
@@ -4639,6 +4644,7 @@
 	layer = 4;
 	pixel_y = 32
 	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/bridge)
 "iy" = (
@@ -8039,6 +8045,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/south,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/bridge/bridge_crew)
 "oE" = (
@@ -8257,7 +8264,7 @@
 /obj/effect/floor_decal/corner/green/full{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "pc" = (
@@ -8331,6 +8338,7 @@
 	dir = 5
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "pk" = (
@@ -14012,6 +14020,18 @@
 	},
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
+"zM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/hallway/deck_three/primary/starboard)
 "zN" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
@@ -14223,6 +14243,10 @@
 /area/engineering/break_room)
 "Aj" = (
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "Ak" = (
@@ -15866,6 +15890,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/paleblue,
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "Dz" = (
@@ -16175,6 +16200,10 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "Ej" = (
@@ -18005,6 +18034,7 @@
 	layer = 4;
 	pixel_y = 32
 	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/security/investigations)
 "Hx" = (
@@ -18973,6 +19003,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/horizon/crew_quarters/fitness/washroom)
+"Jg" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/hallway/deck_three/primary/starboard)
 "Jh" = (
 /obj/machinery/door/airlock/hatch{
 	icon_state = "door_locked";
@@ -19214,7 +19250,7 @@
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_quarters/fitness/hallway)
 "JE" = (
@@ -20755,7 +20791,7 @@
 	dir = 5
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
 "Mr" = (
@@ -24296,6 +24332,12 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/horizon/crew_quarters/fitness/gym)
+"SG" = (
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/hallway/deck_three/primary/starboard)
 "SH" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -25451,6 +25493,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
+"UQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/hallway/deck_three/primary/starboard)
 "UR" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -25533,6 +25587,7 @@
 	dir = 1
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "Vc" = (
@@ -26711,7 +26766,7 @@
 	dir = 5
 	},
 /obj/structure/closet/firecloset/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
 "Xp" = (
@@ -48998,7 +49053,7 @@ fJ
 fJ
 fJ
 Uc
-uk
+SG
 cE
 Vm
 Ie
@@ -49200,10 +49255,10 @@ fJ
 fJ
 fJ
 Uc
-uk
+Jg
 cb
-JS
-gl
+uL
+zM
 ag
 AG
 UV
@@ -49402,7 +49457,7 @@ fJ
 fJ
 fJ
 Uc
-uk
+Jg
 hY
 kF
 tR
@@ -49604,10 +49659,10 @@ fJ
 fJ
 fJ
 Uc
-uk
+Jg
 Dy
-JS
-gl
+aP
+UQ
 iY
 AG
 UV


### PR DESCRIPTION
this PR tweaks the decal mapping around the ship and adds new dedicated outlines for emergency closets and firefighting closets. it also tweaks the central ring on deck 2.

**changes**
-
- renames "fire-safety closet" to "firefighting closet" to better reflect its purpose.
- maps in dedicated "blue emergency closet outline" for emergency closets.
- maps in dedicated "red firefighting closet outline" for firefighting closets.
- tweaks the central ring on deck 2 and makes it more open. gives it some polish.