### PR TITLE
Engineering dept tweaks (plus I fix some mapping stuff I missed last time)

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -1017,8 +1017,9 @@
 	products = list(
 		/obj/item/device/multitool = 4,
 		/obj/item/powerdrill = 2,
+		/obj/item/taperoll/engineering = 4,
 		/obj/item/clothing/glasses/safety/goggles = 4,
-		/obj/item/airlock_electronics = 10,
+		/obj/item/airlock_electronics = 20,
 		/obj/item/module/power_control = 10,
 		/obj/item/airalarm_electronics = 10,
 		/obj/item/firealarm_electronics = 10,

--- a/html/changelogs/omicega-engitweaks.yml
+++ b/html/changelogs/omicega-engitweaks.yml
@@ -10,4 +10,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Tweaked/added various things to engineering. Fixed lowercase area names, added some fire closets, an extra voidsuit, some more lockers to the equipment room, and some other QOL mapping stuff."
+  - maptweak: "Tweaked/added various things to engineering. Fixed lowercase area names, added some fire closets, an extra voidsuit, some more lockers to the equipment room, and some other QOL mapping stuff."

--- a/html/changelogs/omicega-engitweaks.yml
+++ b/html/changelogs/omicega-engitweaks.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Tweaked/added various things to engineering. Fixed lowercase area names, added some fire closets, an extra voidsuit, some more lockers to the equipment room, and some other QOL mapping stuff."

--- a/maps/sccv_horizon/code/sccv_horizon_areas.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_areas.dm
@@ -35,13 +35,13 @@
 	name = "Engineering Substation - Lower Deck"
 
 /area/hallway/engineering
-	name = "Engineering hallway"
+	name = "Engineering - Main Hallway"
 	icon_state = "engineering"
 	ambience = AMBIENCE_ENGINEERING
 	holomap_color = HOLOMAP_AREACOLOR_ENGINEERING
 
 /area/hallway/engineering/tesla
-	name = "Tesla hallway"
+	name = "Engineering - Tesla Hallway"
 
 //Medical
 

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -479,7 +479,8 @@
 /area/engineering/lobby)
 "amt" = (
 /obj/machinery/atmospherics/binary/pump{
-	name = "Reactor to Scrubbers"
+	name = "Reactor to Scrubbers";
+	target_pressure = 15000
 	},
 /obj/effect/landmark/engine_setup/pump_max,
 /turf/simulated/floor/plating,
@@ -2600,14 +2601,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/assembly/chargebay)
 "bhR" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "bhT" = (
@@ -5490,6 +5488,13 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/operations/break_room)
+"cNo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
 "cNz" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -8450,11 +8455,12 @@
 /turf/simulated/floor/wood,
 /area/horizon/hallway/deck_two/fore)
 "eui" = (
-/obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/disposal/small/south,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "euT" = (
@@ -13326,7 +13332,8 @@
 "gNQ" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
-	name = "Reactor to Mix"
+	name = "Reactor to Mix";
+	target_pressure = 15000
 	},
 /obj/effect/landmark/engine_setup/pump_max,
 /turf/simulated/floor/plating,
@@ -14634,6 +14641,8 @@
 /obj/machinery/alarm{
 	pixel_y = 28
 	},
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
 "hwI" = (
@@ -17422,7 +17431,6 @@
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
 "iWO" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -17916,11 +17924,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 6
-	},
 /obj/machinery/alarm{
 	pixel_y = 28
+	},
+/obj/effect/floor_decal/corner/yellow/full{
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
@@ -29168,9 +29176,12 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "pgM" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "pgQ" = (
@@ -36309,10 +36320,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
 "sUw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -40513,12 +40520,11 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/engine_airlock)
 "uYS" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	target_pressure = 15000
-	},
-/turf/simulated/floor/plating,
-/area/engineering/engine_room)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/engineering/locker_room)
 "uYW" = (
 /obj/machinery/door/window/westleft,
 /obj/structure/lattice/catwalk,
@@ -43639,8 +43645,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/obj/structure/closet/firecloset,
-/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/wood,
 /area/hallway/engineering)
 "wzN" = (
@@ -61812,7 +61817,7 @@ vBp
 bib
 xIJ
 jUH
-uYS
+sSY
 jyd
 aSO
 uYK
@@ -62026,7 +62031,7 @@ eyk
 omf
 pKy
 acw
-pgM
+uYS
 pgM
 iWO
 sUw
@@ -62229,7 +62234,7 @@ dWZ
 mKJ
 laB
 eui
-bHe
+cNo
 piz
 iRm
 bHe

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -219,6 +219,7 @@
 	dir = 4
 	},
 /obj/structure/closet/wardrobe/atmospherics_yellow,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
 "aeC" = (
@@ -4366,7 +4367,12 @@
 /area/server)
 "caB" = (
 /obj/structure/table/standard,
-/obj/item/device/flashlight/heavy,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "ccl" = (
@@ -8444,11 +8450,11 @@
 /turf/simulated/floor/wood,
 /area/horizon/hallway/deck_two/fore)
 "eui" = (
-/obj/structure/closet/walllocker/medical{
-	pixel_y = 32
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 5
 	},
-/obj/item/storage/firstaid/regular,
-/obj/effect/floor_decal/industrial/outline/medical,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "euT" = (
@@ -8976,10 +8982,12 @@
 /turf/simulated/floor/tiled/white,
 /area/operations/break_room)
 "eIU" = (
-/obj/structure/table/standard,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
 /obj/machinery/firealarm/south,
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 10
+	},
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "eJl" = (
@@ -9588,7 +9596,8 @@
 /area/turret_protected/ai_upload_foyer)
 "fas" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 8
+	dir = 8;
+	target_pressure = 15000
 	},
 /obj/effect/landmark/engine_setup/pump_max,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -15559,6 +15568,11 @@
 	},
 /turf/template_noop,
 /area/template_noop)
+"hVu" = (
+/obj/machinery/suit_cycler/engineering,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled,
+/area/engineering/storage_eva)
 "hWo" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
@@ -18347,6 +18361,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
+"jua" = (
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/closet/walllocker/medical{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/industrial/outline/medical,
+/obj/item/storage/firstaid/regular,
+/turf/simulated/floor/tiled,
+/area/hallway/engineering)
 "juh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -18551,7 +18579,8 @@
 /area/rnd/telesci)
 "jBj" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 4
+	dir = 4;
+	target_pressure = 15000
 	},
 /obj/effect/landmark/engine_setup/pump_max,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -18562,11 +18591,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 9
-	},
 /obj/item/storage/bag/circuits/basic,
-/obj/item/device/pipe_painter,
+/obj/item/device/flashlight/heavy,
+/obj/effect/floor_decal/corner_wide/yellow/full,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "jBw" = (
@@ -22783,6 +22810,10 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
+/obj/structure/closet/walllocker/firecloset{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "lSV" = (
@@ -24785,6 +24816,7 @@
 	name = "Engineering Locker Room Maintenance";
 	req_access = list(11)
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/locker_room)
 "mUz" = (
@@ -28536,12 +28568,8 @@
 /turf/simulated/floor/tiled,
 /area/security/main)
 "oTE" = (
-/obj/structure/closet/radiation,
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 6
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -28549,6 +28577,10 @@
 	},
 /obj/structure/cable/green,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/floor_decal/corner/yellow/full{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "oTK" = (
@@ -29366,7 +29398,8 @@
 /area/rnd/xenobiology)
 "pmK" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 4
+	dir = 4;
+	target_pressure = 15000
 	},
 /obj/effect/landmark/engine_setup/pump_max,
 /obj/machinery/status_display{
@@ -29406,6 +29439,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
 "pnY" = (
@@ -30925,11 +30959,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "qek" = (
-/obj/machinery/suit_cycler/engineering,
-/obj/effect/floor_decal/corner/yellow/full{
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/window/northright{
+	name = "Engineering Voidsuit Access";
+	req_access = list(11)
+	},
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/engineering,
+/obj/item/clothing/head/helmet/space/void/engineering,
 /turf/simulated/floor/tiled,
 /area/engineering/storage_eva)
 "qen" = (
@@ -31159,6 +31200,7 @@
 	dir = 9
 	},
 /obj/structure/closet/wardrobe/engineering_yellow,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "qlm" = (
@@ -31450,7 +31492,8 @@
 "quD" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 1;
-	name = "Cooling Array to Generators"
+	name = "Cooling Array to Generators";
+	target_pressure = 15000
 	},
 /obj/effect/landmark/engine_setup/pump_max,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -32060,7 +32103,8 @@
 /area/engineering/storage/tech)
 "qFY" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 8
+	dir = 8;
+	target_pressure = 15000
 	},
 /obj/effect/landmark/engine_setup/pump_max,
 /obj/machinery/camera/network/reactor{
@@ -40468,6 +40512,13 @@
 "uYK" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/engine_airlock)
+"uYS" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8;
+	target_pressure = 15000
+	},
+/turf/simulated/floor/plating,
+/area/engineering/engine_room)
 "uYW" = (
 /obj/machinery/door/window/westleft,
 /obj/structure/lattice/catwalk,
@@ -43581,7 +43632,6 @@
 /turf/simulated/floor/reinforced/airless,
 /area/template_noop)
 "wzD" = (
-/obj/structure/flora/pottedplant/random,
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering - Hallway 3";
 	dir = 1
@@ -43589,6 +43639,8 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
+/obj/structure/closet/firecloset,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/wood,
 /area/hallway/engineering)
 "wzN" = (
@@ -61760,7 +61812,7 @@ vBp
 bib
 xIJ
 jUH
-sSY
+uYS
 jyd
 aSO
 uYK
@@ -62374,7 +62426,7 @@ tYj
 gWf
 tYj
 tYj
-eZI
+jua
 dYl
 arb
 laB
@@ -63188,7 +63240,7 @@ vAh
 jvV
 gCj
 xeT
-mfE
+hVu
 mfE
 wTU
 mfE


### PR DESCRIPTION
Fixes/addresses a lot of things that have been irritating about engineering lately:

- Adds an extra voidsuit to engineering's equipment room, for a total of 5.
- Adds 3 extra lockers to engineering's locker room, for a total of 7 (5 engineer slots and 2 apprentice slots)
- Adds some missing floor decals to engineering (oops, my bad)
- Adds two more fire lockers to engineering's main hallway (I just think they're neat...)
- Doubles the amount of airlock electronics in the Engi-Vend from 10 to 20. These can run out surprisingly quickly in some rounds.
- Maxed out the pressure value on the SM pumps by default, making setup less fiddly due to the laggy interface. They still all have to be turned on, though.
- Shuffled some other stuff around to make room for this (the only permanent casualty should be a spare radiation suit closet)