### PR TITLE
Fix Solar Control Panel icon

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -274,6 +274,7 @@
 	name = "solar panel control"
 	desc = "A controller for solar panel arrays."
 	icon = 'icons/obj/modular_console.dmi'
+	icon_state = "computer"
 	light_color = LIGHT_COLOR_YELLOW
 	anchored = 1
 	density = 1

--- a/html/changelogs/solar.yml
+++ b/html/changelogs/solar.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: SpaceBaa
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Solar Control Computer now has an icon."


### PR DESCRIPTION
Fixes #14728
The completed Solar Control computer had no default icon state.

Before:
![image](https://user-images.githubusercontent.com/9057997/194165674-a706dee8-4d9e-4269-b189-e41fb3e37aad.png)

After:
![image](https://user-images.githubusercontent.com/9057997/194165648-99c3531a-cf8d-4714-9ccb-5d534ef7ffa4.png)
