### PR TITLE
Resealable Plastic Bags for the Loadout and Kitchen

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -1688,6 +1688,7 @@
 #include "code\modules\compass\compass_holder.dm"
 #include "code\modules\compass\compass_waypoint.dm"
 #include "code\modules\compass\~compass.dm"
+#include "code\modules\cooking\plasticbag.dm"
 #include "code\modules\cooking\trays.dm"
 #include "code\modules\cooking\machinery\gibber.dm"
 #include "code\modules\cooking\machinery\icecream.dm"

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -921,6 +921,7 @@
 		/obj/item/reagent_containers/ladle = 4,
 		/obj/item/storage/toolbox/lunchbox/nt = 6,
 		/obj/item/reagent_containers/glass/rag = 8,
+		/obj/item/evidencebag/plasticbag = 6,
 		/obj/item/tray = 12,
 	)
 	contraband = list(

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -156,6 +156,10 @@
 	path = /obj/item/clothing/accessory/buddytag
 	cost = 2
 
+/datum/gear/utility/plasticbag
+	display_name = "resealable plastic bag"
+	path = /obj/item/evidencebag/plasticbag
+
 /datum/gear/utility/buddy_tag/New()
 	..()
 	gear_tweaks += new /datum/gear_tweak/buddy_tag_config()

--- a/code/modules/cooking/plasticbag.dm
+++ b/code/modules/cooking/plasticbag.dm
@@ -1,0 +1,32 @@
+/obj/item/evidencebag/plasticbag
+	name = "resealable plastic bag"
+	desc = "An Idris Quiklok plastic bag."
+
+/obj/item/evidencebag/plasticbag/attack_self(mob/user as mob)
+	if(contents.len)
+		var/obj/item/I = contents[1]
+		user.visible_message("<b>[user]</b> takes \the [I] out of \the [src].", SPAN_NOTICE("You take \the [I] out of \the [src]."),\
+		"You hear someone rustle around in a plastic bag, and remove something.")
+		cut_overlays()	//remove the overlays
+
+		user.put_in_hands(I)
+		stored_item = null
+
+		w_class = initial(w_class)
+		icon_state = "evidenceobj"
+		desc = "An empty Idris Quicklok plastic bag."
+	else
+		to_chat(user, "[src] is empty.")
+		icon_state = "evidenceobj"
+	return
+
+/obj/item/storage/box/plasticbag
+	name = "resealable plastic bag box"
+	desc = "A box advertising its dazzling contents. Six resealable Idris Incorporated brand Quiklok bags!"
+	illustration = "evidence"
+	storage_slots = 6
+
+/obj/item/storage/box/plasticbag/fill()
+	..()
+	for(var/i=0;i<storage_slots,i++)
+		new /obj/item/evidencebag/plasticbag(src)

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -48,7 +48,7 @@
 		return
 
 	if(istype(I, /obj/item/evidencebag))
-		to_chat(user, "<span class='notice'>You find putting an evidence bag in another evidence bag to be slightly absurd.</span>")
+		to_chat(user, "<span class='notice'>You find putting a plastic bag in another plastic bag to be slightly absurd and think better of it.</span>")
 		return
 
 	if(I.w_class > 3)
@@ -71,7 +71,7 @@
 	MA.layer = FLOAT_LAYER
 	add_overlay(list(MA, "evidence"))
 
-	desc = "An evidence bag containing [I]."
+	desc = "A plastic bag containing [I]."
 	I.forceMove(src)
 	stored_item = I
 	w_class = I.w_class

--- a/html/changelogs/wickedcybs_plasticbag.yml
+++ b/html/changelogs/wickedcybs_plasticbag.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - rscadd: "Makes an evidence bag variant called 'resealable plastic bag' and adds some to the kitchen and loadout. Now you too, can store your sandwich properly."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -24430,12 +24430,8 @@
 /obj/structure/table/stone/marble,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/item/storage/box/plasticbag{
-	pixel_x = 6;
+	pixel_x = 5;
 	pixel_y = 9
-	},
-/obj/item/storage/box/plasticbag{
-	pixel_x = 6;
-	pixel_y = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/horizon/kitchen)

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -24429,6 +24429,14 @@
 "njB" = (
 /obj/structure/table/stone/marble,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/storage/box/plasticbag{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/storage/box/plasticbag{
+	pixel_x = 6;
+	pixel_y = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/horizon/kitchen)
 "njF" = (


### PR DESCRIPTION
The Anti-Security council allows the masses to enjoy a mechanic previously monopolized by the Security department.

That would be, resealable plastic bags. The kitchen gets two boxes of them and you can get one in the loadout. They're basically just renamed evidence bags, but those could be used for the same purpose anyway. Enjoy roleplaying putting your sandwich inside it or something.

![image](https://user-images.githubusercontent.com/52309324/185035566-b5938a37-fe0f-4295-b876-34cb2f9cdc55.png)
