### PR TITLE
Tajaran ships fixes and improvements

### DIFF
--- a/html/changelogs/alberyk-tajshifixes.yml
+++ b/html/changelogs/alberyk-tajshifixes.yml
@@ -1,0 +1,8 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed some mapping issues in some Tajaran ships."
+  - tweak: "The scrapper and the mining jack ghost roles now spawn inside the ship."
+  - tweak: "Added some food to the mining jack base."

--- a/maps/away/away_site/tajara/mining_jack/mining_jack.dmm
+++ b/maps/away/away_site/tajara/mining_jack/mining_jack.dmm
@@ -502,13 +502,13 @@
 	},
 /area/mining_jack_outpost/atmos)
 "hb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating{
 	temperature = 278.15
@@ -532,8 +532,9 @@
 	},
 /area/mining_jack_outpost/smelter)
 "hi" = (
-/obj/effect/map_effect/airlock/e_to_w,
-/obj/effect/map_effect/window_spawner/reinforced/firedoor,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -689,7 +690,9 @@
 	},
 /area/mining_jack_outpost/smelter)
 "jP" = (
-/obj/effect/map_effect/window_spawner/reinforced/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 1
+	},
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -1666,6 +1669,14 @@
 	temperature = 278.15
 	},
 /area/shuttle/mining_jack/engines)
+"Cn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/shuttle/mining_jack/engines)
 "CD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/structure/cable/green{
@@ -1955,7 +1966,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -2129,12 +2142,8 @@
 	},
 /area/mining_jack_outpost/smelter)
 "Nv" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
+/obj/effect/map_effect/airlock/e_to_w/long/square/wide,
+/turf/simulated/wall/shuttle/raider,
 /area/shuttle/mining_jack/engines)
 "NC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -32004,11 +32013,11 @@ wc
 YW
 YW
 YW
-wc
-wc
-wc
-wc
-wc
+YW
+yQ
+YW
+Nv
+Yz
 wc
 ww
 ww
@@ -32261,11 +32270,11 @@ wc
 PK
 vP
 YW
-wc
-jP
-yQ
-hi
-wc
+Yz
+Yz
+Yz
+YW
+Yz
 wc
 wc
 wc
@@ -32518,11 +32527,11 @@ oP
 yr
 sI
 YW
-wc
-jP
+Yz
+Yz
 Yj
-jP
-wc
+YW
+Yz
 wc
 wc
 wc
@@ -32776,9 +32785,9 @@ YW
 WM
 YW
 YW
-jP
 Yz
-jP
+YW
+YW
 YW
 tc
 Oc
@@ -33031,10 +33040,10 @@ wc
 NK
 YW
 ZZ
-Nv
 fG
 DS
 Xt
+Yz
 TQ
 zX
 tc
@@ -33288,8 +33297,8 @@ Qp
 NK
 YW
 EE
-Yz
 ZZ
+Yz
 Yz
 Yz
 qH
@@ -33545,12 +33554,12 @@ wc
 NK
 YW
 mk
-Yz
-oR
-Yz
+nb
+jP
+Cn
 Du
 oR
-Yz
+hi
 tc
 aN
 Wd
@@ -33803,8 +33812,8 @@ GK
 YW
 YW
 KQ
-hb
 Av
+hb
 OH
 aE
 ug
@@ -34060,7 +34069,7 @@ Ec
 YW
 yF
 hl
-nb
+Yz
 HL
 pQ
 Cl

--- a/maps/away/away_site/tajara/mining_jack/mining_jack.dmm
+++ b/maps/away/away_site/tajara/mining_jack/mining_jack.dmm
@@ -502,13 +502,8 @@
 	},
 /area/mining_jack_outpost/atmos)
 "hb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 10
 	},
 /turf/simulated/floor/plating{
 	temperature = 278.15
@@ -532,8 +527,8 @@
 	},
 /area/mining_jack_outpost/smelter)
 "hi" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 1
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
 	},
 /turf/simulated/floor/plating{
 	temperature = 278.15
@@ -805,14 +800,6 @@
 	temperature = 278.15
 	},
 /area/mining_jack_outpost/hangar)
-"le" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
-/area/shuttle/mining_jack/engines)
 "lk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/machinery/meter,
@@ -953,8 +940,13 @@
 	},
 /area/shuttle/mining_jack/engines)
 "nb" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 4
 	},
 /turf/simulated/floor/plating{
 	temperature = 278.15
@@ -1850,6 +1842,14 @@
 	temperature = 278.15
 	},
 /area/mining_jack_outpost/smelter)
+"Fo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/shuttle/mining_jack/engines)
 "FJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2138,8 +2138,8 @@
 	},
 /area/mining_jack_outpost/smelter)
 "Nv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 1
 	},
 /turf/simulated/floor/plating{
 	temperature = 278.15
@@ -33554,12 +33554,12 @@ wc
 NK
 YW
 mk
-nb
-hi
+hb
 Nv
+Fo
 Du
 oR
-le
+hi
 tc
 aN
 Wd
@@ -33813,7 +33813,7 @@ YW
 YW
 KQ
 Av
-hb
+nb
 OH
 aE
 ug

--- a/maps/away/away_site/tajara/mining_jack/mining_jack.dmm
+++ b/maps/away/away_site/tajara/mining_jack/mining_jack.dmm
@@ -532,8 +532,8 @@
 	},
 /area/mining_jack_outpost/smelter)
 "hi" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 1
 	},
 /turf/simulated/floor/plating{
 	temperature = 278.15
@@ -690,12 +690,8 @@
 	},
 /area/mining_jack_outpost/smelter)
 "jP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 1
-	},
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
+/obj/effect/map_effect/airlock/e_to_w/long/square/wide,
+/turf/simulated/wall/shuttle/raider,
 /area/shuttle/mining_jack/engines)
 "jV" = (
 /obj/machinery/computer/shuttle_control/explore/tajara_mining_jack,
@@ -809,6 +805,14 @@
 	temperature = 278.15
 	},
 /area/mining_jack_outpost/hangar)
+"le" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/shuttle/mining_jack/engines)
 "lk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /obj/machinery/meter,
@@ -1669,14 +1673,6 @@
 	temperature = 278.15
 	},
 /area/shuttle/mining_jack/engines)
-"Cn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
-/area/shuttle/mining_jack/engines)
 "CD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/structure/cable/green{
@@ -2142,8 +2138,12 @@
 	},
 /area/mining_jack_outpost/smelter)
 "Nv" = (
-/obj/effect/map_effect/airlock/e_to_w/long/square/wide,
-/turf/simulated/wall/shuttle/raider,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
 /area/shuttle/mining_jack/engines)
 "NC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -32016,8 +32016,8 @@ YW
 YW
 yQ
 YW
-Nv
-Yz
+jP
+wc
 wc
 ww
 ww
@@ -32274,7 +32274,7 @@ Yz
 Yz
 Yz
 YW
-Yz
+wc
 wc
 wc
 wc
@@ -32531,7 +32531,7 @@ Yz
 Yz
 Yj
 YW
-Yz
+wc
 wc
 wc
 wc
@@ -33555,11 +33555,11 @@ NK
 YW
 mk
 nb
-jP
-Cn
+hi
+Nv
 Du
 oR
-hi
+le
 tc
 aN
 Wd

--- a/maps/away/away_site/tajara/mining_jack/mining_jack.dmm
+++ b/maps/away/away_site/tajara/mining_jack/mining_jack.dmm
@@ -206,6 +206,21 @@
 	req_one_access = list(202);
 	pixel_y = 32
 	},
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/obj/item/reagent_containers/food/drinks/waterbottle,
+/obj/item/reagent_containers/food/snacks/adhomian_can,
+/obj/item/reagent_containers/food/snacks/adhomian_can,
+/obj/item/reagent_containers/food/snacks/adhomian_can,
+/obj/item/reagent_containers/food/snacks/adhomian_can,
+/obj/item/reagent_containers/food/snacks/adhomian_can,
+/obj/item/reagent_containers/food/snacks/hardbread,
+/obj/item/reagent_containers/food/snacks/hardbread,
+/obj/item/reagent_containers/food/snacks/hardbread,
 /turf/simulated/floor/tiled/steel{
 	temperature = 278.15
 	},
@@ -618,6 +633,10 @@
 	brightness_color = "#FA8282";
 	dir = 1
 	},
+/obj/effect/ghostspawpoint{
+	identifier = "tajara_mining_jack";
+	name = "igs - tajara_mining_jack"
+	},
 /turf/simulated/floor/tiled/steel{
 	temperature = 278.15
 	},
@@ -872,10 +891,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/ghostspawpoint{
-	identifier = "tajara_mining_jack";
-	name = "igs - tajara_mining_jack"
-	},
 /turf/simulated/floor/tiled/steel{
 	temperature = 278.15
 	},
@@ -1068,6 +1083,10 @@
 	brightness_color = "#FA8282";
 	dir = 1
 	},
+/obj/effect/ghostspawpoint{
+	identifier = "tajara_mining_jack";
+	name = "igs - tajara_mining_jack"
+	},
 /turf/simulated/floor/tiled/steel{
 	temperature = 278.15
 	},
@@ -1216,10 +1235,6 @@
 	pixel_x = -24;
 	req_access = list(202)
 	},
-/obj/effect/ghostspawpoint{
-	identifier = "tajara_mining_jack";
-	name = "igs - tajara_mining_jack"
-	},
 /turf/simulated/floor/tiled/steel{
 	temperature = 278.15
 	},
@@ -1309,6 +1324,10 @@
 /area/mining_jack_outpost/atmos)
 "vA" = (
 /obj/structure/bed/stool/chair/shuttle,
+/obj/effect/ghostspawpoint{
+	identifier = "tajara_mining_jack";
+	name = "igs - tajara_mining_jack"
+	},
 /turf/simulated/floor/tiled/steel{
 	temperature = 278.15
 	},
@@ -1636,11 +1655,11 @@
 	},
 /area/mining_jack_outpost/atmos)
 "Cl" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating{
@@ -2564,10 +2583,6 @@
 "ZR" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 32
-	},
-/obj/effect/ghostspawpoint{
-	identifier = "tajara_mining_jack";
-	name = "igs - tajara_mining_jack"
 	},
 /turf/simulated/floor/tiled/steel{
 	temperature = 278.15

--- a/maps/away/away_site/tajara/mining_jack/mining_jack_ghostroles.dm
+++ b/maps/away/away_site/tajara/mining_jack/mining_jack_ghostroles.dm
@@ -18,7 +18,7 @@
 	uses_species_whitelist = FALSE
 
 /datum/outfit/admin/tajara_mining_jack
-	name = "Tajaran Miner"
+	name = "Mining Jack Miner"
 
 	uniform = list(
 				/obj/item/clothing/under/serviceoveralls,

--- a/maps/away/away_site/tajara/scrapper/scrapper.dmm
+++ b/maps/away/away_site/tajara/scrapper/scrapper.dmm
@@ -901,6 +901,10 @@
 "lw" = (
 /obj/structure/bed/stool/chair/shuttle,
 /obj/effect/floor_decal/corner/beige,
+/obj/effect/ghostspawpoint{
+	identifier = "tajaran_scrapper";
+	name = "igs - tajaran_scrapper"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/scrapper_ship/bridge)
 "lA" = (
@@ -1180,10 +1184,6 @@
 /area/scrapper_base)
 "ot" = (
 /obj/structure/bed/stool/chair/sofa/right/black,
-/obj/effect/ghostspawpoint{
-	identifier = "tajaran_scrapper";
-	name = "igs - tajaran_scrapper"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/scrapper_base/quarters)
 "ov" = (
@@ -2687,6 +2687,10 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 8
 	},
+/obj/effect/ghostspawpoint{
+	identifier = "tajaran_scrapper";
+	name = "igs - tajaran_scrapper"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/scrapper_ship/bridge)
 "HM" = (
@@ -2907,10 +2911,6 @@
 /area/scrapper_base)
 "Kl" = (
 /obj/structure/bed/stool/chair/sofa/black,
-/obj/effect/ghostspawpoint{
-	identifier = "tajaran_scrapper";
-	name = "igs - tajaran_scrapper"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/scrapper_base/quarters)
 "Kn" = (
@@ -2996,10 +2996,6 @@
 /area/scrapper_base)
 "LB" = (
 /obj/structure/bed/stool/chair/sofa/left/black,
-/obj/effect/ghostspawpoint{
-	identifier = "tajaran_scrapper";
-	name = "igs - tajaran_scrapper"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/scrapper_base/quarters)
 "LC" = (
@@ -3722,6 +3718,10 @@
 /area/scrapper_base/storage)
 "Ue" = (
 /obj/structure/bed/stool/chair/shuttle,
+/obj/effect/ghostspawpoint{
+	identifier = "tajaran_scrapper";
+	name = "igs - tajaran_scrapper"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/scrapper_ship/bridge)
 "Uh" = (

--- a/maps/away/away_site/tajara/scrapper/scrapper_ghostroles.dm
+++ b/maps/away/away_site/tajara/scrapper/scrapper_ghostroles.dm
@@ -18,7 +18,7 @@
 	uses_species_whitelist = FALSE
 
 /datum/outfit/admin/tajaran_scrapper
-	name = "Tajaran Scrapper"
+	name = "Scrapper"
 
 	uniform = list(
 				/obj/item/clothing/under/serviceoveralls,

--- a/maps/away/ships/pra/database_freighter/database_freighter.dmm
+++ b/maps/away/ships/pra/database_freighter/database_freighter.dmm
@@ -830,11 +830,7 @@
 	},
 /area/database_freighter/checkpoint)
 "dw" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/portgen/basic/fusion,
+/obj/structure/reagent_dispensers/coolanttank,
 /turf/simulated/floor/plating,
 /area/database_freighter/engine)
 "dy" = (
@@ -1672,12 +1668,26 @@
 	},
 /area/database_freighter/storage)
 "hJ" = (
-/obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "database_bridge"
+/obj/effect/floor_decal/corner/red{
+	dir = 5
 	},
-/turf/simulated/floor{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 2;
+	id = "database_checkpoint";
+	icon_state = "pdoor0"
+	},
+/turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
 /area/database_freighter)
@@ -1982,11 +1992,6 @@
 /area/database_freighter)
 "jJ" = (
 /obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "database_bridge";
-	icon_state = "pdoor0"
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	id = "database_bridge"
@@ -3041,10 +3046,6 @@
 	},
 /turf/template_noop,
 /area/space)
-"uT" = (
-/obj/structure/reagent_dispensers/coolanttank,
-/turf/simulated/floor/plating,
-/area/database_freighter/engine)
 "uV" = (
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/plating,
@@ -3519,6 +3520,16 @@
 	temperature = 278.15
 	},
 /area/database_freighter/laboratory)
+"Cu" = (
+/obj/effect/map_effect/window_spawner/reinforced/firedoor,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "database_bridge"
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/database_freighter)
 "Cx" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/bio_suit/anomaly,
@@ -3659,29 +3670,13 @@
 /turf/template_noop,
 /area/space)
 "Ea" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "database_checkpoint";
-	icon_state = "pdoor0"
-	},
-/turf/simulated/floor/tiled/dark{
-	temperature = 278.15
-	},
-/area/database_freighter)
+/obj/machinery/power/portgen/basic/fusion,
+/turf/simulated/floor/plating,
+/area/database_freighter/engine)
 "Eh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark{
@@ -4304,11 +4299,6 @@
 /area/database_freighter/engine)
 "PH" = (
 /obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "database_bridge";
-	icon_state = "pdoor0"
-	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -11519,7 +11509,7 @@ fP
 BF
 BF
 iF
-hJ
+Zq
 iB
 iB
 mb
@@ -11681,7 +11671,7 @@ vo
 BF
 BF
 bs
-hJ
+Zq
 iB
 iB
 mb
@@ -11843,7 +11833,7 @@ ki
 BF
 BF
 ew
-hJ
+Cu
 iB
 iB
 mb
@@ -12816,7 +12806,7 @@ XZ
 XZ
 bu
 mb
-Ea
+hJ
 yr
 mb
 mb
@@ -13117,7 +13107,7 @@ iB
 iB
 iB
 xw
-uT
+dw
 Nm
 rj
 xw
@@ -13279,7 +13269,7 @@ iB
 iB
 iB
 xw
-dw
+Ea
 Db
 rj
 xw
@@ -13626,7 +13616,7 @@ Nf
 ge
 yo
 mb
-Ea
+hJ
 mj
 mb
 Kf

--- a/maps/away/ships/pra/database_freighter/database_freighter.dmm
+++ b/maps/away/ships/pra/database_freighter/database_freighter.dmm
@@ -1775,7 +1775,8 @@
 "ik" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/shoes/tajara/jackboots,
-/obj/item/clothing/under/tajaran/database_freighter,
+/obj/item/clothing/under/tajaran/database_freighter/captain,
+/obj/item/clothing/suit/storage/toggle/labcoat,
 /turf/simulated/floor/wood{
 	temperature = 278.15
 	},
@@ -2070,7 +2071,9 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/obj/machinery/media/jukebox/phonograph,
+/obj/machinery/media/jukebox/phonograph{
+	anchored = 1
+	},
 /obj/structure/table/wood,
 /obj/machinery/light{
 	dir = 1

--- a/maps/away/ships/pra/database_freighter/database_freighter.dmm
+++ b/maps/away/ships/pra/database_freighter/database_freighter.dmm
@@ -830,11 +830,7 @@
 	},
 /area/database_freighter/checkpoint)
 "dw" = (
-/obj/machinery/power/portgen/basic/advanced,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/structure/reagent_dispensers/coolanttank,
 /turf/simulated/floor/plating,
 /area/database_freighter/engine)
 "dy" = (
@@ -3045,6 +3041,14 @@
 	temperature = 278.15
 	},
 /area/database_freighter)
+"uq" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/portgen/basic/fusion,
+/turf/simulated/floor/plating,
+/area/database_freighter/engine)
 "ux" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
@@ -3959,11 +3963,9 @@
 /area/database_freighter/engine)
 "Jv" = (
 /obj/structure/closet/crate/secure/large,
-/obj/item/stack/material/uranium/full,
-/obj/item/stack/material/uranium/full,
-/obj/item/stack/material/uranium/full,
-/obj/item/stack/material/uranium/full,
-/obj/item/stack/material/uranium/full,
+/obj/item/stack/material/tritium/full,
+/obj/item/stack/material/tritium/full,
+/obj/item/stack/material/tritium/full,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -4168,14 +4170,12 @@
 /area/database_freighter/hangar)
 "Nm" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_y = 10
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -13304,7 +13304,7 @@ iB
 iB
 iB
 xw
-dw
+uq
 Db
 rj
 xw

--- a/maps/away/ships/pra/database_freighter/database_freighter.dmm
+++ b/maps/away/ships/pra/database_freighter/database_freighter.dmm
@@ -830,7 +830,11 @@
 	},
 /area/database_freighter/checkpoint)
 "dw" = (
-/obj/structure/reagent_dispensers/coolanttank,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/portgen/basic/fusion,
 /turf/simulated/floor/plating,
 /area/database_freighter/engine)
 "dy" = (
@@ -1668,26 +1672,12 @@
 	},
 /area/database_freighter/storage)
 "hJ" = (
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "database_checkpoint";
-	icon_state = "pdoor0"
+/obj/effect/map_effect/window_spawner/reinforced/firedoor,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "database_bridge"
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark{
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/database_freighter)
@@ -1846,10 +1836,10 @@
 "iK" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1380;
-	id_tag = "headmaster_shuttle_dock";
 	req_one_access = list(31,48,67);
 	tag_door = "mining_shuttle_dock_doors";
-	pixel_x = -25
+	pixel_x = -25;
+	id_tag = "database_freighter_shuttle_dock"
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -1996,6 +1986,10 @@
 	dir = 2;
 	id = "database_bridge";
 	icon_state = "pdoor0"
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "database_bridge"
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -2425,14 +2419,14 @@
 	},
 /area/database_freighter/engineering)
 "mj" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 10;
+	icon_state = "corner_white"
+	},
 /obj/machinery/door/blast/regular{
 	dir = 2;
 	id = "database_checkpoint";
 	icon_state = "pdoor0"
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 10;
-	icon_state = "corner_white"
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -2440,10 +2434,9 @@
 /area/database_freighter)
 "mk" = (
 /obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 8;
-	id = "database_bridge";
-	icon_state = "pdoor0"
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "database_bridge"
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -2472,13 +2465,12 @@
 /area/database_freighter/barracks)
 "mr" = (
 /obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 8;
-	id = "database_bridge";
-	icon_state = "pdoor0"
-	},
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, bridge"
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "database_bridge"
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -3041,14 +3033,6 @@
 	temperature = 278.15
 	},
 /area/database_freighter)
-"uq" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/portgen/basic/fusion,
-/turf/simulated/floor/plating,
-/area/database_freighter/engine)
 "ux" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
@@ -3057,6 +3041,10 @@
 	},
 /turf/template_noop,
 /area/space)
+"uT" = (
+/obj/structure/reagent_dispensers/coolanttank,
+/turf/simulated/floor/plating,
+/area/database_freighter/engine)
 "uV" = (
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/plating,
@@ -3235,11 +3223,6 @@
 /turf/simulated/wall/shuttle/raider,
 /area/database_freighter/hangar)
 "yr" = (
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "database_checkpoint";
-	icon_state = "pdoor0"
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 10;
 	icon_state = "corner_white"
@@ -3248,6 +3231,11 @@
 	req_one_access = list(209);
 	dir = 1;
 	pixel_y = -32
+	},
+/obj/machinery/door/blast/regular{
+	dir = 2;
+	id = "database_checkpoint";
+	icon_state = "pdoor0"
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -3671,11 +3659,6 @@
 /turf/template_noop,
 /area/space)
 "Ea" = (
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "database_checkpoint";
-	icon_state = "pdoor0"
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
@@ -3690,8 +3673,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/blast/regular{
+	dir = 2;
+	id = "database_checkpoint";
+	icon_state = "pdoor0"
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -4413,11 +4398,6 @@
 /area/database_freighter)
 "Rg" = (
 /obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 8;
-	id = "database_bridge";
-	icon_state = "pdoor0"
-	},
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, hull"
 	},
@@ -4800,11 +4780,6 @@
 /area/database_freighter/captain_quarters)
 "Zq" = (
 /obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 8;
-	id = "database_bridge";
-	icon_state = "pdoor0"
-	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -11544,7 +11519,7 @@ fP
 BF
 BF
 iF
-Zq
+hJ
 iB
 iB
 mb
@@ -11706,7 +11681,7 @@ vo
 BF
 BF
 bs
-Zq
+hJ
 iB
 iB
 mb
@@ -11868,7 +11843,7 @@ ki
 BF
 BF
 ew
-Zq
+hJ
 iB
 iB
 mb
@@ -12841,7 +12816,7 @@ XZ
 XZ
 bu
 mb
-hJ
+Ea
 yr
 mb
 mb
@@ -13142,7 +13117,7 @@ iB
 iB
 iB
 xw
-dw
+uT
 Nm
 rj
 xw
@@ -13304,7 +13279,7 @@ iB
 iB
 iB
 xw
-uq
+dw
 Db
 rj
 xw
@@ -13489,7 +13464,7 @@ Zf
 Zf
 Zf
 mb
-eX
+gh
 PV
 pN
 nz

--- a/maps/away/ships/pra/database_freighter/database_freighter.dmm
+++ b/maps/away/ships/pra/database_freighter/database_freighter.dmm
@@ -3963,6 +3963,12 @@
 	temperature = 278.15
 	},
 /area/database_freighter/barracks)
+"JX" = (
+/obj/effect/landmark{
+	name = "carpspawn"
+	},
+/turf/template_noop,
+/area/space)
 "JZ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7447,7 +7453,7 @@ iB
 iB
 iB
 iB
-iB
+JX
 iB
 iB
 iB
@@ -8436,7 +8442,7 @@ iB
 iB
 iB
 iB
-iB
+JX
 iB
 iB
 iB
@@ -8565,7 +8571,7 @@ iB
 iB
 iB
 iB
-iB
+JX
 iB
 iB
 iB
@@ -10239,7 +10245,7 @@ iB
 iB
 iB
 iB
-iB
+JX
 iB
 iB
 iB
@@ -12931,7 +12937,7 @@ iB
 iB
 iB
 iB
-iB
+JX
 iB
 iB
 iB
@@ -13637,7 +13643,7 @@ iB
 iB
 iB
 iB
-iB
+JX
 iB
 iB
 iB
@@ -15262,7 +15268,7 @@ iB
 iB
 iB
 iB
-iB
+JX
 iB
 iB
 iB
@@ -16192,7 +16198,7 @@ iB
 iB
 iB
 iB
-iB
+JX
 iB
 iB
 iB
@@ -18487,7 +18493,7 @@ iB
 iB
 iB
 iB
-iB
+JX
 iB
 iB
 iB
@@ -18766,7 +18772,7 @@ iB
 iB
 iB
 iB
-iB
+JX
 iB
 iB
 iB
@@ -19594,7 +19600,7 @@ iB
 iB
 iB
 iB
-iB
+JX
 iB
 iB
 iB

--- a/maps/away/ships/pra/database_freighter/database_freighter.dmm
+++ b/maps/away/ships/pra/database_freighter/database_freighter.dmm
@@ -1682,10 +1682,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/blast/regular{
+/obj/machinery/door/blast/regular/open{
 	dir = 2;
-	id = "database_checkpoint";
-	icon_state = "pdoor0"
+	id = "database_checkpoint"
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -2428,10 +2427,9 @@
 	dir = 10;
 	icon_state = "corner_white"
 	},
-/obj/machinery/door/blast/regular{
+/obj/machinery/door/blast/regular/open{
 	dir = 2;
-	id = "database_checkpoint";
-	icon_state = "pdoor0"
+	id = "database_checkpoint"
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -3233,10 +3231,9 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/obj/machinery/door/blast/regular{
+/obj/machinery/door/blast/regular/open{
 	dir = 2;
-	id = "database_checkpoint";
-	icon_state = "pdoor0"
+	id = "database_checkpoint"
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -3520,16 +3517,6 @@
 	temperature = 278.15
 	},
 /area/database_freighter/laboratory)
-"Cu" = (
-/obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "database_bridge"
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/database_freighter)
 "Cx" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/bio_suit/anomaly,
@@ -4390,6 +4377,16 @@
 /obj/effect/map_effect/window_spawner/reinforced/firedoor,
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, hull"
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/database_freighter)
+"Rs" = (
+/obj/effect/map_effect/window_spawner/reinforced/firedoor,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "database_bridge"
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -11833,7 +11830,7 @@ ki
 BF
 BF
 ew
-Cu
+Rs
 iB
 iB
 mb

--- a/maps/away/ships/pra/database_freighter/database_freighter_ghostroles.dm
+++ b/maps/away/ships/pra/database_freighter/database_freighter_ghostroles.dm
@@ -9,7 +9,7 @@
 	uses_species_whitelist = FALSE
 	respawn_flag = null
 
-	outfit = /datum/outfit/admin/headmaster_kosmostrelki
+	outfit = /datum/outfit/admin/database_freighter_crew
 	possible_species = list(SPECIES_TAJARA, SPECIES_TAJARA_MSAI, SPECIES_TAJARA_ZHAN)
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dm
@@ -85,6 +85,7 @@
 	shuttle_area = list(/area/shuttle/headmaster_shuttle)
 	current_location = "nav_headmaster_shuttle"
 	landmark_transition = "nav_transit_headmaster_shuttle"
+	dock_target = "headmaster_shuttle"
 	range = 1
 	fuel_consumption = 2
 	logging_home_tag = "nav_headmaster_shuttle"

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dmm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dmm
@@ -4392,7 +4392,9 @@
 	},
 /obj/machinery/light,
 /obj/structure/table/standard,
-/obj/machinery/media/jukebox/phonograph,
+/obj/machinery/media/jukebox/phonograph{
+	anchored = 1
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dmm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dmm
@@ -2424,7 +2424,9 @@
 /area/headmaster_ship)
 "hJ" = (
 /obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine,
+/obj/machinery/photocopier/faxmachine{
+	req_one_access = list(209)
+	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dmm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dmm
@@ -2314,11 +2314,9 @@
 /area/headmaster_ship/engineering)
 "hm" = (
 /obj/structure/closet/crate/secure/large,
-/obj/item/stack/material/uranium/full,
-/obj/item/stack/material/uranium/full,
-/obj/item/stack/material/uranium/full,
-/obj/item/stack/material/uranium/full,
-/obj/item/stack/material/uranium/full,
+/obj/item/stack/material/tritium/full,
+/obj/item/stack/material/tritium/full,
+/obj/item/stack/material/tritium/full,
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -3586,7 +3584,11 @@
 	},
 /area/headmaster_ship/medbay)
 "lk" = (
-/obj/machinery/power/portgen/basic/advanced,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/portgen/basic/fusion,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -3673,10 +3675,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/item/reagent_containers/glass/bucket{
+	pixel_y = 10
 	},
 /turf/simulated/floor/plating{
 	temperature = 278.15
@@ -5983,6 +5983,12 @@
 	temperature = 278.15
 	},
 /area/headmaster_ship/hangar)
+"NK" = (
+/obj/structure/reagent_dispensers/coolanttank,
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/headmaster_ship/engineering)
 "NR" = (
 /obj/machinery/floodlight{
 	dir = 4
@@ -15588,7 +15594,7 @@ aS
 aT
 gn
 oh
-lk
+NK
 lw
 oX
 so

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dmm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dmm
@@ -5789,6 +5789,12 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/reinforced/airless,
 /area/headmaster_ship/bridge)
+"Ls" = (
+/obj/effect/landmark{
+	name = "carpspawn"
+	},
+/turf/template_noop,
+/area/space)
 "LD" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11220,7 +11226,7 @@ iB
 iB
 iB
 iB
-iB
+Ls
 iB
 iB
 iB
@@ -11740,7 +11746,7 @@ iB
 iB
 iB
 iB
-iB
+Ls
 iB
 iB
 iB
@@ -13468,7 +13474,7 @@ iB
 iB
 iB
 iB
-iB
+Ls
 iB
 iB
 iB
@@ -16137,7 +16143,7 @@ iB
 iB
 iB
 iB
-iB
+Ls
 iB
 iB
 iB
@@ -18482,7 +18488,7 @@ iB
 iB
 iB
 iB
-iB
+Ls
 iB
 iB
 iB
@@ -20187,7 +20193,7 @@ iB
 iB
 iB
 iB
-iB
+Ls
 iB
 iB
 iB
@@ -21461,7 +21467,7 @@ iB
 iB
 iB
 iB
-iB
+Ls
 iB
 iB
 iB
@@ -22863,7 +22869,7 @@ iB
 iB
 iB
 iB
-iB
+Ls
 iB
 iB
 iB
@@ -23568,7 +23574,7 @@ iB
 iB
 iB
 iB
-iB
+Ls
 iB
 iB
 iB
@@ -24357,7 +24363,7 @@ iB
 iB
 iB
 iB
-iB
+Ls
 iB
 iB
 iB

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dmm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dmm
@@ -1376,10 +1376,9 @@
 /area/headmaster_ship/bridge)
 "dW" = (
 /obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular{
+/obj/machinery/door/blast/regular/open{
 	dir = 2;
-	id = "headmaster_bridge";
-	icon_state = "pdoor0"
+	id = "headmaster_bridge"
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -3102,13 +3101,12 @@
 /area/headmaster_ship/engineering)
 "jD" = (
 /obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "headmaster_bridge";
-	icon_state = "pdoor0"
-	},
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, bridge"
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "headmaster_bridge"
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -3717,10 +3715,9 @@
 /area/headmaster_ship/engineering)
 "lL" = (
 /obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular{
+/obj/machinery/door/blast/regular/open{
 	dir = 8;
-	id = "headmaster_bridge";
-	icon_state = "pdoor0"
+	id = "headmaster_bridge"
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -4216,6 +4213,12 @@
 /obj/effect/shuttle_landmark/nav_headmaster_ship/nav3,
 /turf/template_noop,
 /area/space)
+"nQ" = (
+/obj/structure/reagent_dispensers/coolanttank,
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/headmaster_ship/engineering)
 "nW" = (
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 8
@@ -4317,13 +4320,12 @@
 /area/space)
 "pj" = (
 /obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 8;
-	id = "headmaster_bridge";
-	icon_state = "pdoor0"
-	},
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, bridge"
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 8;
+	id = "headmaster_bridge"
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -5983,12 +5985,6 @@
 	temperature = 278.15
 	},
 /area/headmaster_ship/hangar)
-"NK" = (
-/obj/structure/reagent_dispensers/coolanttank,
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
-/area/headmaster_ship/engineering)
 "NR" = (
 /obj/machinery/floodlight{
 	dir = 4
@@ -15594,7 +15590,7 @@ aS
 aT
 gn
 oh
-NK
+nQ
 lw
 oX
 so

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dmm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dmm
@@ -1755,7 +1755,7 @@
 "fq" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1380;
-	id_tag = "headmaster_shuttle_dock";
+	id_tag = "headmaster_shuttle";
 	name = "Port docking controller";
 	pixel_x = 6;
 	pixel_y = 28;
@@ -3582,11 +3582,7 @@
 	},
 /area/headmaster_ship/medbay)
 "lk" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/portgen/basic/fusion,
+/obj/structure/reagent_dispensers/coolanttank,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -4213,12 +4209,6 @@
 /obj/effect/shuttle_landmark/nav_headmaster_ship/nav3,
 /turf/template_noop,
 /area/space)
-"nQ" = (
-/obj/structure/reagent_dispensers/coolanttank,
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
-/area/headmaster_ship/engineering)
 "nW" = (
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 8
@@ -5040,6 +5030,16 @@
 	temperature = 278.15
 	},
 /area/headmaster_ship/hangar)
+"za" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/portgen/basic/fusion,
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/headmaster_ship/engineering)
 "zi" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
@@ -15428,7 +15428,7 @@ bX
 gH
 ce
 oh
-lk
+za
 jB
 Eh
 so
@@ -15590,7 +15590,7 @@ aS
 aT
 gn
 oh
-nQ
+lk
 lw
 oX
 so


### PR DESCRIPTION
-fixes a wrongly mapped pipe in the mining jack
-mining jack now has a food
-mining jack and scrapp ghost roles now spawn inside the ship
-fixed the fax machine in the headmaster having the wrong access
-the mining jack has a bigger airlock now
-pra ships now have a fusion reactor
-fixed blast doors on the database ship