### PR TITLE
Vaurca projector additions and tweaks.

### DIFF
--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -7,7 +7,7 @@
 	message_frequency = 10
 	var/hologram_message
 	var/possible_messages
-	var/first_message
+	var/first_message = FALSE
 
 
 /obj/item/skrell_projector/vaurca_projector/attack_self(mob/user as mob)
@@ -103,6 +103,6 @@
 
 		else
 			hologram_message = pick(possible_messages)
-
+			first_message = TRUE
 		if(hologram_message)
 			visible_message("<span class='notice'>[hologram_message]</span>")

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -78,7 +78,7 @@
 		if("Athvur's City of Paradise")
 			light_color = "#eff3ef"
 			possible_messages = list(
-		"A transcendent cityscape dominates the area, with towering structures of elegant stone resting atop a blanket of clouds.",
+		"A transcendent cityscape dominates the area, with towering structures of elegant white stone resting atop a blanket of clouds.",
 		"In the distance of the cityscape towers a set of sublime sculptures, accented by light from beneath the clouds.",
 		"Orchestral music resonates from within an auditorium, the melody carried through the heavens.",
 		"An enchanting smell of cedar, cherry and morning freshness penetrates through the air."

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -78,22 +78,22 @@
 		if("Athvur's City of Paradise")
 			light_color = "#eff3ef"
 			possible_messages = list(
-		"A transcendent cityscape dominates the area, with towering structures of elegant white stone resting atop a blanket of clouds.",
-		"In the distance of the cityscape towers a set of sublime sculptures, accented by light from beneath the clouds.",
-		"Orchestral music resonates from within an auditorium, the melody carried through the heavens.",
-		"An enchanting smell of cedar, cherry and morning freshness penetrates through the air.",
-		"A vibrant burst of color permeates through the sky, basking the air in pleasing rainbow luminescence for a moment.", 
-		"In the center of a green park Vaurca workers paint not on canvas but in the air, seemingly looking at the landscape for inspiration."
+			"A transcendent cityscape dominates the area, with towering structures of elegant white stone resting atop a blanket of clouds.",
+			"In the distance of the cityscape towers a set of sublime sculptures, accented by light from beneath the clouds.",
+			"Orchestral music resonates from within an auditorium, the melody carried through the heavens.",
+			"An enchanting smell of cedar, cherry and morning freshness penetrates through the air.",
+			"A vibrant burst of color permeates through the sky, basking the air in pleasing rainbow luminescence for a moment.", 
+			"In the center of a green park Vaurca workers paint not on canvas but in the air, seemingly looking at the landscape for inspiration."
 		)
 		if("Athvur's Garden of Splendour")
 			light_color = "#3adf3a"
 			possible_messages = list( 
-		"A tranquil garden landscape stretches out to the horizon, its peaceful scenery embellished with flowers of every variety.",
-		"Harmonious music accents an indescribable aroma of flowers.",
-		"In the distance of the garden, beyond the soothing plants, workers move through an ornate gazebo.",
-		"A fountain sits nestled within a thicket clearing, producing a golden substance from which gathered workers drink.",
-		"A herd of majestic creatures, each as tall as two people, graze on a patch of grass and lie curled up against each other's silky fur.", 
-		"Lilac-breasted birds dart between the tree-line and sing a soothing melody which seems to carry with it a smell of vanilla."
+			"A tranquil garden landscape stretches out to the horizon, its peaceful scenery embellished with flowers of every variety.",
+			"Harmonious music accents an indescribable aroma of flowers.",
+			"In the distance of the garden, beyond the soothing plants, workers move through an ornate gazebo.",
+			"A fountain sits nestled within a thicket clearing, producing a golden substance from which gathered workers drink.",
+			"A herd of majestic creatures, each as tall as two people, graze on a patch of grass and lie curled up against each other's silky fur.", 
+			"Lilac-breasted birds dart between the tree-line and sing a soothing melody which seems to carry with it a smell of vanilla."
 		)
 		if("Athvur's Museum of Fine Art")
 			light_color = "#e7f0ec"

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -102,7 +102,7 @@
 			"A massive display is decorated with examples of seemingly delicately crafted Zo'rane artwork.",
 			"Workers mull about the museum, seemingly taking in the atmosphere brought forth by the displays.", 
 			"An exhibit showcases reportedly hand-painted landscapes that have won awards.", 
-			"A melodic harmony is carried from a distant display marked with 'Music', only perceptible due to the quiet atmosphere of the sounding exhibition.", 
+			"A melodic harmony is carried from a distant display marked with 'Music' only perceptible due to the quiet atmosphere of the sounding exhibition.", 
 			"Sculptures of notable Zo'rane historical figures dominate their respective corners, carved from a variety of rare materials.", 
 			"Groups of workers move around, seemingly taking a guided tour through the museum, watching each art piece explained to them attentively"
 		)

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -1,6 +1,6 @@
 /obj/item/skrell_projector/vaurca_projector
 	name = "virtual reality looking glass"
-	desc = "A holographic projector using advanced technology that immerses someone into a scene using full panoramic holograms, smell and 3D spatial sound projection. It is developed and distributed by Hive Zo'ra and allows the viewer to peer in real-time into virtual reality realms specifically designed for outside viewing such as those belonging to High Queen Vaur."
+	desc = "A holographic projector using advanced technology that immerses someone into a scene using full panoramic holograms, smell and 3D spatial sound projection. It is developed and distributed by Hive Zo'ra and allows the viewer to peer in real-time into virtual reality realms specifically designed for outside viewing such as those belonging to High Queen Vaur or Queen Athvur."
 	icon = 'icons/obj/vaurca_items.dmi'
 	icon_state = "zora_projector"
 	worlds_selection = list("Vaur's Tranquil Ocean", "Vaur's Hive War Exhibition", "Vaur's Celestial Landing Ground", "Vaur's City of New Sedantis", "Vaur's Titan Prime Recreation", "Athvur's City of Paradise", "Athvur's Garden of Splendour", "Athvur's Museum of Fine Art")

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -78,7 +78,7 @@
 		if("Athvur's City of Paradise")
 			light_color = "#eff3ef"
 			possible_messages = list(
-		"A transcendent cityscape dominates the area, with towering structures of elegant stone sitting atop a blanket of clouds.",
+		"A transcendent cityscape dominates the area, with towering structures of elegant stone resting atop a blanket of clouds.",
 		"In the distance of the cityscape towers a set of sublime sculptures, accented by light from beneath the clouds.",
 		"Orchestral music resonates from within an auditorium, the melody carried through the heavens.",
 		"An enchanting smell of cedar, cherry and morning freshness penetrates through the air."

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -7,6 +7,7 @@
 	message_frequency = 10
 	var/hologram_message
 	var/possible_messages
+	var/first_message
 
 
 /obj/item/skrell_projector/vaurca_projector/attack_self(mob/user as mob)

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -103,7 +103,7 @@
 			"An exhibit showcases reportedly hand-painted landscapes that have won awards.", 
 			"A melodic harmony is carried from a distant display marked with 'Music' only perceptible due to the quiet atmosphere of the surrounding exhibition.", 
 			"Sculptures of notable Zo'rane historical figures dominate their respective corners, carved from a variety of rare materials.", 
-			"Groups of workers move around, seemingly taking a guided tour through the museum, watching each art piece explained to them attentively"
+			"Groups of workers move around, seemingly taking a guided tour through the museum, watching each art piece explained to them attentively."
 		)
 
 

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -7,7 +7,6 @@
 	message_frequency = 10
 	var/hologram_message
 	var/possible_messages
-	var/first_message = FALSE
 
 
 /obj/item/skrell_projector/vaurca_projector/attack_self(mob/user as mob)
@@ -97,12 +96,13 @@
 		return
 
 	if(prob(message_frequency))
-		if(first_message)
+		if(first_message
 			hologram_message = possible_messages[1]
-			first_message = FALSE
+			first_message = FALSE)
 
 		else
 			hologram_message = pick(possible_messages)
-			first_message = TRUE
+			
+
 		if(hologram_message)
 			visible_message("<span class='notice'>[hologram_message]</span>")

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -101,7 +101,7 @@
 			"A massive display is decorated with examples of seemingly delicately crafted Zo'rane artwork.",
 			"Workers mull about the museum, seemingly taking in the atmosphere brought forth by the displays.", 
 			"An exhibit showcases reportedly hand-painted landscapes that have won awards.", 
-			"A melodic harmony is carried from a distant display marked with 'Music' only perceptible due to the quiet atmosphere of the sounding exhibition.", 
+			"A melodic harmony is carried from a distant display marked with 'Music' only perceptible due to the quiet atmosphere of the surrounding exhibition.", 
 			"Sculptures of notable Zo'rane historical figures dominate their respective corners, carved from a variety of rare materials.", 
 			"Groups of workers move around, seemingly taking a guided tour through the museum, watching each art piece explained to them attentively"
 		)

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -7,7 +7,7 @@
 	message_frequency = 10
 	var/hologram_message
 	var/possible_messages
-	var/first_message = TRUE
+	var/first_message
 
 /obj/item/skrell_projector/vaurca_projector/attack_self(mob/user as mob)
 	working = !working
@@ -15,6 +15,7 @@
 	if(working)
 		var/choice = input("You change the projector's holographic viewfinder to display:","Change the projector's viewfinder.") as null|anything in worlds_selection
 		apply_world(choice)
+		first_message = TRUE
 		START_PROCESSING(SSprocessing, src)
 	else
 		set_light(0)

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -7,7 +7,7 @@
 	message_frequency = 10
 	var/hologram_message
 	var/possible_messages
-
+	var/first_message = TRUE
 
 /obj/item/skrell_projector/vaurca_projector/attack_self(mob/user as mob)
 	working = !working
@@ -15,7 +15,6 @@
 	if(working)
 		var/choice = input("You change the projector's holographic viewfinder to display:","Change the projector's viewfinder.") as null|anything in worlds_selection
 		apply_world(choice)
-		var/first_message = TRUE
 		START_PROCESSING(SSprocessing, src)
 	else
 		set_light(0)
@@ -96,13 +95,12 @@
 		return
 
 	if(prob(message_frequency))
-		if(first_message
+		if(first_message)
 			hologram_message = possible_messages[1]
-			first_message = FALSE)
-
+			first_message = FALSE
 		else
 			hologram_message = pick(possible_messages)
-			
+
 
 		if(hologram_message)
 			visible_message("<span class='notice'>[hologram_message]</span>")

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -3,7 +3,7 @@
 	desc = "A holographic projector using advanced technology that immerses someone into a scene using full panoramic holograms, smell and 3D spatial sound projection. It is developed and distributed by Hive Zo'ra and allows the viewer to peer in real-time into virtual reality realms specifically designed for outside viewing such as those belonging to High Queen Vaur."
 	icon = 'icons/obj/vaurca_items.dmi'
 	icon_state = "zora_projector"
-	worlds_selection = list("Vaur's Tranquil Ocean", "Vaur's Hive War Exhibition", "Vaur's Celestial Landing Ground", "Vaur's City of New Sedantis", "Vaur's Titan Prime Recreation", "Athvur's City of Paradise", "Athvur's Garden of Splendour")
+	worlds_selection = list("Vaur's Tranquil Ocean", "Vaur's Hive War Exhibition", "Vaur's Celestial Landing Ground", "Vaur's City of New Sedantis", "Vaur's Titan Prime Recreation", "Athvur's City of Paradise", "Athvur's Garden of Splendour", "Athvur's Museum of Fine Art")
 	message_frequency = 10
 	var/hologram_message
 	var/possible_messages
@@ -81,7 +81,10 @@
 		"A transcendent cityscape dominates the area, with towering structures of elegant white stone resting atop a blanket of clouds.",
 		"In the distance of the cityscape towers a set of sublime sculptures, accented by light from beneath the clouds.",
 		"Orchestral music resonates from within an auditorium, the melody carried through the heavens.",
-		"An enchanting smell of cedar, cherry and morning freshness penetrates through the air."
+		"An enchanting smell of cedar, cherry and morning freshness penetrates through the air.",
+		"A vibrant burst of color permeates through the sky, basking the air in pleasing rainbow luminescence for a moment.", 
+		"In the center of a green park Vaurca workers paint not on canvas but in the air, seemingly looking at the landscape for inspiration."
+
 		)
 		if("Athvur's Garden of Splendour")
 			light_color = "#34b434"
@@ -90,8 +93,21 @@
 		"Harmonious music accents an indescribable aroma of flowers.",
 		"In the distance of the garden, beyond the soothing plants, workers move through an ornate gazebo.",
 		"A fountain sits nestled within a thicket clearing, producing a golden substance from which gathered workers drink.",
+		"A herd of majestic creatures, each as tall as two people, graze on a patch of grass and lie curled up against each other's silky fur.", 
+		"Lilac-breasted birds dart between the tree-line and sing a soothing melody which seems to carry with it a smell of vanilla."
 		)
-		
+		if("Athvur's Museum of Fine Art")
+			light_color = "#e7f0ec"
+			possible_messages = list( 
+			"A massive display is decorated with examples of seemingly delicately crafted Zo'rane artwork.",
+			"Workers mull about the museum, seemingly taking in the atmosphere brought forth by the displays.", 
+			"An exhibit showcases reportedly hand-painted landscapes that have won awards.", 
+			"A melodic harmony is carried from a distant display marked with 'Music', only perceptible due to the quiet atmosphere of the sounding exhibition.", 
+			"Sculptures of notable Zo'rane historical figures dominate their respective corners, carved from a variety of rare materials.", 
+			"Groups of workers move around, seemingly taking a guided tour through the museum, watching each art piece explained to them attentively"
+		)
+
+
 		else
 			brightness = 0
 			working = FALSE

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -76,21 +76,22 @@
             "You see the gas giant Sedantis dominating a starry sky, an imposing vessel of steel blotting out but a small portion of it."
 			)
 		if("Athvur's City of Paradise")
-		light_color = "#eff3ef"
-		possible_messages = list(
+			light_color = "#eff3ef"
+			possible_messages = list(
 		"A transcendent cityscape dominates the area, with towering structures of elegant stone sitting atop a blanket of clouds.",
 		"In the distance of the cityscape towers a set of sublime sculptures, accented by light from beneath the clouds.",
 		"Orchestral music resonates from within an auditorium, the melody carried through the heavens.",
 		"An enchanting smell of cedar, cherry and morning freshness penetrates through the air."
 		)
 		if("Athvur's Garden of Splendour")
-		light_color = "#34b434"
-		possible_messages = list( 
+			light_color = "#34b434"
+			possible_messages = list( 
 		"A tranquil garden landscape stretches out to the horizon, its peaceful scenery embellished with flowers of every variety.",
 		"Harmonious music accents an indescribable aroma of flowers.",
 		"In the distance of the garden, beyond the soothing plants, workers move through an ornate gazebo.",
 		"A fountain sits nestled within a thicket clearing, producing a golden substance from which gathered workers drink.",
 		)
+		
 		else
 			brightness = 0
 			working = FALSE

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -5,6 +5,9 @@
 	icon_state = "zora_projector"
 	worlds_selection = list("Ocean", "Hive War Exhibition", "Celestial Landing Ground", "City of New Sedantis", "Titan Prime")
 	message_frequency = 10
+	var/hologram_message
+	var/possible_messages
+
 
 /obj/item/skrell_projector/vaurca_projector/attack_self(mob/user as mob)
 	working = !working
@@ -12,6 +15,7 @@
 	if(working)
 		var/choice = input("You change the projector's holographic viewfinder to display:","Change the projector's viewfinder.") as null|anything in worlds_selection
 		apply_world(choice)
+		var/first_message = TRUE
 		START_PROCESSING(SSprocessing, src)
 	else
 		set_light(0)
@@ -27,14 +31,52 @@
 	switch(choice)
 		if("Ocean")
 			light_color = "#1122c2"
+			possible_messages = list(
+			"You see a golden fortress floating majestically above an ocean of sapphire.",
+			"A euphoric smell of the ocean fills your senses as the water gently ebbs and flows.",
+			"You hear the faint humming of a hymn as a gentle wave envelops the viewfinder.",
+            "You can hear a quiet celestial chanting the source of which feels just beyond sight.",
+            "The turquoise water emits a jubilant smell of freshly cut lemons which lasts for only for a moment.",
+            "You see the gas giant Sedantis dominating a starry sky."
+			)
 		if("Hive War Exhibition")
 			light_color = "#83290b"
+			possible_messages = list(
+			"You see a carefully crafted exhibition detailing the Great Hive War. It explains in brief the details of the event through paintings and dioramas.",
+			"You smell burning and rusted metal. An exhibition showcases the Battle of a Thousand Titans.",
+			"You see a  memorial to the lives lost, a sad hymn flowing in the background."
+			)
 		if("Celestial Landing Ground")
 			light_color = "#f5e61d"
+			possible_messages = list(
+			"An awe inspiring fortress of gold dominates the landscape and bathes the surrounding area in yellow luminescence.",
+			"A loud hymn is chanted in an unknown language accompanied by a smell of morning dew in the countryside.",
+			"Unbound workers moving through the realm stop to gaze up in awe at the distant structure before returning to previous activities.",
+            "Distant chattering can be heard coming from the fortress including what sounds almost like jovial laughter.",
+            "The turquoise water emits a jubilant smell of freshly cut lemons which lasts for only for a moment.",
+            "You see the gas giant Sedantis dominating a starry sky.",
+			"For a moment the Golden Fortress towering above starts to glimmer majestically, catching the light from the imposing gas giant in the sky."
+			)
 		if("City of New Sedantis")
 			light_color = "#1395c9"
+			possible_messages = list(
+			"A towering cavernous city takes up the viewfinder, great buildings of stone jutting out of the ground and twisting towards the ceiling.",
+			"A loud hymn is being chanted in an unknown language and seems to shake the very ground itself.",
+			"A mellow blue light comes from thousands of resplendent crystals lining the wall and mingles with the inviting yellow glow from a distant golden fortress.",
+            "Distant chattering can be heard coming from the city.",
+            "A distant forge emits Phoron gas from a tower atop its lofty form, as worker drones collect lilac stained glass from within.",
+			"A group of Vaurca warriors move through the streets below seemingly practicing for some task unknown."
+			)
+
+
 		if("Titan Prime")
 			light_color = "#418144"
+			possible_messages = list(
+			"An imposing vessel of steel emits a soft glow as it travels through the starry sky aimlessly.",
+			"The engines of the towering vessel above emit a soft glow, accompanied by a brief smell of a warm ocean breeze.",
+			"A green light flickers from the steel vessel above bathing the surrounding idyllic landscape in its majesty.",
+            "You see the gas giant Sedantis dominating a starry sky, an imposing vessel of steel blotting out but a small portion of it."
+			)
 
 		else
 			brightness = 0
@@ -50,48 +92,16 @@
 		add_overlay(overlay)
 
 /obj/item/skrell_projector/vaurca_projector/process()
-	if(!selected_world)
+	if(!selected_world || !possible_messages)
 		return
 
 	if(prob(message_frequency))
-		var/hologram_message
-		switch(selected_world)
+		if(first_message)
+			hologram_message = possible_messages[1]
+			first_message = FALSE
 
-			if("Ocean")
-				hologram_message = pick("You see a golden fortress floating majestically above an ocean of sapphire.",
-										"A euphoric smell of the ocean fills your senses as the water gently ebbs and flows.",
-										"You hear the faint humming of a hymn as a gentle wave envelops the viewfinder.",
-                                        "You can hear a quiet celestial chanting the source of which feels just beyond sight.",
-                                        "The turquoise water emits a jubilant smell of freshly cut lemons which lasts for only for a moment.",
-                                        "You see the gas giant Sedantis dominating a starry sky.")
-			if("Hive War Exhibition")
-				hologram_message = pick("You see a carefully crafted exhibition detailing the Great Hive War. It explains in brief the details of the event through paintings and dioramas.",
-										"You smell burning and rusted metal. An exhibition showcases the Battle of a Thousand Titans.",
-										"You see a  memorial to the lives lost, a sad hymn flowing in the background.")
-
-			if("Celestial Landing Ground")
-				hologram_message = pick("An awe inspiring fortress of gold dominates the landscape and bathes the surrounding area in yellow luminescence.",
-										"A loud hymn is chanted in an unknown language accompanied by a smell of morning dew in the countryside.",
-										"Unbound workers moving through the realm stop to gaze up in awe at the distant structure before returning to previous activities.",
-                                        "Distant chattering can be heard coming from the fortress including what sounds almost like jovial laughter.",
-                                        "The turquoise water emits a jubilant smell of freshly cut lemons which lasts for only for a moment.",
-                                        "You see the gas giant Sedantis dominating a starry sky.",
-										"For a moment the Golden Fortress towering above starts to glimmer majestically, catching the light from the imposing gas giant in the sky.")
-
-			if("City of New Sedantis")
-				hologram_message = pick("A towering cavernous city takes up the viewfinder, great buildings of stone jutting out of the ground and twisting towards the ceiling.",
-										"A loud hymn is being chanted in an unknown language and seems to shake the very ground itself.",
-										"A mellow blue light comes from thousands of resplendent crystals lining the wall and mingles with the inviting yellow glow from a distant golden fortress.",
-                                        "Distant chattering can be heard coming from the city.",
-                                        "A distant forge emits Phoron gas from a tower atop its lofty form, as worker drones collect lilac stained glass from within.",
-										"A group of Vaurca warriors move through the streets below seemingly practicing for some task unknown.")
-
-			if("Titan Prime")
-				hologram_message = pick("An imposing vessel of steel emits a soft glow as it travels through the starry sky aimlessly.",
-										"The engines of the towering vessel above emit a soft glow, accompanied by a brief smell of a warm ocean breeze.",
-										"A green light flickers from the steel vessel above bathing the surrounding idyllic landscape in its majesty.",
-                                        "You see the gas giant Sedantis dominating a starry sky, an imposing vessel of steel blotting out but a small portion of it.")
-
+		else
+			hologram_message = pick(possible_messages)
 
 		if(hologram_message)
 			visible_message("<span class='notice'>[hologram_message]</span>")

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -1,6 +1,6 @@
 /obj/item/skrell_projector/vaurca_projector
 	name = "virtual reality looking glass"
-	desc = "A holographic projector using advanced technology that immerses someone into a scene using full panoramic holograms, smell and 3D spatial sound projection. It is developed and distributed by Hive Zo'ra and allows the viewer to peer in real-time into virtual reality realms specifically designed for outside viewing such as those belonging to High Queen Vaur or Queen Athvur."
+	desc = "A holographic projector using advanced technology that immerses someone into a scene using full panoramic holograms, smell and 3D spatial sound projection. It is developed and distributed by the Zo'ra Hive and allows the viewer to peer in real-time into virtual reality realms specifically designed for outside viewing such as those belonging to High Queen Vaur or Queen Athvur."
 	icon = 'icons/obj/vaurca_items.dmi'
 	icon_state = "zora_projector"
 	worlds_selection = list("Vaur's Tranquil Ocean", "Vaur's Hive War Exhibition", "Vaur's Celestial Landing Ground", "Vaur's City of New Sedantis", "Vaur's Titan Prime Recreation", "Athvur's City of Paradise", "Athvur's Garden of Splendour", "Athvur's Museum of Fine Art")

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -84,10 +84,9 @@
 		"An enchanting smell of cedar, cherry and morning freshness penetrates through the air.",
 		"A vibrant burst of color permeates through the sky, basking the air in pleasing rainbow luminescence for a moment.", 
 		"In the center of a green park Vaurca workers paint not on canvas but in the air, seemingly looking at the landscape for inspiration."
-
 		)
 		if("Athvur's Garden of Splendour")
-			light_color = "#34b434"
+			light_color = "#3adf3a"
 			possible_messages = list( 
 		"A tranquil garden landscape stretches out to the horizon, its peaceful scenery embellished with flowers of every variety.",
 		"Harmonious music accents an indescribable aroma of flowers.",

--- a/code/game/objects/items/vaurca.dm
+++ b/code/game/objects/items/vaurca.dm
@@ -3,7 +3,7 @@
 	desc = "A holographic projector using advanced technology that immerses someone into a scene using full panoramic holograms, smell and 3D spatial sound projection. It is developed and distributed by Hive Zo'ra and allows the viewer to peer in real-time into virtual reality realms specifically designed for outside viewing such as those belonging to High Queen Vaur."
 	icon = 'icons/obj/vaurca_items.dmi'
 	icon_state = "zora_projector"
-	worlds_selection = list("Ocean", "Hive War Exhibition", "Celestial Landing Ground", "City of New Sedantis", "Titan Prime")
+	worlds_selection = list("Vaur's Tranquil Ocean", "Vaur's Hive War Exhibition", "Vaur's Celestial Landing Ground", "Vaur's City of New Sedantis", "Vaur's Titan Prime Recreation", "Athvur's City of Paradise", "Athvur's Garden of Splendour")
 	message_frequency = 10
 	var/hologram_message
 	var/possible_messages
@@ -29,7 +29,7 @@
 	if(choice)
 		selected_world = choice
 	switch(choice)
-		if("Ocean")
+		if("Vaur's Tranquil Ocean")
 			light_color = "#1122c2"
 			possible_messages = list(
 			"You see a golden fortress floating majestically above an ocean of sapphire.",
@@ -39,14 +39,14 @@
             "The turquoise water emits a jubilant smell of freshly cut lemons which lasts for only for a moment.",
             "You see the gas giant Sedantis dominating a starry sky."
 			)
-		if("Hive War Exhibition")
+		if("Vaur's Hive War Exhibition")
 			light_color = "#83290b"
 			possible_messages = list(
 			"You see a carefully crafted exhibition detailing the Great Hive War. It explains in brief the details of the event through paintings and dioramas.",
 			"You smell burning and rusted metal. An exhibition showcases the Battle of a Thousand Titans.",
 			"You see a  memorial to the lives lost, a sad hymn flowing in the background."
 			)
-		if("Celestial Landing Ground")
+		if("Vaur's Celestial Landing Ground")
 			light_color = "#f5e61d"
 			possible_messages = list(
 			"An awe inspiring fortress of gold dominates the landscape and bathes the surrounding area in yellow luminescence.",
@@ -57,7 +57,7 @@
             "You see the gas giant Sedantis dominating a starry sky.",
 			"For a moment the Golden Fortress towering above starts to glimmer majestically, catching the light from the imposing gas giant in the sky."
 			)
-		if("City of New Sedantis")
+		if("Vaur's City of New Sedantis")
 			light_color = "#1395c9"
 			possible_messages = list(
 			"A towering cavernous city takes up the viewfinder, great buildings of stone jutting out of the ground and twisting towards the ceiling.",
@@ -67,9 +67,7 @@
             "A distant forge emits Phoron gas from a tower atop its lofty form, as worker drones collect lilac stained glass from within.",
 			"A group of Vaurca warriors move through the streets below seemingly practicing for some task unknown."
 			)
-
-
-		if("Titan Prime")
+		if("Vaur's Titan Prime Recreation")
 			light_color = "#418144"
 			possible_messages = list(
 			"An imposing vessel of steel emits a soft glow as it travels through the starry sky aimlessly.",
@@ -77,7 +75,22 @@
 			"A green light flickers from the steel vessel above bathing the surrounding idyllic landscape in its majesty.",
             "You see the gas giant Sedantis dominating a starry sky, an imposing vessel of steel blotting out but a small portion of it."
 			)
-
+		if("Athvur's City of Paradise")
+		light_color = "#eff3ef"
+		possible_messages = list(
+		"A transcendent cityscape dominates the area, with towering structures of elegant stone sitting atop a blanket of clouds.",
+		"In the distance of the cityscape towers a set of sublime sculptures, accented by light from beneath the clouds.",
+		"Orchestral music resonates from within an auditorium, the melody carried through the heavens.",
+		"An enchanting smell of cedar, cherry and morning freshness penetrates through the air."
+		)
+		if("Athvur's Garden of Splendour")
+		light_color = "#34b434"
+		possible_messages = list( 
+		"A tranquil garden landscape stretches out to the horizon, its peaceful scenery embellished with flowers of every variety.",
+		"Harmonious music accents an indescribable aroma of flowers.",
+		"In the distance of the garden, beyond the soothing plants, workers move through an ornate gazebo.",
+		"A fountain sits nestled within a thicket clearing, producing a golden substance from which gathered workers drink.",
+		)
 		else
 			brightness = 0
 			working = FALSE

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Connorjg1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Added two new Vaurca projector locations."
+  - tweak: "The Vaurca projector now plays the first location in a list first."


### PR DESCRIPTION
The Vaurca projector has three new realms in fitting with Athvur's style. 
The Vaurca projector now display's the first line in a list first. Now the first time a realm is turned on it will always set the scene.

Vaurca lore approved. Big thanks to Lewis for the assistance with the new projector code. 