### PR TITLE
New away site safes.

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1262,8 +1262,8 @@
 
 /obj/random/highvalue/cash
 	problist = list(
-	/obj/item/storage/secure/briefcase/money = 1
-	/obj/item/stack/material/phoron/full = 0.1,
+	/obj/item/storage/secure/briefcase/money = 1,
+	/obj/item/stack/material/phoron/full = 0.1
 	)
 
 /obj/random/junk

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1260,6 +1260,12 @@
 		/obj/item/storage/secure/briefcase/money = 0.1
 		)
 
+/obj/random/highvalue/cash
+	problist = list(
+	/obj/item/storage/secure/briefcase/money = 1
+	/obj/item/stack/material/phoron/full = 0.1,
+	)
+
 /obj/random/junk
 	name = "random trash"
 	desc = "This is toss."

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1236,7 +1236,7 @@
 		/obj/item/gun/projectile/automatic/terminator = 0.5,
 		/obj/item/rig/military = 0.5,
 		/obj/item/rig/unathi/fancy = 0.5,
-		/obj/item/rig/vaurca/minimal = 0.5,
+		/obj/item/rig/vaurca = 0.5,
 		/obj/item/anomaly_core = 0.5,
 		/obj/item/reagent_containers/food/drinks/bottle/vintage_wine = 0.1
 	)
@@ -1250,6 +1250,7 @@
 		/obj/item/anomaly_core = 0.5,
 		/obj/item/rig/military = 0.2,
 		/obj/item/rig/unathi/fancy = 0.2,
+		/obj/item/rig/vaurca = 0.2,
 		/obj/item/stack/material/phoron/full = 0.1,
 		/obj/item/stack/material/plasteel/full = 0.8,
 		/obj/random/voidsuit = 1,

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -288,7 +288,6 @@ FLOOR SAFES
 	new /obj/random/highvalue(src)
 	new /obj/random/highvalue(src)
 
-
 /obj/structure/safe/cash 
 	name = "credit safe"
 

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -287,3 +287,23 @@ FLOOR SAFES
 	new /obj/random/highvalue(src)
 	new /obj/random/highvalue(src)
 	new /obj/random/highvalue(src)
+
+
+/obj/structure/safe/cash 
+	name = "credit safe"
+
+/obj/structure/safe/cash/Initialize()
+	. = ..()
+	new /obj/random/highvalue/cash
+	new /obj/random/highvalue/cash
+	new /obj/random/highvalue/cash
+
+/obj/structure/safe/highvalue
+	name = "valuables safe"
+
+/obj/structure/safe/highvalue/Initialize()
+	. = ..()
+	new /obj/random/highvalue/no_weapon
+	new /obj/random/highvalue/no_weapon
+	new /obj/random/highvalue/no_weapon
+	new /obj/random/highvalue/no_weapon

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -293,16 +293,16 @@ FLOOR SAFES
 
 /obj/structure/safe/cash/Initialize()
 	. = ..()
-	new /obj/random/highvalue/cash
-	new /obj/random/highvalue/cash
-	new /obj/random/highvalue/cash
+	new /obj/random/highvalue/cash(src)
+	new /obj/random/highvalue/cash(src)
+	new /obj/random/highvalue/cash(src)
 
 /obj/structure/safe/highvalue
 	name = "valuables safe"
 
 /obj/structure/safe/highvalue/Initialize()
 	. = ..()
-	new /obj/random/highvalue/no_weapon
-	new /obj/random/highvalue/no_weapon
-	new /obj/random/highvalue/no_weapon
-	new /obj/random/highvalue/no_weapon
+	new /obj/random/highvalue/no_weapon(src)
+	new /obj/random/highvalue/no_weapon(src)
+	new /obj/random/highvalue/no_weapon(src)
+	new /obj/random/highvalue/no_weapon(src)

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -38,6 +38,6 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Adds two new types of safe, which have been spread through the away-sites replacing the empty ones."
+  - rscadd: "Adds two new types of safe, which have been spread through the away-sites replacing the empty ones. Also allows the non-minimal version of the Vaurca hardsuit to spawn."
   - bugfix: "Fixes the airlock on the Yacht not working."
   

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Connorjg1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds two new types of safe, which have been spread through the away-sites replacing the empty ones."
+  

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -39,4 +39,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Adds two new types of safe, which have been spread through the away-sites replacing the empty ones."
+  - bugfix: "Fixes the airlock on the Yacht not working."
   

--- a/maps/away/generic/hivebot_hub.dmm
+++ b/maps/away/generic/hivebot_hub.dmm
@@ -387,8 +387,8 @@
 /area/derelict)
 "aN" = (
 /obj/item/paper,
-/obj/structure/safe,
 /obj/random/handgun,
+/obj/structure/safe/cash,
 /turf/simulated/floor/tiled/airless,
 /area/derelict)
 "aO" = (

--- a/maps/away/ships/casino/casino.dmm
+++ b/maps/away/ships/casino/casino.dmm
@@ -1359,7 +1359,7 @@
 /turf/simulated/floor/tiled,
 /area/casino/casino_security)
 "en" = (
-/obj/structure/safe,
+/obj/structure/safe/highvalue,
 /turf/simulated/floor/plating,
 /area/casino/casino_security)
 "eq" = (
@@ -2148,14 +2148,14 @@
 	dir = 8;
 	level = 2
 	},
-/obj/structure/safe,
+/obj/structure/safe/cash,
 /turf/simulated/floor/tiled,
 /area/casino/casino_mainfloor)
 "gr" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/safe,
+/obj/structure/safe/cash,
 /turf/simulated/floor/tiled,
 /area/casino/casino_mainfloor)
 "gs" = (
@@ -5217,6 +5217,10 @@
 /obj/machinery/power/portgen/basic,
 /turf/simulated/floor/plating,
 /area/casino/casino_storage)
+"FC" = (
+/obj/structure/safe/cash,
+/turf/simulated/floor/plating,
+/area/casino/casino_security)
 "Gb" = (
 /obj/item/ammo_casing/pistol/magnum/used,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -11651,9 +11655,9 @@ yb
 Ab
 dB
 bq
-en
+FC
 eD
-en
+FC
 bq
 fr
 cb
@@ -11753,9 +11757,9 @@ cS
 Bb
 dC
 bq
-en
+FC
 eD
-en
+FC
 bq
 Eb
 Gb

--- a/maps/away/ships/yacht/yacht.dmm
+++ b/maps/away/ships/yacht/yacht.dmm
@@ -74,11 +74,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/safe,
 /obj/item/reagent_containers/pill/cyanide,
 /obj/item/gun/energy/captain,
 /obj/effect/spider/stickyweb,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/safe/highvalue,
 /turf/simulated/floor/wood/coloured/walnut,
 /area/shuttle/yacht/bridge)
 "ar" = (

--- a/maps/away/ships/yacht/yacht.dmm
+++ b/maps/away/ships/yacht/yacht.dmm
@@ -1175,10 +1175,9 @@
 /turf/simulated/floor/wood/coloured/walnut,
 /area/shuttle/yacht/living)
 "fb" = (
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1439;
-	master_tag = "yacht_airlock";
-	pixel_x = 24
+/obj/machinery/access_button{
+	pixel_x = 25;
+	master_tag = "yacht_airlock"
 	},
 /turf/template_noop,
 /area/space)
@@ -1188,12 +1187,11 @@
 	icon_state = "0-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/access_button/airlock_interior{
-	frequency = 1439;
-	master_tag = "yacht_airlock";
-	pixel_x = -24
-	},
 /obj/structure/computerframe,
+/obj/machinery/access_button{
+	pixel_x = -26;
+	master_tag = "yacht_airlock"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/yacht/engine)
 "gm" = (


### PR DESCRIPTION
Adds two new types of safes: cash and random high-value objects to replace the (unintentionally mostly empty) ones on the Yacht/Casino map. It also adds a random cash safe to the Hivebot derelict. 

Additionally fixes the airlock on the Yacht not working which was an oversight and changes it so the Vaurca hardsuit that can spawn in said safes is not the minimal version.