### PR TITLE
Mining overalls allowed_roles fix

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -168,7 +168,7 @@
 /datum/gear/accessory/overalls_mining
 	display_name = "overalls, mining"
 	path = /obj/item/clothing/accessory/storage/overalls/mining
-	allowed_roles = list("Shaft Miner, Xenoarchaeologist")
+	allowed_roles = list("Shaft Miner", "Xenoarchaeologist")
 	cost = 2
 
 /datum/gear/accessory/overalls_engineer

--- a/html/changelogs/DreamySkrell-mining-overalls.yml
+++ b/html/changelogs/DreamySkrell-mining-overalls.yml
@@ -1,0 +1,7 @@
+
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes mining overalls broken roles restrictions."


### PR DESCRIPTION
it was `list("Shaft Miner, Xenoarchaeologist")` instead of `list("Shaft Miner", "Xenoarchaeologist")`