### PR TITLE
Hijabs now take ear slot by default

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_head.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_head.dm
@@ -215,6 +215,7 @@
 /datum/gear/head/hijab
 	display_name = "hijab selection"
 	path = /obj/item/clothing/head/hijab
+	slot = slot_r_ear
 
 /datum/gear/head/hijab/New()
 	..()
@@ -233,6 +234,7 @@
 	display_name = "colorable hijab"
 	path = /obj/item/clothing/head/hijab
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
+	slot = slot_r_ear
 
 /datum/gear/head/turban
 	display_name = "turban selection"

--- a/html/changelogs/hijabslot.yml
+++ b/html/changelogs/hijabslot.yml
@@ -1,0 +1,7 @@
+author: listerla
+
+delete-after: True
+
+changes:
+  - tweak: "Hijabs now take the ear slot by default, as to be more easily taken with a hat."
+


### PR DESCRIPTION
Just to allow them to be taken without needing a shuffle to the ear slot to wear a helmet, or to be taken with loadout hats more easily.