### PR TITLE
Mediborg Hacked Hypospray rework

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -294,9 +294,8 @@ var/global/list/robot_modules = list(
 	modules += new /obj/item/device/flash(src) // Non-lethal tool that prevents any 'borg from going lethal on Crew so long as it's an option according to laws.
 	modules += new /obj/item/crowbar/robotic(src) // Base crowbar that all 'borgs should have access to.
 	modules += new /obj/item/gripper/paperwork(src)
-	emag = new /obj/item/reagent_containers/hypospray/cmo(src)
-	emag.reagents.add_reagent(/decl/reagent/wulumunusha, 30)
-	emag.name = "Wulumunusha Hypospray"
+	emag = new /obj/item/reagent_containers/hypospray/borghypo/hacked(src)
+	emag.name = "Hacked Module Hypospray"
 
 	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000)
 	synths += medicine

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -30,7 +30,7 @@
 	reagent_ids = list(/decl/reagent/tricordrazine, /decl/reagent/dexalin, /decl/reagent/inaprovaline, /decl/reagent/dylovene, /decl/reagent/perconol, /decl/reagent/mortaphenyl, /decl/reagent/adrenaline, /decl/reagent/coagzolug)
 
 /obj/item/reagent_containers/hypospray/borghypo/hacked
-	reagent_ids = list(/decl/reagent/toxin/zombiepowder, /decl/reagent/toxin/cyanide, /decl/reagent/polysomnine, /decl/reagent/toxin/panotoxin, /decl/reagent/toxin/berserk)
+	reagent_ids = list(/decl/reagent/toxin/zombiepowder, /decl/reagent/toxin/cyanide, /decl/reagent/polysomnine, /decl/reagent/toxin/panotoxin, /decl/reagent/toxin/berserk, /decl/reagent/wulumunusha)
 
 
 /obj/item/reagent_containers/hypospray/borghypo/Initialize()

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -29,6 +29,10 @@
 /obj/item/reagent_containers/hypospray/borghypo/rescue
 	reagent_ids = list(/decl/reagent/tricordrazine, /decl/reagent/dexalin, /decl/reagent/inaprovaline, /decl/reagent/dylovene, /decl/reagent/perconol, /decl/reagent/mortaphenyl, /decl/reagent/adrenaline, /decl/reagent/coagzolug)
 
+/obj/item/reagent_containers/hypospray/borghypo/hacked
+	reagent_ids = list(/decl/reagent/toxin/zombiepowder, /decl/reagent/toxin/cyanide, /decl/reagent/polysomnine, /decl/reagent/toxin/panotoxin, /decl/reagent/toxin/berserk)
+
+
 /obj/item/reagent_containers/hypospray/borghypo/Initialize()
 	. = ..()
 


### PR DESCRIPTION
Added in hacked hypospray module for emagged standard mediborg, containing a variety of dangerous toxins, to replace the previous presumably interim system.
![image](https://user-images.githubusercontent.com/103293726/189515156-e0448200-77c9-4aec-a932-fbcdd638ace5.png)

Changelog: 

Added in two lines of code to Borghydro:
/obj/item/reagent_containers/hypospray/borghypo/hacked
	reagent_ids = list(/decl/reagent/toxin/zombiepowder, /decl/reagent/toxin/cyanide, /decl/reagent/polysomnine, /decl/reagent/toxin/panotoxin, /decl/reagent/toxin/berserk, /decl/reagent/wulumunusha)
	
This adds a hacked borg hypospray with the above reagents to emagged Mediborgs.

Changed two line of code in Borg modules, replacing the stand-in hacked dispenser with a limited supply of a singular reagent with this more versatile system. Changed the name appropriately. 

Removed one line of code:
Removed a single line of code relating to the filling of the previous dispenser, now unnecessary.

