### PR TITLE
No more SCC Shipyard

### DIFF
--- a/html/changelogs/dansemacabre-noshipyards.yml
+++ b/html/changelogs/dansemacabre-noshipyards.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheDanseMacabre
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Due to some confusion around the existence of an "SCC Shipyard", the Horizon dock location has been renamed to the much more bureaucratic and unimportant "SCC Sector Liaison Facility"."

--- a/html/changelogs/dansemacabre-noshipyards.yml
+++ b/html/changelogs/dansemacabre-noshipyards.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Due to some confusion around the existence of an "SCC Shipyard", the Horizon dock location has been renamed to the much more bureaucratic and unimportant "SCC Sector Liaison Facility"."
+  - tweak: "Due to some confusion around the existence of an SCC Shipyard, the Horizon dock location has been renamed to the much more bureaucratic and unimportant SCC Sector Liaison Post."

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -23,8 +23,8 @@
 
 	station_name = "SCCV Horizon"
 	station_short = "Horizon"
-	dock_name = "SCC Sector Liaison Facility"
-	dock_short = "Sector Liaison Facility"
+	dock_name = "SCC Sector Liaison Post"
+	dock_short = "Sector Liaison Post"
 	boss_name = "Stellar Corporate Conglomerate"
 	boss_short = "SCC"
 	company_name = "Stellar Corporate Conglomerate"

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -23,8 +23,8 @@
 
 	station_name = "SCCV Horizon"
 	station_short = "Horizon"
-	dock_name = "SCC Shipyard"
-	dock_short = "Shipyard"
+	dock_name = "SCC Sector Liaison Facility"
+	dock_short = "Sector Liaison Facility"
 	boss_name = "Stellar Corporate Conglomerate"
 	boss_short = "SCC"
 	company_name = "Stellar Corporate Conglomerate"


### PR DESCRIPTION
Because some people seem to think the "SCC Shipyard" is a real place and not a gameplay contrivance, the Horizon's dock location has been renamed to the SCC Sector Liaison Post, which is much less impressive.