### PR TITLE
Puts away sites with/without ghost roles on separate budgets.

### DIFF
--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -8,6 +8,7 @@
 	var/spawn_weight = 1
 	var/spawn_cost = 0
 	var/player_cost = 0
+	var/ship_cost = 0
 	var/list/sectors = list() //This ruin can only spawn in the sectors in this list.
 
 	var/prefix = null

--- a/html/changelogs/anconfuzedrock-shipbudgets.yml
+++ b/html/changelogs/anconfuzedrock-shipbudgets.yml
@@ -1,0 +1,8 @@
+
+author: anconfuzedrock
+
+delete-after: True
+
+changes:
+  - tweak: "The budgets for away sites with ghost spawners and ruins have been seperated, ensuring a mix of both in rounds."
+ 

--- a/maps/_common/mapsystem/map.dm
+++ b/maps/_common/mapsystem/map.dm
@@ -110,6 +110,8 @@
 	var/list/planet_size  //dimensions of planet zlevel, defaults to world size. Due to how maps are generated, must be (2^n+1) e.g. 17,33,65,129 etc. Map will just round up to those if set to anything other.
 	var/min_offmap_players = 0
 	var/away_site_budget = 0
+	var/away_ship_budget = 0
+	var/away_variance = 0 //how much higher the budgets can randomly go
 
 	var/allow_borgs_to_leave = FALSE //this controls if borgs can leave the station or ship without exploding
 	var/area/warehouse_basearea //this controls where the cargospawner tries to populate warehouse items
@@ -172,19 +174,22 @@
 /proc/resolve_site_selection(datum/map_template/ruin/away_site/site, list/selected, list/available, list/unavailable, list/by_type)
 	var/spawn_cost = 0
 	var/player_cost = 0
+	var/ship_cost = 0
 	if (site in selected)
 		if (!(site.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
-			return list(spawn_cost, player_cost)
+			return list(spawn_cost, player_cost, ship_cost)
 	if (!(site.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
 		available -= site
 	spawn_cost += site.spawn_cost
 	player_cost += site.player_cost
+	ship_cost += site.ship_cost
 	selected += site
 
 	for (var/forced_type in site.force_ruins)
 		var/list/costs = resolve_site_selection(by_type[forced_type], selected, available, unavailable, by_type)
 		spawn_cost += costs[1]
 		player_cost += costs[2]
+		player_cost += costs[3]
 
 	for (var/banned_type in site.ban_ruins)
 		var/datum/map_template/ruin/away_site/banned = by_type[banned_type]
@@ -204,7 +209,7 @@
 				continue
 		available[allowed] = allowed.spawn_weight
 
-	return list(spawn_cost, player_cost)
+	return list(spawn_cost, player_cost, ship_cost)
 
 /datum/map/proc/build_away_sites()
 #ifdef UNIT_TEST
@@ -229,8 +234,10 @@
 			available[site] = site.spawn_weight
 		by_type[site.type] = site
 
-	var/points = away_site_budget
+	var/points = rand(away_site_budget, away_site_budget + away_variance)
 	var/players = -min_offmap_players
+	var/shippoints = rand(away_ship_budget, away_ship_budget + away_variance)
+	var/totalbudget = shippoints + points
 	for (var/client/C)
 		++players
 
@@ -238,18 +245,20 @@
 		var/list/costs = resolve_site_selection(site, selected, available, unavailable, by_type)
 		points -= costs[1]
 		players -= costs[2]
+		shippoints -= costs[3]
 
-	while (points > 0 && length(available))
+	while ((points > 0 || shippoints > 0) && length(available))
 		var/datum/map_template/ruin/away_site/site = pickweight(available)
-		if (site.spawn_cost && site.spawn_cost > points || site.player_cost && site.player_cost > players)
+		if ((site.spawn_cost && site.spawn_cost > points) || (site.player_cost && site.player_cost > players) || (site.ship_cost && site.ship_cost > shippoints))
 			unavailable += site
 			available -= site
 			continue
 		var/list/costs = resolve_site_selection(site, selected, available, unavailable, by_type)
 		points -= costs[1]
 		players -= costs[2]
+		shippoints -= costs[3]
 
-	log_admin("Finished selecting away sites ([english_list(selected)]) for [away_site_budget - points] cost of [away_site_budget] budget.")
+	log_admin("Finished selecting away sites ([english_list(selected)]) for [totalbudget - (points + shippoints)] cost of [totalbudget] budget.")
 
 	for (var/datum/map_template/template in selected)
 		if (template.load_new_z())

--- a/maps/away/away_site/civ_station/civilian_station.dm
+++ b/maps/away/away_site/civ_station/civilian_station.dm
@@ -4,7 +4,7 @@
 	suffix = "away_site/civ_station/civilian_station.dmm"
 	sectors = list(SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
-	spawn_cost = 2
+	ship_cost = 2
 	id = "civilian_station"
 
 /decl/submap_archetype/civilian_station

--- a/maps/away/away_site/romanovich/grand_romanovich.dm
+++ b/maps/away/away_site/romanovich/grand_romanovich.dm
@@ -4,7 +4,7 @@
 	suffix = "away_site/romanovich/grand_romanovich.dmm"
 	sectors = list(SECTOR_ROMANOVICH)
 	spawn_weight = 1
-	spawn_cost = 2
+	ship_cost = 2
 	id = "grand_romanovich"
 
 /decl/submap_archetype/grand_romanovich

--- a/maps/away/away_site/space_bar/space_bar.dm
+++ b/maps/away/away_site/space_bar/space_bar.dm
@@ -4,7 +4,7 @@
 	suffix = "away_site/space_bar/space_bar.dmm"
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE)
 	spawn_weight = 1
-	spawn_cost = 2
+	ship_cost = 2
 	id = "space_bar"
 
 /decl/submap_archetype/space_bar

--- a/maps/away/away_site/tajara/mining_jack/mining_jack.dm
+++ b/maps/away/away_site/tajara/mining_jack/mining_jack.dm
@@ -4,7 +4,7 @@
 	suffix = "away_site/tajara/mining_jack/mining_jack.dmm"
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL, SECTOR_GAKAL)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "tajara_mining_jack"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/tajara_mining_jack)
 

--- a/maps/away/away_site/tajara/scrapper/scrapper.dm
+++ b/maps/away/away_site/tajara/scrapper/scrapper.dm
@@ -4,7 +4,7 @@
 	suffix = "away_site/tajara/scrapper/scrapper.dmm"
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL, SECTOR_GAKAL)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "tajara_scrapper"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/tajara_scrapper)
 

--- a/maps/away/away_site/tajara/taj_safehouse/tajara_safehouse.dm
+++ b/maps/away/away_site/tajara/taj_safehouse/tajara_safehouse.dm
@@ -4,7 +4,7 @@
 	suffix = "away_site/taj_safehouse/tajara_safehouse.dmm"
 	sectors = list(SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS)
 	spawn_weight = 1
-	spawn_cost = 2
+	ship_cost = 2
 	id = "tajara_safehouse"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/tajara_safehouse_shuttle)
 

--- a/maps/away/away_site/unathi_pirate/unathi_pirate_izharshan.dm
+++ b/maps/away/away_site/unathi_pirate/unathi_pirate_izharshan.dm
@@ -4,7 +4,7 @@
 	description = "An empty sector."
 	suffix = "away_site/unathi_pirate/unathi_pirate_izharshan.dmm"
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/unathi_pirate_izharshan)
 	sectors = list(SECTOR_NRRAHRAHUL, SECTOR_BADLANDS, SECTOR_GAKAL, SECTOR_UUEOAESA)
 

--- a/maps/away/ships/coc_ranger/coc_ship.dm
+++ b/maps/away/ships/coc_ranger/coc_ship.dm
@@ -4,7 +4,7 @@
 	suffix = "ships/coc_ranger/coc_ship.dmm"
 	sectors = list(SECTOR_BADLANDS)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "ranger_corvette"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/ranger_shuttle)
 

--- a/maps/away/ships/einstein/ee_spy_ship.dm
+++ b/maps/away/ships/einstein/ee_spy_ship.dm
@@ -4,7 +4,7 @@
 	suffix = "ships/einstein/ee_spy_ship.dmm"
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "ee_spy_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/ee_shuttle)
 

--- a/maps/away/ships/elyra/elyra_strike_craft.dm
+++ b/maps/away/ships/elyra/elyra_strike_craft.dm
@@ -4,7 +4,7 @@
 	suffix = "ships/elyra/elyran_strike_craft.dmm"
 	sectors = list(SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_NEW_ANKARA, SECTOR_AEMAQ)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "elyran_strike_craft"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/elyran_shuttle)
 

--- a/maps/away/ships/kataphracts/kataphract_ship.dm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dm
@@ -3,7 +3,7 @@
 	id = "awaysite_kataphract_ship"
 	description = "Ship with lizard knights."
 	suffix = "ships/kataphracts/kataphract_ship.dmm"
-	spawn_cost = 1
+	ship_cost = 1
 	spawn_weight = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/kataphract_transport)
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_TAU_CETI, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_UUEOAESA)
@@ -12,8 +12,8 @@
 	name = "kataphract chapter ship"
 	desc = "A large corvette manufactured by a Hephaestus sponsered Hegemonic Guild. This is a heavily armoured Kataphract Chapter ship of the venerable 'Voidbreaker' class, a relative of the more common 'Foundation' \
 	class used by their counterparts in the Hegemony Navy. These vessels are rarely seen together and strive for maximum self-suffiency as they are the homes and primary means of transportation \
-	for questing Kataphracts and their followers. They usually carry enough firepower to deter the common pirate as well as a set of boarding pods for offensive actions. This ship however has no weapon hardpoints detected. It remains capable due to its sturdy design." 
-	class = "IHKV" //Izweski Hegemony Kataphract Vessel 
+	for questing Kataphracts and their followers. They usually carry enough firepower to deter the common pirate as well as a set of boarding pods for offensive actions. This ship however has no weapon hardpoints detected. It remains capable due to its sturdy design."
+	class = "IHKV" //Izweski Hegemony Kataphract Vessel
 	icon_state = "ship_green"
 	moving_state = "ship_green_moving"
 	vessel_mass = 10000
@@ -65,11 +65,11 @@
 	name = "Kataphract Ship Starboard Docking"
 	landmark_tag = "nav_kataphract_ship_starboarddock"
 
-/obj/effect/shuttle_landmark/nav_kataphract_ship/dockintrepid // restricted for the intrepid only or else other ships will be able to use this point, and not properly dock 
+/obj/effect/shuttle_landmark/nav_kataphract_ship/dockintrepid // restricted for the intrepid only or else other ships will be able to use this point, and not properly dock
 	name = "Kataphract Ship Intrepid Starboard Docking"
 	landmark_tag = "nav_kataphract_ship_dockintrepid"
 
-//shuttle 
+//shuttle
 /obj/effect/overmap/visitable/ship/landable/kataphract_transport
 	name = "Kataphract Transport"
 	class = "IHKV"

--- a/maps/away/ships/orion/orion_express_ship.dm
+++ b/maps/away/ships/orion/orion_express_ship.dm
@@ -4,7 +4,7 @@
 	suffix = "ships/orion/orion_express_ship.dmm"
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "orion_express_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/orion_express_shuttle)
 

--- a/maps/away/ships/pra/database_freighter/database_freighter.dm
+++ b/maps/away/ships/pra/database_freighter/database_freighter.dm
@@ -3,7 +3,7 @@
 	id = "database_freighter"
 	description = "Made from adapted designs of the first freighter Tajara ever worked upon, Database freighters are PRA vessels made specially for gathering information on star systems and what passes through them."
 	suffix = "ships/pra/database_freighter/database_freighter.dmm"
-	spawn_cost = 1
+	ship_cost = 1
 	spawn_weight = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/database_freighter_shuttle)
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL)

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dm
@@ -3,7 +3,7 @@
 	id = "headmaster_ship"
 	description = "A People's Republic Orbital Fleet ship."
 	suffix = "ships/pra/headmaster/headmaster_ship.dmm"
-	spawn_cost = 1
+	ship_cost = 1
 	spawn_weight = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/headmaster_shuttle)
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL)

--- a/maps/away/ships/skrell_smuggler/tirakqi_freighter.dm
+++ b/maps/away/ships/skrell_smuggler/tirakqi_freighter.dm
@@ -4,7 +4,7 @@
 	suffix = "ships/skrell_smuggler/tirakqi_freighter.dmm"
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "tirakqi_freighter"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/tirakqi_shuttle)
 

--- a/maps/away/ships/sol_merc/fsf_patrol_ship.dm
+++ b/maps/away/ships/sol_merc/fsf_patrol_ship.dm
@@ -4,7 +4,7 @@
 	suffix = "ships/sol_merc/fsf_patrol_ship.dmm"
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "fsf_patrol_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/fsf_shuttle)
 

--- a/maps/away/ships/sol_pirate/sfa_patrol_ship.dm
+++ b/maps/away/ships/sol_pirate/sfa_patrol_ship.dm
@@ -4,7 +4,7 @@
 	suffix = "ships/sol_pirate/sfa_patrol_ship.dmm"
 	sectors = list(SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "sfa_patrol_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/sfa_shuttle)
 

--- a/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dm
+++ b/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dm
@@ -4,7 +4,7 @@
 	suffix = "ships/tajara/taj_smuggler/tajaran_smuggler.dmm"
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL, SECTOR_GAKAL)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "tajaran_smuggler"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/tajaran_smuggler_shuttle, /datum/shuttle/autodock/overmap/tajaran_smuggler_cargo)
 

--- a/maps/away/ships/tcfl_patrol/tcfl_peacekeeper_ship.dm
+++ b/maps/away/ships/tcfl_patrol/tcfl_peacekeeper_ship.dm
@@ -4,7 +4,7 @@
 	suffix = "ships/tcfl_patrol/tcfl_peacekeeper_ship.dmm"
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "tcfl_peacekeeper_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/tcfl_shuttle)
 

--- a/maps/away/ships/tramp_freighter/tramp_freighter.dm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter.dm
@@ -4,7 +4,7 @@
 	suffix = "ships/tramp_freighter/tramp_freighter.dmm"
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_NEW_ANKARA, SECTOR_BADLANDS, SECTOR_AEMAQ)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "tramp_freighter"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/freighter_shuttle)
 

--- a/maps/away/ships/wildlands_militia/militia_ship.dm
+++ b/maps/away/ships/wildlands_militia/militia_ship.dm
@@ -4,7 +4,7 @@
 	suffix = "ships/wildlands_milita/militia_ship.dmm"
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "militia_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/militia_shuttle)
 

--- a/maps/runtime/code/runtime.dm
+++ b/maps/runtime/code/runtime.dm
@@ -45,6 +45,7 @@
 	num_exoplanets = 3
 	planet_size = list(65, 65)
 
-	away_site_budget = 3
+	away_site_budget = 2
+	away_ship_budget = 2
 
 	map_shuttles = list(/datum/shuttle/autodock/overmap/runtime)

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -39,7 +39,9 @@
 	overmap_event_areas = 34
 	planet_size = list(255,255)
 
-	away_site_budget = 3
+	away_site_budget = 2
+	away_ship_budget = 2
+	away_variance = 1
 
 	station_networks = list(
 		NETWORK_COMMAND,


### PR DESCRIPTION
As schemed here:
https://forums.aurorastation.org/topic/17741-split-away-site-spawns-into-ghost-spawns-and-other-away-sites/
This changes the horizon's 3 point away site budget into 2 budgets for away sites with and without ghost roles, each with 2 points each and a 50% chance for a third point. could see about changing the likelihood or numbers, this wasn't easy for me to code so it's the best I could do. A budget of just 2 would make an issue with our more expensive away sites that cost 2 points, like the space bar (though I'll see about changing the price on those later). While it's not very important for us to have ghost roles every round, it's good when they can interact with each other, and it's definitely important for ghost roles to not interfere with away site spawns; can probably meet them more organically that way, too.