### PR TITLE
Spray Tweaks

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -108,7 +108,7 @@
 		return
 	amount_per_transfer_from_this = next_in_list(amount_per_transfer_from_this, possible_transfer_amounts)
 	spray_size = next_in_list(spray_size, spray_sizes)
-	to_chat(user, "<span class='notice'>You adjusted the pressure nozzle. You'll now use [amount_per_transfer_from_this] units per spray.</span>")
+	to_chat(user, SPAN_NOTICE("You adjusted the pressure nozzle. You'll now use [amount_per_transfer_from_this * spray_size] units per spray, with a [spray_size] lane spray."))
 
 /obj/item/reagent_containers/spray/examine(mob/user)
 	if(..(user, 0) && loc == user)
@@ -212,25 +212,33 @@
 	volume = 600
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 
-/obj/item/reagent_containers/spray/chemsprayer/Spray_at(atom/A as mob|obj)
-	var/direction = get_dir(src, A)
-	var/turf/T = get_turf(A)
-	var/turf/T1 = get_step(T,turn(direction, 90))
-	var/turf/T2 = get_step(T,turn(direction, -90))
-	var/list/the_targets = list(T, T1, T2)
+/obj/item/reagent_containers/spray/chemsprayer/Spray_at(atom/target, mob/user)
+	var/direction = get_dir(src, target)
+	var/turf/our_turf = get_turf(target)
+	var/turf/right_turf = get_step(our_turf, turn(direction, 90))
+	var/turf/left_turf = get_step(our_turf, turn(direction, -90))
+	var/list/the_targets = list(our_turf, right_turf, left_turf)
 
-	for(var/a = 1 to spray_size)
-		spawn(0)
-			if(reagents.total_volume < 1) break
-			var/obj/effect/effect/water/chempuff/D = new/obj/effect/effect/water/chempuff(get_turf(src))
-			var/turf/my_target = the_targets[a]
-			D.create_reagents(amount_per_transfer_from_this)
-			if(!src)
-				return
-			reagents.trans_to_obj(D, amount_per_transfer_from_this)
-			D.set_color()
-			D.set_up(my_target, rand(6, 8), 2)
-	return
+	var/reagents_after_spray = reagents.total_volume - (amount_per_transfer_from_this * spray_size)
+	for(var/spray_index = 1 to spray_size)
+		if(reagents.total_volume < 1)
+			break
+		INVOKE_ASYNC(src, .proc/handle_spray, the_targets[spray_index])
+
+	if(reagents_after_spray <= 0)
+		to_chat(user, SPAN_WARNING("\The [src] is <b>empty</b>!"))
+		playsound(get_turf(src), 'sound/items/condiment_shaking.ogg', 20, TRUE)
+	else
+		to_chat(user, SPAN_WARNING("\The [src] has <b>[reagents_after_spray]u</b> of reagents left!"))
+
+/obj/item/reagent_containers/spray/chemsprayer/proc/handle_spray(var/atom/target)
+	var/obj/effect/effect/water/chempuff/reagent_spray = new /obj/effect/effect/water/chempuff(get_turf(src))
+	reagent_spray.create_reagents(amount_per_transfer_from_this)
+	if(!src)
+		return
+	reagents.trans_to_obj(reagent_spray, amount_per_transfer_from_this)
+	reagent_spray.set_color()
+	reagent_spray.set_up(target, rand(6, 8), 2)
 
 /obj/item/reagent_containers/spray/chemsprayer/xenobiology
 	name = "xenoblaster"

--- a/html/changelogs/geeves-spray_tweaks.yml
+++ b/html/changelogs/geeves-spray_tweaks.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Chemsprayers and xenoblasters now report how many units of reagent they have left after you spray something."
+  - tweak: "Adjusting the pressure nozzle of a spray now accurately tells you how many reagents you'll use, and in how many lanes your spray will go."


### PR DESCRIPTION
* Chemsprayers and xenoblasters now report how many units of reagent they have left after you spray something.
* Adjusting the pressure nozzle of a spray now accurately tells you how many reagents you'll use, and in how many lanes your spray will go.