### PR TITLE
Restores unique outfits to Idris Librarian alt titles

### DIFF
--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -46,6 +46,8 @@
 		"Hydroponicist" = /datum/outfit/job/hydro/idris,
 		"Janitor" = /datum/outfit/job/janitor/idris,
 		"Librarian" = /datum/outfit/job/librarian/idris,
+		"Curator" = /datum/outfit/job/librarian/idris/curator,
+		"Tech Support" = /datum/outfit/job/librarian/idris/tech_support,
 		"Corporate Liaison" = /datum/outfit/job/representative/idris
 	)
 
@@ -157,6 +159,23 @@
 	satchel_faction = /obj/item/storage/backpack/satchel/idris
 	dufflebag_faction = /obj/item/storage/backpack/duffel/idris
 	messengerbag_faction = /obj/item/storage/backpack/messenger/idris
+
+/datum/outfit/job/librarian/idris/curator
+	name = "Curator - Idris"
+	jobtype = /datum/job/librarian
+
+	r_pocket = /obj/item/device/price_scanner
+	l_hand = null
+
+/datum/outfit/job/librarian/idris/tech_support
+	name = "Tech Support - Idris"
+	jobtype = /datum/job/librarian
+
+	l_pocket = /obj/item/modular_computer/handheld/preset
+	r_pocket = /obj/item/card/tech_support
+	r_hand = /obj/item/storage/bag/circuits/basic
+	l_hand = /obj/item/modular_computer/laptop/preset
+	gloves = /obj/item/modular_computer/handheld/wristbound/preset/advanced/civilian
 
 /datum/outfit/job/representative/idris
 	name = "Idris Corporate Liaison"

--- a/html/changelogs/feartheblackout-librarianfix.yml
+++ b/html/changelogs/feartheblackout-librarianfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FearTheBlackout
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Idris Librarians using their respective alt titles will now receive the correct items again."


### PR DESCRIPTION
Because Idris Librarians with alt titles had unique outfits, they weren't receiving the same items as their NanoTrasen counterparts. This fixes that.