### PR TITLE
Fix electrical storm runtiming on ships w/o APCs

### DIFF
--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -33,6 +33,8 @@
 	for(var/obj/machinery/power/apc/A in SSmachinery.machinery)
 		if(A.z in affecting_z && !A.is_critical)
 			valid_apcs.Add(A)
+	if(!valid_apcs.len)
+		kill(TRUE)
 	endWhen = (severity * 60) + startWhen
 
 /datum/event/electrical_storm/tick()


### PR DESCRIPTION
title
no player-facing changes it just stops constant runtiming