### PR TITLE
Adds scrubbers, vents, and air alarms to clear up areas with messy atmos + adds some holopads

### DIFF
--- a/html/changelogs/omicega-atmosandpads.yml
+++ b/html/changelogs/omicega-atmosandpads.yml
@@ -1,0 +1,14 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Adds some vents, scrubbers, and air alarms to generally tidy up areas with messy atmos alarms."
+  - maptweak: "Adds some more holopads around the ship."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -625,6 +625,8 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
 "apd" = (
@@ -4009,6 +4011,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/horizon/exterior)
 "bTg" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/smes/tesla)
 "bTo" = (
@@ -4234,6 +4237,12 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
 "bYW" = (
@@ -4406,6 +4415,9 @@
 /obj/effect/floor_decal/corner/yellow,
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -7642,6 +7654,12 @@
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -11280,6 +11298,8 @@
 /obj/effect/floor_decal/corner_wide/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
 "fUc" = (
@@ -11379,16 +11399,12 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hydroponics)
 "fWp" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	external_pressure_bound = 102;
-	external_pressure_bound_default = 102;
-	icon_state = "map_vent_in";
-	pump_direction = 0
-	},
 /obj/effect/floor_decal/spline/plain,
 /obj/structure/sign/electricshock/tesla{
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/engineering/engine_monitoring/tesla)
@@ -12494,6 +12510,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
+"gvW" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28;
+	req_one_access = list(24,11,55)
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/engineering/engine_room/tesla)
 "gwe" = (
 /obj/structure/bed/stool/chair{
 	dir = 4
@@ -13722,6 +13749,13 @@
 /obj/item/reagent_containers/hypospray/autoinjector/inaprovaline,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
+"hbG" = (
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled,
+/area/hallway/engineering/tesla)
 "hcF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14280,6 +14314,9 @@
 "hpw" = (
 /obj/machinery/camera/network/reactor{
 	c_tag = "Engineering - SMES Room 1";
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -17971,6 +18008,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/full,
 /area/engineering/atmos/storage)
 "jow" = (
@@ -18650,11 +18693,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
@@ -18754,6 +18797,10 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/plain,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/engineering/engine_monitoring/tesla)
 "jIY" = (
@@ -20051,6 +20098,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
 "kyX" = (
@@ -21248,6 +21300,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
+"lgh" = (
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
+/area/hallway/engineering/tesla)
 "lgm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/trunk{
@@ -29339,6 +29398,19 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/lino/grey,
 /area/horizon/crew_quarters/lounge/bar)
+"prh" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
+/area/hallway/engineering/tesla)
 "prk" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
 /obj/effect/decal/cleanable/dirt,
@@ -29812,6 +29884,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/bar)
+"pFx" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos/storage)
 "pFU" = (
 /obj/machinery/camera/network/service{
 	c_tag = "Dinner - Kitchen Service";
@@ -31402,6 +31480,9 @@
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
+	},
+/obj/machinery/alarm{
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/aft_airlock)
@@ -33407,6 +33488,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/full,
 /area/engineering/atmos/storage)
 "rvJ" = (
@@ -36933,6 +37015,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
+"tts" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos/storage)
 "tue" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
@@ -39693,6 +39781,15 @@
 /obj/effect/floor_decal/corner_wide/green/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/exam)
+"uIx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos/storage)
 "uIM" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -40309,6 +40406,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28;
+	req_one_access = list(24,11,55)
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/smes/tesla)
 "uZD" = (
@@ -41848,12 +41950,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/smes/tesla)
 "vQs" = (
@@ -44295,6 +44395,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
+"wTD" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/engineering/engine_room/tesla)
 "wTU" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -44818,6 +44928,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/checkpoint2)
+"xhQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/full,
+/area/hallway/engineering/tesla)
 "xhW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67781,8 +67904,8 @@ bSK
 bmH
 vbc
 lMD
-lnv
-gci
+hbG
+prh
 ulg
 fnn
 aau
@@ -67983,12 +68106,12 @@ hBN
 hBN
 uph
 inD
-lnv
-gci
+lgh
+xhQ
 mMn
 puO
 aor
-xWL
+tts
 xWL
 xWL
 sDz
@@ -68191,7 +68314,7 @@ fTZ
 rvC
 aoQ
 kyV
-xWL
+pFx
 xWL
 gAt
 nlG
@@ -68998,7 +69121,7 @@ eDf
 gLj
 fnn
 qSm
-xWL
+uIx
 mpX
 oAN
 uHh
@@ -69996,7 +70119,7 @@ pRf
 rwW
 jKV
 jKV
-jKV
+wTD
 tZr
 hax
 mUe
@@ -72822,7 +72945,7 @@ fJv
 ntt
 rlj
 pVY
-jKV
+gvW
 jKV
 jKV
 dKB

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -20098,7 +20098,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -33489,6 +33488,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/full,
 /area/engineering/atmos/storage)
 "rvJ" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -656,6 +656,16 @@
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
+"aqk" = (
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
+/area/hallway/engineering)
 "aql" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -713,6 +723,15 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"arb" = (
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/engineering)
 "aru" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/firealarm/west,
@@ -1077,6 +1096,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/prison)
+"ayc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/full,
+/area/hallway/engineering)
 "ayo" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -2609,6 +2641,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/lobby)
 "biI" = (
@@ -3043,6 +3078,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/chapel/main)
+"bvf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/full,
+/area/engineering/lobby)
 "bvV" = (
 /obj/structure/plasticflaps/airtight,
 /obj/machinery/door/window/westleft{
@@ -3356,6 +3402,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/horizon/bar)
+"bCZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/full,
+/area/engineering/lobby)
 "bDd" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5590,6 +5647,10 @@
 	req_access = null
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "cSS" = (
@@ -7669,6 +7730,21 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room)
+"dYl" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/full,
+/area/hallway/engineering)
 "dYr" = (
 /obj/structure/closet/l3closet/security,
 /turf/simulated/floor/tiled/dark,
@@ -7734,14 +7810,14 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room)
 "eau" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
@@ -13284,6 +13360,21 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/horizon/hydroponics)
+"gQV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/full,
+/area/engineering/lobby)
 "gRh" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -13652,6 +13743,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room/tesla)
+"hdx" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/lobby)
 "hdz" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -13885,6 +13982,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/conference)
+"hiz" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "hiH" = (
 /obj/structure/table/stone/marble,
 /obj/item/reagent_containers/food/condiment/sugar{
@@ -14809,6 +14917,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "hFm" = (
@@ -15377,6 +15486,10 @@
 	},
 /turf/template_noop,
 /area/template_noop)
+"hWo" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/security/security_office)
 "hWE" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/green{
@@ -15497,6 +15610,9 @@
 /area/engineering/storage_eva)
 "ibE" = (
 /obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "ibU" = (
@@ -16010,6 +16126,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"ioX" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/full,
+/area/engineering/lobby)
 "ipr" = (
 /obj/structure/table/standard,
 /obj/item/paper_scanner,
@@ -16288,6 +16417,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"iAW" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/central_two)
 "iBa" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
@@ -19026,11 +19160,11 @@
 /turf/simulated/floor/tiled/full,
 /area/operations/lobby)
 "jUU" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/green{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
@@ -19588,6 +19722,7 @@
 /turf/simulated/wall,
 /area/operations/qm)
 "kmr" = (
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/operations/qm)
 "kmx" = (
@@ -20263,6 +20398,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "kKk" = (
@@ -20806,6 +20942,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/chapel/main)
 "kZj" = (
@@ -23265,6 +23402,9 @@
 "mnm" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
@@ -26690,6 +26830,9 @@
 	pixel_x = 11;
 	pixel_y = 12
 	},
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
 "odq" = (
@@ -29391,6 +29534,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/hor)
+"pxG" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/storage/primary)
 "pxY" = (
 /obj/item/modular_computer/console/preset/research{
 	dir = 4
@@ -30374,8 +30524,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "pXI" = (
-/turf/simulated/floor/carpet,
-/area/crew_quarters/heads/chief)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/engineering/lobby)
 "pXP" = (
 /obj/structure/table/rack,
 /obj/random/loot,
@@ -32171,6 +32322,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
+"qUc" = (
+/obj/machinery/door/airlock{
+	name = "Emergency Supplies Closet"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/storage/primary)
 "qUt" = (
 /obj/machinery/door/airlock/multi_tile/glass,
 /turf/simulated/floor/tiled,
@@ -32334,6 +32496,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/engineering/lobby)
 "qYL" = (
@@ -41861,7 +42024,6 @@
 /obj/effect/floor_decal/corner_wide/lime{
 	dir = 5
 	},
-/obj/machinery/hologram/holopad,
 /obj/machinery/ringer_button{
 	id = "medbay_ringer";
 	pixel_y = 19
@@ -42771,6 +42933,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
+"wne" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/lobby)
 "wnj" = (
 /obj/structure/bed/stool/chair/office/light{
 	dir = 8
@@ -43159,10 +43327,9 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/medical/or2)
 "wye" = (
-/obj/machinery/shower{
-	pixel_y = 20
+/obj/machinery/alarm{
+	pixel_y = 28
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
 "wyK" = (
@@ -43271,6 +43438,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "wBq" = (
@@ -46291,6 +46461,9 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 4
 	},
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "ybl" = (
@@ -46317,7 +46490,7 @@
 /obj/item/storage/slide_projector{
 	pixel_y = 12
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
 "ybR" = (
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
@@ -46578,8 +46751,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room)
 "ygK" = (
-/obj/item/modular_computer/console/preset/engineering,
-/turf/simulated/floor/carpet,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
 "ygL" = (
 /obj/structure/table/standard,
@@ -57557,7 +57730,7 @@ nFO
 aTa
 fzh
 tCG
-ibE
+pxG
 fzh
 rSP
 whe
@@ -57759,7 +57932,7 @@ mpV
 qTC
 fzh
 fzh
-hFg
+qUc
 fzh
 fzh
 oeF
@@ -61959,8 +62132,8 @@ gWf
 tYj
 tYj
 eZI
-dWZ
-mKJ
+dYl
+arb
 laB
 jlp
 wrA
@@ -62160,8 +62333,8 @@ ioF
 tjk
 bFN
 tYj
-eZI
-dWZ
+aqk
+ayc
 aDI
 laB
 laB
@@ -64797,7 +64970,7 @@ xEH
 sYl
 nge
 qYK
-nbJ
+ioX
 ltG
 wyV
 uoq
@@ -64999,7 +65172,7 @@ vrJ
 cLt
 nge
 jVn
-nbJ
+gQV
 biE
 wyV
 jUs
@@ -65803,7 +65976,7 @@ mxs
 nge
 xlz
 sUi
-gbT
+pXI
 isH
 iji
 mhj
@@ -65823,7 +65996,7 @@ mBI
 fAk
 clz
 eqR
-taX
+hiz
 ctz
 bzY
 vTY
@@ -65999,7 +66172,7 @@ gOi
 voz
 kRH
 kKk
-pXI
+wAT
 fAK
 iVg
 nge
@@ -66610,8 +66783,8 @@ dto
 usj
 kvG
 elz
-elz
-elz
+bCZ
+bvf
 elz
 elz
 elz
@@ -66812,8 +66985,8 @@ xgG
 hjI
 sMv
 gbT
-gbT
-gbT
+wne
+hdx
 gbT
 gbT
 gbT
@@ -68851,7 +69024,7 @@ oFp
 lTn
 ygu
 jvI
-tOW
+iAW
 hEF
 eNj
 hWE
@@ -70676,7 +70849,7 @@ dyZ
 tXR
 uiq
 xBX
-xBX
+hWo
 suc
 flb
 fJn

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -3014,6 +3014,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "fF" = (
@@ -4268,6 +4274,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "hX" = (
@@ -4758,6 +4770,9 @@
 	dir = 4
 	},
 /obj/structure/flora/pottedplant/random,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "iK" = (
@@ -5314,6 +5329,8 @@
 	req_access = list(5)
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/washroom)
 "jH" = (
@@ -7538,10 +7555,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -8071,7 +8089,9 @@
 /area/security/forensics_morgue)
 "oI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/lounge/secondary)
 "oJ" = (
@@ -9813,6 +9833,12 @@
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
@@ -14118,6 +14144,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
 "zQ" = (
@@ -16087,11 +16119,11 @@
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/washroom)
@@ -17363,6 +17395,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_quarters/fitness/hallway)
+"Ge" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
+/area/hallway/secondary/entry/emergency)
 "Gf" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -21267,6 +21309,9 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/lounge/secondary)
 "MX" = (
@@ -23993,9 +24038,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24614,6 +24657,9 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "Tb" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/washroom)
 "Tc" = (
@@ -25073,6 +25119,10 @@
 	pixel_x = 24;
 	specialfunctions = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/freezer,
 /area/medical/washroom)
 "TT" = (
@@ -25192,6 +25242,12 @@
 	},
 /obj/structure/bed/stool/chair{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/emergency)
@@ -25313,6 +25369,9 @@
 /obj/structure/mirror{
 	pixel_x = 26;
 	pixel_y = 3
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/washroom)
@@ -27558,6 +27617,14 @@
 /obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/lawoffice/representative)
+"Ys" = (
+/obj/effect/floor_decal/corner/grey/diagonal{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/washroom)
 "Yt" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -41730,7 +41797,7 @@ lO
 TP
 wg
 DM
-TP
+Ys
 jG
 TS
 Ur
@@ -55456,7 +55523,7 @@ at
 at
 at
 Cu
-Wx
+uH
 Uf
 Gr
 Lo
@@ -55658,7 +55725,7 @@ at
 yP
 yP
 yP
-eS
+Ge
 iJ
 Gr
 Lo


### PR DESCRIPTION
See title. In particular, the xenobiology lab had no air alarms _at all_ in it, which was causing more than a few issues if a fire or something ever started in there. There were also several areas with an air alarm but no corresponding vents/scrubbers to help refill bad atmos there, or which suffered from the opposite problem.

I added a few holopads just because I thought the ship could use more of them, especially places like engineering.