### PR TITLE
Broken windows now drop all their materials when shattered

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -697,6 +697,7 @@
 	playsound(src, /decl/sound_category/glass_break_sound, 70, 1)
 	if(display_message)
 		visible_message(SPAN_WARNING("\The [src] shatters!"))
+	var/index = 0
 	while (index < 4)
 		new shardtype(loc)
 		if(reinf)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -697,12 +697,10 @@
 	playsound(src, /decl/sound_category/glass_break_sound, 70, 1)
 	if(display_message)
 		visible_message(SPAN_WARNING("\The [src] shatters!"))
-	var/index = 0
-	while (index < 4)
+	if(reinf)
+		new /obj/item/stack/rods(loc, 4)
+	for(var/i = 1 to 4)
 		new shardtype(loc)
-		if(reinf)
-			new /obj/item/stack/rods(loc)
-		index++
 
 	qdel(src)
 	return

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -697,18 +697,11 @@
 	playsound(src, /decl/sound_category/glass_break_sound, 70, 1)
 	if(display_message)
 		visible_message(SPAN_WARNING("\The [src] shatters!"))
-	if(dir == SOUTHWEST)
-		var/index = null
-		index = 0
-		while(index < 2)
-			new shardtype(loc)
-			if(reinf)
-				new /obj/item/stack/rods(loc)
-			index++
-	else
+	while (index < 4)
 		new shardtype(loc)
 		if(reinf)
 			new /obj/item/stack/rods(loc)
+		index++
 
 	qdel(src)
 	return

--- a/html/changelogs/omicega-glassbreakingtime.yml
+++ b/html/changelogs/omicega-glassbreakingtime.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Reinforced windows now drop more materials when broken."


### PR DESCRIPTION
See title. Previously broken windows were only dropping 1 rod and glass shard when you need 4 to reconstruct it; most other things drop their full materials when destroyed (a wall broken into a girder drops the 2 metal you need to rebuild it, same if you blow up the girder too, etc.)

If this is too much I would be happy to make these windows at _least_ drop 2 rods and glass shards so that you don't end up with odd amounts of material after making the repairs.