### PR TITLE
Removes SCC Assistants and Representatives

### DIFF
--- a/code/__defines/jobs.dm
+++ b/code/__defines/jobs.dm
@@ -24,7 +24,7 @@
 // Factions
 // Used to know what what roles are allowed to play as which factions.
 // Note that independent isn't a faction by itself, as faction in this case means a megacorporation.
-#define SCC_ROLES list(COMMAND_ROLES, COMMAND_SUPPORT_ROLES, EQUIPMENT_ROLES, ALL_FACTION_ROLES)
+#define SCC_ROLES list(COMMAND_ROLES, COMMAND_SUPPORT_ROLES, EQUIPMENT_ROLES, /datum/job/visitor)
 #define NT_ROLES list(SCIENCE_ROLES, MEDICAL_ROLES, SERVICE_ROLES, ALL_FACTION_ROLES)
 #define PMC_ROLES list(SECURITY_ROLES, MEDICAL_ROLES, ALL_FACTION_ROLES)
 #define IDRIS_ROLES list(SECURITY_ROLES, SERVICE_ROLES, ALL_FACTION_ROLES)

--- a/html/changelogs/generalcamo-removesccassistants.yml
+++ b/html/changelogs/generalcamo-removesccassistants.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Removed SCC Assistants and Representatives that were unintentionally added."


### PR DESCRIPTION
This removes the SCC assistants and representatives that were unintentionally added in #14832. By lore team request, the SCC should not have representatives or assistants.

This maintains the addition of off-duty crewmembers for the SCC, as there shouldn't be any issues there from a lore perspective.