### PR TITLE
Removes Security-only restriction on PMCG shoulder patches, substantially buffs PMCG drip

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_factions.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_factions.dm
@@ -253,8 +253,7 @@
 	path = /obj/item/clothing/accessory/sleevepatch/erisec
 	slot = slot_tie
 	faction = "Private Military Contracting Group"
-	allowed_roles = list("Security Cadet", "Security Officer", "Investigator", "Warden")
-
+	
 /datum/gear/faction/pmc_patch
 	display_name = "PMCG armband"
 	path = /obj/item/clothing/accessory/armband/pmc

--- a/html/changelogs/sheeplets.yml
+++ b/html/changelogs/sheeplets.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Sheeplets
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Allowed the PMCG shoulder patch to be selected in the loadout by any member of the faction."


### PR DESCRIPTION
The item doesn't explicitly state that it's intended to identify officers, just that it the wearer is an EPMC contractor. 

Gimmie, gimmie.