### PR TITLE
Fixes some ship weapon bugs.

### DIFF
--- a/code/__defines/ship_weapons.dm
+++ b/code/__defines/ship_weapons.dm
@@ -8,6 +8,7 @@
 #define SHIP_GUN_ERROR_NO_AMMO "no ammunition loaded"
 
 #define NO_PROJECTILE "no projectile"
+#define SHIP_HAZARD_TARGET "Automatic Hazard Targeting"
 
 #define SHIP_AMMO_CAN_HIT_HAZARDS 1
 #define SHIP_AMMO_CAN_HIT_SHIPS 2

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -259,6 +259,7 @@ var/list/ruin_landmarks = list()
 /obj/effect/landmark/entry_point
 	name = "entry point landmark"
 	icon_state = "dir_arrow"
+	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 
 /obj/effect/landmark/entry_point/Initialize()
 	..()

--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -54,6 +54,9 @@
 			var/obj/machinery/computer/ship/targeting/GS = H.machine
 			if(GS.targeting)
 				return
+			if(!istype(GS.connected.loc, /turf/unsimulated/map))
+				to_chat(H, SPAN_WARNING("The safeties won't let you target while you're not on the Overmap!"))
+				return
 			var/my_sector = map_sectors["[H.z]"]
 			if(istype(my_sector, /obj/effect/overmap/visitable))
 				var/obj/effect/overmap/visitable/V = my_sector

--- a/code/modules/overmap/ship_weaponry/_ship_gun.dm
+++ b/code/modules/overmap/ship_weaponry/_ship_gun.dm
@@ -398,7 +398,10 @@
 		var/obj/effect/landmark/LM
 		if(!selected_entrypoint)
 			return
-		if(selected_entrypoint == "Automatic Hazard Targeting")
+		if(!istype(connected.loc, /turf/unsimulated/map))
+			to_chat(usr, SPAN_WARNING("The safeties are engaged! You need to be undocked in order to fire."))
+			return
+		if(selected_entrypoint == SHIP_HAZARD_TARGET || !selected_entrypoint)
 			LM = null
 		else
 			LM = names_to_entries[selected_entrypoint]
@@ -429,4 +432,4 @@
 				. += capitalize_first_letters(O.name)
 				names_to_entries[capitalize_first_letters(O.name)] = O
 	if(!length(.))
-		. += "Automatic Hazard Targeting" //No entrypoints == hazard
+		. += SHIP_HAZARD_TARGET //No entrypoints == hazard

--- a/code/modules/overmap/ship_weaponry/_ship_gun.dm
+++ b/code/modules/overmap/ship_weaponry/_ship_gun.dm
@@ -431,5 +431,6 @@
 			for(var/obj/effect/O in V.generic_waypoints)
 				. += capitalize_first_letters(O.name)
 				names_to_entries[capitalize_first_letters(O.name)] = O
+		. = sortList(.)
 	if(!length(.))
 		. += SHIP_HAZARD_TARGET //No entrypoints == hazard

--- a/code/modules/overmap/ship_weaponry/projectiles/_overmap_projectiles.dm
+++ b/code/modules/overmap/ship_weaponry/projectiles/_overmap_projectiles.dm
@@ -38,58 +38,61 @@
 	return ..()
 
 /obj/effect/overmap/projectile/proc/check_entry()
+	if(!ammunition)
+		return
 	var/turf/T = get_turf(src)
-	for(var/obj/effect/overmap/visitable/V in T)
-		if(V == ammunition.origin)
+	for(var/obj/effect/overmap/A in T)
+		if(A == ammunition.origin)
 			continue
-		
-		if((V.check_ownership(entry_target)) || (V == target)) //Target spotted!
-			if(istype(V, /obj/effect/overmap/visitable/sector/exoplanet) && (ammunition.overmap_behaviour & SHIP_AMMO_CAN_HIT_SHIPS))
-				//Manually stopping & going invisible because this proc needs to sleep for a bit.
-				invisibility = 100
-				moving = FALSE
-				STOP_PROCESSING(SSprocessing, src) //Also, don't sleep in process().
-				var/obj/item/projectile/ship_ammo/widowmaker = new ammunition.original_projectile.type
-				widowmaker.ammo = ammunition
-				qdel(ammunition.original_projectile) //No longer needed.
-				var/turf/laze = get_turf(entry_target)
-				ammunition.original_projectile = widowmaker
-				playsound(laze, 'sound/weapons/gunshot/ship_weapons/orbital_travel.ogg')
-				laze.visible_message(SPAN_DANGER("<font size=6>A bright star is getting closer from the sky...!</font>"))
-				sleep(11 SECONDS) //Let the sound play!
-				widowmaker.primed = TRUE
-				widowmaker.forceMove(entry_target)
-				widowmaker.on_hit(laze, is_landmark_hit = TRUE)
-				log_and_message_admins("A projectile ([name]) has entered a z-level at [entry_target.name]! (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[widowmaker.x];Y=[widowmaker.y];Z=[widowmaker.z]'>JMP</a>)")
-				qdel(widowmaker)
-				qdel(src)
-			else if(istype(V, /obj/effect/overmap/visitable) && (ammunition.overmap_behaviour & SHIP_AMMO_CAN_HIT_SHIPS))
-				if(istype(V, /obj/effect/overmap/visitable/ship))
-					var/obj/effect/overmap/visitable/ship/VS = V
-					if(istype(ammunition.origin, /obj/effect/overmap/visitable/ship))
-						var/obj/effect/overmap/visitable/ship/OR = ammunition.origin
-						if(VS.fore_dir != OR.fore_dir)
-							var/naval_heading = SSatlas.headings_to_naval["[OR.fore_dir]"]["[ammunition.heading]"]
-							var/corrected_heading = SSatlas.naval_to_dir["[VS.fore_dir]"][naval_heading]
-							ammunition.heading = corrected_heading
-				var/obj/item/projectile/ship_ammo/widowmaker = new ammunition.original_projectile.type
-				widowmaker.ammo = ammunition
-				qdel(ammunition.original_projectile) //No longer needed.
-				ammunition.original_projectile = widowmaker
-				widowmaker.primed = TRUE
-				var/turf/entry_turf_initial = get_ranged_target_turf(entry_target, reverse_dir[entry_target.dir], 20)
-				var/turf/entry_turf = get_ranged_target_turf(entry_turf_initial, pick(list(EAST, WEST)), 5)
-				widowmaker.forceMove(entry_turf)
-				widowmaker.dir = ammunition.heading
-				var/turf/target_turf = get_step(widowmaker, widowmaker.dir)
-				widowmaker.on_translate(entry_turf, target_turf)
-				log_and_message_admins("A projectile ([widowmaker.name]) has entered a z-level at [entry_target.name], with direction [dir_name(widowmaker.dir)]! (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[widowmaker.x];Y=[widowmaker.y];Z=[widowmaker.z]'>JMP</a>)")
-				widowmaker.launch_projectile(target_turf)
-				qdel(src)
-			else if(istype(V, /obj/effect/overmap/event) && (ammunition.overmap_behaviour & SHIP_AMMO_CAN_HIT_HAZARDS))
-				var/obj/effect/overmap/event/EV = V
-				if(EV.can_be_destroyed)
-					qdel(EV)
+		if(istype(A, /obj/effect/overmap/visitable))
+			var/obj/effect/overmap/visitable/V = A
+			if((V.check_ownership(entry_target)) || (V == target)) //Target spotted!
+				if(istype(V, /obj/effect/overmap/visitable/sector/exoplanet) && (ammunition.overmap_behaviour & SHIP_AMMO_CAN_HIT_SHIPS))
+					//Manually stopping & going invisible because this proc needs to sleep for a bit.
+					invisibility = 100
+					moving = FALSE
+					STOP_PROCESSING(SSprocessing, src) //Also, don't sleep in process().
+					var/obj/item/projectile/ship_ammo/widowmaker = new ammunition.original_projectile.type
+					widowmaker.ammo = ammunition
+					qdel(ammunition.original_projectile) //No longer needed.
+					var/turf/laze = get_turf(entry_target)
+					ammunition.original_projectile = widowmaker
+					playsound(laze, 'sound/weapons/gunshot/ship_weapons/orbital_travel.ogg')
+					laze.visible_message(SPAN_DANGER("<font size=6>A bright star is getting closer from the sky...!</font>"))
+					sleep(11 SECONDS) //Let the sound play!
+					widowmaker.primed = TRUE
+					widowmaker.forceMove(entry_target)
+					widowmaker.on_hit(laze, is_landmark_hit = TRUE)
+					log_and_message_admins("A projectile ([name]) has entered a z-level at [entry_target.name]! (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[widowmaker.x];Y=[widowmaker.y];Z=[widowmaker.z]'>JMP</a>)")
+					qdel(widowmaker)
+					qdel(src)
+				else if(istype(V, /obj/effect/overmap/visitable) && (ammunition.overmap_behaviour & SHIP_AMMO_CAN_HIT_SHIPS))
+					if(istype(V, /obj/effect/overmap/visitable/ship))
+						var/obj/effect/overmap/visitable/ship/VS = V
+						if(istype(ammunition.origin, /obj/effect/overmap/visitable/ship))
+							var/obj/effect/overmap/visitable/ship/OR = ammunition.origin
+							if(VS.fore_dir != OR.fore_dir)
+								var/naval_heading = SSatlas.headings_to_naval["[OR.fore_dir]"]["[ammunition.heading]"]
+								var/corrected_heading = SSatlas.naval_to_dir["[VS.fore_dir]"][naval_heading]
+								ammunition.heading = corrected_heading
+					var/obj/item/projectile/ship_ammo/widowmaker = new ammunition.original_projectile.type
+					widowmaker.ammo = ammunition
+					qdel(ammunition.original_projectile) //No longer needed.
+					ammunition.original_projectile = widowmaker
+					widowmaker.primed = TRUE
+					var/turf/entry_turf_initial = get_ranged_target_turf(entry_target, reverse_dir[entry_target.dir], 20)
+					var/turf/entry_turf = get_ranged_target_turf(entry_turf_initial, pick(list(EAST, WEST)), 5)
+					widowmaker.forceMove(entry_turf)
+					widowmaker.dir = ammunition.heading
+					var/turf/target_turf = get_step(widowmaker, widowmaker.dir)
+					widowmaker.on_translate(entry_turf, target_turf)
+					log_and_message_admins("A projectile ([widowmaker.name]) has entered a z-level at [entry_target.name], with direction [dir_name(widowmaker.dir)]! (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[widowmaker.x];Y=[widowmaker.y];Z=[widowmaker.z]'>JMP</a>)")
+					widowmaker.launch_projectile(target_turf)
+					qdel(src)
+		if(istype(A, /obj/effect/overmap/event))
+			var/obj/effect/overmap/event/EV = A
+			if(EV.can_be_destroyed && (ammunition.overmap_behaviour & SHIP_AMMO_CAN_HIT_HAZARDS))
+				qdel(EV)
 				qdel(src)
 
 /obj/effect/overmap/projectile/proc/move_to()

--- a/code/modules/overmap/ship_weaponry/weaponry/leviathan.dm
+++ b/code/modules/overmap/ship_weaponry/weaponry/leviathan.dm
@@ -370,6 +370,7 @@
 					possible_entry_points[O.name] = O
 				for(var/obj/effect/O in V.entry_points)
 					possible_entry_points[O.name] = O
+				possible_entry_points = sortList(possible_entry_points)
 			if(istype(linked.targeting, /obj/effect/overmap/event))
 				possible_entry_points += SHIP_HAZARD_TARGET
 			var/targeted_landmark = input(user, "Select an entry point.", "Leviathan Control") as null|anything in possible_entry_points

--- a/code/modules/overmap/ship_weaponry/weaponry/leviathan.dm
+++ b/code/modules/overmap/ship_weaponry/weaponry/leviathan.dm
@@ -304,7 +304,9 @@
 	icon_state = "safeguard_open"
 
 /obj/machinery/leviathan_safeguard/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/leviathan_key) && !key && !stat && !locked)
+	if(!opened || locked)
+		return
+	if(istype(I, /obj/item/leviathan_key) && !key && !stat)
 		var/obj/item/leviathan_key/LK = I
 		if(use_check_and_message(user))
 			return
@@ -316,7 +318,7 @@
 			playsound(src, 'sound/effects/ship_weapons/levi_key_insert.ogg')
 
 /obj/machinery/leviathan_safeguard/attack_hand(mob/user)
-	if(key && !stat && !locked)
+	if(key && !stat && opened && !locked)
 		if(use_check_and_message(user))
 			return
 		if(do_after(user, 1 SECOND))
@@ -368,12 +370,14 @@
 					possible_entry_points[O.name] = O
 				for(var/obj/effect/O in V.entry_points)
 					possible_entry_points[O.name] = O
+			if(istype(linked.targeting, /obj/effect/overmap/event))
+				possible_entry_points += SHIP_HAZARD_TARGET
 			var/targeted_landmark = input(user, "Select an entry point.", "Leviathan Control") as null|anything in possible_entry_points
 			if(!targeted_landmark && length(possible_entry_points))
 				return
 			var/obj/effect/landmark
-			if(length(possible_entry_points))
-			 landmark = possible_entry_points[targeted_landmark]
+			if(length(possible_entry_points) && !(targeted_landmark == SHIP_HAZARD_TARGET))
+				landmark = possible_entry_points[targeted_landmark]
 			if(do_after(user, 1 SECOND) && !use_check_and_message(user))
 				playsound(src, 'sound/effects/ship_weapons/levi_button_press.ogg')
 				visible_message(SPAN_DANGER("[user] presses \the [src]!"))

--- a/code/modules/overmap/ship_weaponry/weaponry/longbow_ammo.dm
+++ b/code/modules/overmap/ship_weaponry/weaponry/longbow_ammo.dm
@@ -14,7 +14,7 @@
 		var/mob/living/carbon/human/H = user
 		if(istype(I, /obj/item/primer) && !primer)
 			var/obj/item/primer/P = I
-			visible_message(SPAN_NOTICE("You start connecting \the [P] to the casing..."), SPAN_NOTICE("[H] starts connecting \the [P] to the casing..."))
+			user.visible_message(SPAN_NOTICE("[H] starts connecting \the [P] to the casing..."), SPAN_NOTICE("You start connecting \the [P] to the casing..."))
 			if(do_after(H, 3 SECONDS))
 				visible_message(SPAN_NOTICE("You connect \the [P] to the casing!"), SPAN_NOTICE("[H] connects \the [P] to the casing!"))
 				H.drop_from_inventory(P)
@@ -22,7 +22,7 @@
 				playsound(src, 'sound/machines/rig/rig_deploy.ogg')
 		if(istype(I, /obj/item/warhead) && !warhead)
 			var/obj/item/warhead/W = I
-			visible_message(SPAN_NOTICE("You start connecting \the [W] to the casing..."), SPAN_NOTICE("[H] starts connecting \the [W] to the casing..."))
+			user.visible_message( SPAN_NOTICE("[H] starts connecting \the [W] to the casing..."), SPAN_NOTICE("You start connecting \the [W] to the casing..."))
 			if(do_after(H, 5 SECONDS))
 				visible_message(SPAN_NOTICE("You connect \the [W] to the casing!"), SPAN_NOTICE("[H] connects \the [W] to the casing!"))
 				H.drop_from_inventory(W)
@@ -122,8 +122,8 @@
 	warhead_type = SHIP_AMMO_IMPACT_HE
 	slowdown = 2
 	var/drop_counter = 0
-	var/cookoff_devastation = 2
-	var/cookoff_heavy = 2
+	var/cookoff_devastation = 0
+	var/cookoff_heavy = 3
 	var/cookoff_light = 4
 
 /obj/item/warhead/longbow/too_heavy_to_throw()
@@ -162,7 +162,7 @@
 	icon_state = "armor_piercing_obj"
 	warhead_state = "armor_piercing"
 	warhead_type = SHIP_AMMO_IMPACT_AP
-	cookoff_devastation = 1
+	cookoff_devastation = 0
 	cookoff_heavy = 2
 	cookoff_light = 6
 

--- a/html/changelogs/mattatlas-theraid.yml
+++ b/html/changelogs/mattatlas-theraid.yml
@@ -45,3 +45,4 @@ changes:
   - bugfix: "Entry point landmarks now properly move with shuttles."
   - bugfix: "Fixed the Leviathan activation terminal. You can no longer interact with it before unlocking the safeties."
   - bugfix: "Fixed some chat messages."
+  - bugfix: "Entry point lists are now sorted."

--- a/html/changelogs/mattatlas-theraid.yml
+++ b/html/changelogs/mattatlas-theraid.yml
@@ -43,4 +43,5 @@ changes:
   - bugfix: "Ship weapons can no longer fire if the ship is not on the overmap."
   - bugfix: "You can no longer target overmap objects if you're not on the overmap."
   - bugfix: "Entry point landmarks now properly move with shuttles."
+  - bugfix: "Fixed the Leviathan activation terminal. You can no longer interact with it before unlocking the safeties."
   - bugfix: "Fixed some chat messages."

--- a/html/changelogs/mattatlas-theraid.yml
+++ b/html/changelogs/mattatlas-theraid.yml
@@ -1,0 +1,46 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Ops techs now have access to the Intrepid armament area and the ammunitions storage."
+  - bugfix: "Ship weapons can now actually hit overmap hazards."
+  - bugfix: "Ship weapons can no longer fire if the ship is not on the overmap."
+  - bugfix: "You can no longer target overmap objects if you're not on the overmap."
+  - bugfix: "Entry point landmarks now properly move with shuttles."
+  - bugfix: "Fixed some chat messages."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -14599,7 +14599,8 @@
 /obj/machinery/door/airlock/glass_command{
 	id_tag = "intrepid_cockpit";
 	name = "Close-in Weapons System Bay";
-	req_access = list(73)
+	req_access = null;
+	req_one_access = list(73, 31)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
@@ -20754,7 +20755,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
-/obj/machinery/door/window/eastright,
+/obj/machinery/door/window/eastright{
+	req_access = list(73)
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -10283,7 +10283,7 @@
 	name = "Door Bolt Control";
 	pixel_x = 25;
 	pixel_y = -7;
-	req_one_access = list(10,19,20,36,74);
+	req_one_access = list(10,19,20,31,74);
 	specialfunctions = 4
 	},
 /obj/machinery/button/remote/blast_door{
@@ -10292,7 +10292,7 @@
 	name = "Blast Door Control";
 	pixel_x = 25;
 	pixel_y = 7;
-	req_one_access = list(10,19,20,36,74)
+	req_one_access = list(10,19,20,31,74)
 	},
 /turf/simulated/floor/tiled/full,
 /area/horizon/secure_ammunition_storage)
@@ -11768,7 +11768,7 @@
 	name = "Door Bolt Control";
 	pixel_x = -25;
 	pixel_y = 7;
-	req_one_access = list(10,19,20,36,74);
+	req_one_access = list(10,19,20,31,74);
 	specialfunctions = 4
 	},
 /obj/machinery/button/remote/blast_door{
@@ -11777,7 +11777,7 @@
 	name = "Blast Door Control";
 	pixel_x = -25;
 	pixel_y = -7;
-	req_one_access = list(10,19,20,36,74)
+	req_one_access = list(10,19,20,31,74)
 	},
 /turf/simulated/floor/tiled/full,
 /area/horizon/secure_ammunition_storage)


### PR DESCRIPTION
  - bugfix: "Ops techs now have access to the Intrepid armament area and the ammunitions storage."
  - bugfix: "Ship weapons can now actually hit overmap hazards."
  - bugfix: "Ship weapons can no longer fire if the ship is not on the overmap."
  - bugfix: "You can no longer target overmap objects if you're not on the overmap."
  - bugfix: "Fixed the Leviathan activation terminal. You can no longer interact with it before unlocking the safeties."
  - bugfix: "Entry point landmarks now properly move with shuttles."
  - bugfix: "Fixed some chat messages."
