### PR TITLE
makes horizon docking ports functional 2: the dockening: rise of the orion ship

### DIFF
--- a/html/changelogs/anconfuzedrock-oriondock.yml
+++ b/html/changelogs/anconfuzedrock-oriondock.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - tweak: "the horizon's docking port that's used by the orion express ship now shares a frequency with it, allowing it to actually dock."
+  - tweak: "The mining pod transit marks have been moved, so they can now dock properly with any functional south-facing dock."

--- a/html/changelogs/anconfuzedrock-oriondock.yml
+++ b/html/changelogs/anconfuzedrock-oriondock.yml
@@ -3,5 +3,5 @@ author: anconfuzedrock
 delete-after: True
 
 changes:
-  - tweak: "the horizon's docking port that's used by the orion express ship now shares a frequency with it, allowing it to actually dock."
-  - tweak: "The mining pod transit marks have been moved, so they can now dock properly with any functional south-facing dock."
+  - tweak: "The Horizon's docking port that's used by the orion express ship now shares a frequency with it, allowing it to actually dock."
+  - tweak: "The Spark's transit marks have been moved, so they can now dock properly with any functional south-facing dock."

--- a/html/changelogs/anconfuzedrock-oriondock.yml
+++ b/html/changelogs/anconfuzedrock-oriondock.yml
@@ -1,0 +1,6 @@
+author: anconfuzedrock
+
+delete-after: True
+
+changes:
+  - tweak: "the horizon's docking port that's used by the orion express ship now shares a frequency with it, allowing it to actually dock."

--- a/maps/away/away_site/unathi_pirate/unathi_pirate_izharshan.dmm
+++ b/maps/away/away_site/unathi_pirate/unathi_pirate_izharshan.dmm
@@ -137,14 +137,14 @@
 "eu" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
-	frequency = 3001;
+	frequency = 1380;
 	master_tag = "unathi_pirate_izharshan_shuttle";
 	name = "interior access button";
 	pixel_x = 26;
 	pixel_y = -9
 	},
 /obj/machinery/door/airlock/external{
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "unathi_pirate_izharshan_inner";
 	name = "Ship External Access"
 	},
@@ -223,7 +223,7 @@
 /area/shuttle/unathi_pirate_izharshan/operations)
 "gE" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "unathi_pirate_izharshan_pump"
 	},
 /obj/structure/bed/handrail{
@@ -429,7 +429,7 @@
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "oZ" = (
 /obj/machinery/door/airlock/external{
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "unathi_pirate_izharshan_inner";
 	name = "Ship External Access"
 	},
@@ -480,14 +480,14 @@
 "rY" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
-	frequency = 3001;
+	frequency = 1380;
 	master_tag = "unathi_pirate_izharshan_shuttle";
 	name = "exterior access button";
 	pixel_x = 26;
 	pixel_y = 10
 	},
 /obj/machinery/door/airlock/external{
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "unathi_pirate_izharshan_outer";
 	name = "Ship External Access"
 	},
@@ -1117,7 +1117,7 @@
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "LL" = (
 /obj/machinery/door/airlock/external{
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "unathi_pirate_izharshan_outer";
 	name = "Ship External Access"
 	},
@@ -1316,20 +1316,20 @@
 /area/space)
 "Tt" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "unathi_pirate_izharshan";
 	pixel_x = -26;
 	req_access = list(210);
 	pixel_y = -8
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "unathi_pirate_izharshan_sensor";
 	pixel_x = -25;
 	pixel_y = 9
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "unathi_pirate_izharshan_pump"
 	},
 /obj/structure/bed/handrail{

--- a/maps/away/ships/orion/orion_express_ship.dm
+++ b/maps/away/ships/orion/orion_express_ship.dm
@@ -34,7 +34,8 @@
 	vessel_size = SHIP_SIZE_SMALL
 	fore_dir = SOUTH
 	initial_restricted_waypoints = list(
-		"Orion Express Shuttle" = list("nav_hangar_orion_express")
+		"Orion Express Shuttle" = list("nav_hangar_orion_express"),
+		"Intrepid" = list("nav_orion_express_ship_dockintrepid")
 	)
 
 	initial_generic_waypoints = list(
@@ -63,14 +64,19 @@
 	name = "Orion Express Mobile Station - Aft Airlock"
 	landmark_tag = "nav_orion_express_ship_3"
 	docking_controller = "orion_traveler_port"
-	base_area = /area/ship/orion_express_ship
+	base_area = /area/space
 	base_turf = /turf/simulated/floor/plating
-	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 
 /obj/effect/shuttle_landmark/orion_express_ship/transit
 	name = "In transit"
 	landmark_tag = "nav_transit_orion_express_ship"
 	base_turf = /turf/space/transit/north
+
+/obj/effect/shuttle_landmark/orion_express_ship/dockintrepid // restricted for the intrepid only or else other ships will be able to use this point, and not properly dock
+	name = "Orion Express Mobile Station - Aft Airlock"
+	landmark_tag = "nav_orion_express_ship_dockintrepid"
+	base_turf = /turf/space/dynamic
+	base_area = /area/space
 
 //shuttle stuff
 /obj/effect/overmap/visitable/ship/landable/orion_express_shuttle

--- a/maps/away/ships/orion/orion_express_ship.dm
+++ b/maps/away/ships/orion/orion_express_ship.dm
@@ -39,7 +39,8 @@
 
 	initial_generic_waypoints = list(
 		"nav_orion_express_ship_1",
-		"nav_orion_express_ship_2"
+		"nav_orion_express_ship_2",
+		"nav_orion_express_ship_3"
 	)
 
 /obj/effect/overmap/visitable/ship/orion_express_ship/New()
@@ -57,6 +58,14 @@
 	landmark_tag = "nav_orion_express_ship_2"
 	base_turf = /turf/space/dynamic
 	base_area = /area/space
+
+/obj/effect/shuttle_landmark/orion_express_ship/nav3
+	name = "Orion Express Mobile Station - Aft Airlock"
+	landmark_tag = "nav_orion_express_ship_3"
+	docking_controller = "orion_traveler_port"
+	base_area = /area/ship/orion_express_ship
+	base_turf = /turf/simulated/floor/plating
+	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 
 /obj/effect/shuttle_landmark/orion_express_ship/transit
 	name = "In transit"
@@ -90,12 +99,13 @@
 	range = 1
 	fuel_consumption = 2
 	logging_home_tag = "nav_hangar_orion_express"
+	dock_target = "orion_express_shuttle"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/orion_express_shuttle/hangar
 	name = "Orion Express Shuttle Hangar"
 	landmark_tag = "nav_hangar_orion_express"
-	docking_controller = "orion_express_shuttle_dock"
+	docking_controller = "orion_traveler_n_port"
 	base_area = /area/ship/orion_express_ship
 	base_turf = /turf/simulated/floor/plating
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -867,11 +867,11 @@
 "gtw" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "orion_traveler_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "orion_traveler_sensor";
 	pixel_x = -32
 	},
@@ -1022,7 +1022,7 @@
 /area/ship/orion_express_ship)
 "hrj" = (
 /obj/machinery/door/airlock/external{
-	frequency = 3001;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "orion_traveler_in"
 	},
@@ -1379,7 +1379,7 @@
 /area/ship/orion_express_ship)
 "krz" = (
 /obj/machinery/door/airlock/external{
-	frequency = 3001;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "orion_traveler_in"
 	},
@@ -2020,24 +2020,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion_express_ship)
 "pll" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 3001;
-	master_tag = "orion_traveler_port";
-	name = "exterior access button";
-	pixel_y = 32
-	},
+/obj/effect/shuttle_landmark/orion_express_ship/dockintrepid,
 /turf/template_noop,
-/area/ship/orion_express_ship)
+/area/space)
 "ppM" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "orion_traveler_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "orion_traveler_port";
 	layer = 3.3;
 	pixel_x = -32;
@@ -2746,7 +2739,7 @@
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
-	frequency = 3001;
+	frequency = 1380;
 	master_tag = "orion_traveler_port";
 	name = "interior access button";
 	pixel_y = -32
@@ -2952,12 +2945,19 @@
 /area/space)
 "vfR" = (
 /obj/machinery/door/airlock/external{
-	frequency = 3001;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "orion_traveler_out"
 	},
 /obj/effect/landmark/entry_point/fore{
 	name = "aft, airlock"
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "orion_traveler_port";
+	name = "exterior access button";
+	pixel_x = -32
 	},
 /turf/simulated/floor,
 /area/ship/orion_express_ship)
@@ -3468,7 +3468,7 @@
 /area/ship/orion_express_ship)
 "yks" = (
 /obj/machinery/door/airlock/external{
-	frequency = 3001;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "orion_traveler_out"
 	},
@@ -35202,7 +35202,7 @@ qBd
 riA
 riA
 qBd
-soM
+xRX
 xRX
 xRX
 xRX
@@ -35459,7 +35459,7 @@ rrQ
 ppM
 gtw
 hPR
-pll
+xRX
 xRX
 xRX
 xRX
@@ -35716,7 +35716,7 @@ krz
 dYD
 rvq
 vfR
-soM
+xRX
 xRX
 xRX
 xRX
@@ -35973,7 +35973,6 @@ hrj
 rvq
 oEN
 yks
-soM
 xRX
 xRX
 xRX
@@ -35985,6 +35984,7 @@ xRX
 xRX
 xRX
 xRX
+pll
 xRX
 xRX
 xRX
@@ -36230,7 +36230,7 @@ qBd
 riA
 riA
 qBd
-soM
+xRX
 xRX
 xRX
 xRX

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -867,11 +867,11 @@
 "gtw" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
-	frequency = 1380;
+	frequency = 3001;
 	id_tag = "orion_traveler_pump"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1380;
+	frequency = 3001;
 	id_tag = "orion_traveler_sensor";
 	pixel_x = -32
 	},
@@ -1022,7 +1022,7 @@
 /area/ship/orion_express_ship)
 "hrj" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
+	frequency = 3001;
 	icon_state = "door_locked";
 	id_tag = "orion_traveler_in"
 	},
@@ -1379,7 +1379,7 @@
 /area/ship/orion_express_ship)
 "krz" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
+	frequency = 3001;
 	icon_state = "door_locked";
 	id_tag = "orion_traveler_in"
 	},
@@ -2023,7 +2023,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
-	frequency = 1380;
+	frequency = 3001;
 	master_tag = "orion_traveler_port";
 	name = "exterior access button";
 	pixel_y = 32
@@ -2033,11 +2033,11 @@
 "ppM" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
-	frequency = 1380;
+	frequency = 3001;
 	id_tag = "orion_traveler_pump"
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1380;
+	frequency = 3001;
 	id_tag = "orion_traveler_port";
 	layer = 3.3;
 	pixel_x = -32;
@@ -2746,7 +2746,7 @@
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
-	frequency = 1380;
+	frequency = 3001;
 	master_tag = "orion_traveler_port";
 	name = "interior access button";
 	pixel_y = -32
@@ -2952,7 +2952,7 @@
 /area/space)
 "vfR" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
+	frequency = 3001;
 	icon_state = "door_locked";
 	id_tag = "orion_traveler_out"
 	},
@@ -3468,10 +3468,11 @@
 /area/ship/orion_express_ship)
 "yks" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1380;
+	frequency = 3001;
 	icon_state = "door_locked";
 	id_tag = "orion_traveler_out"
 	},
+/obj/effect/shuttle_landmark/orion_express_ship/nav3,
 /turf/simulated/floor,
 /area/ship/orion_express_ship)
 

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -39,7 +39,7 @@
 	overmap_event_areas = 34
 	planet_size = list(255,255)
 
-	away_site_budget = 3
+	away_site_budget = 30 //set this back to three, rock.
 
 	station_networks = list(
 		NETWORK_COMMAND,

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -39,7 +39,7 @@
 	overmap_event_areas = 34
 	planet_size = list(255,255)
 
-	away_site_budget = 30 //set this back to three, rock.
+	away_site_budget = 3
 
 	station_networks = list(
 		NETWORK_COMMAND,

--- a/maps/sccv_horizon/code/sccv_horizon_overmap.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_overmap.dm
@@ -87,6 +87,7 @@
 /obj/effect/shuttle_landmark/horizon/dock1
 	name = "Starboard Primary Docking Arm"
 	landmark_tag = "nav_dock_horizon_1"
+	docking_controller = "dock_horizon_1_airlock"
 	base_turf = /turf/simulated/floor/reinforced/airless
 	base_area = /area/space
 

--- a/maps/sccv_horizon/code/sccv_horizon_shuttles.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_shuttles.dm
@@ -192,8 +192,9 @@
 	name = "Mining Shuttle Hangar"
 	landmark_tag = "nav_hangar_mining"
 	docking_controller = "mining_shuttle_dock"
-	base_turf = /turf/simulated/floor/airless
+	base_turf = /turf/simulated/floor/plating
 	base_area = /area/hangar/operations
+	movable_flags = MOVABLE_FLAG_EFFECTMOVE
 
 /obj/effect/shuttle_landmark/mining/transit
 	name = "In transit"

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -13803,6 +13803,7 @@
 	},
 /obj/structure/plasticflaps/airtight,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/shuttle_landmark/mining/hangar,
 /turf/simulated/floor/tiled/full,
 /area/hangar/operations)
 "kKz" = (
@@ -27830,7 +27831,6 @@
 	id_tag = "mining_shuttle_external";
 	req_access = list(13)
 	},
-/obj/effect/shuttle_landmark/mining/hangar,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/mining)

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -999,14 +999,14 @@
 /area/horizon/crew_armoury)
 "aOx" = (
 /obj/machinery/airlock_sensor{
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "dock_horizon_3_sensor";
 	master_tag = "dock_horizon_3_airlock";
 	pixel_y = -32;
 	pixel_x = 25
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "dock_horizon_3_airlock";
 	pixel_y = 0;
 	req_one_access = list(13);
@@ -1017,7 +1017,7 @@
 	pixel_x = 26
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "dock_horizon_3_pump";
 	dir = 8
 	},
@@ -2740,7 +2740,7 @@
 "csI" = (
 /obj/effect/shuttle_landmark/horizon/dock3,
 /obj/machinery/door/airlock/external{
-	frequency = 3001;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "dock_horizon_3_outer";
 	locked = 1;
@@ -2749,7 +2749,7 @@
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
-	frequency = 3001;
+	frequency = 1380;
 	master_tag = "dock_horizon_3_airlock";
 	name = "exterior access button";
 	pixel_x = 21;
@@ -18223,7 +18223,7 @@
 /area/crew_quarters/heads/hop/xo)
 "oAl" = (
 /obj/machinery/door/airlock/external{
-	frequency = 3001;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "dock_horizon_3_outer";
 	locked = 1;
@@ -18649,7 +18649,7 @@
 	},
 /obj/machinery/access_button{
 	command = "cycle_interior";
-	frequency = 3001;
+	frequency = 1380;
 	master_tag = "dock_horizon_3_airlock";
 	name = "interior access button";
 	pixel_x = -24;
@@ -19512,7 +19512,7 @@
 /area/horizon/crew_quarters/fitness/gym)
 "pIp" = (
 /obj/machinery/door/airlock/external{
-	frequency = 3001;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "dock_horizon_3_inner";
 	locked = 1;
@@ -28040,7 +28040,7 @@
 /area/bridge/aibunker)
 "wev" = (
 /obj/machinery/door/airlock/external{
-	frequency = 3001;
+	frequency = 1380;
 	icon_state = "door_locked";
 	id_tag = "dock_horizon_3_inner";
 	locked = 1;
@@ -28132,7 +28132,7 @@
 /area/medical/washroom)
 "wiJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	frequency = 3001;
+	frequency = 1380;
 	id_tag = "dock_horizon_3_pump";
 	dir = 1
 	},

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -999,9 +999,9 @@
 /area/horizon/crew_armoury)
 "aOx" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1337;
-	id_tag = "nuke_shuttle_dock_sensor";
-	master_tag = "nuke_shuttle_dock_airlock";
+	frequency = 3001;
+	id_tag = "dock_horizon_3_sensor";
+	master_tag = "dock_horizon_3_airlock";
 	pixel_y = -32;
 	pixel_x = 25
 	},
@@ -2750,7 +2750,7 @@
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 3001;
-	master_tag = "nuke_shuttle_dock_airlock";
+	master_tag = "dock_horizon_3_airlock";
 	name = "exterior access button";
 	pixel_x = 21;
 	pixel_y = -12;
@@ -2799,6 +2799,17 @@
 /obj/item/device/radio,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
+"cud" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "dock_horizon_1_outer";
+	locked = 1;
+	name = "Docking Port Airlock";
+	req_access = list(13)
+	},
+/turf/simulated/floor/plating,
+/area/horizon/hallway/deck_three/primary/starboard/docks)
 "cur" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -3005,6 +3016,17 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/command)
+"cFr" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "dock_horizon_1_inner";
+	locked = 1;
+	name = "Docking Port Airlock";
+	req_access = list(13)
+	},
+/turf/simulated/floor/plating,
+/area/horizon/hallway/deck_three/primary/starboard/docks)
 "cFJ" = (
 /obj/effect/floor_decal/corner_wide/blue,
 /obj/effect/floor_decal/spline/plain/corner,
@@ -3893,6 +3915,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/vacantoffice2)
+"dtr" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1380;
+	id_tag = "dock_horizon_1_pump"
+	},
+/turf/simulated/floor/plating,
+/area/horizon/hallway/deck_three/primary/starboard/docks)
 "dtx" = (
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 4
@@ -5623,6 +5652,32 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/investigations)
+"eQR" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1380;
+	id_tag = "dock_horizon_1_pump";
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "dock_horizon_1_airlock";
+	pixel_y = 0;
+	req_one_access = list(13);
+	tag_airpump = "dock_horizon_1_pump";
+	tag_chamber_sensor = "dock_horizon_1_sensor";
+	tag_exterior_door = "dock_horizon_1_outer";
+	tag_interior_door = "dock_horizon_1_inner";
+	pixel_x = 26
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "dock_horizon_1_sensor";
+	master_tag = "dock_horizon_1_airlock";
+	pixel_y = 32;
+	pixel_x = 25
+	},
+/turf/simulated/floor/plating,
+/area/horizon/hallway/deck_three/primary/starboard/docks)
 "eQY" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -11329,8 +11384,22 @@
 /turf/simulated/floor/plating,
 /area/engineering/break_room)
 "jkC" = (
-/obj/effect/map_effect/airlock/s_to_n/long/square,
-/turf/simulated/wall/shuttle/scc_space_ship/cardinal,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "dock_horizon_1_inner";
+	locked = 1;
+	name = "Docking Port Airlock";
+	req_access = list(13)
+	},
+/turf/simulated/floor/plating,
+/area/horizon/hallway/deck_three/primary/starboard/docks)
+"jkN" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
 "jlq" = (
 /obj/effect/floor_decal/corner/blue{
@@ -22788,6 +22857,15 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "dock_horizon_1_airlock";
+	name = "interior access button";
+	pixel_x = -24;
+	pixel_y = 21;
+	req_one_access = list(13)
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
 "snj" = (
@@ -22859,6 +22937,23 @@
 /area/maintenance/engineering_ladder)
 "spn" = (
 /obj/effect/shuttle_landmark/horizon/dock1,
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "dock_horizon_1_outer";
+	locked = 1;
+	name = "Docking Port Airlock";
+	req_access = list(13)
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "dock_horizon_1_airlock";
+	name = "exterior access button";
+	pixel_x = 21;
+	pixel_y = 11;
+	req_one_access = list(13)
+	},
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
 "sps" = (
@@ -41033,7 +41128,7 @@ wGH
 ebZ
 dce
 dce
-jkC
+ebZ
 iHq
 sEe
 ebZ
@@ -41232,10 +41327,10 @@ wGH
 wGH
 wGH
 wGH
-jIO
-jIO
-jIO
-jIO
+cud
+dtr
+jkN
+jkC
 smM
 oRv
 wev
@@ -41436,8 +41531,8 @@ wGH
 wGH
 spn
 jIO
-jIO
-jIO
+eQR
+cFr
 pTP
 xyA
 pIp


### PR DESCRIPTION
This modifies one of the horizon's docking ports, namely the one used by the orion ship, to actually function for docking, giving it the same frequency as the orion ship. This also fixes the orion ship's docking controller not functioning for docking. This allows it to dock with the horizon's fixed docking port. Finally, this fixes the orion ship's aft docking port and adds a transit marker to it, allowing other ships to dock with the orion ship if their entrance is north facing.

edit: additionally, this moves the transit area of the mining shuttle up so that it itself can dock with docking ports properly now, and it sets the airlock and shuttle I recently moved around to the same frequency as the common general ship docking frequency to avoid conflicts in the future.