### PR TITLE
[wip] Flavor text mob image

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -687,11 +687,11 @@
 
 	if(href_list["flavor_more"])
 		var/datum/browser/flavor_win = new(usr, name, capitalize_first_letters(name), 500, 250)
-		var/html = replacetext(flavor_text, "\n", "<BR>")
 		var/icon/front = getFlatIcon(src, SOUTH, ignore_parent_dir = TRUE)
 		front.Scale(128, 128)
 		send_rsc(usr, front, "front.png")
-		html += "<img src=front.png height=128 width=128 border=4>"
+		var/html = {"<img src=front.png height=128 width=128 border=4 style="float:left">"}
+		html += replacetext(flavor_text, "\n", "<BR>")
 		flavor_win.set_content(html)
 		flavor_win.open()
 	if(href_list["flavor_change"])

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -687,7 +687,12 @@
 
 	if(href_list["flavor_more"])
 		var/datum/browser/flavor_win = new(usr, name, capitalize_first_letters(name), 500, 250)
-		flavor_win.set_content(replacetext(flavor_text, "\n", "<BR>"))
+		var/html = replacetext(flavor_text, "\n", "<BR>")
+		var/icon/front = getFlatIcon(src, SOUTH, ignore_parent_dir = TRUE)
+		front.Scale(128, 128)
+		send_rsc(usr, front, "front.png")
+		html += "<img src=front.png height=128 width=128 border=4>"
+		flavor_win.set_content(html)
 		flavor_win.open()
 	if(href_list["flavor_change"])
 		update_flavor_text()

--- a/html/changelogs/DreamySkrell-flavor-text-image-65478.yml
+++ b/html/changelogs/DreamySkrell-flavor-text-image-65478.yml
@@ -1,0 +1,7 @@
+
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - rscadd: "Flavor text window shows the front sprite of the examined mob."


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/107256943/198858836-a6407c9f-70fa-4f3e-aa00-f00c13de50b8.png)

changes:
  - rscadd: "Flavor text window shows the front sprite of the examined mob."

The image is not updated in real time when the window is open - only when the flavor text link is clicked.
The image is the "current" look of the mob, with all the clothing and gear they are wearing currently. If they're in a full voidsuit, they will be on the image in the flavor text as well.

But, flavor text windows can be clicked and opened up on any past examine in the chat, and then this would get the current mob image, with no regard how far the mob is or if they are visible currently, and that is undesirable of course.

- [x] first impl
- [ ] make sure this is actually wanted
- [ ] make sure it can't be used for metagaming
- [ ] maybe add a toggle in the prefs for people who don't want to see this
- [ ] maybe test merge to see the performance impact
- [ ] ???
- [ ] profit
