### PR TITLE
Cult Armor Generalization

### DIFF
--- a/code/game/gamemodes/cult/items/armor.dm
+++ b/code/game/gamemodes/cult/items/armor.dm
@@ -19,8 +19,8 @@
 	icon_state = "cult_helmet"
 	armor = list(
 		melee = ARMOR_MELEE_VERY_HIGH,
-		bullet = ARMOR_BALLISTIC_MEDIUM,
-		laser = ARMOR_LASER_MEDIUM,
+		bullet = ARMOR_BALLISTIC_CARBINE,
+		laser = ARMOR_LASER_RIFLE,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT

--- a/code/game/gamemodes/cult/items/armor.dm
+++ b/code/game/gamemodes/cult/items/armor.dm
@@ -19,8 +19,8 @@
 	icon_state = "cult_helmet"
 	armor = list(
 		melee = ARMOR_MELEE_VERY_HIGH,
-		bullet = ARMOR_BALLISTIC_SMALL,
-		laser = ARMOR_LASER_MAJOR,
+		bullet = ARMOR_BALLISTIC_MEDIUM,
+		laser = ARMOR_LASER_MEDIUM,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
@@ -44,8 +44,8 @@
 	slowdown = 1
 	armor = list(
 		melee = ARMOR_MELEE_VERY_HIGH,
-		bullet = ARMOR_BALLISTIC_SMALL,
-		laser = ARMOR_LASER_MAJOR,
+		bullet = ARMOR_BALLISTIC_MEDIUM,
+		laser = ARMOR_LASER_MEDIUM,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT

--- a/code/game/gamemodes/cult/items/armor.dm
+++ b/code/game/gamemodes/cult/items/armor.dm
@@ -44,8 +44,8 @@
 	slowdown = 1
 	armor = list(
 		melee = ARMOR_MELEE_VERY_HIGH,
-		bullet = ARMOR_BALLISTIC_MEDIUM,
-		laser = ARMOR_LASER_MEDIUM,
+		bullet = ARMOR_BALLISTIC_CARBINE,
+		laser = ARMOR_LASER_RIFLE,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT

--- a/code/game/gamemodes/cult/items/clothes.dm
+++ b/code/game/gamemodes/cult/items/clothes.dm
@@ -7,7 +7,7 @@
 	body_parts_covered = HEAD|EYES
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
-		bullet = ARMOR_BALLISTIC_PISTOL,
+		bullet = ARMOR_BALLISTIC_MEDIUM,
 		laser = ARMOR_LASER_MEDIUM,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SMALL
@@ -34,7 +34,7 @@
 	allowed = list(/obj/item/book/tome, /obj/item/melee/cultblade)
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
-		bullet = ARMOR_BALLISTIC_PISTOL,
+		bullet = ARMOR_BALLISTIC_MEDIUM,
 		laser = ARMOR_LASER_MEDIUM,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SMALL
@@ -61,7 +61,7 @@
 	siemens_coefficient = 0.35 //antags don't get exceptions, it's just heavy armor by magical standards
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
-		bullet = ARMOR_BALLISTIC_PISTOL,
+		bullet = ARMOR_BALLISTIC_MEDIUM,
 		laser = ARMOR_LASER_MEDIUM,
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SMALL

--- a/html/changelogs/cult_armorbutter.yml
+++ b/html/changelogs/cult_armorbutter.yml
@@ -1,0 +1,14 @@
+# Your name.
+author: Butterrobber202
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Cult Armor is no longer specialized against lasers. It will now guard against ballistics as well."
+  

--- a/html/changelogs/cult_armorbutter.yml
+++ b/html/changelogs/cult_armorbutter.yml
@@ -10,5 +10,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Cult Armor is no longer specialized against lasers. It will now guard against ballistics as well."
+  - tweak: "Cult armour has been tweaked to not have as high of a protection against lasers. Its ballistics protection has been raised to compensate."
   


### PR DESCRIPTION
Cult armor is no longer specialized against lasers. Cult armor/robes armor values were equalized.

Original plan for capping at medium protection didn't work out, as the default cult robes would have been nerfed across the board.