### PR TITLE
Loadout QoL - used items always at the top

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -178,7 +178,8 @@ var/list/gear_datums = list()
 	. += "<tr><td colspan=3><b><center>[LC.category]</center></b></td></tr>"
 	. += "<tr><td colspan=3><hr></td></tr>"
 
-	var/available_items_html = "" // to be added to the top/beginning of the list
+	var/ticked_items_html = "" // to be added to the top/beginning of the list
+	var/available_items_html = "" // to be added to the middle of the list
 	var/unavailable_items_html = "" // to be added to the end/bottom of the list
 
 	var/list/player_valid_gear_choices = valid_gear_choices()
@@ -243,11 +244,15 @@ var/list/gear_datums = list()
 			for(var/datum/gear_tweak/tweak in G.gear_tweaks)
 				temp_html += " <a href='?src=\ref[src];gear=[G.display_name];tweak=\ref[tweak]'>[tweak.get_contents(get_tweak_metadata(G, tweak))]</a>"
 			temp_html += "</td></tr>"
-		if(!available)
+		
+		if(ticked) 
+			ticked_items_html += temp_html
+		else if(!available)
 			available_items_html += temp_html
 		else
 			unavailable_items_html += temp_html
 	
+	. += ticked_items_html
 	. += unavailable_items_html
 	. += available_items_html
 	. += "</table>"

--- a/html/changelogs/DreamySkrell-loadout-qol-used-items-to-top.yml
+++ b/html/changelogs/DreamySkrell-loadout-qol-used-items-to-top.yml
@@ -1,0 +1,8 @@
+
+author: DreamySkrell
+
+delete-after: True
+
+
+changes:
+  - tweak: "Used items in the loadout always appear at the top of the list."


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/107256943/199370194-31f9448c-6454-475b-940f-914db49031b9.png)

  - tweak: "Used items in the loadout always appear at the top of the list."