### PR TITLE
Reskins some mapped-in radios to their departmental colours + minor responder bay tweaks

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -107,6 +107,7 @@
 	new /obj/item/clothing/suit/storage/toggle/fr_jacket(src)
 	new /obj/item/clothing/suit/storage/toggle/fr_jacket/zeng(src)
 	new /obj/item/clothing/suit/storage/toggle/fr_jacket/pmc(src)
+	new /obj/item/clothing/accessory/armband/medgreen(src)
 
 
 /obj/structure/closet/secure_closet/CMO

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -43,7 +43,6 @@
 	armbands["red armband"] = /obj/item/clothing/accessory/armband
 	armbands["security armband"] = /obj/item/clothing/accessory/armband/sec
 	armbands["operations armband"] = /obj/item/clothing/accessory/armband/operations
-	armbands["first responder armband"] = /obj/item/clothing/accessory/armband/medgreen
 	armbands["medical armband"] = /obj/item/clothing/accessory/armband/med
 	armbands["engineering armband"] = /obj/item/clothing/accessory/armband/engine
 	armbands["hydroponics armband"] = /obj/item/clothing/accessory/armband/hydro

--- a/html/changelogs/omicega-rewrewfsdfmsdifsiewerw.yml
+++ b/html/changelogs/omicega-rewrewfsdfmsdifsiewerw.yml
@@ -1,0 +1,14 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Added armbands to first responder lockers and made it clearer there are two rescue RIGs now."
+  - maptweak: "Changed some roundstart station-bounced radios to use departmental colours."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -27867,11 +27867,11 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
+/obj/item/device/radio/sec,
+/obj/item/device/radio/sec,
+/obj/item/device/radio/sec,
+/obj/item/device/radio/sec,
+/obj/item/device/radio/sec,
 /obj/machinery/firealarm/south,
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -2393,19 +2393,19 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/obj/item/device/radio{
+/obj/item/device/radio/med{
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/item/device/radio{
+/obj/item/device/radio/med{
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/item/device/radio{
+/obj/item/device/radio/med{
 	pixel_x = 5;
 	pixel_y = 6
 	},
-/obj/item/device/radio{
+/obj/item/device/radio/med{
 	pixel_x = 5;
 	pixel_y = 6
 	},
@@ -46059,9 +46059,11 @@
 /area/operations/lobby)
 "xWa" = (
 /obj/item/rig/medical/equipped{
+	pixel_x = -2;
 	pixel_y = -2
 	},
 /obj/item/rig/medical/equipped{
+	pixel_x = 2;
 	pixel_y = -2
 	},
 /obj/structure/window/reinforced{


### PR DESCRIPTION
See title. I offset the rescue RIGs in the responder bay from each other to make it clear there are two and moved FR armbands from the loadout to their lockers.

Furthermore, only the responders' lockers had the medical stationbounceds in them before; now the ones on the table use that skin too. Security had no security-themed stationbounceds either, and now it does.