### PR TITLE
Fixes Old NSS Aurora jobs being used for Taj items

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_xeno/tajara.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/tajara.dm
@@ -380,7 +380,7 @@
 	path = /obj/item/voidsuit_modkit/himeo/tajara
 	sort_category = "Xenowear - Tajara"
 	whitelisted = list(SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI)
-	allowed_roles = list("Cargo Technician", "Shaft Miner", "Quartermaster", "Head of Personnel", "Station Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice")
+	allowed_roles = list("Shaft Miner", "Operations Manager", "Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice")
 	origin_restriction = list(/decl/origin_item/origin/free_council)
 
 /datum/gear/tajaran_tarot


### PR DESCRIPTION
:cl: PurplePineapple
bugfix: Tajaran can now select the Himeo voidsuit again.
/:cl:

An extremely minor bug-fix requested by someone. Allows Tajaran in the correct jobs to use the Himeo voidsuit kit from the xenowear loadout. Currently it still uses the old Aurora jobs.