### PR TITLE
Replaces cough syrup in NanoMed Plus vendors with Coagzolug

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -521,7 +521,7 @@
 		/obj/item/reagent_containers/glass/bottle/inaprovaline = 4,
 		/obj/item/reagent_containers/glass/bottle/perconol = 3,
 		/obj/item/reagent_containers/glass/bottle/toxin = 1,
-		/obj/item/reagent_containers/glass/bottle/coughsyrup = 4,
+		/obj/item/reagent_containers/glass/bottle/coagzolug = 2,
 		/obj/item/reagent_containers/glass/bottle/thetamycin = 1,
 		/obj/item/reagent_containers/syringe = 12,
 		/obj/item/device/healthanalyzer = 5,

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -177,6 +177,12 @@
 	desc = "A small bottle of cough syrup. Don't take too much!"
 	icon_state = "bottle-3"
 	reagents_to_add = list(/decl/reagent/coughsyrup = 60)
+	
+/obj/item/reagent_containers/glass/bottle/coagzolug
+	name = "coagzolug bottle"
+	desc = "A small bottle of coagzolug. A medication that encourages the coagulation of blood, slowing down any bleeding. Overdose causes damage to the heart."
+	icon_state = "bottle-3"
+	reagents_to_add = list(/decl/reagent/coagzolug = 60)
 
 /obj/item/reagent_containers/glass/bottle/thetamycin
 	name = "thetamycin bottle"

--- a/html/changelogs/Sheeplets.yml
+++ b/html/changelogs/Sheeplets.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Sheeplets
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Replaced the cough syrup in NanoMed Plus vendors with two bottles of liquid coagzolug."


### PR DESCRIPTION
The final nail in Lean's purple coffin. Sorry, Lean fiends.

Cough syrup is never used on-label and has only ever seen use as an ingredient in for coagzolug, and pneumalin to a lesser extent. It very, very rarely sees use as a recreational drug or as an (incredibly) minor painkiller. The recipe is untouched, and it's relatively cheap to produce in the lab if it's ever actually needed.

Two bottles per vendor, 60u per bottle. People just mix it in beakers anyways, let's cut out the middle man.
![image](https://user-images.githubusercontent.com/44004468/194439309-77e61149-9830-4f7e-ae45-afbeda1fdba5.png)
