### PR TITLE
All Corporate Representatives have mindshield implants

### DIFF
--- a/code/game/jobs/faction/hephaestus.dm
+++ b/code/game/jobs/faction/hephaestus.dm
@@ -122,7 +122,6 @@
 	head = /obj/item/clothing/head/beret/corporate/heph
 	uniform = /obj/item/clothing/under/rank/liaison/heph
 	suit = /obj/item/clothing/suit/storage/liaison/heph
-	implants = null
 	id = /obj/item/card/id/hephaestus
 	accessory = /obj/item/clothing/accessory/tie/corporate/heph
 	suit_accessory = /obj/item/clothing/accessory/pin/corporate/heph

--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -183,7 +183,6 @@
 	head = /obj/item/clothing/head/beret/corporate/idris
 	uniform = /obj/item/clothing/under/rank/liaison/idris
 	suit = /obj/item/clothing/suit/storage/liaison/idris
-	implants = null
 	id = /obj/item/card/id/idris
 	accessory = /obj/item/clothing/accessory/tie/corporate/idris
 	suit_accessory = /obj/item/clothing/accessory/pin/corporate/idris

--- a/code/game/jobs/faction/orion_express.dm
+++ b/code/game/jobs/faction/orion_express.dm
@@ -80,7 +80,6 @@
 	head = /obj/item/clothing/head/beret/corporate/orion
 	uniform = /obj/item/clothing/under/rank/liaison/orion
 	suit = /obj/item/clothing/suit/storage/liaison/orion
-	implants = null
 	id = /obj/item/card/id/orion
 	accessory = /obj/item/clothing/accessory/tie/corporate/orion
 	suit_accessory = /obj/item/clothing/accessory/pin/corporate/orion

--- a/code/game/jobs/faction/pmc.dm
+++ b/code/game/jobs/faction/pmc.dm
@@ -180,7 +180,6 @@
 	head =  /obj/item/clothing/head/beret/corporate/pmc
 	uniform = /obj/item/clothing/under/rank/liaison/pmc
 	suit = /obj/item/clothing/suit/storage/liaison/pmc
-	implants = null
 	id = /obj/item/card/id/pmc
 	accessory = /obj/item/clothing/accessory/tie/corporate/pmc
 	suit_accessory = /obj/item/clothing/accessory/pin/corporate/pmc

--- a/code/game/jobs/faction/zavodskoi.dm
+++ b/code/game/jobs/faction/zavodskoi.dm
@@ -204,7 +204,6 @@
 	head = /obj/item/clothing/head/beret/corporate/zavod
 	uniform = /obj/item/clothing/under/rank/liaison/zavod
 	suit = /obj/item/clothing/suit/storage/liaison/zavod
-	implants = null
 	id = /obj/item/card/id/zavodskoi
 	accessory = /obj/item/clothing/accessory/tie/corporate/zavod
 	suit_accessory = /obj/item/clothing/accessory/pin/corporate/zavod

--- a/code/game/jobs/faction/zeng_hu.dm
+++ b/code/game/jobs/faction/zeng_hu.dm
@@ -196,7 +196,6 @@
 	head = /obj/item/clothing/head/beret/corporate/zeng
 	uniform = /obj/item/clothing/under/rank/liaison/zeng
 	suit = /obj/item/clothing/suit/storage/liaison/zeng
-	implants = null
 	id = /obj/item/card/id/zeng_hu
 	accessory = /obj/item/clothing/accessory/tie/corporate/zeng
 	suit_accessory = /obj/item/clothing/accessory/pin/corporate/zeng

--- a/html/changelogs/generalcamo - mindshields.yml
+++ b/html/changelogs/generalcamo - mindshields.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "All Corporate Representatives aboard the SCCV Horizon (not just NanoTrasen representatives) are now required to have a mindshield implant, as part of their duties for the Conglomorate. An implant has been complementarily injected during the last scheduled physical for all Corporate Representatives."


### PR DESCRIPTION
As discussed on the discord, NanoTrasen reps having exclusive access to the Mindshield implant is a holdover from when the NSS Aurora was strictly a NanoTrasen facility. Now that the SCC is a thing, and all corporate representatives are expected to represent them to the best of their ability aboard the Horizon, this feels like a bizarre holdover of that time. This removes the nulling out of implants for Zeng-Hu, Orion Express, PCMC, Idris, Hephaestus, and Zavodskoi representatives. This PR does not touch consular officers, as they are not entrusted with sensitive SCC information under a strict NDA.

Mutually exclusive with and the inverse of #15196.