### PR TITLE
SecHUD QoL Things

### DIFF
--- a/code/defines/procs/hud.dm
+++ b/code/defines/procs/hud.dm
@@ -92,12 +92,9 @@ mob/proc/in_view(var/turf/T)
 
 proc/get_sec_hud_icon(var/mob/living/carbon/human/H)//This function is called from human/life,dm, ~line 1663
 	var/state
-	if(H.wear_id)
-		var/obj/item/card/id/I = H.wear_id.GetID()
-		if(I)
-			state = "hud[ckey(I.GetJobName())]"
-		else
-			state = "hudunknown"
+	var/obj/item/card/id/I = H.GetIdCard()
+	if(I)
+		state = "hud[ckey(I.GetJobName())]"
 	else
 		state = "hudunknown"
 

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -182,7 +182,7 @@
 	faction = "Station"
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "the service managaer"
+	supervisors = "the executive officer"
 	selection_color = "#90524b"
 
 	minimum_character_age = list(
@@ -418,7 +418,7 @@
 	faction = "Station"
 	total_positions = 3
 	spawn_positions = 3
-	supervisors = "the supply manager"
+	supervisors = "the operations manager"
 	selection_color = "#7B431C"
 
 	minimum_character_age = list(
@@ -458,7 +458,7 @@
 	faction = "Station"
 	total_positions = 3
 	spawn_positions = 3
-	supervisors = "the supply manager"
+	supervisors = "the operations manager"
 	selection_color = "#7B431C"
 	economic_modifier = 5
 
@@ -510,7 +510,7 @@
 	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
-	supervisors = "operations manager"
+	supervisors = "the operations manager"
 	selection_color = "#7B431C"
 	economic_modifier = 5
 

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -135,7 +135,7 @@
 
 /datum/outfit/job/doctor/surgeon
 	name = "Surgeon"
-	jobtype = /datum/job/doctor
+	jobtype = /datum/job/surgeon
 
 	uniform = /obj/item/clothing/under/rank/medical/surgeon
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/nt

--- a/code/game/jobs/job/ship_crew.dm
+++ b/code/game/jobs/job/ship_crew.dm
@@ -45,11 +45,15 @@
 	blacklisted_species = list(SPECIES_VAURCA_BREEDER)
 
 /datum/outfit/job/visitor
-	name = "Visitor"
+	name = "Off-Duty Crew Member"
 	jobtype = /datum/job/visitor
 
 	uniform = /obj/item/clothing/under/color/black
 	shoes = /obj/item/clothing/shoes/black
+
+/datum/outfit/job/visitor/passenger
+	name = "Passenger"
+	jobtype = /datum/job/passenger
 
 /datum/job/passenger
 	title = "Passenger"
@@ -64,6 +68,6 @@
 	economic_modifier = 1
 	access = list()
 	minimal_access = list()
-	outfit = /datum/outfit/job/visitor
+	outfit = /datum/outfit/job/visitor/passenger
 	blacklisted_species = null
 	blacklisted_species = list(SPECIES_VAURCA_BREEDER)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -131,6 +131,11 @@ var/const/NO_EMAG_ACT = -50
 	if (..(user, 1))
 		show(user)
 
+/obj/item/card/id/on_slotmove(var/mob/living/user, slot)
+	. = ..(user, slot)
+	BITSET(user.hud_updateflag, ID_HUD) //Update ID HUD if an ID is ever moved
+
+
 /obj/item/card/id/proc/prevent_tracking()
 	return 0
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -21,6 +21,11 @@ var/mob/living/next_point_time = 0
 	if(.)
 		visible_message("<b>\The [src]</b> points to \the [A].")
 
+/mob/living/drop_from_inventory(var/obj/item/W, var/atom/target)
+	. = ..(W, target)
+	if(istype(W, /obj/item/card/id) || istype(W, /obj/item/modular_computer))
+		BITSET(hud_updateflag, ID_HUD) //If we drop our ID, update ID HUD
+
 /*one proc, four uses
 swapping: if it's 1, the mobs are trying to switch, if 0, non-passive is pushing passive
 default behaviour is:

--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -492,3 +492,7 @@
 	silent = !silent
 	for (var/datum/computer_file/program/P in hard_drive.stored_files)
 		P.event_silentmode()
+
+/obj/item/modular_computer/on_slotmove(var/mob/living/user, slot)
+	. = ..(user, slot)
+	BITSET(user.hud_updateflag, ID_HUD) //Same reasoning as for IDs

--- a/html/changelogs/HUDandRankFixes.yml
+++ b/html/changelogs/HUDandRankFixes.yml
@@ -1,0 +1,7 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - tweak: "All roles should now use the correct security HUD icon."
+  - tweak: "Security HUDs now read IDs in the same manner as airlocks."


### PR DESCRIPTION
Adds a unique rank for both Surgeon and Passenger, who previously used the Physician and Visitor ("Off-Duty") ranks, so used their ID icons.

Changes get_sec_hud_icon to use GetIdCard like airlocks, so IDs in hand or on a wrist slot are recognised.

