### PR TITLE
Fix cables not taking their direction from icon state

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -66,16 +66,16 @@ By design, d1 is the smallest direction and d2 is the highest
 /obj/structure/cable/white
 	color = COLOR_WHITE
 
+// Needs to run before init or we have sad cable knots on away sites
+/obj/structure/cable/New()
+	. = ..()
+	// ensure d1 & d2 reflect the icon_state for entering and exiting cable
+	var/dash = findtext(icon_state, "-")
+	d1 = text2num(copytext(icon_state, 1, dash))
+	d2 = text2num(copytext(icon_state, dash + 1))
+
 /obj/structure/cable/Initialize(mapload)
 	. = ..()
-
-	// ensure d1 & d2 reflect the icon_state for entering and exiting cable
-
-	var/dash = findtext(icon_state, "-")
-
-	d1 = text2num( copytext( icon_state, 1, dash ) )
-
-	d2 = text2num( copytext( icon_state, dash+1 ) )
 
 	var/turf/T = src.loc			// hide if turf is not intact
 	if(level == 1 && !T.is_hole)

--- a/html/changelogs/johnwildkins-powerinit.yml
+++ b/html/changelogs/johnwildkins-powerinit.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - backend: "Cables now correctly override their direction vars to match the set icon state, making mapped-in d1/d2 vars superfluous."


### PR DESCRIPTION
title
means you don't have to use hardcoded d1 and d2 vars anymore when mapping in cables
which was always the intent but the code was scuffed