### PR TITLE
Adds mechanical trait functionality based on character origins

### DIFF
--- a/code/__defines/origin.dm
+++ b/code/__defines/origin.dm
@@ -1,0 +1,3 @@
+// A set of constants used to determine which origin quirks to apply to characters.
+#define ORIGIN_TRAIT_IGNORE_CAPSAICIN 1
+#define ORIGIN_TRAIT_ALCOHOL_RESISTANCE 2

--- a/code/modules/background/origins/_origins.dm
+++ b/code/modules/background/origins/_origins.dm
@@ -2,6 +2,7 @@
     var/name = "generic origin item"
     var/desc = "You shouldn't be seeing this."
     var/important_information //Big red text. Should only be used if not following it would incur a bwoink.
+    var/origin_traits
 
 /decl/origin_item/culture
     name = "generic culture"
@@ -14,3 +15,5 @@
     var/list/datum/accent/possible_accents = list()
     var/list/datum/citizenship/possible_citizenships = list()
     var/list/datum/religion/possible_religions = list()
+
+/decl/origin_item/proc/on_apply(var/mob/living/carbon/human/H)

--- a/code/modules/background/origins/origins/human/coalition.dm
+++ b/code/modules/background/origins/origins/human/coalition.dm
@@ -54,12 +54,18 @@
 	possible_citizenships = list(CITIZENSHIP_COALITION)
 	possible_religions = list(RELIGION_NONE, RELIGION_CHRISTIANITY, RELIGION_ISLAM, RELIGION_BUDDHISM, RELIGION_HINDU, RELIGION_TAOISM, RELIGION_JUDAISM, RELIGION_OTHER)
 
+/decl/origin_item/origin/gadpathur/on_apply(var/mob/living/carbon/human/H)
+  H.AddComponent(/datum/component/armor, list(rad = ARMOR_RAD_MINOR))
+
 /decl/origin_item/origin/gadpathur_exile
 	name = "Gadpathurian Exile"
 	desc = "As an exile from Gadpathur you are, above all other things, a failure. A failure to meet the standards of Gadpathurian society found unworthy of defending it from the Solarian imperialists. You are a weakness that the planet and its people cannot afford to keep around, lest you compromise its defense. Stripped over everything that makes you Gadpathurian and cast aside to the Republic of Biesel or Coalition of Colonies, it is now up to you -- and you alone -- to make something of yourself despite your status as a failure. The one certainty is that your home will not take you back, no matter what you do."
 	possible_accents = list(ACCENT_GADPATHUR)
 	possible_citizenships = list(CITIZENSHIP_COALITION, CITIZENSHIP_BIESEL)
 	possible_religions = RELIGIONS_COALITION
+
+/decl/origin_item/origin/gadpathur_exile/on_apply(var/mob/living/carbon/human/H)
+  H.AddComponent(/datum/component/armor, list(rad = ARMOR_RAD_MINOR))
 
 /decl/origin_item/origin/assunzione
 	name = "Republic of Assunzione"

--- a/code/modules/background/origins/origins/human/elyra.dm
+++ b/code/modules/background/origins/origins/human/elyra.dm
@@ -40,6 +40,7 @@
 	possible_accents = list(ACCENT_AEMAQ)
 	possible_citizenships = list(CITIZENSHIP_ELYRA)
 	possible_religions = RELIGIONS_ELYRA
+	origin_traits = ORIGIN_TRAIT_IGNORE_CAPSAICIN
 
 /decl/origin_item/origin/new_suez
 	name = "New Suez"

--- a/code/modules/background/origins/origins/human/sol.dm
+++ b/code/modules/background/origins/origins/human/sol.dm
@@ -95,6 +95,7 @@
 	possible_accents = list(ACCENT_PHONG)
 	possible_citizenships = list(CITIZENSHIP_SOL, CITIZENSHIP_BIESEL, CITIZENSHIP_COALITION)
 	possible_religions = RELIGIONS_SOLARIAN
+	origin_traits = ORIGIN_TRAIT_IGNORE_CAPSAICIN
 
 /decl/origin_item/origin/silversun
 	name = "Silversun"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -464,6 +464,7 @@ datum/preferences
 	character.religion = religion
 	character.accent = accent
 	character.origin = decls_repository.get_decl(text2path(origin))
+	character.origin.on_apply(character)
 	character.culture = decls_repository.get_decl(text2path(culture))
 
 	character.skills = skills

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -768,6 +768,8 @@
 	M.adjustToxLoss(0.5 * removed)
 
 /decl/reagent/capsaicin/initial_effect(var/mob/living/carbon/M, var/alien)
+	if(M.species.origin_traits & ORIGIN_TRAIT_IGNORE_CAPSAICIN)
+		return
 	to_chat(M, discomfort_message)
 
 /decl/reagent/capsaicin/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
@@ -778,6 +780,9 @@
 
 	if(M.chem_doses[type] >= agony_dose && prob(5))
 		to_chat(M, discomfort_message)
+		if(M.species.origin_traits & ORIGIN_TRAIT_IGNORE_CAPSAICIN)
+			return
+
 		M.visible_message("<b>[M]</b> [pick("dry heaves!", "coughs!", "splutters!")]")
 		M.apply_effect(agony_amount, PAIN, 0)
 
@@ -839,7 +844,7 @@
 		if (!mouth_covered && (eyes_covered & EYES_PROTECTED))
 			message = "<span class='warning'>Your [eye_protection] protects your eyes from the pepperspray!</span>"
 		else if (eyes_covered & EYES_MECH)
-			message = "<span class='warning'>Your mechanical eyes are invulnurable to pepperspray!</span>"
+			message = "<span class='warning'>Your mechanical eyes are invulnerable to pepperspray!</span>"
 	else
 		message = "<span class='warning'>The pepperspray gets in your eyes!</span>"
 		if(mouth_covered)


### PR DESCRIPTION
See title. For now, this is only going in for any human origins I can think of that can/should get little flavourful quirks.

These are intended to be very minor and serve as flavour rather than truly impactful mechanical advantages -- nothing on the level of a species or subspecies positive or negative, for instance. Examples include things like Gadpathurians getting a very minor boost to their radiation resistance, Hai Phongers ignoring the spicy food pain messages and spluttering/coughing, and stuff along those lines.

**This is all still a WIP** but should not be too arduous to see to completion. Gaddie rad resistance is already working, for instance.