### PR TITLE
Public Garden Biogenerator

### DIFF
--- a/html/changelogs/wickedcybs_bio.yml
+++ b/html/changelogs/wickedcybs_bio.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - rscadd: "Adds a small biogenerator to the public garden."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -11834,6 +11834,7 @@
 /obj/structure/table/standard,
 /obj/item/book/manual/hydroponics_beekeeping,
 /obj/item/toy/figure/gardener,
+/obj/machinery/biogenerator/small/west,
 /turf/simulated/floor/wood,
 /area/horizon/hydroponics/garden)
 "fVo" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -11834,7 +11834,6 @@
 /obj/structure/table/standard,
 /obj/item/book/manual/hydroponics_beekeeping,
 /obj/item/toy/figure/gardener,
-/obj/machinery/biogenerator/small/west,
 /turf/simulated/floor/wood,
 /area/horizon/hydroponics/garden)
 "fVo" = (
@@ -26977,6 +26976,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/machinery/biogenerator/small/west,
 /turf/simulated/floor/wood,
 /area/horizon/hydroponics/garden)
 "nxz" = (


### PR DESCRIPTION
Adds a small biogenerator to the public garden. It's the inefficent cousin of the biogenerator within hydroponics. Something that's used when no gardener is on for the visitors or off-duty crew growing plants for whatever reason.