### PR TITLE
Typecheck all return_air calls

### DIFF
--- a/code/ZAS/ConnectionGroup.dm
+++ b/code/ZAS/ConnectionGroup.dm
@@ -208,7 +208,8 @@ Class Procs:
 	src.A = A
 	src.B = B
 	LAZYADD(A.edges, src)
-	air = B.return_air()
+	if(B)
+		air = B.return_air()
 	//id = 52*A.id
 //	log_debug("New edge from [A] to [B].")
 

--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -179,6 +179,7 @@
 
 /proc/air_sound(atom/source, var/required_pressure = SOUND_MINIMUM_PRESSURE)
 	var/turf/T = get_turf(source)
+	if(!istype(T)) return FALSE
 	var/datum/gas_mixture/environment = T.return_air()
 	var/pressure = (environment)? environment.return_pressure() : 0
 	if(pressure < required_pressure)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -47,8 +47,6 @@
 /atom/proc/return_air()
 	if(loc)
 		return loc.return_air()
-	else
-		return null
 
 // Returns src and all recursive contents in a list.
 /atom/proc/GetAllContents()

--- a/code/game/gamemodes/technomancer/spells/radiance.dm
+++ b/code/game/gamemodes/technomancer/spells/radiance.dm
@@ -30,6 +30,7 @@
 
 /obj/item/spell/radiance/process()
 	var/turf/T = get_turf(src)
+	if(!istype(T)) return
 	var/datum/gas_mixture/removed = null
 	var/datum/gas_mixture/env = null
 	var/adjusted_power = calculate_spell_power(power)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -500,6 +500,7 @@
 
 /obj/machinery/alarm/proc/populate_status(var/data)
 	var/turf/location = get_turf(src)
+	if(!istype(location)) return
 	var/datum/gas_mixture/environment = location.return_air()
 	var/total = environment.total_moles
 

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -241,8 +241,9 @@ update_flag
 		var/datum/gas_mixture/environment
 		if(holding)
 			environment = holding.air_contents
-		else
+		else if(loc)
 			environment = loc.return_air()
+		else return
 
 		var/env_pressure = environment.return_pressure()
 		var/pressure_delta = release_pressure - env_pressure

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -73,8 +73,9 @@
 		var/datum/gas_mixture/environment
 		if(holding)
 			environment = holding.air_contents
-		else
+		else if(loc)
 			environment = loc.return_air()
+		else return
 
 		var/pressure_delta
 		var/output_volume

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -63,8 +63,9 @@
 		var/datum/gas_mixture/environment
 		if(holding)
 			environment = holding.air_contents
-		else
+		else if(loc)
 			environment = loc.return_air()
+		else return
 
 		var/transfer_moles = min(1, volume_rate/environment.volume)*environment.total_moles
 
@@ -196,6 +197,8 @@
 
 	var/power_draw = -1
 
+	if(!loc)
+		return
 	var/datum/gas_mixture/environment = loc.return_air()
 
 	var/transfer_moles = min(1, volume_rate/environment.volume)*environment.total_moles

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -403,8 +403,6 @@
 	//draws from the cryo tube's environment, instead of the cold internal air.
 	if(loc)
 		return loc.return_air()
-	else
-		return null
 
 /datum/data/function/proc/reset()
 	return

--- a/code/game/machinery/overview.dm
+++ b/code/game/machinery/overview.dm
@@ -41,7 +41,7 @@
 
 
 
-			if(!T)
+			if(!isturf(T))
 				colour = rgb(0,0,0)
 
 			else
@@ -119,7 +119,7 @@
 
 					colour = rgb(red, green, blue)
 
-			if(!colour2 && !T.density)
+			if(!colour2 && isturf(T) && !T.density)
 				var/datum/gas_mixture/environment = T.return_air()
 				var/turf_total = environment.total_moles()
 				//var/turf_total = T.co2 + T.oxygen + T.poison + T.sl_gas + T.n2
@@ -342,4 +342,3 @@ proc/getb(col)
 
 	mapobjs = null
 	src.unset_machine()
-

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -167,7 +167,7 @@
 
 
 /obj/machinery/space_heater/process()
-	if(on)
+	if(on && loc)
 		if(cell && cell.charge)
 			var/datum/gas_mixture/env = loc.return_air()
 			if(env && abs(env.temperature - set_temperature) <= 0.1)

--- a/code/game/machinery/telecomms/telecommunications.dm
+++ b/code/game/machinery/telecomms/telecommunications.dm
@@ -138,6 +138,7 @@
 
 /obj/machinery/telecomms/proc/check_heat()
 	// Checks heat from the environment and applies any integrity damage
+	if(!loc) return
 	var/datum/gas_mixture/environment = loc.return_air()
 	var/damage_chance = 0                           // Percent based chance of applying 1 integrity damage this tick
 	switch(environment.temperature)

--- a/code/game/objects/items/airbubble.dm
+++ b/code/game/objects/items/airbubble.dm
@@ -580,8 +580,7 @@
 /obj/structure/closet/airbubble/proc/get_turf_air()
 	var/turf/T = get_turf(src)
 	if(T)
-		. = T.return_air()
-	return
+		return T.return_air()
 
 /obj/structure/closet/airbubble/proc/return_pressure()
 	. = 0

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -377,9 +377,9 @@ BREATH ANALYZER
 	origin_tech = list(TECH_MAGNET = 1, TECH_ENGINEERING = 1)
 
 /obj/item/device/analyzer/atmosanalyze(var/mob/user)
+	if(!user) return
 	var/air = user.return_air()
-	if (!air)
-		return
+	if (!air) return
 
 	return atmosanalyzer_scan(src, air, user)
 

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -84,7 +84,7 @@
 			return C.air_contents.temperature
 
 	var/turf/T = get_turf(src)
-	if(istype(T, /turf/space))
+	if(istype(T, /turf/space) || !isturf(T))
 		return FALSE	//space has no temperature, this just makes sure the cooling unit works in space
 
 	var/datum/gas_mixture/environment = T.return_air()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -101,8 +101,6 @@
 /obj/return_air()
 	if(loc)
 		return loc.return_air()
-	else
-		return null
 
 /obj/proc/updateUsrDialog()
 	if(in_use)

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -62,8 +62,6 @@
 /obj/structure/pit/return_air()
 	if(open && loc)
 		return loc.return_air()
-	else
-		return null
 
 /obj/structure/pit/proc/digout(mob/escapee)
 	var/breakout_time = 1 //2 minutes by default

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -366,6 +366,7 @@ obj/structure/ex_act(severity)
 //  giving it a chance to mix its internal air supply with the turf it is
 //  currently on.
 /obj/structure/transit_tube_pod/proc/mix_air()
+	if(!loc) return
 	var/datum/gas_mixture/environment = loc.return_air()
 
 	//note that share_ratio assumes both gas mixes have the same volume,

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -193,7 +193,7 @@
 
 		S.volume -= max(distance - world.view, 0) * 2
 
-		if (use_pressure)
+		if (use_pressure && istype(T))
 			var/datum/gas_mixture/hearer_env = T.return_air()
 			var/datum/gas_mixture/source_env = source_turf.return_air()
 

--- a/code/modules/admin/verbs/clear_toxins.dm
+++ b/code/modules/admin/verbs/clear_toxins.dm
@@ -5,6 +5,8 @@
 	if (!check_rights(R_ADMIN))
 		return
 
+	if(!usr.loc) return
+
 	var/datum/gas_mixture/environment = usr.loc.return_air()
 	environment.gas[GAS_PHORON] = 0
 	environment.gas[GAS_NITROGEN] = 82.1472

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -22,9 +22,9 @@
 	set name = "Cell"
 	if(!mob)
 		return
-	var/turf/T = mob.loc
+	var/turf/T = get_turf(mob)
 
-	if (!( istype(T, /turf) ))
+	if (!istype(T))
 		return
 
 	var/datum/gas_mixture/env = T.return_air()

--- a/code/modules/atmospherics/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/dp_vent_pump.dm
@@ -112,6 +112,8 @@
 		broadcast_status()
 		broadcast_status_next_process = FALSE
 
+	if(!loc) return FALSE
+
 	var/datum/gas_mixture/environment = loc.return_air()
 
 	var/power_draw = -1

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -279,6 +279,7 @@
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], turn it off first.</span>")
 		return TRUE
 	var/datum/gas_mixture/int_air = return_air()
+	if (!loc) return FALSE
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > PRESSURE_EXERTED)
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it too exerted due to internal pressure.</span>")

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -225,6 +225,7 @@ Thus, the two variables affect pump operation are set in New():
 		to_chat(user, "<span class='warning'>You cannot unwrench this [src], turn it off first.</span>")
 		return TRUE
 	var/datum/gas_mixture/int_air = return_air()
+	if (!loc) return FALSE
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > PRESSURE_EXERTED && !istype(W, /obj/item/pipewrench))
 		to_chat(user, "<span class='warning'>You cannot unwrench this [src], it's too exerted due to internal pressure.</span>")

--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -88,6 +88,7 @@
 	var/int_pressure = 0
 	for(var/datum/omni_port/P in ports)
 		int_pressure += P.air.return_pressure()
+	if(!loc) return FALSE
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_pressure - env_air.return_pressure()) > PRESSURE_EXERTED)
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it is too exerted due to internal pressure.</span>")

--- a/code/modules/atmospherics/components/portables_connector.dm
+++ b/code/modules/atmospherics/components/portables_connector.dm
@@ -139,6 +139,7 @@
 	if (locate(/obj/machinery/portable_atmospherics, src.loc))
 		return TRUE
 	var/datum/gas_mixture/int_air = return_air()
+	if(!loc) return FALSE
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > PRESSURE_EXERTED)
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it too exerted due to internal pressure.</span>")

--- a/code/modules/atmospherics/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/components/trinary_devices/filter.dm
@@ -135,6 +135,7 @@
 	if (!W.iswrench())
 		return ..()
 	var/datum/gas_mixture/int_air = return_air()
+	if(!loc) return FALSE
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > PRESSURE_EXERTED)
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it too exerted due to internal pressure.</span>")

--- a/code/modules/atmospherics/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/components/trinary_devices/mixer.dm
@@ -107,6 +107,7 @@
 	if (!W.iswrench())
 		return ..()
 	var/datum/gas_mixture/int_air = return_air()
+	if (!loc) return FALSE
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > PRESSURE_EXERTED)
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it too exerted due to internal pressure.</span>")

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -350,6 +350,7 @@
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it's too complicated.</span>")
 		return TRUE
 	var/datum/gas_mixture/int_air = return_air()
+	if(!loc) return FALSE
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > PRESSURE_EXERTED)
 		to_chat(user, "<span class='warnng'>You cannot unwrench \the [src], it too exerted due to internal pressure.</span>")

--- a/code/modules/atmospherics/components/unary/heat_exchanger.dm
+++ b/code/modules/atmospherics/components/unary/heat_exchanger.dm
@@ -73,6 +73,7 @@
 			to_chat(user, "<span class='warning'>You must remove the plating first.</span>")
 			return 1
 		var/datum/gas_mixture/int_air = return_air()
+		if (!loc) return FALSE
 		var/datum/gas_mixture/env_air = loc.return_air()
 		if ((int_air.return_pressure()-env_air.return_pressure()) > PRESSURE_EXERTED)
 			to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it is too exerted due to internal pressure.</span>")

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -65,6 +65,7 @@
 		return
 
 	var/power_draw = -1
+	if(!loc) return FALSE
 	var/datum/gas_mixture/environment = loc.return_air()
 
 	if(environment && air_contents.temperature > 0)
@@ -81,7 +82,7 @@
 	return 1
 
 /obj/machinery/atmospherics/unary/outlet_injector/proc/inject()
-	if(injecting || (stat & NOPOWER))
+	if(injecting || (stat & NOPOWER) || !loc)
 		return 0
 
 	var/datum/gas_mixture/environment = loc.return_air()

--- a/code/modules/atmospherics/components/unary/thermal_plate.dm
+++ b/code/modules/atmospherics/components/unary/thermal_plate.dm
@@ -21,6 +21,8 @@
 	process()
 		..()
 
+		if (!loc) return FALSE
+
 		var/datum/gas_mixture/environment = loc.return_air()
 
 		//Get processable air sample and thermal info from environment

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -199,6 +199,8 @@
 	if(!can_pump())
 		return 0
 
+	if(!loc) return FALSE
+
 	var/datum/gas_mixture/environment = loc.return_air()
 
 	var/power_draw = -1
@@ -435,6 +437,7 @@
 		to_chat(user, SPAN_WARNING("You must remove the plating first."))
 		return TRUE
 	var/datum/gas_mixture/int_air = return_air()
+	if(!loc) return FALSE
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > PRESSURE_EXERTED)
 		to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], it is too exerted due to internal pressure."))

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -172,7 +172,7 @@
 		broadcast_status()
 		broadcast_status_next_process = FALSE
 
-	if(!use_power || (stat & (NOPOWER|BROKEN)))
+	if(!use_power || (stat & (NOPOWER|BROKEN)) || !loc)
 		return 0
 	if(welded)
 		return 0
@@ -305,6 +305,7 @@
 			to_chat(user, SPAN_WARNING("You must remove the plating first."))
 			return TRUE
 		var/datum/gas_mixture/int_air = return_air()
+		if(!loc) return FALSE
 		var/datum/gas_mixture/env_air = loc.return_air()
 		if ((int_air.return_pressure()-env_air.return_pressure()) > PRESSURE_EXERTED)
 			to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], it is too exerted due to internal pressure."))

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -308,6 +308,7 @@
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it's too complicated.</span>")
 		return TRUE
 	var/datum/gas_mixture/int_air = return_air()
+	if (!loc) return FALSE
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > PRESSURE_EXERTED)
 		to_chat(user, "<span class='warning'>You cannot unwrench \the [src], it is too exerted due to internal pressure.</span>")

--- a/code/modules/atmospherics/datum_pipeline.dm
+++ b/code/modules/atmospherics/datum_pipeline.dm
@@ -131,7 +131,7 @@
 
 		target.zone.air.merge(turf_copy)
 
-	else
+	else if(target)
 		var/datum/gas_mixture/turf_air = target.return_air()
 
 		equalize_gases(list(air_sample, turf_air))

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -94,6 +94,7 @@
 		to_chat(user, "<span class='warning'>You must remove the plating first.</span>")
 		return TRUE
 	var/datum/gas_mixture/int_air = return_air()
+	if(!loc) return FALSE
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > PRESSURE_EXERTED)
 		if(!istype(W, /obj/item/pipewrench))
@@ -216,6 +217,7 @@
 		. = PROCESS_KILL
 
 /obj/machinery/atmospherics/pipe/simple/check_pressure(pressure)
+	if(!loc) return
 	var/datum/gas_mixture/environment = loc.return_air()
 
 	var/pressure_difference = pressure - environment.return_pressure()

--- a/code/modules/cooking/machinery/cooking_machines/_cooker.dm
+++ b/code/modules/cooking/machinery/cooking_machines/_cooker.dm
@@ -131,6 +131,7 @@
 	overlays += light
 
 /obj/machinery/appliance/cooker/process()
+	if (!loc) return FALSE
 	var/datum/gas_mixture/loc_air = loc.return_air()
 	if (stat || (use_power != 2)) // if we're not actively heating
 		temperature -= min(loss, temperature - loc_air.temperature)

--- a/code/modules/custom_ka/projectiles.dm
+++ b/code/modules/custom_ka/projectiles.dm
@@ -26,6 +26,7 @@
 		strike_thing(target_turf)
 
 /obj/item/projectile/kinetic/proc/do_damage(var/turf/T, var/living_damage = 1, var/mineral_damage = 1)
+	if(!istype(T)) return
 	var/datum/gas_mixture/environment = T.return_air()
 	living_damage *= max(1 - (environment.return_pressure() / 100) * 0.75, 0)
 	new /obj/effect/overlay/temp/kinetic_blast(T)

--- a/code/modules/heavy_vehicle/mecha.dm
+++ b/code/modules/heavy_vehicle/mecha.dm
@@ -230,7 +230,7 @@
 		MR.start_charging(src)
 
 /mob/living/heavy_vehicle/return_air()
-	return (body && body.pilot_coverage >= 100 && hatch_closed) ? body.cockpit : loc.return_air()
+	return (body && body.pilot_coverage >= 100 && hatch_closed) ? body.cockpit : loc?.return_air()
 
 /mob/living/heavy_vehicle/GetIdCard()
 	return access_card

--- a/code/modules/mob/abstract/observer/observer.dm
+++ b/code/modules/mob/abstract/observer/observer.dm
@@ -540,6 +540,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			continue
 
 		var/turf/T = get_turf(testvent)
+		if(!istype(T)) continue
 
 		//Skip areas that contain turrets
 		var/area/A = T.loc

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1200,6 +1200,8 @@ mob/living/carbon/human/proc/change_monitor()
 	else
 		custom_emote(VISIBLE_MESSAGE, "flicks their tongue out.")
 
+	if(!src.loc) return
+
 	var/datum/gas_mixture/mixture = src.loc.return_air()
 	var/total_moles = mixture.total_moles
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -280,6 +280,10 @@
 	return fire_stacks
 
 /mob/living/proc/handle_fire()
+	if(!loc)
+		ExtinguishMobCompletely()
+		return TRUE
+
 	if(fire_stacks < 0)
 		fire_stacks = min(0, ++fire_stacks) //If we've doused ourselves in water to avoid fire, dry off slowly
 

--- a/code/modules/multiz/pipes.dm
+++ b/code/modules/multiz/pipes.dm
@@ -69,6 +69,7 @@
 		. = PROCESS_KILL
 
 /obj/machinery/atmospherics/pipe/zpipe/check_pressure(pressure)
+	if(!loc) return FALSE
 	var/datum/gas_mixture/environment = loc.return_air()
 
 	var/pressure_difference = pressure - environment.return_pressure()

--- a/code/modules/power/portgen.dm
+++ b/code/modules/power/portgen.dm
@@ -206,6 +206,7 @@
 		Gives traitors more opportunities to sabotage the generator or allows enterprising engineers to build additional
 		cooling in order to get more power out.
 	*/
+	if(!loc) return
 	var/datum/gas_mixture/environment = loc.return_air()
 	if (environment)
 		var/ratio = min(environment.return_pressure()/ONE_ATMOSPHERE, 1)
@@ -336,8 +337,11 @@
 	data["temperature_max"] = max_temperature
 	data["temperature_overheat"] = overheating
 
-	var/datum/gas_mixture/environment = loc.return_air()
-	data["temperature_min"] = Floor(environment.temperature - T0C)
+	if(loc)
+		var/datum/gas_mixture/environment = loc.return_air()
+		if(environment)
+			data["temperature_min"] = Floor(environment.temperature - T0C)
+
 	data["output_min"] = initial(power_output)
 	data["is_broken"] = IsBroken()
 	data["is_ai"] = (isAI(user) || (isrobot(user) && !Adjacent(user)))

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -70,7 +70,9 @@
 		stat |= BROKEN
 		return
 	rpm = 0.9* rpm + 0.1 * rpmtarget
+	if(!inturf) return
 	var/datum/gas_mixture/environment = inturf.return_air()
+	if(!environment) return
 	var/transfer_moles = environment.total_moles / 10
 	//var/transfer_moles = rpm/10000*capacity
 	var/datum/gas_mixture/removed = inturf.remove_air(transfer_moles)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -198,8 +198,10 @@
 				if(istype(H, /obj/machinery/portable_atmospherics/hydroponics/soil/invisible))
 					qdel(H)
 
-	var/datum/gas_mixture/environment = T.return_air()
-	environment.adjust_gas(GAS_PHORON,-amount*10)
+	if(istype(T))
+		var/datum/gas_mixture/environment = T.return_air()
+		if(environment)
+			environment.adjust_gas(GAS_PHORON,-amount*10)
 
 /decl/reagent/toxin/cyanide //Fast and Lethal
 	name = "Cyanide"

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -401,10 +401,12 @@
 	playsound(src.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
 	INVOKE_ASYNC(S, /datum/effect/effect/system/smoke_spread/.proc/start)
 
-	var/datum/gas_mixture/env = src.loc.return_air()
-	if(env)
-		if (reagents.total_volume > 750)
-			env.temperature = 0
-		else if (reagents.total_volume > 500)
-			env.temperature -= 100
-		QDEL_IN(src, 10)
+	if(src.loc)
+		var/datum/gas_mixture/env = src.loc.return_air()
+		if(env)
+			if (reagents.total_volume > 750)
+				env.temperature = 0
+			else if (reagents.total_volume > 500)
+				env.temperature -= 100
+
+	QDEL_IN(src, 10)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -500,6 +500,7 @@
 		return
 
 	var/atom/L = loc						// recharging from loc turf
+	if(!loc) return
 	var/datum/gas_mixture/env = L.return_air()
 
 	var/power_draw = -1

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -59,6 +59,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 
+	if(!loc) return
 	var/datum/gas_mixture/environment = loc.return_air()
 	switch(environment.temperature)
 		if(0 to T0C)

--- a/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
@@ -95,6 +95,7 @@
 	var/trigger_nitro = 0
 	if( (my_effect.trigger >= TRIGGER_HEAT && my_effect.trigger <= TRIGGER_NITRO) || (my_effect.trigger >= TRIGGER_HEAT && my_effect.trigger <= TRIGGER_NITRO) )
 		var/turf/T = get_turf(src)
+		if(!istype(T)) return
 		var/datum/gas_mixture/env = T.return_air()
 		if(env)
 			if(env.temperature < 225)

--- a/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_atmospheric.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/unknown_effect_atmospheric.dm
@@ -162,12 +162,13 @@
 			to_chat(user, SPAN_NOTICE("You detect a decrease in temperature throughout your systems!"))
 		else
 			to_chat(user, SPAN_NOTICE("A chill passes up your spine!"))
+		if(!holder.loc) return
 		var/datum/gas_mixture/env = holder.loc.return_air()
 		if(env)
 			env.temperature = max(env.temperature - rand(5,50), 0)
 
 /datum/artifact_effect/cold/DoEffectAura()
-	if(holder)
+	if(holder && holder.loc)
 		var/datum/gas_mixture/env = holder.loc.return_air()
 		if(env && env.temperature > target_temp)
 			env.temperature -= pick(0, 0, 1)
@@ -186,7 +187,7 @@
 	effect = pick(EFFECT_TOUCH, EFFECT_AURA)
 
 /datum/artifact_effect/heat/DoEffectTouch(var/mob/living/user)
-	if(holder)
+	if(holder && holder.loc)
 		if(user.isSynthetic())
 			to_chat(user, SPAN_WARNING("You detect a wave of heat surging through your systems."))
 		else
@@ -196,7 +197,7 @@
 			env.temperature += rand(5,50)
 
 /datum/artifact_effect/heat/DoEffectAura()
-	if(holder)
+	if(holder && holder.loc)
 		var/datum/gas_mixture/env = holder.loc.return_air()
 		if(env && env.temperature < target_temp)
 			env.temperature += pick(0, 0, 1)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -371,7 +371,7 @@
 	data = ..() || list()
 	data["integrity_percentage"] = round(get_integrity())
 	var/datum/gas_mixture/env = null
-	if(!istype(src.loc, /turf/space))
+	if(loc && !istype(src.loc, /turf/space))
 		env = src.loc.return_air()
 	data["ambient_temp"] = round(env?.temperature)
 	data["ambient_pressure"] = round(env?.return_pressure())


### PR DESCRIPTION
largest source of runtime errors is stuff calling return_air while it has a null loc/obj/whatever

there's probably a bigger issue with stuff existing when it is null loc'd to begin with, but this at least clears up that issue