### PR TITLE
Atmospheric machines max power rating buff

### DIFF
--- a/code/__defines/atmos.dm
+++ b/code/__defines/atmos.dm
@@ -93,6 +93,8 @@
 #define ZONE_ACTIVE   1
 #define ZONE_SLEEPING 0
 
+#define MAX_PUMP_PRESSURE		15000	// Maximal pressure setting for pumps and vents
+
 // Defines how much of certain gas do the Atmospherics tanks start with. Values are in kpa per tile (assuming 20C)
 #define ATMOSTANK_NITROGEN      90000 // A lot of N2 is needed to produce air mix, that's why we keep 90MPa of it
 #define ATMOSTANK_OXYGEN        40000 // O2 is also important for airmix, but not as much as N2 as it's only 21% of it.

--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -115,8 +115,8 @@ var/list/restricted_camera_networks = list(NETWORK_ERT,NETWORK_MERCENARY,"Secret
 // The flow rate/effectiveness of various atmos devices is limited by their internal volume,
 // so for many atmos devices these will control maximum flow rates in L/s.
 #define ATMOS_DEFAULT_VOLUME_PUMP   200 // Liters.
-#define ATMOS_DEFAULT_VOLUME_FILTER 200 // L.
-#define ATMOS_DEFAULT_VOLUME_MIXER  200 // L.
+#define ATMOS_DEFAULT_VOLUME_FILTER 500 // L.
+#define ATMOS_DEFAULT_VOLUME_MIXER  500 // L.
 #define ATMOS_DEFAULT_VOLUME_PIPE   70  // L.
 #define ATMOS_DEFAULT_VOLUME_HE_PIPE 70 // L.
 

--- a/code/modules/atmospherics/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/dp_vent_pump.dm
@@ -22,7 +22,7 @@
 
 	use_power = POWER_USE_OFF
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500			//7500 W ~ 10 HP
+	power_rating = 30000			//30000 W ~ 40 HP
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY|CONNECT_TYPE_SCRUBBER //connects to regular, supply and scrubbers pipes
 

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -26,7 +26,7 @@ Thus, the two variables affect pump operation are set in New():
 
 	use_power = POWER_USE_OFF
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500			//7500 W ~ 10 HP
+	power_rating = 30000			//30000 W ~ 40 HP
 
 	var/max_pressure_setting = ATMOS_PUMP_MAX_PRESSURE	//kPa
 

--- a/code/modules/atmospherics/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/volume_pump.dm
@@ -6,7 +6,9 @@
 	name = "high power gas pump"
 	desc = "A pump. Has double the power rating of the standard gas pump."
 
-	power_rating = 15000	//15000 W ~ 20 HP
+	idle_power_usage = 450
+
+	power_rating = 45000	//45000 W ~ 60 HP
 
 /obj/machinery/atmospherics/binary/pump/high_power/on
 	use_power = POWER_USE_IDLE

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -99,7 +99,7 @@
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, data, force_open)
 
 	if (!ui)
-		ui = new(user, src, ui_key, "omni_filter.tmpl", "Omni Filter Control", 330, 330)
+		ui = new(user, src, ui_key, "omni_filter.tmpl", "Omni Filter Control", 470, 330)
 		ui.set_initial_data(data)
 
 		ui.open()
@@ -109,6 +109,8 @@
 
 	data["power"] = use_power
 	data["config"] = configuring
+	data["last_power_draw"] = last_power_draw
+	data["max_power_draw"] = power_rating
 
 	var/portData[0]
 	for(var/datum/omni_port/P in ports)
@@ -140,7 +142,6 @@
 	if(output)
 		data["set_flow_rate"] = round(set_flow_rate*10)		//because nanoui can't handle rounded decimals.
 		data["last_flow_rate"] = round(last_flow_rate*10)
-	if(power_rating)
 
 	return data
 

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -13,10 +13,12 @@
 	var/datum/omni_port/output
 
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500			//7500 W ~ 10 HP
+	power_rating = 15000			//15000 W ~ 20 HP
 
-	var/max_flow_rate = 200
-	var/set_flow_rate = 200
+	var/max_output_pressure = 15000
+
+	var/max_flow_rate = ATMOS_DEFAULT_VOLUME_FILTER
+	var/set_flow_rate = ATMOS_DEFAULT_VOLUME_FILTER
 
 	var/list/filtering_outputs = list()	//maps gasids to gas_mixtures
 
@@ -138,6 +140,7 @@
 	if(output)
 		data["set_flow_rate"] = round(set_flow_rate*10)		//because nanoui can't handle rounded decimals.
 		data["last_flow_rate"] = round(last_flow_rate*10)
+	if(power_rating)
 
 	return data
 

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -15,8 +15,6 @@
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
 	power_rating = 15000			//15000 W ~ 20 HP
 
-	var/max_output_pressure = 15000
-
 	var/max_flow_rate = ATMOS_DEFAULT_VOLUME_FILTER
 	var/set_flow_rate = ATMOS_DEFAULT_VOLUME_FILTER
 

--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -135,7 +135,7 @@
 	ui = SSnanoui.try_update_ui(user, src, ui_key, ui, data, force_open)
 
 	if (!ui)
-		ui = new(user, src, ui_key, "omni_mixer.tmpl", "Omni Mixer Control", 360, 330)
+		ui = new(user, src, ui_key, "omni_mixer.tmpl", "Omni Mixer Control", 470, 330)
 		ui.set_initial_data(data)
 
 		ui.open()
@@ -145,6 +145,8 @@
 
 	data["power"] = use_power
 	data["config"] = configuring
+	data["last_power_draw"] = last_power_draw
+	data["max_power_draw"] = power_rating
 
 	var/portData[0]
 	for(var/datum/omni_port/P in ports)

--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -9,7 +9,7 @@
 
 	use_power = POWER_USE_IDLE
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 3700			//3700 W ~ 5 HP
+	power_rating = 15000			//15000 W ~ 20 HP
 
 	var/list/inputs = new()
 	var/datum/omni_port/output
@@ -20,8 +20,8 @@
 	var/tag_east_con
 	var/tag_west_con
 
-	var/max_flow_rate = 200
-	var/set_flow_rate = 200
+	var/max_flow_rate = ATMOS_DEFAULT_VOLUME_MIXER
+	var/set_flow_rate = ATMOS_DEFAULT_VOLUME_MIXER
 
 	var/list/mixing_inputs = list()
 

--- a/code/modules/atmospherics/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/components/trinary_devices/filter.dm
@@ -8,7 +8,7 @@
 
 	use_power = POWER_USE_IDLE
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500	//This also doubles as a measure of how powerful the filter is, in Watts. 7500 W ~ 10 HP
+	power_rating = 15000			//15000 W ~ 20 HP
 
 	var/temp = null // -- TLE
 

--- a/code/modules/atmospherics/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/components/trinary_devices/mixer.dm
@@ -8,7 +8,7 @@
 
 	use_power = POWER_USE_IDLE
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 3700	//This also doubles as a measure of how powerful the mixer is, in Watts. 3700 W ~ 5 HP
+	power_rating = 15000			//15000 W ~ 20 HP
 
 	var/set_flow_rate = ATMOS_DEFAULT_VOLUME_MIXER
 	var/list/mixing_inputs

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -13,7 +13,7 @@
 
 	use_power = POWER_USE_OFF
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 15000	//15000 W ~ 20 HP
+	power_rating = 45000	//45000 W ~ 60 HP
 
 	var/injecting = 0
 

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -16,7 +16,7 @@
 
 	use_power = POWER_USE_OFF
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500			//7500 W ~ 10 HP
+	power_rating = 30000			//30000 W ~ 40 HP
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SUPPLY //connects to regular and supply pipes
 
@@ -62,8 +62,8 @@
 	icon_state = "map_vent_in"
 	external_pressure_bound = 0
 	external_pressure_bound_default = 0
-	internal_pressure_bound = 2000
-	internal_pressure_bound_default = 2000
+	internal_pressure_bound = MAX_PUMP_PRESSURE
+	internal_pressure_bound_default = MAX_PUMP_PRESSURE
 	pressure_checks = 2
 	pressure_checks_default = 2
 
@@ -76,8 +76,8 @@
 	icon_state = "map_vent_in"
 	external_pressure_bound = 0
 	external_pressure_bound_default = 0
-	internal_pressure_bound = 2000
-	internal_pressure_bound_default = 2000
+	internal_pressure_bound = MAX_PUMP_PRESSURE
+	internal_pressure_bound_default = MAX_PUMP_PRESSURE
 	pressure_checks = 2
 	pressure_checks_default = 2
 
@@ -119,7 +119,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume
 	name = "Large Air Vent"
 	power_channel = EQUIP
-	power_rating = 15000	//15 kW ~ 20 HP
+	power_rating = 45000	//45 kW ~ 60 HP
 
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/Initialize()
 	. = ..()
@@ -128,7 +128,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/engine
 	name = "Reactor Core Vent"
 	power_channel = ENVIRON
-	power_rating = 30000	//15 kW ~ 20 HP
+	power_rating = 30000	//30 kW ~ 40 HP
 
 /obj/machinery/atmospherics/unary/vent_pump/engine/Initialize()
 	. = ..()

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -8,7 +8,7 @@
 
 	use_power = POWER_USE_OFF
 	idle_power_usage = 150		//internal circuitry, friction losses and stuff
-	power_rating = 7500			//7500 W ~ 10 HP
+	power_rating = 30000			//30000 W ~ 40 HP
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER //connects to regular and scrubber pipes
 

--- a/html/changelogs/Sindorman-atmos.yml
+++ b/html/changelogs/Sindorman-atmos.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Majorily increased maximum power rating for most atmospheric devices. Refer to the pull request for exact numbers (https://forums.aurorastation.org/topic/14761-full-chem-rework-feedback-thread/)."
+  - tweak: "Refactored atmospheric omi gas filter's UI to be more like a gas pump, added display of current power usage."

--- a/html/changelogs/Sindorman-atmos.yml
+++ b/html/changelogs/Sindorman-atmos.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - balance: "Majorily increased maximum power rating for most atmospheric devices. Refer to the pull request for exact numbers (https://forums.aurorastation.org/topic/14761-full-chem-rework-feedback-thread/)."
-  - tweak: "Refactored atmospheric omi gas filter's UI to be more like a gas pump, added display of current power usage."
+  - balance: "Majorily increased maximum power rating for most atmospheric devices. Refer to the pull request for exact numbers (https://github.com/Aurorastation/Aurora.3/pull/15229)."
+  - tweak: "Refactored atmospheric omi gas filter's and mixer's UI to be more like a gas pump, added display of current power usage."

--- a/html/changelogs/Sindorman-atmos.yml
+++ b/html/changelogs/Sindorman-atmos.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - balance: "Majorily increased maximum power rating for most atmospheric devices. Refer to the pull request for exact numbers (https://github.com/Aurorastation/Aurora.3/pull/15229)."
-  - tweak: "Refactored atmospheric omi gas filter's and mixer's UI to be more like a gas pump, added display of current power usage."
+  - tweak: "Majorily increased maximum power rating for most atmospherics devices. Refer to the pull request for exact numbers: https://github.com/Aurorastation/Aurora.3/pull/15229"
+  - tweak: "Refactored atmospherics omni gas filters' and mixers' UI to be more like a gas pump. Added display of current power usage."

--- a/html/changelogs/Sindorman-atmos.yml
+++ b/html/changelogs/Sindorman-atmos.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: PoZe
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/nano/templates/omni_filter.tmpl
+++ b/nano/templates/omni_filter.tmpl
@@ -1,86 +1,125 @@
 <div class="item">
-	<div class="itemContent" style="padding: 5px">
+	<div class="itemLabel">
+		Power:
+	</div>
+	<div class="itemContent">
 		{{:helper.link(data.power ? 'On' : 'Off', null, {'command' : 'power'}, data.config ? 'disabled' : null)}}
 	</div>
-	<div class="itemContent" style="padding: 5px">
+</div>
+
+<div class="item">
+	<div class="itemLabel">
+		Config:
+	</div>
+	<div class="itemContent">
 		{{:helper.link('Configure', null, {'command' : 'configure'}, null, data.config ? 'selected' : null)}}
 	</div>
-
-    {{if data.config}}
-
-        <div style="width: 315px; text-align: center">
-            <div style="float: left">
-                <div class="white" style="height: 26">Port</div>
-                {{for data.ports}}
-                    <div class="average" style="height: 26">{{:value.dir}} Port</div>
-                {{/for}}
-            </div>
-            <div style="float: left; margin-left: 10">
-                <div class="white" style="height: 26">Input</div>
-                {{for data.ports}}
-                    <div style="height: 26">
-                        {{:helper.link(' ', null, {'command' : 'switch_mode', 'mode' : 'in', 'dir' : value.dir}, null, value.input ? 'selected' : null)}}
-                    </div>
-                {{/for}}
-            </div>
-            <div style="float: left; margin-left: 10">
-                <div class="white" style="height: 26">Output</div>
-                {{for data.ports}}
-                    <div style="height: 26">
-                        {{:helper.link(' ', null, {'command' : 'switch_mode', 'mode' : 'out', 'dir' : value.dir}, null, value.output ? 'selected' : null)}}
-                    </div>
-                {{/for}}
-            </div>
-            <div style="float: left; margin-left: 10">
-                <div class="white" style="height: 26">Filter</div>
-                {{for data.ports}}
-                    <div style="height: 26">
-                        {{:helper.link(value.f_type ? value.f_type : 'None', null, {'command' : 'switch_filter', 'mode' : value.f_type, 'dir' : value.dir}, value.filter ? null : 'disabled', value.f_type ? 'selected' : null)}}
-                    </div>
-                {{/for}}
-            </div>
-        </div>
-
-        <div class="itemContent" style="padding: 5px">
-            Set Flow Rate Limit: {{:(data.set_flow_rate/10)}} L/s
-        </div>
-        <div class="itemContent" style="padding: 5px">
-            {{:helper.link('Set Flow Rate Limit', null, {'command' : 'set_flow_rate'})}}
-        </div>
-
-    {{else}}
-
-        <div style="width: 315px; text-align: center">
-            <div style="float: left">
-                <div class="white" style="height: 26">Port</div>
-                {{for data.ports}}
-                    <div class="average" style="height: 26">{{:value.dir}} Port</div>
-                {{/for}}
-            </div>
-            <div style="float: left; margin-left: 10">
-                <div class="white" style="height: 26">Mode</div>
-                {{for data.ports}}
-                    <div style="height: 26">
-                            {{if value.input}}
-                                Input
-                            {{else value.output}}
-                                Output
-                            {{else value.f_type}}
-                                {{:value.f_type}}
-                            {{else}}
-                                Disabled
-                            {{/if}}
-                    </div>
-                {{/for}}
-            </div>
-        </div>
-
-        <div class="itemContent" style="padding: 5px">
-            Set Flow Rate Limit: {{:(data.set_flow_rate/10)}} L/s
-        </div>
-		
-        <div class="itemContent" style="padding: 5px">
-            Flow Rate: {{:(data.last_flow_rate/10)}} L/s
-        </div>
-    {{/if}}
 </div>
+
+<div class="item">
+	<div class="itemLabel">
+		Set Flow Rate Limit:
+	</div>
+	<div class="itemContent">
+		<div class="statusValue">
+		{{if data.config}}
+			{{:helper.link(data.set_flow_rate/10, null, {'command' : 'set_flow_rate'})}} L/s
+		{{else}}
+			{{:(data.set_flow_rate/10)}} L/s
+		{{/if}}
+		</div>
+	</div>
+</div>
+
+<div class="item">
+	<div class="itemLabel">
+		Current Flow Rate:
+	</div>
+	<div class="itemContent">
+		<div class="statusValue">
+			{{:(data.last_flow_rate/10)}} L/s
+		</div>
+	</div>
+</div>
+
+<div class="item">
+	<div class="itemLabel">
+		Load:
+	</div>
+	<div class="itemContent">
+		{{:helper.displayBar(data.last_power_draw, 0, data.max_power_draw, (data.last_power_draw < data.max_power_draw - 5) ? 'good' : 'average')}}
+		<div class="statusValue">
+			{{:data.last_power_draw}} W
+		</div>
+	</div>
+</div>
+
+{{if data.config}}
+
+	<div class="item">
+		<div style="width: 315px; text-align: center">
+			<div style="float: left">
+				<div class="white" style="height: 26">Port</div>
+				{{for data.ports}}
+					<div class="average" style="height: 26">{{:value.dir}} Port</div>
+				{{/for}}
+			</div>
+
+			<div style="float: left; margin-left: 10">
+				<div class="white" style="height: 26">Input</div>
+				{{for data.ports}}
+					<div style="height: 26">
+						{{:helper.link(' ', null, {'command' : 'switch_mode', 'mode' : 'in', 'dir' : value.dir}, null, value.input ? 'selected' : null)}}
+					</div>
+				{{/for}}
+			</div>
+
+			<div style="float: left; margin-left: 10">
+				<div class="white" style="height: 26">Output</div>
+				{{for data.ports}}
+					<div style="height: 26">
+						{{:helper.link(' ', null, {'command' : 'switch_mode', 'mode' : 'out', 'dir' : value.dir}, null, value.output ? 'selected' : null)}}
+					</div>
+				{{/for}}
+			</div>
+
+			<div style="float: left; margin-left: 10">
+				<div class="white" style="height: 26">Filter</div>
+				{{for data.ports}}
+					<div style="height: 26">
+						{{:helper.link(value.f_type ? value.f_type : 'None', null, {'command' : 'switch_filter', 'mode' : value.f_type, 'dir' : value.dir}, value.filter ? null : 'disabled', value.f_type ? 'selected' : null)}}
+					</div>
+				{{/for}}
+			</div>
+		</div>
+	</div>
+{{else}}
+
+	<div class="item">
+		<div style="width: 315px; text-align: center">
+			<div style="float: left">
+				<div class="white" style="height: 26">Port</div>
+				{{for data.ports}}
+					<div class="average" style="height: 26">{{:value.dir}} Port</div>
+				{{/for}}
+			</div>
+			<div style="float: left; margin-left: 10">
+				<div class="white" style="height: 26">Mode</div>
+				{{for data.ports}}
+					<div style="height: 26">
+							{{if value.input}}
+								Input
+							{{else value.output}}
+								Output
+							{{else value.f_type}}
+								{{:value.f_type}}
+							{{else}}
+								Disabled
+							{{/if}}
+					</div>
+				{{/for}}
+			</div>
+		</div>
+	</div>
+
+{{/if}}

--- a/nano/templates/omni_mixer.tmpl
+++ b/nano/templates/omni_mixer.tmpl
@@ -1,101 +1,141 @@
 <div class="item">
-	<div class="itemContent" style="padding: 5px">
+	<div class="itemLabel">
+		Power:
+	</div>
+	<div class="itemContent">
 		{{:helper.link(data.power ? 'On' : 'Off', null, {'command' : 'power'}, data.config ? 'disabled' : null)}}
 	</div>
-	<div class="itemContent" style="padding: 5px">
+</div>
+
+<div class="item">
+	<div class="itemLabel">
+		Config:
+	</div>
+	<div class="itemContent">
 		{{:helper.link('Configure', null, {'command' : 'configure'}, null, data.config ? 'selected' : null)}}
 	</div>
-	
-	{{if data.config}}
-	
-        <div style="width: 315px; text-align: center">
-            <div style="float: left">
-                <div class="white" style="height: 26">Port</div>
-                {{for data.ports}}
-                    <div class="average" style="height: 26">{{:value.dir}} Port</div>
-                {{/for}}
-            </div>
-            <div style="float: left; margin-left: 10">
-                <div class="white" style="height: 26">Input</div>
-                {{for data.ports}}
-                    <div style="height: 26">
-                        {{:helper.link(' ', null, value.input ? {'command' : 'switch_mode', 'mode' : 'none', 'dir' : value.dir} : {'command' : 'switch_mode', 'mode' : 'in', 'dir' : value.dir}, value.output ? 'disabled' : null, value.input ? 'selected' : null)}}
-                    </div>
-                {{/for}}
-            </div>
-            <div style="float: left; margin-left: 10">
-                <div class="white" style="height: 26">Output</div>
-                {{for data.ports}}
-                    <div style="height: 26">
-                        {{:helper.link(' ', null, value.output ? null : {'command' : 'switch_mode', 'mode' : 'out', 'dir' : value.dir}, null, value.output ? 'selected' : null)}}
-                    </div>
-                {{/for}}
-            </div>
-            <div style="float: left; margin-left: 10">
-                <div class="white" style="height: 26">Concentration</div>
-                {{for data.ports}}
-                    <div style="height: 26">
-                        {{:helper.link( value.input ? helper.round(value.concentration*100)+' %' : '-', null, {'command' : 'switch_con', 'dir' : value.dir}, value.input ? null : 'disabled')}}
-                    </div>
-                {{/for}}
-            </div>
-            <div style="float: left; margin-left: 10">
-                <div class="white" style="height: 26">Lock</div>
-                {{for data.ports}}
-                    <div style="height: 26">
-                        {{:helper.link(' ', value.con_lock ? 'locked' : 'unlocked', {'command' : 'switch_conlock', 'dir' : value.dir}, value.input ? null : 'disabled', value.con_lock ? 'selected' : null)}}
-                    </div>
-                {{/for}}
-            </div>
-        </div>
-
-        <div class="itemContent" style="padding: 5px">
-            Set Flow Rate Limit: {{:(data.set_flow_rate/10)}} L/s
-        </div>
-        <div class="itemContent" style="padding: 5px">
-            {{:helper.link('Set Flow Rate Limit', null, {'command' : 'set_flow_rate'})}}
-        </div>
-	
-	{{else}}
-	
-        <div style="width: 315px; text-align: center">
-            <div style="float: left">
-                <div class="white" style="height: 26">Port</div>
-                {{for data.ports}}
-                    <div class="average" style="height: 26">{{:value.dir}} Port</div>
-                {{/for}}
-            </div>
-            <div style="float: left; margin-left: 10">
-                <div class="white" style="height: 26">Mode</div>
-                {{for data.ports}}
-                    <div style="height: 26">
-                            {{if value.input}}
-                                Input
-                            {{else value.output}}
-                                Output
-                            {{else}}
-                                Disabled
-                            {{/if}}
-                    </div>
-                {{/for}}
-            </div>
-            <div style="float: left; margin-left: 10">
-                <div class="white" style="height: 26">Concentration</div>
-                {{for data.ports}}
-                    <div style="height: 26">
-                        {{if value.input}}
-                            {{:helper.round(value.concentration*100)}} %
-                        {{else}}
-                            -
-                        {{/if}}
-                    </div>
-                {{/for}}
-            </div>
-        </div>
-
-        <div class="itemContent" style="padding: 5px">
-            Flow Rate: {{:(data.last_flow_rate/10)}} L/s
-        </div>
-
-	{{/if}}
 </div>
+
+<div class="item">
+	<div class="itemLabel">
+		Set Flow Rate Limit:
+	</div>
+	<div class="itemContent">
+		<div class="statusValue">
+		{{if data.config}}
+			{{:helper.link(data.set_flow_rate/10, null, {'command' : 'set_flow_rate'})}} L/s
+		{{else}}
+			{{:(data.set_flow_rate/10)}} L/s
+		{{/if}}
+		</div>
+	</div>
+</div>
+
+<div class="item">
+	<div class="itemLabel">
+		Current Flow Rate:
+	</div>
+	<div class="itemContent">
+		<div class="statusValue">
+			{{:(data.last_flow_rate/10)}} L/s
+		</div>
+	</div>
+</div>
+
+<div class="item">
+	<div class="itemLabel">
+		Load:
+	</div>
+	<div class="itemContent">
+		{{:helper.displayBar(data.last_power_draw, 0, data.max_power_draw, (data.last_power_draw < data.max_power_draw - 5) ? 'good' : 'average')}}
+		<div class="statusValue">
+			{{:data.last_power_draw}} W
+		</div>
+	</div>
+</div>
+
+{{if data.config}}
+
+	<div class="item">
+		<div style="width: 315px; text-align: center">
+			<div style="float: left">
+				<div class="white" style="height: 26">Port</div>
+				{{for data.ports}}
+					<div class="average" style="height: 26">{{:value.dir}} Port</div>
+				{{/for}}
+			</div>
+			<div style="float: left; margin-left: 10">
+				<div class="white" style="height: 26">Input</div>
+				{{for data.ports}}
+					<div style="height: 26">
+						{{:helper.link(' ', null, value.input ? {'command' : 'switch_mode', 'mode' : 'none', 'dir' : value.dir} : {'command' : 'switch_mode', 'mode' : 'in', 'dir' : value.dir}, value.output ? 'disabled' : null, value.input ? 'selected' : null)}}
+					</div>
+				{{/for}}
+			</div>
+			<div style="float: left; margin-left: 10">
+				<div class="white" style="height: 26">Output</div>
+				{{for data.ports}}
+					<div style="height: 26">
+						{{:helper.link(' ', null, value.output ? null : {'command' : 'switch_mode', 'mode' : 'out', 'dir' : value.dir}, null, value.output ? 'selected' : null)}}
+					</div>
+				{{/for}}
+			</div>
+			<div style="float: left; margin-left: 10">
+				<div class="white" style="height: 26">Concentration</div>
+				{{for data.ports}}
+					<div style="height: 26">
+						{{:helper.link( value.input ? helper.round(value.concentration*100)+' %' : '-', null, {'command' : 'switch_con', 'dir' : value.dir}, value.input ? null : 'disabled')}}
+					</div>
+				{{/for}}
+			</div>
+			<div style="float: left; margin-left: 10">
+				<div class="white" style="height: 26">Lock</div>
+				{{for data.ports}}
+					<div style="height: 26">
+						{{:helper.link(' ', value.con_lock ? 'locked' : 'unlocked', {'command' : 'switch_conlock', 'dir' : value.dir}, value.input ? null : 'disabled', value.con_lock ? 'selected' : null)}}
+					</div>
+				{{/for}}
+			</div>
+		</div>
+	</div>
+
+{{else}}
+
+	<div class="item">
+		<div style="width: 315px; text-align: center">
+			<div style="float: left">
+				<div class="white" style="height: 26">Port</div>
+				{{for data.ports}}
+					<div class="average" style="height: 26">{{:value.dir}} Port</div>
+				{{/for}}
+			</div>
+			<div style="float: left; margin-left: 10">
+				<div class="white" style="height: 26">Mode</div>
+				{{for data.ports}}
+					<div style="height: 26">
+							{{if value.input}}
+								Input
+							{{else value.output}}
+								Output
+							{{else}}
+								Disabled
+							{{/if}}
+					</div>
+				{{/for}}
+			</div>
+			<div style="float: left; margin-left: 10">
+				<div class="white" style="height: 26">Concentration</div>
+				{{for data.ports}}
+					<div style="height: 26">
+						{{if value.input}}
+							{{:helper.round(value.concentration*100)}} %
+						{{else}}
+							-
+						{{/if}}
+					</div>
+				{{/for}}
+			</div>
+		</div>
+	</div>
+
+{{/if}}


### PR DESCRIPTION
After playing for a while it is noticeable and engineering/atmos players agree that refilling large areas of Horizon after it was depressurized is very very slow. After poking our atmos code, gas transfer formulas, ratios, doing some calculations, testing things and trying to find bottleneck I decided to compare our atmos code to Bay's as it was mirrored from Bay originally and largely is still similar. So I noticed that main difference is that they increased all of their atmos device's max power usage by a lot some time ago. It make sense, as largely the gas transfer code for active devices depend on how much max power device can use and how much power (converted) does it take to transfer the gas. I think we are due for increasing the max power rating for all atmos devices. So I mirrored the values from Bay.

An example is that now an airlock size 4x4 air space that has 2 large air vents will take 35 seconds to depressurize instead of 49 seconds. I have not tested how long it takes to pressurize it compared to old values, but with new it takes around 5 seconds or less.

So in this PR:
**Note:** `power rating` refers to the max power device can consume, if it is trying to move a lot of gas that requires lots of power. It doesn't mean it consumes same rating idling or on average.

- Increased Syphon Vent internal pressure and max internal pressure from 2000 kPa to 15000 kPa.
- Increased double vent pump's power rating 7500 -> 30000 W
- Increased regular pump's power rating 7500 -> 30000 W
- Increased high volume pump's power rating 15000 -> 45000 W. Increased idle power usage 150 -> 450 W
- Increased Omni gas filter's power rating 7500 -> 15000 W
- Increased gas mixer's power rating 3700 -> 15000 W
- Increased air injector's power rating 15000 -> 45000 W
- Increased air vent's power rating 7500 -> 30000 W
- Increased high volume air vent's power rating 15000 -> 45000 W
- Increased scrubbers power rating 7500 -> 30000 W
- Improved omi gas filter's and mixer's UI by making it similar to the gas pump's UI, added display of power consumption.
- Increased omni gas filter's and omni gas mixer's default and max flow rates 200 -> 500 L/s(This does not make it go faster in any way, just allows much finer flow precision)

Omni gas filter's new UI:
![3qVpriUL7Y](https://user-images.githubusercontent.com/25555314/205485896-fee023eb-e0d0-423d-baf9-53923a931ee3.png)
Configure mode:
![Ut3Tvk22Po](https://user-images.githubusercontent.com/25555314/205485897-64253293-1c54-4199-9c0f-fa8ec08ae384.png)

Omi gas mixer's new UI:
![UpWfJT3LQd](https://user-images.githubusercontent.com/25555314/205486393-17964e40-b274-44ab-96e2-c988ce6de63c.png)

Configure Mode:
![TgjaLHOxhl](https://user-images.githubusercontent.com/25555314/205486396-03fd0535-86a4-49a6-b15f-c876bb5f8ca6.png)
