### PR TITLE
Xenobio/Xenobot have access to R&D

### DIFF
--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -165,7 +165,7 @@
 	)
 
 	access = list(access_tox, access_tox_storage, access_research, access_xenobiology)
-	minimal_access = list(access_research, access_xenobiology, access_tox_storage)
+	minimal_access = list(access_tox, access_research, access_xenobiology, access_tox_storage)
 
 	minimal_player_age = 14
 
@@ -197,7 +197,7 @@
 	)
 
 	access = list(access_tox_storage, access_research, access_xenobotany, access_tox)
-	minimal_access = list(access_tox_storage, access_research, access_xenobotany)
+	minimal_access = list(access_tox, access_tox_storage, access_research, access_xenobotany)
 
 	minimal_player_age = 14
 

--- a/html/changelogs/RustingWithYou - joexenoswildride.yml
+++ b/html/changelogs/RustingWithYou - joexenoswildride.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Gives xenobotanists and xenobiologists access to the main R&D lab."


### PR DESCRIPTION
Gives xenobiologists and xenobotanists access to the main R&D lab. Seemed like kind of an oversight they didn't have it before, and I was told they were meant to, so here we go.