### PR TITLE
Makes the default hijab the white hijab

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -219,19 +219,19 @@
 /datum/gear/head/hijab/New()
 	..()
 	var/list/hijab = list()
-	hijab["black hijab"] = /obj/item/clothing/head/hijab
+	hijab["white hijab"] = /obj/item/clothing/head/hijab
 	hijab["grey hijab"] = /obj/item/clothing/head/hijab/grey
 	hijab["red hijab"] = /obj/item/clothing/head/hijab/red
 	hijab["brown hijab"] = /obj/item/clothing/head/hijab/brown
 	hijab["green hijab"] = /obj/item/clothing/head/hijab/green
 	hijab["blue hijab"] = /obj/item/clothing/head/hijab/blue
-	hijab["white hijab"] = /obj/item/clothing/head/hijab/white
+	hijab["black hijab"] = /obj/item/clothing/head/hijab/black
 
 	gear_tweaks += new /datum/gear_tweak/path(hijab)
 
 /datum/gear/head/hijab_colorable
 	display_name = "colorable hijab"
-	path = /obj/item/clothing/head/hijab/white
+	path = /obj/item/clothing/head/hijab
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
 
 /datum/gear/head/turban

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -277,8 +277,8 @@
 	name = "hijab"
 	desc = "Encompassing cloth headwear worn by some human cultures and religions."
 	icon = 'icons/obj/clothing/hijabs.dmi'
-	icon_state = "hijab_black"
-	item_state = "hijab_black"
+	icon_state = "hijab_white"
+	item_state = "hijab_white"
 	flags_inv = BLOCKHAIR
 	body_parts_covered = 0
 	contained_sprite = 1
@@ -312,10 +312,10 @@
 	icon_state = "hijab_blue"
 	item_state = "hijab_blue"
 
-/obj/item/clothing/head/hijab/white
-	name = "white hijab"
-	icon_state = "hijab_white"
-	item_state = "hijab_white"
+/obj/item/clothing/head/hijab/black
+	name = "black hijab"
+	icon_state = "hijab_black"
+	item_state = "hijab_black"
 
 /obj/item/clothing/head/cowboy
 	name = "cowboy hat"

--- a/html/changelogs/hijab.yml
+++ b/html/changelogs/hijab.yml
@@ -1,0 +1,6 @@
+author: listerla
+
+delete-after: True
+
+changes:
+  - tweak: "Made the white hijab the default, as to fix the colorable hijab's name."


### PR DESCRIPTION
Right now, colorable hijabs are called 'white hijab' when spawned in - even if very obviously not.

![image](https://user-images.githubusercontent.com/57296132/188348106-05eda2e2-da86-4480-a3e1-d1be9bbd77b5.png)
![image](https://user-images.githubusercontent.com/57296132/188348124-594a82db-d3fb-4330-b3de-64e45cbee9f2.png)

Changing the white to be the default is a quick way to fix this.