### PR TITLE
Allows Officer and Warden access to Evidence Storage

### DIFF
--- a/html/changelogs/evidenceacces.yml
+++ b/html/changelogs/evidenceacces.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - tweak: "Security Officers and the Warden can now access Evidence Storage."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -20591,7 +20591,7 @@
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
 	req_access = null;
-	req_one_access = list(4,68)
+	req_one_access = list(2,4,68)
 	},
 /obj/structure/plasticflaps/airtight,
 /obj/machinery/door/firedoor,


### PR DESCRIPTION
Title. Uses Brig access rather than Security because that means Cadets are still locked out, which I believe is how it was on the Aurora too.
