### PR TITLE
Unapologetic Xenobio Buffs

### DIFF
--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -561,13 +561,13 @@
 /mob/living/carbon/slime/proc/will_hunt(var/hunger) // Check for being stopped from feeding and chasing
 	if(hunger == 2 || rabid || attacked)
 		return TRUE
-	if(nutrition > get_max_nutrition() * 0.8)
+	if(nutrition > get_grow_nutrition())
 		return FALSE
 	if(leader)
 		return FALSE
 	if(holding_still)
 		return FALSE
-	if(hunger == 1 || prob(25))
+	if(hunger == 1 || prob(35))
 		return TRUE
 	return FALSE
 

--- a/html/changelogs/geeves-unapologetic_xenobio_buffs.yml
+++ b/html/changelogs/geeves-unapologetic_xenobio_buffs.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Slimes will now consider hunting when they're under the grow threshold, instead of when they're at 80% of their maximum nutrition, so they should hunt more often."
+  - tweak: "Raised the slime random hunt chance to 35%, up from 25%."


### PR DESCRIPTION
* Slimes will now consider hunting when they're under the grow threshold, instead of when they're at 80% of their maximum nutrition, so they should hunt more often.
* Raised the slime random hunt chance to 35%, up from 25%.

An issue I noticed while playing xenobio was that slimes would just sit there for a long time and do nothing, even when they're under the grow threshold. With this change, they still do exactly that, but to a less maddening extent.