### PR TITLE
Xenoarch belt buff

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -464,7 +464,8 @@
 		/obj/item/extraction_pack,
 		/obj/item/rfd/mining,
 		/obj/item/gun/custom_ka,
-		/obj/item/device/orbital_dropper
+		/obj/item/device/orbital_dropper,
+		/obj/item/ore_detector
 		)
 
 /obj/item/storage/belt/hydro

--- a/code/modules/research/xenoarchaeology/tools/gearbelt.dm
+++ b/code/modules/research/xenoarchaeology/tools/gearbelt.dm
@@ -4,6 +4,7 @@
 	desc = "Can hold various excavation gear."
 	icon_state = "gearbelt"
 	item_state = "utility"
+	storage_slots = 9
 	can_hold = list(
 		/obj/item/storage/box/samplebags,
 		/obj/item/device/core_sampler,
@@ -26,5 +27,6 @@
 		/obj/item/wrench,
 		/obj/item/storage/box/excavation,
 		/obj/item/anobattery,
-		/obj/item/device/ano_scanner
+		/obj/item/device/ano_scanner,
+		/obj/item/ore_detector
 		)

--- a/html/changelogs/miningbelts.yml
+++ b/html/changelogs/miningbelts.yml
@@ -1,0 +1,7 @@
+author: listerla
+
+delete-after: True
+
+changes:
+  - rscadd: "Buffed the xenoarch belt to have 9 slots."
+  - rscdel: "Explorer's belt and xenoarch's belt may now hold ore detectors."


### PR DESCRIPTION
Xenoarch belts now have 9 slots. Looking at what they can hold, I felt it was inoffensive enough - but a buff allows it to carry all the standard equipment one would already put in it (counting 7 slots,) plus a wrench and an ore detector, which are both largely mandatory to do the job.

Both it and the explorer's belt may hold an ore detector because - why wouldn't they be allowed to?