### PR TITLE
Blast Doors and Shutter Tweaks

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -35,8 +35,6 @@
 	var/_wifi_id
 	var/datum/wifi/receiver/button/door/wifi_receiver
 
-	var/securitylock = TRUE
-
 /obj/machinery/door/blast/Initialize()
 	. = ..()
 	if(_wifi_id)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -184,9 +184,9 @@
 // Controls how blast doors and shutters should act when power is lost or gained.
 /obj/machinery/door/blast/power_change()
 	..()
-	if(src.operating || (stat & BROKEN)
+	if(src.operating || (stat & BROKEN))
 		return
-	if(stat & NOPOWER) && fail_secure)
+	if((stat & NOPOWER) && fail_secure)
 		securitylock = !density // Blast doors will only re-open when power is restored if they were open originally.
 		INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_close)
 	else if(securitylock && fail_secure)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -10,7 +10,7 @@
 #define SHUTTER_CRUSH_DAMAGE 10
 
 /obj/machinery/door/blast
-	name = "Blast Door"
+	name = "blast door"
 	desc = "That looks like it doesn't open easily."
 	icon = 'icons/obj/doors/rapid_pdoor.dmi'
 	icon_state = null
@@ -36,7 +36,6 @@
 	var/datum/wifi/receiver/button/door/wifi_receiver
 
 	var/securitylock = TRUE
-	var/is_critical = FALSE
 
 /obj/machinery/door/blast/Initialize()
 	. = ..()
@@ -177,22 +176,9 @@
 	if(stat & BROKEN)
 		stat &= ~BROKEN
 
-
 /obj/machinery/door/blast/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group) return 1
 	return ..()
-
-
-/obj/machinery/door/blast/power_change()
-	..()
-	if(src.operating || (stat & BROKEN) || is_critical)
-		return
-	if(stat & NOPOWER)
-		securitylock = !density // blast doors will only re-open when power is restored if they were open originally
-		INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_close)
-	else if(securitylock)
-		INVOKE_ASYNC(src, /obj/machinery/door/blast/.proc/force_open)
-		securitylock = FALSE
 
 /obj/machinery/door/blast/attack_hand(mob/user as mob)
 	return
@@ -210,12 +196,13 @@
 
 /obj/machinery/door/blast/regular/open
 	icon_state = "pdoor0"
-	density = 0
-	opacity = 0
+	density = FALSE
+	opacity = FALSE
 
 // SUBTYPE: Shutters
 // Nicer looking, and also weaker, shutters. Found in kitchen and similar areas.
 /obj/machinery/door/blast/shutters
+	name = "shutter"
 	icon_state_open = "shutter0"
 	icon_state_opening = "shutterc0"
 	icon_state_closed = "shutter1"
@@ -225,8 +212,8 @@
 
 /obj/machinery/door/blast/shutters/open
 	icon_state = "shutter0"
-	density = 0
-	opacity = 0
+	density = FALSE
+	opacity = FALSE
 
 // SUBTYPE: Odin
 // Found on the odin, or where people really shouldnt get into

--- a/html/changelogs/blastdoors_and_shutters_fix.yml
+++ b/html/changelogs/blastdoors_and_shutters_fix.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - tweak: "Blast doors and shutters now stay in the state they were in when power is lost."

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -2593,7 +2593,6 @@
 	},
 /obj/machinery/door/blast/regular{
 	id = "iso_b_purge";
-	is_critical = 1;
 	name = "Exterior Blast Door"
 	},
 /turf/simulated/floor/plating,
@@ -5811,7 +5810,6 @@
 	},
 /obj/machinery/door/blast/regular{
 	id = "iso_a_purge";
-	is_critical = 1;
 	name = "Exterior Blast Door"
 	},
 /turf/simulated/floor/plating,
@@ -35783,7 +35781,6 @@
 	},
 /obj/machinery/door/blast/regular{
 	id = "iso_c_purge";
-	is_critical = 1;
 	name = "Exterior Blast Door"
 	},
 /turf/simulated/floor/plating,

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -10580,7 +10580,6 @@
 	dir = 4;
 	icon_state = "pdoor0";
 	id = "SupermatterPort";
-	is_critical = 1;
 	name = "Reactor Blast Door";
 	opacity = 0
 	},
@@ -10597,7 +10596,6 @@
 	dir = 4;
 	icon_state = "pdoor0";
 	id = "SupermatterPort";
-	is_critical = 1;
 	name = "Reactor Blast Door";
 	opacity = 0
 	},
@@ -10617,7 +10615,6 @@
 	dir = 4;
 	icon_state = "pdoor0";
 	id = "SupermatterPort";
-	is_critical = 1;
 	name = "Reactor Blast Door";
 	opacity = 0
 	},
@@ -12401,7 +12398,6 @@
 /obj/machinery/door/blast/regular{
 	dir = 4;
 	id = "EngineVent";
-	is_critical = 1;
 	name = "Reactor Vent"
 	},
 /turf/simulated/floor/airless{
@@ -12449,7 +12445,6 @@
 	density = 0;
 	icon_state = "pdoor0";
 	id = "SupermatterPort";
-	is_critical = 1;
 	name = "Reactor Blast Door";
 	opacity = 0
 	},
@@ -59897,7 +59892,6 @@
 "eiB" = (
 /obj/machinery/door/blast/shutters{
 	dir = 2;
-	is_critical = 1;
 	name = "shutter"
 	},
 /obj/machinery/conveyor{

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -10313,7 +10313,6 @@
 "ifE" = (
 /obj/machinery/door/blast/regular{
 	id = "iso_c_purge";
-	is_critical = 1;
 	name = "Exterior Blast Door"
 	},
 /turf/simulated/floor/reinforced,
@@ -25230,7 +25229,6 @@
 "uwm" = (
 /obj/machinery/door/blast/regular{
 	id = "iso_a_purge";
-	is_critical = 1;
 	name = "Exterior Blast Door"
 	},
 /turf/simulated/floor/reinforced,
@@ -29427,7 +29425,6 @@
 "xRN" = (
 /obj/machinery/door/blast/regular{
 	id = "iso_b_purge";
-	is_critical = 1;
 	name = "Exterior Blast Door"
 	},
 /turf/simulated/floor/reinforced,

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -859,7 +859,8 @@
 	icon_state = "pdoor0";
 	id = "xenobio";
 	name = "Xenobiology Blast Door";
-	opacity = 0
+	opacity = 0;
+	fail_secure = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
@@ -7638,14 +7639,15 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "egB" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
 	id = "xenobio";
 	name = "Xenobiology Blast Door";
-	opacity = 0
+	opacity = 0;
+	fail_secure = 1
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /turf/simulated/floor/tiled/dark/full,
 /area/rnd/xenobiology)
 "egY" = (
@@ -8966,7 +8968,8 @@
 	icon_state = "pdoor0";
 	id = "xenobio";
 	name = "Xenobiology Blast Door";
-	opacity = 0
+	opacity = 0;
+	fail_secure = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
@@ -28172,6 +28175,15 @@
 /area/engineering/storage_hard)
 "pnj" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "xenobio";
+	name = "Xenobiology Blast Door";
+	opacity = 0;
+	fail_secure = 1;
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/rnd/xenobiology)
 "pnF" = (
@@ -33768,7 +33780,8 @@
 	icon_state = "pdoor0";
 	id = "xenobio";
 	name = "Xenobiology Blast Door";
-	opacity = 0
+	opacity = 0;
+	fail_secure = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/xenobiology)
@@ -36922,10 +36935,10 @@
 	name = "Xenobiology Blast Door";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/research{
+/obj/machinery/door/airlock/glass_research{
 	name = "Autopsy and Incineration"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/rnd/xenobiology)
 "ubz" = (
 /obj/effect/floor_decal/industrial/warning,

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -13030,7 +13030,6 @@
 /obj/machinery/door/blast/regular{
 	dir = 4;
 	id = "EngineVent";
-	is_critical = 1;
 	name = "Reactor Vent"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -22157,7 +22156,6 @@
 /obj/machinery/door/blast/regular{
 	dir = 4;
 	id = "EngineVent";
-	is_critical = 1;
 	name = "Reactor Vent"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -29871,7 +29869,6 @@
 	dir = 2;
 	icon_state = "pdoor0";
 	id = "SupermatterPort";
-	is_critical = 1;
 	name = "Reactor Blast Door";
 	opacity = 0
 	},
@@ -34016,7 +34013,6 @@
 	dir = 4;
 	icon_state = "pdoor0";
 	id = "SupermatterPort";
-	is_critical = 1;
 	name = "Reactor Blast Door";
 	opacity = 0
 	},

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -14830,7 +14830,6 @@
 	},
 /obj/machinery/door/blast/shutters{
 	id = "shutters_runcaprun";
-	is_critical = 1;
 	name = "Decrepit Maintenance Shutter"
 	},
 /obj/structure/curtain/black,
@@ -24563,8 +24562,7 @@
 	},
 /obj/machinery/door/blast/regular{
 	dir = 4;
-	id = "blastdoors_tcomms";
-	is_critical = 1
+	id = "blastdoors_tcomms"
 	},
 /turf/simulated/floor/tiled,
 /area/tcommsat/chamber)


### PR DESCRIPTION
this PR tweaks so that blast doors and shutters now stay in the state they were in when power is lost and changes the critical variable and functionality to a fail-secure functionality instead.