### PR TITLE
Removes cyborg as a joinable job

### DIFF
--- a/code/__defines/jobs.dm
+++ b/code/__defines/jobs.dm
@@ -16,7 +16,7 @@
 #define CIVILIAN_ROLES list(/datum/job/assistant, /datum/job/visitor, /datum/job/passenger)
 #define SECURITY_ROLES list(/datum/job/warden, /datum/job/investigator, /datum/job/officer, /datum/job/intern_sec)
 #define OPERATIONS_ROLES list(/datum/job/hangar_tech, /datum/job/mining, /datum/job/machinist)
-#define EQUIPMENT_ROLES list(/datum/job/ai, /datum/job/cyborg)
+#define EQUIPMENT_ROLES list(/datum/job/ai)
 
 #define ALL_ROLES list(COMMAND_ROLES, COMMAND_SUPPORT_ROLES, ENGINEERING_ROLES, SERVICE_ROLES, CIVILIAN_ROLES, OPERATIONS_ROLES, MEDICAL_ROLES, SCIENCE_ROLES, SECURITY_ROLES, EQUIPMENT_ROLES)
 #define ALL_FACTION_ROLES list(/datum/job/representative, /datum/job/assistant, /datum/job/visitor)

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -61,7 +61,7 @@ var/global/static/list/valid_player_genders = list(MALE, FEMALE, NEUTER, PLURAL)
 //Backpacks
 var/global/list/backbaglist = list("Nothing", "Backpack", "Satchel", "Leather satchel", "Duffel Bag", "Messenger Bag", "Black Rucksack", "Blue Rucksack", "Green Rucksack", "Navy Rucksack", "Tan Rucksack", "Khaki Satchel", "Black Satchel", "Navy Satchel", "Olive Satchel", "Auburn Satchel", "Black Pocketbook", "Brown Pocketbook", "Auburn Pocketbook", "Classic leather satchel")
 var/global/list/backbagstyles = list("Job-specific", "Grey")
-var/global/list/exclude_jobs = list(/datum/job/ai,/datum/job/cyborg, /datum/job/merchant)
+var/global/list/exclude_jobs = list(/datum/job/ai, /datum/job/merchant)
 
 //PDA choice
 var/global/list/pdalist = list("Nothing", "Standard PDA", "Classic PDA", "Rugged PDA", "Slate PDA", "Smart PDA", "Tablet", "Wristbound")

--- a/code/datums/uplink/specialty.dm
+++ b/code/datums/uplink/specialty.dm
@@ -34,7 +34,6 @@ Quick and easy list of all the occupations for farther expansion and addition.
 /datum/job/forensics
 /datum/job/officer
 /datum/job/ai
-/datum/job/cyborg
 /datum/job/intern_sec
 /datum/job/intern_med
 /datum/job/intern_sci

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -38,27 +38,3 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/straight_jacket(H), slot_wear_suit)
 	H.equip_to_slot_or_del(new /obj/item/clothing/head/cardborg(H), slot_head)
 	return 1
-
-/datum/job/cyborg
-	title = "Cyborg"
-	flag = CYBORG
-	departments = SIMPLEDEPT(DEPARTMENT_EQUIPMENT)
-	department_flag = ENGSEC
-	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
-	supervisors = "your laws and the AI"	//Nodrak
-	selection_color = "#6c5b73"
-	minimal_player_age = 1
-	alt_titles = list("Android", "Robot")
-	account_allowed = 0
-	economic_modifier = 0
-
-/datum/job/cyborg/equip(var/mob/living/carbon/human/H, var/alt_title)
-		if(!H)	return 0
-		return 1
-
-/datum/job/cyborg/equip_preview(mob/living/carbon/human/H)
-	H.equip_to_slot_or_del(new /obj/item/clothing/suit/cardborg(H), slot_wear_suit)
-	H.equip_to_slot_or_del(new /obj/item/clothing/head/cardborg(H), slot_head)
-	return 1

--- a/code/modules/mob/abstract/new_player/preferences_setup.dm
+++ b/code/modules/mob/abstract/new_player/preferences_setup.dm
@@ -208,7 +208,7 @@
 		var/list/leftovers = list()
 		var/list/used_slots = list()
 
-		if((equip_preview_mob & EQUIP_PREVIEW_LOADOUT) && !(previewJob && (equip_preview_mob & EQUIP_PREVIEW_JOB) && (previewJob.type == /datum/job/ai || previewJob.type == /datum/job/cyborg)))
+		if((equip_preview_mob & EQUIP_PREVIEW_LOADOUT) && !(previewJob && (equip_preview_mob & EQUIP_PREVIEW_JOB) && (previewJob.type == /datum/job/ai)))
 			SSjobs.EquipCustom(mannequin, previewJob, src, leftovers, null, used_slots)
 
 		if((equip_preview_mob & EQUIP_PREVIEW_JOB) && previewJob)

--- a/code/modules/mob/living/silicon/robot/items/robot_parts.dm
+++ b/code/modules/mob/living/silicon/robot/items/robot_parts.dm
@@ -288,37 +288,8 @@
 				return
 
 			else
-				if(jobban_isbanned(M.brainmob, "Cyborg"))
-					to_chat(user, SPAN_WARNING("\The [W] does not seem to fit. (The player has been banned from playing this role)"))
-					return
-
-				var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(src), TRUE)
-				if(!O)
-					return
-
-				user.drop_from_inventory(M, O)
-				O.mmi = W
-				O.invisibility = 0
-				O.custom_name = created_name
-				O.updatename("Default")
-
-				M.brainmob.mind.transfer_to(O)
-
-				O.job = "Cyborg"
-				O.cell = chest.cell
-				O.cell.forceMove(O)
-				W.forceMove(O) //Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.
-
-				// Since we "magically" installed a cell, we also have to update the correct component.
-				if(O.cell)
-					var/datum/robot_component/cell_component = O.components["power cell"]
-					cell_component.wrapped = O.cell
-					cell_component.installed = TRUE
-
-				feedback_inc("cyborg_birth", 1)
-				callHook("borgify", list(O))
-				O.Namepick()
-				qdel(src)
+				to_chat(user, SPAN_WARNING("\The [W] does not seem to fit, the connections appear incompatible with this type of model."))
+				return
 		else
 			to_chat(user, SPAN_WARNING("\The [W] can only be inserted after everything else is installed."))
 		return

--- a/html/changelogs/flpfs_borgremove.yml
+++ b/html/changelogs/flpfs_borgremove.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Flpfs
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Cyborg has been removed as a joinable job. They still exist in the game, however."


### PR DESCRIPTION
Removes cyborg as a joinable job from the menu. It no longer appears in preferences, or the latejoin menu. I've playtested it with the menu + spawning a borg and playing around in it and it looked fine to me.


Please tell me if there's anything missing or gamebreaking. I've ran it and there were no errors, but there might be something I haven't caught and that might do a random runtime in specific circumstances.

https://forums.aurorastation.org/topic/17615-remove-cyborg/

edit forgot to add thread

Edit2 - I've edited the Pull Request so that cyborgs cannot be created. Once you reach the final step where you click on the completed frame with a hand, it tells you the connections are incompatible. IPCs can still be created, though.