### PR TITLE
Adds additional manoeuvre jump distance to the calf augment

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_augments.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_augments.dm
@@ -119,6 +119,7 @@
 	description = "An augment that provides additional jump distance and slightly reduces the damage from falling from heights."
 	path = /obj/item/organ/internal/augment/suspension
 	cost = 4
+	whitelisted = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_IPC, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_UNATHI)
 
 /datum/gear/augment/taste_boosters
 	display_name = "taste booster selection"

--- a/code/modules/client/preference_setup/loadout/loadout_augments.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_augments.dm
@@ -116,10 +116,10 @@
 
 /datum/gear/augment/suspension
 	display_name = "calf suspension"
-	description = "An augment that provides additional jump distance and slightly reduces the damage from falling from heights."
+	description = "An augment that allows the wearer to jump further and slightly reduces the damage from falling from heights."
 	path = /obj/item/organ/internal/augment/suspension
 	cost = 4
-	whitelisted = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_IPC, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_UNATHI)
+	whitelisted = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA_ZHAN, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_IPC, SPECIES_IPC_XION, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL, SPECIES_VAURCA_WORKER, SPECIES_UNATHI)
 
 /datum/gear/augment/taste_boosters
 	display_name = "taste booster selection"

--- a/code/modules/client/preference_setup/loadout/loadout_augments.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_augments.dm
@@ -116,7 +116,7 @@
 
 /datum/gear/augment/suspension
 	display_name = "calf suspension"
-	description = "An augment that reduces the damage from falling from heights."
+	description = "An augment that provides additional jump distance and slightly reduces the damage from falling from heights."
 	path = /obj/item/organ/internal/augment/suspension
 	cost = 4
 

--- a/code/modules/mob/living/carbon/human/human_maneuvers.dm
+++ b/code/modules/mob/living/carbon/human/human_maneuvers.dm
@@ -8,7 +8,12 @@
 			. -= limb.status & ORGAN_SPLINTED ? 0.25 : 0.5
 
 /mob/living/carbon/human/get_jump_distance()
-	return species.standing_jump_range
+	. = species.standing_jump_range
+	
+	var/obj/item/organ/internal/augment/suspension/suspension = internal_organs_by_name[BP_AUG_SUSPENSION]
+
+	if(suspension && . < 3)
+		. = max(. + suspension.jump_bonus, 3) 
 
 /mob/living/carbon/human/can_do_maneuver(var/decl/maneuver/maneuver, var/silent = FALSE)
 	. = ..()

--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -395,6 +395,7 @@
 	min_broken_damage = 20
 	max_damage = 20
 	var/suspension_mod = 0.8
+	var/jump_bonus = 1
 
 /obj/item/organ/internal/augment/suspension/advanced
 	name = "advanced calf suspension"

--- a/html/changelogs/omicega-jumpjumpsugarlump.yml
+++ b/html/changelogs/omicega-jumpjumpsugarlump.yml
@@ -10,4 +10,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "The calf suspension augment now allows you to jump a little further (via the manoeuvre system) in addition to providing slight protection against fall damage.
+  - rscadd: "The calf suspension augment now allows you to jump a little further (via the manoeuvre system) in addition to providing slight protection against fall damage."

--- a/html/changelogs/omicega-jumpjumpsugarlump.yml
+++ b/html/changelogs/omicega-jumpjumpsugarlump.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omicega
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "The calf suspension augment now allows you to jump a little further (via the manoeuvre system) in addition to providing slight protection against fall damage.


### PR DESCRIPTION
See title. The calf suspension augment is super underwhelming -- 20% less fall damage taken for 4 full loadout points, and I'm pretty sure it breaks after it helps with only 2 falls as well.

Now it adds one tile to your jumpable distance by manoeuvres, capped at 3 total tiles so things like ZH frames can't take it and jump half the screen. Big, heavy species can't take this augment either; that means breeders, bulwarks, and industrials for now.