### PR TITLE
Francisca buffs, fixes maneuvers.

### DIFF
--- a/code/modules/overmap/ship_weaponry/_ship_ammunition.dm
+++ b/code/modules/overmap/ship_weaponry/_ship_ammunition.dm
@@ -11,6 +11,7 @@
 	var/written_message
 	var/wielded = FALSE
 	var/caliber = SHIP_CALIBER_NONE
+	var/burst = 0 //If set to a number, this many projectiles will spawn to the side of the main projectile.
 	var/impact_type = SHIP_AMMO_IMPACT_HE //This decides what happens when the ammo hits. Is it a bunkerbuster? HE? AP?
 	var/ammunition_status = SHIP_AMMO_STATUS_GOOD //Currently unused, but will be relevant for chemical ammo.
 	var/ammunition_flags = SHIP_AMMO_FLAG_INFLAMMABLE|SHIP_AMMO_FLAG_VERY_HEAVY
@@ -216,4 +217,13 @@
 	return ..()
 
 /obj/item/projectile/ship_ammo/proc/on_translate(var/turf/entry_turf, var/target_turf) //This proc is called when the projectile enters a new ship's overmap zlevel.
-	return
+	if(ammo.burst)
+		for(var/i = 1 to ammo.burst)
+			var/turf/new_turf = get_random_turf_in_range(entry_turf, ammo.burst + rand(0, ammo.burst),  ammo.burst + rand(0, ammo.burst), TRUE, TRUE)
+			var/obj/item/projectile/ship_ammo/pellet = new type(new_turf)
+			pellet.ammo = new ammo.type
+			pellet.ammo.origin = ammo.origin
+			pellet.ammo.impact_type = ammo.impact_type
+			pellet.dir = dir
+			var/turf/front_turf = get_step(pellet, pellet.dir)
+			pellet.launch_projectile(front_turf)

--- a/code/modules/overmap/ship_weaponry/_ship_ammunition.dm
+++ b/code/modules/overmap/ship_weaponry/_ship_ammunition.dm
@@ -189,6 +189,7 @@
 	range = 250
 	anti_materiel_potential = 3
 	impact_sounds = list(BULLET_IMPACT_MEAT = SOUNDS_BULLET_MEAT, BULLET_IMPACT_METAL = SOUNDS_BULLET_METAL)
+	accuracy = 100
 	var/obj/item/ship_ammunition/ammo
 	var/primed = FALSE //If primed, we don't interact with map edges. Projectiles might spawn on a landmark at the edge of space, and we don't want them to get tp'd away.
 	var/hit_target = FALSE //First target we hit. Used to report if a hit was successful.
@@ -220,8 +221,9 @@
 /obj/item/projectile/ship_ammo/proc/on_translate(var/turf/entry_turf, var/target_turf) //This proc is called when the projectile enters a new ship's overmap zlevel.
 	if(ammo.burst)
 		for(var/i = 1 to ammo.burst)
-			var/turf/new_turf = get_random_turf_in_range(entry_turf, ammo.burst + rand(0, ammo.burst),  ammo.burst + rand(0, ammo.burst), TRUE, TRUE)
-			var/obj/item/projectile/ship_ammo/pellet = new type(new_turf)
+			var/turf/new_turf = get_random_turf_in_range(entry_turf, ammo.burst + rand(0, ammo.burst),  0, TRUE, FALSE)
+			var/obj/item/projectile/ship_ammo/pellet = new type
+			pellet.forceMove(new_turf)
 			pellet.ammo = new ammo.type
 			pellet.ammo.origin = ammo.origin
 			pellet.ammo.impact_type = ammo.impact_type

--- a/code/modules/overmap/ship_weaponry/_ship_ammunition.dm
+++ b/code/modules/overmap/ship_weaponry/_ship_ammunition.dm
@@ -188,6 +188,7 @@
 	icon_state = "small"
 	range = 250
 	anti_materiel_potential = 3
+	impact_sounds = list(BULLET_IMPACT_MEAT = SOUNDS_BULLET_MEAT, BULLET_IMPACT_METAL = SOUNDS_BULLET_METAL)
 	var/obj/item/ship_ammunition/ammo
 	var/primed = FALSE //If primed, we don't interact with map edges. Projectiles might spawn on a landmark at the edge of space, and we don't want them to get tp'd away.
 	var/hit_target = FALSE //First target we hit. Used to report if a hit was successful.

--- a/code/modules/overmap/ship_weaponry/weaponry/francisca.dm
+++ b/code/modules/overmap/ship_weaponry/weaponry/francisca.dm
@@ -21,7 +21,8 @@
 	impact_type = SHIP_AMMO_IMPACT_FMJ
 	ammunition_flags = SHIP_AMMO_FLAG_INFLAMMABLE|SHIP_AMMO_FLAG_VERY_HEAVY|SHIP_AMMO_FLAG_INFLAMMABLE
 	caliber = SHIP_CALIBER_40MM
-	burst = 6
+	burst = 8
+	cookoff_heavy = 0
 
 /obj/item/ship_ammunition/francisca/ap
 	name = "40mm AP ammunition box"

--- a/code/modules/overmap/ship_weaponry/weaponry/francisca.dm
+++ b/code/modules/overmap/ship_weaponry/weaponry/francisca.dm
@@ -21,6 +21,7 @@
 	impact_type = SHIP_AMMO_IMPACT_FMJ
 	ammunition_flags = SHIP_AMMO_FLAG_INFLAMMABLE|SHIP_AMMO_FLAG_VERY_HEAVY|SHIP_AMMO_FLAG_INFLAMMABLE
 	caliber = SHIP_CALIBER_40MM
+	burst = 6
 
 /obj/item/ship_ammunition/francisca/ap
 	name = "40mm AP ammunition box"
@@ -35,7 +36,7 @@
 	icon_state = "small"
 	damage = 50
 	armor_penetration = 50
-	penetrating = 1
+	penetrating = 2
 
 /obj/item/projectile/ship_ammo/francisca/ap
 	name = "40mm AP bullet"

--- a/code/modules/overmap/ship_weaponry/weaponry/grauwolf.dm
+++ b/code/modules/overmap/ship_weaponry/weaponry/grauwolf.dm
@@ -20,6 +20,7 @@
 	caliber = SHIP_CALIBER_90MM
 	ammunition_behaviour = SHIP_AMMO_BEHAVIOUR_DUMBFIRE
 	projectile_type_override = /obj/item/projectile/ship_ammo/grauwolf
+	burst = 4
 
 /obj/item/ship_ammunition/grauwolf_bundle/ap
 	name = "grauwolf armor-piercing flak bundle"
@@ -47,13 +48,3 @@
 	damage = 50
 	armor_penetration = 50
 	penetrating = 2
-
-/obj/item/projectile/ship_ammo/grauwolf/on_translate(var/turf/entry_turf, var/turf/target_turf)
-	for(var/i = 1 to 4)
-		var/turf/new_turf = get_random_turf_in_range(entry_turf, 5, 5, TRUE, TRUE)
-		var/obj/item/projectile/ship_ammo/grauwolf/burst = new(new_turf)
-		burst.ammo = new ammo.type
-		burst.ammo.impact_type = ammo.impact_type
-		var/turf/front_turf = get_step(new_turf, dir)
-		burst.dir = dir
-		burst.launch_projectile(front_turf)

--- a/code/modules/overmap/ship_weaponry/weaponry/leviathan.dm
+++ b/code/modules/overmap/ship_weaponry/weaponry/leviathan.dm
@@ -137,6 +137,7 @@
 	armor_penetration = 1000
 	penetrating = 100
 	hitscan = TRUE
+	impact_sounds = list(BULLET_IMPACT_MEAT = SOUNDS_LASER_MEAT, BULLET_IMPACT_METAL = SOUNDS_LASER_METAL)
 
 	muzzle_type = /obj/effect/projectile/muzzle/pulse
 	tracer_type = /obj/effect/projectile/tracer/pulse

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -224,7 +224,7 @@
 		var/ndir = text2num(href_list["roll"])
 		if(ishuman(usr))
 			var/mob/living/carbon/human/H = usr
-			visible_message(SPAN_DANGER("[H] starts tilting the yoke all the way to the [ndir == WEST ? "right" : "left"]!"))
+			visible_message(SPAN_DANGER("[H] starts tilting the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
 			if(do_after(H, 1 SECOND))
 				connected.combat_roll(ndir)
 
@@ -232,7 +232,7 @@
 		var/ndir = text2num(href_list["turn"])
 		if(ishuman(usr))
 			var/mob/living/carbon/human/H = usr
-			visible_message(SPAN_DANGER("[H] starts twisting the yoke all the way to the [ndir == WEST ? "right" : "left"]!"))
+			visible_message(SPAN_DANGER("[H] starts twisting the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
 			if(do_after(H, 1 SECOND))
 				connected.combat_turn(ndir)
 

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -273,7 +273,8 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 
 /obj/effect/overmap/visitable/ship/proc/combat_roll(var/new_dir)
 	burn()
-	forceMove(get_step(src, new_dir))
+	var/dir_to_move = turn(dir, new_dir == WEST ? 90 : -90)
+	forceMove(get_step(src, dir_to_move))
 	for(var/mob/living/L in living_mob_list)
 		if(L.z in map_z)
 			to_chat(L, SPAN_DANGER("<font size=4>The ship rapidly inclines under your feet!</font>"))
@@ -286,10 +287,26 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 
 /obj/effect/overmap/visitable/ship/proc/combat_turn(var/new_dir)
 	burn()
-	var/angle = 45
+	var/angle = -45
 	if(new_dir == WEST)
-		angle = -45
-	dir = turn(dir, angle)
+		angle = 45
+	var/direction = turn(dir, angle)
+	accelerate(direction, 1000)
+	if(direction & EAST)
+		speed[1] = abs(speed[1])
+	else if(direction & WEST)
+		if(speed[1] > 0)
+			speed[1] = -speed[1]
+	else
+		speed[1] = 0
+	if(direction & NORTH)
+		speed[2] = abs(speed[2])
+	else if(direction & SOUTH)
+		if(speed[2] > 0)
+			speed[2] = -speed[2]
+	else
+		speed[2] = 0
+	update_icon()
 	for(var/mob/living/L in living_mob_list)
 		if(L.z in map_z)
 			to_chat(L, SPAN_DANGER("The ship rapidly turns under your feet!"))

--- a/html/changelogs/mattatlas-theraid.yml
+++ b/html/changelogs/mattatlas-theraid.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The Francisca is now actually a gatling gun as it was meant to be. When fired, it spawns eight extra projectiles."
+  - tweak: "Francisca normal ammo now has 1 more penetration so that it actually gets through hulls."
+  - bugfix: "Maneuvers now work correctly. Do note that the left/right distinction is relative to ship direction ONLY for combat rolls, whereas it is absolute for combat turning (imagine a compass)."
+  - bugfix: "Physical ship ammunition projectiles now have hit sound effects."

--- a/html/changelogs/mattatlas-theraid.yml
+++ b/html/changelogs/mattatlas-theraid.yml
@@ -42,3 +42,4 @@ changes:
   - tweak: "Francisca normal ammo now has 1 more penetration so that it actually gets through hulls."
   - bugfix: "Maneuvers now work correctly. Do note that the left/right distinction is relative to ship direction ONLY for combat rolls, whereas it is absolute for combat turning (imagine a compass)."
   - bugfix: "Physical ship ammunition projectiles now have hit sound effects."
+  - bugfix: "Ship weapon projectiles no longer miss when they enter a ship. Get down if you want to dodge them!"


### PR DESCRIPTION
  - bugfix: "The Francisca is now actually a gatling gun as it was meant to be. When fired, it spawns eight extra projectiles."
  - tweak: "Francisca normal ammo now has 1 more penetration so that it actually gets through hulls."
  - bugfix: "Maneuvers now work correctly. Do note that the left/right distinction is relative to ship direction ONLY for combat rolls, whereas it is absolute for combat turning (imagine a compass)."
  - bugfix: "Physical ship ammunition projectiles now have hit sound effects."
