### PR TITLE
Tricordrazine Recipe Tweak

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -299,7 +299,7 @@
 	id = "tricordrazine"
 	result = /decl/reagent/tricordrazine
 	required_reagents = list(/decl/reagent/water = 1, /decl/reagent/inaprovaline = 1, /decl/reagent/dylovene = 1)
-	result_amount = 2
+	result_amount = 3
 
 /datum/chemical_reaction/alkysine
 	name = "Alkysine"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -298,7 +298,7 @@
 	name = "Tricordrazine"
 	id = "tricordrazine"
 	result = /decl/reagent/tricordrazine
-	required_reagents = list(/decl/reagent/phosphorus = 1, /decl/reagent/inaprovaline = 1, /decl/reagent/dylovene = 1)
+	required_reagents = list(/decl/reagent/water = 1, /decl/reagent/inaprovaline = 1, /decl/reagent/dylovene = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/alkysine

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -299,7 +299,7 @@
 	id = "tricordrazine"
 	result = /decl/reagent/tricordrazine
 	required_reagents = list(/decl/reagent/water = 1, /decl/reagent/inaprovaline = 1, /decl/reagent/dylovene = 1)
-	result_amount = 3
+	result_amount = 2
 
 /datum/chemical_reaction/alkysine
 	name = "Alkysine"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -298,8 +298,8 @@
 	name = "Tricordrazine"
 	id = "tricordrazine"
 	result = /decl/reagent/tricordrazine
-	required_reagents = list(/decl/reagent/inaprovaline = 1, /decl/reagent/dylovene = 1)
-	result_amount = 2
+	required_reagents = list(/decl/reagent/phosphorus = 1, /decl/reagent/inaprovaline = 1, /decl/reagent/dylovene = 1)
+	result_amount = 3
 
 /datum/chemical_reaction/alkysine
 	name = "Alkysine"

--- a/html/changelogs/tricordrazine_removal.yml
+++ b/html/changelogs/tricordrazine_removal.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - tweak: "Makes Tricordrazine no longer mix in your bloodstream if you inject inaprovaline and dylovene at the same time."

--- a/html/changelogs/tricordrazine_removal.yml
+++ b/html/changelogs/tricordrazine_removal.yml
@@ -3,4 +3,4 @@ author: SleepyGemmy
 delete-after: True
 
 changes:
-  - tweak: "Makes Tricordrazine no longer mix in your bloodstream if you inject inaprovaline and dylovene at the same time."
+  - tweak: "Tricordrazine now needs water to react, which makes Tricordrazine no longer mix in your bloodstream if you inject inaprovaline and dylovene at the same time."


### PR DESCRIPTION
this PR makes tricordrazine need water in its recipe to prevent accidental bloodstream reactions.

## changes
- tricordrazine now needs 1 part water as well as its previous 1 part inaprovaline and 1 part dylovene to mix, to prevent accidental bloodstream mixings. increases the parts you get from 2 to 3.