### PR TITLE
fixes autakh graspers being undeployable

### DIFF
--- a/code/modules/organs/subtypes/autakh.dm
+++ b/code/modules/organs/subtypes/autakh.dm
@@ -283,8 +283,6 @@
 
 		owner.last_special = world.time + 100
 		var/obj/item/M = new augment_type(owner)
-		M.canremove = FALSE
-		M.item_flags |= NOMOVE
 		owner.put_in_active_hand(M)
 		owner.visible_message("<span class='notice'>\The [M] slides out of \the [owner]'s [src].</span>","<span class='notice'>You deploy \the [M]!</span>")
 

--- a/html/changelogs/anconfuzedrock-autakhfix.yml
+++ b/html/changelogs/anconfuzedrock-autakhfix.yml
@@ -1,0 +1,6 @@
+author: anconfuzedrock
+
+delete-after: True
+
+changes:
+  - bugfix: "Autakh graspers can be deployed properly again."


### PR DESCRIPTION
Apparently the PR that gave the autakh graspers these flags didn't test the effects of it. The Aut'akh graspers work differently from normal tool mods and so #14266 made them incapable of being properly extended. They retract properly when dropped, too.

Fixes #14632