### PR TITLE
Telecomms Adjustment: Swaps the Common Server and Black Box

### DIFF
--- a/html/changelogs/wickedcybs_telecom.yml
+++ b/html/changelogs/wickedcybs_telecom.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "The blackbox and the common server in telecomms had their positions swapped so people can repair the common server easier."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -46064,7 +46064,7 @@ Gc
 Gc
 Gc
 fc
-Pp
+Wi
 gd
 Lc
 vP
@@ -47080,7 +47080,7 @@ eB
 OO
 OO
 OW
-Wi
+Pp
 XJ
 hZ
 wA


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52309324/197310193-c36e5007-a1a5-423e-8f80-f22f14474600.png)

Reasoning is that if the place breaks you can't easily reach the common server and probably have to break down a wall. The black box is mainly a prop anyway so it being moved into the corner is fine.