### PR TITLE
Fixes security front door access applying deeper into the department

### DIFF
--- a/html/changelogs/omicega-fdsfdsrfereiotetd.yml
+++ b/html/changelogs/omicega-fdsfdsrfereiotetd.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes some erronous access requirements in the security department."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -30634,7 +30634,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
 "qlV" = (
-/obj/machinery/door/airlock/glass_security,
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Desk";
+	req_access = list(1)
+	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -9192,7 +9192,7 @@
 /obj/machinery/door/airlock/glass_security{
 	id_tag = null;
 	name = "Armory Entrance";
-	req_access = list(63)
+	req_access = list(1)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
@@ -37814,7 +37814,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Security Equipment Room";
-	req_access = list(63)
+	req_access = list(1)
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)


### PR DESCRIPTION
See title. The access code for security's front doors, given to janitorial and first responders for ease of access, was also applying to the equipment room door and the armoury entrance door. I replaced the access for these with regular security access checks.

Also, the front office door for security had no access check at all, despite being somewhere where equipment is regularly left lying around to charge behind the desk, et cetera. That's been fixed too.