### PR TITLE
Kataphract Ship - Giga Fix Collection

### DIFF
--- a/code/game/jobs/access_datum.dm
+++ b/code/game/jobs/access_datum.dm
@@ -534,16 +534,6 @@ var/const/access_kataphract_knight = 114
 	id = access_kataphract_knight
 	desc = "Kataphract Knight Access"
 
-var/const/access_kataphract_quartermaster = 115
-/datum/access/kataphract/quartermaster
-	id = access_kataphract_quartermaster
-	desc = "Kataphract Quartermaster Access"
-
-var/const/access_kataphract_trader = 116
-/datum/access/kataphract/trader
-	id = access_kataphract_trader
-	desc = "Kataphract Trader Access"
-
 /***************
 * Antag access *
 ***************/

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -497,6 +497,9 @@
 	if(do_set_light)
 		set_light(2, 0.5, COLOR_SUN)
 
+/obj/machinery/door/firedoor/noid
+	req_one_access = null
+
 //These are playing merry hell on ZAS.  Sorry fellas :(
 
 /*/obj/machinery/door/firedoor/border_only

--- a/code/modules/merchant/merchant_programs.dm
+++ b/code/modules/merchant/merchant_programs.dm
@@ -10,8 +10,8 @@
 	size = 12
 	usage_flags = PROGRAM_CONSOLE
 	requires_access_to_run = PROGRAM_ACCESS_LIST_ONE
-	required_access_run = list(access_merchant, access_kataphract_trader)
-	required_access_download = list(access_merchant, access_kataphract_trader)
+	required_access_run = list(access_merchant)
+	required_access_download = list(access_merchant)
 	var/obj/machinery/merchant_pad/pad = null
 	var/current_merchant = 0
 	var/show_trades = 0

--- a/html/changelogs/wickedcybs_medmaint.yml
+++ b/html/changelogs/wickedcybs_medmaint.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - rscadd: "There's a door to maint from the medical recovery room now."

--- a/html/changelogs/wickedcybs_medmaint.yml
+++ b/html/changelogs/wickedcybs_medmaint.yml
@@ -1,6 +1,0 @@
-author: WickedCybs
-
-delete-after: True
-
-changes:
-  - rscadd: "There's a door to maint from the medical recovery room now."

--- a/html/changelogs/wickedcybs_noid.yml
+++ b/html/changelogs/wickedcybs_noid.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "If venting happened, third parties wouldn't be able to use their emergency shutters to escape since it inherently has horizon engineering access required, which is ideally supposed to make it so non-engineers can't open the way into vented areas. Was rectified by adding a variant that needs no access to open. Every window and door has the proper type of emergency shutter now."
+  - rscadd: "Defined more areas for the kataphract ship since a lot of what was mapped in was pulling double duty for extra rooms. This would lead to some buggy and confusing interactions, especially for those far apart."
+  - tweak: "Lights in the kataship hangar were swapped for spotlights, as intended. Still looks the same, it just shines brighter."
+  - tweak: "Some of the air alarms still had engineering access requirements, which was hopefully fixed on a second pass and changed to kata id stuff instead."
+  - rscdel: "Removed the unused kata trader and quartermaster access types."
+  - tweak: "The kata ship docking airlock will actually start bolted now."
+  - tweak: "the kata ship airlock pumps will both cycle now instead of just one working."
+  - rscdel: "There were catwalks visible on the solars of the kataship when you look at the map using dream maker or strongdmm. These didn't spawn in the game itself as they weren't the interior type. Removed those from the map file."
+  - tweak: "Moved the position of the kata shuttle's docking port controller, since it was positioned in a way that it would overlay over anything put on the table it was originally on."

--- a/html/changelogs/wickedcybs_noid.yml
+++ b/html/changelogs/wickedcybs_noid.yml
@@ -13,3 +13,4 @@ changes:
   - rscdel: "There were catwalks visible on the solars of the kataship when you look at the map using dream maker or strongdmm. These didn't spawn in the game itself as they weren't the interior type. Removed those from the map file."
   - tweak: "Moved the position of the kata shuttle's docking port controller, since it was positioned in a way that it would overlay over anything put on the table it was originally on."
   - rscadd: "Added the missing air alarms and other minor atmos equipment where it was missing on the kataphract ship, like the janitorial room or the brig."
+  - tweak: "Fixes blastdoor orientations on the kata ship bridge and transport shuttle."

--- a/html/changelogs/wickedcybs_noid.yml
+++ b/html/changelogs/wickedcybs_noid.yml
@@ -1,31 +1,3 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes:
-#   bugfix
-#   wip (For works in progress)
-#   tweak
-#   soundadd
-#   sounddel
-#   rscadd (general adding of nice things)
-#   rscdel (general deleting of nice things)
-#   imageadd
-#   imagedel
-#   maptweak
-#   spellcheck (typo fixes)
-#   experiment
-#   balance
-#   admin
-#   backend
-#   security
-#   refactor
-#################################
-
 author: WickedCybs
 
 delete-after: True
@@ -40,3 +12,4 @@ changes:
   - tweak: "the kata ship airlock pumps will both cycle now instead of just one working."
   - rscdel: "There were catwalks visible on the solars of the kataship when you look at the map using dream maker or strongdmm. These didn't spawn in the game itself as they weren't the interior type. Removed those from the map file."
   - tweak: "Moved the position of the kata shuttle's docking port controller, since it was positioned in a way that it would overlay over anything put on the table it was originally on."
+  - rscadd: "Added the missing air alarms and other minor atmos equipment where it was missing on the kataphract ship, like the janitorial room or the brig."

--- a/maps/away/ships/kataphracts/kataphract_areas.dm
+++ b/maps/away/ships/kataphracts/kataphract_areas.dm
@@ -25,6 +25,14 @@
 	name = "Kataphract Chapter - Main Ring"
 	icon_state = "yellow"
 
+/area/kataphract_chapter/aft_hall
+	name = "Kataphract Chapter - Aft Hall"
+	icon_state = "yellow"
+
+/area/kataphract_chapter/entry
+	name = "Kataphract Chapter - Entry"
+	icon_state = "yellow"
+
 /area/kataphract_chapter/medical
 	name = "Kataphract Chapter - Medicine Room"
 	icon_state = "law"
@@ -48,38 +56,50 @@
 	name = "Kataphract Chapter - Cafeteria"
 	icon_state = "kitchen"
 
+/area/kataphract_chapter/brig
+	name = "Kataphract Chapter - Brig"
+	icon_state = "security"
+
 /area/kataphract_chapter/engineering
 	name = "Kataphract Chapter - Engineering"
-	icon_state = "engineering_workshop"
-	ambience = AMBIENCE_ENGINEERING
-
-/area/kataphract_chapter/port_solars_array
-	name = "Kataphract Chapter - Port solars Array"
 	icon_state = "engineering_workshop"
 	ambience = AMBIENCE_ENGINEERING
 
 /area/kataphract_chapter/port_solars
 	name = "Kataphract Chapter - Port Solars"
 	icon_state = "panelsA"
+	ambience = AMBIENCE_ENGINEERING
+
+/area/kataphract_chapter/port_solars_array
+	name = "Kataphract Chapter - Port solars Array"
+	icon_state = "panelsA"
 	ambience = AMBIENCE_SPACE
 
 /area/kataphract_chapter/starboard_solars
 	name = "Kataphract Chapter - Starboard Solars"
 	icon_state = "panelsA"
-	ambience = AMBIENCE_SPACE
+	ambience = AMBIENCE_ENGINEERING
 
 /area/kataphract_chapter/starboard_solars_array
 	name = "Kataphract Chapter - Starboard Solars Array"
-	icon_state = "engineering_workshop"
-	ambience = AMBIENCE_ENGINEERING
+	icon_state = "panelsA"
+	ambience = AMBIENCE_SPACE
 
 /area/kataphract_chapter/trading_area
 	name = "Kataphract Chapter - Trading Area"
 	icon_state = "quartoffice"
 
-/area/kataphract_chapter/propulsion
-	name = "Kataphract Chapter - Propulsion"
+/area/kataphract_chapter/starboardpropulsion
+	name = "Kataphract Chapter - Starboard Propulsion"
 	icon_state = "engineering_workshop"
+
+/area/kataphract_chapter/portpropulsion
+	name = "Kataphract Chapter - Starboard Propulsion"
+	icon_state = "engineering_workshop"
+
+/area/kataphract_chapter/janitorial
+	name = "Kataphract Chapter - Janitorial"
+	icon_state = "janitor"
 
 /area/kataphract_chapter/warehouse
 	name = "Kataphract Chapter - Warehouse"

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -1182,7 +1182,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/kataphract_chapter/toilets)
 "cN" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
 "cO" = (
@@ -2108,6 +2108,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/brig)
 "eN" = (
@@ -2258,14 +2259,12 @@
 /turf/simulated/floor/tiled/freezer,
 /area/kataphract_chapter/toilets)
 "eW" = (
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
 /obj/machinery/door/airlock/glass{
 	name = "Chapter Cafeteria and Knight's Office";
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
 "eX" = (
@@ -3052,9 +3051,6 @@
 	icon_state = "corner_white";
 	dir = 1
 	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3071,6 +3067,7 @@
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
 "gD" = (
@@ -3243,9 +3240,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/white,
 /area/kataphract_chapter/cafeteria)
 "gS" = (
@@ -3866,12 +3863,12 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
 "in" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Chapter Cafeteria";
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/white,
 /area/kataphract_chapter/cafeteria)
 "io" = (
@@ -6235,17 +6232,7 @@
 	},
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/dorms)
-"mV" = (
-/obj/machinery/door/airlock/glass{
-	name = "Chapter Engineering and Hangar";
-	req_access = null;
-	req_one_access = list(113)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/kataphract_chapter/aft_hall)
 "mW" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -6270,6 +6257,7 @@
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/aft_hall)
 "mX" = (
@@ -6316,12 +6304,12 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/janitorial)
 "nb" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Chapter Engineering and Hangar";
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/aft_hall)
 "nc" = (
@@ -6590,7 +6578,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
 "nB" = (
@@ -6663,7 +6651,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/office)
 "op" = (
@@ -6671,7 +6659,7 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/entry)
 "ou" = (
@@ -6905,6 +6893,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/brig)
 "qK" = (
@@ -7095,7 +7084,7 @@
 	icon_state = "corner_white";
 	dir = 10
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/entry)
 "sC" = (
@@ -7203,7 +7192,6 @@
 	name = "Propulsion";
 	req_one_access = list(113)
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7212,6 +7200,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/starboardpropulsion)
 "uh" = (
@@ -7229,7 +7218,7 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/aft_hall)
 "un" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/aft_hall)
 "uy" = (
@@ -7582,7 +7571,7 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/medical)
 "yr" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/entry)
 "yw" = (
@@ -7609,7 +7598,7 @@
 	icon_state = "corner_white";
 	dir = 5
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/entry)
 "yE" = (
@@ -8652,14 +8641,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/starboardpropulsion)
-"Ko" = (
-/obj/machinery/door/airlock/glass{
-	name = "Chapter Trading Area"
-	},
-/obj/machinery/door/firedoor/noid,
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled,
-/area/kataphract_chapter/aft_hall)
 "Ks" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 4
@@ -8907,7 +8888,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/hangar)
 "Ni" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -8927,6 +8907,7 @@
 	icon_state = "corner_white";
 	dir = 8
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/aft_hall)
 "Nl" = (
@@ -9781,7 +9762,7 @@
 	icon_state = "corner_white";
 	dir = 10
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/entry)
 "Wi" = (
@@ -9915,7 +9896,6 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/engineering)
 "Ya" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -9927,6 +9907,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/entry)
 "Yb" = (
@@ -23616,7 +23597,7 @@ cP
 cf
 cp
 cf
-mV
+nb
 OT
 wl
 iK
@@ -23963,7 +23944,7 @@ ul
 Aq
 OT
 lK
-Ko
+Jr
 FX
 mQ
 mi

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -6270,13 +6270,9 @@
 /turf/simulated/floor/airless,
 /area/kataphract_chapter/starboard_solars_array)
 "mY" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 1;
-	icon_state = "pdoor0";
-	id = "katashroud";
-	name = "Sensor Shroud";
-	opacity = 0
+/obj/machinery/door/blast/regular/open{
+	dir = 8;
+	id = "katashroud"
 	},
 /turf/simulated/floor/airless,
 /area/kataphract_chapter/bridge)
@@ -9515,14 +9511,15 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/high{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24;
-	req_access = list(113)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = list(113)
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/janitorial)
@@ -9969,6 +9966,15 @@
 /obj/item/clothing/glasses/sunglasses,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
+"YP" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/firedoor/noid,
+/obj/machinery/door/blast/regular/open{
+	dir = 8;
+	id = "katabridgeshutter"
+	},
+/turf/simulated/floor/plating,
+/area/kataphract_chapter/bridge)
 "YQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -21941,7 +21947,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 aG
 aN
 bb
@@ -22103,7 +22109,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 az
 aO
 bc
@@ -22265,7 +22271,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 ay
 aP
 bd
@@ -22427,7 +22433,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 az
 aQ
 be
@@ -22911,7 +22917,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 FC
 bJ
 aI
@@ -23073,7 +23079,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 az
 aC
 aC
@@ -23235,7 +23241,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 hm
 aC
 aC
@@ -23397,7 +23403,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 az
 aC
 aC
@@ -23559,7 +23565,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 ay
 aC
 aC
@@ -23721,7 +23727,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 az
 aC
 aI
@@ -23883,7 +23889,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 ay
 aC
 aC
@@ -24045,7 +24051,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 az
 aC
 aC
@@ -24207,7 +24213,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 hm
 aC
 aC
@@ -24369,7 +24375,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 az
 aC
 aC
@@ -24531,7 +24537,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 Mk
 bI
 aI
@@ -25019,7 +25025,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 az
 aQ
 be
@@ -25181,7 +25187,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 ay
 aP
 bf
@@ -25343,7 +25349,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 az
 aR
 bb
@@ -25505,7 +25511,7 @@ iB
 iB
 iB
 iB
-ms
+YP
 aK
 aZ
 bc

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -1056,7 +1056,6 @@
 	req_one_access = list(113)
 	},
 /obj/machinery/door/firedoor/noid,
-/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/freezer,
 /area/kataphract_chapter/toilets)
 "cB" = (
@@ -6229,15 +6228,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/dorms)
-"mV" = (
-/obj/machinery/door/airlock/glass{
-	name = "Chapter Engineering and Hangar";
-	req_access = null;
-	req_one_access = list(113)
-	},
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled,
-/area/kataphract_chapter/aft_hall)
 "mW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6309,6 +6299,15 @@
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/janitorial)
+"nb" = (
+/obj/machinery/door/airlock/glass{
+	name = "Chapter Engineering and Hangar";
+	req_access = null;
+	req_one_access = list(113)
+	},
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/aft_hall)
 "nc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7201,9 +7200,7 @@
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/starboardpropulsion)
 "uh" = (
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
 "ul" = (
@@ -7387,9 +7384,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
 "wl" = (
@@ -8201,9 +8196,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
 "Fc" = (
@@ -23594,7 +23587,7 @@ cP
 cf
 cp
 cf
-mV
+nb
 OT
 wl
 iK
@@ -23918,7 +23911,7 @@ cQ
 cf
 cp
 cf
-mV
+nb
 OT
 Aq
 Wt

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -2474,20 +2474,13 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
 "fo" = (
-/obj/machinery/door/firedoor{
-	dir = 8
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/firedoor/noid,
+/obj/machinery/door/blast/regular/open{
+	id = "egg_blastdoors"
 	},
-/obj/machinery/door/airlock/glass{
-	name = "Chapter Cafeteria and Knight's Office";
-	req_access = null;
-	req_one_access = list(113)
-	},
-/obj/machinery/alarm{
-	pixel_y = 25;
-	req_one_access = list(113)
-	},
-/turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/turf/simulated/floor/plating,
+/area/shuttle/kataphract_shuttle/main_compartment)
 "fp" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 4
@@ -5644,6 +5637,12 @@
 	dir = 9;
 	pixel_y = 0
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24;
+	req_one_access = list(24,11,55)
+	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/entry)
 "lG" = (
@@ -8396,12 +8395,6 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/hangar)
 "GX" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24;
-	req_one_access = list(24,11,55)
-	},
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
 	dir = 6
@@ -9283,14 +9276,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/engineering)
-"Qz" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
-/obj/machinery/door/firedoor/noid,
-/obj/machinery/door/blast/regular/open{
-	id = "egg_blastdoors"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/kataphract_shuttle/main_compartment)
 "QD" = (
 /obj/structure/flora/pottedplant,
 /obj/effect/floor_decal/corner/red{
@@ -10092,6 +10077,16 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/white,
 /area/kataphract_chapter/cafeteria)
+"ZO" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 25;
+	req_one_access = list(113)
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/main_ring)
 
 (1,1,1) = {"
 iB
@@ -20556,11 +20551,11 @@ Yg
 aa
 aa
 aa
-Qz
-Qz
-Qz
-Qz
-Qz
+fo
+fo
+fo
+fo
+fo
 aa
 aa
 aa
@@ -22146,7 +22141,7 @@ bc
 bI
 aC
 ab
-cf
+cj
 cp
 cf
 cN
@@ -22794,7 +22789,7 @@ bb
 bJ
 Xy
 ab
-cj
+cf
 cp
 cf
 du
@@ -25716,7 +25711,7 @@ cf
 cN
 cf
 cf
-cf
+dG
 cf
 fl
 cf
@@ -25879,7 +25874,7 @@ nw
 nw
 cu
 cu
-fo
+eW
 gC
 eW
 fW
@@ -27013,7 +27008,7 @@ lI
 lI
 lI
 lI
-cg
+ZO
 fl
 CX
 fW

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -26,7 +26,8 @@
 /turf/simulated/wall/r_wall,
 /area/shuttle/kataphract_shuttle/main_compartment)
 "ah" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/trading_area)
 "ai" = (
@@ -34,7 +35,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "aj" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -45,15 +46,16 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "ak" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/machinery/door/airlock/maintenance{
 	name = "Propulsion";
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "al" = (
 /turf/simulated/wall/r_wall,
 /area/shuttle/kataphract_shuttle/engine_compartment)
@@ -65,13 +67,12 @@
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/engineering)
 "an" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/machinery/door/blast/regular/open{
-	dir = 8;
-	id = "egg_blastdoors"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/shuttle/kataphract_shuttle/main_compartment)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/kataphract_chapter/brig)
 "ao" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/paper_bin,
@@ -117,7 +118,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/trading_area)
 "au" = (
@@ -169,7 +170,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/light{
+/obj/machinery/light/spot{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -205,7 +206,7 @@
 "aE" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "aF" = (
 /obj/machinery/computer/ship/sensors{
 	dir = 4;
@@ -256,7 +257,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
 "aL" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/cafeteria)
 "aM" = (
@@ -449,12 +451,8 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/warehouse)
 "bk" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/hangar)
 "bn" = (
@@ -591,7 +589,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "bH" = (
 /obj/machinery/shipsensors/weak,
 /obj/structure/railing/mapped{
@@ -736,6 +734,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25;
+	req_one_access = list(113)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
 "bX" = (
@@ -744,13 +747,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "bY" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25;
-	req_one_access = list(113)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	pixel_y = 0
@@ -765,22 +763,28 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/portpropulsion)
 "ca" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "cb" = (
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge Glass Airlock";
 	req_access = list(113);
 	req_one_access = null
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
 "cc" = (
@@ -791,12 +795,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_command{
 	name = "Bridge Glass Airlock";
 	req_access = list(113);
 	req_one_access = null
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
 "cd" = (
@@ -805,16 +809,15 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "ce" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_command{
-	name = "Bridge Glass Airlock";
-	req_access = list(113);
-	req_one_access = null
+/obj/structure/bed/padded,
+/obj/machinery/alarm{
+	pixel_y = 25;
+	req_one_access = list(113)
 	},
 /turf/simulated/floor/tiled/dark,
-/area/kataphract_chapter/bridge)
+/area/kataphract_chapter/brig)
 "cf" = (
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
@@ -863,8 +866,9 @@
 	name = "Propulsion";
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "cn" = (
 /turf/simulated/wall,
 /area/kataphract_chapter/toilets)
@@ -1051,6 +1055,8 @@
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/freezer,
 /area/kataphract_chapter/toilets)
 "cB" = (
@@ -1130,7 +1136,7 @@
 "cH" = (
 /obj/structure/foamedmetal,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "cI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1140,17 +1146,29 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "cJ" = (
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/office)
 "cK" = (
 /obj/structure/bed/padded,
 /turf/simulated/floor/tiled/dark,
-/area/kataphract_chapter/office)
+/area/kataphract_chapter/brig)
 "cL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/kataphract_chapter/office)
+/area/kataphract_chapter/brig)
 "cM" = (
 /obj/structure/sink{
 	icon_state = "sink";
@@ -1239,9 +1257,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
 "cX" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/office)
+/area/kataphract_chapter/brig)
 "cY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1278,12 +1297,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
 "dd" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Chapter Residential Area";
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
 "de" = (
@@ -1426,7 +1445,8 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
 "du" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/sparring_chamber)
 "dv" = (
@@ -1441,6 +1461,7 @@
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/freezer,
 /area/kataphract_chapter/toilets)
 "dx" = (
@@ -1512,12 +1533,13 @@
 /area/kataphract_chapter/main_ring)
 "dF" = (
 /turf/space,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/port_solars_array)
 "dG" = (
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
-	pixel_y = 0
+	pixel_y = 0;
+	req_one_access = list(113)
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
@@ -1637,7 +1659,7 @@
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
-	pixel_x = -22;
+	pixel_x = -24;
 	req_one_access = list(113)
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1750,14 +1772,12 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance"
 	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/hangar)
+/area/kataphract_chapter/starboardpropulsion)
 "ec" = (
 /obj/machinery/power/solar,
 /obj/structure/cable/yellow{
@@ -1765,16 +1785,14 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/port_solars_array)
 "ed" = (
 /obj/machinery/door/airlock/glass{
 	name = "Chapter Cafeteria and Knight's Office";
 	req_access = null;
 	req_one_access = list(113)
 	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/medical)
 "ee" = (
@@ -1806,7 +1824,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/port_solars_array)
 "eh" = (
 /obj/structure/window/reinforced{
 	icon_state = "rwindow";
@@ -1851,7 +1869,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/starboard_solars_array)
 "en" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1887,17 +1905,17 @@
 /area/kataphract_chapter/hangar)
 "er" = (
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "es" = (
 /obj/machinery/door/airlock/glass{
 	name = "Canisters and Supplies";
 	req_one_access = list(113)
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/hangar)
 "et" = (
@@ -1939,7 +1957,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/port_solars_array)
 "ez" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1956,9 +1974,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -1969,6 +1984,7 @@
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/commissary)
 "eB" = (
@@ -2036,7 +2052,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "eJ" = (
 /obj/machinery/alarm{
 	pixel_y = 25;
@@ -2085,8 +2101,15 @@
 	name = "Brig";
 	req_access = list(113)
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/kataphract_chapter/office)
+/area/kataphract_chapter/brig)
 "eN" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -2104,7 +2127,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/starboard_solars_array)
 "eO" = (
 /obj/effect/shuttle_landmark/nav_kataphract_ship/nav2,
 /turf/template_noop,
@@ -2221,7 +2244,6 @@
 "eV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -2232,6 +2254,7 @@
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/freezer,
 /area/kataphract_chapter/toilets)
 "eW" = (
@@ -2256,14 +2279,12 @@
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/office)
 "eY" = (
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
 /obj/machinery/door/airlock/glass{
 	name = "Quartermaster";
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/commissary)
 "eZ" = (
@@ -2311,7 +2332,8 @@
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
-	pixel_x = -22
+	pixel_x = -22;
+	req_one_access = list(113)
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/commissary)
@@ -2372,7 +2394,6 @@
 	icon_state = "corner_white";
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2389,6 +2410,7 @@
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
 "fl" = (
@@ -2444,25 +2466,25 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
 "fo" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red{
+/obj/machinery/door/firedoor{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 1
+/obj/machinery/door/airlock/glass{
+	name = "Chapter Cafeteria and Knight's Office";
+	req_access = null;
+	req_one_access = list(113)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/alarm{
+	pixel_y = 25;
+	req_one_access = list(113)
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
@@ -2488,18 +2510,7 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
 "fq" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/yellow{
-	icon_state = "corner_white";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/wall/r_wall,
 /area/kataphract_chapter/main_ring)
 "fr" = (
 /obj/machinery/light{
@@ -2536,8 +2547,13 @@
 /area/kataphract_chapter/main_ring)
 "fw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/portpropulsion)
 "fx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2547,12 +2563,12 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
 "fy" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Chapter Toilets";
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/freezer,
 /area/kataphract_chapter/toilets)
 "fz" = (
@@ -2606,6 +2622,7 @@
 /obj/item/device/gps,
 /obj/item/device/gps,
 /obj/item/device/gps,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/commissary)
 "fE" = (
@@ -2623,10 +2640,10 @@
 /area/kataphract_chapter/cafeteria)
 "fG" = (
 /obj/machinery/door/airlock/hatch,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/kataphract_shuttle/engine_compartment)
 "fH" = (
@@ -2652,7 +2669,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/kataphract_shuttle/main_compartment)
 "fM" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -2664,6 +2680,7 @@
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/dorms)
 "fN" = (
@@ -2838,14 +2855,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
 /obj/machinery/door/airlock/glass{
 	name = "Sparring Chamber";
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/sparring_chamber)
 "gi" = (
@@ -2859,14 +2874,12 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/hangar)
 "gk" = (
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
 /obj/machinery/door/airlock/glass{
 	name = "Sparring Chamber";
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/sparring_chamber)
 "gl" = (
@@ -2965,7 +2978,8 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
 "gu" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/commissary)
 "gv" = (
@@ -2981,11 +2995,11 @@
 	name = "Pod Bay";
 	req_one_access = list(113)
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/hangar)
 "gx" = (
@@ -3247,7 +3261,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "gT" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -3334,7 +3348,7 @@
 	id = "kata_armoury";
 	name = "Armoury Entrance Control";
 	pixel_x = 25;
-	req_one_access = list(115,113)
+	req_one_access = list(113)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10;
@@ -3400,7 +3414,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/hangar)
+/area/kataphract_chapter/aft_hall)
 "hl" = (
 /obj/structure/table/wood/gamblingtable,
 /obj/item/reagent_containers/food/snacks/bacon_flatbread,
@@ -3520,6 +3534,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/commissary)
 "hw" = (
@@ -3604,12 +3619,12 @@
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/dorms)
 "hI" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Chapter Dormitory";
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/dorms)
 "hJ" = (
@@ -3666,14 +3681,13 @@
 /turf/simulated/floor/lino,
 /area/kataphract_chapter/cafeteria)
 "hT" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/starboard_solars_array)
 "hU" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -3691,14 +3705,13 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/starboard_solars_array)
 "hV" = (
-/obj/structure/lattice/catwalk,
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/starboard_solars_array)
 "hW" = (
 /turf/simulated/wall/r_wall,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/cafeteria)
 "hX" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable/yellow{
@@ -3706,13 +3719,8 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/space)
 "hY" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
@@ -3720,6 +3728,12 @@
 	name = "Sparring Chamber";
 	req_access = null;
 	req_one_access = list(113)
+	},
+/obj/machinery/door/firedoor/noid,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/sparring_chamber)
@@ -3730,14 +3744,14 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/port_solars_array)
 "ia" = (
 /turf/simulated/wall,
 /area/kataphract_chapter/engineering)
 "ib" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "ic" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -3750,7 +3764,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "id" = (
 /obj/structure/sign/securearea{
 	pixel_y = -32
@@ -3871,7 +3885,8 @@
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
-	pixel_x = -22
+	pixel_x = -22;
+	req_one_access = list(113)
 	},
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -3919,7 +3934,7 @@
 	},
 /obj/structure/bed/stool/chair,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "is" = (
 /obj/machinery/power/terminal{
 	icon_state = "term";
@@ -3951,7 +3966,7 @@
 	name = "Trading Desk";
 	req_one_access = list(114,116)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/trading_area)
 "iu" = (
@@ -4070,17 +4085,24 @@
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/engineering)
 "iJ" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/power/apc/high{
+	dir = 4;
+	name = "north bump";
+	pixel_x = 24;
+	req_access = list(113)
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "iK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "iL" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4122,7 +4144,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "iP" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -4159,7 +4181,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "iR" = (
 /turf/simulated/wall,
 /area/kataphract_chapter/warehouse)
@@ -4171,8 +4193,12 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/alarm{
+	pixel_y = 28;
+	req_one_access = list(113)
+	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "iT" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -4181,7 +4207,7 @@
 	},
 /obj/machinery/power/smes/buildable/autosolars,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "iU" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -4200,7 +4226,7 @@
 /area/kataphract_chapter/engineering)
 "iV" = (
 /turf/simulated/wall/r_wall,
-/area/space)
+/area/kataphract_chapter/brig)
 "iW" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -4286,13 +4312,8 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/engineering)
 "jc" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/turf/simulated/wall,
+/area/kataphract_chapter/entry)
 "jd" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -4326,7 +4347,6 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/engineering)
 "jf" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -4343,11 +4363,12 @@
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/engineering)
 "jg" = (
 /turf/simulated/wall/r_wall,
-/area/kataphract_chapter/hull)
+/area/kataphract_chapter/toilets)
 "jh" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -4365,7 +4386,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/port_solars_array)
 "ji" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1983;
@@ -4379,7 +4400,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "jj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8;
@@ -4391,23 +4412,22 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "jk" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/starboard_solars_array)
 "jl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black{
 	dir = 8
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "jm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -4424,16 +4444,15 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "jn" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/starboard_solars_array)
 "jo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -4449,7 +4468,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "jp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4463,9 +4482,10 @@
 	},
 /obj/machinery/power/smes/buildable/autosolars,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "jr" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/bridge)
 "js" = (
@@ -4479,9 +4499,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "jt" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -4498,14 +4518,13 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/engineering)
 "jv" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/port_solars_array)
 "jw" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -4514,8 +4533,12 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/alarm{
+	pixel_y = 28;
+	req_one_access = list(113)
+	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "jx" = (
 /obj/machinery/button/remote/airlock{
 	id = "kataofficedoor";
@@ -4566,7 +4589,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/portpropulsion)
 "jD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4586,10 +4609,12 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/engineering)
 "jF" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
+	dir = 8;
 	id = "egg_blastdoors"
 	},
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/shuttle/kataphract_shuttle/main_compartment)
 "jG" = (
@@ -4598,7 +4623,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/portpropulsion)
 "jH" = (
 /obj/structure/sign/electricshock{
 	pixel_y = 32
@@ -4615,14 +4640,14 @@
 	req_access = null;
 	req_one_access = list(113)
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "jJ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4636,9 +4661,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "jK" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -4649,6 +4673,7 @@
 	req_access = null;
 	req_one_access = list(113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/engineering)
 "jL" = (
@@ -4667,7 +4692,7 @@
 	tag_interior_door = "chapter_port_interior"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "jM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4687,13 +4712,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "jO" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/warehouse)
 "jP" = (
@@ -4714,7 +4738,8 @@
 	req_one_access = list(113)
 	},
 /obj/machinery/door/firedoor/multi_tile{
-	dir = 1
+	dir = 1;
+	req_one_access = list(113)
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/trading_area)
@@ -4733,7 +4758,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "jR" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1984;
@@ -4750,7 +4775,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "jS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
@@ -4762,7 +4787,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "jT" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1984;
@@ -4776,7 +4801,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "jU" = (
 /obj/machinery/door/window{
 	dir = 4;
@@ -4795,11 +4820,11 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "jV" = (
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "jW" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -4816,22 +4841,21 @@
 	tag_interior_door = "chapter_starboard_interior"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "jX" = (
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1984;
-	master_tag = "chapter_starboard_airlock";
-	pixel_x = -28
-	},
-/obj/structure/lattice/catwalk,
-/turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/turf/simulated/wall/r_wall,
+/area/space)
 "jY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 9
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/portpropulsion)
 "jZ" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -4839,18 +4863,19 @@
 	},
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "ka" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/medical)
 "kb" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/solar_control/autostart,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "kc" = (
 /obj/structure/bed/stool/chair/office/bridge/generic,
 /turf/simulated/floor/tiled/dark,
@@ -4874,7 +4899,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "ke" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -4979,6 +5004,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/hangar)
 "ko" = (
@@ -5012,7 +5042,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "kp" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5020,7 +5050,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "kq" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5041,7 +5071,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "kv" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -5049,10 +5079,10 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "kw" = (
 /turf/simulated/wall/r_wall,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "kx" = (
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/coffee/full,
@@ -5065,7 +5095,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "ky" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5092,7 +5122,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "kz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5114,13 +5144,13 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "kA" = (
 /obj/structure/sign/securearea{
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "kB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5142,7 +5172,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "kC" = (
 /obj/machinery/vending/engivend{
 	req_access = null;
@@ -5190,19 +5220,24 @@
 	req_one_access = list(113)
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "kI" = (
 /obj/machinery/firealarm/west,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "kJ" = (
 /turf/simulated/wall/r_wall,
 /area/kataphract_chapter/warehouse)
 "kK" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/machinery/door/blast/regular/open{
+	dir = 8;
+	id = "egg_blastdoors"
+	},
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/shuttle/kataphract_shuttle/main_compartment)
@@ -5237,7 +5272,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "kN" = (
 /turf/simulated/wall,
 /area/kataphract_chapter/hangar)
@@ -5254,7 +5289,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "kP" = (
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/trading_area)
@@ -5290,7 +5325,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/hangar)
+/area/kataphract_chapter/aft_hall)
 "kU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -5328,7 +5363,7 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "kX" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5345,28 +5380,29 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/trading_area)
 "kY" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/engineering)
 "kZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "la" = (
 /turf/simulated/wall,
 /area/kataphract_chapter/trading_area)
 "lb" = (
 /obj/structure/foamedmetal,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "lc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 10
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "ld" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -5473,7 +5509,12 @@
 	name = "Pod Bay";
 	req_one_access = list(113)
 	},
-/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/hangar)
 "lp" = (
@@ -5498,7 +5539,6 @@
 /turf/simulated/wall/r_wall,
 /area/shuttle/kataphract_shuttle/engine_compartment)
 "lt" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Chapter Trading Desk";
 	req_one_access = list(113)
@@ -5509,6 +5549,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/trading_area)
 "lu" = (
@@ -5551,7 +5592,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "lA" = (
 /obj/structure/sign/securearea{
 	pixel_x = 32
@@ -5564,7 +5605,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "lC" = (
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
@@ -5574,7 +5615,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "lD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	icon_state = "map-scrubbers";
@@ -5584,7 +5625,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "lE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -5593,7 +5634,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "lF" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -5604,7 +5645,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "lG" = (
 /obj/structure/bed/stool/chair{
 	dir = 4
@@ -5613,11 +5654,10 @@
 /area/kataphract_chapter/trading_area)
 "lH" = (
 /turf/simulated/floor,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "lI" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/plating,
-/area/kataphract_chapter/hangar)
+/turf/simulated/wall,
+/area/kataphract_chapter/brig)
 "lJ" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -5628,7 +5668,7 @@
 "lK" = (
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/hangar)
+/area/kataphract_chapter/aft_hall)
 "lL" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/dark,
@@ -5640,14 +5680,14 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "lN" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "lO" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/random/loot,
@@ -5681,7 +5721,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "lT" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 8
@@ -5689,19 +5729,15 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/kataphract_shuttle/engine_compartment)
 "lU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "lV" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced,
@@ -5805,15 +5841,26 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "mg" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "mh" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/bed/handrail{
@@ -5827,7 +5874,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "mj" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -5879,7 +5926,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "mq" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -5889,9 +5936,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "ms" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 1;
@@ -5900,6 +5946,8 @@
 	name = "Bridge Blast Door";
 	opacity = 0
 	},
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/bridge)
 "mt" = (
@@ -5922,7 +5970,7 @@
 	req_access = list(113)
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "mv" = (
 /obj/machinery/bodyscanner{
 	dir = 8
@@ -5942,16 +5990,16 @@
 /obj/machinery/door/airlock/glass{
 	name = "Chapter Trading Area"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/trading_area)
 "my" = (
 /obj/machinery/door/airlock/glass{
 	name = "Chapter Trading Area"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/trading_area)
 "mz" = (
@@ -6002,7 +6050,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "mE" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -6010,7 +6058,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "mF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -6032,7 +6080,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/hangar)
+/area/kataphract_chapter/aft_hall)
 "mG" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -6048,7 +6096,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "mJ" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -6070,9 +6118,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
 "mM" = (
@@ -6108,7 +6154,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "mP" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -6132,14 +6178,19 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/warehouse)
 "mQ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/entry)
 "mR" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -6166,7 +6217,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/port_solars_array)
 "mT" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -6193,7 +6244,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "mW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -6221,7 +6272,7 @@
 	req_one_access = list(113)
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "mX" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -6234,7 +6285,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/starboard_solars_array)
 "mY" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -6247,14 +6298,13 @@
 /turf/simulated/floor/airless,
 /area/kataphract_chapter/bridge)
 "mZ" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/port_solars_array)
 "na" = (
 /obj/machinery/light/small{
 	brightness_color = "#FA8282";
@@ -6265,7 +6315,7 @@
 	},
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "nb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -6274,7 +6324,7 @@
 	req_one_access = list(113)
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "nc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6297,8 +6347,9 @@
 /area/kataphract_chapter/hangar)
 "ne" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "nf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black{
 	dir = 8
@@ -6311,9 +6362,10 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/portpropulsion)
 "nh" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/medical)
 "ni" = (
@@ -6386,17 +6438,18 @@
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	icon_state = "door_locked";
-	id_tag = "kata_ship_out"
+	id_tag = "kata_ship_out";
+	locked = 1
 	},
 /obj/effect/shuttle_landmark/nav_kataphract_ship/starboarddock,
 /turf/simulated/floor,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "no" = (
 /obj/structure/table/steel,
 /obj/effect/floor_decal/corner/purple/full,
 /obj/item/storage/box/mousetraps,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "np" = (
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
@@ -6430,13 +6483,13 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "ns" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide{
 	start_pressure = 8000.63
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "nt" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -6467,12 +6520,14 @@
 	opacity = 0
 	},
 /obj/machinery/recharger,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/commissary)
 "nw" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/polarized/firedoor{
+/obj/effect/map_effect/window_spawner/full/reinforced/polarized{
 	id = "kataoffice"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/office)
 "nx" = (
@@ -6568,7 +6623,7 @@
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "nD" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -6595,7 +6650,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "nW" = (
 /obj/machinery/door/airlock/silver{
 	id_tag = "kataofficedoor";
@@ -6619,10 +6674,10 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "ou" = (
 /turf/simulated/wall/r_wall,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "oC" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light{
@@ -6678,7 +6733,7 @@
 /area/kataphract_chapter/commissary)
 "pf" = (
 /turf/simulated/wall/r_wall,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "pg" = (
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
@@ -6698,6 +6753,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/hangar)
+"po" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	is_critical = 1;
+	name = "north bump";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access = list(113)
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/trading_area)
 "pp" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -6707,9 +6777,8 @@
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/hangar)
 "px" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/plating,
-/area/shuttle/kataphract_shuttle/main_compartment)
+/turf/simulated/floor/tiled/dark,
+/area/kataphract_chapter/brig)
 "pH" = (
 /obj/structure/bed/stool/padded/red,
 /turf/simulated/floor/wood,
@@ -6730,7 +6799,7 @@
 	name = "Trading Desk";
 	req_one_access = list(114,116)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/trading_area)
 "pM" = (
@@ -6767,13 +6836,17 @@
 /turf/simulated/floor/plating,
 /area/shuttle/kataphract_shuttle/main_compartment)
 "pX" = (
-/turf/template_noop,
-/area/kataphract_chapter/hangar)
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/kataphract_chapter/starboardpropulsion)
 "qd" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	icon_state = "door_locked";
-	id_tag = "kata_ship_out"
+	id_tag = "kata_ship_out";
+	locked = 1
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -6784,7 +6857,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "qm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -6811,24 +6884,30 @@
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/warehouse)
+"qq" = (
+/turf/simulated/wall/r_wall,
+/area/kataphract_chapter/janitorial)
 "qt" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	icon_state = "door_locked";
-	id_tag = "kata_ship_in"
+	id_tag = "kata_ship_in";
+	locked = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
 /turf/simulated/floor,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "qA" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Cell";
 	req_access = list(113)
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
-/area/kataphract_chapter/office)
+/area/kataphract_chapter/brig)
 "qK" = (
 /obj/effect/shuttle_landmark/kataphract_transport/hangar,
 /turf/simulated/floor/plating,
@@ -6839,11 +6918,14 @@
 	req_one_access = list(113)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/machinery/door/firedoor{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/hangar)
+/area/kataphract_chapter/portpropulsion)
 "qW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6862,7 +6944,8 @@
 	req_one_access = list(113)
 	},
 /obj/machinery/door/firedoor/multi_tile{
-	dir = 1
+	dir = 1;
+	req_one_access = list(113)
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/warehouse)
@@ -6887,7 +6970,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "rm" = (
 /obj/structure/foamedmetal,
 /turf/simulated/floor/plating,
@@ -6919,13 +7002,18 @@
 /obj/machinery/door/airlock/glass_security{
 	name = "Hangar and Pod Bay"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/hangar)
 "rv" = (
@@ -6942,7 +7030,15 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
+"rA" = (
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/airless,
+/area/kataphract_chapter/starboard_solars_array)
 "rM" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide,
 /turf/simulated/floor/tiled,
@@ -7002,7 +7098,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "sC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -7012,6 +7108,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/commissary)
+"sG" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/high{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24;
+	req_access = list(113)
+	},
+/turf/simulated/floor/plating,
+/area/kataphract_chapter/portpropulsion)
 "sX" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -7028,25 +7141,18 @@
 /area/kataphract_chapter/engineering)
 "th" = (
 /turf/simulated/wall/r_wall,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "tk" = (
 /obj/machinery/door/airlock/glass{
 	name = "Canisters and Supplies";
 	req_one_access = list(113)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/hangar)
 "tu" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24;
-	req_one_access = list(113)
-	},
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/plating,
-/area/kataphract_chapter/engineering)
+/turf/simulated/wall/r_wall,
+/area/kataphract_chapter/dorms)
 "tw" = (
 /obj/item/reagent_containers/food/snacks/hatchling_suprise,
 /obj/structure/table/standard,
@@ -7056,12 +7162,18 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Telecommunications"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/medical)
 "tH" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/hangar)
@@ -7073,8 +7185,13 @@
 	brightness_color = "#FA8282";
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/portpropulsion)
 "ud" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
@@ -7097,13 +7214,25 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "uh" = (
 /obj/machinery/door/firedoor{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
+"ul" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/aft_hall)
+"un" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/aft_hall)
 "uy" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 32
@@ -7121,7 +7250,8 @@
 	child_tags_txt = "kataphract_shuttle";
 	frequency = 1380;
 	id_tag = "kataphract_transport";
-	pixel_y = 35
+	pixel_y = 39;
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/kataphract_shuttle/main_compartment)
@@ -7140,7 +7270,7 @@
 	name = "Trading Desk Shutters";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/trading_area)
 "uN" = (
@@ -7157,11 +7287,11 @@
 /area/kataphract_chapter/medical)
 "uR" = (
 /turf/simulated/wall,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "vf" = (
 /obj/effect/floor_decal/corner/purple,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "vj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -7187,7 +7317,25 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/hangar)
+/area/kataphract_chapter/aft_hall)
+"vL" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless,
+/area/kataphract_chapter/starboard_solars_array)
 "vQ" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -7216,6 +7364,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/warehouse)
+"wf" = (
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/entry)
 "wh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7245,12 +7407,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
+"wl" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/aft_hall)
 "wp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black{
 	dir = 1
 	},
 /turf/simulated/wall/r_wall,
 /area/shuttle/kataphract_shuttle/engine_compartment)
+"wz" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/hangar)
 "wI" = (
 /obj/structure/table/reinforced/steel,
 /obj/machinery/photocopier/faxmachine{
@@ -7294,6 +7470,23 @@
 /obj/item/storage/pill_bottle/dylovene,
 /turf/simulated/floor/tiled/white,
 /area/kataphract_chapter/medical)
+"xr" = (
+/obj/effect/map_effect/window_spawner/full/reinforced,
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/plating,
+/area/shuttle/kataphract_shuttle/main_compartment)
+"xB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/kataphract_chapter/portpropulsion)
 "xC" = (
 /obj/structure/table/wood,
 /obj/machinery/button/switch/windowtint{
@@ -7317,7 +7510,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/hangar)
+/area/kataphract_chapter/aft_hall)
 "xX" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 4
@@ -7350,7 +7543,7 @@
 	},
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "yj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -7381,24 +7574,22 @@
 	req_access = null;
 	req_one_access = list(113)
 	},
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/medical)
 "yr" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "yw" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "yy" = (
 /obj/structure/flora/pottedplant,
 /obj/effect/floor_decal/corner/red{
@@ -7421,7 +7612,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "yE" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7436,6 +7627,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
+"yM" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/kataphract_chapter/port_solars_array)
 "yO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6;
@@ -7475,7 +7674,7 @@
 	pixel_y = 23
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "zI" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -7483,7 +7682,7 @@
 	id_tag = "kata_ship_pump"
 	},
 /turf/simulated/floor,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "zL" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -7546,6 +7745,17 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
+/area/kataphract_chapter/aft_hall)
+"Ak" = (
+/obj/structure/sign/securearea{
+	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
 /area/kataphract_chapter/hangar)
 "Ap" = (
 /obj/machinery/light{
@@ -7557,23 +7767,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/kataphract_shuttle/main_compartment)
 "Aq" = (
-/obj/machinery/alarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/hangar)
+/area/kataphract_chapter/aft_hall)
 "Av" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide{
 	start_pressure = 8000.63
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "Aw" = (
 /turf/simulated/floor/tiled/white,
 /area/kataphract_chapter/medical)
@@ -7623,7 +7828,7 @@
 	name = "Trading Desk";
 	req_one_access = list(114,116)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/trading_area)
 "AY" = (
@@ -7651,12 +7856,25 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "Bi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/commissary)
+"Bp" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/hangar)
 "Bv" = (
 /obj/effect/shuttle_landmark/nav_kataphract_ship/nav4,
 /turf/template_noop,
@@ -7686,7 +7904,7 @@
 	name = "Trading Desk";
 	req_one_access = list(114,116)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/trading_area)
 "BV" = (
@@ -7707,7 +7925,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "BY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
@@ -7724,10 +7942,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/kataphract_shuttle/engine_compartment)
+"Ck" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/kataphract_chapter/brig)
 "Cp" = (
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "Cx" = (
 /obj/effect/shuttle_landmark/nav_kataphract_ship/dockintrepid,
 /turf/template_noop,
@@ -7762,7 +7987,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/hangar)
+/area/kataphract_chapter/aft_hall)
 "CS" = (
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
@@ -7803,13 +8028,14 @@
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
 	icon_state = "door_locked";
-	id_tag = "kata_ship_in"
+	id_tag = "kata_ship_in";
+	locked = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "Dm" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(113);
@@ -7818,8 +8044,11 @@
 /obj/item/melee/baton/stunrod,
 /obj/item/melee/baton/stunrod,
 /obj/item/storage/box/zipties,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
-/area/kataphract_chapter/office)
+/area/kataphract_chapter/brig)
 "Dx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7832,18 +8061,26 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
+"DC" = (
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/airless,
+/area/kataphract_chapter/port_solars_array)
 "DE" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/solar_control/autostart,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "DG" = (
 /obj/machinery/button/remote/blast_door{
 	id = "kataqmblast";
 	name = "Shutter Control";
 	pixel_x = -27;
-	req_one_access = list(115)
+	req_one_access = list(113)
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/commissary)
@@ -7866,17 +8103,20 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "Ea" = (
 /turf/simulated/wall,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "Ef" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/floor_decal/corner/purple/full{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "Eg" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -7898,9 +8138,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/kataphract_shuttle/main_compartment)
+"En" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/hangar)
 "Er" = (
 /obj/machinery/alarm{
-	pixel_y = 28
+	pixel_y = 28;
+	req_one_access = list(113)
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/trading_area)
@@ -7909,7 +8164,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/kataphract_chapter/office)
+/area/kataphract_chapter/brig)
 "Ew" = (
 /obj/structure/table/wood/gamblingtable,
 /obj/item/spacecash/c50{
@@ -7922,9 +8177,16 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Janitorial"
 	},
-/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "EG" = (
 /obj/machinery/computer/guestpass{
 	pixel_y = 32
@@ -7936,8 +8198,12 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	icon_state = "map_scrubber_on";
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "EP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7960,8 +8226,11 @@
 /obj/structure/flora/pottedplant/random{
 	pixel_y = 5
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
-/area/kataphract_chapter/office)
+/area/kataphract_chapter/brig)
 "Fd" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot{
 	dir = 8
@@ -7990,7 +8259,6 @@
 /obj/machinery/door/airlock/glass{
 	name = "Chapter Trading Area"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -7998,12 +8266,27 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/aft_hall)
 "FK" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/medical)
+"FL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/kataphract_chapter/brig)
 "FS" = (
 /obj/structure/janitorialcart/full,
 /obj/effect/floor_decal/corner/purple/full{
@@ -8011,11 +8294,18 @@
 	},
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "FX" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/plating,
-/area/kataphract_chapter/trading_area)
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/entry)
+"Gi" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/kataphract_chapter/hangar)
 "Gj" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8046,6 +8336,19 @@
 /obj/random/tech_supply,
 /turf/simulated/floor/tiled,
 /area/shuttle/kataphract_shuttle/engine_compartment)
+"Gw" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless,
+/area/kataphract_chapter/port_solars_array)
 "Gx" = (
 /obj/structure/closet/walllocker/medical/secure{
 	name = "O- Blood Locker";
@@ -8077,7 +8380,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/hangar)
 "GV" = (
@@ -8085,6 +8388,7 @@
 	name = "Quartermaster";
 	req_one_access = list(115,113)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/commissary)
 "GW" = (
@@ -8109,7 +8413,7 @@
 /obj/machinery/vending/cola,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "GZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -8119,6 +8423,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/hangar)
+"Hh" = (
+/turf/simulated/wall,
+/area/kataphract_chapter/starboardpropulsion)
 "Hr" = (
 /obj/machinery/alarm{
 	pixel_y = 25;
@@ -8128,7 +8435,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "Ht" = (
 /obj/effect/overmap/visitable/ship/kataphract_ship,
 /obj/machinery/hologram/holopad/long_range,
@@ -8145,7 +8452,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "HS" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor/plating,
@@ -8171,7 +8478,18 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
+"Is" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/light/small{
+	brightness_color = "#FA8282";
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/kataphract_chapter/starboardpropulsion)
 "Iw" = (
 /obj/effect/shuttle_landmark/nav_kataphract_ship/nav3,
 /turf/template_noop,
@@ -8194,6 +8512,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/engineering)
+"II" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/kataphract_chapter/starboardpropulsion)
 "IJ" = (
 /obj/structure/table/reinforced/steel,
 /obj/machinery/button/remote/blast_door{
@@ -8215,6 +8540,13 @@
 /obj/structure/bed/stool/padded/red,
 /turf/simulated/floor/tiled/white,
 /area/kataphract_chapter/cafeteria)
+"Jr" = (
+/obj/machinery/door/airlock/glass{
+	name = "Chapter Trading Area"
+	},
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/aft_hall)
 "Jy" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -8239,6 +8571,9 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/kataphract_shuttle/main_compartment)
+"JF" = (
+/turf/simulated/wall/r_wall,
+/area/kataphract_chapter/portpropulsion)
 "JI" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -8261,7 +8596,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/hangar)
+/area/kataphract_chapter/aft_hall)
 "JW" = (
 /obj/effect/decal/fake_object{
 	desc = "An SUPB Pod, also know as a Single Use Personal Boarding Pod. These pods are utilized across the Spur for interdictions and hostile boarding actions across the Spur.";
@@ -8279,8 +8614,13 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/portpropulsion)
 "Ka" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
@@ -8293,7 +8633,7 @@
 	tag_interior_door = "kata_ship_in"
 	},
 /turf/simulated/floor,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "Kd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -8304,7 +8644,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "Kg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -8318,14 +8658,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "Ko" = (
 /obj/machinery/door/airlock/glass{
 	name = "Chapter Trading Area"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/aft_hall)
 "Ks" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 4
@@ -8337,7 +8678,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "Kw" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -8402,7 +8743,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "KT" = (
 /obj/effect/shuttle_landmark/nav_kataphract_ship/nav5,
 /turf/template_noop,
@@ -8412,8 +8753,12 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
 	},
+/obj/machinery/alarm{
+	pixel_y = 25;
+	req_one_access = list(113)
+	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "Ll" = (
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -8423,7 +8768,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "LD" = (
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
@@ -8473,7 +8818,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "Mk" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -8499,7 +8844,7 @@
 /obj/machinery/door/airlock/glass_security{
 	name = "Hangar and Pod Bay"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/hangar)
 "MD" = (
@@ -8521,14 +8866,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/kataphract_shuttle/main_compartment)
 "MH" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "MP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "MT" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -8552,7 +8908,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "Nh" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled/dark,
@@ -8579,7 +8935,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/main_ring)
+/area/kataphract_chapter/aft_hall)
 "Nl" = (
 /obj/structure/sign/securearea{
 	pixel_y = -32
@@ -8593,11 +8949,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
 "Nq" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
 	dir = 8
@@ -8622,8 +8973,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/hangar)
+/area/kataphract_chapter/aft_hall)
 "Nv" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/bed/handrail{
@@ -8658,6 +9014,24 @@
 	},
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/dorms)
+"NR" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless,
+/area/kataphract_chapter/port_solars_array)
 "NU" = (
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
@@ -8677,6 +9051,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/commissary)
+"Od" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/trading_area)
 "Oh" = (
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
@@ -8686,7 +9079,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
+"Oi" = (
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/janitorial)
 "Os" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/structure/cable{
@@ -8701,9 +9097,10 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/kataphract_shuttle/engine_compartment)
 "Ou" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/office)
+/area/kataphract_chapter/brig)
 "OA" = (
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
@@ -8732,20 +9129,10 @@
 "OJ" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "OT" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/high{
-	dir = 4;
-	name = "north bump";
-	pixel_x = 24;
-	req_access = list(113)
-	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/hangar)
+/area/kataphract_chapter/aft_hall)
 "OY" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/closet/crate,
@@ -8754,15 +9141,23 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/warehouse)
 "Pb" = (
-/obj/machinery/access_button/airlock_exterior{
-	frequency = 1983;
-	master_tag = "chapter_port_airlock";
-	pixel_x = 21;
-	pixel_y = -22
-	},
-/obj/structure/lattice/catwalk,
 /turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/area/kataphract_chapter/port_solars_array)
+"Pl" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/entry)
 "Pm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -8775,7 +9170,7 @@
 "Pr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "Ps" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8783,24 +9178,41 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/hangar)
 "PD" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light,
-/turf/simulated/floor/airless,
-/area/kataphract_chapter/port_solars)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/red{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	icon_state = "corner_white";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow,
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/aft_hall)
 "PG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "PI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8821,8 +9233,34 @@
 	icon_state = "corner_white";
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/hangar)
+/area/kataphract_chapter/aft_hall)
+"PJ" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow,
+/obj/effect/floor_decal/corner/yellow{
+	icon_state = "corner_white";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/main_ring)
 "PO" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -8836,7 +9274,7 @@
 	pixel_y = 23
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/port_solars_array)
+/area/kataphract_chapter/starboard_solars)
 "PW" = (
 /obj/effect/shuttle_landmark/kataphract_transport/transit,
 /turf/template_noop,
@@ -8845,6 +9283,14 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/engineering)
+"Qz" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/firedoor/noid,
+/obj/machinery/door/blast/regular/open{
+	id = "egg_blastdoors"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/kataphract_shuttle/main_compartment)
 "QD" = (
 /obj/structure/flora/pottedplant,
 /obj/effect/floor_decal/corner/red{
@@ -8873,14 +9319,14 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "QF" = (
 /obj/effect/floor_decal/corner/red{
 	icon_state = "corner_white";
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "QT" = (
 /obj/machinery/firealarm/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8932,6 +9378,9 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/kataphract_chapter/medical)
+"Rz" = (
+/turf/space,
+/area/kataphract_chapter/starboard_solars_array)
 "RA" = (
 /obj/machinery/computer/ship/sensors,
 /obj/structure/window/reinforced{
@@ -8966,8 +9415,9 @@
 	dir = 1
 	},
 /obj/structure/bed/stool/bar/padded,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
-/area/kataphract_chapter/office)
+/area/kataphract_chapter/brig)
 "RY" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/bed/handrail{
@@ -9039,7 +9489,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "Sx" = (
 /obj/machinery/light{
 	dir = 1
@@ -9053,7 +9503,7 @@
 	req_one_access = list(113)
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "Sy" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	frequency = 1983;
@@ -9069,13 +9519,21 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/starboard_solars_array)
+/area/kataphract_chapter/port_solars)
 "Sz" = (
 /obj/structure/sign/flag/hegemony/left{
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/office)
+"SG" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless,
+/area/kataphract_chapter/starboard_solars_array)
 "SZ" = (
 /obj/structure/table/rack,
 /obj/item/stack/rods,
@@ -9092,18 +9550,31 @@
 "Td" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "Th" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
 	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/high{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24;
+	req_access = list(113)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "Tp" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
-	id_tag = "militia_ship_pump"
+	id_tag = "kata_ship_pump"
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
@@ -9112,7 +9583,7 @@
 	pixel_x = 4
 	},
 /turf/simulated/floor,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "Tt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 6
@@ -9140,6 +9611,25 @@
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/hangar)
+"TJ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/machinery/power/apc{
+	dir = 2;
+	is_critical = 1;
+	name = "south bump";
+	pixel_y = -24;
+	req_access = list(113)
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/kataphract_chapter/brig)
 "TN" = (
 /obj/structure/table/rack,
 /obj/item/clothing/shoes/magboots/hegemony,
@@ -9206,7 +9696,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
 "UC" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -9216,7 +9706,7 @@
 	name = "trashbin"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "UE" = (
 /obj/structure/table/reinforced/steel,
 /obj/structure/window/reinforced{
@@ -9224,6 +9714,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bridge)
+"UM" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/airless,
+/area/kataphract_chapter/starboard_solars_array)
 "UT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /turf/simulated/wall/r_wall,
@@ -9236,6 +9739,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/kataphract_chapter/medical)
+"Ve" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/alarm{
+	pixel_y = 25;
+	req_one_access = list(113)
+	},
+/turf/simulated/floor/plating,
+/area/kataphract_chapter/portpropulsion)
 "Vj" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/void/kataphract,
@@ -9262,6 +9776,17 @@
 /obj/machinery/appliance/cooker/stove,
 /turf/simulated/floor/lino,
 /area/kataphract_chapter/cafeteria)
+"VN" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/hangar)
 "VU" = (
 /obj/structure/bed/stool/padded/red,
 /turf/simulated/floor/tiled,
@@ -9273,10 +9798,14 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "Wi" = (
 /obj/item/pipewrench,
 /obj/random/tech_supply,
+/obj/machinery/alarm{
+	pixel_y = 25;
+	req_one_access = list(113)
+	},
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/engineering)
 "Wr" = (
@@ -9295,6 +9824,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/hangar)
+"Wt" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/aft_hall)
 "WG" = (
 /obj/machinery/firealarm/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9322,7 +9862,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "WV" = (
 /obj/effect/floor_decal/corner/yellow{
 	icon_state = "corner_white";
@@ -9353,11 +9893,24 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/hangar)
 "Xf" = (
 /turf/simulated/wall,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/janitorial)
+"Xy" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25;
+	req_one_access = list(113)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/kataphract_chapter/bridge)
 "XI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
@@ -9371,17 +9924,41 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/kataphract_chapter/trading_area)
+/area/kataphract_chapter/entry)
 "XZ" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/engineering)
+"Ya" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/entry)
 "Yb" = (
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24;
+	req_one_access = list(113)
+	},
 /turf/simulated/floor/tiled/dark,
-/area/kataphract_chapter/office)
+/area/kataphract_chapter/brig)
 "Yg" = (
 /obj/machinery/light/spot{
 	dir = 1
@@ -9397,7 +9974,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/kataphract_chapter/propulsion)
+/area/kataphract_chapter/starboardpropulsion)
 "Yo" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9436,6 +10013,18 @@
 /obj/item/clothing/glasses/sunglasses,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
+"YQ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/hangar)
 "YT" = (
 /obj/structure/table/wood/gamblingtable,
 /obj/item/spacecash/c200,
@@ -9446,7 +10035,6 @@
 /area/kataphract_chapter/dorms)
 "YX" = (
 /obj/machinery/door/airlock/hatch,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -9455,6 +10043,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/kataphract_shuttle/engine_compartment)
 "Ze" = (
@@ -9487,6 +10076,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
+"Zf" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/high{
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/hangar)
 "Zz" = (
 /obj/item/reagent_containers/food/snacks/meatsteak,
 /obj/structure/table/standard,
@@ -15398,7 +15998,7 @@ ec
 dF
 ec
 dF
-jc
+yM
 dF
 ec
 dF
@@ -15554,11 +16154,11 @@ iB
 iB
 eg
 ey
-eN
+NR
 ey
-eN
+NR
 ey
-eN
+NR
 ey
 jh
 ey
@@ -15568,7 +16168,7 @@ mS
 ey
 mS
 ey
-mX
+Gw
 iB
 iB
 iB
@@ -15714,23 +16314,23 @@ iB
 iB
 iB
 iB
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-jc
+yM
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 iB
 iB
 iB
@@ -15884,7 +16484,7 @@ dF
 dF
 dF
 dF
-jc
+yM
 dF
 dF
 dF
@@ -16046,7 +16646,7 @@ ec
 dF
 ec
 dF
-jc
+yM
 dF
 ec
 dF
@@ -16202,11 +16802,11 @@ iB
 iB
 eg
 ey
-eN
+NR
 ey
-eN
+NR
 ey
-eN
+NR
 ey
 jh
 ey
@@ -16216,7 +16816,7 @@ mS
 ey
 mS
 ey
-mX
+Gw
 iB
 iB
 iB
@@ -16362,23 +16962,23 @@ iB
 iB
 iB
 iB
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-jc
+yM
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 iB
 iB
 iB
@@ -16532,7 +17132,7 @@ dF
 dF
 dF
 dF
-jc
+yM
 dF
 dF
 dF
@@ -16694,7 +17294,7 @@ ec
 dF
 ec
 dF
-jc
+yM
 dF
 ec
 dF
@@ -16850,11 +17450,11 @@ iB
 iB
 eg
 ey
-eN
+NR
 ey
-eN
+NR
 ey
-eN
+NR
 ey
 jh
 ey
@@ -16864,7 +17464,7 @@ mS
 ey
 mS
 ey
-mX
+Gw
 iB
 iB
 iB
@@ -17010,23 +17610,23 @@ iB
 iB
 iB
 iB
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-jc
+yM
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 iB
 iB
 iB
@@ -17180,7 +17780,7 @@ dF
 dF
 dF
 dF
-jc
+yM
 dF
 dF
 dF
@@ -17342,7 +17942,7 @@ ec
 dF
 ec
 dF
-jc
+yM
 dF
 ec
 dF
@@ -17498,11 +18098,11 @@ iB
 iB
 eg
 ey
-eN
+NR
 ey
-eN
+NR
 ey
-eN
+NR
 ey
 jh
 ey
@@ -17512,7 +18112,7 @@ mS
 ey
 mS
 ey
-mX
+Gw
 iB
 iB
 iB
@@ -17658,23 +18258,23 @@ iB
 iB
 iB
 iB
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-jc
+yM
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 iB
 iB
 iB
@@ -17828,7 +18428,7 @@ dF
 dF
 dF
 dF
-jc
+yM
 dF
 dF
 dF
@@ -17990,7 +18590,7 @@ ec
 dF
 ec
 dF
-jc
+yM
 dF
 ec
 dF
@@ -18146,11 +18746,11 @@ iB
 iB
 eg
 ey
-eN
+NR
 ey
-eN
+NR
 ey
-eN
+NR
 ey
 jh
 ey
@@ -18160,7 +18760,7 @@ mS
 ey
 mS
 ey
-mX
+Gw
 iB
 iB
 iB
@@ -18306,23 +18906,23 @@ iB
 iB
 iB
 iB
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-jc
+yM
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 dF
-em
+DC
 iB
 iB
 iB
@@ -18476,7 +19076,7 @@ iB
 iB
 iB
 iB
-jc
+yM
 iB
 iB
 iB
@@ -18638,7 +19238,7 @@ iB
 iB
 iB
 iB
-jk
+yM
 iB
 iB
 iB
@@ -18799,9 +19399,9 @@ iB
 iB
 iB
 iB
-hV
-jk
-hV
+Pb
+yM
+Pb
 iB
 iB
 iB
@@ -18961,19 +19561,19 @@ iB
 iB
 iB
 iB
-hV
+Pb
 jv
-mQ
-mQ
-mQ
-mQ
-mQ
-mQ
-mQ
-PD
-mQ
-mQ
-mQ
+ey
+ey
+ey
+ey
+ey
+ey
+ey
+ey
+ey
+ey
+ey
 mZ
 iB
 iB
@@ -19123,20 +19723,20 @@ jg
 jg
 jg
 jg
-hW
-hW
-hW
-hW
-hW
-hW
-hW
-hW
-hW
-hW
-hW
-hW
-hW
-jk
+fq
+fq
+fq
+tu
+tu
+tu
+tu
+tu
+tu
+tu
+tu
+tu
+tu
+yM
 iB
 iB
 iB
@@ -19297,8 +19897,8 @@ fK
 fK
 fK
 fK
-hW
-jk
+tu
+yM
 iB
 iB
 iB
@@ -19459,8 +20059,8 @@ fZ
 mR
 ge
 fK
-hW
-jk
+tu
+yM
 iB
 iB
 iB
@@ -19621,8 +20221,8 @@ ge
 ge
 hF
 fK
-hW
-jk
+tu
+yM
 iB
 iB
 iB
@@ -19642,7 +20242,7 @@ ig
 ig
 ig
 kr
-pX
+iB
 iB
 iB
 iB
@@ -19783,12 +20383,12 @@ ge
 ge
 Gk
 fK
-hW
+tu
 jv
-mQ
+ey
 mZ
-hV
-iB
+Pb
+jX
 kr
 aa
 aa
@@ -19945,22 +20545,22 @@ pH
 ge
 hH
 fK
-hW
-hV
-hV
-jk
+tu
 Pb
-iB
+Pb
+yM
+Pb
+jX
 kr
 Yg
 aa
 aa
 aa
-jF
-jF
-jF
-jF
-jF
+Qz
+Qz
+Qz
+Qz
+Qz
 aa
 aa
 aa
@@ -20603,7 +21203,7 @@ ia
 aa
 ae
 ae
-ae
+xr
 ae
 ME
 Af
@@ -20622,7 +21222,7 @@ kr
 kr
 kr
 kr
-th
+JF
 iB
 iB
 iB
@@ -20763,7 +21363,7 @@ kW
 Ea
 ia
 aa
-an
+jF
 JD
 LD
 iC
@@ -20774,7 +21374,7 @@ HK
 kK
 sn
 pW
-px
+jF
 aa
 eq
 Nl
@@ -20784,8 +21384,8 @@ zT
 lL
 Nh
 kr
-th
-th
+JF
+JF
 iB
 iB
 iB
@@ -20925,7 +21525,7 @@ kd
 Ea
 ia
 aa
-an
+jF
 xX
 bi
 bi
@@ -20946,10 +21546,10 @@ iw
 ff
 zm
 kr
-th
-th
-th
-th
+JF
+JF
+JF
+JF
 iB
 iB
 iB
@@ -21087,7 +21687,7 @@ Ea
 Ea
 ia
 aa
-an
+jF
 mc
 fU
 eo
@@ -21108,8 +21708,8 @@ iz
 ff
 pi
 kr
-th
-th
+JF
+JF
 jG
 bZ
 iB
@@ -21270,10 +21870,10 @@ oC
 cT
 oX
 kr
-th
-th
+JF
+JF
 ng
-th
+JF
 iB
 iB
 iB
@@ -21432,9 +22032,9 @@ kr
 kr
 kr
 kr
-th
-th
-nC
+JF
+JF
+Ve
 bZ
 iB
 iB
@@ -21594,10 +22194,10 @@ TH
 iM
 dR
 kr
-th
-th
+JF
+JF
 jC
-th
+JF
 iB
 iB
 iB
@@ -21756,9 +22356,9 @@ aw
 ix
 yE
 kr
-th
-th
-nC
+JF
+JF
+sG
 bZ
 iB
 iB
@@ -21911,17 +22511,17 @@ WY
 iP
 Iz
 hJ
-hJ
+Zf
 kr
 JW
 RL
 iM
 iw
 kr
-th
-th
-ng
-th
+JF
+JF
+xB
+JF
 iB
 iB
 iB
@@ -22073,7 +22673,7 @@ ax
 nd
 Iz
 hJ
-Nl
+Ak
 kr
 aw
 aw
@@ -22192,7 +22792,7 @@ bb
 bt
 bb
 bJ
-aC
+Xy
 ab
 cj
 cp
@@ -22232,20 +22832,20 @@ dM
 aa
 aa
 ax
-nd
-Iz
-hJ
-hJ
+YQ
+VN
+wz
+Bp
 lo
-ff
-ff
+Gi
+Gi
 Xe
 kn
 qS
 jY
-th
-th
-th
+JF
+JF
+JF
 iB
 iB
 iB
@@ -22404,8 +23004,8 @@ kQ
 Pm
 mw
 kr
-th
-th
+JF
+JF
 iB
 iB
 iB
@@ -22566,8 +23166,8 @@ gZ
 lk
 Eg
 kr
-th
-iB
+JF
+JF
 iB
 iB
 iB
@@ -22698,7 +23298,7 @@ cf
 cp
 cf
 ia
-tu
+ih
 WG
 iL
 je
@@ -22718,7 +23318,7 @@ aa
 aa
 rq
 eq
-dW
+En
 hJ
 lA
 zL
@@ -22729,7 +23329,7 @@ CE
 iA
 kr
 th
-iB
+th
 iB
 iB
 iB
@@ -22870,28 +23470,28 @@ ia
 ia
 kN
 kN
-kN
-kN
 bk
-lI
-lI
-lI
-lI
-lI
+bk
+bk
+bk
+bk
+bk
+bk
+bk
 kN
 GP
 ru
 MC
-la
-la
-la
-la
-la
+kN
+kN
+kN
+kN
+kN
 kN
 eb
 kr
 th
-iB
+th
 iB
 iB
 iB
@@ -23022,38 +23622,38 @@ cf
 cp
 cf
 mV
-cf
-ep
+OT
+wl
 iK
 jJ
 kp
 kA
 kH
 kI
-cf
-cf
-cf
-cN
+OT
+OT
+OT
+un
 xW
-hJ
-hJ
+OT
+OT
 kT
-hJ
-hJ
-hJ
-hJ
-dW
-hJ
-Ko
-kP
-kP
+OT
+OT
+OT
+OT
+kO
+OT
+Jr
+FX
+FX
 mi
-Xf
-Xf
+Hh
+Hh
 mI
 MP
 th
-iB
+th
 iB
 iB
 iB
@@ -23184,8 +23784,8 @@ EG
 ni
 iq
 mW
-iq
-iq
+PD
+PD
 iQ
 ko
 ky
@@ -23210,12 +23810,12 @@ FJ
 cI
 QE
 mp
-Xf
+Hh
 Av
 MP
 ai
 th
-iB
+th
 iB
 iB
 iB
@@ -23327,7 +23927,7 @@ aC
 aC
 aC
 bV
-ce
+cb
 cf
 cp
 cf
@@ -23346,38 +23946,38 @@ cf
 cp
 cf
 nb
-cf
-iJ
-gt
-cf
+OT
+Aq
+Wt
+OT
 kp
-cf
-cf
-iJ
-cf
+OT
+OT
+Aq
+OT
 kO
-cf
-cN
-hJ
-hJ
-hJ
+OT
+un
+OT
+iJ
+OT
 vJ
-hJ
-hJ
-hJ
+OT
+OT
+ul
 Aq
 OT
 lK
 Ko
-kP
-kS
+FX
+mQ
 mi
-Xf
+Hh
 gS
 Pr
 lS
 th
-iB
+th
 iB
 iB
 iB
@@ -23526,20 +24126,20 @@ la
 ah
 ah
 ah
-la
-la
-la
-la
-la
+jc
+jc
+jc
+jc
+jc
 lM
 nr
 mq
-Xf
+Hh
 aE
 Pr
 ai
 th
-iB
+th
 iB
 iB
 iB
@@ -23688,20 +24288,20 @@ AP
 lW
 lG
 lG
-la
+jc
 kx
 lB
 Oh
 mO
 lN
-kS
+mQ
 mi
-Xf
+Hh
 jV
 Lq
 WR
 th
-iB
+th
 iB
 iB
 iB
@@ -23850,12 +24450,12 @@ BN
 lX
 lp
 mo
-la
+jc
 aj
-kP
-kP
-kP
-kP
+FX
+FX
+FX
+FX
 KQ
 rv
 ue
@@ -23863,7 +24463,7 @@ bF
 Ks
 Kg
 th
-iB
+th
 iB
 iB
 iB
@@ -24013,20 +24613,20 @@ lY
 md
 lp
 mx
-kP
-kP
-kP
-kP
-kP
-kS
+FX
+FX
+FX
+FX
+FX
+mQ
 mi
-Xf
+Hh
 Hr
 lc
 Pr
 th
 th
-iV
+th
 iB
 iB
 iB
@@ -24182,7 +24782,7 @@ kZ
 kZ
 lU
 mE
-Xf
+Hh
 AZ
 er
 mI
@@ -24336,22 +24936,22 @@ uA
 ma
 ml
 mo
-la
+jc
 yi
 lE
-kP
-kP
-kP
+FX
+FX
+FX
 ca
 mi
-Xf
+Hh
 ns
 HR
 ns
 th
 Yi
 jl
-bZ
+pX
 iB
 iB
 iB
@@ -24489,8 +25089,8 @@ ly
 MD
 la
 la
-kP
-kS
+po
+Od
 la
 yO
 nc
@@ -24498,7 +25098,7 @@ at
 mb
 QT
 gT
-la
+jc
 jZ
 mf
 kv
@@ -24507,12 +25107,12 @@ XS
 mg
 mp
 Xf
-th
-th
-th
-th
-th
-ng
+qq
+qq
+qq
+qq
+qq
+II
 th
 iB
 iB
@@ -24660,22 +25260,22 @@ la
 la
 la
 la
-la
+jc
 GX
 lF
 DX
 ic
 bX
-kP
+ca
 mi
 Xf
 Uz
 Sw
 no
-th
-th
+qq
+qq
 nC
-bZ
+pX
 iB
 iB
 iB
@@ -24822,21 +25422,21 @@ rm
 rm
 rm
 rm
-la
-la
-la
-la
-la
+jc
+jc
+jc
+jc
+jc
 yD
-yr
+Ya
 VZ
 Xf
 na
-MH
+Oi
 BX
-th
-th
-jC
+qq
+qq
+Is
 th
 iB
 iB
@@ -24974,7 +25574,7 @@ uN
 ly
 fm
 fm
-la
+iR
 iR
 lh
 qW
@@ -24987,19 +25587,19 @@ iR
 iR
 iR
 iR
-la
-la
+jc
+jc
 lz
-kP
+ca
 mi
 Xf
 KX
-MH
+Oi
 ku
-th
-th
+qq
+qq
 nC
-bZ
+pX
 iB
 iB
 iB
@@ -25136,7 +25736,7 @@ jM
 ly
 fm
 fm
-kJ
+iR
 iR
 lh
 lf
@@ -25149,18 +25749,18 @@ mA
 lh
 mA
 lh
-la
-la
+jc
+jc
 lC
-kP
+ca
 mp
 Xf
 EJ
-MH
-MH
-MH
+Oi
+Oi
+Oi
 cm
-ng
+II
 th
 iB
 iB
@@ -25271,7 +25871,7 @@ iB
 iB
 mY
 ks
-cv
+ab
 cu
 cu
 nw
@@ -25279,7 +25879,7 @@ nw
 nw
 cu
 cu
-eW
+fo
 gC
 eW
 fW
@@ -25298,7 +25898,7 @@ jN
 uR
 uR
 fm
-kJ
+iR
 iR
 lh
 lf
@@ -25311,19 +25911,19 @@ mA
 lP
 mA
 lh
-la
-la
+jc
+jc
 UC
-kP
-mi
+Pl
+wf
 Ez
 MH
-MH
+Oi
 ku
-th
-th
+qq
+qq
 cd
-bZ
+pX
 iB
 iB
 iB
@@ -25433,7 +26033,7 @@ iB
 iB
 ab
 ab
-cv
+ab
 cv
 cu
 xC
@@ -25459,8 +26059,8 @@ jq
 mD
 jU
 uR
-pf
-kJ
+uR
+iR
 iR
 bj
 qm
@@ -25473,17 +26073,17 @@ mj
 mP
 vV
 mC
-la
-la
+jc
+jc
 Sx
-kP
+FX
 nM
 Xf
 Th
 vf
 Ne
-th
-th
+qq
+qq
 th
 th
 iB
@@ -25621,8 +26221,8 @@ jw
 eI
 mu
 uR
-pf
-kJ
+uR
+iR
 iR
 lh
 lh
@@ -25635,17 +26235,17 @@ mA
 mk
 mA
 lh
-la
-la
+jc
+jc
 lz
-kP
+FX
 mi
 Xf
 Ef
 FS
-th
-th
-th
+qq
+qq
+qq
 iB
 iB
 iB
@@ -25783,8 +26383,8 @@ PO
 jQ
 kb
 uR
-pf
-kJ
+uR
+iR
 iR
 NU
 li
@@ -25797,16 +26397,16 @@ mA
 lh
 mA
 lh
-la
-la
+jc
+jc
 QF
-kP
+FX
 mp
 Xf
-th
-th
-th
-th
+qq
+qq
+qq
+qq
 iB
 iB
 iB
@@ -25964,10 +26564,10 @@ kw
 op
 yr
 sB
-th
-th
-th
-th
+qq
+qq
+qq
+qq
 iB
 iB
 iB
@@ -26109,6 +26709,9 @@ jW
 pf
 pf
 kJ
+kJ
+kJ
+kJ
 iB
 iB
 iB
@@ -26116,19 +26719,16 @@ iB
 iB
 iB
 iB
-iB
-iB
-iB
-iB
-iB
+kJ
+kJ
 kw
 Cp
-kP
-kP
-kP
+FX
+FX
+FX
 Cp
 kw
-iB
+kw
 iB
 iB
 iB
@@ -26252,7 +26852,7 @@ dx
 mM
 cu
 cf
-fo
+fl
 cf
 in
 gz
@@ -26282,15 +26882,15 @@ iB
 iB
 iB
 iB
-iB
+kJ
 kw
 ir
-kP
-kP
-kP
+FX
+FX
+FX
 ib
 kw
-iB
+kw
 iB
 iB
 iB
@@ -26406,15 +27006,15 @@ iB
 iB
 iB
 iB
-cv
-cu
-cu
-cu
-cu
-cu
-cu
+iV
+lI
+lI
+lI
+lI
+lI
+lI
 cg
-fo
+fl
 CX
 fW
 go
@@ -26429,7 +27029,7 @@ hW
 hV
 hV
 jk
-jX
+hV
 iB
 iB
 iB
@@ -26444,7 +27044,7 @@ iB
 iB
 iB
 iB
-iB
+kJ
 kw
 zF
 PG
@@ -26452,7 +27052,7 @@ Td
 Td
 LS
 kw
-iB
+kw
 iB
 iB
 iB
@@ -26568,16 +27168,16 @@ iB
 iB
 iB
 iB
-cv
-cK
+iV
+ce
 cK
 cX
 Et
 cL
 eM
-ch
-fp
-cD
+cC
+PJ
+cf
 fW
 np
 tw
@@ -26589,7 +27189,7 @@ hQ
 fW
 hW
 hT
-mQ
+SG
 jn
 hV
 iB
@@ -26608,10 +27208,10 @@ iB
 iB
 iB
 kw
-FX
+ne
 Dl
 qt
-FX
+ne
 kw
 kw
 iB
@@ -26731,15 +27331,15 @@ iB
 iB
 iB
 cX
-cL
-cL
+px
+px
 cX
-cL
-cL
+px
+FL
 Ou
-cf
-fq
-cf
+ch
+fp
+cD
 fW
 dS
 fF
@@ -26892,13 +27492,13 @@ iB
 iB
 iB
 iB
-cv
+iV
 RR
-cL
+Ck
 qA
-cL
-cL
-cu
+an
+TJ
+lI
 iD
 fr
 VU
@@ -27054,13 +27654,13 @@ iB
 iB
 iB
 iB
-cv
-cv
+iV
+iV
 Fc
 cX
 Yb
 Dm
-cu
+lI
 eu
 eu
 eu
@@ -27217,15 +27817,15 @@ iB
 iB
 iB
 iB
-cv
-cv
-cv
-cv
-cv
-cv
-hW
-hW
-hW
+iV
+iV
+iV
+iV
+iV
+iV
+fq
+fq
+fq
 hW
 hW
 hW
@@ -27380,24 +27980,24 @@ iB
 iB
 iB
 iB
-iB
-iB
-iB
-iB
+iV
+iV
+iV
+iV
 iB
 hV
 hT
-mQ
-mQ
-mQ
-mQ
-mQ
-mQ
-mQ
-mQ
-mQ
-mQ
-mQ
+SG
+SG
+SG
+SG
+SG
+SG
+SG
+SG
+SG
+SG
+SG
 jn
 iB
 iB
@@ -27872,7 +28472,7 @@ iB
 iB
 iB
 iB
-jc
+jk
 iB
 iB
 iB
@@ -28026,23 +28626,23 @@ iB
 iB
 iB
 iB
-ec
-dF
-ec
-dF
-ec
-dF
-ec
-dF
-jc
-dF
-ec
-dF
-ec
-dF
-ec
-dF
-ec
+rA
+Rz
+rA
+Rz
+rA
+Rz
+rA
+Rz
+jk
+Rz
+rA
+Rz
+rA
+Rz
+rA
+Rz
+rA
 iB
 iB
 iB
@@ -28188,22 +28788,22 @@ iB
 iB
 iB
 iB
-eg
-ey
+UM
+SG
 eN
-ey
+SG
 eN
-ey
+SG
 eN
-ey
+SG
 hU
-ey
-mS
-ey
-mS
-ey
-mS
-ey
+SG
+vL
+SG
+vL
+SG
+vL
+SG
 mX
 iB
 iB
@@ -28351,21 +28951,21 @@ iB
 iB
 iB
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
-jc
-dF
+Rz
+jk
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
 iB
 iB
@@ -28512,23 +29112,23 @@ iB
 iB
 iB
 iB
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-jc
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+jk
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
 iB
 iB
 iB
@@ -28674,23 +29274,23 @@ iB
 iB
 iB
 iB
-ec
-dF
-ec
-dF
-ec
-dF
-ec
-dF
-jc
-dF
-ec
-dF
-ec
-dF
-ec
-dF
-ec
+rA
+Rz
+rA
+Rz
+rA
+Rz
+rA
+Rz
+jk
+Rz
+rA
+Rz
+rA
+Rz
+rA
+Rz
+rA
 iB
 iB
 iB
@@ -28836,22 +29436,22 @@ iB
 iB
 iB
 iB
-eg
-ey
+UM
+SG
 eN
-ey
+SG
 eN
-ey
+SG
 eN
-ey
+SG
 hU
-ey
-mS
-ey
-mS
-ey
-mS
-ey
+SG
+vL
+SG
+vL
+SG
+vL
+SG
 mX
 iB
 iB
@@ -28999,21 +29599,21 @@ iB
 iB
 iB
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
-jc
-dF
+Rz
+jk
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
 iB
 iB
@@ -29160,23 +29760,23 @@ iB
 iB
 iB
 iB
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-jc
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+jk
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
 iB
 iB
 iB
@@ -29322,23 +29922,23 @@ iB
 iB
 iB
 iB
-ec
-dF
-ec
-dF
-ec
-dF
-ec
-dF
-jc
-dF
-ec
-dF
-ec
-dF
-ec
-dF
-ec
+rA
+Rz
+rA
+Rz
+rA
+Rz
+rA
+Rz
+jk
+Rz
+rA
+Rz
+rA
+Rz
+rA
+Rz
+rA
 iB
 iB
 iB
@@ -29484,22 +30084,22 @@ iB
 iB
 iB
 iB
-eg
-ey
+UM
+SG
 eN
-ey
+SG
 eN
-ey
+SG
 eN
-ey
+SG
 hU
-ey
-mS
-ey
-mS
-ey
-mS
-ey
+SG
+vL
+SG
+vL
+SG
+vL
+SG
 mX
 iB
 iB
@@ -29647,21 +30247,21 @@ iB
 iB
 iB
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
-jc
-dF
+Rz
+jk
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
 iB
 iB
@@ -29808,23 +30408,23 @@ iB
 iB
 iB
 iB
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-jc
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+jk
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
 iB
 iB
 iB
@@ -29970,23 +30570,23 @@ iB
 iB
 iB
 iB
-ec
-dF
-ec
-dF
-ec
-dF
-ec
-dF
-jc
-dF
-ec
-dF
-ec
-dF
-ec
-dF
-ec
+rA
+Rz
+rA
+Rz
+rA
+Rz
+rA
+Rz
+jk
+Rz
+rA
+Rz
+rA
+Rz
+rA
+Rz
+rA
 iB
 iB
 iB
@@ -30132,22 +30732,22 @@ iB
 iB
 iB
 iB
-eg
-ey
+UM
+SG
 eN
-ey
+SG
 eN
-ey
+SG
 eN
-ey
+SG
 hU
-ey
-mS
-ey
-mS
-ey
-mS
-ey
+SG
+vL
+SG
+vL
+SG
+vL
+SG
 mX
 iB
 iB
@@ -30295,21 +30895,21 @@ iB
 iB
 iB
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
-jc
-dF
+Rz
+jk
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
 iB
 iB
@@ -30456,23 +31056,23 @@ iB
 iB
 iB
 iB
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-jc
-dF
-dF
-dF
-dF
-dF
-dF
-dF
-dF
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+jk
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
 iB
 iB
 iB
@@ -30618,23 +31218,23 @@ iB
 iB
 iB
 iB
-ec
-dF
-ec
-dF
-ec
-dF
-ec
-dF
-jc
-dF
-ec
-dF
-ec
-dF
-ec
-dF
-ec
+rA
+Rz
+rA
+Rz
+rA
+Rz
+rA
+Rz
+jk
+Rz
+rA
+Rz
+rA
+Rz
+rA
+Rz
+rA
 iB
 iB
 iB
@@ -30780,22 +31380,22 @@ iB
 iB
 iB
 iB
-eg
-ey
+UM
+SG
 eN
-ey
+SG
 eN
-ey
+SG
 eN
-ey
+SG
 hU
-ey
-mS
-ey
-mS
-ey
-mS
-ey
+SG
+vL
+SG
+vL
+SG
+vL
+SG
 mX
 iB
 iB
@@ -30943,21 +31543,21 @@ iB
 iB
 iB
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
-jc
-dF
+Rz
+jk
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
-dF
+Rz
 em
 iB
 iB

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -3711,9 +3711,6 @@
 /turf/simulated/floor/airless,
 /area/space)
 "hY" = (
-/obj/machinery/door/firedoor{
-	dir = 8
-	},
 /obj/machinery/door/airlock/glass{
 	name = "Sparring Chamber";
 	req_access = null;
@@ -6232,6 +6229,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/dorms)
+"mV" = (
+/obj/machinery/door/airlock/glass{
+	name = "Chapter Engineering and Hangar";
+	req_access = null;
+	req_one_access = list(113)
+	},
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/tiled,
+/area/kataphract_chapter/aft_hall)
 "mW" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6303,15 +6309,6 @@
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/janitorial)
-"nb" = (
-/obj/machinery/door/airlock/glass{
-	name = "Chapter Engineering and Hangar";
-	req_access = null;
-	req_one_access = list(113)
-	},
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled,
-/area/kataphract_chapter/aft_hall)
 "nc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23597,7 +23594,7 @@ cP
 cf
 cp
 cf
-nb
+mV
 OT
 wl
 iK
@@ -23921,7 +23918,7 @@ cQ
 cf
 cp
 cf
-nb
+mV
 OT
 Aq
 Wt

--- a/maps/away/ships/kataphracts/kataphract_ship_ghostroles.dm
+++ b/maps/away/ships/kataphracts/kataphract_ship_ghostroles.dm
@@ -89,7 +89,7 @@
 		H.w_uniform.color = pick("#1f8c3c", "#ab7318", "#1846ba")
 
 /datum/outfit/admin/kataphract/get_id_access()
-	return list(access_kataphract, access_kataphract_trader, access_external_airlocks)
+	return list(access_kataphract, access_external_airlocks)
 
 /datum/outfit/admin/kataphract/klax
 
@@ -132,7 +132,7 @@
 	
 
 /datum/outfit/admin/kataphract/knight/get_id_access()
-	return list(access_kataphract, access_kataphract_knight, access_kataphract_quartermaster, access_kataphract_trader, access_external_airlocks)
+	return list(access_kataphract, access_kataphract_knight, access_external_airlocks)
 
 /datum/outfit/admin/kataphract/quartermaster
 	name = "Kataphract Quartermaster"
@@ -140,10 +140,4 @@
 	back = /obj/item/storage/backpack/satchel/hegemony
 
 /datum/outfit/admin/kataphract/quartermaster/get_id_access()
-	return list(access_kataphract, access_kataphract_quartermaster, access_kataphract_trader, access_external_airlocks)
-
-/datum/outfit/admin/kataphract/trader // Unused from an old trimmed out ghostrole, but handy to have still
-	name = "Kataphract Trader"
-
-/datum/outfit/admin/kataphract/trader/get_id_access()
-	return list(access_kataphract, access_kataphract_trader, access_external_airlocks)
+	return list(access_kataphract, access_kataphract_knight, access_external_airlocks)


### PR DESCRIPTION
There was an issue with how the areas were mapped in that was the most important bit and it was breaking stuff. Lot of other fixes too though. I will just copypaste the changelog out of laziness. 

changes:
  - tweak: "If venting happened, third parties wouldn't be able to use their emergency shutters to escape since it inherently has horizon engineering access required, which is ideally supposed to make it so non-engineers can't open the way into vented areas. Was rectified by adding a variant that needs no access to open. Every window and door has the proper type of emergency shutter now."
  - rscadd: "Defined more areas for the kataphract ship since a lot of what was mapped in was pulling double duty for extra rooms. This would lead to some buggy and confusing interactions, especially for those far apart."
  - tweak: "Lights in the kataship hangar were swapped for spotlights, as intended. Still looks the same, it just shines brighter."
  - tweak: "Some of the air alarms still had engineering access requirements, which was hopefully fixed on a second pass and changed to kata id stuff instead."
  - rscdel: "Removed the unused kata trader and quartermaster access types."
  - tweak: "The kata ship docking airlock will actually start bolted now."
  - tweak: "the kata ship airlock pumps will both cycle now instead of just one working."
  - rscdel: "There were catwalks visible on the solars of the kataship when you look at the map using dream maker or strongdmm. These didn't spawn in the game itself as they weren't the interior type. Removed those from the map file."
  - tweak: "Moved the position of the kata shuttle's docking port controller, since it was positioned in a way that it would overlay over anything put on the table it was originally on."
  - rscadd: "Added the missing air alarms and other minor atmos equipment where it was missing on the kataphract ship, like the janitorial room or the brig."