### PR TITLE
Even More Xenobiology Buffs

### DIFF
--- a/code/modules/mob/living/carbon/slime/death.dm
+++ b/code/modules/mob/living/carbon/slime/death.dm
@@ -10,6 +10,7 @@
 		var/mob/living/carbon/slime/M = new /mob/living/carbon/slime(loc, colour)
 		M.rabid = TRUE
 		M.friends = friends.Copy()
+		M.mutation_chance = clamp(mutation_chance + rand(-3, 3), 0, 100)
 		step_away(M, src)
 		is_adult = FALSE
 		maxHealth = 150

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -261,19 +261,19 @@
 		if(leader)
 			if(holding_still)
 				holding_still = max(holding_still - 1, 0)
-			else if(canmove && isturf(loc))
+			else if(canmove && !pulledby && !length(grabbed_by) && isturf(loc))
 				step_to(src, leader)
 
 		else if(hungry)
 			if(holding_still)
 				holding_still = max(holding_still - 1 - hungry, 0)
-			else if(canmove && isturf(loc) && prob(50))
+			else if(canmove && !pulledby && !length(grabbed_by) && isturf(loc) && prob(50))
 				step(src, pick(cardinal))
 
 		else
 			if(holding_still)
 				holding_still = max(holding_still - 1, 0)
-			else if(canmove && isturf(loc) && prob(33))
+			else if(canmove && !pulledby && !length(grabbed_by) && isturf(loc) && prob(33))
 				step(src, pick(cardinal))
 
 /mob/living/carbon/slime/proc/handle_AI() // the master AI process
@@ -332,7 +332,13 @@
 					UnarmedAttack(target)
 
 		else if(target in view(7, src))
-			step_to(src, target)
+			var/blue_grabbed = FALSE
+			for(var/obj/item/grab/G as anything in grabbed_by)
+				if(G.state >= GRAB_AGGRESSIVE)
+					blue_grabbed = TRUE
+					break
+			if(!blue_grabbed)
+				step_to(src, target)
 
 		else
 			target = null

--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -164,6 +164,7 @@
 				if(i != 1)
 					step_away(M, src)
 				M.friends = friends.Copy()
+				M.mutation_chance = clamp(mutation_chance + rand(-3, 3), 0, 100)
 				babies += M
 				M.set_content(TRUE)
 				addtimer(CALLBACK(M, .proc/set_content, FALSE), 1200) // You get two minutes of safety

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -455,6 +455,11 @@
 		affect_blood(M, alien, removed, holder)
 
 /decl/reagent/mutagen/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
+	if(isslime(M)) // destabilize slime mutation by adding unstable mutagen
+		var/mob/living/carbon/slime/slime = M
+		slime.mutation_chance = min(slime.mutation_chance + removed, 100)
+		return
+
 	var/mob/living/carbon/human/H = M
 	if(istype(H) && (H.species.flags & NO_SCAN))
 		return
@@ -479,6 +484,11 @@
 	taste_mult = 1.3
 
 /decl/reagent/slimejelly/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
+	if(isslime(M)) // stabilize slime mutation by reintroducing slime jelly into the slime
+		var/mob/living/carbon/slime/slime = M
+		slime.mutation_chance = max(slime.mutation_chance - removed, 0)
+		return
+
 	var/mob/living/carbon/human/H = M
 	if(istype(H) && (H.species.flags & NO_BLOOD))
 		return

--- a/html/changelogs/geeves-slime_tweaks.yml
+++ b/html/changelogs/geeves-slime_tweaks.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Slimes now pass their mutation chance on to their offspring."
+  - rscadd: "You can now increase a slime's mutation chance by injecting them with unstable mutagen, and you can decrease it by injecting them with slime jelly."
+  - rscadd: "Slimes will no longer wander or follow their leader while pulled or grabbed, and you can prevent them from chasing their target with a blue, aggressive, grab."


### PR DESCRIPTION
* Slimes now pass their mutation chance on to their offspring.
* You can now increase a slime's mutation chance by injecting them with unstable mutagen, and you can decrease it by injecting them with slime jelly.
* Slimes will no longer wander or follow their leader while pulled or grabbed, and you can prevent them from chasing their target with a blue, aggressive, grab.