### PR TITLE
Removes the second emergency tesla beacon from the tesla room itself

### DIFF
--- a/html/changelogs/omicega-stopbreakingthetesla.yml
+++ b/html/changelogs/omicega-stopbreakingthetesla.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Removed the emergency beacon spawn in the Tesla room itself to help curb teslas getting loose."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -7342,9 +7342,7 @@
 /area/maintenance/aft)
 "dNF" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/power/singularity_beacon/emergency{
-	name = "emergency tesla beacon"
-	},
+/obj/machinery/power/portgen/basic,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room/tesla)
 "dOi" = (
@@ -11149,6 +11147,8 @@
 /area/crew_quarters/heads/chief)
 "fSA" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/stack/material/graphite/full,
+/obj/structure/closet/crate,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room/tesla)
 "fSG" = (


### PR DESCRIPTION
See title. This thing consistently caused the tesla to get loose, since if the beacon was left 'visible' to the tesla ball it would refuse to zap the coils. There's always been a beacon in hard storage and now that's the only one left, which is far enough away that it won't ever interfere with the tesla as long as it's moved and set up properly.

I replaced it with a portable generator for hypothetical 'cold start' scenarios.