### PR TITLE
Phoron Punch to Contraband

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -373,7 +373,7 @@
 	)
 	contraband = list(
 		/obj/item/reagent_containers/food/drinks/cans/thirteenloko = 5,
-		/obj/item/reagent_containers/food/drinks/cans/koispunch = 2
+		/obj/item/reagent_containers/food/drinks/cans/koispunch = 3
 	)
 	premium = list(
 		/obj/item/reagent_containers/food/drinks/bottle/cola = 2,

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -365,7 +365,6 @@
 		/obj/item/reagent_containers/food/drinks/cans/iced_tea = 10,
 		/obj/item/reagent_containers/food/drinks/cans/grape_juice = 10,
 		/obj/item/reagent_containers/food/drinks/cans/peach_soda = 10,
-		/obj/item/reagent_containers/food/drinks/cans/koispunch = 5,
 		/obj/item/reagent_containers/food/drinks/cans/beetle_milk = 10,
 		/obj/item/reagent_containers/food/drinks/cans/hrozamal_soda = 10,
 		/obj/item/reagent_containers/food/drinks/small_milk = 10,
@@ -373,7 +372,8 @@
 		/obj/item/reagent_containers/food/drinks/small_milk_strawberry = 10
 	)
 	contraband = list(
-		/obj/item/reagent_containers/food/drinks/cans/thirteenloko = 5
+		/obj/item/reagent_containers/food/drinks/cans/thirteenloko = 5,
+		/obj/item/reagent_containers/food/drinks/cans/koispunch = 2
 	)
 	premium = list(
 		/obj/item/reagent_containers/food/drinks/bottle/cola = 2,

--- a/html/changelogs/wickedcybs_phoron.yml
+++ b/html/changelogs/wickedcybs_phoron.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Phoron punch was moved to the softdrink vending machine's contraband list. There's also a little less due to the scarcity."


### PR DESCRIPTION
The fact that there is a label saying it contains phoron doesn't really help. I moved phoron punch out of the easily accessible usual menu to the contraband list. People can still hack it for the phoron punch if they want, this way it just won't kill anymore new players.

There's also 2 less cans, since 5 entire phoron cans during a scarcity is probably an oversight.
