### PR TITLE
Bag Fixes

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -39,12 +39,14 @@
 	if(use_check_and_message(usr))
 		return 0
 	switch(input(usr, "Choose your bag strap style.", "[src]") as null|anything in backbagstrap)
-		if("Thick")
-			alpha_mask = null
-		if("Normal")
-			alpha_mask = "normal"
 		if("Hidden")
 			alpha_mask = "hidden"
+		if("Thin")
+			alpha_mask = "thin"
+		if("Normal")
+			alpha_mask = "normal"
+		if("Thick")
+			alpha_mask = null
 	to_chat(usr, SPAN_NOTICE("You adjust your bag strap to be [alpha_mask ? "[alpha_mask]" : "thick"]."))
 	var/mob/living/carbon/human/H = src.loc
 	H.update_icon()

--- a/code/modules/client/preference_setup/general/04_equipment.dm
+++ b/code/modules/client/preference_setup/general/04_equipment.dm
@@ -37,6 +37,7 @@
 				"backbag",
 				"backbag_style",
 				"backbag_color",
+				"backbag_strap",
 				"pda_choice",
 				"headset_choice",
 				"primary_radio_slot"
@@ -56,6 +57,7 @@
 			"backbag",
 			"backbag_style",
 			"backbag_color",
+			"backbag_strap",
 			"pda_choice",
 			"headset_choice",
 			"primary_radio_slot",
@@ -152,7 +154,8 @@
 
 	. += "Backpack Type: <a href='?src=\ref[src];change_backpack=1'><b>[backbaglist[pref.backbag]]</b></a><br>"
 	. += "Backpack Style: <a href='?src=\ref[src];change_backpack_style=1'><b>[backbagstyles[pref.backbag_style]]</b></a><br>"
-	. += "Backpack Color: <a href='?src=\ref[src];change_backpack_color=1'><b>[backbagcolors[pref.backbag_color]]</b></a><br>"
+	if(pref.backbag == OUTFIT_SATCHEL_ALT || pref.backbag == OUTFIT_RUCKSACK || pref.backbag == OUTFIT_POCKETBOOK) // Hardcoded. Sucks, I know.
+		. += "Backpack Color: <a href='?src=\ref[src];change_backpack_color=1'><b>[backbagcolors[pref.backbag_color]]</b></a><br>"
 	. += "Backpack Strap: <a href='?src=\ref[src];change_backbag_strap=1'><b>[backbagstrap[pref.backbag_strap]]</b></a><br>"
 	. += "PDA Type: <a href='?src=\ref[src];change_pda=1'><b>[pdalist[pref.pda_choice]]</b></a><br>"
 	. += "Headset Type: <a href='?src=\ref[src];change_headset=1'><b>[headsetlist[pref.headset_choice]]</b></a><br>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -42,7 +42,7 @@ datum/preferences
 	var/spawnpoint = "Arrivals Shuttle" //where this character will spawn (0-2).
 	var/b_type = "A+"					//blood type (not-chooseable)
 	var/backbag = OUTFIT_BACKPACK		//backpack type (defines in outfit.dm)
-	var/backbag_style = OUTFIT_JOBSPECIFIC
+	var/backbag_style = OUTFIT_FACTIONSPECIFIC
 	var/backbag_color = OUTFIT_NOTHING
 	var/backbag_strap = OUTFIT_NORMAL
 	var/pda_choice = OUTFIT_TAB_PDA

--- a/html/changelogs/wezzy_bagfixes3.yml
+++ b/html/changelogs/wezzy_bagfixes3.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Wowzewow (Wezzy)
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes odd behavior with bags saving."
+  - bugfix: "Bag strap adjusting works properly now."
+  - bugfix: "You no longer can color bags that can't be colored."
+  - tweak: "Faction specific bags are now default."


### PR DESCRIPTION
Fixes #15153, Fixes #15017, Fixes #14979

Also makes Bags Faction specific by default since Job Bags were just there for grandfathering purposes.
