### PR TITLE
Removes photon grenades from the uplink.

### DIFF
--- a/code/datums/uplink/grenades.dm
+++ b/code/datums/uplink/grenades.dm
@@ -16,12 +16,6 @@
 	path = /obj/item/grenade/spawnergrenade/manhacks/lubed
 	desc = "A grenade that deploys five lubed viscerator combat drones. Deadly in numbers, will not attack you or your allies. Works best when killed."
 
-/datum/uplink_item/item/grenades/anti_photon
-	name = "5xPhoton Disruption Grenades"
-	item_cost = 1
-	path = /obj/item/storage/box/anti_photons
-	desc = "A box of five grenades that cause total darkness in the area they explode in. Circumvented by vision altering headgear. Useful for get-aways."
-
 /datum/uplink_item/item/grenades/smoke
 	name = "5xSmoke Grenades"
 	item_cost = 1

--- a/html/changelogs/mattatlas-nocheese.yml
+++ b/html/changelogs/mattatlas-nocheese.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Removed photon grenades from the antag uplink."


### PR DESCRIPTION
There is no real possible counter to photon grenades + thermals, and we can't stop thermals from working with photon grenades. Shortening the effect would make them either useless or just as strong, so they have to go.