### PR TITLE
Bridge Control APC is Now Critical

### DIFF
--- a/html/changelogs/wickedcybs_bridgecrit.yml
+++ b/html/changelogs/wickedcybs_bridgecrit.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - bugfix: "The bridge control APC is now critical and won't turn off during an electrical storm"

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -3733,14 +3733,12 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24;
-	is_critical = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/power/apc/critical{
+	dir = 1;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -3736,7 +3736,8 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_y = 24
+	pixel_y = 24;
+	is_critical = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4


### PR DESCRIPTION
The bridge control APC (command room, with the piloting consoles and stuff) had a non-critical APC, so during the random electrical storm event the ship might potentially go out of control when the helm loses power. It's been marked critical due to its extreme importance, just like the how the thrusters are marked the same.
