### PR TITLE
Uplink item buy limit mechanism

### DIFF
--- a/code/datums/uplink/devices_and_tools.dm
+++ b/code/datums/uplink/devices_and_tools.dm
@@ -73,7 +73,7 @@
 	desc = "A personal shield that, when kept in your hand and activated, will protect its user from five projectile shots. \
 	        This can only be bought once."
 	item_cost = 1
-	item_limit = 4
+	item_limit = 1
 	path = /obj/item/device/personal_shield
 
 /datum/uplink_item/item/tools/hacking_tool

--- a/code/datums/uplink/devices_and_tools.dm
+++ b/code/datums/uplink/devices_and_tools.dm
@@ -73,7 +73,7 @@
 	desc = "A personal shield that, when kept in your hand and activated, will protect its user from five projectile shots. \
 	        This can only be bought once."
 	item_cost = 1
-	item_limit = 1
+	item_limit = 4
 	path = /obj/item/device/personal_shield
 
 /datum/uplink_item/item/tools/hacking_tool

--- a/code/datums/uplink/devices_and_tools.dm
+++ b/code/datums/uplink/devices_and_tools.dm
@@ -72,6 +72,7 @@
 	name = "Personal Shield"
 	desc = "A personal shield that, when kept in your hand and activated, will protect its user from five projectile shots."
 	item_cost = 1
+	item_limit = 1
 	path = /obj/item/device/personal_shield
 
 /datum/uplink_item/item/tools/hacking_tool

--- a/code/datums/uplink/devices_and_tools.dm
+++ b/code/datums/uplink/devices_and_tools.dm
@@ -70,7 +70,8 @@
 
 /datum/uplink_item/item/tools/personal_shield
 	name = "Personal Shield"
-	desc = "A personal shield that, when kept in your hand and activated, will protect its user from five projectile shots."
+	desc = "A personal shield that, when kept in your hand and activated, will protect its user from five projectile shots. \
+	        This can only be bought once."
 	item_cost = 1
 	item_limit = 1
 	path = /obj/item/device/personal_shield

--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -29,7 +29,7 @@
 
 /datum/uplink_item/item/implants/imp_uplink
 	name = "Uplink Implant"
-	path = /obj/item/storage/box/syndie_kit/imp_uplink
+	path = /obj/item/implanter/uplink
 
 /datum/uplink_item/item/implants/imp_uplink/New()
 	..()

--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -61,6 +61,13 @@
 	item_cost = 1
 	path = /obj/item/storage/firstaid/regular
 
+/datum/uplink_item/item/medical/firstaid
+	name = "Standard First-Aid Kit (Free)"
+	item_cost = 0
+	item_limit = 1
+	path = /obj/item/storage/firstaid/regular
+	desc = "You can claim this first-aid kit only once."
+
 /datum/uplink_item/item/medical/advfirstaid
 	name = "Advanced First-Aid Kit"
 	item_cost = 1

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -29,6 +29,7 @@ var/datum/uplink/uplink
 	var/name
 	var/desc
 	var/item_cost = 0
+	var/item_limit = -1 // how many times can this item be bought from a uplink; -1 is no limit
 	var/datum/uplink_category/category		// Item category
 	var/list/datum/antagonist/antag_roles	// Antag roles this item is displayed to. If empty, display to all.
 	var/list/datum/antagonist/antag_job     // Antag job this item is displayed to, if empty, display to all.
@@ -64,6 +65,9 @@ var/datum/uplink/uplink
 
 /datum/uplink_item/proc/can_buy(obj/item/device/uplink/U)
 	if(cost(U.uses) > U.uses)
+		return 0
+
+	if(item_limit >= 0 && U.purchase_log[src] && U.purchase_log[src] >= item_limit)
 		return 0
 
 	return can_view(U)

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -54,6 +54,14 @@ var/datum/uplink/uplink
 	if(!goods)
 		return
 
+	var/obj/item/implanter/implanter = goods
+	if(istype(implanter))
+		var/obj/item/implant/uplink/uplink_implant = implanter.imp
+		if(istype(uplink_implant))
+			var/obj/item/device/uplink/hidden/hidden_uplink = uplink_implant.hidden_uplink
+			if(istype(hidden_uplink))
+				hidden_uplink.purchase_log = U.purchase_log
+	
 	purchase_log(U)
 	U.uses -= cost
 	U.used_TC += cost

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -75,7 +75,6 @@ var/datum/uplink/uplink
 /datum/uplink_item/proc/items_left(obj/item/device/uplink/U)
 	return item_limit - U.purchase_log[src]
 		
-
 /datum/uplink_item/proc/can_view(obj/item/device/uplink/U)
 	// Making the assumption that if no uplink was supplied, then we don't care about antag roles
 	if(!U || (!length(antag_roles) && !antag_job))

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -29,7 +29,7 @@ var/datum/uplink/uplink
 	var/name
 	var/desc
 	var/item_cost = 0
-	var/item_limit = -1 // how many times can this item be bought from a uplink; -1 is no limit
+	var/item_limit = 999 // how many times can this item be bought from a uplink (high limit is not shown in the uplink gui)
 	var/datum/uplink_category/category		// Item category
 	var/list/datum/antagonist/antag_roles	// Antag roles this item is displayed to. If empty, display to all.
 	var/list/datum/antagonist/antag_job     // Antag job this item is displayed to, if empty, display to all.
@@ -67,10 +67,14 @@ var/datum/uplink/uplink
 	if(cost(U.uses) > U.uses)
 		return 0
 
-	if(item_limit >= 0 && U.purchase_log[src] && U.purchase_log[src] >= item_limit)
+	if(items_left(U) <= 0)
 		return 0
 
 	return can_view(U)
+
+/datum/uplink_item/proc/items_left(obj/item/device/uplink/U)
+	return item_limit - U.purchase_log[src]
+		
 
 /datum/uplink_item/proc/can_view(obj/item/device/uplink/U)
 	// Making the assumption that if no uplink was supplied, then we don't care about antag roles

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -167,7 +167,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 						"cost" = cost,
 						"left" = item.items_left(src),
 						"ref" = "\ref[item]"
-					)
+				)
 		nanoui_data["items"] = items
 	else if(nanoui_menu == 2)
 		var/permanentData[0]

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -163,7 +163,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 				items[++items.len] = list(
 						"name" = item.name,
 						"description" = replacetext(item.description(), "\n", "<br>"),
-						"can_buy" = item.can_buy(src),
+					"can_buy" = item.can_buy(src),
 						"cost" = cost,
 					"left" = item.items_left(src),
 					"ref" = "\ref[item]"

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -160,7 +160,14 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 			if(item.can_view(src))
 				var/cost = item.cost(uses)
 				if(!cost) cost = "???"
-				items[++items.len] = list("name" = item.name, "description" = replacetext(item.description(), "\n", "<br>"), "can_buy" = item.can_buy(src), "cost" = cost, "ref" = "\ref[item]")
+				items[++items.len] = list(
+						"name" = item.name,
+						"description" = replacetext(item.description(), "\n", "<br>"),
+						"can_buy" = item.can_buy(src),
+						"cost" = cost,
+						"left" = item.items_left(src),
+						"ref" = "\ref[item]"
+					)
 		nanoui_data["items"] = items
 	else if(nanoui_menu == 2)
 		var/permanentData[0]

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -165,7 +165,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 						"description" = replacetext(item.description(), "\n", "<br>"),
 						"can_buy" = item.can_buy(src),
 						"cost" = cost,
-						"left" = item.items_left(src),
+					"left" = item.items_left(src),
 					"ref" = "\ref[item]"
 				)
 		nanoui_data["items"] = items

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -164,7 +164,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 						"name" = item.name,
 						"description" = replacetext(item.description(), "\n", "<br>"),
 					"can_buy" = item.can_buy(src),
-						"cost" = cost,
+					"cost" = cost,
 					"left" = item.items_left(src),
 					"ref" = "\ref[item]"
 				)

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -161,7 +161,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 				var/cost = item.cost(uses)
 				if(!cost) cost = "???"
 				items[++items.len] = list(
-						"name" = item.name,
+					"name" = item.name,
 					"description" = replacetext(item.description(), "\n", "<br>"),
 					"can_buy" = item.can_buy(src),
 					"cost" = cost,

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -15,7 +15,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	var/nanoui_menu = 0					// The current menu we are in
 	var/list/nanoui_data = new 			// Additional data for NanoUI use
 
-	var/list/purchase_log = new
+	var/list/purchase_log = new			// 
 	var/datum/mind/uplink_owner = null
 	var/used_TC = 0
 

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -166,7 +166,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 						"can_buy" = item.can_buy(src),
 						"cost" = cost,
 						"left" = item.items_left(src),
-						"ref" = "\ref[item]"
+					"ref" = "\ref[item]"
 				)
 		nanoui_data["items"] = items
 	else if(nanoui_menu == 2)

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -162,7 +162,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 				if(!cost) cost = "???"
 				items[++items.len] = list(
 						"name" = item.name,
-						"description" = replacetext(item.description(), "\n", "<br>"),
+					"description" = replacetext(item.description(), "\n", "<br>"),
 					"can_buy" = item.can_buy(src),
 					"cost" = cost,
 					"left" = item.items_left(src),

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -15,7 +15,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	var/nanoui_menu = 0					// The current menu we are in
 	var/list/nanoui_data = new 			// Additional data for NanoUI use
 
-	var/list/purchase_log = new			// 
+	var/list/purchase_log = new			// Assoc list of item to times bought; shared/referenced by child uplinks
 	var/datum/mind/uplink_owner = null
 	var/used_TC = 0
 
@@ -159,7 +159,6 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 		for(var/datum/uplink_item/item in category.items)
 			if(item.can_view(src))
 				var/cost = item.cost(uses)
-				if(!cost) cost = "???"
 				items[++items.len] = list(
 					"name" = item.name,
 					"description" = replacetext(item.description(), "\n", "<br>"),

--- a/html/changelogs/DreamySkrell-uplink-item-limit.yml
+++ b/html/changelogs/DreamySkrell-uplink-item-limit.yml
@@ -5,4 +5,5 @@ delete-after: True
 
 changes:
   - rscadd: "Adds a uplink item limit mechanism."
-  - tweak: "Uplink personal shield can only be bought once."
+  - rscadd: "One free medkit can be claimed from an uplink."
+  - tweak: "Personal shield can only be bought once from an uplink."

--- a/html/changelogs/DreamySkrell-uplink-item-limit.yml
+++ b/html/changelogs/DreamySkrell-uplink-item-limit.yml
@@ -1,0 +1,8 @@
+
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - rscadd: "Adds a uplink item limit mechanism."
+  - tweak: "Uplink personal shield can only be bought once."

--- a/html/changelogs/DreamySkrell-uplink-item-limit.yml
+++ b/html/changelogs/DreamySkrell-uplink-item-limit.yml
@@ -4,6 +4,6 @@ author: DreamySkrell
 delete-after: True
 
 changes:
-  - rscadd: "Adds a uplink item limit mechanism."
+  - rscadd: "Adds a per-uplink item limit mechanism."
   - rscadd: "One free medkit can be claimed from an uplink."
   - tweak: "Personal shield can only be bought once from an uplink."

--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -42,7 +42,11 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 	
 	{{for data.items}}
 		<div class="item">
-			{{:helper.link(value.name, 'gear', {'buy_item' : value.ref}, value.can_buy ? null : 'disabled')}} - <span class="white">{{:value.cost}}</span>
+			{{:helper.link(value.name, 'gear', {'buy_item' : value.ref}, value.can_buy ? null : 'disabled')}} 
+			- <span class="white">{{:value.cost}}</span> 	
+			{{if value.left <= 10}}
+				- <span class="white">{{:value.left}} left</span> 
+            {{/if}}
 		</div>
 		<div class="item">
 			{{:value.description}}

--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -43,7 +43,7 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 	{{for data.items}}
 		<div class="item">
 			{{:helper.link(value.name, 'gear', {'buy_item' : value.ref}, value.can_buy ? null : 'disabled')}} 
-			- <span class="white">{{:value.cost}}</span> 	
+			- <span class="white">{{:value.cost}} TC</span> 	
 			{{if value.left <= 10}}
 				- <span class="white">{{:value.left}} left in the uplink</span> 
             {{/if}}

--- a/nano/templates/uplink.tmpl
+++ b/nano/templates/uplink.tmpl
@@ -45,7 +45,7 @@ Used In File(s): \code\game\objects\items\devices\uplinks.dm
 			{{:helper.link(value.name, 'gear', {'buy_item' : value.ref}, value.can_buy ? null : 'disabled')}} 
 			- <span class="white">{{:value.cost}}</span> 	
 			{{if value.left <= 10}}
-				- <span class="white">{{:value.left}} left</span> 
+				- <span class="white">{{:value.left}} left in the uplink</span> 
             {{/if}}
 		</div>
 		<div class="item">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/107256943/200694672-ed40c892-01f2-4847-8ab3-24e015c5457a.png)

![image](https://user-images.githubusercontent.com/107256943/200694677-9d065f50-1550-49e8-9c16-bb4eb3f3998a.png)

  - rscadd: "Adds a per-uplink item limit mechanism."
  - rscadd: "One free medkit can be claimed from an uplink."
  - tweak: "Personal shield can only be bought once from an uplink."

~~note: This limit is specific to a uplink, not to the antag. This also means that a traitor can buy a shield from their first uplink, buy an implanted uplink and implant it, and then buy another shield from that implanted uplink. Should be discussed if this is a feature, or a bug that needs to be fixed, or a oversight not worth fixing in code.~~
The above problem is fixed. Child uplinks (implanted uplinks) share buy list and item limits with their parent limits (normal uplinks).

As said below, I will try to implement faction limits in another PR, as I have no idea how to implement it at the moment, and currently there are some other PRs up that could use this per-uplink item limit mechanism.
