### PR TITLE
Abyss Turfs and Maintenance Turf Initializer Fix

### DIFF
--- a/code/game/turfs/initialization/maintenance.dm
+++ b/code/game/turfs/initialization/maintenance.dm
@@ -5,7 +5,7 @@
 	if(locate(/obj/structure/grille, T) || locate(/obj/structure/window_frame, T) || locate(/obj/structure/window/full, T))
 		return
 	//Don't place on openspace!
-	if(istype(T,/turf/simulated/open))
+	if(T.is_open())
 		return
 	//Dont place on unsimulated!
 	if(istype(T,/turf/unsimulated))

--- a/code/game/turfs/simulated/abyss.dm
+++ b/code/game/turfs/simulated/abyss.dm
@@ -22,7 +22,7 @@
 
 	else if(istype(AM, /mob/living))
 		var/mob/living/L = AM
-		if(locate(/obj/structure/lattice/catwalk, src))	//should be safe to walk upon
+		if(locate(/obj/structure/lattice, src))	// Should be safe to walk upon.
 			return TRUE
 		if(!L.CanAvoidGravity())
 			L.visible_message(SPAN_DANGER("\The [L] falls into \the [src]."), SPAN_DANGER("You plummet down into \the [src]!"))
@@ -41,3 +41,6 @@
 
 	else
 		..()
+
+/turf/simulated/abyss/is_open()
+	return TRUE

--- a/html/changelogs/is_open_fix.yml
+++ b/html/changelogs/is_open_fix.yml
@@ -4,4 +4,5 @@ delete-after: True
 
 changes:
   - bugfix: "Fixes the maintenance turf initializer not respecting the is_open() proc."
+  - bugfix: "Fixes abyss turfs not utilizing the is_open() proc."
   - bugfix: "Fixes abyss turfs not respecting lattices and its children, only catwalks."

--- a/html/changelogs/is_open_fix.yml
+++ b/html/changelogs/is_open_fix.yml
@@ -1,0 +1,7 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the maintenance turf initializer not respecting the is_open() proc."
+  - bugfix: "Fixes abyss turfs not respecting lattices and its children, only catwalks."


### PR DESCRIPTION
this PR fixes abyss turfs not utilizing the is_open() proc and fixes the maintenance turf initializer not respecting the is_open() proc. also removes a old unused object.