### PR TITLE
Yacht Airlock Fix

### DIFF
--- a/html/changelogs/wickedcybs_yachtairlock.yml
+++ b/html/changelogs/wickedcybs_yachtairlock.yml
@@ -1,0 +1,7 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - bugfix: "Correctly tags and replaces the interior/exterior airlock buttons for the yacht so they should actually work now if anyone ever fixes that ship."
+  - tweak: "The yacht's airlock is being fed by an air canister as intended instead of an entire air pressure tank."

--- a/maps/away/ships/yacht/yacht.dmm
+++ b/maps/away/ships/yacht/yacht.dmm
@@ -1174,13 +1174,6 @@
 /obj/item/gun/energy/blaster,
 /turf/simulated/floor/wood/coloured/walnut,
 /area/shuttle/yacht/living)
-"fb" = (
-/obj/machinery/access_button{
-	pixel_x = 25;
-	master_tag = "yacht_airlock"
-	},
-/turf/template_noop,
-/area/space)
 "gb" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -1188,10 +1181,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/computerframe,
-/obj/machinery/access_button{
-	pixel_x = -26;
-	master_tag = "yacht_airlock"
-	},
 /turf/simulated/floor/plating,
 /area/shuttle/yacht/engine)
 "gm" = (
@@ -1250,6 +1239,14 @@
 	locked = 1;
 	name = "External Access"
 	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1439;
+	master_tag = "yacht_airlock";
+	name = "exterior access button";
+	pixel_x = -9;
+	pixel_y = 23
+	},
 /turf/simulated/floor/airless,
 /area/shuttle/yacht/engine)
 "kb" = (
@@ -1284,9 +1281,10 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/shuttle/yacht/engine)
 "lb" = (
@@ -1305,6 +1303,14 @@
 	id_tag = "yacht_inner";
 	locked = 1;
 	name = "External Access"
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1439;
+	master_tag = "yacht_airlock";
+	name = "interior access button";
+	pixel_x = 7;
+	pixel_y = 23
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/yacht/engine)
@@ -5782,7 +5788,7 @@ aa
 aa
 aa
 aa
-fb
+aa
 cu
 aa
 aa


### PR DESCRIPTION
When attempts were made to actually fix the ship, I noted that the airlock failed to work still. I tagged the access buttons wrong and put in the wrong frequency as well. The airlock also had an entire air pressure tank feeding it instead of just an air can.

Fixed both.
