### PR TITLE
adds more transit spots to the hangars of various away sites to ensure all shuttles can fit in them properly.

### DIFF
--- a/html/changelogs/anconfuzedrocks-moretransitspots.yml
+++ b/html/changelogs/anconfuzedrocks-moretransitspots.yml
@@ -1,0 +1,7 @@
+
+author: anconfuzedrock
+
+delete-after: True
+
+changes:
+  - rscadd: "Away site hangars have more transit spots, so ships are more likely to be able to land in them."

--- a/maps/away/away_site/abandoned_mining/cursed.dmm
+++ b/maps/away/away_site/abandoned_mining/cursed.dmm
@@ -37890,7 +37890,7 @@ iui
 iui
 iui
 iui
-iui
+wkw
 iui
 iui
 iui
@@ -37908,7 +37908,7 @@ iui
 iui
 iui
 iui
-iui
+wkw
 iui
 iui
 iui

--- a/maps/away/away_site/abandoned_mining/cursed.dmm
+++ b/maps/away/away_site/abandoned_mining/cursed.dmm
@@ -2855,6 +2855,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/cursed/computer_core)
+"qtV" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/shuttle_landmark/automatic{
+	name = "Hangar Navpoint"
+	},
+/turf/simulated/floor,
+/area/cursed/hangar)
 "qwO" = (
 /obj/structure/table/stone/marble,
 /obj/item/towel/random,
@@ -37886,11 +37893,11 @@ xRX
 xRX
 xRX
 qqY
-iui
-iui
-iui
-iui
 wkw
+iui
+iui
+iui
+iui
 iui
 iui
 iui
@@ -37908,13 +37915,13 @@ iui
 iui
 iui
 iui
-wkw
+iui
 iui
 iui
 iui
 iui
 lqi
-qAz
+qtV
 qAz
 xbU
 qAz

--- a/maps/away/away_site/civ_station/civilian_station.dmm
+++ b/maps/away/away_site/civ_station/civilian_station.dmm
@@ -374,9 +374,7 @@
 /turf/simulated/floor/tiled/white,
 /area/civilian_station)
 "aTn" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
+/obj/effect/floor_decal/industrial/warning,
 /obj/effect/shuttle_landmark/automatic{
 	name = "Hangar Navpoint"
 	},
@@ -26879,8 +26877,8 @@ xRX
 xRX
 xRX
 jiW
-hBd
-aTn
+hlr
+aVe
 hBd
 hBd
 hBd
@@ -26902,8 +26900,8 @@ hBd
 hBd
 hBd
 hBd
-hlr
-hNl
+hBd
+aTn
 pRm
 xRX
 xRX
@@ -30734,8 +30732,8 @@ xRX
 xRX
 xRX
 jiW
-hBd
-aTn
+hlr
+aVe
 hBd
 hBd
 hBd
@@ -30757,8 +30755,8 @@ hBd
 hBd
 hBd
 qmJ
-hlr
-hNl
+hBd
+aTn
 pRm
 xRX
 xRX

--- a/maps/away/away_site/civ_station/civilian_station.dmm
+++ b/maps/away/away_site/civ_station/civilian_station.dmm
@@ -373,6 +373,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/civilian_station)
+"aTn" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/shuttle_landmark/automatic{
+	name = "Hangar Navpoint"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/civilian_station/hangar)
 "aVe" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -1039,6 +1048,12 @@
 /obj/structure/closet/cabinet,
 /turf/simulated/floor/wood,
 /area/civilian_station)
+"hlr" = (
+/obj/effect/shuttle_landmark/automatic{
+	name = "Hangar Navpoint"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/civilian_station/hangar)
 "hmL" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -26865,7 +26880,7 @@ xRX
 xRX
 jiW
 hBd
-aVe
+aTn
 hBd
 hBd
 hBd
@@ -26887,7 +26902,7 @@ hBd
 hBd
 hBd
 hBd
-hBd
+hlr
 hNl
 pRm
 xRX
@@ -30720,7 +30735,7 @@ xRX
 xRX
 jiW
 hBd
-aVe
+aTn
 hBd
 hBd
 hBd
@@ -30742,7 +30757,7 @@ hBd
 hBd
 hBd
 qmJ
-hBd
+hlr
 hNl
 pRm
 xRX

--- a/maps/away/away_site/racers/racers.dmm
+++ b/maps/away/away_site/racers/racers.dmm
@@ -1320,6 +1320,11 @@
 /obj/machinery/vending/cigarette/hacked,
 /turf/simulated/floor/tiled/steel,
 /area/racers)
+"gki" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/shuttle_landmark/automatic,
+/turf/simulated/floor/tiled/steel,
+/area/racers)
 "gkj" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/effect/decal/cleanable/blood/drip/oil,
@@ -1541,6 +1546,13 @@
 "hzI" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/tiled/steel,
+/area/racers)
+"hAq" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/shuttle_landmark/automatic,
 /turf/simulated/floor/tiled/steel,
 /area/racers)
 "hAS" = (
@@ -25709,7 +25721,7 @@ xRX
 xRX
 gbX
 ctn
-cLC
+hAq
 ctn
 ctn
 ctn
@@ -25732,7 +25744,7 @@ ctn
 ctn
 ctn
 ctn
-ctn
+rQw
 cBN
 huE
 xRX
@@ -31911,7 +31923,7 @@ nfm
 xRX
 huE
 ctn
-cLC
+hAq
 ctn
 ctn
 ctn
@@ -31934,7 +31946,7 @@ ctn
 ctn
 ctn
 ctn
-pJZ
+gki
 gbX
 xRX
 xRX

--- a/maps/away/away_site/racers/racers.dmm
+++ b/maps/away/away_site/racers/racers.dmm
@@ -1549,9 +1549,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/racers)
 "hAq" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/floodlight,
 /obj/effect/shuttle_landmark/automatic,
 /turf/simulated/floor/tiled/steel,
 /area/racers)
@@ -2209,6 +2208,7 @@
 /area/racers)
 "kFu" = (
 /obj/item/device/suit_cooling_unit,
+/obj/effect/shuttle_landmark/automatic,
 /turf/simulated/floor/tiled/steel,
 /area/racers)
 "kFN" = (
@@ -25720,8 +25720,8 @@ xRX
 xRX
 xRX
 gbX
-ctn
-hAq
+rQw
+cLC
 ctn
 ctn
 ctn
@@ -25744,8 +25744,8 @@ ctn
 ctn
 ctn
 ctn
-rQw
-cBN
+ctn
+hAq
 huE
 xRX
 nfm
@@ -31922,8 +31922,8 @@ xjB
 nfm
 xRX
 huE
-ctn
-hAq
+rQw
+cLC
 ctn
 ctn
 ctn
@@ -35030,7 +35030,7 @@ ctn
 ctn
 lvc
 ctn
-pJZ
+gki
 gbX
 xRX
 xRX

--- a/maps/away/away_site/space_bar/space_bar.dmm
+++ b/maps/away/away_site/space_bar/space_bar.dmm
@@ -934,11 +934,6 @@
 /obj/item/deck/cards,
 /turf/simulated/floor/carpet/rubber,
 /area/space_bar)
-"nDO" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/shuttle_landmark/automatic,
-/turf/simulated/floor/tiled/steel,
-/area/space_bar/hangar)
 "nGj" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 1
@@ -1177,9 +1172,7 @@
 /turf/simulated/floor/holofloor/tiled,
 /area/space_bar)
 "sMP" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
+/obj/effect/floor_decal/industrial/warning,
 /obj/effect/shuttle_landmark/automatic,
 /turf/simulated/floor/tiled/steel,
 /area/space_bar/hangar)
@@ -27122,8 +27115,8 @@ xRX
 xRX
 xRX
 jiW
-hBd
-sMP
+lOr
+aVe
 hBd
 hBd
 hBd
@@ -27146,7 +27139,7 @@ hBd
 hBd
 hBd
 hBd
-nDO
+sMP
 pRm
 xRX
 xRX
@@ -29692,8 +29685,8 @@ xRX
 xRX
 xRX
 jiW
-hBd
-sMP
+lOr
+aVe
 hBd
 hBd
 hBd
@@ -29716,7 +29709,7 @@ hBd
 hBd
 qmJ
 hBd
-nDO
+sMP
 pRm
 xRX
 xRX

--- a/maps/away/away_site/space_bar/space_bar.dmm
+++ b/maps/away/away_site/space_bar/space_bar.dmm
@@ -934,6 +934,11 @@
 /obj/item/deck/cards,
 /turf/simulated/floor/carpet/rubber,
 /area/space_bar)
+"nDO" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/shuttle_landmark/automatic,
+/turf/simulated/floor/tiled/steel,
+/area/space_bar/hangar)
 "nGj" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 1
@@ -1171,6 +1176,13 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/holofloor/tiled,
 /area/space_bar)
+"sMP" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/shuttle_landmark/automatic,
+/turf/simulated/floor/tiled/steel,
+/area/space_bar/hangar)
 "taa" = (
 /obj/structure/table/stone/marble,
 /obj/item/holomenu{
@@ -27111,7 +27123,7 @@ xRX
 xRX
 jiW
 hBd
-aVe
+sMP
 hBd
 hBd
 hBd
@@ -27134,7 +27146,7 @@ hBd
 hBd
 hBd
 hBd
-hNl
+nDO
 pRm
 xRX
 xRX
@@ -29681,7 +29693,7 @@ xRX
 xRX
 jiW
 hBd
-aVe
+sMP
 hBd
 hBd
 hBd
@@ -29704,7 +29716,7 @@ hBd
 hBd
 qmJ
 hBd
-hNl
+nDO
 pRm
 xRX
 xRX

--- a/maps/away/away_site/tajara/taj_safehouse/tajara_safehouse.dmm
+++ b/maps/away/away_site/tajara/taj_safehouse/tajara_safehouse.dmm
@@ -28798,7 +28798,7 @@ xQ
 xQ
 zp
 yV
-kD
+WM
 kD
 kD
 kD
@@ -28820,7 +28820,7 @@ kD
 kD
 kD
 kD
-kD
+WM
 xi
 Kn
 Kn


### PR DESCRIPTION
Existing hangars outside the horizon had transit spots only in the centers, which was all well and good until you consider that many ships that use docking ports (which other hangars often lack)  expect the transit spot to be north or south of wherever they're landing. This adds transit spots to the north and south inside the hangars, so those ships can land.