### PR TITLE
Tweaks Audible Emote Visual Feedback

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -34,10 +34,11 @@
 #define HAS_FBP           0x80   // If for whatever ungodly reason we decide to ever have non-Shell FBPs.
 #define HAS_SKIN_PRESET   0x100  // Skin color presets selectable in character generation.
 
-// Tau-Ceti basic, language common to all crew.
+// Innate Languages
+#define LANGUAGE_NOISE "Noise" // Used for audible emotes.
 #define LANGUAGE_TCB "Ceti Basic"
 
-// Species languages
+// Species Languages
 #define LANGUAGE_SOL_COMMON "Sol Common"
 #define LANGUAGE_ELYRAN_STANDARD "Elyran Standard"
 #define LANGUAGE_UNATHI "Sinta'unathi"

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -319,6 +319,18 @@
 			break
 	return copytext_char(t, 1, i) + uppertext(copytext_char(t, i, i + 1)) + copytext_char(t, i + 1)
 
+//Returns a string with the first element of the string uncapitalized, ignoring html-tags
+/proc/uncapitalize(t as text)
+	var/i = 1
+	while(copytext_char(t, i, i + 1) == "<")
+		i = findtext_char(t, ">", i + 1)
+		if(i)
+			i++
+		else
+			i = 2
+			break
+	return copytext_char(t, 1, i) + lowertext(copytext_char(t, i, i + 1)) + copytext_char(t, i + 1)
+
 //This proc strips html properly, remove < > and all text between
 //for complete text sanitizing should be used sanitize()
 /proc/strip_html_properly(input)

--- a/code/modules/mob/floating_messages.dm
+++ b/code/modules/mob/floating_messages.dm
@@ -23,6 +23,9 @@ var/list/floating_chat_colors = list()
 		limit = 30
 		style += "font-weight: bold;"
 
+	if(istype(language, /datum/language/noise))
+		message = "<font color='#7F7F7F'>*</font> " + uncapitalize(message)
+
 	if(length(message) > limit)
 		message = "[copytext(message, 1, limit)]..."
 

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -76,7 +76,7 @@
 // Sign language
 /datum/language/sign
 	name = LANGUAGE_SIGN
-	desc = "A signed version of Ceti Basic, though its intent is primarily to help out people who are deaf and mute."
+	desc = "A signed version of Tau Ceti Basic. It is primarily used by those who are deaf, hearing impaired, or mute."
 	speech_verb = list("signs")
 	signlang_verb = list("signs", "gestures")
 	sing_verb = null

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -1,9 +1,9 @@
 // Noise "language", for audible emotes.
 /datum/language/noise
-	name = "Noise"
-	desc = "Noises"
+	name = LANGUAGE_NOISE
+	desc = "Noises."
 	key = ""
-	flags = RESTRICTED|NONGLOBAL|INNATE|NO_TALK_MSG|NO_STUTTER|TCOMSSIM
+	flags = RESTRICTED | NONGLOBAL | INNATE | NO_TALK_MSG | NO_STUTTER | TCOMSSIM
 	allow_accents = TRUE
 
 /datum/language/noise/format_message(message, verb)
@@ -76,13 +76,13 @@
 // Sign language
 /datum/language/sign
 	name = LANGUAGE_SIGN
-	desc = "A signed version of Ceti Basic, though its intent is primarily to help out people who are deaf and mute, "
+	desc = "A signed version of Ceti Basic, though its intent is primarily to help out people who are deaf and mute."
 	speech_verb = list("signs")
 	signlang_verb = list("signs", "gestures")
 	sing_verb = null
 	colour = "i"
 	key = "s"
-	flags = NO_STUTTER|SIGNLANG
+	flags = NO_STUTTER | SIGNLANG
 
 // Helper
 /proc/get_lang_name(var/datum/language/language)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -146,7 +146,7 @@
 /mob/proc/parse_language(var/message)
 	var/prefix = copytext(message,1,2)
 	if(length(message) >= 1 && prefix == "!")
-		return all_languages["Noise"]
+		return all_languages[LANGUAGE_NOISE]
 
 	if(length(message) >= 2 && is_language_prefix(prefix))
 		var/language_prefix = lowertext(copytext(message, 2, 4))

--- a/html/changelogs/audible_emote_marker.yml
+++ b/html/changelogs/audible_emote_marker.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - tweak: "Makes overhead text for audible emotes visually separate from regular talking."


### PR DESCRIPTION
this PR makes overhead text for audible emotes visually separate from regular talking.

## screenshots
<details>
<summary>🖼️ click to view</summary>

![image](https://user-images.githubusercontent.com/99297919/203654287-e36fb7d3-c733-4304-a2ba-591e2c852f2c.png)
**figure 1:** demonstration of the visual feedback.
</details>