### PR TITLE
Tweaks the 2nd Deck Sec Checkpoint

### DIFF
--- a/html/changelogs/wickedcybs_checkpoint.yml
+++ b/html/changelogs/wickedcybs_checkpoint.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Tweaks the second deck security checkpoint by removing the extra paper bin and pencil and the white hard hats."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -6994,18 +6994,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/wing_starboard)
 "dwy" = (
-/obj/item/device/binoculars,
+/obj/item/device/binoculars{
+	pixel_y = 3
+	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
-	},
-/obj/item/clothing/head/hardhat/white{
-	pixel_y = -5
-	},
-/obj/item/clothing/head/hardhat/white{
-	pixel_y = -5
-	},
-/obj/item/clothing/head/hardhat/white{
-	pixel_y = -5
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -7017,6 +7010,7 @@
 	dir = 4
 	},
 /obj/structure/table/steel,
+/obj/item/storage/box/fancy/donut,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint2)
 "dwK" = (
@@ -19088,10 +19082,9 @@
 /area/horizon/zta)
 "jsS" = (
 /obj/machinery/recharger{
-	pixel_y = 4
+	pixel_y = 1
 	},
 /obj/effect/floor_decal/corner/blue/full,
-/obj/item/storage/box/fancy/donut,
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint2)
@@ -26600,18 +26593,9 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical)
 "nkM" = (
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = -3;
-	pixel_y = 7
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/item/paper_scanner,
 /obj/item/device/flash,
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,


### PR DESCRIPTION
The checkpoint has two paper bins and pencils mapped in, so one set was removed. The hardhats were also removed because sec already gets helmets and it doesn't really fit up there.