### PR TITLE
Combined business card holder and cards loadout item

### DIFF
--- a/code/game/objects/items/weapons/storage/business_card.dm
+++ b/code/game/objects/items/weapons/storage/business_card.dm
@@ -1,7 +1,7 @@
 /obj/item/storage/business_card_holder
 	name = "business card holder"
 	desc = "A sleek holster for your business card. You wouldn't want it getting damaged in any way."
-	storage_slots = 5
+	storage_slots = 10
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "holder"
 	w_class = ITEMSIZE_TINY
@@ -33,9 +33,33 @@
 /obj/item/storage/business_card_holder/plastic
 	icon_state = "holder_plastic"
 
+// Business cards (copied from lunchbox code)
+var/list/business_cards_ = list(
+	/obj/item/paper/business_card,
+	/obj/item/paper/business_card/alt,
+	/obj/item/paper/business_card/rounded,
+	/obj/item/paper/business_card/glass,
+	/obj/item/paper/business_card/glass/b,
+	/obj/item/paper/business_card/glass/g,
+	/obj/item/paper/business_card/glass/s,
+	/obj/item/paper/business_card/glass/w
+	)
+
+/proc/business_cards()
+	if(!(business_cards_[business_cards_[1]]))
+		business_cards_ = init_cardable_list(business_cards_)
+	return business_cards_
+
+/proc/init_cardable_list(var/list/cardables)
+	. = list()
+	for(var/card in cardables)
+		var/obj/O = card
+		.[initial(O.name)] = card
+
+	sortTim(., /proc/cmp_text_asc)
 
 /obj/item/paper/business_card
-	name = "business card"
+	name = "business card, divided"
 	desc = "A small slip of paper, capable of elevating your status on the social hierachy between you and your co-workers, provided you picked the right font."
 	icon_state = "business_card"
 	var/last_flash = 0 //spam limiter
@@ -71,9 +95,11 @@
 	paper_win.open()
 
 /obj/item/paper/business_card/alt
+	name = "business card, plain"
 	icon_state = "business_card-alt"
 
 /obj/item/paper/business_card/rounded
+	name = "business card, rounded"
 	icon_state = "business_card-rounded"
 
 /obj/item/paper/business_card/glass
@@ -91,13 +117,17 @@
 	return ..(user, quality, complement)
 
 /obj/item/paper/business_card/glass/b
+	name = "glass business card, black flair"
 	worn_overlay = "business_card-glass-b"
 
 /obj/item/paper/business_card/glass/g
+	name = "glass business card, grey flair"
 	worn_overlay = "business_card-glass-g"
 
 /obj/item/paper/business_card/glass/s
+	name = "glass business card, silver flair"
 	worn_overlay = "business_card-glass-s"
 
 /obj/item/paper/business_card/glass/w
+	name = "glass business card, white flair"
 	worn_overlay = "business_card-glass-w"

--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -149,7 +149,7 @@ Content adjustment
 		else if(metadata[i] == "None")
 			continue
 		else
-			path = 	contents[metadata[i]]
+			path = contents[metadata[i]]
 		if(path)
 			new path(I)
 
@@ -216,7 +216,7 @@ var/datum/gear_tweak/custom_name/gear_tweak_free_name = new()
 	var/datum/component/base_name/BN = I.GetComponent(/datum/component/base_name)
 	if(BN)
 		BN.rename(metadata)
-	
+
 /*
 Custom Description
 */
@@ -262,12 +262,15 @@ Paper Data
 /datum/gear_tweak/paper_data/get_metadata(var/user, var/metadata)
 	return sanitize(input(user, "Choose a pre-written message on the item.", "Pre-written Message", metadata) as message|null, MAX_PAPER_MESSAGE_LEN, extra = 0)
 
-/datum/gear_tweak/paper_data/tweak_item(var/obj/item/paper/P, var/metadata, var/mob/living/carbon/human/H)
-	if(!metadata || !istype(P))
+/datum/gear_tweak/paper_data/tweak_item(var/obj/item/I, var/metadata, var/mob/living/carbon/human/H)
+	if(!metadata)
 		return
-	P.info = P.parsepencode(metadata)
-
-
+	var/obj/item/paper/P
+	if(istype(I, P))
+		P.info = P.parsepencode(metadata)
+	if(istype(I, /obj/item/storage))
+		for(P in I.contents)
+			P.info = P.parsepencode(metadata)
 
 // Buddy Tag Settings
 /datum/gear_tweak/buddy_tag_config/get_contents(var/metadata)

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -103,10 +103,17 @@
 	cost = 4
 
 /datum/gear/utility/business_card_holder
-	display_name = "business card holder"
-	description = "Comes in different materials."
+	display_name = "business card holder, business cards"
+	description = "Comes in different selections for both! And with four cards inside, so you are always ready to exchange cards with others."
 	path = /obj/item/storage/business_card_holder
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
+
+/datum/gear/utility/business_card_holder/spawn_item(var/location, var/metadata)
+	. = ..()
+	var/obj/item/storage/business_card_holder/spawned_holder = .
+	//new /obj/item/paper/business_card/rounded(spawned_holder)
+	//spawned_holder.contents[1].description = "bruh what"
+	spawned_holder.update_icon()
 
 /datum/gear/utility/business_card_holder/New()
 	..()
@@ -116,10 +123,12 @@
 	holders["business card holder, leather"] = /obj/item/storage/business_card_holder/leather
 	holders["business card holder, plastic"] = /obj/item/storage/business_card_holder/plastic
 	gear_tweaks += new /datum/gear_tweak/path(holders)
+	gear_tweaks += new /datum/gear_tweak/contents(business_cards())
+	gear_tweaks += new /datum/gear_tweak/paper_data()
 
 /datum/gear/utility/business_card
 	display_name = "business card"
-	description = "A selection of business cards." // I'm not smart enough to make it spawn inside the holders and carry over the text so we'll have to live with this
+	description = "A selection of business cards. Card holder not included."
 	path = /obj/item/paper/business_card
 	flags = GEAR_HAS_COLOR_SELECTION
 
@@ -135,7 +144,6 @@
 	cards["glass business card, silver flair"] = /obj/item/paper/business_card/glass/s
 	cards["glass business card, white flair"] = /obj/item/paper/business_card/glass/w
 	gear_tweaks += new /datum/gear_tweak/path(cards)
-	gear_tweaks += new /datum/gear_tweak/paper_data()
 
 /datum/gear/utility/pills
 	display_name = "pill bottle selection"

--- a/code/modules/client/preference_setup/loadout/loadout_utility.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility.dm
@@ -104,15 +104,19 @@
 
 /datum/gear/utility/business_card_holder
 	display_name = "business card holder, business cards"
-	description = "Comes in different selections for both! And with four cards inside, so you are always ready to exchange cards with others."
+	description = "Comes in different selections for both! And with five cards inside, so you are always ready to show off and exchange the cards with others."
 	path = /obj/item/storage/business_card_holder
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/utility/business_card_holder/spawn_item(var/location, var/metadata)
 	. = ..()
 	var/obj/item/storage/business_card_holder/spawned_holder = .
-	//new /obj/item/paper/business_card/rounded(spawned_holder)
-	//spawned_holder.contents[1].description = "bruh what"
+	var/obj/item/paper/card_orig = locate() in spawned_holder
+	if (card_orig)
+		var/t = card_orig.type
+		for(var/i = 1 to 4)
+			var/obj/item/paper/card_new = new t(spawned_holder)
+			card_new.info = card_orig.info
 	spawned_holder.update_icon()
 
 /datum/gear/utility/business_card_holder/New()

--- a/html/changelogs/DreamySkrell.yml
+++ b/html/changelogs/DreamySkrell.yml
@@ -1,0 +1,6 @@
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - rscadd: "Adds a combined business card holder and cards loadout item."


### PR DESCRIPTION
Adds a combined business card holder and cards loadout item.
Costs 1 loadout point.
Holder and card styles can be picked separately.
Holder has 5 cards inside.

Implementation stolen from #14419, slightly improved.