### PR TITLE
Gives the tramp freighter a freakin' gun

### DIFF
--- a/html/changelogs/anconfuzedrock-freightgun.yml
+++ b/html/changelogs/anconfuzedrock-freightgun.yml
@@ -1,0 +1,7 @@
+author: anconfuzedrock
+
+delete-after: True
+
+
+changes:
+  - rscadd: "The tramp freighter now has a gun. yeah."

--- a/maps/away/ships/tramp_freighter/tramp_freighter.dmm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter.dmm
@@ -339,6 +339,11 @@
 /obj/machinery/atmospherics/binary/pump/high_power,
 /turf/simulated/floor/shuttle/black,
 /area/shuttle/freighter_shuttle)
+"bOP" = (
+/obj/structure/ship_weapon_dummy,
+/obj/structure/ship_weapon_dummy,
+/turf/simulated/floor/airless,
+/area/ship/tramp_freighter)
 "bQB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor,
@@ -996,6 +1001,15 @@
 "gqO" = (
 /turf/simulated/floor/shuttle/black,
 /area/shuttle/freighter_shuttle)
+"guF" = (
+/obj/structure/ship_weapon_dummy,
+/obj/machinery/ship_weapon/francisca{
+	pixel_x = -64;
+	pixel_y = -162;
+	weapon_id = "Tramp Francisca Rotary Gun"
+	},
+/turf/simulated/floor/airless,
+/area/ship/tramp_freighter)
 "gwv" = (
 /obj/effect/landmark/entry_point/port{
 	name = "port hangar"
@@ -1109,7 +1123,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/tramp_freighter)
 "hsz" = (
-/obj/machinery/computer/ship/navigation{
+/obj/machinery/computer/ship/targeting{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1233,6 +1247,12 @@
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
 /obj/item/toy/desk/fan,
+/turf/simulated/floor/tiled/dark,
+/area/ship/tramp_freighter)
+"hWD" = (
+/obj/machinery/ammunition_loader/francisca{
+	weapon_id = "Tramp Francisca Rotary Gun"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/tramp_freighter)
 "hZq" = (
@@ -1450,6 +1470,10 @@
 	},
 /turf/simulated/floor,
 /area/ship/tramp_freighter)
+"lwq" = (
+/obj/structure/ship_weapon_dummy,
+/turf/simulated/floor/airless,
+/area/ship/tramp_freighter)
 "lGR" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -1525,6 +1549,15 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Cargo Compartment"
 	},
+/turf/simulated/floor,
+/area/ship/tramp_freighter)
+"nHp" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor,
 /area/ship/tramp_freighter)
 "nHD" = (
@@ -1687,6 +1720,20 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white,
+/area/ship/tramp_freighter)
+"qpc" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/ap,
+/turf/simulated/floor,
+/area/ship/tramp_freighter)
+"qpg" = (
+/obj/structure/ship_weapon_dummy{
+	is_barrel = 1
+	},
+/turf/simulated/floor/airless,
 /area/ship/tramp_freighter)
 "que" = (
 /obj/effect/step_trigger/teleporter,
@@ -1918,6 +1965,17 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/dark,
+/area/ship/tramp_freighter)
+"uqZ" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/turf/simulated/floor,
 /area/ship/tramp_freighter)
 "uCl" = (
 /obj/structure/closet,
@@ -30247,11 +30305,11 @@ xRX
 xRX
 xRX
 xRX
-xRX
-xRX
-xRX
-xRX
-xRX
+lwq
+bOP
+lwq
+lwq
+qpg
 xRX
 xRX
 xRX
@@ -30504,8 +30562,8 @@ xRX
 xRX
 xRX
 xRX
-xRX
-xRX
+guF
+lwq
 xRX
 xRX
 xRX
@@ -30759,10 +30817,10 @@ ylV
 ylV
 ylV
 ylV
-xRX
-xRX
-xRX
-xRX
+ylV
+ylV
+hWD
+ylV
 xRX
 xRX
 xRX
@@ -31007,18 +31065,18 @@ aSi
 aCu
 gMG
 bci
-dmm
+nHp
 bci
 hlD
 fji
 aSi
 bci
-aSi
+dmm
 bci
+aSJ
 ylV
-ylV
-ylV
-ylV
+jfa
+lfq
 ylV
 xRX
 xRX
@@ -31266,16 +31324,16 @@ ktI
 aCu
 ktI
 fji
-sDf
+ktI
 bci
 hCv
 bci
-wZp
+uqZ
 fji
 aSJ
 ylV
 ehI
-jfa
+lfq
 ylV
 ylV
 wYA
@@ -31525,9 +31583,9 @@ ktI
 fji
 ktI
 bci
-sDf
-bci
 wZp
+bci
+qpc
 eTq
 sLj
 fXG


### PR DESCRIPTION
Adds a francisca to the tramp freighter with 9 boxes of ammo, so it isn't completely defenseless. I feel like it makes sense for any ship of that size to have a weapon in the badlands, and that amount of ammo means that even if someone tried to use it to go goblin mode (which they could do with any ship) it can't cause much harm. Should be good for interactions between offships.