### PR TITLE
Mechs now can open and close inflatables

### DIFF
--- a/code/modules/heavy_vehicle/mech_interaction.dm
+++ b/code/modules/heavy_vehicle/mech_interaction.dm
@@ -153,6 +153,10 @@
 	if(A == src)
 		setClickCooldown(5)
 		return attack_self(user)
+	else if(istype(A, /obj/structure/inflatable/door) && a_intent == I_HELP) //allow mech to open inflatables
+		var/obj/structure/inflatable/door/D = A
+		D.TryToSwitchState(user)
+		return
 	else if(adj)
 		setClickCooldown(arms ? arms.action_delay : 15)
 		playsound(src.loc, arms.punch_sound, 45 + 25 * (arms.melee_damage / 50), -1 )
@@ -665,7 +669,7 @@
 				if(toggle_lock())
 					say("Hatch [hatch_locked ? "locked" : "unlocked"].")
 				return
-			
+
 			// unlink the leader to get a new one
 			if(findtext(text, "unlink"))
 				if(!maintenance_protocols) // Can't lock yourself out
@@ -675,7 +679,7 @@
 				unassign_leader()
 				say("Leader dropped, awaiting new leader.")
 				return
-			
+
 			// stop following who you were assigned to follow
 			if(findtext(text, "stop"))
 				unassign_following()

--- a/html/changelogs/Ben10083 - MechInflatables.yml
+++ b/html/changelogs/Ben10083 - MechInflatables.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Exosuits can now toggle inflatable doors when interacting with them in help intent and with no modules selected."


### PR DESCRIPTION
If exosuits click on an inflatable door with no module selected and help intent, they will toggle the door state.

Exosuits being unable to get past an inflatable door without destroying them made using them in depressurized areas too unwieldly. 