### PR TITLE
Various Slime Based Fixes

### DIFF
--- a/code/game/objects/items/weapons/storage/slime_core_bag.dm
+++ b/code/game/objects/items/weapons/storage/slime_core_bag.dm
@@ -21,6 +21,28 @@
 	drop_sound = 'sound/items/drop/backpack.ogg'
 	pickup_sound = 'sound/items/pickup/backpack.ogg'
 
+/obj/item/storage/slimes/orient2hud(mob/user as mob, defer_overlays = FALSE)
+	var/list/numbered_contents_by_name = list()
+
+	for(var/obj/item/I in contents)
+		var/datum/numbered_display/display = numbered_contents_by_name[I.name]
+		if(display)
+			display.number++
+		else
+			numbered_contents_by_name[I.name] = new /datum/numbered_display(I)
+
+	numbered_contents_by_name = sortAssoc(numbered_contents_by_name)
+
+	var/list/datum/numbered_display/numbered_contents = list()
+	for(var/display_name in numbered_contents_by_name)
+		numbered_contents += numbered_contents_by_name[display_name]
+
+	var/row_num = 0
+	var/col_count = force_column_number ? force_column_number : min(7, storage_slots) - 1
+	if(length(numbered_contents) > 7)
+		row_num = round((length(numbered_contents) - 1) / 7) // 7 is the maximum allowed width.
+	slot_orient_objs(row_num, col_count, numbered_contents)
+
 /obj/item/storage/slimes/handle_name_initials(var/sample_name)
 	var/name_initials = ..()
 	return replacetext(name_initials, "SE", "")

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -182,6 +182,13 @@
 			LAZYREMOVE(is_seeing, M)
 	return cansee
 
+
+/obj/item/storage/proc/update_storage_ui()
+	for(var/mob/seer as anything in is_seeing)
+		orient2hud(seer)
+		if(seer.s_active)
+			seer.s_active.show_to(seer)
+
 //This proc draws out the inventory and places the items on it. tx and ty are the upper left tile and mx, my are the bottm right.
 //The numbers are calculated from the bottom-left The bottom-left slot being 1,1.
 /obj/item/storage/proc/orient_objs(tx, ty, mx, my)

--- a/code/modules/cooking/machinery/smartfridge.dm
+++ b/code/modules/cooking/machinery/smartfridge.dm
@@ -319,7 +319,7 @@
 		SSvueui.check_uis_for_change(src)
 		return
 
-	if(istype(O, /obj/item/storage/bag) || istype(O, /obj/item/storage/box/produce))
+	if(istype(O, /obj/item/storage))
 		var/obj/item/storage/P = O
 		var/plants_loaded = 0
 		for(var/obj/G in P.contents)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1065,6 +1065,9 @@
 		T.visible_message("[icon2html(T, viewers(get_turf(src)))]<span class='notice'>\The [T]'s power is consumed in the reaction.</span>")
 		T.name = "used slime extract"
 		T.desc = "This extract has been used up."
+		if(istype(T.loc, /obj/item/storage))
+			var/obj/item/storage/storage = T.loc
+			storage.update_storage_ui()
 
 //Grey
 /datum/chemical_reaction/slime/spawn

--- a/html/changelogs/geeves-slime_bag_fix.yml
+++ b/html/changelogs/geeves-slime_bag_fix.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "You can now click on the slime smart fridge with the slime core bag to insert all the cores into the fridge again. As a side-effect, you can now fill fridges by clicking on them with any storage item."
+  - bugfix: "Slime core bags sort their contents by name instead of type, and used extracts are displayed seperately."
+  - bugfix: "A slime extract that turns used while in the bag now automatically updates your storage UI."


### PR DESCRIPTION
* You can now click on the slime smart fridge with the slime core bag to insert all the cores into the fridge again. As a side-effect, you can now fill fridges by clicking on them with any storage item.
* Slime core bags sort their contents by name instead of type, and used extracts are displayed seperately.
* A slime extract that turns used while in the bag now automatically updates your storage UI.

Fixes #15356 