### PR TITLE
People's Station and Tajara ship fixes

### DIFF
--- a/html/changelogs/alberyk-shipandmapfixes.yml
+++ b/html/changelogs/alberyk-shipandmapfixes.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed some mapping and access issues in the People's Space Station and Tajaran ships."

--- a/maps/away/away_site/tajara/mining_jack/mining_jack.dmm
+++ b/maps/away/away_site/tajara/mining_jack/mining_jack.dmm
@@ -346,7 +346,9 @@
 	},
 /area/mining_jack_outpost/atmos)
 "eX" = (
-/obj/machinery/computer/ship/sensors,
+/obj/machinery/computer/ship/sensors{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel{
 	temperature = 278.15
 	},
@@ -689,7 +691,9 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/mining_jack/engines)
 "jV" = (
-/obj/machinery/computer/shuttle_control/explore/tajara_mining_jack,
+/obj/machinery/computer/shuttle_control/explore/tajara_mining_jack{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel{
 	temperature = 278.15
 	},
@@ -1160,7 +1164,8 @@
 /area/shuttle/mining_jack/engines)
 "sJ" = (
 /obj/machinery/computer/ship/helm{
-	req_access = null
+	req_access = null;
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel{
 	temperature = 278.15

--- a/maps/away/away_site/tajara/peoples_station/peoples_station.dmm
+++ b/maps/away/away_site/tajara/peoples_station/peoples_station.dmm
@@ -511,7 +511,7 @@
 	},
 /area/peoples_station/mess_hall)
 "cr" = (
-/obj/machinery/computer/ship/navigation{
+/obj/item/modular_computer/console/preset/civilian{
 	dir = 1
 	},
 /turf/simulated/floor/wood{
@@ -1095,11 +1095,6 @@
 	},
 /area/peoples_station/range)
 "eS" = (
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "peoples_station_hangar";
-	icon_state = "pdoor0"
-	},
 /obj/machinery/door/airlock/engineering{
 	name = "Fang Hangar";
 	req_access = list(209)
@@ -1308,13 +1303,11 @@
 	name = "Hangar"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "peoples_station_hangar";
-	icon_state = "pdoor0"
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "peoples_station_hangar"
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -1495,7 +1488,9 @@
 /area/peoples_station/barracks)
 "gs" = (
 /obj/structure/window/reinforced,
-/obj/item/modular_computer/console/preset/civilian,
+/obj/item/modular_computer/console/preset/civilian{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -1951,7 +1946,7 @@
 	},
 /area/peoples_station/bridge)
 "iF" = (
-/obj/machinery/computer/ship/navigation{
+/obj/item/modular_computer/console/preset/civilian{
 	dir = 1
 	},
 /turf/simulated/floor/wood{
@@ -2455,16 +2450,14 @@
 	name = "Hangar"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "peoples_station_hangar";
-	icon_state = "pdoor0"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "peoples_station_hangar"
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -3087,13 +3080,12 @@
 /area/peoples_station/captain_quarters)
 "nq" = (
 /obj/structure/table/steel,
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "peoples_station_armory"
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/paper_bin,
 /obj/item/pen/fountain,
+/obj/machinery/door/blast/regular/open{
+	id = "peoples_station_armory"
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -3197,10 +3189,8 @@
 	name = "Hangar"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "peoples_station_hangar";
-	icon_state = "pdoor0"
+/obj/machinery/door/blast/regular/open{
+	id = "peoples_station_hangar"
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -4018,11 +4008,6 @@
 	req_access = list(209)
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "peoples_station_hangar";
-	icon_state = "pdoor0"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark{
@@ -4198,11 +4183,6 @@
 	name = "Hangar"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "peoples_station_hangar";
-	icon_state = "pdoor0"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -4211,6 +4191,9 @@
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 10
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "peoples_station_hangar"
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -4798,9 +4781,8 @@
 /obj/machinery/door/firedoor,
 /obj/item/paper_bin,
 /obj/item/pen/black,
-/obj/machinery/door/blast/regular{
+/obj/machinery/door/blast/regular/open{
 	id = "peoples_station_hangar";
-	icon_state = "pdoor0";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark{
@@ -5501,7 +5483,7 @@
 "yQ" = (
 /obj/structure/table/standard,
 /obj/structure/window/reinforced,
-/obj/machinery/chemical_dispenser/coffeemaster,
+/obj/machinery/chemical_dispenser/coffeemaster/full,
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -6821,7 +6803,9 @@
 	},
 /area/peoples_station/medbay)
 "EJ" = (
-/obj/item/modular_computer/console/preset/civilian,
+/obj/item/modular_computer/console/preset/civilian{
+	dir = 1
+	},
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -6995,8 +6979,7 @@
 	pixel_x = -5;
 	name = "accepted stamp"
 	},
-/obj/machinery/door/blast/regular{
-	dir = 2;
+/obj/machinery/door/blast/regular/open{
 	id = "peoples_station_armory"
 	},
 /turf/simulated/floor/tiled/dark{
@@ -8252,6 +8235,14 @@
 	temperature = 278.15
 	},
 /area/peoples_station/living_quarters)
+"Mo" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/mob/living/heavy_vehicle/premade/ripley/loader,
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/shuttle/fang/engine)
 "Mp" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -8690,9 +8681,8 @@
 /obj/machinery/door/firedoor,
 /obj/item/paper_bin,
 /obj/item/pen/black,
-/obj/machinery/door/blast/regular{
+/obj/machinery/door/blast/regular/open{
 	id = "peoples_station_hangar";
-	icon_state = "pdoor0";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark{
@@ -9147,7 +9137,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/light/small/red{
+/obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -9752,14 +9742,14 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/light/small/red{
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -9970,6 +9960,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/pra,
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -10673,11 +10664,6 @@
 	},
 /area/peoples_station/visitor)
 "Xo" = (
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "peoples_station_hangar";
-	icon_state = "pdoor0"
-	},
 /obj/machinery/door/airlock/engineering{
 	name = "Fang Hangar";
 	req_access = list(209)
@@ -53832,7 +53818,7 @@ dI
 vF
 vF
 vF
-bD
+dI
 vF
 vF
 vF
@@ -58224,7 +58210,7 @@ tv
 dg
 dg
 dg
-dg
+Mo
 xh
 xh
 xh

--- a/maps/away/away_site/tajara/peoples_station/peoples_station_ghostroles.dm
+++ b/maps/away/away_site/tajara/peoples_station/peoples_station_ghostroles.dm
@@ -31,7 +31,7 @@
 	accessory = /obj/item/clothing/accessory/badge/hadii_card
 	r_pocket = /obj/item/storage/wallet/random
 
-/datum/outfit/admin/headmaster_kosmostrelki/get_id_access()
+/datum/outfit/admin/peoples_station_crew/get_id_access()
 	return list(access_pra, access_external_airlocks)
 
 /datum/ghostspawner/human/peoples_station_crew/captain

--- a/maps/away/away_site/tajara/scrapper/scrapper.dmm
+++ b/maps/away/away_site/tajara/scrapper/scrapper.dmm
@@ -1802,7 +1802,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/scrapper_base)
 "vT" = (
-/obj/machinery/computer/shuttle_control/explore/tajara_scrapper,
+/obj/machinery/computer/shuttle_control/explore/tajara_scrapper{
+	dir = 1
+	},
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
 	},
@@ -2619,7 +2621,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/scrapper_base/atmos)
 "Hg" = (
-/obj/machinery/computer/ship/sensors,
+/obj/machinery/computer/ship/sensors{
+	dir = 1
+	},
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
 	},
@@ -2675,7 +2679,8 @@
 /area/shuttle/scrapper_ship/workshop)
 "HA" = (
 /obj/machinery/computer/ship/helm{
-	req_access = null
+	req_access = null;
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
@@ -2844,7 +2849,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/scrapper_base/storage)
 "JH" = (
-/obj/machinery/computer/ship/navigation,
+/obj/machinery/computer/ship/navigation{
+	dir = 1
+	},
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 4
 	},
@@ -4064,7 +4071,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/scrapper_base/storage)
 "Yo" = (
-/obj/machinery/computer/ship/engines,
+/obj/machinery/computer/ship/engines{
+	dir = 1
+	},
 /obj/effect/floor_decal/corner/beige/full,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/scrapper_ship/bridge)

--- a/maps/away/ships/pra/database_freighter/database_freighter.dmm
+++ b/maps/away/ships/pra/database_freighter/database_freighter.dmm
@@ -226,7 +226,9 @@
 	},
 /area/database_freighter)
 "aO" = (
-/obj/machinery/computer/ship/sensors,
+/obj/machinery/computer/ship/sensors{
+	dir = 1
+	},
 /obj/effect/floor_decal/corner/red/full,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark{
@@ -240,7 +242,9 @@
 /turf/simulated/floor/shuttle/black,
 /area/shuttle/database_freighter_shuttle)
 "aV" = (
-/obj/machinery/computer/ship/navigation,
+/obj/machinery/computer/ship/navigation{
+	dir = 1
+	},
 /obj/effect/floor_decal/corner/red/full{
 	dir = 4
 	},
@@ -356,7 +360,8 @@
 /area/database_freighter/captain_quarters)
 "bE" = (
 /obj/machinery/computer/ship/helm{
-	req_access = null
+	req_access = null;
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -993,7 +998,9 @@
 	},
 /area/database_freighter/engine)
 "ei" = (
-/obj/machinery/computer/ship/engines,
+/obj/machinery/computer/ship/engines{
+	dir = 1
+	},
 /obj/effect/floor_decal/corner/red/full,
 /obj/structure/cable/green,
 /obj/machinery/power/apc/high{
@@ -2396,7 +2403,9 @@
 	},
 /area/database_freighter)
 "lZ" = (
-/obj/item/modular_computer/console/preset/civilian,
+/obj/item/modular_computer/console/preset/civilian{
+	dir = 1
+	},
 /obj/machinery/alarm/cold{
 	req_one_access = list(209);
 	pixel_y = -32;
@@ -4661,7 +4670,7 @@
 /area/database_freighter/eva)
 "Xf" = (
 /obj/machinery/computer/ship/navigation{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/wood{
 	temperature = 278.15

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dmm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dmm
@@ -868,10 +868,9 @@
 /area/headmaster_ship/bridge)
 "cB" = (
 /obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 2;
+/obj/machinery/door/blast/regular/open{
 	id = "headmaster_gun";
-	icon_state = "pdoor0"
+	dir = 4
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -1609,9 +1608,7 @@
 	},
 /area/headmaster_ship/commissar_quarters)
 "eF" = (
-/obj/machinery/computer/ship/navigation{
-	dir = 1
-	},
+/obj/machinery/computer/ship/navigation,
 /turf/simulated/floor/wood{
 	temperature = 278.15
 	},
@@ -3790,10 +3787,6 @@
 /area/headmaster_ship/medbay)
 "lX" = (
 /obj/structure/table/steel,
-/obj/machinery/door/blast/regular{
-	dir = 8;
-	id = "headmaster_armory"
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/stamp/denied{
 	pixel_x = 5
@@ -3801,6 +3794,10 @@
 /obj/item/stamp{
 	pixel_x = -5;
 	name = "accepted stamp"
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "headmaster_armory"
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -3826,7 +3823,9 @@
 	},
 /area/headmaster_ship/engineering)
 "ma" = (
-/obj/machinery/computer/ship/sensors,
+/obj/machinery/computer/ship/sensors{
+	dir = 1
+	},
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
@@ -4739,17 +4738,6 @@
 	temperature = 278.15
 	},
 /area/headmaster_ship/bridge)
-"vb" = (
-/obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id = "headmaster_gun";
-	icon_state = "pdoor0"
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/headmaster_ship/gun_deck)
 "vj" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/red{
@@ -4980,10 +4968,8 @@
 /area/headmaster_ship)
 "yy" = (
 /obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular{
-	id = "headmaster_gun";
-	icon_state = "pdoor0";
-	dir = 4
+/obj/machinery/door/blast/regular/open{
+	id = "headmaster_gun"
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -5050,13 +5036,17 @@
 /turf/template_noop,
 /area/space)
 "zm" = (
-/obj/machinery/computer/ship/navigation,
+/obj/machinery/computer/ship/navigation{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
 /area/headmaster_ship/gun_deck)
 "zT" = (
-/obj/machinery/computer/ship/navigation,
+/obj/machinery/computer/ship/navigation{
+	dir = 1
+	},
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
@@ -5753,13 +5743,12 @@
 /area/headmaster_ship)
 "KX" = (
 /obj/effect/map_effect/window_spawner/reinforced/firedoor,
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "headmaster_gun";
-	icon_state = "pdoor0"
-	},
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, gun deck"
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "headmaster_gun";
+	dir = 4
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -6080,9 +6069,6 @@
 /obj/item/reagent_containers/food/drinks/carton/fatshouters,
 /obj/item/reagent_containers/food/drinks/carton/fatshouters,
 /obj/item/reagent_containers/food/drinks/carton/fatshouters,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -6489,10 +6475,9 @@
 /area/headmaster_ship/armory)
 "Ul" = (
 /obj/structure/viewport,
-/obj/machinery/door/blast/regular{
-	dir = 4;
+/obj/machinery/door/blast/regular/open{
 	id = "headmaster_gun";
-	icon_state = "pdoor0"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -6741,19 +6726,21 @@
 /area/headmaster_ship/mess_hall)
 "Ys" = (
 /obj/structure/table/steel,
-/obj/machinery/door/blast/regular{
-	dir = 8;
-	id = "headmaster_armory"
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/paper_bin,
 /obj/item/pen/fountain,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "headmaster_armory"
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
 /area/headmaster_ship/armory)
 "YE" = (
-/obj/machinery/computer/ship/targeting,
+/obj/machinery/computer/ship/targeting{
+	dir = 1
+	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -16446,7 +16433,7 @@ Mm
 jI
 dc
 Mm
-vb
+yy
 yy
 cB
 ll

--- a/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dmm
+++ b/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dmm
@@ -37,9 +37,7 @@
 	},
 /area/tajaran_smuggler)
 "aci" = (
-/obj/machinery/computer/ship/engines{
-	dir = 1
-	},
+/obj/machinery/computer/ship/engines,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -277,7 +275,9 @@
 	},
 /area/tajaran_smuggler/dorms)
 "aSi" = (
-/obj/machinery/computer/ship/sensors,
+/obj/machinery/computer/ship/sensors{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/art{
 	temperature = 278.15
 	},
@@ -676,7 +676,8 @@
 /area/tajaran_smuggler)
 "dhp" = (
 /obj/machinery/computer/ship/helm{
-	req_access = null
+	req_access = null;
+	dir = 1
 	},
 /turf/simulated/floor/carpet/art{
 	temperature = 278.15
@@ -2824,7 +2825,10 @@
 	},
 /area/tajaran_smuggler)
 "pfE" = (
-/turf/simulated/floor/foamedmetal,
+/obj/structure/foamedmetal,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
 /area/tajaran_smuggler)
 "phC" = (
 /obj/structure/table/steel,
@@ -3469,7 +3473,10 @@
 	},
 /area/tajaran_smuggler/atmos)
 "uhO" = (
-/turf/simulated/floor/foamedmetal,
+/obj/structure/foamedmetal,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
 /area/tajaran_smuggler/engine)
 "utm" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -3943,7 +3950,9 @@
 	},
 /area/tajaran_smuggler)
 "yin" = (
-/obj/machinery/computer/ship/navigation,
+/obj/machinery/computer/ship/navigation{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/art{
 	temperature = 278.15
 	},


### PR DESCRIPTION
-fixes a couple of issues with the People's Station map access and mapping, including a missing loader in the fang, lack of lights in some places and messed up blast doors.
-fixes consoles at the wrong direction on the tajaran ships, some blastdoors and the wrong foam type being used in the smuggler ship