### PR TITLE
Moves the ship control circuit boards into secure tech storage

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/computer/computer.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/computer.dm
@@ -124,31 +124,31 @@
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3, TECH_POWER = 5)
 
 /obj/item/circuitboard/telesci_console
-	name = T_BOARD("Telescience Console")
+	name = T_BOARD("telescience Console")
 	build_path = /obj/machinery/computer/telescience
 	origin_tech = list(TECH_DATA = 3, TECH_BLUESPACE = 2)
 
 /obj/item/circuitboard/slot_machine
-	name = T_BOARD("Slot Machine")
+	name = T_BOARD("slot machine")
 	build_path = /obj/machinery/computer/slot_machine
 	origin_tech = list(TECH_DATA = 2)
 
 /obj/item/circuitboard/ship/helm
-	name = T_BOARD("Helm Control Console")
+	name = T_BOARD("helm control console")
 	origin_tech = list(TECH_ENGINEERING = 3)
 	build_path = /obj/machinery/computer/ship/helm
 
 /obj/item/circuitboard/ship/sensors
-	name = T_BOARD("Ship Sensors Console")
+	name = T_BOARD("ship sensors console")
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 2)
 	build_path = /obj/machinery/computer/ship/sensors
 
 /obj/item/circuitboard/ship/engines
-	name = T_BOARD("Ship Engines Control Console")
+	name = T_BOARD("ship engines control console")
 	origin_tech = list(TECH_ENGINEERING = 3)
 	build_path = /obj/machinery/computer/ship/engines
 
 /obj/item/circuitboard/ship/targeting
-	name = T_BOARD("Ajax Targeting Systems Console")
+	name = T_BOARD("Ajax targeting systems console")
 	origin_tech = list(TECH_ENGINEERING = 3)
 	build_path = /obj/machinery/computer/ship/targeting

--- a/html/changelogs/omicega-fdsfiosdifodsogifmogid.yml
+++ b/html/changelogs/omicega-fdsfiosdifodsogifmogid.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Moves the ship control systems' circuit boards into secure tech storage rather than regular tech storage."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -527,7 +527,7 @@
 	},
 /obj/item/circuitboard/borgupload{
 	pixel_x = -1;
-	pixel_y = 1
+	pixel_y = 3
 	},
 /obj/item/circuitboard/aiupload{
 	pixel_x = 2;
@@ -537,6 +537,10 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/circuitboard/robotics{
+	pixel_x = -4;
+	pixel_y = -5
+	},
 /turf/simulated/floor/reinforced,
 /area/engineering/storage/tech)
 "anJ" = (
@@ -3573,7 +3577,7 @@
 	name = "Primary Armament Exterior Bolts";
 	pixel_x = 22;
 	pixel_y = 22;
-	req_access = list(19, 11);
+	req_access = list(19,11);
 	specialfunctions = 4
 	},
 /obj/structure/cable{
@@ -15767,12 +15771,14 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/circuitboard/robotics{
-	pixel_x = -2;
-	pixel_y = 2
-	},
 /obj/effect/floor_decal/corner_wide/blue/full,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/circuitboard/ship/targeting{
+	pixel_x = 3
+	},
+/obj/item/circuitboard/ship/engines,
+/obj/item/circuitboard/ship/sensors,
+/obj/item/circuitboard/ship/helm,
 /turf/simulated/floor/reinforced,
 /area/engineering/storage/tech)
 "hIV" = (
@@ -28603,18 +28609,12 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/circuitboard/ship/helm,
-/obj/item/circuitboard/ship/sensors,
-/obj/item/circuitboard/ship/engines,
 /obj/effect/floor_decal/corner/yellow/diagonal,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/item/circuitboard/ship/targeting{
-	pixel_x = 3
-	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage/tech)
 "otI" = (


### PR DESCRIPTION
See title. These boards are kind of important both OOC and IC, so I think they deserve being shuffled into the secure storage room. There might be an actual reason to break into it now.