### PR TITLE
Adds a ladder between bridge maint and bar maint

### DIFF
--- a/html/changelogs/DreamySkrell-bridge-maint-ladder-2.yml
+++ b/html/changelogs/DreamySkrell-bridge-maint-ladder-2.yml
@@ -1,0 +1,6 @@
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - rscadd: "Adds a ladder between Horizon's top deck bridge maint and middle deck bar maint."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -9213,8 +9213,10 @@
 /turf/simulated/floor/lino/grey,
 /area/horizon/bar)
 "eTf" = (
-/obj/structure/table/rack,
-/obj/random/loot,
+/obj/structure/ladder/up{
+	pixel_y = 13
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/horizon/maintenance/deck_two/fore/starboard)
 "eTQ" = (
@@ -26674,6 +26676,12 @@
 "nTS" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/engineering)
+"nUb" = (
+/obj/structure/table/rack,
+/obj/random/loot,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/horizon/maintenance/deck_two/fore/starboard)
 "nUh" = (
 /obj/machinery/button/remote/blast_door{
 	id = "bar_starboard";
@@ -64429,7 +64437,7 @@ xHc
 ccl
 khK
 gVn
-eTf
+nUb
 iBa
 kYw
 gun

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -6182,6 +6182,7 @@
 	dir = 4;
 	pixel_x = 32
 	},
+/obj/structure/railing/mapped,
 /turf/simulated/floor,
 /area/maintenance/bridge)
 "lf" = (
@@ -14439,12 +14440,14 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/crew_quarters/fitness/washroom)
 "Ap" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/flag/sol/right{
 	dir = 4;
 	pixel_x = 32
 	},
-/turf/simulated/floor,
+/obj/structure/ladder{
+	pixel_y = 10
+	},
+/turf/simulated/open,
 /area/maintenance/bridge)
 "Aq" = (
 /obj/structure/railing/mapped{


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/107256943/197570674-77777fa4-8396-4afc-aa48-865aa9dba67f.png)


Adds a ladder between Horizon's top deck bridge maint and middle deck bar maint.
Like #14945, but not absolutely broken.