### PR TITLE
Glowbulbs bugfix

### DIFF
--- a/code/modules/random_map/automata/diona.dm
+++ b/code/modules/random_map/automata/diona.dm
@@ -87,7 +87,7 @@
 	light_range = 3
 	light_color = "#557733"
 	density = FALSE
-	destroy_spawntype = /mob/living/carbon/alien/diona
+	destroy_spawntype = null
 
 /obj/structure/diona/bulb/unpowered
 	name = "unpowered glow bulb"

--- a/html/changelogs/Ben10083 - Dionae.yml
+++ b/html/changelogs/Ben10083 - Dionae.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Glowbulbs no longer spawn diona when destroyed."


### PR DESCRIPTION
Fixes #14131 
Just stole what the first PR did.

Glowbulbs should no longer spawn full grown diona when destroyed.