### PR TITLE
Psych Disposals Swap

### DIFF
--- a/html/changelogs/KingOfThePing - psych_disposals.yml
+++ b/html/changelogs/KingOfThePing - psych_disposals.yml
@@ -1,0 +1,14 @@
+# Your name.
+author: KingOfThePing
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Replaced disposals in the psych office with one you cant use to commit die."
+

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -14717,10 +14717,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hor)
 "hzY" = (
-/obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/disposal/small/east,
 /turf/simulated/floor/wood,
 /area/medical/psych)
 "hAh" = (


### PR DESCRIPTION
Replaces the disposals system in the psych office with a small one, in which you cant jump in, per player request.
