### PR TITLE
Hangar Deck Third Party Pad Fix

### DIFF
--- a/html/changelogs/wickedcybs_hangarpad.yml
+++ b/html/changelogs/wickedcybs_hangarpad.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - bugfix: "Moves the navpoint for the second horizon hangar navpoint (the one third parties use to go inside) up by one tile. This will stop the Orion Express shuttle from using the pad and destroying the hangar wires and floors, as it was perfectly sized to land in just barely."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -57071,8 +57071,8 @@ moI
 moI
 nYD
 bJa
-bJa
 dTk
+bJa
 bJa
 bJa
 bJa


### PR DESCRIPTION
This is what happens when the OX shuttle lands in the interior hangar and not the docking ports. This was actually brought up to me months ago too but I forgot to do anything when it was mentioned... until now.

![image](https://user-images.githubusercontent.com/52309324/196577354-cd489f39-60be-4b38-a4ce-777c1837f1a5.png)

It is basically perfectly sized to do this and the problem is it destroys all wiring and flooring underneath it. It barely "fits" but it still doesn't fit the size of the hangar pads. The fix was easy enough. I moved the navpoint up a tile. All the shuttles that properly fit here will still comfortably stay in the confines of the second hangar pad.

I think ideally in the future, we restrict interior pads like this to favoured factions or shuttle types that can fit inside only.
