### PR TITLE
Taj Smuggler Ship Fixes

### DIFF
--- a/html/changelogs/wickedcybs_taj.yml
+++ b/html/changelogs/wickedcybs_taj.yml
@@ -1,0 +1,7 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - bugfix: "The Taj smuggler ship fuel port will start with a fuel tank in it now. "
+  - bugfix: "The engineering cycler in the Taj smuggler ship should be access unrestricted now."

--- a/maps/away/ships/tajaran_smuggler.dmm
+++ b/maps/away/ships/tajaran_smuggler.dmm
@@ -661,7 +661,7 @@
 /turf/simulated/floor,
 /area/ship/tajaran_smuggler)
 "gyL" = (
-/obj/structure/fuel_port{
+/obj/structure/fuel_port/phoron{
 	pixel_x = -32
 	},
 /turf/simulated/floor/shuttle/black,
@@ -1208,7 +1208,9 @@
 /turf/simulated/floor,
 /area/ship/tajaran_smuggler)
 "phC" = (
-/obj/machinery/suit_cycler/engineering,
+/obj/machinery/suit_cycler/engineering{
+	req_access = null
+	},
 /turf/simulated/floor,
 /area/ship/tajaran_smuggler)
 "pPS" = (


### PR DESCRIPTION
The shuttle fuel port now uses the phoron subtype and the engineering cycler on the ship shouldn't be access locked anymore.