### PR TITLE
Re-adds Mining/Intrepid Docking Controllers

### DIFF
--- a/html/changelogs/wickedcybs_dockcontrol.yml
+++ b/html/changelogs/wickedcybs_dockcontrol.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - bugfix: "Re-adds the missing docking controllers to the deck one pilot prep room."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -27465,6 +27465,22 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "mining_dock";
+	name = "mining docking hatch controller";
+	pixel_x = -39;
+	pixel_y = -25;
+	req_one_access = list(31,48,67)
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "intrepid_dock";
+	name = "intrepid docking port controller";
+	pixel_x = -26;
+	pixel_y = -25;
+	req_one_access = list(31,48,67)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "vJy" = (


### PR DESCRIPTION
Was removed in an earlier remap of the EVA storage.