### PR TITLE
Accent tags clickable, show name and desc in new window

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -689,6 +689,19 @@
 		var/datum/browser/flavor_win = new(usr, name, capitalize_first_letters(name), 500, 250)
 		flavor_win.set_content(replacetext(flavor_text, "\n", "<BR>"))
 		flavor_win.open()
+
+	if(href_list["accent_tag"])
+		var/datum/accent/accent = SSrecords.accents[href_list["accent_tag"]]
+		if(accent && istype(accent))
+			var/datum/browser/accent_win = new(usr, accent.name, capitalize_first_letters(accent.name), 500, 250)
+			var/html = "[accent.description]<br>"
+			var/datum/asset/spritesheet/S = get_asset_datum(/datum/asset/spritesheet/goonchat)
+			html += "[S.css_tag()]<br>"
+			html += {"[S.icon_tag(accent.tag_icon)]<br>"}
+			html += "([accent.text_tag])<br>"
+			accent_win.set_content(html)
+			accent_win.open()
+
 	if(href_list["flavor_change"])
 		update_flavor_text()
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -1193,15 +1193,11 @@ proc/is_blind(A)
 		var/datum/accent/a = SSrecords.accents[used_accent]
 		if(istype(a))
 			if(hearer && hearer.client && hearer.client.prefs?.toggles_secondary & ACCENT_TAG_TEXT)
-				return {"<a \
-					href='byond://?src=\ref[src];accent_tag=[url_encode(a)]' \
-					>([a.text_tag])</a>"}
+				return {"<a href='byond://?src=\ref[src];accent_tag=[url_encode(a)]'>([a.text_tag])</a>"}
 			else
 				var/final_icon = a.tag_icon
 				var/datum/asset/spritesheet/S = get_asset_datum(/datum/asset/spritesheet/goonchat)
-				return {"<span \
-					onclick="window.location.href='byond://?src=\ref[src];accent_tag=[url_encode(a)]'" \
-					>[S.icon_tag(final_icon)]</span>"}
+				return {"<span onclick="window.location.href='byond://?src=\ref[src];accent_tag=[url_encode(a)]'">[S.icon_tag(final_icon)]</span>"}
 				
 
 /mob/proc/flash_eyes(intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, type = /obj/screen/fullscreen/flash)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -1193,11 +1193,15 @@ proc/is_blind(A)
 		var/datum/accent/a = SSrecords.accents[used_accent]
 		if(istype(a))
 			if(hearer && hearer.client && hearer.client.prefs?.toggles_secondary & ACCENT_TAG_TEXT)
-				return "([a.text_tag])"
+				return {"<a \
+					href='byond://?src=\ref[src];accent_tag=[url_encode(a)]' \
+					>([a.text_tag])</a>"}
 			else
 				var/final_icon = a.tag_icon
 				var/datum/asset/spritesheet/S = get_asset_datum(/datum/asset/spritesheet/goonchat)
-				return S.icon_tag(final_icon)
+				return {"<span \
+					onclick="window.location.href='byond://?src=\ref[src];accent_tag=[url_encode(a)]'" \
+					>[S.icon_tag(final_icon)]</span>"}
 				
 
 /mob/proc/flash_eyes(intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, visual = FALSE, type = /obj/screen/fullscreen/flash)

--- a/html/changelogs/DreamySkrell-accent-tag-35.yml
+++ b/html/changelogs/DreamySkrell-accent-tag-35.yml
@@ -1,0 +1,7 @@
+
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - rscadd: "Accent tags in the chat are now clickable, and show a window with the accent name and description."


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/107256943/198857418-39c2f262-a4c4-4dfd-ad8c-e92ad1cd0d00.png)

Accent tags in the chat are now clickable, and show a window with the accent name and description.

Works with the accent tag icons disabled too.