### PR TITLE
Kataphract Vessel Tweaks (round 2) 

### DIFF
--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -39,4 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
  - tweak: "Changed access on the Kataphract vessel to allow Hopeful's to open the armory. Additonally added a Hegemony flag to the armory, changed the hammers to hegemony power-hammers, added bins and changed the hanger lights to spotlights. Also removes the boxing gloves for lore reasons. "
- - bufix: "Fixed an incorrect amount of rods on the Kataphract vessel."
+ - bugfix: "Fixed an incorrect amount of rods on the Kataphract vessel."

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
- - tweak: "Changed access on the Kataphract vessel to allow Hopeful's to open the armory. Additonally added a Hegemony flag to the armory, changed the hammers to hegemony power-hammers, added bins and changed the hanger lights to spotlights. Also removes the boxing gloves for lore reasons. "
+ - tweak: "Changed access on the Kataphract vessel to allow Hopeful's to open the armory. Additonally added a Hegemony flag to the armory, changed the hammers to hegemony power-hammers, added bins and changed the hanger lights to spotlights.. Also removes the boxing gloves for lore reasons. Finally those hopeful's without flash proof voidsuits now have glasses. "
  - bugfix: "Fixed an incorrect amount of rods on the Kataphract vessel."

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Connorjg1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+ - tweak: "Changed access on the Kataphract vessel to allow Hopeful's to open the armory. Additonally added a Hegemony flag to the armory, changed the hammers to hegemony power-hammers, added bins and changed the hanger lights to spotlights. Also removes the boxing gloves for lore reasons. "
+ - bufix: "Fixed an incorrect amount of rods on the Kataphract vessel."

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
- - tweak: "Changed access on the Kataphract vessel to allow Hopeful's to open the armory. Additonally added a Hegemony flag to the armory, changed the hammers to hegemony power-hammers, added bins and changed the hanger lights to spotlights.. Also removes the boxing gloves for lore reasons. Finally those hopeful's without flash proof voidsuits now have glasses. "
+ - tweak: "Changed access on the Kataphract vessel to allow Hopeful's to open the armory. Additonally added a Hegemony flag to the armory, changed the hammers/satchels to hegemony variation, added bins and changed the hanger lights to spotlights.. Also removes the boxing gloves for lore reasons. Finally those hopeful's without flash proof voidsuits now have glasses. "
  - bugfix: "Fixed an incorrect amount of rods on the Kataphract vessel."

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -1315,7 +1315,6 @@
 /area/kataphract_chapter/sparring_chamber)
 "dh" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/gloves/boxing/blue,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -1327,7 +1326,6 @@
 /area/kataphract_chapter/sparring_chamber)
 "di" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/gloves/boxing/green,
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
 	dir = 5
@@ -1336,7 +1334,6 @@
 /area/kataphract_chapter/sparring_chamber)
 "dj" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/gloves/boxing/yellow,
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
 	dir = 5
@@ -1345,7 +1342,6 @@
 /area/kataphract_chapter/sparring_chamber)
 "dk" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/gloves/boxing,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -1501,6 +1497,9 @@
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/kataphract_chapter/toilets)
@@ -2926,30 +2925,6 @@
 /obj/item/device/radio,
 /obj/item/device/radio,
 /obj/item/device/radio,
-/obj/item/device/gps{
-	pixel_x = -6;
-	pixel_y = -3
-	},
-/obj/item/device/gps{
-	pixel_x = -6;
-	pixel_y = -3
-	},
-/obj/item/device/gps{
-	pixel_x = -6;
-	pixel_y = -3
-	},
-/obj/item/device/gps{
-	pixel_x = -6;
-	pixel_y = -3
-	},
-/obj/item/device/gps{
-	pixel_x = -6;
-	pixel_y = -3
-	},
-/obj/item/device/gps{
-	pixel_x = -6;
-	pixel_y = -3
-	},
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
 "gr" = (
@@ -3358,7 +3333,7 @@
 	id = "kata_armoury";
 	name = "Armoury Entrance Control";
 	pixel_x = 25;
-	req_one_access = list(115)
+	req_one_access = list(115,113)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10;
@@ -3532,7 +3507,7 @@
 "hv" = (
 /obj/machinery/door/airlock/glass{
 	name = "Quartermaster";
-	req_one_access = list(115)
+	req_one_access = list(115,113)
 	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -5551,6 +5526,9 @@
 /obj/structure/sign/flag/hegemony/right{
 	pixel_y = 32
 	},
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/trading_area)
 "lx" = (
@@ -6055,13 +6033,13 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/hangar)
 "mG" = (
-/obj/machinery/light{
+/obj/machinery/light/spot{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/hangar)
 "mH" = (
-/obj/machinery/light,
+/obj/machinery/light/spot,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/hangar)
 "mI" = (
@@ -6083,8 +6061,7 @@
 "mL" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Armoury";
-	req_access = list(115);
-	req_one_access = null
+	req_one_access = list(115,113)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6918,7 +6895,7 @@
 /obj/structure/sign/securearea{
 	pixel_x = 32
 	},
-/obj/machinery/light{
+/obj/machinery/light/spot{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -7374,13 +7351,13 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/trading_area)
 "yj" = (
-/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/machinery/light/spot,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/hangar)
 "yk" = (
@@ -7599,6 +7576,16 @@
 "Aw" = (
 /turf/simulated/floor/tiled/white,
 /area/kataphract_chapter/medical)
+"AC" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 10;
+	icon_state = "corner_white"
+	},
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/kataphract_chapter/sparring_chamber)
 "AD" = (
 /obj/structure/sign/flag/hegemony/right{
 	dir = 4;
@@ -7774,10 +7761,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/hangar)
+"CS" = (
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/main_ring)
 "CW" = (
 /obj/effect/shuttle_landmark/nav_kataphract_ship/nav1,
 /turf/template_noop,
 /area/space)
+"CX" = (
+/obj/machinery/light,
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/main_ring)
 "CY" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/device/flashlight/lamp,
@@ -8025,6 +8025,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/engineering)
+"Gk" = (
+/obj/structure/sign/flag/hegemony/right{
+	pixel_y = -32
+	},
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
+/turf/simulated/floor/wood,
+/area/kataphract_chapter/dorms)
 "Gr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 6
@@ -8341,6 +8350,16 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/engineering)
+"KK" = (
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 6
+	},
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/kataphract_chapter/bridge)
 "KP" = (
 /obj/structure/fuel_port/hydrogen{
 	pixel_y = -31
@@ -8630,6 +8649,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/dorms)
+"NU" = (
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/warehouse)
 "Oa" = (
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
@@ -9096,8 +9121,8 @@
 "TF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table/rack,
-/obj/item/melee/hammer/powered,
-/obj/item/melee/hammer/powered,
+/obj/item/melee/hammer/powered/hegemony,
+/obj/item/melee/hammer/powered/hegemony,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
 "TH" = (
@@ -9173,6 +9198,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/propulsion)
+"UC" = (
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 5
+	},
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/trading_area)
 "UE" = (
 /obj/structure/table/reinforced/steel,
 /obj/structure/window/reinforced{
@@ -9339,7 +9374,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/office)
 "Yg" = (
-/obj/machinery/light{
+/obj/machinery/light/spot{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -19736,7 +19771,7 @@ pH
 pH
 ge
 ge
-hG
+Gk
 fK
 hW
 jv
@@ -22809,7 +22844,7 @@ fb
 ek
 ek
 ek
-nm
+AC
 cP
 cf
 cp
@@ -24901,7 +24936,7 @@ bc
 aZ
 bc
 VG
-bc
+KK
 ab
 cg
 ct
@@ -25081,7 +25116,7 @@ cf
 cN
 cf
 cf
-cf
+CS
 ly
 ly
 ly
@@ -25268,7 +25303,7 @@ mA
 lh
 la
 la
-lz
+UC
 kP
 mi
 Ez
@@ -25741,7 +25776,7 @@ uR
 pf
 kJ
 iR
-lh
+NU
 li
 ll
 lO
@@ -26370,7 +26405,7 @@ cu
 cu
 cg
 fo
-fI
+CX
 fW
 go
 gY

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -8080,6 +8080,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/hangar)
+"GV" = (
+/obj/machinery/door/airlock/glass{
+	name = "Quartermaster";
+	req_one_access = list(115,113)
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/commissary)
 "GW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -8165,21 +8172,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/port_solars_array)
-"Ip" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/clothing/glasses/sunglasses/blindfold/tape,
-/turf/simulated/floor/tiled/dark,
-/area/kataphract_chapter/sparring_chamber)
 "Iw" = (
 /obj/effect/shuttle_landmark/nav_kataphract_ship/nav3,
 /turf/template_noop,
@@ -8947,13 +8939,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
-"RH" = (
-/obj/machinery/door/airlock/glass{
-	name = "Quartermaster";
-	req_one_access = list(115,113)
-	},
-/turf/simulated/floor/tiled,
-/area/kataphract_chapter/commissary)
 "RJ" = (
 /obj/structure/bed/stool/chair/office/bridge/generic{
 	dir = 4
@@ -23024,7 +23009,7 @@ cp
 cf
 cP
 dm
-Ip
+dK
 ek
 eF
 fc
@@ -23508,7 +23493,7 @@ ab
 cl
 cp
 cf
-RH
+GV
 do
 sC
 Bi

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -8165,6 +8165,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/port_solars_array)
+"Ip" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/clothing/glasses/sunglasses/blindfold/tape,
+/turf/simulated/floor/tiled/dark,
+/area/kataphract_chapter/sparring_chamber)
 "Iw" = (
 /obj/effect/shuttle_landmark/nav_kataphract_ship/nav3,
 /turf/template_noop,
@@ -8932,6 +8947,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
+"RH" = (
+/obj/machinery/door/airlock/glass{
+	name = "Quartermaster";
+	req_one_access = list(115,113)
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/commissary)
 "RJ" = (
 /obj/structure/bed/stool/chair/office/bridge/generic{
 	dir = 4
@@ -9429,21 +9451,6 @@
 /obj/item/clothing/glasses/sunglasses,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
-"YQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/clothing/glasses/sunglasses/blindfold/tape,
-/turf/simulated/floor/tiled/dark,
-/area/kataphract_chapter/sparring_chamber)
 "YT" = (
 /obj/structure/table/wood/gamblingtable,
 /obj/item/spacecash/c200,
@@ -23017,7 +23024,7 @@ cp
 cf
 cP
 dm
-YQ
+Ip
 ek
 eF
 fc
@@ -23501,7 +23508,7 @@ ab
 cl
 cp
 cf
-gu
+RH
 do
 sC
 Bi

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -529,6 +529,7 @@
 /obj/item/clothing/suit/armor/unathi/hegemony,
 /obj/item/clothing/head/helmet/unathi/hegemony,
 /obj/item/clothing/head/helmet/unathi/hegemony,
+/obj/item/clothing/glasses/sunglasses,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
 "bz" = (
@@ -7595,6 +7596,7 @@
 /obj/item/clothing/suit/armor/unathi/klax,
 /obj/item/clothing/head/helmet/unathi/klax,
 /obj/item/clothing/shoes/magboots/hegemony,
+/obj/item/clothing/glasses/sunglasses/blinders,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
 "AG" = (
@@ -9424,8 +9426,24 @@
 /obj/item/clothing/suit/armor/unathi/hegemony,
 /obj/item/clothing/head/helmet/unathi/hegemony,
 /obj/item/clothing/head/helmet/unathi/hegemony,
+/obj/item/clothing/glasses/sunglasses,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
+"YQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/item/clothing/glasses/sunglasses/blindfold/tape,
+/turf/simulated/floor/tiled/dark,
+/area/kataphract_chapter/sparring_chamber)
 "YT" = (
 /obj/structure/table/wood/gamblingtable,
 /obj/item/spacecash/c200,
@@ -22999,7 +23017,7 @@ cp
 cf
 cP
 dm
-dK
+YQ
 ek
 eF
 fc

--- a/maps/away/ships/kataphracts/kataphract_ship_ghostroles.dm
+++ b/maps/away/ships/kataphracts/kataphract_ship_ghostroles.dm
@@ -47,6 +47,7 @@
 	spawnpoints = list("kataphract_knight")
 
 	outfit = /datum/outfit/admin/kataphract/knight
+	
 
 	assigned_role = "Kataphract Knight Captain"
 	special_role = "Kataphract Knight Captain"
@@ -74,7 +75,7 @@
 	belt = /obj/item/melee/energy/sword/hegemony
 	shoes = /obj/item/clothing/shoes/caligae
 	id = /obj/item/card/id/distress/kataphract
-	back = /obj/item/storage/backpack/satchel
+	back = /obj/item/storage/backpack/satchel/hegemony
 
 
 	l_ear = /obj/item/device/radio/headset/ship
@@ -97,7 +98,7 @@
 	belt = /obj/item/melee/energy/sword/hegemony
 	shoes = /obj/item/clothing/shoes/vaurca
 	id = /obj/item/card/id/distress/kataphract
-	back = /obj/item/storage/backpack/satchel
+	back = /obj/item/storage/backpack/satchel/hegemony
 
 	l_hand = /obj/item/martial_manual/vaurca
 
@@ -127,12 +128,16 @@
 	name = "Kataphract Knight"
 
 	suit = /obj/item/clothing/accessory/poncho/red
+	back = /obj/item/storage/backpack/satchel/hegemony
+	
 
 /datum/outfit/admin/kataphract/knight/get_id_access()
 	return list(access_kataphract, access_kataphract_knight, access_kataphract_quartermaster, access_kataphract_trader, access_external_airlocks)
 
 /datum/outfit/admin/kataphract/quartermaster
 	name = "Kataphract Quartermaster"
+	
+	back = /obj/item/storage/backpack/satchel/hegemony
 
 /datum/outfit/admin/kataphract/quartermaster/get_id_access()
 	return list(access_kataphract, access_kataphract_quartermaster, access_kataphract_trader, access_external_airlocks)


### PR DESCRIPTION
First PR broke.

Adjusted several elements of the Kataphract vessel: The armoury doors now allow greater access for ghost-roles, the rods are a full pile, lights have been changed in the hanger for spotlights, boxing gloves have been removed due to not fitting lore, the powered hammer is now the Hegemony variation and a Hegemony flag has been added to the armoury. Also adds some flash protection to those Kataphracts taking the body-armor or those that can't take the voidsuits such as the Vaurca. Finally adds an extra door and some trash bins.
