### PR TITLE
Adds some basic medicine autoinjectors/bottles to the code so I can deviously try to add them to ops orders later.

### DIFF
--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -177,7 +177,7 @@
 	desc = "A small bottle of cough syrup. Don't take too much!"
 	icon_state = "bottle-3"
 	reagents_to_add = list(/decl/reagent/coughsyrup = 60)
-	
+
 /obj/item/reagent_containers/glass/bottle/coagzolug
 	name = "coagzolug bottle"
 	desc = "A small bottle of coagzolug. A medication that encourages the coagulation of blood, slowing down any bleeding. Overdose causes damage to the heart."
@@ -225,3 +225,9 @@
 	desc = "A small bottle. Contains perconol - treats minor-moderate pain as a result of physical injury."
 	icon_state = "bottle-3"
 	reagents_to_add = list(/decl/reagent/perconol = 60)
+
+/obj/item/reagent_containers/glass/bottle/hyronalin
+	name = "hyronalin bottle"
+	desc = "A small bottle. Contains hyronalin - treats mild moderate radiation poisoning."
+	icon_state = "bottle-4"
+	reagents_to_add = list(/decl/reagent/hyronalin = 60)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -328,7 +328,6 @@
 	desc = "An autoinjector loaded with bicaridine, a chemical used to treat physical trauma."
 	volume = 15
 	amount_per_transfer_from_this = 15
-
 	reagents_to_add = list(/decl/reagent/bicaridine = 15)
 
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -322,3 +322,28 @@
 	amount_per_transfer_from_this = 20
 
 	reagents_to_add = list(/decl/reagent/sanasomnum = 20)
+
+/obj/item/reagent_containers/hypospray/autoinjector/bicaridine
+	name = "bicaridine autoinjector"
+	desc = "An autoinjector loaded with bicaridine, a chemical used to treat physical trauma."
+	volume = 15
+	amount_per_transfer_from_this = 15
+
+	reagents_to_add = list(/decl/reagent/bicaridine = 15)
+
+
+/obj/item/reagent_containers/hypospray/autoinjector/kelotane
+	name = "kelotane autoinjector"
+	desc = "An autoinjector loaded with kelotane, a chemical used to treat burnt tissue."
+	volume = 15
+	amount_per_transfer_from_this = 15
+
+	reagents_to_add = list(/decl/reagent/kelotane = 15)
+
+/obj/item/reagent_containers/hypospray/autoinjector/peridaxon
+	name = "peridaxon autoinjector"
+	desc = "An autoinjector loaded with peridaxon, a chemical used to treat minor organ damage."
+	volume = 10
+	amount_per_transfer_from_this = 10
+
+	reagents_to_add = list(/decl/reagent/peridaxon = 10)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -345,5 +345,4 @@
 	desc = "An autoinjector loaded with peridaxon, a chemical used to treat minor organ damage."
 	volume = 10
 	amount_per_transfer_from_this = 10
-
 	reagents_to_add = list(/decl/reagent/peridaxon = 10)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -335,7 +335,6 @@
 	desc = "An autoinjector loaded with kelotane, a chemical used to treat burnt tissue."
 	volume = 15
 	amount_per_transfer_from_this = 15
-
 	reagents_to_add = list(/decl/reagent/kelotane = 15)
 
 /obj/item/reagent_containers/hypospray/autoinjector/peridaxon

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -330,7 +330,6 @@
 	amount_per_transfer_from_this = 15
 	reagents_to_add = list(/decl/reagent/bicaridine = 15)
 
-
 /obj/item/reagent_containers/hypospray/autoinjector/kelotane
 	name = "kelotane autoinjector"
 	desc = "An autoinjector loaded with kelotane, a chemical used to treat burnt tissue."

--- a/html/changelogs/anconfuzedrock-cheminjectors.yml
+++ b/html/changelogs/anconfuzedrock-cheminjectors.yml
@@ -1,0 +1,6 @@
+author: anconfuzedrock
+
+delete-after: True
+
+changes:
+  - rscadd: "There are now pure bicaridine, kelotane, and peridaxon autoinjectors, as well as hyronalin bottles, as adminspawn items."


### PR DESCRIPTION
Based on feedback from
https://forums.aurorastation.org/topic/17493-allow-operations-to-order-more-complicated-medicines
I have finally gotten off my ass and added some bottles and injectors, so that I can later attempt to have these to operations orders as **expensive** emergency items. These are:
-15u injectors of bicaridine and kelotane
-10 injectors of peridaxon
-60u bottles of hyronalin
the injectors coming in injector form so they're less versatile and can't feasibly subvert having a pharmacist. This pr itself doesn't add them to ops yet, though that's basically the point. I'm thinking like 1000 credits for a peridax injector, 500 for one of the other injectors or the hyronalin bottle?