### PR TITLE
Polarized Windows for Bridge Conference

### DIFF
--- a/html/changelogs/arrow768-brigeconf.yml
+++ b/html/changelogs/arrow768-brigeconf.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds polarized windows to the bridge conference room."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -1261,8 +1261,8 @@
 "ct" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
-	req_one_access = list(12,26);
-	name = "Nature Showcase Maintenance"
+	name = "Nature Showcase Maintenance";
+	req_one_access = list(12,26)
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
@@ -2547,7 +2547,13 @@
 	dir = 8;
 	id = "conference_room";
 	name = "Conference Room Bolts";
+	pixel_x = 6;
 	specialfunctions = 4
+	},
+/obj/machinery/button/switch/windowtint{
+	dir = 4;
+	id = "bridgeconf";
+	pixel_x = -4
 	},
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
@@ -5204,9 +5210,9 @@
 	c_tag = "Third Deck - Crew Armoury Entrance"
 	},
 /obj/structure/sign/securearea{
-	pixel_y = 32;
+	desc = "A sign which reads 'CREW ARMOURY'.";
 	name = "\improper CREW ARMOURY sign";
-	desc = "A sign which reads 'CREW ARMOURY'."
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/port)
@@ -13723,12 +13729,12 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/button/remote/blast_door{
+	dir = 8;
 	id = "crew_armory";
 	name = "Crew Armoury Main Access";
-	req_access = list(60);
-	dir = 8;
 	pixel_x = 25;
-	pixel_y = -7
+	pixel_y = -7;
+	req_access = list(60)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_armory)
@@ -18028,9 +18034,9 @@
 	dir = 8;
 	id = "crew_armoury_desk";
 	name = "Crew Armoury Auxiliary Access";
-	req_access = list(60);
+	pixel_x = 25;
 	pixel_y = -25;
-	pixel_x = 25
+	req_access = list(60)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_armory)
@@ -20270,7 +20276,9 @@
 /turf/simulated/floor/reinforced/airless,
 /area/horizon/exterior)
 "Ll" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/polarized/firedoor{
+	id = "bridgeconf"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/bridge/meeting_room)
 "Lm" = (
@@ -20913,8 +20921,8 @@
 	id = "crew_armoury_desk";
 	name = "Crew Armoury Auxiliary Access";
 	pixel_x = -25;
-	req_access = list(60);
-	pixel_y = 7
+	pixel_y = 7;
+	req_access = list(60)
 	},
 /obj/machinery/light{
 	dir = 8


### PR DESCRIPTION
Adds polarized Windows for the Bridge Conference Room.

Used the bugfix label as the HRA does not currently have a room with polarized windows that can be locked down.