### PR TITLE
Fix incorrect description for Portable Fusion Generator

### DIFF
--- a/code/modules/power/portgen.dm
+++ b/code/modules/power/portgen.dm
@@ -348,7 +348,7 @@
 		"fuel_usage" = active ? round((power_output / time_per_sheet) * 1000) : FALSE,
 		"fuel_type" = sheet_name
 		)
-	
+
 	//coolant stuff
 	data["uses_coolant"] = !!reagents
 	data["coolant_stored"] = reagents?.total_volume
@@ -457,8 +457,8 @@
 
 /obj/machinery/power/portgen/basic/fusion
 	name = "minature fusion reactor"
-	desc = "The RT7-0, an industrial all-in-one nuclear fusion power plant created by Hephaestus. It uses uranium as a fuel source and relies on coolant to keep the reactor cool. Rated for 500 kW max safe output."
-	power_gen =  100000	
+	desc = "The RT7-0, an industrial all-in-one nuclear fusion power plant created by Hephaestus. It uses tritium as a fuel source and relies on coolant to keep the reactor cool. Rated for 500 kW max safe output."
+	power_gen =  100000
 	icon_state = "reactor"
 	base_icon = "reactor"
 	portgen_lightcolour = "#458943"
@@ -474,7 +474,7 @@
 
 	anchored = TRUE
 	flags = OPENCONTAINER
-	
+
 	var/coolant_volume = 360
 	var/coolant_use = 0.2
 	var/coolant_reagent = /decl/reagent/coolant

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: Connorjg1/Talion
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -38,5 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - bugfix: "Portable Fusion Generator incorrectly had Uranium listed as the fuel source. It is not Tritium as expected."

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - rscdel: "Killed innocent kittens."


### PR DESCRIPTION
Changes the Portable Fusion Generator from listing Uranium as the fuel source incorrectly. It now states Tritium as expected. 

This time from the right Github account. 
