### PR TITLE
Slightly nerf's Vaurca warrior brute resistance. 

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
@@ -8,7 +8,7 @@
 	icobase = 'icons/mob/human_races/vaurca/r_vaurcab.dmi'
 	slowdown = 0
 
-	brute_mod = 0.7
+	brute_mod = 0.8
 	oxy_mod = 1
 	radiation_mod = 0.5
 	standing_jump_range = 3


### PR DESCRIPTION
Vaurca warriors were stronger against brute damage then they otherwise should be following the buff's. They are now less broken on that front and no longer suck up bullet's like IPC's. 
