### PR TITLE
Makes More Objects Climbable

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -28,6 +28,10 @@
 	var/release_log = ""
 	var/update_flag = 0
 
+	// Climbing Variables
+	climbable = TRUE
+	climb_time = 10 SECONDS
+
 /obj/machinery/portable_atmospherics/canister/drain_power()
 	return -1
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -279,6 +279,7 @@
 		shake_object()
 
 /obj/Initialize()
+	..()
 	if(climbable)
 		verbs += /obj/proc/climb_onto_object
 

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -3,11 +3,9 @@
 	w_class = ITEMSIZE_IMMENSE
 	layer = OBJ_LAYER - 0.01
 
-	var/climbable
-	var/climb_time = 5 SECONDS
 	var/breakable
 	var/parts
-	var/list/climbers
+
 	var/list/footstep_sound	//footstep sounds when stepped on
 
 	var/material/material
@@ -17,8 +15,8 @@
 
 /obj/structure/Destroy()
 	if(parts)
-		new parts(loc)
-	if (smooth)
+		new parts(get_turf(src))
+	if(smooth)
 		queue_smooth_neighbors(src)
 	return ..()
 
@@ -31,11 +29,6 @@
 			var/mob/living/carbon/human/H = user
 			if(H.species.can_shred(user))
 				attack_generic(user,1,"slices")
-
-	if(LAZYLEN(climbers) && !(user in climbers))
-		user.visible_message("<span class='warning'>[user] shakes \the [src].</span>", \
-					"<span class='notice'>You shake \the [src].</span>")
-		structure_shaken()
 
 	return ..()
 
@@ -67,153 +60,11 @@
 
 /obj/structure/Initialize(mapload)
 	. = ..()
-	if (!mapload)
+	if(!mapload)
 		updateVisibility(src)	// No point checking this before visualnet initializes.
-	if(climbable)
-		verbs += /obj/structure/proc/climb_on
-	if (smooth)
+	if(smooth)
 		queue_smooth(src)
 		queue_smooth_neighbors(src)
-
-/obj/structure/proc/climb_on()
-	set name = "Climb Onto"
-	set desc = "Climbs onto something"
-	set category = "Object"
-	set src in oview(1)
-
-	if(can_climb(usr))
-		do_climb(usr)
-
-/obj/structure/handle_middle_mouse_click(mob/user)
-	if(can_climb(user))
-		do_climb(usr)
-		return TRUE
-	return FALSE
-
-/obj/structure/MouseDrop_T(mob/target, mob/user)
-
-	var/mob/living/H = user
-	if(istype(H) && can_climb(H) && target == user)
-		do_climb(target)
-	else
-		return ..()
-
-/obj/structure/proc/can_climb(var/mob/living/user, post_climb_check=0)
-	if (!climbable || !can_touch(user) || (!post_climb_check && (user in climbers)))
-		return 0
-
-	if (!user.Adjacent(src))
-		to_chat(user, "<span class='danger'>You can't climb there, the way is blocked.</span>")
-		return 0
-
-	var/obj/occupied = turf_is_crowded()
-	if(occupied)
-		to_chat(user, "<span class='danger'>There's \a [occupied] in the way.</span>")
-		return 0
-	return 1
-
-/obj/structure/proc/turf_is_crowded(var/exclude_self = FALSE)
-	var/turf/T = get_turf(src)
-	if(!T || !istype(T))
-		return 0
-	for(var/obj/O in T.contents)
-		if(istype(O,/obj/structure))
-			var/obj/structure/S = O
-			if(S.climbable)
-				continue
-		if(O && O.density && !(O.flags & ON_BORDER)) //ON_BORDER structures are handled by the Adjacent() check.
-			if(exclude_self && O == src)
-				continue
-			return O
-	return 0
-
-/obj/structure/proc/do_climb(var/mob/living/user)
-	if (!can_climb(user))
-		return
-
-	user.visible_message(SPAN_WARNING("[user] starts [flags & ON_BORDER ? "leaping over" : "climbing onto"] \the [src]!"))
-	LAZYADD(climbers, user)
-
-	if(!do_after(user, climb_time))
-		LAZYREMOVE(climbers, user)
-		return
-
-	if (!can_climb(user, post_climb_check=1))
-		LAZYREMOVE(climbers, user)
-		return
-		
-	var/turf/TT = get_turf(src)
-	if(flags & ON_BORDER)
-		TT = get_step(get_turf(src), dir)
-		if(user.loc == TT)
-			TT = get_turf(src)
-
-	user.visible_message("<span class='warning'>[user] [flags & ON_BORDER ? "leaps over" : "climbs onto"] \the [src]!</span>")
-	user.forceMove(TT)
-	LAZYREMOVE(climbers, user)
-
-/obj/structure/proc/structure_shaken()
-	for(var/mob/living/M in climbers)
-		M.Weaken(1)
-		to_chat(M, "<span class='danger'>You topple as you are shaken off \the [src]!</span>")
-		LAZYREMOVE(climbers, M)
-
-	for(var/mob/living/M in get_turf(src))
-		if(M.lying) return //No spamming this on people.
-
-		M.Weaken(3)
-		to_chat(M, "<span class='danger'>You topple as \the [src] moves under you!</span>")
-
-		if(prob(25))
-
-			var/damage = rand(15,30)
-			var/mob/living/carbon/human/H = M
-			if(!istype(H))
-				to_chat(H, "<span class='danger'>You land heavily!</span>")
-				M.adjustBruteLoss(damage)
-				return
-
-			var/obj/item/organ/external/affecting
-
-			switch(pick(list("ankle","wrist",BP_HEAD,"knee","elbow")))
-				if("ankle")
-					affecting = H.get_organ(pick(BP_L_FOOT, BP_R_FOOT))
-				if("knee")
-					affecting = H.get_organ(pick(BP_L_LEG, BP_R_LEG))
-				if("wrist")
-					affecting = H.get_organ(pick(BP_L_HAND, BP_R_HAND))
-				if("elbow")
-					affecting = H.get_organ(pick(BP_L_ARM, BP_R_ARM))
-				if(BP_HEAD)
-					affecting = H.get_organ(BP_HEAD)
-
-			if(affecting)
-				to_chat(M, "<span class='danger'>You land heavily on your [affecting.name]!</span>")
-				affecting.take_damage(damage, 0)
-				if(affecting.parent)
-					affecting.parent.add_autopsy_data("Misadventure", damage)
-			else
-				to_chat(H, "<span class='danger'>You land heavily!</span>")
-				H.adjustBruteLoss(damage)
-
-			H.UpdateDamageIcon()
-			H.updatehealth()
-	return
-
-/obj/structure/proc/can_touch(var/mob/user)
-	if (!user)
-		return 0
-	if(!Adjacent(user))
-		return 0
-	if (user.restrained() || user.buckled_to)
-		to_chat(user, "<span class='notice'>You need your hands and legs free for this.</span>")
-		return 0
-	if (user.stat || user.paralysis || user.sleeping || user.lying || user.weakened)
-		return 0
-	if (issilicon(user))
-		to_chat(user, "<span class='notice'>You need hands for this.</span>")
-		return 0
-	return 1
 
 /obj/structure/attack_generic(var/mob/user, var/damage, var/attack_verb, var/wallbreaker)
 	if(!breakable || !damage || !wallbreaker)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -4,6 +4,7 @@
 	layer = OBJ_LAYER - 0.01
 
 	var/climbable
+	var/climb_time = 5 SECONDS
 	var/breakable
 	var/parts
 	var/list/climbers
@@ -75,7 +76,6 @@
 		queue_smooth_neighbors(src)
 
 /obj/structure/proc/climb_on()
-
 	set name = "Climb structure"
 	set desc = "Climbs onto a structure."
 	set category = "Object"
@@ -134,7 +134,7 @@
 	user.visible_message(SPAN_WARNING("[user] starts [flags & ON_BORDER ? "leaping over" : "climbing onto"] \the [src]!"))
 	LAZYADD(climbers, user)
 
-	if(!do_after(user,50))
+	if(!do_after(user, climb_time))
 		LAZYREMOVE(climbers, user)
 		return
 

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -76,8 +76,8 @@
 		queue_smooth_neighbors(src)
 
 /obj/structure/proc/climb_on()
-	set name = "Climb structure"
-	set desc = "Climbs onto a structure."
+	set name = "Climb Onto"
+	set desc = "Climbs onto something"
 	set category = "Object"
 	set src in oview(1)
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -58,6 +58,9 @@
 	var/door_hinge_alt = 6.5 // for closets with two doors. why a seperate var? because some closets may be weirdly shaped or something.
 	var/door_anim_time = 2.5 // set to 0 to make the door not animate at all
 
+	// Climbing Variables
+	climbable = TRUE
+	climb_time = 10 SECONDS
 
 /obj/structure/closet/LateInitialize()
 	if(opened)	// if closed, any item at the crate's loc is put in the contents

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -162,7 +162,7 @@
 		return 0
 
 	if(climbable)
-		structure_shaken()
+		shake_object()
 	opened = TRUE
 	dump_contents()
 	animate_door(FALSE)

--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -1,11 +1,8 @@
-//added by cael from old bs12
-//not sure if there's an immediate place for secure wall lockers, but i'm sure the players will think of something
-
 /obj/structure/closet/walllocker
 	name = "wall locker"
 	desc = "A wall mounted storage locker."
 	icon = 'icons/obj/walllocker.dmi'
-	icon_state = "walllocker" //...man, how OLD is this $#!?
+	icon_state = "walllocker"
 	door_anim_angle = 132
 	door_anim_squish = 0.38
 	door_hinge = -7
@@ -14,6 +11,10 @@
 	density = FALSE
 	anchored = TRUE
 	wall_mounted = TRUE
+
+	// Climbing Variables
+	climbable = FALSE // Self-explanatory.
+	climb_time = null // Not used.
 
 /obj/structure/closet/walllocker/emerglocker
 	name = "emergency locker"

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -16,7 +16,7 @@
 	var/obj/structure/ladder/target_down
 	var/base_icon = "ladder"
 
-	var/const/climb_time = 2 SECONDS
+	var/const/ladder_climb_time = 2 SECONDS
 	var/list/climbsounds = list('sound/effects/ladder1.ogg','sound/effects/ladder2.ogg','sound/effects/ladder3.ogg','sound/effects/ladder4.ogg')
 	var/climb_sound_vol = 50
 	var/climb_sound_vary = FALSE
@@ -95,7 +95,7 @@
 
 	target_ladder.audible_message("<span class='notice'>You hear something coming [direction] \the [src]</span>")
 
-	if(do_after(M, istype(G) ? (climb_time*2) : climb_time))
+	if(do_after(M, istype(G) ? (ladder_climb_time*2) : ladder_climb_time))
 		climbLadder(M, target_ladder)
 
 /obj/structure/ladder/attack_ghost(var/mob/M)

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -7,9 +7,9 @@
 	desc = "A ladder. You can climb it up and down."
 	icon_state = "ladder01"
 	icon = 'icons/obj/structures.dmi'
-	density = 0
-	opacity = 0
-	anchored = 1
+	anchored = TRUE
+	density = FALSE
+	opacity = FALSE
 
 	var/allowed_directions = DOWN
 	var/obj/structure/ladder/target_up

--- a/code/modules/tables/flipping.dm
+++ b/code/modules/tables/flipping.dm
@@ -28,7 +28,7 @@
 	usr.visible_message(SPAN_WARNING("[usr] flips \the [src]!"), intent_message = THUNK_SOUND)
 
 	if(climbable)
-		structure_shaken()
+		shake_object()
 
 	return
 

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -101,7 +101,7 @@
 	)
 	LAZYADD(climbers, user)
 
-	if(!do_after(user,25))
+	if(!do_after(user, climb_time))
 		LAZYREMOVE(climbers, user)
 		return
 

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -86,7 +86,7 @@
 		)
 
 
-/obj/structure/table/structure_shaken()
+/obj/structure/table/shake_object()
 	..()
 	throw_things()
 

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -3,9 +3,8 @@
 	icon = 'icons/obj/tables.dmi'
 	icon_state = "frame"
 	desc = "It's a table, for putting things on. Or standing on, if you really want to."
-	density = 1
-	anchored = 1
-	climbable = TRUE
+	density = TRUE
+	anchored = TRUE
 	layer = LAYER_TABLE
 	throwpass = 1
 	var/flipped = 0
@@ -24,6 +23,10 @@
 	var/carpeted = 0
 
 	var/list/connections = list("nw0", "ne0", "sw0", "se0")
+
+	// Climbing Variables
+	climbable = TRUE
+	climb_time = 2.5 SECONDS
 
 /obj/structure/table/proc/update_material()
 	var/old_maxhealth = maxhealth

--- a/html/changelogs/climbable_objects.yml
+++ b/html/changelogs/climbable_objects.yml
@@ -1,0 +1,7 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - rscadd: "Makes the portable gas canisters climbable."
+  - rscadd: "Makes closets and lockers climbable, excluding wall-mounted ones."


### PR DESCRIPTION
this PR makes gas canisters and closets climbable.

## changes
- makes gas canisters climbable.
- makes closets and lockers climbable, excluding wall mounted ones.
- adds a `climb_time` variable to objects so each object can have its own required time to climb it.
- makes all `/obj` climbable, if the variable is set to `TRUE`.
- adds a dedicated `shakable` variable to objects, for things that can't be shaken, like anchored or heavy structures/machinery.