### PR TITLE
Fixes Some Bugs and Oversights in Engineering

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -2,7 +2,7 @@
 	name = "portable air conditioning unit"
 	desc = "A portable air conditioning unit. It can heat or cool a room to your liking."
 	icon = 'icons/obj/atmos.dmi'
-	icon_state = "sheater0"
+	icon_state = "sheater-off"
 	anchored = FALSE
 	density = TRUE
 	use_power = POWER_USE_OFF

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -69,6 +69,13 @@
 	new /obj/item/taperoll/engineering(src)
 	new /obj/item/clothing/accessory/storage/overalls/engineer(src)
 	new /obj/item/device/radio/eng/off(src)
+	new /obj/item/storage/belt/utility(src)
+	new /obj/item/device/gps/engineering(src)
+	new /obj/item/pipewrench(src)
+
+	// Painters
+	new /obj/item/device/floor_painter(src)
+	new /obj/item/device/pipe_painter(src)
 
 // Atmospherics Technician
 /obj/structure/closet/secure_closet/atmos_personal
@@ -93,6 +100,15 @@
 	new /obj/item/reagent_containers/extinguisher_refill(src)
 	new /obj/item/rfd/piping(src)
 	new /obj/item/device/radio/eng/off(src)
+	new /obj/item/storage/belt/utility(src)
+	new /obj/item/device/gps/engineering(src)
+	new /obj/item/pipewrench(src)
+	new /obj/item/crowbar/rescue_axe(src)
+	new /obj/item/device/flashlight/heavy(src)
+
+	// Painters
+	new /obj/item/device/floor_painter(src)
+	new /obj/item/device/pipe_painter(src)
 
 // Electrical Supplies
 /obj/structure/closet/secure_closet/engineering_electrical

--- a/html/changelogs/engineering_bugfixes.yml
+++ b/html/changelogs/engineering_bugfixes.yml
@@ -1,0 +1,9 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - maptweak: "Maps in portable air conditioning units in engineering."
+  - bugfix: "Moves items mapped on top of engineering and atmos tech lockers from map to code."
+  - bugfix: "Gives engineers and atmos technicians floor- and pipe painters in their lockers."
+  - bugfix: "Fixes the portable air conditioning unit missing its sprite when mapping."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -425,7 +425,7 @@
 /area/medical/reception)
 "akn" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/machinery/space_heater,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/lobby)
 "aky" = (
@@ -472,7 +472,7 @@
 "amk" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/lobby)
 "amt" = (
@@ -490,10 +490,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
 "amE" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/shieldgen,
-/turf/simulated/floor/tiled/dark/full,
-/area/engineering/lobby)
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/tiled,
+/area/hallway/engineering)
 "amF" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -905,8 +906,7 @@
 	dir = 1
 	},
 /obj/structure/closet/walllocker/firecloset/medical{
-	pixel_x = -32;
-	pixel_y = 31
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
@@ -7864,8 +7864,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room)
 "ego" = (
-/obj/machinery/shieldgen,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/lobby)
 "egq" = (
@@ -10772,11 +10772,6 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
-"fKB" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/tiled/dark/full,
-/area/engineering/lobby)
 "fKG" = (
 /obj/structure/closet/crate,
 /obj/random/loot,
@@ -16534,11 +16529,6 @@
 /area/maintenance/wing/starboard)
 "iHQ" = (
 /obj/structure/closet/secure_closet/atmos_personal,
-/obj/item/storage/belt/utility,
-/obj/item/device/gps/engineering,
-/obj/item/pipewrench,
-/obj/item/crowbar/rescue_axe/red,
-/obj/item/device/pipe_painter,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 1
 	},
@@ -16546,7 +16536,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
 	},
-/obj/item/device/flashlight/heavy,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -17696,10 +17685,7 @@
 /obj/machinery/alarm{
 	pixel_y = 28
 	},
-/obj/item/storage/belt/utility,
-/obj/item/device/gps/engineering,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/pipewrench,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "jlQ" = (
@@ -28889,6 +28875,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
+"piC" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/space_heater,
+/turf/simulated/floor/tiled/dark/full,
+/area/hallway/engineering)
 "piE" = (
 /obj/machinery/cryopod/living_quarters{
 	pixel_y = 8
@@ -32089,11 +32080,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/storage/belt/utility,
-/obj/item/device/gps/engineering,
-/obj/item/pipewrench,
-/obj/item/crowbar/rescue_axe/red,
-/obj/item/device/pipe_painter,
 /obj/machinery/alarm{
 	pixel_y = 28
 	},
@@ -32103,7 +32089,6 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
 	},
-/obj/item/device/flashlight/heavy,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -32742,9 +32727,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/pharmacy)
 "rjk" = (
-/obj/machinery/shieldgen,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/lobby)
 "rju" = (
@@ -42998,10 +42983,7 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 6
 	},
-/obj/item/storage/belt/utility,
-/obj/item/device/gps/engineering,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/pipewrench,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "wrK" = (
@@ -64001,9 +63983,9 @@ eZI
 idZ
 mKJ
 mqq
-mqq
 mzS
-mzS
+piC
+amE
 nkT
 rAw
 nTS
@@ -65626,7 +65608,7 @@ eMT
 fKi
 nbJ
 isH
-fKB
+akn
 oUt
 xWa
 auU
@@ -66030,7 +66012,7 @@ eMT
 fKi
 nbJ
 isH
-akn
+ego
 oUt
 auj
 axS
@@ -66637,7 +66619,7 @@ elz
 qFf
 uMn
 guQ
-amE
+akn
 ayF
 wTb
 pyc


### PR DESCRIPTION
this PR fixes some bugs and oversights in engineering.

fixes #14800.

## changes
- maps in portable air conditioning units in engineering.
- moves items mapped on top of engineering and atmos tech lockers from map to code.
- gives engineers and atmos technicians floor- and pipe painters in their lockers.
- fixes the portable air conditioning unit missing its sprite when mapping.