### PR TITLE
Adjusts sanasomnum injector cost

### DIFF
--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -16,8 +16,9 @@
 
 /datum/uplink_item/item/medical/sanasomnum
 	name = "Sanasomnum Injector"
-	item_cost = 2
+	item_cost = 9
 	path = /obj/item/reagent_containers/hypospray/autoinjector/sanasomnum
+	desc = "An autoinjector for Sanasomnum, a miracle drug that can recover extreme injuries regardless of their source at the cost of being unconscious for a few minutes. Not a foolproof revival if you end up getting too injured, and can't remove foreign bodies."
 
 /datum/uplink_item/item/medical/combathypo
 	name = "Combat Hypospray"

--- a/html/changelogs/kyres1-#15054.yml
+++ b/html/changelogs/kyres1-#15054.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: kyres1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Adjusts sanasomnum injector cost to 9 telecrystals in the medical uplink tab instead of 2."


### PR DESCRIPTION
This PR adjusts the sanasomnum prices from 2 to 9 telecrystals, meaning mercs/ninjas can only purchase one. Weaker antagonists such as traitor and burglar are still able to purchase two, but only if they almost explicitly save for it (since it leaves them with a total of 2 telecrystals.) Extraordinary circumstances like looting your buddy's corpse would still give you one extra shot at using it, so you're not completely without hope even then, but at least you have to do something to obtain it.

The thread for this is here; 
https://forums.aurorastation.org/topic/17684-limit-sana-injectors/
