### PR TITLE
Fix slurring, commanding, alarms and loopsounds

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -253,6 +253,12 @@
 #define GHOSTS_ALL_HEAR 1
 #define ONLY_GHOSTS_IN_VIEW 0
 
+// Handle speech problems defines
+#define HSP_MSG 		"message"
+#define HSP_VERB 		"verb"
+#define HSP_MSGMODE 	"message mode"
+#define HSP_MSGRANGE 	"message range"
+
 // Defines mob sizes, used by lockers and to determine what is considered a small sized mob, etc.
 #define MOB_LARGE  		16
 #define MOB_MEDIUM 		9

--- a/code/controllers/subsystems/alarm.dm
+++ b/code/controllers/subsystems/alarm.dm
@@ -8,6 +8,7 @@ var/datum/controller/subsystem/alarm/SSalarm
 
 /datum/controller/subsystem/alarm
 	name = "Alarms"
+	init_order = SS_INIT_MISC_FIRST
 	priority = SS_PRIORITY_ALARMS
 	
 	var/list/datum/alarm/all_handlers

--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -16,7 +16,7 @@
 */
 
 /datum/looping_sound
-	var/list/atom/output_atoms
+	var/list/atom/output_atoms = list()
 	var/mid_sounds
 	var/mid_length
 	var/start_volume
@@ -39,7 +39,7 @@
 		WARNING("A looping sound datum was created without sounds to play.")
 		return
 
-	output_atoms = _output_atoms
+	output_atoms |= _output_atoms
 	direct = _direct
 
 	if(start_immediately)

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -20,11 +20,10 @@
 	monitor_type = /datum/nano_module/alarm_monitor/all
 
 /obj/machinery/computer/station_alert/Initialize()
-	alarm_monitor = new monitor_type(src)
-	alarm_monitor.register_alarm(src, /atom/.proc/update_icon)
 	. = ..()
 	if(monitor_type)
 		register_monitor(new monitor_type(src))
+		alarm_monitor.register_alarm(src, /atom/.proc/update_icon)
 
 /obj/machinery/computer/station_alert/Destroy()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -125,7 +125,13 @@
 	if(!message_range)
 		message_range = world.view
 
-	. = ..(message, say_verb, message_mode, message_range)
+	var/list/speech_params = ..(message, say_verb, message_mode, message_range)
+	if(speech_params)
+		message = speech_params[HSP_MSG] || message
+		say_verb = speech_params[HSP_VERB] || say_verb
+		message_mode = speech_params[HSP_MSGMODE] || message_mode
+		message_range = speech_params[HSP_MSGRANGE] || message_range
+		. = TRUE
 
 	if(losebreath >= 5 && prob(50))
 		var/list/words = splittext(message," ")
@@ -151,7 +157,13 @@
 			say_verb = pick(M.say_verbs)
 			. = TRUE
 
-	return species.handle_speech_problems(message, say_verb, message_mode, message_range) || .
+	if(.)
+		return list(
+			HSP_MSG = message,
+			HSP_VERB = say_verb,
+			HSP_MSGMODE = message_mode,
+			HSP_MSGRANGE = message_range,
+		)
 
 /mob/living/carbon/human/get_radio()
 	var/list/headsets = list()

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -122,6 +122,14 @@ proc/get_radio_key_from_channel(var/channel)
 		say_verb = pick("slobbers", "slurs")
 		. = TRUE
 
+	if(.)
+		return list(
+			HSP_MSG = message,
+			HSP_VERB = say_verb,
+			HSP_MSGMODE = message_mode,
+			HSP_MSGRANGE = message_range
+		)
+
 /mob/living/proc/get_stutter_verbs()
 	return list("stammers", "stutters")
 
@@ -223,7 +231,12 @@ proc/get_radio_key_from_channel(var/channel)
 	var/message_range = world.view
 	if(!(speaking && (speaking.flags & NO_STUTTER)))
 		message = handle_autohiss(message, speaking)
-		handle_speech_problems(message, verb, message_mode, message_range)
+		var/list/hsp_params = handle_speech_problems(message, verb, message_mode, message_range)
+		if(hsp_params)
+			message = hsp_params[HSP_MSG] || message
+			verb = hsp_params[HSP_VERB] || verb
+			message_mode = hsp_params[HSP_MSGMODE] || message_mode
+			message_range = hsp_params[HSP_MSGRANGE] || message_range
 
 	if(!message || message == "")
 		return FALSE

--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -43,15 +43,23 @@
 		return
 	short_name = input
 
+/mob/living/simple_animal/hostile/commanded/proc/get_command(cmdtext, list/searchnames)
+	searchnames |= list("everyone", "everybody")
+	for(var/name in searchnames)
+		if(dd_hasprefix(cmdtext, name))
+			return copytext(cmdtext, length(name) + 1)
+
 /mob/living/simple_animal/hostile/commanded/think()
 	while(command_buffer.len > 0)
 		var/mob/speaker = command_buffer[1]
 		var/text = command_buffer[2]
 		var/filtered_name = lowertext(html_decode(name))
 		var/filtered_short = lowertext(html_decode(short_name))
-		if(dd_hasprefix(text,filtered_name) || dd_hasprefix(text,filtered_short) || dd_hasprefix(text,"everyone") || dd_hasprefix(text, "everybody")) //in case somebody wants to command 8 bears at once.
-			var/substring = copytext(text,length(filtered_name)+1) //get rid of the name.
-			listen(speaker,substring)
+		var/substring = get_command(text, list(filtered_name, filtered_short))
+
+		if(substring)
+			listen(speaker, substring)
+
 		command_buffer.Remove(command_buffer[1],command_buffer[2])
 	..()
 	switch(stance)

--- a/html/changelogs/johnwildkins-shotgune.yml
+++ b/html/changelogs/johnwildkins-shotgune.yml
@@ -1,0 +1,9 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed an issue where speech problems (drunk slurring, etc) weren't being applied properly."
+  - bugfix: "Fixed commandable animals not listening when their short name was used."
+  - bugfix: "Fixed alarm consoles not displaying any alarms."
+  - bugfix: "Fixed looping sounds not initializing properly."


### PR DESCRIPTION
  - bugfix: "Fixed an issue where speech problems (drunk slurring, etc) weren't being applied properly."
  - bugfix: "Fixed commandable animals not listening when their short name was used."
  - bugfix: "Fixed alarm consoles not displaying any alarms."
  - bugfix: "Fixed looping sounds not initializing properly."

Fixes #14032
Fixes #13505
Fixes #11026