### PR TITLE
Medical Intern Alt-Titles

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -319,11 +319,12 @@
 	departments = SIMPLEDEPT(DEPARTMENT_MEDICAL)
 	department_flag = MEDSCI
 	faction = "Station"
+	alt_titles = list("Medic Trainee", "Surgical Resident")
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = "the Chief Medical Officer"
 	selection_color = "#15903a"
-	access = list(access_medical, access_surgery, access_medical_equip)
+	access = list(access_medical, access_surgery, access_medical_equip, access_first_responder)
 	minimal_access = list(access_medical, access_surgery, access_medical_equip)
 	minimum_character_age = list(
 		SPECIES_HUMAN = 18,

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -319,12 +319,12 @@
 	departments = SIMPLEDEPT(DEPARTMENT_MEDICAL)
 	department_flag = MEDSCI
 	faction = "Station"
-	alt_titles = list("Medic Trainee", "Surgical Resident")
+	alt_titles = list("First Responder Intern", "Surgeon Intern")
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = "the Chief Medical Officer"
 	selection_color = "#15903a"
-	access = list(access_medical, access_surgery, access_medical_equip, access_first_responder)
+	access = list(access_medical, access_medical_equip)
 	minimal_access = list(access_medical, access_surgery, access_medical_equip)
 	minimum_character_age = list(
 		SPECIES_HUMAN = 18,

--- a/html/changelogs/KingOfThePing - all_the_student_slaves.yml
+++ b/html/changelogs/KingOfThePing - all_the_student_slaves.yml
@@ -39,4 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Added two alternative job titles for medical intern. One is for aspiring surgeons, one for Medics in the making."
-  - rscadd: "Gave medical interns access to the FR Quarters as a result of this."
+  - rscadd: "To be more consistent, interns dont have specialized medical access anymore."

--- a/html/changelogs/KingOfThePing - all_the_student_slaves.yml
+++ b/html/changelogs/KingOfThePing - all_the_student_slaves.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: KingOfThePing
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added two alternative job titles for medical intern. One is for aspiring surgeons, one for Medics in the making."
+  - rscadd: "Gave medical interns access to the FR Quarters as a result of this."


### PR DESCRIPTION
**WHAT?**
To make the learning role of medical intern more logical, this PR adds two new alt titles:

- Surgical Resident
- Medic Trainee

For surgeons and first responders respectively. It is tiring to ask interns everyone (or tell as intern every round) what your field of study is. In accordance to this medical interns now also have access to the first responder's quarters.

The existing title or Medical Intern is reserved for more general physician residents or students in an early stage without specialization yet.

**WHY?**
Alt-titles like these do not differentiate the job in it's responsibilities and thus do not create discrepancies in expectations. It is merely an RP tool for character development, put into a logical perspective. IRL students who are in their residency are also titles as the respective residency - e.g. "Surgical Resident", so everyone knows in what department they are used as. 