### PR TITLE
Binoculars for the Intrepid

### DIFF
--- a/html/changelogs/wickedcybs_bino.yml
+++ b/html/changelogs/wickedcybs_bino.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - rscadd: "A pair of high powered binoculars was added to the Intrepid."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -2845,6 +2845,10 @@
 	dir = 1;
 	pixel_y = -28
 	},
+/obj/item/device/binoculars/high_power{
+	pixel_x = -2;
+	pixel_y = -1
+	},
 /turf/simulated/floor/wood,
 /area/shuttle/intrepid/crew_compartment)
 "chW" = (


### PR DESCRIPTION
Adds one set of high powered binoculars to the Intrepid. Was debating on if the normal version would be better or not, though It's hard to powergame with the high powered variant due to how far it sees out.
