### PR TITLE
Tweaks the Robco Vending Selection

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -1098,24 +1098,25 @@
 	req_access = list(access_engine_equip)
 	vend_id = "tools"
 	products = list(
-		/obj/item/clothing/under/rank/chief_engineer = 4,
-		/obj/item/clothing/under/rank/engineer = 4,
-		/obj/item/clothing/shoes/orange = 4,
 		/obj/item/clothing/head/hardhat = 4,
-		/obj/item/storage/belt/utility = 4,
+		/obj/item/storage/belt/utility = 5,
 		/obj/item/clothing/glasses/safety/goggles = 4,
 		/obj/item/clothing/gloves/yellow = 4,
-		/obj/item/screwdriver = 12,
-		/obj/item/crowbar = 12,
-		/obj/item/wirecutters = 12,
-		/obj/item/device/multitool = 12,
-		/obj/item/wrench = 12,
-		/obj/item/device/t_scanner = 12,
-		/obj/item/stack/cable_coil/heavyduty = 8,
-		/obj/item/cell = 8,
+		/obj/item/screwdriver = 8,
+		/obj/item/crowbar = 8,
+		/obj/item/wirecutters = 8,
+		/obj/item/device/multitool = 8,
+		/obj/item/wrench = 8,
+		/obj/item/powerdrill = 4,
+		/obj/item/device/t_scanner = 8,
+		/obj/item/stack/cable_coil/random = 10,
+		/obj/item/cell = 5,
+		/obj/item/device/analyzer = 5,
+		/obj/item/cell/high = 2,
 		/obj/item/weldingtool = 8,
 		/obj/item/clothing/head/welding = 8,
 		/obj/item/light/tube = 10,
+		/obj/item/clothing/head/hardhat/firefighter = 4,
 		/obj/item/clothing/suit/fire = 4,
 		/obj/item/stock_parts/scanning_module = 5,
 		/obj/item/stock_parts/micro_laser = 5,
@@ -1124,11 +1125,9 @@
 		/obj/item/stock_parts/console_screen = 5,
 		/obj/item/tape_roll = 5
 	)
-	// There was an incorrect entry (cablecoil/power).  I improvised to cablecoil/heavyduty.
-	// Another invalid entry, /obj/item/circuitry.  I don't even know what that would translate to, removed it.
-	// The original products list wasn't finished.  The ones without given quantities became quantity 5.  -Sayu
+
 	restock_blocked_items = list(
-		/obj/item/stack/cable_coil/heavyduty,
+		/obj/item/stack/cable_coil
 		/obj/item/weldingtool,
 		/obj/item/light/tube
 	)

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -1127,7 +1127,7 @@
 	)
 
 	restock_blocked_items = list(
-		/obj/item/stack/cable_coil
+		/obj/item/stack/cable_coil,
 		/obj/item/weldingtool,
 		/obj/item/light/tube
 	)

--- a/html/changelogs/wickedcybs_robco.yml
+++ b/html/changelogs/wickedcybs_robco.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Changes the robco vending machine selection and adds some more stuff to it while removing the horizon engineering clothing from it. It's more of a rarely seen all-in-one engineering vendor now. "


### PR DESCRIPTION
A little-seen vending machine often only really found in operations or sometimes away sites. I looked over its selection and removed some items (horizon engineering clothing like the CE uniform) and added some more engineering stuff. A lot of the crazy high numbers were also lowered, since it had something like 12 of each main tool.

I think this will come in handy now as an all-in-one solution for stuff like away sites, when mapping space is at a premium. It has most of what one might find in the engineering vendors, circuits aside.