### PR TITLE
Spawning Tweaks and Fixes

### DIFF
--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -414,7 +414,7 @@
 				I.icon = 'icons/obj/pda_smart.dmi'
 				I.desc_extended += "NanoTrasen originally designed this as a portable media player. Unfortunately, Royalty-free and corporate-approved ukulele isn't particularly popular."
 		I.update_icon()
-		if (H.pda_choice == OUTFIT_WRISTBOUND)
+		if(!H.wrists && H.pda_choice == OUTFIT_WRISTBOUND)
 			H.equip_or_collect(I, slot_wrists)
 		else
 			H.equip_or_collect(I, slot_wear_id)
@@ -425,23 +425,41 @@
 		if(r_pocket)
 			equip_item(H, r_pocket, slot_r_store)
 
-		for(var/path in backpack_contents)
-			var/number = backpack_contents[path]
-			for(var/i in 1 to number)
-				H.equip_or_collect(new path(H), slot_in_backpack)
+		if(H.back) // you would think, right
+			for(var/path in backpack_contents)
+				var/number = backpack_contents[path]
+				for(var/i in 1 to number)
+					H.equip_or_collect(new path(H), slot_in_backpack)
+		else
+			var/obj/item/storage/storage_item
+			if(!H.l_hand)
+				storage_item = new /obj/item/storage/bag/plasticbag(H)
+				H.equip_to_slot_or_del(storage_item, slot_l_hand)
+			if(!storage_item && !H.r_hand)
+				storage_item = new /obj/item/storage/bag/plasticbag(H)
+				H.equip_to_slot_or_del(storage_item, slot_r_hand)
+			if(storage_item)
+				for(var/path in backpack_contents)
+					var/number = backpack_contents[path]
+					for(var/i in 1 to number)
+						storage_item.handle_item_insertion(new path(H.loc), TRUE)
 		for(var/path in belt_contents)
 			var/number = belt_contents[path]
 			for(var/i in 1 to number)
 				H.equip_or_collect(new path(H), slot_in_belt)
 
 		if(id)
-			var/obj/item/modular_computer/P = H.wear_id
-			var/obj/item/I = new id(H)
-			imprint_idcard(H,I)
-			if(istype(P) && P.card_slot)
-				addtimer(CALLBACK(src, .proc/register_pda, P, I), 2 SECOND)
+			var/obj/item/modular_computer/personal_computer
+			if(istype(H.wear_id, /obj/item/modular_computer))
+				personal_computer = H.wear_id
+			else if(istype(H.wrists, /obj/item/modular_computer))
+				personal_computer = H.wrists
+			var/obj/item/ID = new id(H)
+			imprint_idcard(H, ID)
+			if(personal_computer?.card_slot)
+				addtimer(CALLBACK(src, .proc/register_pda, personal_computer, ID), 2 SECOND)
 			else
-				H.equip_or_collect(I, slot_wear_id)
+				H.equip_or_collect(ID, slot_wear_id)
 
 	post_equip(H, visualsOnly)
 

--- a/html/changelogs/geeves-in_the_bag.yml
+++ b/html/changelogs/geeves-in_the_bag.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Your emergency survival box and loadout items will now spawn in a plastic bag if you don't have a backpack."
+  - bugfix: "Your wristbound portable computer will now attach to your ID slot if you spawn with a wristbound radio."
+  - bugfix: "Your wristbound will now hold your ID and automatically register you, even if it spawns in the wrist slot."


### PR DESCRIPTION
* Your emergency survival box and loadout items will now spawn in a plastic bag if you don't have a backpack.
* Your wristbound portable computer will now attach to your ID slot if you spawn with a wristbound radio.
* Your wristbound will now hold your ID and automatically register you, even if it spawns in the wrist slot.