### PR TITLE
Kata Shuttle Fixes

### DIFF
--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -84,14 +84,15 @@
 	output_level = 1300000
 	charge = 5.55e+007
 
-/obj/machinery/power/smes/buildable/third_party_shuttle/Initialize() 
+/obj/machinery/power/smes/buildable/third_party_shuttle/Initialize() //Identical to the horizon_shuttle for now as we try to work out specifics
 	. = ..()
+	component_parts += new /obj/item/smes_coil/super_io(src)
 	component_parts += new /obj/item/smes_coil/super_capacity(src)
 	input_attempt = TRUE
 	output_attempt = TRUE
-	input_level = 1000000
-	output_level = 1000000
-	charge = 6.56158e+007
+	input_level = 1300000
+	output_level = 1300000
+	charge = 5.55e+007
 
 /obj/machinery/power/smes/buildable/autosolars/Initialize() //for third parties that have their solars autostart, It's slightly upgraded for them
 	. = ..()

--- a/html/changelogs/wickedcybs_shuttlefix.yml
+++ b/html/changelogs/wickedcybs_shuttlefix.yml
@@ -1,0 +1,7 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - bugfix: "A solars wire on the kataphract ship bugged out and so the ship wasn't getting power from one of its arrays, that was fixed ."
+  - tweak: "Kataphract ship had its vessel mass increased, APCs upgraded and SMES tweaked as I didn't account for the power drain, which was making the engine compartment lose power mid flight."

--- a/maps/away/ships/kataphracts/kataphract_ship.dm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dm
@@ -76,7 +76,7 @@
 	moving_state = "shuttle_green_moving"
 	max_speed = 1/(3 SECONDS)
 	burn_delay = 2 SECONDS
-	vessel_mass = 4000 
+	vessel_mass = 6000 //Ship has a lot of thrusters, so if its too low the shuttle goes too fast. Also, imagine a hard egg flying towards you.
 	fore_dir = WEST
 	vessel_size = SHIP_SIZE_TINY
 
@@ -92,8 +92,8 @@
 	current_location = "nav_hangar_kataphract_shuttle"
 	dock_target = "kataphract_transport"
 	landmark_transition = "nav_kataphract_transport_transit"
-	range = 2
-	fuel_consumption = 3
+	range = 2 // It's a big boy
+	fuel_consumption = 4
 	logging_home_tag = "nav_hangar_kataphract_shuttle"
 	defer_initialisation = TRUE
 

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -3285,12 +3285,11 @@
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/trading_area)
 "gU" = (
-/obj/machinery/power/apc{
-	name = "south bump";
+/obj/structure/cable,
+/obj/machinery/power/apc/high{
 	pixel_y = -24;
 	req_access = list(113)
 	},
-/obj/structure/cable,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/kataphract_shuttle/main_compartment)
 "gV" = (
@@ -4300,13 +4299,13 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/engineering)
@@ -7060,6 +7059,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/hangar)
+"tp" = (
+/obj/machinery/light/spot,
+/turf/simulated/floor/plating,
+/area/kataphract_chapter/hangar)
 "tu" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -8656,16 +8659,14 @@
 /area/kataphract_chapter/trading_area)
 "Os" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24;
-	req_access = list(113)
-	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2";
 	pixel_y = 0
+	},
+/obj/machinery/power/apc/high{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/kataphract_shuttle/engine_compartment)
@@ -22340,7 +22341,7 @@ jB
 ki
 mJ
 ia
-aa
+tp
 bP
 aa
 aa

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -7059,10 +7059,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/hangar)
-"tp" = (
-/obj/machinery/light/spot,
-/turf/simulated/floor/plating,
-/area/kataphract_chapter/hangar)
 "tu" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -22341,7 +22337,7 @@ jB
 ki
 mJ
 ia
-tp
+aa
 bP
 aa
 aa


### PR DESCRIPTION
The Kataphract shuttle was losing power midflight since the APCs weren't the high variant and the main SMES had no transmission coil in it. The fuel pump takes way more power than I expected it too as well. Thus, the APCs are the high variant, SMES was made identical to the Intrepid's as I fine-tune stuff.

Vessel mass was also increased for the shuttle, because it turns out 6 fueled thrusters make it go really fast to a (compared to the rest of the shuttles) kind of unreasonable degree. Like over 8 gmh per thrust. This might need more looking into, but I want to fix it quick.

A solars wire on the kataphract ship was bugged and facing the wrong direction despite strongdmm showing otherwise, so that was also changed as the entire ship wasn't getting power from one of its solar arrays, which meant the shuttle was overly taxing the main SMES.