### PR TITLE
Removes the Rescue/Burglar Pod from Random Event Spawning

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -227,8 +227,6 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Moderate Spider Infestation",		/datum/event/spider_infestation/moderate,	50,		list(ASSIGNMENT_SECURITY = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Moderate Vermin Infestation",		/datum/event/infestation/moderate, 			30,		list(ASSIGNMENT_JANITOR = 15, ASSIGNMENT_SECURITY = 15, ASSIGNMENT_MEDICAL = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Uprising",					/datum/event/rogue_maint_drones,			25,		list(ASSIGNMENT_ENGINEER = 30)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rescue Pod",						/datum/event/rescue_pod, 					50,		list(ASSIGNMENT_MEDICAL = 10, ASSIGNMENT_SECURITY = 2), TRUE),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Burglar Pod",						/datum/event/rescue_pod/burglar, 			50,		list(ASSIGNMENT_SECURITY = 5), TRUE, excluded_roundtypes = list("Extended"))
 	)
 
 // Severity Level, Event Name, Event Type, Base Weight, Role Weight(s), One Shot (TRUE/FALSE), Min Weight, Max Weight. Last two only used if set and non-zero.

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -226,7 +226,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Rogue Drones",						/datum/event/rogue_drone, 					15,		list(ASSIGNMENT_SECURITY = 15)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Moderate Spider Infestation",		/datum/event/spider_infestation/moderate,	50,		list(ASSIGNMENT_SECURITY = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Moderate Vermin Infestation",		/datum/event/infestation/moderate, 			30,		list(ASSIGNMENT_JANITOR = 15, ASSIGNMENT_SECURITY = 15, ASSIGNMENT_MEDICAL = 10)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Uprising",					/datum/event/rogue_maint_drones,			25,		list(ASSIGNMENT_ENGINEER = 30)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Uprising",					/datum/event/rogue_maint_drones,			25,		list(ASSIGNMENT_ENGINEER = 30))
 	)
 
 // Severity Level, Event Name, Event Type, Base Weight, Role Weight(s), One Shot (TRUE/FALSE), Min Weight, Max Weight. Last two only used if set and non-zero.

--- a/html/changelogs/wickedcybs_pod.yml
+++ b/html/changelogs/wickedcybs_pod.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "The rescue and burglar pods won't spawn as a random event anymore. They can still be manually spawned by an admin if desired for now."


### PR DESCRIPTION
Trying to keep this random event alive hasn't been much of a success and it is generally not interesting for both sides. For the poddie, they are stuck on (for now) undeveloped exoplanets and can only really wait for help that usually doesn't arrive. For the rescuer, It can also take a lot of time finding exactly where the pod went and then forming a rescue team if an announcement is sent at all.

I removed the chance for it to roll as an event but it can still be manually spawned for now. Wasn't sure if it would be a good idea to remove the code entirely if something more can be done with it or it can be adjusted into something else (but I can easily do this if requested). I'll also note, it wasn't in the event probabilities.xlsx file so I didn't need to remove it from that.

I do have future plans to try and add a more appropriate lifepod style type of ghost role in need of rescue once exoplanets are more fleshed out.