### PR TITLE
Making discruptor's lethal projectile pass glass and grille

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -182,7 +182,6 @@
 
 /obj/item/projectile/energy/blaster/disruptor
 	damage = 20
-	pass_flags = PASSTABLE | PASSRAILING
 
 /obj/item/projectile/energy/blaster/disruptor/practice
 	damage = 5

--- a/html/changelogs/Sindorman-discruptor.yml
+++ b/html/changelogs/Sindorman-discruptor.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: PoZe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Disruptor's lethal mode rounds can now pass grille and glass."


### PR DESCRIPTION
Disruptor rounds area already weaker version of the blaster, and the weapons that use them usually have reduced number of shots they can hold. It think it only make sense to allow them to pass glass and grille to make them a bit better. While keeping stun mode not being able to pass glass and grille of course
