### PR TITLE
Organ Damage Threshold Fix

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -54,11 +54,6 @@
 		args[1] = TRUE
 		SSatoms.InitAtom(src, args)
 
-	if(max_damage)
-		min_broken_damage = Floor(max_damage / 2)
-	else
-		max_damage = min_broken_damage * 2
-
 /obj/item/organ/Destroy()
 	STOP_PROCESSING(SSprocessing, src)
 	if(!owner)

--- a/html/changelogs/wezzy_organfix.yml
+++ b/html/changelogs/wezzy_organfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Wowzewow (Wezzy)
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes damage thresholds for organs."


### PR DESCRIPTION
This was all supposed to be handled by the set_max_damage() proc, but this loose bit of code overwrote it making it completely useless.

Hence, all organs would "break" on 50% damage, when it was supposed to be 75% or something else, skipping all the proper gradient of ailments and made you collapse almost immediately.

Now people should probably keel over and die more realistically of organ failiure instead of immediately dying on the spot.