### PR TITLE
Minor Casino Ship Fixes

### DIFF
--- a/html/changelogs/wickedcybs_tilefix.yml
+++ b/html/changelogs/wickedcybs_tilefix.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - bugfix: "The casino ship away site had some improper tiles, missing fire shutters and misaligned air alarms that were fixed."

--- a/maps/away/ships/casino/casino.dmm
+++ b/maps/away/ships/casino/casino.dmm
@@ -2160,6 +2160,7 @@
 /area/casino/casino_mainfloor)
 "gs" = (
 /obj/structure/table/stone/marble,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/casino/casino_mainfloor)
 "gt" = (
@@ -3275,6 +3276,7 @@
 /obj/machinery/vending/boozeomat{
 	req_access = list()
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/casino/casino_mainfloor)
 "ju" = (
@@ -3383,6 +3385,7 @@
 "jH" = (
 /obj/item/material/ashtray/bronze,
 /obj/structure/table/stone/marble,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/casino/casino_mainfloor)
 "jJ" = (
@@ -3468,7 +3471,8 @@
 "jT" = (
 /obj/random/coin,
 /obj/structure/table/stone/marble,
-/turf/simulated/floor/tiled/steel,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
 /area/casino/casino_mainfloor)
 "jU" = (
 /obj/item/trash/plate,
@@ -3555,6 +3559,7 @@
 "kh" = (
 /obj/item/reagent_containers/food/drinks/bottle/cognac,
 /obj/structure/table/stone/marble,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/casino/casino_mainfloor)
 "ki" = (
@@ -3619,6 +3624,7 @@
 "ko" = (
 /obj/item/reagent_containers/food/drinks/h_chocolate,
 /obj/structure/table/stone/marble,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel,
 /area/casino/casino_mainfloor)
 "kq" = (
@@ -3630,6 +3636,7 @@
 "kr" = (
 /obj/random/loot,
 /obj/structure/table/stone/marble,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/casino/casino_mainfloor)
 "ks" = (
@@ -4355,6 +4362,7 @@
 "mr" = (
 /obj/structure/table/stone/marble,
 /obj/item/flame/lighter/random,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/casino/casino_mainfloor)
 "mt" = (
@@ -5567,7 +5575,7 @@
 "Qe" = (
 /obj/structure/bed/stool/chair/shuttle,
 /obj/machinery/alarm{
-	pixel_y = 25
+	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/casino_cutter)


### PR DESCRIPTION
The casino ship away site had some improper tiles, missing fire shutters and misaligned air alarms. I've corrected that, as it was an oversight.