### PR TITLE
Adds Bucket to CivStation Map

### DIFF
--- a/html/changelogs/zelm-bucket.yml
+++ b/html/changelogs/zelm-bucket.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Zelmana
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Adds bucket to Civilian Station's janitorial closet."

--- a/maps/away/generic/civilian_station.dmm
+++ b/maps/away/generic/civilian_station.dmm
@@ -1710,6 +1710,7 @@
 /area/civilian_station)
 "pmw" = (
 /obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/tiled/dark,
 /area/civilian_station)
 "pqp" = (


### PR DESCRIPTION
There's no bucket for janitors to fill their mopbucket.

Mopbuckets need to be filled with a container, and can't directly fill from Water Tanks. All other custodial-use watertanks have a bucket nearby. This one does not, causing pain.


First forray into some minor mapping stuff. Thanks King
![image](https://user-images.githubusercontent.com/30159393/197587475-77163190-f8f7-48ca-84df-5c79039b836e.png)
