### PR TITLE
Guns For Days

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -54,7 +54,7 @@
 
 /datum/uplink_item/item/ammo/carbine_mag
 	name = "5.56 carbine magazine"
-	item_cost = 2
+	item_cost = 1
 	path = /obj/item/ammo_magazine/a556/carbine 
 	desc = "Contains 15 rounds of 5.56."
 
@@ -77,15 +77,9 @@
 
 /datum/uplink_item/item/ammo/shotgun_slug
 	name = "Shotgun Slug"
-	item_cost = 2
+	item_cost = 1
 	path = /obj/item/ammo_casing/shotgun
 	desc = "A shotgun slug."
-
-/datum/uplink_item/item/ammo/shotgun_buckshot
-	name = "Buckshot Shell"
-	item_cost = 1
-	path = /obj/item/ammo_casing/shotgun/pellet
-	desc = "A shotgun buckshot shell."
 
 /datum/uplink_item/item/ammo/tungsten_ammo_box
 	name = "Tungsten Ammo Box"
@@ -93,27 +87,27 @@
 	path = /obj/item/ammo_magazine/gauss
 	desc = "A tungsten ammo box."
 
-/datum/uplink_item/item/ammo/buckshot_magazine
+/datum/uplink_item/item/ammo/slug_magazine
 	name = "Slug Magazine"
-	item_cost = 8
+	item_cost = 4
 	path = /obj/item/ammo_magazine/assault_shotgun
 	desc = "A magazine for an assault shotgun, loaded with slug shells."
 
 /datum/uplink_item/item/ammo/buckshot_magazine
 	name = "Buckshot Magazine"
-	item_cost = 4
+	item_cost = 2
 	path = /obj/item/ammo_magazine/assault_shotgun/shells
 	desc = "A magazine for an assault shotgun, loaded with buckshot shells."
 
-/datum/uplink_item/item/ammo/buckshot_magazine
+/datum/uplink_item/item/ammo/railgun_ammo
 	name = "Tungsten Railgun Ammunition"
-	item_cost = 8
+	item_cost = 6
 	path = /obj/item/ammo_magazine/trodpack
 	desc = "Two tungsten rods, used by a railgun."
 
-/datum/uplink_item/item/ammo/buckshot_magazine
+/datum/uplink_item/item/ammo/ar_ammo
 	name = "7.62 Assault Rifle magazine"
-	item_cost = 3
+	item_cost = 2
 	path = /obj/item/ammo_magazine/c762
 	desc = "A magazine for an assault rifle."
 
@@ -125,24 +119,24 @@
 
 /datum/uplink_item/item/ammo/gryojet_magazine
 	name = "20mm Rocket Magazine"
-	item_cost = 6
+	item_cost = 4
 	path = /obj/item/ammo_magazine/a75
 	desc = "A 20mm rocket magazine."
 
 /datum/uplink_item/item/ammo/bullpup_magazine
 	name = "5.56 Rifle Magazine"
-	item_cost = 4
+	item_cost = 2
 	path = /obj/item/ammo_magazine/a556
 	desc = "A magazine for 5.56 rifle."
 
 /datum/uplink_item/item/ammo/uzi_magazine
 	name = ".45 Autopistol Magazine"
-	item_cost = 4
+	item_cost = 1
 	path = /obj/item/ammo_magazine/c45uzi
 	desc = "A magazine for a .45 automatic pistol."
 
 /datum/uplink_item/item/ammo/deagle_magazine
 	name = ".50 Pistol Magazine"
-	item_cost = 3
+	item_cost = 1
 	path = /obj/item/ammo_magazine/a50
 	desc = "A magazine for a .50 pistol."

--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -74,3 +74,75 @@
 	item_cost = 2
 	path = /obj/item/ammo_magazine/super_heavy
 	desc = "A spare magazine, for the super heavy K2557 pistol."
+
+/datum/uplink_item/item/ammo/shotgun_slug
+	name = "Shotgun Slug"
+	item_cost = 2
+	path = /obj/item/ammo_casing/shotgun
+	desc = "A shotgun slug."
+
+/datum/uplink_item/item/ammo/shotgun_buckshot
+	name = "Buckshot Shell"
+	item_cost = 1
+	path = /obj/item/ammo_casing/shotgun/pellet
+	desc = "A shotgun buckshot shell."
+
+/datum/uplink_item/item/ammo/tungsten_ammo_box
+	name = "Tungsten Ammo Box"
+	item_cost = 2
+	path = /obj/item/ammo_magazine/gauss
+	desc = "A tungsten ammo box."
+
+/datum/uplink_item/item/ammo/buckshot_magazine
+	name = "Slug Magazine"
+	item_cost = 8
+	path = /obj/item/ammo_magazine/assault_shotgun
+	desc = "A magazine for an assault shotgun, loaded with slug shells."
+
+/datum/uplink_item/item/ammo/buckshot_magazine
+	name = "Buckshot Magazine"
+	item_cost = 4
+	path = /obj/item/ammo_magazine/assault_shotgun/shells
+	desc = "A magazine for an assault shotgun, loaded with buckshot shells."
+
+/datum/uplink_item/item/ammo/buckshot_magazine
+	name = "Tungsten Railgun Ammunition"
+	item_cost = 8
+	path = /obj/item/ammo_magazine/trodpack
+	desc = "Two tungsten rods, used by a railgun."
+
+/datum/uplink_item/item/ammo/buckshot_magazine
+	name = "7.62 Assault Rifle magazine"
+	item_cost = 3
+	path = /obj/item/ammo_magazine/c762
+	desc = "A magazine for an assault rifle."
+
+/datum/uplink_item/item/ammo/sniper_ammo
+	name = "7.62 Sniper Magazine"
+	item_cost = 4
+	path = /obj/item/ammo_magazine/d762
+	desc = "A magazine for 7.62 sniper rifle."
+
+/datum/uplink_item/item/ammo/gryojet_magazine
+	name = "20mm Rocket Magazine"
+	item_cost = 6
+	path = /obj/item/ammo_magazine/a75
+	desc = "A 20mm rocket magazine."
+
+/datum/uplink_item/item/ammo/bullpup_magazine
+	name = "5.56 Rifle Magazine"
+	item_cost = 4
+	path = /obj/item/ammo_magazine/a556
+	desc = "A magazine for 5.56 rifle."
+
+/datum/uplink_item/item/ammo/uzi_magazine
+	name = ".45 Autopistol Magazine"
+	item_cost = 4
+	path = /obj/item/ammo_magazine/c45uzi
+	desc = "A magazine for a .45 automatic pistol."
+
+/datum/uplink_item/item/ammo/deagle_magazine
+	name = ".50 Pistol Magazine"
+	item_cost = 3
+	path = /obj/item/ammo_magazine/a50
+	desc = "A magazine for a .50 pistol."

--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -127,7 +127,7 @@
 	name = "5.56 Rifle Magazine"
 	item_cost = 2
 	path = /obj/item/ammo_magazine/a556
-	desc = "A magazine for 5.56 rifle."
+	desc = "A magazine for a 5.56 rifle."
 
 /datum/uplink_item/item/ammo/uzi_magazine
 	name = ".45 Autopistol Magazine"

--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -115,7 +115,7 @@
 	name = "7.62 Sniper Magazine"
 	item_cost = 4
 	path = /obj/item/ammo_magazine/d762
-	desc = "A magazine for 7.62 sniper rifle."
+	desc = "A magazine for a 7.62 sniper rifle."
 
 /datum/uplink_item/item/ammo/gryojet_magazine
 	name = "20mm Rocket Magazine"

--- a/code/datums/uplink/highly visible and dangerous weapons.dm
+++ b/code/datums/uplink/highly visible and dangerous weapons.dm
@@ -82,6 +82,7 @@
 /datum/uplink_item/item/visible_weapons/gatling
 	name = "Gatling Machine Gun"
 	item_cost = 40
+	item_limit = 1
 	path = /obj/item/minigunpack
 
 /datum/uplink_item/item/visible_weapons/chainsaw
@@ -187,6 +188,7 @@
 /datum/uplink_item/item/visible_weapons/gyrojet_pistol
 	name = "Gyrojet Pistol"
 	item_cost = 20
+	item_limit = 1
 	path = /obj/item/gun/projectile/gyropistol
 
 /datum/uplink_item/item/visible_weapons/bullpup_assault_carbine
@@ -202,6 +204,7 @@
 /datum/uplink_item/item/visible_weapons/gatling_laser
 	name = "Gatling Laser"
 	item_cost = 40
+	item_limit = 1
 	path = /obj/item/gun/energy/vaurca/gatlinglaser
 
 /datum/uplink_item/item/visible_weapons/laser_shotgun
@@ -252,6 +255,7 @@
 /datum/uplink_item/item/visible_weapons/railgun
 	name = "Railgun"
 	item_cost = 30
+	item_limit = 1
 	path = /obj/item/gun/projectile/automatic/railgun
 
 /datum/uplink_item/item/visible_weapons/deagle

--- a/code/datums/uplink/highly visible and dangerous weapons.dm
+++ b/code/datums/uplink/highly visible and dangerous weapons.dm
@@ -184,16 +184,6 @@
 	item_cost = 2
 	path = /obj/item/gun/energy/pistol
 
-/datum/uplink_item/item/visible_weapons/pulse_pistol
-	name = "Pulse Pistol"
-	item_cost = 12
-	path = /obj/item/gun/energy/pulse/pistol
-
-/datum/uplink_item/item/visible_weapons/pulse_carbine
-	name = "Pulse Carbine"
-	item_cost = 16
-	path = /obj/item/gun/energy/pulse
-
 /datum/uplink_item/item/visible_weapons/gyrojet_pistol
 	name = "Gyrojet Pistol"
 	item_cost = 20
@@ -203,11 +193,6 @@
 	name = "Bullpup Assault Carbine"
 	item_cost = 12
 	path = /obj/item/gun/projectile/automatic/rifle/z8
-
-/datum/uplink_item/item/visible_weapons/bullpup_scout_carbine
-	name = "Bullpup Scout Carbine"
-	item_cost = 20
-	path = /obj/item/gun/projectile/automatic/rifle/w556
 
 /datum/uplink_item/item/visible_weapons/assault_shotgun
 	name = "Assault Shotgun"
@@ -219,20 +204,10 @@
 	item_cost = 40
 	path = /obj/item/gun/energy/vaurca/gatlinglaser
 
-/datum/uplink_item/item/visible_weapons/laser_sniper_rifle
-	name = "Laser Sniper Rifle"
-	item_cost = 20
-	path = /obj/item/gun/energy/sniperrifle
-
 /datum/uplink_item/item/visible_weapons/laser_shotgun
 	name = "Laser Shotgun"
 	item_cost = 10
 	path = /obj/item/gun/energy/laser/shotgun
-
-/datum/uplink_item/item/visible_weapons/sniper_rifle
-	name = "Sniper Rifle"
-	item_cost = 16
-	path = /obj/item/gun/projectile/dragunov
 
 /datum/uplink_item/item/visible_weapons/xray_laser
 	name = "X-Ray Laser Rifle"
@@ -266,7 +241,7 @@
 
 /datum/uplink_item/item/visible_weapons/derringer
 	name = "Derringer"
-	item_cost = 2
+	item_cost = 1
 	path = /obj/item/gun/projectile/revolver/derringer
 
 /datum/uplink_item/item/visible_weapons/gauss_thumper
@@ -274,17 +249,12 @@
 	item_cost = 10
 	path = /obj/item/gun/projectile/gauss
 
-/datum/uplink_item/item/visible_weapons/bolt_slinger
-	name = "Bolt Slinger"
-	item_cost = 15
-	path = /obj/item/gun/energy/blaster/rifle
-
 /datum/uplink_item/item/visible_weapons/railgun
 	name = "Railgun"
-	item_cost = 35
+	item_cost = 30
 	path = /obj/item/gun/projectile/automatic/railgun
 
 /datum/uplink_item/item/visible_weapons/deagle
 	name = ".50 Pistol"
-	item_cost = 6
+	item_cost = 5
 	path = /obj/item/gun/projectile/deagle/adhomai

--- a/code/datums/uplink/highly visible and dangerous weapons.dm
+++ b/code/datums/uplink/highly visible and dangerous weapons.dm
@@ -191,7 +191,7 @@
 
 /datum/uplink_item/item/visible_weapons/pulse_carbine
 	name = "Pulse Carbine"
-	item_cost = 15
+	item_cost = 16
 	path = /obj/item/gun/energy/pulse
 
 /datum/uplink_item/item/visible_weapons/gyrojet_pistol

--- a/code/datums/uplink/highly visible and dangerous weapons.dm
+++ b/code/datums/uplink/highly visible and dangerous weapons.dm
@@ -183,3 +183,108 @@
 	name = "Energy Pistol"
 	item_cost = 2
 	path = /obj/item/gun/energy/pistol
+
+/datum/uplink_item/item/visible_weapons/pulse_pistol
+	name = "Pulse Pistol"
+	item_cost = 12
+	path = /obj/item/gun/energy/pulse/pistol
+
+/datum/uplink_item/item/visible_weapons/pulse_carbine
+	name = "Pulse Carbine"
+	item_cost = 15
+	path = /obj/item/gun/energy/pulse
+
+/datum/uplink_item/item/visible_weapons/gyrojet_pistol
+	name = "Gyrojet Pistol"
+	item_cost = 20
+	path = /obj/item/gun/projectile/gyropistol
+
+/datum/uplink_item/item/visible_weapons/bullpup_assault_carbine
+	name = "Bullpup Assault Carbine"
+	item_cost = 12
+	path = /obj/item/gun/projectile/automatic/rifle/z8
+
+/datum/uplink_item/item/visible_weapons/bullpup_scout_carbine
+	name = "Bullpup Scout Carbine"
+	item_cost = 20
+	path = /obj/item/gun/projectile/automatic/rifle/w556
+
+/datum/uplink_item/item/visible_weapons/assault_shotgun
+	name = "Assault Shotgun"
+	item_cost = 15
+	path = /obj/item/gun/projectile/automatic/rifle/shotgun
+
+/datum/uplink_item/item/visible_weapons/gatling_laser
+	name = "Gatling Laser"
+	item_cost = 40
+	path = /obj/item/gun/energy/vaurca/gatlinglaser
+
+/datum/uplink_item/item/visible_weapons/laser_sniper_rifle
+	name = "Laser Sniper Rifle"
+	item_cost = 20
+	path = /obj/item/gun/energy/sniperrifle
+
+/datum/uplink_item/item/visible_weapons/laser_shotgun
+	name = "Laser Shotgun"
+	item_cost = 10
+	path = /obj/item/gun/energy/laser/shotgun
+
+/datum/uplink_item/item/visible_weapons/sniper_rifle
+	name = "Sniper Rifle"
+	item_cost = 16
+	path = /obj/item/gun/projectile/dragunov
+
+/datum/uplink_item/item/visible_weapons/xray_laser
+	name = "X-Ray Laser Rifle"
+	item_cost = 12
+	path = /obj/item/gun/energy/rifle/laser/xray
+
+/datum/uplink_item/item/visible_weapons/combat_shotgun
+	name = "Combat Shotgun"
+	item_cost = 10
+	path = /obj/item/gun/projectile/shotgun/pump/combat
+
+/datum/uplink_item/item/visible_weapons/automatic_45_pistol
+	name = "Automatic .45 Pistol"
+	item_cost = 5
+	path = /obj/item/gun/projectile/automatic/mini_uzi
+
+/datum/uplink_item/item/visible_weapons/shortened_assault_rifle
+	name = "Shortened Assault Rifle"
+	item_cost = 12
+	path = /obj/item/gun/projectile/automatic/rifle/shorty
+
+/datum/uplink_item/item/visible_weapons/assault_rifle
+	name = "Assault Rifle"
+	item_cost = 12
+	path = /obj/item/gun/projectile/automatic/rifle/sts35
+
+/datum/uplink_item/item/visible_weapons/laser_cannon
+	name = "Laser Cannon"
+	item_cost = 12
+	path = /obj/item/gun/energy/lasercannon
+
+/datum/uplink_item/item/visible_weapons/derringer
+	name = "Derringer"
+	item_cost = 2
+	path = /obj/item/gun/projectile/revolver/derringer
+
+/datum/uplink_item/item/visible_weapons/gauss_thumper
+	name = "Gauss Thumper"
+	item_cost = 10
+	path = /obj/item/gun/projectile/gauss
+
+/datum/uplink_item/item/visible_weapons/bolt_slinger
+	name = "Bolt Slinger"
+	item_cost = 15
+	path = /obj/item/gun/energy/blaster/rifle
+
+/datum/uplink_item/item/visible_weapons/railgun
+	name = "Railgun"
+	item_cost = 35
+	path = /obj/item/gun/projectile/automatic/railgun
+
+/datum/uplink_item/item/visible_weapons/deagle
+	name = ".50 Pistol"
+	item_cost = 6
+	path = /obj/item/gun/projectile/deagle/adhomai

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -216,12 +216,13 @@
 /obj/item/melee/energy/sword
 	color
 	name = "energy sword"
-	desc = "May the force be within you."
+	desc = "An energy sword. Quite rare, very dangerous."
 	desc_antag = "The energy sword is a very strong melee weapon, capable of severing limbs easily, if they are targeted.  It can also has a chance \
 	to block projectiles and melee attacks while it is on and being held.  The sword can be toggled on or off by using it in your hand.  While it is off, \
 	it can be concealed in your pocket or bag."
 	icon_state = "sword0"
 	active_force = 30
+	armor_penetration = 25
 	active_throwforce = 20
 	active_w_class = ITEMSIZE_LARGE
 	force = 3

--- a/html/changelogs/dansemacabre-gunsfordays.yml
+++ b/html/changelogs/dansemacabre-gunsfordays.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheDanseMacabre
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a large number of weapons to the antag uplink. Some are very strong, and very expensive!"
+  - balance: "Gave the energy sword enough armor penetration to do around half damage through heavy armor."


### PR DESCRIPTION
Adds a large number of weapons that were previously random gun or admin-spawn only to the uplink. Most are pretty expensive, some prohibitively so.
Also buffs the energy sword, which did paltry damage through armor.

Some of these weapons may be too strong for the uplink, or there may be problems with pricing. This PR should probably be test-merged before actual merging, and I expect some things may need to be cut or changed.