### PR TITLE
Long-Range Holopads on Connected Z-Levels Can Call Each Other

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -442,8 +442,6 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/hologram/holopad/long_range/can_connect(var/obj/machinery/hologram/holopad/HP)
 	if(HP.long_range != long_range)
 		return FALSE
-	if(AreConnectedZLevels(HP.z, z))
-		return FALSE
 	if(current_map.use_overmap)
 		if(!linked || !HP.linked)
 			return FALSE

--- a/html/changelogs/wickedcybs_longrange.yml
+++ b/html/changelogs/wickedcybs_longrange.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Long-range holopads can now call each other even if they're on the same Z-level."

--- a/html/changelogs/wickedcybs_longrange.yml
+++ b/html/changelogs/wickedcybs_longrange.yml
@@ -3,4 +3,4 @@ author: WickedCybs
 delete-after: True
 
 changes:
-  - tweak: "Long-range holopads can now call each other even if they're on the same Z-level."
+  - tweak: "Long-range holopads can now call each other even if they're on the same connected Z-levels. That means if they dock at the Horizon they can still call a long range on any deck of it."


### PR DESCRIPTION
It really salted my onions to suddenly not be able to do holocalls with the bridge or see what's even happening if I was docked at the Horizon at all. Radio doesn't really cut it. It's a voluntary system, lets you see whats up on each end + get emotes and for third parties stuck in their docks it's way easier to just communicate with the bridge like that than just yell on the radio for someone to open up.
