### PR TITLE
Handheld health analyzer shows bloodtype, formatting fixed.

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -131,7 +131,7 @@ BREATH ANALYZER
 
 	// Brain activity.
 	var/brain_status = H.get_brain_status()
-	dat += "Brain activity: [brain_status]."
+	dat += "Brain activity: [brain_status]"
 	var/brain_result = H.get_brain_result()
 
 	if(sound_scan)
@@ -169,13 +169,14 @@ BREATH ANALYZER
 			pulse_result = "<span class='scan_warning'>[pulse_result]</span>"
 	else
 		pulse_result = "<span class='scan_danger'>0</span>"
-	dat += "Pulse rate: [pulse_result]bpm."
+	dat += "Pulse rate: [pulse_result] bpm"
 
-	// Blood pressure. Based on the idea of a normal blood pressure being 120 over 80.
+	// Blood pressure and blood type. Based on the idea of a normal blood pressure being 120 over 80.
 	if(H.should_have_organ(BP_HEART))
 		if(H.get_blood_volume() <= 70)
 			dat += "<span class='scan_danger'>Severe blood loss detected.</span>"
 		var/oxygenation_string = "<span class='scan_green'>[H.get_blood_oxygenation()]% blood oxygenation</span>"
+		dat += "Blood type: <span class ='scan_green'>[H.dna.b_type]</span>"
 		switch(H.get_blood_oxygenation())
 			if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
 				oxygenation_string = "<span class='scan_notice'>[oxygenation_string]</span>"
@@ -194,16 +195,16 @@ BREATH ANALYZER
 				blood_pressure_string = "<span class='scan_warning'>[H.get_blood_pressure()]</span>"
 			if(4)
 				blood_pressure_string = "<span class='scan_danger'>[H.get_blood_pressure()]</span>"
-		dat += "[b]Blood pressure:[endb] [blood_pressure_string] ([oxygenation_string])"
+		dat += "Blood pressure: [blood_pressure_string] ([oxygenation_string])"
 	else
-		dat += "[b]Blood pressure:[endb] N/A"
+		dat += "Blood pressure: N/A"
 
-	// Body temperature.
+	// Body temperature. Rounds to one digit after decimal.
 	var/temperature_string
 	if(H.bodytemperature < H.species.cold_level_1 || H.bodytemperature > H.species.heat_level_1)
-		temperature_string = "<span class='scan_warning'>Body temperature: [H.bodytemperature-T0C]&deg;C ([H.bodytemperature*1.8-459.67]&deg;F)</span>"
+		temperature_string = "Body temperature: <span class='scan_warning'>[round(H.bodytemperature-T0C, 0.1)]&deg;C ([round(H.bodytemperature*1.8-459.67, 0.1)]&deg;F)</span>"
 	else
-		temperature_string = "<span class='scan_green'>Body temperature: [H.bodytemperature-T0C]&deg;C ([H.bodytemperature*1.8-459.67]&deg;F)</span>"
+		temperature_string = "Body temperature: <span class='scan_green'>[round(H.bodytemperature-T0C, 0.1)]&deg;C ([round(H.bodytemperature*1.8-459.67, 0.1)]&deg;F)</span>"
 	dat += temperature_string
 
 	// Traumatic shock.

--- a/html/changelogs/flpfs-scannerplus.yml
+++ b/html/changelogs/flpfs-scannerplus.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Flpfs
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Handheld health scanner now displays blood type."
+  - tweak: "The bolding and formatting on the handheld health scanner has been made consistent."
+  - tweak: "Body temperature on the handheld scanner now rounds to one digit after the dot."


### PR DESCRIPTION
Handheld health scanner now displays blood type.
The bolding and formatting on the handheld health scanner has been made consistent.
Body temperature on the handheld scanner now rounds to one digit after the dot.

Tested it on all species, works fine!
![coolchange](https://user-images.githubusercontent.com/70925284/196533471-3fb872c9-4410-4537-b3c2-ae426178f290.png)
