### PR TITLE
Coffee machines in XO's and Liasion's offices are no longer empty

### DIFF
--- a/html/changelogs/DreamySkrell.yml
+++ b/html/changelogs/DreamySkrell.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Coffee machines in XO's and Liasion's offices are no longer empty."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -13485,7 +13485,7 @@
 /area/template_noop)
 "yG" = (
 /obj/structure/table/wood,
-/obj/machinery/chemical_dispenser/coffee,
+/obj/machinery/chemical_dispenser/coffee/full,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop/xo)
 "yH" = (
@@ -28370,7 +28370,7 @@
 	dir = 6
 	},
 /obj/machinery/light,
-/obj/machinery/chemical_dispenser/coffee,
+/obj/machinery/chemical_dispenser/coffee/full,
 /turf/simulated/floor/wood,
 /area/lawoffice/representative)
 "ZM" = (


### PR DESCRIPTION
they were `/obj/machinery/chemical_dispenser/coffee` instead of `/obj/machinery/chemical_dispenser/coffee/full`