### PR TITLE
Makes the operations desk holopad long-ranged

### DIFF
--- a/html/changelogs/anconfuzedrock-opsholopad.yml
+++ b/html/changelogs/anconfuzedrock-opsholopad.yml
@@ -1,0 +1,7 @@
+
+author: anconfuzedrock
+
+delete-after: True
+
+changes:
+  - rscadd: "Operations now has a long-range holopad at the front desk that can be used to call the hangar's shuttles."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -11245,7 +11245,7 @@
 /turf/simulated/floor/wood,
 /area/horizon/hydroponics/garden)
 "fVo" = (
-/obj/machinery/hologram/holopad,
+/obj/machinery/hologram/holopad/long_range,
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "fVs" = (


### PR DESCRIPTION
This swaps the regular holopad in ops for a long range one. Ops, especially hangar techs, really get the short end of the stick right now, to me. One place to start would be to at least vaguely connect the department to each other, and the hangar techs to the hangar; This allows the hangar techs to keep in touch with the miners as they head out. 