### PR TITLE
Lets Away Sites Be Multi-Z if Desired

### DIFF
--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -11,7 +11,7 @@
 	var/list/sectors = list() //This ruin can only spawn in the sectors in this list.
 
 	var/prefix = null
-	var/suffix = null
+	var/suffixes = null
 	template_flags = TEMPLATE_FLAG_NO_RUINS // Don't let ruins spawn on top of ruins
 
 	// !! Currently only implemented for away sites
@@ -20,7 +20,8 @@
 	var/list/ban_ruins   // Listed ruins are removed from the set of available spawns. Beats allowed.
 
 /datum/map_template/ruin/New()
-	if (suffix)
-		mappath += (prefix + suffix)
-
+	if (suffixes)
+		mappaths = list()
+		for (var/suffix in suffixes)
+			mappaths += (prefix + suffix)
 	..()

--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -11,7 +11,7 @@
 	var/list/sectors = list() //This ruin can only spawn in the sectors in this list.
 
 	var/prefix = null
-	var/suffixes = null
+	var/suffix = null
 	template_flags = TEMPLATE_FLAG_NO_RUINS // Don't let ruins spawn on top of ruins
 
 	// !! Currently only implemented for away sites
@@ -20,8 +20,9 @@
 	var/list/ban_ruins   // Listed ruins are removed from the set of available spawns. Beats allowed.
 
 /datum/map_template/ruin/New()
-	if (suffixes)
-		mappaths = list()
-		for (var/suffix in suffixes)
-			mappaths += (prefix + suffix)
+	if (suffix)
+		mappath = list()
+		for (var/suffix in suffix)
+			mappath += (prefix + suffix)
+
 	..()

--- a/html/changelogs/wickedcybs_suffix.yml
+++ b/html/changelogs/wickedcybs_suffix.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Makes a back-end tweak that lets multi-z away sites be possible, if desired."

--- a/maps/away/generic/bigderelict.dm
+++ b/maps/away/generic/bigderelict.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/big_derelict
 	name = "large derelict"
 	description = "A very large derelict station. According to the starmap, it shouldn't exist."
-	suffix = "generic/bigderelict.dmm"
+	suffix = list("generic/bigderelict.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_NEW_ANKARA, SECTOR_BADLANDS, SECTOR_AEMAQ)
 	spawn_weight = 1
 	spawn_cost = 2

--- a/maps/away/generic/bunker.dm
+++ b/maps/away/generic/bunker.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/abandoned_bunker
 	name = "lone asteroid"
 	description = "A lone asteroid. Strange signals are coming from this one."
-	suffix = "generic/bunker.dmm"
+	suffix = list("generic/bunker.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/generic/civilian_station.dm
+++ b/maps/away/generic/civilian_station.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/civilian_station
 	name = "civilian station"
 	description = "A modestly-sized independently-owned civilian space station. Many of these exist all throughout inhabited space, offering a place to rest, food to eat, shopping, and refueling - part mall, part motel. This one appears to have been active in the region long before Biesel took control, and an information lookup indicates that it is operated by a small company that is Solarian in origin. This one's transponder says it's open for business!"
-	suffix = "generic/civilian_station.dmm"
+	suffix = list("generic/civilian_station.dmm")
 	sectors = list(SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	spawn_cost = 2

--- a/maps/away/generic/cursed.dm
+++ b/maps/away/generic/cursed.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/cursed
 	name = "lone asteroid"
 	description = "A lone asteroid with a hangar. Latest data from this sector shows it as a Hephaestus mining station, two years ago."
-	suffix = "generic/cursed.dmm"
+	suffix = list("generic/cursed.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/generic/derelict.dm
+++ b/maps/away/generic/derelict.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/space_derelict
 	name = "space derelict"
 	description = "An abandoned space structure."
-	suffix = "generic/derelict.dmm"
+	suffix = list("generic/derelict.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_NEW_ANKARA, SECTOR_BADLANDS, SECTOR_AEMAQ)
 	spawn_weight = 1
 	spawn_cost = 2

--- a/maps/away/generic/hivebot_hub.dm
+++ b/maps/away/generic/hivebot_hub.dm
@@ -1,11 +1,12 @@
 /datum/map_template/ruin/away_site/hivebot_hub
 	name = "derelict supply hub"
 	description = "An abandoned supply hub. This one's releasing the telltale signals of a potential hivebot infestation."
-	suffix = "generic/hivebot_hub.dmm"
+	suffix = list("generic/hivebot_hub.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_NEW_ANKARA, SECTOR_BADLANDS, SECTOR_AEMAQ)
 	spawn_weight = 1
 	spawn_cost = 1
 	id = "hivebot_hub"
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 /decl/submap_archetype/hivebot_hub
 	map = "derelict supply hub"

--- a/maps/away/generic/overgrown_mining_station.dm
+++ b/maps/away/generic/overgrown_mining_station.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/overgrown_mining_station
 	name = "overgrown_mining_station"
 	description = "An abandoned mining station with a dionae growing into it"
-	suffix = "generic/overgrown_mining_station.dmm"
+	suffix = list("generic/overgrown_mining_station.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE)
 	spawn_weight = 1
 	spawn_cost = 2

--- a/maps/away/generic/racers.dm
+++ b/maps/away/generic/racers.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/racers
 	name = "unregistered station"
 	description = "A station that doesn't appear to have been legally registered. It has four large hangar bays and a small habitation module - and the signals emittered by its dying equipment seem to identify it as belonging to an underground racing group."
-	suffix = "generic/racers.dmm"
+	suffix = list("generic/racers.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_NEW_ANKARA, SECTOR_BADLANDS, SECTOR_AEMAQ)
 	spawn_weight = 1
 	spawn_cost = 2

--- a/maps/away/generic/space_bar.dm
+++ b/maps/away/generic/space_bar.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/space_bar
 	name = "space bar"
 	description = "An abandoned space structure."
-	suffix = "generic/space_bar.dmm"
+	suffix = list("generic/space_bar.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE)
 	spawn_weight = 1
 	spawn_cost = 2

--- a/maps/away/generic/tajara_safehouse.dm
+++ b/maps/away/generic/tajara_safehouse.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/tajara_safehouse
 	name = "abandoned outpost"
 	description = "A derelict space outpost."
-	suffix = "generic/tajara_safehouse.dmm"
+	suffix = list("generic/tajara_safehouse.dmm")
 	sectors = list(SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS)
 	spawn_weight = 1
 	spawn_cost = 2

--- a/maps/away/generic/wrecked_nt_ship.dm
+++ b/maps/away/generic/wrecked_nt_ship.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/wrecked_nt_ship
 	name = "wrecked NT ship"
 	description = "A wrecked ship once owned by NanoTrasen."
-	suffix = "generic/wrecked_nt_ship.dmm"
+	suffix = list("generic/wrecked_nt_ship.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS)
 	spawn_weight = 1
 	spawn_cost = 2

--- a/maps/away/romanovich/first_aurora.dm
+++ b/maps/away/romanovich/first_aurora.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/first_aurora
 	name = "space station derelict"
 	description = "An abandoned space station."
-	suffix = "romanovich/first_aurora.dmm"
+	suffix = list("romanovich/first_aurora.dmm")
 	sectors = list(SECTOR_ROMANOVICH)
 	spawn_weight = 1
 	spawn_cost = 2

--- a/maps/away/romanovich/grand_romanovich.dm
+++ b/maps/away/romanovich/grand_romanovich.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/grand_romanovich
 	name = "grand romanovich casino"
 	description = "An adhomian style casino in Tau Ceti's space."
-	suffix = "romanovich/grand_romanovich.dmm"
+	suffix = list("romanovich/grand_romanovich.dmm")
 	sectors = list(SECTOR_ROMANOVICH)
 	spawn_weight = 1
 	spawn_cost = 2

--- a/maps/away/ships/biesel.dm
+++ b/maps/away/ships/biesel.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/tcfl_peacekeeper_ship
 	name = "TCFL Peacekeeper Ship"
 	description = "Serving as the very foundation of the SCC's (And more specifically, NanoTrasen's) fleet of asset protection vessels, the Cetus-class is versatile and durable, but also clumsy and somewhat underpowered in regards to its engine and propulsion. It features small weapon hardpoints in its thruster arms, and a massive hangar host to the design's interdiction counterpart - the Hydrus-class shuttle. This one's transponder identifies it as a Tau Ceti Foreign Legion patrol vessel, and as a Decanus-class Clipper - the TCFL designation for this design."
-	suffixes = list("ships/tcfl_peacekeeper_ship.dmm")
+	suffix = list("ships/tcfl_peacekeeper_ship.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/ships/biesel.dm
+++ b/maps/away/ships/biesel.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/tcfl_peacekeeper_ship
 	name = "TCFL Peacekeeper Ship"
 	description = "Serving as the very foundation of the SCC's (And more specifically, NanoTrasen's) fleet of asset protection vessels, the Cetus-class is versatile and durable, but also clumsy and somewhat underpowered in regards to its engine and propulsion. It features small weapon hardpoints in its thruster arms, and a massive hangar host to the design's interdiction counterpart - the Hydrus-class shuttle. This one's transponder identifies it as a Tau Ceti Foreign Legion patrol vessel, and as a Decanus-class Clipper - the TCFL designation for this design."
-	suffix = "ships/tcfl_peacekeeper_ship.dmm"
+	suffixes = list("ships/tcfl_peacekeeper_ship.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/ships/casino/casino.dm
+++ b/maps/away/ships/casino/casino.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/casino
 	name = "Casino"
 	description = "A casino ship!"
-	suffixes = list("ships/casino/casino.dmm") 
+	suffix = list("ships/casino/casino.dmm") 
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_TAU_CETI, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_NEW_ANKARA, SECTOR_AEMAQ, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL, SECTOR_GAKAL, SECTOR_UUEOAESA)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/ships/casino/casino.dm
+++ b/maps/away/ships/casino/casino.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/casino
 	name = "Casino"
 	description = "A casino ship!"
-	suffix = "ships/casino/casino.dmm"
+	suffixes = list("ships/casino/casino.dmm") 
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_TAU_CETI, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_NEW_ANKARA, SECTOR_AEMAQ, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL, SECTOR_GAKAL, SECTOR_UUEOAESA)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/ships/corporate.dm
+++ b/maps/away/ships/corporate.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/orion_express_ship
 	name = "Orion Express Mobile Station"
 	description = "The Traveler-class mobile station is a relatively old design, but nonetheless venerable and one of the building blocks of interstellar commerce. While relatively small, is a treasured asset in the Orion Express corporation's fleet, and has been referred to as “the gas station of the stars”, offering food, supplies, and fuel to anyone who may need it. This one's transponder identifies it as an Orion Express refueling station."
-	suffix = "ships/orion_express_ship.dmm"
+	suffixes = list("ships/orion_express_ship.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	spawn_cost = 1
@@ -108,7 +108,7 @@
 /datum/map_template/ruin/away_site/ee_spy_ship
 	name = "Einstein Engines Research Ship"
 	description = "A research ship belonging to Einstein Engines, the Stellar Corporate Conglomerate's main competitor."
-	suffix = "ships/ee_spy_ship.dmm"
+	suffixes = list("ships/ee_spy_ship.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/ships/corporate.dm
+++ b/maps/away/ships/corporate.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/orion_express_ship
 	name = "Orion Express Mobile Station"
 	description = "The Traveler-class mobile station is a relatively old design, but nonetheless venerable and one of the building blocks of interstellar commerce. While relatively small, is a treasured asset in the Orion Express corporation's fleet, and has been referred to as “the gas station of the stars”, offering food, supplies, and fuel to anyone who may need it. This one's transponder identifies it as an Orion Express refueling station."
-	suffixes = list("ships/orion_express_ship.dmm")
+	suffix = list("ships/orion_express_ship.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	spawn_cost = 1
@@ -108,7 +108,7 @@
 /datum/map_template/ruin/away_site/ee_spy_ship
 	name = "Einstein Engines Research Ship"
 	description = "A research ship belonging to Einstein Engines, the Stellar Corporate Conglomerate's main competitor."
-	suffixes = list("ships/ee_spy_ship.dmm")
+	suffix = list("ships/ee_spy_ship.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/ships/elyra.dm
+++ b/maps/away/ships/elyra.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/elyran_strike_craft
 	name = "Elyran Naval Strike Craft"
 	description = "The Aslan-class Strike Craft is among the oldest designs in the Elyran naval arsenal, and is one of the ship classes slated to be retired in the ongoing Elyran military modernization plan. Not an independent vessel in of itself, it is instead an oversized attack craft designed to be launched from the General Abd Al-Hamid-class Carrier, a type of Elyran capital ship, named after the Republic's foremost national hero. As such, it has limited crew facilities and life support capabilities, and is instead reliant on its mothership for long-term operation. This ship is an interdiction variant, with its torpedo bay and railgun hardpoint replaced by a hangar and a boarding pod launch room, respectively. This one's transponder identifies it as an Elyran Naval Infantry interdiction vessel."
-	suffix = "ships/elyran_strike_craft.dmm"
+	suffixes = list("ships/elyran_strike_craft.dmm")
 	sectors = list(SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_NEW_ANKARA, SECTOR_AEMAQ)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/ships/elyra.dm
+++ b/maps/away/ships/elyra.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/elyran_strike_craft
 	name = "Elyran Naval Strike Craft"
 	description = "The Aslan-class Strike Craft is among the oldest designs in the Elyran naval arsenal, and is one of the ship classes slated to be retired in the ongoing Elyran military modernization plan. Not an independent vessel in of itself, it is instead an oversized attack craft designed to be launched from the General Abd Al-Hamid-class Carrier, a type of Elyran capital ship, named after the Republic's foremost national hero. As such, it has limited crew facilities and life support capabilities, and is instead reliant on its mothership for long-term operation. This ship is an interdiction variant, with its torpedo bay and railgun hardpoint replaced by a hangar and a boarding pod launch room, respectively. This one's transponder identifies it as an Elyran Naval Infantry interdiction vessel."
-	suffixes = list("ships/elyran_strike_craft.dmm")
+	suffix = list("ships/elyran_strike_craft.dmm")
 	sectors = list(SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_NEW_ANKARA, SECTOR_AEMAQ)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/ships/kataphracts/kataphract_ship.dm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dm
@@ -2,7 +2,7 @@
 	name = "kataphract ship"
 	id = "awaysite_kataphract_ship"
 	description = "Ship with lizard knights."
-	suffixes = list("ships/kataphracts/kataphract_ship.dmm")
+	suffix = list("ships/kataphracts/kataphract_ship.dmm")
 	spawn_cost = 1
 	spawn_weight = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/kataphract_transport)

--- a/maps/away/ships/kataphracts/kataphract_ship.dm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dm
@@ -2,7 +2,7 @@
 	name = "kataphract ship"
 	id = "awaysite_kataphract_ship"
 	description = "Ship with lizard knights."
-	suffix = "ships/kataphracts/kataphract_ship.dmm"
+	suffixes = list("ships/kataphracts/kataphract_ship.dmm")
 	spawn_cost = 1
 	spawn_weight = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/kataphract_transport)

--- a/maps/away/ships/sol.dm
+++ b/maps/away/ships/sol.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/sfa_patrol_ship
 	name = "SFA Patrol Ship"
 	description = "A small corvette manufactured for the Solarian Navy by Hephaestus, the Montevideo-class is an anti-piracy vessel through and through - with a shuttle bay that takes up a third of the ship and only a single weapon hardpoint located in one arm of the ship, the Montevideo is designed for long-term, self-sufficient operations in inhabited space against small-time pirate vessels that would be unable to overcome the ship's lackluster armaments. Generous automation and streamlined equipment allows it to function with a very small crew. This one's transponder identifies it as belonging to the Southern Fleet Administration, an all-but-defunct Solarian warlord state."
-	suffixes = list("ships/sfa_patrol_ship.dmm")
+	suffix= list("ships/sfa_patrol_ship.dmm")
 	sectors = list(SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	spawn_cost = 1
@@ -108,7 +108,7 @@
 /datum/map_template/ruin/away_site/fsf_patrol_ship
 	name = "FSF Patrol Ship"
 	description = "A small corvette manufactured for the Solarian Navy by Hephaestus, the Montevideo-class is an anti-piracy vessel through and through - with a shuttle bay that takes up a third of the ship and only a single weapon hardpoint located in one arm of the ship, the Montevideo is designed for long-term, self-sufficient operations in inhabited space against small-time pirate vessels that would be unable to overcome the ship's lackluster armaments. Generous automation and streamlined equipment allows it to function with a very small crew. This one's transponder identifies it as belonging to the Free Solarian Fleets, a Solarian warlord's mercenary fleet."
-	suffixes = list("ships/fsf_patrol_ship.dmm")
+	suffix = list("ships/fsf_patrol_ship.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/ships/sol.dm
+++ b/maps/away/ships/sol.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/sfa_patrol_ship
 	name = "SFA Patrol Ship"
 	description = "A small corvette manufactured for the Solarian Navy by Hephaestus, the Montevideo-class is an anti-piracy vessel through and through - with a shuttle bay that takes up a third of the ship and only a single weapon hardpoint located in one arm of the ship, the Montevideo is designed for long-term, self-sufficient operations in inhabited space against small-time pirate vessels that would be unable to overcome the ship's lackluster armaments. Generous automation and streamlined equipment allows it to function with a very small crew. This one's transponder identifies it as belonging to the Southern Fleet Administration, an all-but-defunct Solarian warlord state."
-	suffix = "ships/sfa_patrol_ship.dmm"
+	suffixes = list("ships/sfa_patrol_ship.dmm")
 	sectors = list(SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	spawn_cost = 1
@@ -108,7 +108,7 @@
 /datum/map_template/ruin/away_site/fsf_patrol_ship
 	name = "FSF Patrol Ship"
 	description = "A small corvette manufactured for the Solarian Navy by Hephaestus, the Montevideo-class is an anti-piracy vessel through and through - with a shuttle bay that takes up a third of the ship and only a single weapon hardpoint located in one arm of the ship, the Montevideo is designed for long-term, self-sufficient operations in inhabited space against small-time pirate vessels that would be unable to overcome the ship's lackluster armaments. Generous automation and streamlined equipment allows it to function with a very small crew. This one's transponder identifies it as belonging to the Free Solarian Fleets, a Solarian warlord's mercenary fleet."
-	suffix = "ships/fsf_patrol_ship.dmm"
+	suffixes = list("ships/fsf_patrol_ship.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/ships/tirakqi_freighter.dm
+++ b/maps/away/ships/tirakqi_freighter.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/tirakqi_freighter
 	name = "Ti'Rakqi Freighter"
 	description = "A large skrellian freighter often seen skulking around space near the borders of the Traverse. This model has a large cargo hold, swift engines, and a deceptively large fuel reserve. Perfect for any smuggler on the go. This one's transponder identifies it as belonging to an independent freighter."
-	suffix = "ships/tirakqi_freighter.dmm"
+	suffixes = list("ships/tirakqi_freighter.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/ships/tirakqi_freighter.dm
+++ b/maps/away/ships/tirakqi_freighter.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/tirakqi_freighter
 	name = "Ti'Rakqi Freighter"
 	description = "A large skrellian freighter often seen skulking around space near the borders of the Traverse. This model has a large cargo hold, swift engines, and a deceptively large fuel reserve. Perfect for any smuggler on the go. This one's transponder identifies it as belonging to an independent freighter."
-	suffixes = list("ships/tirakqi_freighter.dmm")
+	suffix = list("ships/tirakqi_freighter.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/ships/wildcard.dm
+++ b/maps/away/ships/wildcard.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/tramp_freighter
 	name = "Tramp Freighter"
 	description = "A freighter of mixed repute, the Catspaw-class is a rare independent design, and a favorite of small-scale freight businesses. It has a shielded cargo bay and an internal hangar, capable of accommodating a small shuttle. Its other features, however, are lacking - with cramped crew amenities and no defenses to speak of, the Catspaw is risky to operate in unpoliced space. This one's transponder identifies it as an independent vessel."
-	suffix = "ships/tramp_freighter.dmm"
+	suffixes = list("ships/tramp_freighter.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_NEW_ANKARA, SECTOR_BADLANDS, SECTOR_AEMAQ)
 	spawn_weight = 1
 	spawn_cost = 1
@@ -108,7 +108,7 @@
 /datum/map_template/ruin/away_site/militia_ship
 	name = "Militia Ship"
 	description = "An unarmed and extremely prolific design of large, self-sufficient shuttle, prized for its modularity. Found all throughout the spur, the Yak-class shuttle can be configured to conceivably serve in any role, though it is only rarely armed with ship-to-ship weapons. Manufactured by Hephaestus. This one's transponder identifies it as a local militia vessel."
-	suffix = "ships/militia_ship.dmm"
+	suffixes = list("ships/militia_ship.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/ships/wildcard.dm
+++ b/maps/away/ships/wildcard.dm
@@ -1,7 +1,7 @@
 /datum/map_template/ruin/away_site/tramp_freighter
 	name = "Tramp Freighter"
 	description = "A freighter of mixed repute, the Catspaw-class is a rare independent design, and a favorite of small-scale freight businesses. It has a shielded cargo bay and an internal hangar, capable of accommodating a small shuttle. Its other features, however, are lacking - with cramped crew amenities and no defenses to speak of, the Catspaw is risky to operate in unpoliced space. This one's transponder identifies it as an independent vessel."
-	suffixes = list("ships/tramp_freighter.dmm")
+	suffix = list("ships/tramp_freighter.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_NEW_ANKARA, SECTOR_BADLANDS, SECTOR_AEMAQ)
 	spawn_weight = 1
 	spawn_cost = 1
@@ -108,7 +108,7 @@
 /datum/map_template/ruin/away_site/militia_ship
 	name = "Militia Ship"
 	description = "An unarmed and extremely prolific design of large, self-sufficient shuttle, prized for its modularity. Found all throughout the spur, the Yak-class shuttle can be configured to conceivably serve in any role, though it is only rarely armed with ship-to-ship weapons. Manufactured by Hephaestus. This one's transponder identifies it as a local militia vessel."
-	suffixes = list("ships/militia_ship.dmm")
+	suffix = list("ships/militia_ship.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/ships/yacht/yacht.dm
+++ b/maps/away/ships/yacht/yacht.dm
@@ -2,7 +2,7 @@
 	name = "Yacht"
 	id = "awaysite_yacht"
 	description = "Tiny movable ship with spiders."
-	suffixes = list("ships/yacht/yacht.dmm")
+	suffix = list("ships/yacht/yacht.dmm")
 	spawn_cost = 0.5
 	spawn_weight = 0.5
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_TAU_CETI, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_NEW_ANKARA, SECTOR_AEMAQ, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL, SECTOR_GAKAL, SECTOR_UUEOAESA)

--- a/maps/away/ships/yacht/yacht.dm
+++ b/maps/away/ships/yacht/yacht.dm
@@ -2,7 +2,7 @@
 	name = "Yacht"
 	id = "awaysite_yacht"
 	description = "Tiny movable ship with spiders."
-	suffix = "ships/yacht/yacht.dmm"
+	suffixes = list("ships/yacht/yacht.dmm")
 	spawn_cost = 0.5
 	spawn_weight = 0.5
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_TAU_CETI, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_NEW_ANKARA, SECTOR_AEMAQ, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL, SECTOR_GAKAL, SECTOR_UUEOAESA)

--- a/maps/random_ruins/exoplanets/asteroid/asteroid.dm
+++ b/maps/random_ruins/exoplanets/asteroid/asteroid.dm
@@ -6,7 +6,7 @@
 	spawn_weight = 1
 	spawn_cost = 2
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE)
-	suffix = "asteroid/mining_base.dmm"
+	suffix = list("asteroid/mining_base.dmm")
 
 	ruin_tags = RUIN_HUMAN|RUIN_VOID
 
@@ -18,7 +18,7 @@
 	spawn_weight = 1
 	spawn_cost = 2
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE)
-	suffix = "asteroid/carp_nest.dmm"
+	suffix = list("asteroid/carp_nest.dmm")
 
 	ruin_tags = RUIN_ALIEN|RUIN_VOID
 
@@ -30,7 +30,7 @@
 	spawn_weight = 0.5
 	spawn_cost = 4
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE)
-	suffix = "asteroid/hideout.dmm"
+	suffix = list("asteroid/hideout.dmm")
 
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK|RUIN_VOID
 
@@ -42,7 +42,7 @@
 	spawn_weight = 1
 	spawn_cost = 2
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE)
-	suffix = "asteroid/crashed_shuttle_01.dmm"
+	suffix = list("asteroid/crashed_shuttle_01.dmm")
 
 	ruin_tags = RUIN_WRECK|RUIN_VOID
 

--- a/maps/random_ruins/exoplanets/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanets/crashed_pod/crashed_pod.dm
@@ -2,7 +2,7 @@
 	name = "crashed survival pod" //This map is not very elaborate and is meant to be an example on how to make a ruin.
 	id = "crashed_pod"
 	description = "A crashed survival pod from a destroyed ship."
-	suffix = "crashed_pod/crashed_pod.dmm"
+	suffix = list("crashed_pod/crashed_pod.dmm")
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
 	spawn_weight = 0.33

--- a/maps/random_ruins/space_ruins/space_ruins.dm
+++ b/maps/random_ruins/space_ruins/space_ruins.dm
@@ -8,5 +8,5 @@
 	name = "Multi-ZAS Test"
 	id = "multi_zas_test"
 	description = "if this has vacuum in it, that's not good!"
-	suffix = "multi_zas_test.dmm"
+	suffix = list("multi_zas_test.dmm")
 	spawn_cost = 1


### PR DESCRIPTION
Away sites can only have a single z due to how it was ported apparently. I would like to have the opportunity to have sites with multiple levels for current and future mapping purposes.

This PR probably won't be finished for a bit but when it is and (hopefully) works it should be merged after https://github.com/Aurorastation/Aurora.3/pull/14822 so I can set the suffixes var on that properly.