### PR TITLE
Fixes deck 2 service wing being totally disconnected from the atmos loop

### DIFF
--- a/html/changelogs/omicega-atmosdfffdsfsdifusd.yml
+++ b/html/changelogs/omicega-atmosdfffdsfsdifusd.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes an atmospherics mapping error affecting all of deck two's service wing."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -725,6 +725,11 @@
 	},
 /turf/simulated/wall,
 /area/maintenance/wing/port/far)
+"asr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/horizon/hallway/deck_two/fore)
 "asB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8850,6 +8855,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"eUH" = (
+/obj/machinery/door/airlock/glass,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/horizon/hallway/deck_two/fore)
 "eUT" = (
 /obj/structure/bed/stool/chair/padded/black{
 	dir = 4
@@ -24107,10 +24119,10 @@
 /turf/simulated/floor/tiled,
 /area/engineering/smes)
 "neZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "nfs" = (
@@ -27215,14 +27227,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "oPM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
 	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -27230,6 +27236,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_two/fore)
@@ -28738,7 +28750,7 @@
 	},
 /obj/machinery/vending/mredispenser{
 	pixel_y = 24;
-  density = 0
+	density = 0
 	},
 /turf/simulated/floor/lino/grey,
 /area/horizon/kitchen/hallway)
@@ -40200,6 +40212,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_quarters/lounge/bar)
+"vNQ" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/central_two)
 "vNX" = (
 /obj/structure/bed/stool/chair/office/dark{
 	dir = 1
@@ -65441,9 +65461,9 @@ sZT
 sZT
 sZT
 neZ
-fqr
-vvt
-sBy
+vNQ
+eUH
+asr
 oPM
 cUZ
 gjM


### PR DESCRIPTION
See title. At some point, presumably during one of the earlier Horizon remaps, deck 2's service wing (south of the library, including the frontside bar, kitchen etc) was left entirely disconnected from the ship's atmospherics loop, and all the pipes therein would spawn empty and stay that way. This also means that none of those vents and scrubbers have been working for weeks or even months now, as far as I can tell.