### PR TITLE
Fixes the Skrell casual wetsuit

### DIFF
--- a/code/modules/clothing/under/xenos/skrell.dm
+++ b/code/modules/clothing/under/xenos/skrell.dm
@@ -319,7 +319,23 @@
 	icon_state = "wetsuit"
 	item_state = "wetsuit"
 	var/additional_color = COLOR_GRAY
-	
+
+/obj/item/clothing/under/skrell/wetsuit/update_icon()
+	cut_overlays()
+	var/image/accent = image(icon, null, "wetsuit_un_accent")
+	accent.appearance_flags = RESET_COLOR
+	accent.color = additional_color
+	add_overlay(accent)
+
+/obj/item/clothing/under/skrell/wetsuit/get_mob_overlay(var/mob/living/carbon/human/H, var/mob_icon, var/mob_state, var/slot)
+	var/image/I = ..()
+	if(slot == slot_w_uniform_str)
+		var/image/accent = image(mob_icon, null, "wetsuit_un_accent")
+		accent.appearance_flags = RESET_COLOR
+		accent.color = additional_color
+		I.add_overlay(accent)
+	return I
+
 /obj/item/clothing/suit/storage/toggle/skrell/starcoat
 	name = "star coat"
 	desc = "A very fashionable coat, that traps moisture and provides good insulation. Starry patterns have been woven into its fabric."

--- a/html/changelogs/skrellwetsuitfix.yml
+++ b/html/changelogs/skrellwetsuitfix.yml
@@ -1,0 +1,12 @@
+author: WhatsUpBrotendo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes issues with the casual wetsuit."


### PR DESCRIPTION
I somehow deleted the code in the last PR that allowed the casual wetsuit to have two colour choices. This adds it back.

![image](https://user-images.githubusercontent.com/52638996/184206451-bf470ea6-b153-4b09-9e89-8c9227ca9f6f.png)
