### PR TITLE
Hole and Hole-Adjacent Changes

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -281,7 +281,7 @@ var/list/mob/living/forced_ambiance_list = new
 	var/area/oldarea = L.lastarea
 	if((oldarea.has_gravity() == FALSE) && (newarea.has_gravity() == TRUE) && (L.m_intent == M_RUN)) // Being ready when you change areas gives you a chance to avoid falling all together.
 		thunk(L)
-		L.update_floating(L.Check_Dense_Object())
+		L.update_floating()
 
 	L.lastarea = newarea
 
@@ -339,7 +339,7 @@ var/list/mob/living/forced_ambiance_list = new
 			thunk(M)
 		else
 			to_chat(M, SPAN_NOTICE("The sudden lack of gravity makes you feel weightless and float cluelessly."))
-		M.update_floating(M.Check_Dense_Object())
+		M.update_floating()
 
 /area/proc/thunk(mob)
 	if(istype(get_turf(mob), /turf/space)) // Can't fall onto nothing.

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -31,6 +31,15 @@
 	for(var/obj/structure/lattice/LAT in loc)
 		if(LAT != src)
 			qdel(LAT)
+	if(isturf(loc))
+		var/turf/turf = loc
+		turf.is_hole = FALSE
+
+/obj/structure/lattice/Destroy()
+	if(isturf(loc))
+		var/turf/turf = loc
+		turf.is_hole = initial(turf.is_hole)
+	return ..()
 
 /obj/structure/lattice/ex_act(severity)
 	switch(severity)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -237,14 +237,20 @@ var/const/enterloopsanity = 100
 		var/mob/M = AM
 		if(!M.lastarea)
 			M.lastarea = get_area(M.loc)
-		if(M.lastarea.has_gravity() == 0)
+
+		var/has_gravity = M.lastarea.has_gravity()
+		if(!has_gravity)
 			inertial_drift(M)
 
 		// Footstep SFX logic moved to human_movement.dm - Move().
 
-		else if (type != /turf/space)
+		else if(!is_hole)
 			M.inertia_dir = 0
-			M.make_floating(0)
+
+		if(!M.is_floating && (is_hole || !has_gravity))
+			M.update_floating()
+		else if(M.is_floating && !is_hole && has_gravity)
+			M.update_floating()
 
 	if(does_footprint && footprint_color && ishuman(AM))
 		var/mob/living/carbon/human/H = AM

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -51,6 +51,7 @@
 		to_chat(user, "You enable the mag-pulse traction system.")
 	user.update_inv_shoes()	//so our mob-overlays update
 	user.update_action_buttons()
+	user.update_floating()
 
 /obj/item/clothing/shoes/magboots/negates_gravity()
 	if(magpulse)

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -497,12 +497,10 @@
 /obj/item/rig_module/maneuvering_jets/installed()
 	..()
 	jets.holder = holder
-	jets.ion_trail.bind(holder)
 
 /obj/item/rig_module/maneuvering_jets/removed()
 	..()
 	jets.holder = null
-	jets.ion_trail.bind(jets)
 
 /obj/item/rig_module/device/paperdispenser
 	name = "hardsuit paper dispenser"

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -24,7 +24,7 @@
 /mob/proc/equip_to_slot_if_possible(obj/item/W as obj, slot, del_on_fail = FALSE, disable_warning = FALSE, redraw_mob = TRUE, ignore_blocked = FALSE, assisted_equip = FALSE)
 	if(!istype(W))
 		return FALSE
-	if(W.item_flags & NOMOVE) //Cannot move NOMOVE items from one inventory slot to another. Cannot do canremove here because then BSTs spawn naked. 
+	if(W.item_flags & NOMOVE) //Cannot move NOMOVE items from one inventory slot to another. Cannot do canremove here because then BSTs spawn naked.
 		return FALSE
 
 	if(!W.mob_can_equip(src, slot, disable_warning, ignore_blocked))
@@ -398,12 +398,12 @@ var/list/slot_equipment_priority = list( \
 			for(var/obj/O in T)
 				if(!O.density) //We don't care about you.
 					continue
-				if(O.CanPass(item, T)) //Items have CANPASS for tables/railings, allows placement. Also checks windows. 
+				if(O.CanPass(item, T)) //Items have CANPASS for tables/railings, allows placement. Also checks windows.
 					continue
 				if(istype(O, /obj/structure/closet/crate)) //Placing on/in crates is fine.
 					continue
 				return TRUE //Something is stopping us. Takes off throw mode.
-				
+
 		if(unEquip(I))
 			make_item_drop_sound(I)
 			I.forceMove(T)
@@ -431,7 +431,7 @@ var/list/slot_equipment_priority = list( \
 			playsound(src, 'sound/effects/throw.ogg', volume, TRUE, -1)
 
 		// Animate the mob throwing.
-		animate_throw(src)
+		animate_throw()
 
 		item.throw_at(target, item.throw_range, item.throw_speed, src)
 

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -6,7 +6,7 @@
 /mob/living/silicon/robot/Allow_Spacemove()
 	if(module)
 		for(var/obj/item/tank/jetpack/J in module.modules)
-			if(J && J.allow_thrust(0.01))
+			if(J?.allow_thrust(0.01, src))
 				return TRUE
 	. = ..()
 
@@ -24,7 +24,7 @@
 
 /mob/living/silicon/robot/Move()
 	. = ..()
-	
+
 	if(client)
 		var/turf/B = GetAbove(get_turf(src))
 		if(up_hint)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -504,16 +504,15 @@
 	var/turf/T = get_turf(src)
 
 	if (!T) // nullspace so sure, have gravity.
-		return 1
-	else if (istype(T, /turf/space))
-		return 0
+		return TRUE
+	else if(T.is_hole)
+		return FALSE
 
 	var/area/A = T.loc
-
 	if (!A.has_gravity() && !Check_Shoegrip())
-		return 0
+		return FALSE
 
-	return 1
+	return TRUE
 
 
 /mob/proc/Check_Dense_Object() //checks for anything to push off in the vicinity. also handles magboots on gravity-less floors tiles

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -11,7 +11,6 @@
 
 	if(zMove(UP))
 		visible_message(SPAN_NOTICE("[src] has moved upwards."), SPAN_NOTICE("You move upwards."))
-
 /**
  * Verb for the mob to move down a z-level if possible.
  */
@@ -52,11 +51,11 @@
 
 	var/turf/start = get_turf(src)
 	if(!start.CanZPass(src, direction))
-		to_chat(src, SPAN_WARNING("\The [start] is in the way."))
+		to_chat(src, SPAN_WARNING("\The [start.GetZPassBlocker()] is in the way."))
 		return FALSE
 
 	if(!destination.CanZPass(src, direction))
-		to_chat(src, SPAN_WARNING("\The [destination] is in the way!"))
+		to_chat(src, SPAN_WARNING("\The [destination.GetZPassBlocker()] is in the way!"))
 		return FALSE
 
 	var/area/area = get_area(src)

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -11,6 +11,7 @@
 
 	if(zMove(UP))
 		visible_message(SPAN_NOTICE("[src] has moved upwards."), SPAN_NOTICE("You move upwards."))
+
 /**
  * Verb for the mob to move down a z-level if possible.
  */

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -158,10 +158,10 @@
 	if(istype(target_ladder, target_down))
 		direction = DOWN
 	if(!LAD.CanZPass(M, direction))
-		to_chat(M, "<span class='notice'>\The [LAD] is blocking \the [src].</span>")
+		to_chat(M, "<span class='notice'>\The [LAD.GetZPassBlocker()] is blocking \the [src].</span>")
 		return FALSE
 	if(!T.CanZPass(M, direction))
-		to_chat(M, "<span class='notice'>\The [T] is blocking \the [src].</span>")
+		to_chat(M, "<span class='notice'>\The [T.GetZPassBlocker()] is blocking \the [src].</span>")
 		return FALSE
 	for(var/atom/A in T)
 		if(!isliving(A))

--- a/code/modules/multiz/turfs/open_space.dm
+++ b/code/modules/multiz/turfs/open_space.dm
@@ -39,14 +39,23 @@
 		if(direction == DOWN) //on a turf above, trying to enter
 			return !density
 
+/turf/proc/GetZPassBlocker()
+	return src
+
 /turf/simulated/open/CanZPass(atom/A, direction)
 	if(locate(/obj/structure/lattice/catwalk, src))
 		if(z == A.z)
 			if(direction == DOWN)
-				return 0
+				return FALSE
 		else if(direction == UP)
-			return 0
+			return FALSE
 	return 1
+
+/turf/simulated/open/GetZPassBlocker()
+	var/obj/structure/lattice/catwalk/catwalk = locate(/obj/structure/lattice/catwalk, src)
+	if(catwalk)
+		return catwalk
+	return src
 
 /turf/space/CanZPass(atom/A, direction)
 	if(locate(/obj/structure/lattice/catwalk, src))
@@ -56,6 +65,12 @@
 		else if(direction == UP)
 			return 0
 	return 1
+
+/turf/space/GetZPassBlocker()
+	var/obj/structure/lattice/catwalk/catwalk = locate(/obj/structure/lattice/catwalk, src)
+	if(catwalk)
+		return catwalk
+	return src
 
 
 // Add a falling atom by default. Even if it's not an atom that can actually fall.

--- a/html/changelogs/geeves-hole_changes.yml
+++ b/html/changelogs/geeves-hole_changes.yml
@@ -1,0 +1,10 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Putting a lattice/catwalk on an open space makes it not be a hole anymore, meaning you won't fall through it, not use jetpack fuel to traverse them, and mechs can now walk over them."
+  - rscadd: "Jetpack users will now visibly float when they're jetting over an open turf."
+  - tweak: "Jetpack ion trails now fire whenever the jetpack thrusts, not on a processing timer."
+  - bugfix: "Attacking someone or throwing someone no longer resets your floating state."
+  - bugfix: "Trying to pass through an open space with a catwalk will now report the catwalk as the blocker, instead of the open space."


### PR DESCRIPTION
* Putting a lattice/catwalk on an open space makes it not be a hole anymore, meaning you won't fall through it, not use jetpack fuel to traverse them, and mechs can now walk over them.
* Jetpack users will now visibly float when they're jetting over an open turf.
* Jetpack ion trails now fire whenever the jetpack thrusts, not on a processing timer.
* Attacking someone or throwing someone no longer resets your floating state.
* Trying to pass through an open space with a catwalk will now report the catwalk as the blocker, instead of the open space.
