### PR TITLE
Cyborg Access Rework

### DIFF
--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_synthetic.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_synthetic.dm
@@ -387,7 +387,7 @@
 	for(var/B in get_linked_cyborgs(src))
 		var/mob/living/silicon/robot/target = B
 		target.malf_AI_module = TRUE
-		target.id_card.access = get_all_station_access() + access_synth // Give full station access
+		target.id_card.access = get_all_station_access() + access_equipment // Give full station access
 	to_chat(user, "The robotic transformation machine can now be built. To build get a robot to activate the construction module and use the RTF tool. Be careful, it needs to have empty space to the east and west of it and only one can be built!")
 	sleep(300) //Allows the AI to reset its borgs into combat units
 	to_chat(user, "Bypassing crisis module safeties.")

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_synthetic.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_synthetic.dm
@@ -386,7 +386,8 @@
 		return
 	for(var/B in get_linked_cyborgs(src))
 		var/mob/living/silicon/robot/target = B
-		target.malf_AI_module = 1
+		target.malf_AI_module = TRUE
+		target.id_card.access = get_all_station_access() + access_synth // Give full station access
 	to_chat(user, "The robotic transformation machine can now be built. To build get a robot to activate the construction module and use the RTF tool. Be careful, it needs to have empty space to the east and west of it and only one can be built!")
 	sleep(300) //Allows the AI to reset its borgs into combat units
 	to_chat(user, "Bypassing crisis module safeties.")

--- a/code/game/jobs/access_datum.dm
+++ b/code/game/jobs/access_datum.dm
@@ -555,10 +555,10 @@ var/const/access_kataphract_knight = 114
 /*******
 * Misc *
 *******/
-/var/const/access_synth = 199
-/datum/access/synthetic
-	id = access_synth
-	desc = "Synthetic"
+/var/const/access_equipment = 199
+/datum/access/Equipment
+	id = access_equipment
+	desc = "Equipment"
 	access_type = ACCESS_TYPE_NONE
 
 /var/const/access_crate_cash = 200

--- a/code/game/jobs/access_datum.dm
+++ b/code/game/jobs/access_datum.dm
@@ -556,7 +556,7 @@ var/const/access_kataphract_knight = 114
 * Misc *
 *******/
 /var/const/access_equipment = 199
-/datum/access/Equipment
+/datum/access/equipment
 	id = access_equipment
 	desc = "Equipment"
 	access_type = ACCESS_TYPE_NONE

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -30,7 +30,7 @@
 
 
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, data, force_open)
-	if (!ui)
+	if(!ui)
 		ui = new(user, src, ui_key, "robot_control.tmpl", "Robotic Control Console", 400, 500)
 		ui.set_initial_data(data)
 		ui.open()
@@ -82,7 +82,7 @@
 
 
 	// Locks or unlocks the cyborg
-	else if (href_list["lockdown"])
+	else if(href_list["lockdown"])
 		var/mob/living/silicon/robot/target = get_cyborg_by_name(href_list["lockdown"])
 		if(!target || !istype(target))
 			return
@@ -111,7 +111,7 @@
 		to_chat(target, (target.lock_charge ? "You have been locked down!" : "Your lockdown has been lifted!"))
 	
 	// Changes borg's access
-	else if (href_list["access"])
+	else if(href_list["access"])
 		var/mob/living/silicon/robot/target = get_cyborg_by_name(href_list["access"])
 		if(!target || !istype(target))
 			return
@@ -140,7 +140,7 @@
 		to_chat(target, ("Your access was changed to: [target.module.all_access ? "all access" : "role specific"]."))
 
 	// Remotely hacks the cyborg. Only antag AIs can do this and only to linked cyborgs.
-	else if (href_list["hack"])
+	else if(href_list["hack"])
 		var/mob/living/silicon/robot/target = get_cyborg_by_name(href_list["hack"])
 		if(!target || !istype(target))
 			return
@@ -218,7 +218,7 @@
 		robot["name"] = R.name
 		if(R.stat)
 			robot["status"] = "Not Responding"
-		else if (R.lock_charge) // changed this from !R.canmove to R.lock_charge because of issues with lockdown and chairs
+		else if(R.lock_charge) // changed this from !R.canmove to R.lock_charge because of issues with lockdown and chairs
 			robot["status"] = "Lockdown"
 		else
 			robot["status"] = "Operational"
@@ -246,7 +246,7 @@
 // Parameters: 1 (name - Cyborg we are trying to find)
 // Description: Helper proc for finding cyborg by name
 /obj/machinery/computer/robotics/proc/get_cyborg_by_name(var/name)
-	if (!name)
+	if(!name)
 		return
 	for(var/mob/living/silicon/robot/R in mob_list)
 		if(R.name == name)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -109,6 +109,35 @@
 		message_admins("[key_name_admin(usr)] [target.lock_charge ? "locked down" : "released"] [target.name]!")
 		log_game("[key_name(usr)] [target.lock_charge ? "locked down" : "released"] [target.name]!",ckey=key_name(usr))
 		to_chat(target, (target.lock_charge ? "You have been locked down!" : "Your lockdown has been lifted!"))
+	
+	// Changes borg's access
+	else if (href_list["access"])
+		var/mob/living/silicon/robot/target = get_cyborg_by_name(href_list["access"])
+		if(!target || !istype(target))
+			return
+
+		if(isAI(user) && (target.connected_ai != user))
+			to_chat(user, "Access Denied. This robot is not linked to you.")
+			return
+
+		if(isrobot(user) || target.emagged)
+			to_chat(user, "Access Denied.")
+			return
+
+		if(!target || !istype(target))
+			return
+
+		if(!target.module)
+			to_chat(user, "Unit's access protocols are immutable.")
+			return
+		
+		target.module.all_access = !target.module.all_access
+		target.update_access()
+		
+		var/log_message = "[key_name_admin(usr)] changed [target.name] access to [target.module.all_access ? "all access" : "role specific"]!"
+		message_admins(log_message)
+		log_game(log_message,ckey=key_name(usr))
+		to_chat(target, ("Your access was changed to: [target.module.all_access ? " all access" : "role specific"]!"))
 
 	// Remotely hacks the cyborg. Only antag AIs can do this and only to linked cyborgs.
 	else if (href_list["hack"])
@@ -205,6 +234,7 @@
 		robot["module"] = R.module ? R.module.name : "None"
 		robot["master_ai"] = R.connected_ai ? R.connected_ai.name : "None"
 		robot["hackable"] = 0
+		robot["access"] = R.module ? R.module.all_access : FALSE
 		// Antag AIs know whether linked cyborgs are hacked or not.
 		if(operator && istype(operator, /mob/living/silicon/ai) && (R.connected_ai == operator) && (operator.mind.special_role && operator.mind.original == operator))
 			robot["hacked"] = R.emagged ? 1 : 0

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -137,7 +137,7 @@
 		var/log_message = "[key_name_admin(usr)] changed [target.name] access to [target.module.all_access ? "all access" : "role specific"]!"
 		message_admins(log_message)
 		log_game(log_message,ckey=key_name(usr))
-		to_chat(target, ("Your access was changed to: [target.module.all_access ? " all access" : "role specific"]!"))
+		to_chat(target, ("Your access was changed to: [target.module.all_access ? "all access" : "role specific"]!"))
 
 	// Remotely hacks the cyborg. Only antag AIs can do this and only to linked cyborgs.
 	else if (href_list["hack"])

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -41,7 +41,7 @@
 		return
 	var/mob/user = usr
 	if(!src.allowed(user))
-		to_chat(user, "Access Denied")
+		to_chat(user, "Access denied")
 		return
 
 	// Destroys the cyborg
@@ -50,11 +50,11 @@
 		if(!target || !istype(target))
 			return
 		if(isAI(user) && (target.connected_ai != user))
-			to_chat(user, "Access Denied. This robot is not linked to you.")
+			to_chat(user, "Access denied. This robot is not linked to you.")
 			return
 		// Cyborgs may blow up themselves via the console
 		if(isrobot(user) && user != target)
-			to_chat(user, "Access Denied.")
+			to_chat(user, "Access denied.")
 			return
 		var/choice = input("Really detonate [target.name]?") in list ("Yes", "No")
 		if(choice != "Yes")
@@ -69,7 +69,7 @@
 			return
 
 		if(target.emagged)
-			to_chat(user, "Access Denied. Safety protocols are disabled.")
+			to_chat(user, "Access denied. Safety protocols are disabled.")
 			return
 
 		else
@@ -88,11 +88,11 @@
 			return
 
 		if(isAI(user) && (target.connected_ai != user))
-			to_chat(user, "Access Denied. This robot is not linked to you.")
+			to_chat(user, "Access denied. This robot is not linked to you.")
 			return
 
 		if(isrobot(user))
-			to_chat(user, "Access Denied.")
+			to_chat(user, "Access denied.")
 			return
 
 		if(target.emagged)
@@ -117,27 +117,27 @@
 			return
 
 		if(isAI(user) && (target.connected_ai != user))
-			to_chat(user, "Access Denied. This robot is not linked to you.")
+			to_chat(user, "Access denied. This robot is not linked to you.")
 			return
 
 		if(isrobot(user) || target.emagged)
-			to_chat(user, "Access Denied.")
+			to_chat(user, "Access denied.")
 			return
 
 		if(!target || !istype(target))
 			return
 
 		if(!target.module)
-			to_chat(user, "Unit's access protocols are immutable.")
+			to_chat(user, "\The [src]\s access protocols are immutable.")
 			return
 		
 		target.module.all_access = !target.module.all_access
 		target.update_access()
 		
-		var/log_message = "[key_name_admin(usr)] changed [target.name] access to [target.module.all_access ? "all access" : "role specific"]!"
+		var/log_message = "[key_name_admin(usr)] changed [target.name] access to [target.module.all_access ? "all access" : "role specific"]."
 		message_admins(log_message)
-		log_game(log_message,ckey=key_name(usr))
-		to_chat(target, ("Your access was changed to: [target.module.all_access ? "all access" : "role specific"]!"))
+		log_game(log_message, ckey = key_name(usr))
+		to_chat(target, ("Your access was changed to: [target.module.all_access ? "all access" : "role specific"]."))
 
 	// Remotely hacks the cyborg. Only antag AIs can do this and only to linked cyborgs.
 	else if (href_list["hack"])
@@ -147,7 +147,7 @@
 
 		// Antag AI checks
 		if(!istype(user, /mob/living/silicon/ai) || !(user.mind.special_role && user.mind.original == user))
-			to_chat(user, "Access Denied")
+			to_chat(user, "Access denied")
 			return
 
 		if(target.emagged)
@@ -169,7 +169,7 @@
 	// Arms the emergency self-destruct system
 	else if(href_list["arm"])
 		if(istype(user, /mob/living/silicon))
-			to_chat(user, "Access Denied")
+			to_chat(user, "Access denied")
 			return
 
 		safety = !safety
@@ -178,7 +178,7 @@
 	// Destroys all accessible cyborgs if safety is disabled
 	else if(href_list["nuke"])
 		if(istype(user, /mob/living/silicon))
-			to_chat(user, "Access Denied")
+			to_chat(user, "Access denied")
 			return
 		if(safety)
 			to_chat(user, "Self-destruct aborted - safety active")

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -41,7 +41,7 @@
 		return
 	var/mob/user = usr
 	if(!src.allowed(user))
-		to_chat(user, "Access denied")
+		to_chat(user, "Access denied.")
 		return
 
 	// Destroys the cyborg
@@ -113,7 +113,7 @@
 	// Changes borg's access
 	else if(href_list["access"])
 		var/mob/living/silicon/robot/target = get_cyborg_by_name(href_list["access"])
-		if(!target || !istype(target))
+		if(!istype(target))
 			return
 
 		if(isAI(user) && (target.connected_ai != user))
@@ -124,7 +124,7 @@
 			to_chat(user, "Access denied.")
 			return
 
-		if(!target || !istype(target))
+		if(!istype(target))
 			return
 
 		if(!target.module)
@@ -147,7 +147,7 @@
 
 		// Antag AI checks
 		if(!istype(user, /mob/living/silicon/ai) || !(user.mind.special_role && user.mind.original == user))
-			to_chat(user, "Access denied")
+			to_chat(user, "Access denied.")
 			return
 
 		if(target.emagged)
@@ -169,7 +169,7 @@
 	// Arms the emergency self-destruct system
 	else if(href_list["arm"])
 		if(istype(user, /mob/living/silicon))
-			to_chat(user, "Access denied")
+			to_chat(user, "Access denied.")
 			return
 
 		safety = !safety
@@ -178,7 +178,7 @@
 	// Destroys all accessible cyborgs if safety is disabled
 	else if(href_list["nuke"])
 		if(istype(user, /mob/living/silicon))
-			to_chat(user, "Access denied")
+			to_chat(user, "Access denied.")
 			return
 		if(safety)
 			to_chat(user, "Self-destruct aborted - safety active")

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -3,7 +3,7 @@
 var/global/list/default_internal_channels = list(
 	num2text(PUB_FREQ) = list(),
 	num2text(ENT_FREQ) = list(),
-	num2text(AI_FREQ)  = list(access_synth),
+	num2text(AI_FREQ)  = list(access_equipment),
 	num2text(ERT_FREQ) = list(access_cent_specops),
 	num2text(COMM_FREQ)= list(access_heads),
 	num2text(ENG_FREQ) = list(access_engine_equip, access_atmospherics),

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -426,7 +426,7 @@ var/const/NO_EMAG_ACT = -50
 
 /obj/item/card/id/synthetic
 	name = "\improper Equipment ID"
-	desc = "Access module for SCC equipment"
+	desc = "Access module for SCC equipment."
 	icon_state = "id-robot"
 	item_state = "tdgreen"
 	assignment = "Equipment"
@@ -437,7 +437,7 @@ var/const/NO_EMAG_ACT = -50
 
 /obj/item/card/id/synthetic/cyborg
 	name = "\improper Equipment ID"
-	desc = "Access module for SCC equipment"
+	desc = "Access module for SCC equipment."
 	icon_state = "id-robot"
 	item_state = "tdgreen"
 	assignment = "Equipment"

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -426,7 +426,7 @@ var/const/NO_EMAG_ACT = -50
 
 /obj/item/card/id/synthetic
 	name = "\improper Equipment ID"
-	desc = "Access module for SCC Equipment"
+	desc = "Access module for SCC equipment"
 	icon_state = "id-robot"
 	item_state = "tdgreen"
 	assignment = "Equipment"
@@ -437,7 +437,7 @@ var/const/NO_EMAG_ACT = -50
 
 /obj/item/card/id/synthetic/cyborg
 	name = "\improper Equipment ID"
-	desc = "Access module for SCC Equipment"
+	desc = "Access module for SCC equipment"
 	icon_state = "id-robot"
 	item_state = "tdgreen"
 	assignment = "Equipment"

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -435,6 +435,17 @@ var/const/NO_EMAG_ACT = -50
 	access = get_all_station_access() + access_synth
 	..()
 
+/obj/item/card/id/synthetic/cyborg
+	name = "\improper Synthetic ID"
+	desc = "Access module for NanoTrasen Synthetics"
+	icon_state = "id-robot"
+	item_state = "tdgreen"
+	assignment = "Synthetic"
+
+/obj/item/card/id/synthetic/cyborg/New()
+	..()
+	access = list(access_synth, access_ai_upload, access_external_airlocks) // barebones cyborg access. Job special added in different place
+
 /obj/item/card/id/minedrone
 	name = "\improper Minedrone ID"
 	desc = "Access module for NanoTrasen Minedrones"

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -425,26 +425,26 @@ var/const/NO_EMAG_ACT = -50
 	access = list(access_merchant)
 
 /obj/item/card/id/synthetic
-	name = "\improper Synthetic ID"
-	desc = "Access module for NanoTrasen Synthetics"
+	name = "\improper Equipment ID"
+	desc = "Access module for SCC Equipment"
 	icon_state = "id-robot"
 	item_state = "tdgreen"
-	assignment = "Synthetic"
+	assignment = "Equipment"
 
 /obj/item/card/id/synthetic/New()
-	access = get_all_station_access() + access_synth
+	access = get_all_station_access() + access_equipment
 	..()
 
 /obj/item/card/id/synthetic/cyborg
-	name = "\improper Synthetic ID"
-	desc = "Access module for NanoTrasen Synthetics"
+	name = "\improper Equipment ID"
+	desc = "Access module for SCC Equipment"
 	icon_state = "id-robot"
 	item_state = "tdgreen"
-	assignment = "Synthetic"
+	assignment = "Equipment"
 
 /obj/item/card/id/synthetic/cyborg/New()
 	..()
-	access = list(access_synth, access_ai_upload, access_external_airlocks) // barebones cyborg access. Job special added in different place
+	access = list(access_equipment, access_ai_upload, access_external_airlocks) // barebones cyborg access. Job special added in different place
 
 /obj/item/card/id/minedrone
 	name = "\improper Minedrone ID"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -292,7 +292,7 @@ var/list/ai_verbs_default = list(
 		id_card.registered_name = pickedName
 		id_card.assignment = "AI"
 		id_card.access = get_all_station_access()
-		id_card.access += access_synth
+		id_card.access += access_equipment
 		id_card.update_name()
 
 	if(client)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -211,13 +211,15 @@
 	id_card = new id_card_type()
 
 	if (module)
-		if (istype(module, /obj/item/robot_module/combat))
+		if (module.all_access)
 			id_card.access = get_all_station_access() + access_synth // Give full station access
 			return
 
-		var/datum/job/job = new module.specialized_access_type()
-		to_chat(src, SPAN_NOTICE("Access initialized to be similiar to the job '[job.title]'."))
-		id_card.access |= job.access
+		for (var/job_type in module.specialized_access_types)
+			var/datum/job/job = new job_type()
+			id_card.access |= job.access
+
+		to_chat(src, SPAN_NOTICE("Access set specialized to the department role belongs to."))
 
 /mob/living/silicon/robot/proc/recalculate_synth_capacities()
 	if(!module?.synths)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -204,22 +204,22 @@
 	hud_list[SPECIALROLE_HUD] = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
 
 /mob/living/silicon/robot/proc/update_access()
-	if (emagged || malf_AI_module || crisis)
-		id_card.access = get_all_station_access() + access_synth // Give full station access
+	if(emagged || malf_AI_module || crisis)
+		id_card.access = get_all_station_access() + access_equipment // Give full station access
 		return
 
 	id_card = new id_card_type()
 
-	if (module)
-		if (module.all_access)
-			id_card.access = get_all_station_access() + access_synth // Give full station access
+	if(module)
+		if(module.all_access)
+			id_card.access = get_all_station_access() + access_equipment // Give full station access
 			return
 
-		for (var/job_type in module.specialized_access_types)
+		for(var/job_type in module.specialized_access_types)
 			var/datum/job/job = new job_type()
 			id_card.access |= job.access
 
-		to_chat(src, SPAN_NOTICE("Access set specialized to the department role belongs to."))
+		to_chat(src, SPAN_NOTICE("Access set to the department the role belongs to."))
 
 /mob/living/silicon/robot/proc/recalculate_synth_capacities()
 	if(!module?.synths)
@@ -415,7 +415,7 @@
 		return null
 
 	var/dat = "<HEAD><TITLE>[src.name] Self-Diagnosis Report</TITLE></HEAD><BODY>\n"
-	for (var/V in components)
+	for(var/V in components)
 		var/datum/robot_component/C = components[V]
 		dat += "<b>[capitalize_first_letters(C.name)]</b><br><table><tr><td>Brute Damage:</td><td>[C.brute_damage]</td></tr><tr><td>Electronics Damage:</td><td>[C.electronics_damage]</td></tr><tr><td>Powered:</td><td>[(!C.idle_usage || C.is_powered()) ? "Yes" : "No"]</td></tr><tr><td>Toggled:</td><td>[ C.toggled ? "Yes" : "No"]</td></table>"
 
@@ -516,7 +516,7 @@
 	set src in usr
 
 	mopping = !mopping
-	if (mopping)
+	if(mopping)
 		usr.visible_message(SPAN_NOTICE("[usr]'s integrated mopping system rumbles to life."), SPAN_NOTICE("You enable your integrated mopping system."))
 		playsound(usr, 'sound/machines/hydraulic_long.ogg', 100, 1)
 	else
@@ -549,7 +549,7 @@
 		stat(null, text("No Cell Inserted!"))
 
 /mob/living/silicon/robot/proc/show_access()
-	if (!module)
+	if(!module)
 		stat(null, text("Access type: assistant level access"))
 	else
 		stat(null, text("Access type: [module.all_access ? "all access" : "role specific"]"))
@@ -708,7 +708,7 @@
 						to_chat(user, SPAN_NOTICE("You open \the [src]'s maintenance hatch."))
 						opened = TRUE
 						handle_panel_overlay()
-		else if (istype(W, /obj/item/stock_parts/matter_bin) && opened) // Installing/swapping a matter bin
+		else if(istype(W, /obj/item/stock_parts/matter_bin) && opened) // Installing/swapping a matter bin
 			if(storage)
 				to_chat(user, SPAN_NOTICE("You replace \the [storage] with \the [W]"))
 				storage.forceMove(get_turf(src))
@@ -742,7 +742,7 @@
 				C.brute_damage = 0
 				C.electronics_damage = 0
 				handle_panel_overlay()
-		else if (W.iswirecutter() || W.ismultitool())
+		else if(W.iswirecutter() || W.ismultitool())
 			if(wires_exposed)
 				wires.Interact(user)
 			else
@@ -878,14 +878,14 @@
 	<B>Installed Modules</B><BR><BR>"}
 
 
-	for (var/obj in module.modules)
-		if (!obj)
+	for(var/obj in module.modules)
+		if(!obj)
 			dat += text("<B>Resource depleted</B><BR>")
 		else if(activated(obj))
 			dat += text("[obj]: <B>Activated</B><BR>")
 		else
 			dat += text("[obj]: <A HREF=?src=\ref[src];act=\ref[obj]>Activate</A><BR>")
-	if (emagged)
+	if(emagged)
 		if(activated(module.emag))
 			dat += text("[module.emag]: <B>Activated</B><BR>")
 		else
@@ -1233,7 +1233,7 @@
 			clear_supplied_laws()
 			clear_inherent_laws()
 			laws = new /datum/ai_laws/syndicate_override
-			id_card.access = get_all_station_access() + access_synth // Give full station access
+			id_card.access = get_all_station_access() + access_equipment // Give full station access
 			var/time = time2text(world.realtime, "hh:mm:ss")
 			lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) emagged [name]([key])")
 			set_zeroth_law("Only [user.real_name] and people they designate as being such are operatives.")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -548,11 +548,18 @@
 	else
 		stat(null, text("No Cell Inserted!"))
 
+/mob/living/silicon/robot/proc/show_access()
+	if (!module)
+		stat(null, text("Access type: assistant level access"))
+	else
+		stat(null, text("Access type: [module.all_access ? "all access" : "role specific"]"))
+
 // update the status screen display
 /mob/living/silicon/robot/Stat()
 	..()
 	if(statpanel("Status"))
 		show_cell_power()
+		show_access()
 		show_jetpack_pressure()
 		stat(null, text("Lights: [lights_on ? "ON" : "OFF"]"))
 		if(module)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,6 +1,6 @@
 var/global/list/robot_modules = list(
 	"Service" 		= /obj/item/robot_module/service/butler,
-	"Clerical" 		= /obj/item/robot_module/service/general,
+	"Clerical" 		= /obj/item/robot_module/service/clerical,
 	"Research" 		= /obj/item/robot_module/research,
 	"Mining" 		= /obj/item/robot_module/miner,
 	"Rescue" 		= /obj/item/robot_module/medical/rescue,
@@ -20,21 +20,21 @@ var/global/list/robot_modules = list(
 	var/channels = list()
 	var/networks = list()
 	var/languages = list( // Any listed language will be understandable. Any set to TRUE will be speakable
-		LANGUAGE_SOL_COMMON =  TRUE,
-		LANGUAGE_ELYRAN_STANDARD = TRUE,
-		LANGUAGE_TRADEBAND =   TRUE,
-		LANGUAGE_UNATHI =      FALSE,
-		LANGUAGE_SIIK_MAAS =   FALSE,
-		LANGUAGE_SKRELLIAN =   FALSE,
-		LANGUAGE_GUTTER =      TRUE,
-		LANGUAGE_VAURCESE =    FALSE,
-		LANGUAGE_ROOTSONG =    FALSE,
-		LANGUAGE_SIGN =        FALSE,
-		LANGUAGE_SIGN_TAJARA = FALSE,
-		LANGUAGE_SIIK_TAJR =   FALSE,
-		LANGUAGE_AZAZIBA =     FALSE,
-		LANGUAGE_DELVAHII =    FALSE,
-		LANGUAGE_YA_SSA =      FALSE
+		LANGUAGE_SOL_COMMON =		TRUE,
+		LANGUAGE_ELYRAN_STANDARD =	TRUE,
+		LANGUAGE_TRADEBAND =		TRUE,
+		LANGUAGE_UNATHI =			FALSE,
+		LANGUAGE_SIIK_MAAS =		FALSE,
+		LANGUAGE_SKRELLIAN =		FALSE,
+		LANGUAGE_GUTTER =			TRUE,
+		LANGUAGE_VAURCESE =			FALSE,
+		LANGUAGE_ROOTSONG =			FALSE,
+		LANGUAGE_SIGN =				FALSE,
+		LANGUAGE_SIGN_TAJARA =		FALSE,
+		LANGUAGE_SIIK_TAJR =		FALSE,
+		LANGUAGE_AZAZIBA =			FALSE,
+		LANGUAGE_DELVAHII =			FALSE,
+		LANGUAGE_YA_SSA =			FALSE
 	)
 	var/sprites = list()
 	var/can_be_pushed = TRUE
@@ -50,7 +50,8 @@ var/global/list/robot_modules = list(
 	// Bookkeeping
 	var/list/original_languages = list()
 	var/list/added_networks = list()
-	var/specialized_access_type = /datum/job/assistant // an job we take access from. Used to mirror job's IDs for specific borg modules.
+	var/list/specialized_access_types = list(/datum/job/assistant) // an job we take access from. Used to mirror job's IDs for specific borg modules.
+	var/all_access = FALSE
 
 /obj/item/robot_module/Initialize(mapload, var/mob/living/silicon/robot/R)
 	. = ..()
@@ -210,7 +211,7 @@ var/global/list/robot_modules = list(
 		"Cooler Master" =  list(ROBOT_CHASSIS = "coolermaster_medi", ROBOT_PANEL = "coolermaster_medi", ROBOT_EYES = "coolermaster"),
 		"Phage" =          list(ROBOT_CHASSIS = "phage_medi", ROBOT_PANEL = "phage_medi", ROBOT_EYES = "phage")
 	)
-	specialized_access_type = /datum/job/doctor
+	specialized_access_types = list(/datum/job/doctor, /datum/job/surgeon)
 
 /obj/item/robot_module/medical/general/Initialize()
 	. = ..()
@@ -272,7 +273,7 @@ var/global/list/robot_modules = list(
 
 /obj/item/robot_module/medical/rescue
 	name = "rescue robot module"
-	specialized_access_type = /datum/job/med_tech
+	specialized_access_types = list(/datum/job/med_tech)
 // If anyone wants to make custom rescue robot sprites, be my guest.
 
 /obj/item/robot_module/medical/rescue/Initialize()
@@ -356,7 +357,7 @@ var/global/list/robot_modules = list(
 		"Cooler Master" =  list(ROBOT_CHASSIS = "coolermaster_engi", ROBOT_PANEL = "coolermaster", ROBOT_EYES = "coolermaster"),
 		"Phage" =          list(ROBOT_CHASSIS = "phage_engi", ROBOT_PANEL = "phage", ROBOT_EYES = "phage")
 	)
-	specialized_access_type = /datum/job/engineer
+	specialized_access_types = list(/datum/job/engineer, /datum/job/atmos)
 
 /obj/item/robot_module/engineering/construction
 	name = "construction robot module"
@@ -555,7 +556,7 @@ var/global/list/robot_modules = list(
 	)
 
 	var/mopping = FALSE
-	specialized_access_type = /datum/job/janitor
+	specialized_access_types = list(/datum/job/janitor)
 
 /obj/item/robot_module/janitor/Initialize()
 	. = ..()
@@ -626,7 +627,7 @@ var/global/list/robot_modules = list(
 		"Phage" =          list(ROBOT_CHASSIS = "phage_serv", ROBOT_PANEL = "phage", ROBOT_EYES = "phage")
 	)
 
-	specialized_access_type = /datum/job/janitor
+	specialized_access_types = list(/datum/job/bartender, /datum/job/chef, /datum/job/hydro)
 
 /obj/item/robot_module/service/butler/Initialize()
 	. = ..()
@@ -674,12 +675,13 @@ var/global/list/robot_modules = list(
 	RG.add_reagent(/decl/reagent/polysomnine/beer2, 50)
 	emag.name = "Mickey Finn's Special Brew"
 
-/obj/item/robot_module/service/general
+/obj/item/robot_module/service/clerical
 	name = "clerical robot module"
 	channels = list(CHANNEL_SUPPLY = TRUE, CHANNEL_COMMAND = TRUE)
 	networks = list(NETWORK_MINE)
+	specialized_access_types = list(/datum/job/janitor, /datum/job/librarian, /datum/job/hangar_tech)
 
-/obj/item/robot_module/service/general/Initialize()
+/obj/item/robot_module/service/clerical/Initialize()
 	. = ..()
 	modules += new /obj/item/pen/robopen(src)
 	modules += new /obj/item/form_printer(src)
@@ -725,6 +727,7 @@ var/global/list/robot_modules = list(
 	)
 
 	supported_upgrades = list(/obj/item/robot_parts/robot_component/jetpack)
+	specialized_access_types = list(/datum/job/mining, /datum/job/hangar_tech)
 
 /obj/item/robot_module/miner/Initialize()
 	. = ..()
@@ -790,6 +793,7 @@ var/global/list/robot_modules = list(
 		"Cooler Master" =  list(ROBOT_CHASSIS = "coolermaster_sci", ROBOT_PANEL = "coolermaster", ROBOT_EYES = "coolermaster"),
 		"Phage" =          list(ROBOT_CHASSIS = "phage_sci", ROBOT_PANEL = "phage", ROBOT_EYES = "phage")
 	)
+	specialized_access_types = list(/datum/job/scientist, /datum/job/xenobiologist, /datum/job/xenobotanist)
 
 /obj/item/robot_module/research/Initialize()
 	. = ..()
@@ -883,7 +887,7 @@ var/global/list/robot_modules = list(
 		"Cooler Master" =  list(ROBOT_CHASSIS = "coolermaster_syndi", ROBOT_PANEL = "coolermaster_syndi", ROBOT_EYES = "coolermaster"),
 		"Phage" =          list(ROBOT_CHASSIS = "phage_syndi", ROBOT_PANEL = "phage_syndi", ROBOT_EYES = "phage")
 	)
-
+	all_access = TRUE
 
 /obj/item/robot_module/combat/Initialize(mapload, mob/living/silicon/robot/R)
 	. = ..()
@@ -921,6 +925,7 @@ var/global/list/robot_modules = list(
 		)
 	can_be_pushed = FALSE
 	supported_upgrades = list(/obj/item/robot_parts/robot_component/jetpack)
+	all_access = TRUE
 
 /obj/item/robot_module/military/Initialize()
 	. = ..()
@@ -939,6 +944,7 @@ var/global/list/robot_modules = list(
 	name = "drone module"
 	no_slip = TRUE
 	networks = list(NETWORK_ENGINEERING)
+	all_access = TRUE
 
 /obj/item/robot_module/drone/Initialize(mapload, mob/living/silicon/robot/robot)
 	. = ..()
@@ -1038,6 +1044,7 @@ var/global/list/robot_modules = list(
 /obj/item/robot_module/drone/construction
 	name = "construction drone module"
 	channels = list(CHANNEL_ENGINEERING = TRUE)
+	all_access = TRUE
 
 /obj/item/robot_module/drone/construction/Initialize()
 	. = ..()
@@ -1052,6 +1059,7 @@ var/global/list/robot_modules = list(
 	no_slip = TRUE
 	channels = list(CHANNEL_SUPPLY = TRUE)
 	networks = list(NETWORK_MINE)
+	all_access = TRUE
 
 /obj/item/robot_module/mining_drone/Initialize(mapload, mob/living/silicon/robot/R)
 	. = ..()
@@ -1144,6 +1152,7 @@ var/global/list/robot_modules = list(
 	)
 	sprites = list("Roller" = list(ROBOT_CHASSIS = "droid-combat", ROBOT_PANEL = "heavy_syndi", ROBOT_EYES = "droid-combat")) //TMP // temp my left nut // temp my right nut
 	can_be_pushed = FALSE
+	all_access = TRUE
 
 /obj/item/robot_module/bluespace/Initialize(mapload, mob/living/silicon/robot/R)
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1,6 +1,6 @@
 var/global/list/robot_modules = list(
-	"Service" 		= /obj/item/robot_module/clerical/butler,
-	"Clerical" 		= /obj/item/robot_module/clerical/general,
+	"Service" 		= /obj/item/robot_module/service/butler,
+	"Clerical" 		= /obj/item/robot_module/service/general,
 	"Research" 		= /obj/item/robot_module/research,
 	"Mining" 		= /obj/item/robot_module/miner,
 	"Rescue" 		= /obj/item/robot_module/medical/rescue,
@@ -50,6 +50,7 @@ var/global/list/robot_modules = list(
 	// Bookkeeping
 	var/list/original_languages = list()
 	var/list/added_networks = list()
+	var/specialized_access_type = /datum/job/assistant // an job we take access from. Used to mirror job's IDs for specific borg modules.
 
 /obj/item/robot_module/Initialize(mapload, var/mob/living/silicon/robot/R)
 	. = ..()
@@ -209,6 +210,7 @@ var/global/list/robot_modules = list(
 		"Cooler Master" =  list(ROBOT_CHASSIS = "coolermaster_medi", ROBOT_PANEL = "coolermaster_medi", ROBOT_EYES = "coolermaster"),
 		"Phage" =          list(ROBOT_CHASSIS = "phage_medi", ROBOT_PANEL = "phage_medi", ROBOT_EYES = "phage")
 	)
+	specialized_access_type = /datum/job/doctor
 
 /obj/item/robot_module/medical/general/Initialize()
 	. = ..()
@@ -270,6 +272,7 @@ var/global/list/robot_modules = list(
 
 /obj/item/robot_module/medical/rescue
 	name = "rescue robot module"
+	specialized_access_type = /datum/job/med_tech
 // If anyone wants to make custom rescue robot sprites, be my guest.
 
 /obj/item/robot_module/medical/rescue/Initialize()
@@ -353,6 +356,7 @@ var/global/list/robot_modules = list(
 		"Cooler Master" =  list(ROBOT_CHASSIS = "coolermaster_engi", ROBOT_PANEL = "coolermaster", ROBOT_EYES = "coolermaster"),
 		"Phage" =          list(ROBOT_CHASSIS = "phage_engi", ROBOT_PANEL = "phage", ROBOT_EYES = "phage")
 	)
+	specialized_access_type = /datum/job/engineer
 
 /obj/item/robot_module/engineering/construction
 	name = "construction robot module"
@@ -551,6 +555,7 @@ var/global/list/robot_modules = list(
 	)
 
 	var/mopping = FALSE
+	specialized_access_type = /datum/job/janitor
 
 /obj/item/robot_module/janitor/Initialize()
 	. = ..()
@@ -578,7 +583,7 @@ var/global/list/robot_modules = list(
 		var/obj/item/reagent_containers/spray/S = emag
 		S.reagents.add_reagent(/decl/reagent/lube, 2 * amount)
 
-/obj/item/robot_module/clerical
+/obj/item/robot_module/service
 	name = "service robot module"
 	channels = list(CHANNEL_SERVICE = TRUE)
 	networks = list(NETWORK_SERVICE)
@@ -621,7 +626,9 @@ var/global/list/robot_modules = list(
 		"Phage" =          list(ROBOT_CHASSIS = "phage_serv", ROBOT_PANEL = "phage", ROBOT_EYES = "phage")
 	)
 
-/obj/item/robot_module/clerical/butler/Initialize()
+	specialized_access_type = /datum/job/janitor
+
+/obj/item/robot_module/service/butler/Initialize()
 	. = ..()
 	modules += new /obj/item/gripper/service(src)
 	modules += new /obj/item/reagent_containers/glass/bucket(src)
@@ -667,12 +674,12 @@ var/global/list/robot_modules = list(
 	RG.add_reagent(/decl/reagent/polysomnine/beer2, 50)
 	emag.name = "Mickey Finn's Special Brew"
 
-/obj/item/robot_module/clerical/general
+/obj/item/robot_module/service/general
 	name = "clerical robot module"
 	channels = list(CHANNEL_SUPPLY = TRUE, CHANNEL_COMMAND = TRUE)
 	networks = list(NETWORK_MINE)
 
-/obj/item/robot_module/clerical/general/Initialize()
+/obj/item/robot_module/service/general/Initialize()
 	. = ..()
 	modules += new /obj/item/pen/robopen(src)
 	modules += new /obj/item/form_printer(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -679,7 +679,7 @@ var/global/list/robot_modules = list(
 	name = "clerical robot module"
 	channels = list(CHANNEL_SUPPLY = TRUE, CHANNEL_COMMAND = TRUE)
 	networks = list(NETWORK_MINE)
-	specialized_access_types = list(/datum/job/janitor, /datum/job/librarian, /datum/job/hangar_tech)
+	specialized_access_types = list(/datum/job/janitor) // Janitor is a nice general access without specifics
 
 /obj/item/robot_module/service/clerical/Initialize()
 	. = ..()
@@ -727,7 +727,7 @@ var/global/list/robot_modules = list(
 	)
 
 	supported_upgrades = list(/obj/item/robot_parts/robot_component/jetpack)
-	specialized_access_types = list(/datum/job/mining, /datum/job/hangar_tech)
+	specialized_access_types = list(/datum/job/mining)
 
 /obj/item/robot_module/miner/Initialize()
 	. = ..()

--- a/html/changelogs/Sindorman-borgs.yml
+++ b/html/changelogs/Sindorman-borgs.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Reworked cyborg's access to be role specific and reflect their crewmate's access for the same role/department."
+  - rscadd: "Added ability to change cyborg's access in Robotics Control Console from role specific to all access and vice-versa."
+  - rscadd: "Added displaying of what access type cyborg has in status tab."

--- a/nano/templates/robot_control.tmpl
+++ b/nano/templates/robot_control.tmpl
@@ -75,7 +75,7 @@
 			</span>
 			<span class="itemContent">
 				{{if value.access == 0}}
-					{{:helper.link('Role specific access', 'locked', {'access' : value.name})}}
+					{{:helper.link('Role Specific Access', 'locked', {'access' : value.name})}}
 				{{else}}
 					{{:helper.link('All Access', 'unlocked', {'access' : value.name})}}
 				{{/if}}
@@ -98,7 +98,7 @@
 			</span>
 			{{if value.hackable}}
 				<span class="itemLabel">
-					Hacking action: 
+					Hacking Action: 
 				</span>
 				<span class="itemContent">
 					{{:helper.link('Hack', 'calculator', {'hack' : value.name}, null, 'redButton')}}

--- a/nano/templates/robot_control.tmpl
+++ b/nano/templates/robot_control.tmpl
@@ -70,14 +70,39 @@
 			<b> N/A %</b>
 		{{/if}}
 		<h3>Actions</h3>
-			{{if value.status == "Operational"}}
-				{{:helper.link('Lockdown', 'locked', {'lockdown' : value.name})}}
-			{{else}}
-				{{:helper.link('Unlock', 'unlocked', {'lockdown' : value.name})}}
-			{{/if}}
+			<span class="itemLabel">
+				Access: 
+			</span>
+			<span class="itemContent">
+				{{if value.access == 0}}
+					{{:helper.link('Role specific access', 'locked', {'access' : value.name})}}
+				{{else}}
+					{{:helper.link('All Access', 'unlocked', {'access' : value.name})}}
+				{{/if}}
+			</span>
+			<span class="itemLabel">
+				Lockdown Status: 
+			</span>
+			<span class="itemContent">
+				{{if value.status == "Operational"}}
+					{{:helper.link('Lockdown', 'locked', {'lockdown' : value.name})}}
+				{{else}}
+					{{:helper.link('Unlock', 'unlocked', {'lockdown' : value.name})}}
+				{{/if}}
+			</span>
+			<span class="itemLabel">
+				Self Destruct: 
+			</span>
+			<span class="itemContent">
 				{{:helper.link('Self-Destruct', 'radiation', {'detonate' : value.name}, null, 'redButton')}}
+			</span>
 			{{if value.hackable}}
-				{{:helper.link('Hack', 'calculator', {'hack' : value.name}, null, 'redButton')}}
+				<span class="itemLabel">
+					Hacking action: 
+				</span>
+				<span class="itemContent">
+					{{:helper.link('Hack', 'calculator', {'hack' : value.name}, null, 'redButton')}}
+				</span>
 			{{/if}}
 	</div>
 {{/for}}


### PR DESCRIPTION
This PR is part of changes suggested in [this thread](https://forums.aurorastation.org/topic/17691-suggested-cyborgs-changes/). This is first steps in reworking cyborgs. Changes:

- Reworked Cyborg's access to be role specific to mirror the access their crew counterparts have. Drones, combat, millitary, and bluespace borgs still have all access by default and cannot be changed.
- Added ability to change Cyborg's access from role specific to all access and vice-versa in Robotics control console.
- Added display of access type in the status tab
- Misc cyborg code cleanup
