### PR TITLE
Adds a vent and scrubber to the Central Primary Hallway, cleans up excess toolboxes in responder quarters

### DIFF
--- a/html/changelogs/omicega-testsfdsfdsfgdsgfd.yml
+++ b/html/changelogs/omicega-testsfdsfdsfgdsgfd.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Adds a vent and scrubber to a section of the central hallway which keeps sectioning itself off with shutters."
+  - maptweak: "Removes a full four toolboxes from the first responders' quarters and adds one for shared usage."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -817,11 +817,6 @@
 	c_tag = "Medical - First Responder Room"
 	},
 /obj/structure/closet/secure_closet/medical_fr,
-/obj/item/storage/toolbox/emergency,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -1;
-	pixel_y = 5
-	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "auG" = (
@@ -908,6 +903,10 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -1;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
@@ -9268,6 +9267,12 @@
 "fdV" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
@@ -20052,11 +20057,12 @@
 /turf/simulated/floor/plating,
 /area/operations/office)
 "kXU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
@@ -23161,15 +23167,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
 "mHa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "mHh" = (
@@ -26459,6 +26466,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/break_room)
+"ovP" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_two)
 "ovY" = (
 /obj/machinery/light{
 	dir = 4
@@ -28738,7 +28755,7 @@
 	},
 /obj/machinery/vending/mredispenser{
 	pixel_y = 24;
-  density = 0
+	density = 0
 	},
 /turf/simulated/floor/lino/grey,
 /area/horizon/kitchen/hallway)
@@ -29849,6 +29866,16 @@
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room)
+"qkb" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_two)
 "qkm" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -30498,6 +30525,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/operations/qm)
+"qCX" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/central_two)
 "qDU" = (
 /obj/machinery/light{
 	dir = 1
@@ -35104,6 +35143,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 6
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "tcQ" = (
@@ -39038,6 +39078,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "veu" = (
@@ -43893,11 +43937,6 @@
 	pixel_y = 32
 	},
 /obj/structure/closet/secure_closet/medical_fr,
-/obj/item/storage/toolbox/emergency,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -1;
-	pixel_y = 5
-	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "xBX" = (
@@ -45162,6 +45201,10 @@
 "ygw" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
@@ -60385,12 +60428,12 @@ nTp
 jjr
 amf
 tcE
-tcE
+qkb
 veq
-tcE
-tcE
+ovP
+ovP
 ygw
-fdV
+qCX
 vXs
 gJj
 vHy


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/57604458/184225230-c407441d-bec2-42b4-a0f9-9f919d21dd01.png)

See title. Here are the vent and scrubber in question.

This is basically a test PR for my first usage of StrongDMM, since I finally bothered to get around to downloading it and figuring out how it works. I noticed this tiny section of hallway can cause atmos alarms to persist throughout the _entire_ Central Primary Hallway area, which is absolutely colossal. Now it should refill itself without needing the shutters to be manually opened.

While I was at it, I removed the four mapped-in toolboxes in the responder bay and replaced them with a single toolbox for responder usage. They're only really used for maintaining the RIG, anyway.