### PR TITLE
Reduce machinery and mob processing

### DIFF
--- a/code/__defines/dcs/signals.dm
+++ b/code/__defines/dcs/signals.dm
@@ -30,6 +30,7 @@
 // /atom signals
 
 // /area signals
+#define COMSIG_AREA_FIRE_ALARM "fire_alarm"
 
 // /turf signals
 

--- a/code/__defines/important_recursive_contents.dm
+++ b/code/__defines/important_recursive_contents.dm
@@ -5,3 +5,5 @@
 // the client mobs channel of the important_recursive_contents list, everything in here will be a mob with an attached client
 // this is given to both a clients mob, and a clients eye, both point to the clients mob
 #define RECURSIVE_CONTENTS_CLIENT_MOBS "recursive_contents_client_mobs"
+// List of everything AI should evalulate as targets: all /mob/living, /obj/machinery/porta_turret, /obj/machinery/bot
+#define RECURSIVE_CONTENTS_AI_TARGETS "recursive_contents_ai_targets"

--- a/code/__defines/spatial_gridmap.dm
+++ b/code/__defines/spatial_gridmap.dm
@@ -11,6 +11,9 @@
 #define SPATIAL_GRID_CONTENTS_TYPE_HEARING RECURSIVE_CONTENTS_HEARING_SENSITIVE
 // Every movable that has a client in it is stored in this channel
 #define SPATIAL_GRID_CONTENTS_TYPE_CLIENTS RECURSIVE_CONTENTS_CLIENT_MOBS
+// Every /mob is stored in this channel
+#define SPATIAL_GRID_CONTENTS_TYPE_TARGETS	RECURSIVE_CONTENTS_AI_TARGETS
 
 // Whether movable is itself or containing something which should be in one of the spatial grid channels
-#define HAS_SPATIAL_GRID_CONTENTS(movable) (movable.important_recursive_contents && (movable.important_recursive_contents[RECURSIVE_CONTENTS_HEARING_SENSITIVE] || movable.important_recursive_contents[RECURSIVE_CONTENTS_CLIENT_MOBS]))
+#define HAS_SPATIAL_GRID_CONTENTS(movable) (movable.important_recursive_contents && \
+	(movable.important_recursive_contents[RECURSIVE_CONTENTS_HEARING_SENSITIVE] || movable.important_recursive_contents[RECURSIVE_CONTENTS_CLIENT_MOBS] || movable.important_recursive_contents[RECURSIVE_CONTENTS_AI_TARGETS]))

--- a/code/controllers/subsystems/machinery.dm
+++ b/code/controllers/subsystems/machinery.dm
@@ -100,7 +100,7 @@ if(Datum.isprocessing) {\
 		timer = world.tick_usage
 		process_pipenets(resumed, no_mc_tick)
 		cost_pipenets = MC_AVERAGE(cost_pipenets, TICK_DELTA_TO_MS(world.tick_usage - timer))
-		if (state != SS_RUNNING)
+		if (state != SS_RUNNING && init_state == SS_INITSTATE_DONE)
 			return
 		current_step = SSMACHINERY_MACHINERY
 		resumed = FALSE
@@ -108,7 +108,7 @@ if(Datum.isprocessing) {\
 		timer = world.tick_usage
 		process_machinery(resumed, no_mc_tick)
 		cost_machinery = MC_AVERAGE(cost_machinery, TICK_DELTA_TO_MS(world.tick_usage - timer))
-		if(state != SS_RUNNING)
+		if(state != SS_RUNNING && init_state == SS_INITSTATE_DONE)
 			return
 		current_step = SSMACHINERY_POWERNETS
 		resumed = FALSE
@@ -116,7 +116,7 @@ if(Datum.isprocessing) {\
 		timer = world.tick_usage
 		process_powernets(resumed, no_mc_tick)
 		cost_powernets = MC_AVERAGE(cost_powernets, TICK_DELTA_TO_MS(world.tick_usage - timer))
-		if(state != SS_RUNNING)
+		if(state != SS_RUNNING && init_state == SS_INITSTATE_DONE)
 			return
 		current_step = SSMACHINERY_POWER_OBJECTS
 		resumed = FALSE
@@ -124,7 +124,7 @@ if(Datum.isprocessing) {\
 		timer = world.tick_usage
 		process_power_objects(resumed, no_mc_tick)
 		cost_power_objects = MC_AVERAGE(cost_power_objects, TICK_DELTA_TO_MS(world.tick_usage - timer))
-		if (state != SS_RUNNING)
+		if (state != SS_RUNNING && init_state == SS_INITSTATE_DONE)
 			return
 		current_step = SSMACHINERY_PIPENETS
 

--- a/code/controllers/subsystems/spatial_gridmap.dm
+++ b/code/controllers/subsystems/spatial_gridmap.dm
@@ -52,6 +52,8 @@
 	var/list/hearing_contents
 	///every client possessed mob inside this cell
 	var/list/client_contents
+	///every mob inside this cell
+	var/list/tgt_contents
 
 /datum/spatial_grid_cell/New(cell_x, cell_y, cell_z)
 	. = ..()
@@ -67,6 +69,7 @@
 
 	hearing_contents = dummy_list
 	client_contents = dummy_list
+	tgt_contents = dummy_list
 
 /datum/spatial_grid_cell/Destroy(force, ...)
 	if(force)//the response to someone trying to qdel this is a right proper fuck you
@@ -102,7 +105,7 @@
 	///list of the spatial_grid_cell datums per z level, arranged in the order of y index then x index
 	var/list/grids_by_z_level = list()
 	///everything that spawns before us is added to this list until we initialize
-	var/list/waiting_to_add_by_type = list(RECURSIVE_CONTENTS_HEARING_SENSITIVE = list(), RECURSIVE_CONTENTS_CLIENT_MOBS = list())
+	var/list/waiting_to_add_by_type = list(RECURSIVE_CONTENTS_HEARING_SENSITIVE = list(), RECURSIVE_CONTENTS_CLIENT_MOBS = list(), RECURSIVE_CONTENTS_AI_TARGETS = list())
 
 	var/cells_on_x_axis = 0
 	var/cells_on_y_axis = 0
@@ -316,6 +319,12 @@
 
 					. += grid_level[row][x_index].hearing_contents
 
+		if(SPATIAL_GRID_CONTENTS_TYPE_TARGETS)
+			for(var/row in BOUNDING_BOX_MIN(center_y) to BOUNDING_BOX_MAX(center_y, cells_on_y_axis))
+				for(var/x_index in BOUNDING_BOX_MIN(center_x) to BOUNDING_BOX_MAX(center_x, cells_on_x_axis))
+
+					. += grid_level[row][x_index].tgt_contents
+
 	return .
 
 ///get the grid cell encomapassing targets coordinates
@@ -369,7 +378,7 @@
 	var/datum/spatial_grid_cell/intersecting_cell = grids_by_z_level[z_index][y_index][x_index]
 
 	if(new_target.important_recursive_contents[RECURSIVE_CONTENTS_CLIENT_MOBS])
-		GRID_CELL_SET(intersecting_cell.client_contents, new_target.important_recursive_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
+		GRID_CELL_SET(intersecting_cell.client_contents, new_target.important_recursive_contents[RECURSIVE_CONTENTS_CLIENT_MOBS])
 
 		SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(RECURSIVE_CONTENTS_CLIENT_MOBS), new_target)
 
@@ -377,6 +386,12 @@
 		GRID_CELL_SET(intersecting_cell.hearing_contents, new_target.important_recursive_contents[RECURSIVE_CONTENTS_HEARING_SENSITIVE])
 
 		SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(RECURSIVE_CONTENTS_HEARING_SENSITIVE), new_target)
+
+	if(new_target.important_recursive_contents[RECURSIVE_CONTENTS_AI_TARGETS])
+		GRID_CELL_SET(intersecting_cell.tgt_contents, new_target.important_recursive_contents[RECURSIVE_CONTENTS_AI_TARGETS])
+
+		SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(RECURSIVE_CONTENTS_AI_TARGETS), new_target)
+
 
 /**
  * find the spatial map cell that target used to belong to, then subtract target's important_recusive_contents from it.
@@ -389,9 +404,6 @@
 /datum/controller/subsystem/spatial_grid/proc/exit_cell(atom/movable/old_target, turf/target_turf, exclusive_type)
 	if(init_state != SS_INITSTATE_DONE)
 		return
-
-	if(QDELETED(old_target))
-		CRASH("qdeleted or null target trying to enter the spatial grid")
 
 	if(!target_turf || !old_target?.important_recursive_contents)
 		CRASH("/datum/controller/subsystem/spatial_grid/proc/exit_cell() was given null arguments or a new_target without important_recursive_contents!")
@@ -411,6 +423,9 @@
 			if(RECURSIVE_CONTENTS_HEARING_SENSITIVE)
 				GRID_CELL_REMOVE(intersecting_cell.hearing_contents, old_target.important_recursive_contents[RECURSIVE_CONTENTS_HEARING_SENSITIVE])
 
+			if(RECURSIVE_CONTENTS_AI_TARGETS)
+				GRID_CELL_REMOVE(intersecting_cell.tgt_contents, old_target.important_recursive_contents[RECURSIVE_CONTENTS_AI_TARGETS])
+
 		SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(exclusive_type), old_target)
 		return
 
@@ -423,6 +438,11 @@
 		GRID_CELL_REMOVE(intersecting_cell.hearing_contents, old_target.important_recursive_contents[RECURSIVE_CONTENTS_HEARING_SENSITIVE])
 
 		SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(RECURSIVE_CONTENTS_HEARING_SENSITIVE), old_target)
+
+	if(old_target.important_recursive_contents[RECURSIVE_CONTENTS_AI_TARGETS])
+		GRID_CELL_REMOVE(intersecting_cell.hearing_contents, old_target.important_recursive_contents[RECURSIVE_CONTENTS_AI_TARGETS])
+
+		SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(RECURSIVE_CONTENTS_AI_TARGETS), old_target)
 
 ///find the cell this movable is associated with and removes it from all lists
 /datum/controller/subsystem/spatial_grid/proc/force_remove_from_cell(atom/movable/to_remove, datum/spatial_grid_cell/input_cell)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -480,6 +480,28 @@
 	for(var/atom/movable/movable_loc as anything in get_nested_locs(src) + src)
 		LAZYREMOVEASSOC(movable_loc.important_recursive_contents, RECURSIVE_CONTENTS_CLIENT_MOBS, former_client.mob)
 
+// This proc adds atom/movables to the AI targetable list, i.e. things that the AI (turrets, hostile animals) will attempt to target
+/atom/movable/proc/add_to_target_grid()
+	for (var/atom/movable/location as anything in get_nested_locs(src) + src)
+		LAZYADDASSOCLIST(location.important_recursive_contents, RECURSIVE_CONTENTS_AI_TARGETS, src)
+
+	var/turf/our_turf = get_turf(src)
+	if(our_turf && SSspatial_grid.init_state == SS_INITSTATE_DONE)
+		SSspatial_grid.enter_cell(src, our_turf)
+
+	else if(our_turf && SSspatial_grid.init_state != SS_INITSTATE_DONE)//SSspatial_grid isnt init'd yet, add ourselves to the queue
+		SSspatial_grid.enter_pre_init_queue(src, RECURSIVE_CONTENTS_AI_TARGETS)
+
+/atom/movable/proc/clear_from_target_grid()
+	var/turf/our_turf = get_turf(src)
+	if(our_turf && SSspatial_grid.init_state == SS_INITSTATE_DONE)
+		SSspatial_grid.exit_cell(src, our_turf)
+	else if(our_turf && SSspatial_grid.init_state != SS_INITSTATE_DONE)
+		SSspatial_grid.remove_from_pre_init_queue(src, RECURSIVE_CONTENTS_AI_TARGETS)
+
+	for(var/atom/movable/location as anything in get_nested_locs(src) + src)
+		LAZYREMOVEASSOC(location.important_recursive_contents, RECURSIVE_CONTENTS_AI_TARGETS, src)
+
 /atom/movable/proc/do_simple_ranged_interaction(var/mob/user)
 	return FALSE
 

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -71,7 +71,7 @@
 	//Perform the connection
 	connected_port = new_port
 	connected_port.connected_device = src
-	connected_port.on = 1 //Activate port updates
+	connected_port.toggle_process()
 
 	anchored = 1 //Prevent movement
 
@@ -95,6 +95,7 @@
 
 	connected_port.connected_device = null
 	connected_port = null
+	connected_port.toggle_process()
 
 	return 1
 

--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -15,6 +15,14 @@
 	var/locked = 1
 	//var/emagged = 0 //Urist: Moving that var to the general /bot tree as it's used by most bots
 
+/obj/machinery/bot/Initialize(mapload, d, populate_components, is_internal)
+	. = ..()
+	add_to_target_grid()
+
+/obj/machinery/bot/Destroy()
+	clear_from_target_grid()
+	return ..()
+
 /obj/machinery/bot/proc/turn_on()
 	if(stat)	return 0
 	on = 1

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -60,6 +60,8 @@
 	var/open_sound = 'sound/machines/firelockopen.ogg'
 	var/close_sound = 'sound/machines/firelockclose.ogg'
 
+	init_flags = 0
+
 /obj/machinery/door/firedoor/Initialize(var/mapload)
 	. = ..()
 	for(var/obj/machinery/door/firedoor/F in loc)
@@ -355,8 +357,6 @@
 
 // CHECK PRESSURE
 /obj/machinery/door/firedoor/process()
-	..()
-
 	if(density && next_process_time <= world.time)
 		next_process_time = world.time + 100		// 10 second delays between process updates
 		var/changed = 0
@@ -399,6 +399,9 @@
 		if(changed)
 			update_icon()
 
+	else if(!density)
+		return PROCESS_KILL
+
 /obj/machinery/door/firedoor/proc/latetoggle()
 	if(operating || !nextstate)
 		return
@@ -424,6 +427,7 @@
 		return
 	cut_overlays()
 	latetoggle()
+	START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 	return ..()
 
 /obj/machinery/door/firedoor/open(forced = 0, user = usr)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -3,13 +3,12 @@
 	desc = "<i>\"Pull this in case of emergency\"</i>. Thus, keep pulling it forever."
 	icon = 'icons/obj/monitors.dmi'
 	icon_state = "fire0"
-	var/previous_state = 0
-	var/previous_fire_state = FALSE
 	var/detecting = 1
 	var/working = 1
 	var/time = 10
 	var/timing = 0
 	var/lockdownbyai = 0
+	init_flags = 0 // Processing is only for timed alarms now
 	anchored = 1
 	idle_power_usage = 2
 	active_power_usage = 6
@@ -56,19 +55,14 @@
 			icon_state = "fire0"
 			switch(seclevel)
 				if("green")
-					previous_state = icon_state
 					set_light(l_range = L_WALLMOUNT_RANGE, l_power = L_WALLMOUNT_POWER, l_color = LIGHT_COLOR_GREEN)
 				if("blue")
-					previous_state = icon_state
 					set_light(l_range = L_WALLMOUNT_RANGE, l_power = L_WALLMOUNT_POWER, l_color = LIGHT_COLOR_BLUE)
 				if("yellow")
-					previous_state = icon_state
 					set_light(l_range = L_WALLMOUNT_HI_RANGE, l_power = L_WALLMOUNT_HI_POWER, l_color = LIGHT_COLOR_YELLOW)
 				if("red")
-					previous_state = icon_state
 					set_light(l_range = L_WALLMOUNT_HI_RANGE, l_power = L_WALLMOUNT_HI_POWER, l_color = LIGHT_COLOR_RED)
 				if("delta")
-					previous_state = icon_state
 					set_light(l_range = L_WALLMOUNT_HI_RANGE, l_power = L_WALLMOUNT_HI_POWER, l_color = LIGHT_COLOR_ORANGE)
 
 		add_overlay(image(icon, "overlay_[seclevel]", layer = EFFECTS_ABOVE_LIGHTING_LAYER))
@@ -154,33 +148,23 @@
 	src.alarm()
 
 /obj/machinery/firealarm/process()//Note: this processing was mostly phased out due to other code, and only runs when needed
-	var/area/A = get_area(src)
-	if (A.fire != previous_fire_state)
-		update_icon()
-		previous_fire_state = A.fire
-
-	if (stat != previous_state)
-		update_icon()
-		previous_state = stat
-
 	if(stat & (NOPOWER|BROKEN))
 		return
 
-	if(src.timing)
-		if(src.time > 0)
-			src.time = src.time - ((world.timeofday - last_process)/10)
-		else
-			src.alarm()
-			src.time = 0
-			src.timing = 0
-			STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
-		src.updateDialog()
-	last_process = world.timeofday
+	if(!timing)
+		return PROCESS_KILL
 
-	if(locate(/obj/fire) in loc)
+	if(src.time <= 0)
 		alarm()
+		src.time = 0
+		timing = FALSE
+		. = PROCESS_KILL
+	else
+		src.time = src.time - ((world.timeofday - last_process) / 10)
 
-	return
+	updateDialog()
+
+	last_process = world.timeofday
 
 /obj/machinery/firealarm/power_change()
 	..()
@@ -264,6 +248,9 @@
 	if(isContactLevel(z))
 		set_security_level(security_level ? get_security_level() : "green")
 	soundloop = new(src, FALSE)
+
+	var/area/A = get_area(src)
+	RegisterSignal(A, COMSIG_AREA_FIRE_ALARM, /atom/.proc/update_icon)
 
 /obj/machinery/firealarm/Destroy()
 	QDEL_NULL(soundloop)

--- a/code/game/machinery/telecomms/telecommunications.dm
+++ b/code/game/machinery/telecomms/telecommunications.dm
@@ -113,10 +113,10 @@
 	icon_state = state
 
 /obj/machinery/telecomms/process()
-	if(!use_power) return
+	if(!use_power) return PROCESS_KILL
 	if(inoperable(EMPED))
 		toggle_power(additional_flags = EMPED)
-		return
+		return PROCESS_KILL
 
 	// Check heat and generate some
 	check_heat()
@@ -124,17 +124,26 @@
 
 	if(traffic > 0)
 		toggle_power(POWER_USE_ACTIVE)
-	else
+	else if(use_power != POWER_USE_IDLE)
 		toggle_power(POWER_USE_IDLE)
+
+/obj/machinery/telecomms/toggle_power(power_set, additional_flags = 0)
+	. = ..()
+	if(use_power)
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
+	else
+		STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 /obj/machinery/telecomms/emp_act(severity)
 	. = ..()
 	if(stat & EMPED || !prob(100/severity))
 		return
 	stat |= EMPED
-	var/duration = (300 SECONDS)/severity
-	spawn(duration + rand(-20, 20))
-		stat &= ~EMPED
+	addtimer(CALLBACK(src, .proc/post_emp_act), (300 SECONDS) / severity)
+
+/obj/machinery/telecomms/proc/post_emp_act()
+	stat &= ~EMPED
+	toggle_power(POWER_USE_IDLE)
 
 /obj/machinery/telecomms/proc/check_heat()
 	// Checks heat from the environment and applies any integrity damage

--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -163,8 +163,13 @@
 		else
 			returnval = call(target, procname)()
 	else
+		var/procpath = text2path("/proc/[procname]")
+		if(!procpath)
+			to_chat(usr, "Invalid proc path /proc/[procname].")
+			return
+
 		log_admin("[key_name(src)] called [procname]() with [arguments.len ? "the arguments [list2params(arguments)]" : "no arguments"].",admin_key=key_name(src))
-		returnval = call(procname)(arglist(arguments))
+		returnval = call(procpath)(arglist(arguments))
 
 	to_chat(usr, "<span class='info'>[procname]() returned: [isnull(returnval) ? "null" : returnval]</span>")
 	feedback_add_details("admin_verb","APC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/alarm/fire_alarm.dm
+++ b/code/modules/alarm/fire_alarm.dm
@@ -8,4 +8,6 @@
 			A.fire_alert()
 		else
 			A.fire_reset()
+
+	SEND_SIGNAL(A, COMSIG_AREA_FIRE_ALARM, A.fire)
 	..()

--- a/code/modules/atmospherics/components/portables_connector.dm
+++ b/code/modules/atmospherics/components/portables_connector.dm
@@ -14,14 +14,17 @@
 
 	var/datum/pipe_network/network
 
-	var/on = 0
 	use_power = POWER_USE_OFF
 	level = 1
 
 
 /obj/machinery/atmospherics/portables_connector/Initialize()
 	initialize_directions = dir
-	. = ..()
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/atmospherics/portables_connector/LateInitialize()
+	toggle_process()
 
 /obj/machinery/atmospherics/portables_connector/update_icon()
 	icon_state = "connector"
@@ -37,16 +40,15 @@
 /obj/machinery/atmospherics/portables_connector/hide(var/i)
 	update_underlays()
 
+/obj/machinery/atmospherics/portables_connector/proc/toggle_process()
+	if(connected_device)
+		START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
+	else
+		STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
+
 /obj/machinery/atmospherics/portables_connector/process()
-	..()
-	if(!on)
-		return
-	if(!connected_device)
-		on = 0
-		return
 	if(network)
 		network.update = 1
-	return 1
 
 // Housekeeping and pipe network stuff below
 /obj/machinery/atmospherics/portables_connector/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -896,6 +896,10 @@ default behaviour is:
 	to_chat(src, "<span class='notice'>Remember to stay in character for a mob of this type!</span>")
 	return 1
 
+/mob/living/Initialize()
+	. = ..()
+	add_to_target_grid()
+
 /mob/living/Destroy()
 	if(loc)
 		for(var/mob/M in contents)
@@ -904,6 +908,7 @@ default behaviour is:
 		for(var/mob/M in contents)
 			qdel(M)
 	QDEL_NULL(reagents)
+	clear_from_target_grid()
 
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -116,7 +116,7 @@
 			stop_automated_movement = 1
 			stance_step++
 			if(stance_step >= 15) //rests for 10 ticks
-				if(target_mob && (target_mob in ListTargets(10)))
+				if(target_mob && (target_mob in get_targets_in_LOS(10, src)))
 					set_stance(HOSTILE_STANCE_ATTACK) //If the mob he was chasing is still nearby, resume the attack, otherwise go idle.
 				else
 					set_stance(HOSTILE_STANCE_IDLE)
@@ -124,7 +124,7 @@
 		if(HOSTILE_STANCE_ALERT)
 			stop_automated_movement = 1
 			var/found_mob = 0
-			if(target_mob && (target_mob in ListTargets(10)) && !(SA_attackable(target_mob)))
+			if(target_mob && (target_mob in get_targets_in_LOS(10, src)) && !(SA_attackable(target_mob)))
 				found_mob = 1
 			else
 				LoseTarget()
@@ -182,7 +182,7 @@
 	var/mob/nearest_downed_target = null
 	var/nearest_downed_dist = 99999
 
-	for(var/atom/A in ListTargets(10))
+	for(var/atom/A in get_targets_in_LOS(10, src))
 
 		if(A == src || A == target_mob)//We're only interested in alternatives to our current target
 			continue

--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -102,7 +102,7 @@
 	stop_automated_movement = 1
 	if(!target_mob)
 		return
-	if(target_mob in ListTargets(10))
+	if(get_dist(src, target_mob) <= 10)
 		walk_to(src,target_mob,1,move_to_delay)
 
 /mob/living/simple_animal/hostile/commanded/proc/commanded_stop() //basically a proc that runs whenever we are asked to stay put. Probably going to remain unused.

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -133,7 +133,7 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 	return
 
 /mob/living/simple_animal/hostile/proc/see_target()
-	return (target_mob in view(10, src)) ? (TRUE) : (FALSE)
+	return check_los(src, target_mob)
 
 /mob/living/simple_animal/hostile/proc/MoveToTarget()
 	stop_automated_movement = 1
@@ -255,7 +255,7 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 
 	switch(stance)
 		if(HOSTILE_STANCE_IDLE)
-			targets = ListTargets(10)
+			targets = get_targets_in_LOS(10, src)
 			target_mob = FindTarget()
 			if(destroy_surroundings && isnull(target_mob))
 				DestroySurroundings()
@@ -269,7 +269,7 @@ mob/living/simple_animal/hostile/hitby(atom/movable/AM as mob|obj,var/speed = TH
 			if(!AttackTarget() && destroy_surroundings)	//hit a window OR a mob, not both at once
 				DestroySurroundings(TRUE)
 			if(attacked_times >= rand(0, 4))
-				targets = ListTargets(10)
+				targets = get_targets_in_LOS(10, src)
 				target_mob = FindTarget()
 				attacked_times = 0
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
@@ -119,6 +119,8 @@
 	var/ore_message = 0
 	var/target_ore
 	var/ore_count = 0
+	var/list/found_turfs = list()
+	var/scan_timer = 0
 
 /mob/living/simple_animal/hostile/retaliate/minedrone/Initialize()
 	. = ..()
@@ -140,35 +142,62 @@
 	..()
 	if(ore_count<20)
 		FindOre()
+	else if(!scan_timer)
+		// reusing vars is funny
+		visible_message(SPAN_WARNING("\The [src] pings, \"Mineral hopper full.\""))
+		playsound(src.loc, 'sound/machines/ping.ogg', 50, 0)
+		scan_timer = rand(90, 150) // Life() ticks, so 3-5 minutes
+	else
+		scan_timer--
 
 /mob/living/simple_animal/hostile/retaliate/minedrone/proc/FindOre()
-	if(!enemies.len)
-		setClickCooldown(attack_delay)
-		if(!(target_ore in ListTargets(10)))
+	if(enemies.len)
+		return
+
+	setClickCooldown(attack_delay)
+	if(target_ore && !(get_dist(src, target_ore) <= 10))
+		target_ore = null
+
+	for(var/obj/item/ore/O in oview(1, src))
+		O.forceMove(src)
+		loot += O
+		ore_count++
+		if(target_ore == O)
 			target_ore = null
-		for(var/obj/item/ore/O in oview(1,src))
-			O.forceMove(src)
-			loot += O
-			ore_count ++
-			if(target_ore == O)
-				target_ore = null
-			if(!ore_message)
-				ore_message = 1
-		if(ore_message)
-			visible_message("<span class='notice'>\The [src] collects the ore into a metallic hopper.</span>")
-			ore_message = 0
-		for(var/obj/item/ore/O in oview(7,src))
+		if(!ore_message)
+			ore_message = TRUE
+
+	if(ore_message)
+		visible_message(SPAN_NOTICE("\The [src] collects the ore into a metallic hopper."))
+		ore_message = FALSE
+
+	if(!target_ore)
+		for(var/obj/item/ore/O in oview(7, src))
 			target_ore = O
 			break
-		if(target_ore)
-			walk_to(src, target_ore, 1, move_to_delay)
-		else
-			for(var/turf/simulated/mineral/M in orange(7,src))
-				if(M.mineral)
-					rapid = 1
-					OpenFire(M)
-					rapid = 0
-					break
+
+	if(target_ore)
+		walk_to(src, target_ore, 1, move_to_delay)
+	else if(found_turfs.len)
+		for(var/turf/simulated/mineral/M in found_turfs)
+			if(!QDELETED(M) || !M.mineral)
+				found_turfs -= M
+			else
+				rapid = TRUE
+				OpenFire(M)
+				rapid = FALSE
+				break
+
+	if(!found_turfs.len && !scan_timer) // we do a little caching, it's called we do a little caching
+		for(var/turf/simulated/mineral/M in oview(7, src))
+			if(M.mineral)
+				found_turfs |= M
+
+		if(!found_turfs.len) // there's no ore left, let's not waste processing for a bit
+			scan_timer = 30 // Life() ticks
+
+	else if(scan_timer)
+		scan_timer--
 
 /mob/living/simple_animal/hostile/retaliate/minedrone/adjustToxLoss(var/damage)
 	return

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -37,6 +37,7 @@
 	if(SC && (get_dist(src, SC) > SOLAR_MAX_DIST))
 		return 0
 	control = SC
+	START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 	return 1
 
 //set the control of the panel to null and removes it from the control list of the previous control computer if needed
@@ -44,6 +45,7 @@
 	if(control)
 		control.connected_panels.Remove(src)
 	control = null
+	STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
 
 /obj/machinery/power/solar/proc/Make(var/obj/item/solar_assembly/S)
 	if(!S)
@@ -118,21 +120,18 @@
 	sunfrac = cos(p_angle) ** 2
 	//isn't the power received from the incoming light proportionnal to cos(p_angle) (Lambert's cosine law) rather than cos(p_angle)^2 ?
 
-/obj/machinery/power/solar/process()//TODO: remove/add this from machines to save on processing as needed ~Carn PRIORITY
-	if(stat & BROKEN)
-		return
-	if(!sun || !control) //if there's no sun or the panel is not linked to a solar control computer, no need to proceed
-		return
+/obj/machinery/power/solar/process()
+	if(stat & BROKEN || !control || !sun)
+		return PROCESS_KILL
 
-	if(powernet)
-		if(powernet == control.powernet)//check if the panel is still connected to the computer
-			if(obscured) //get no light from the sun, so don't generate power
-				return
-			var/sgen = SOLARGENRATE * sunfrac
-			add_avail(sgen)
-			control.gen += sgen
-		else //if we're no longer on the same powernet, remove from control computer
-			unset_control()
+	if(powernet && powernet == control.powernet)
+		if(obscured) //get no light from the sun, so don't generate power
+			return
+		var/sgen = SOLARGENRATE * sunfrac
+		add_avail(sgen)
+		control.gen += sgen
+	else //if we're no longer on the same powernet, remove from control computer
+		unset_control()
 
 /obj/machinery/power/solar/proc/broken()
 	stat |= BROKEN

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -115,7 +115,7 @@
 /* Holder-to-chemical */
 
 /datum/reagents/proc/add_reagent(var/rtype, var/amount, var/data = null, var/safety = 0, var/temperature = 0, var/new_thermal_energy = 0)
-	if(amount <= 0)
+	if(amount <= 0 || !REAGENTS_FREE_SPACE(src))
 		return FALSE
 	new_thermal_energy /= amount // Re-multiplied later
 	amount = min(amount, REAGENTS_FREE_SPACE(src))

--- a/html/changelogs/johnwildkins-process.yml
+++ b/html/changelogs/johnwildkins-process.yml
@@ -1,0 +1,10 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - refactor: "Moved a significant portion of machinery processing to on-demand processing, lightening the load on the server."
+  - refactor: "Shifted turret targeting and simple mob targeting to use the spatial grid system for searching."
+  - bugfix: "Telecomms machines will now once again reboot themselves after being EMPed."
+  - bugfix: "Fixed a divide-by-zero runtime with adding reagents to a full container."
+  - bugfix: "Fixed an issue with admin proc call failing on unowned procs."


### PR DESCRIPTION
Clickbait title: Deranged coder shaves milliseconds off of procs and claims to have solved lag. How? Just review this free PR vvv

Moving turrets to SSspatialgrid: 
![image](https://user-images.githubusercontent.com/6022823/208592049-46e51672-d9a0-49ac-a6de-fd2ede0e5961.png)

Before:
![image](https://user-images.githubusercontent.com/6022823/208596810-05145f4d-36a6-4b60-9928-1d9e1533bf2a.png)
![image](https://user-images.githubusercontent.com/6022823/208596871-32bd68e4-b346-456a-ad33-c3ace31864ac.png)


Now:
![image](https://user-images.githubusercontent.com/6022823/208597177-b0b5ac64-71c4-47b2-a824-78655fa813bd.png)
![image](https://user-images.githubusercontent.com/6022823/208597195-934848d0-7f07-4949-bbc6-1b52a33f06db.png)


changes:
  - refactor: "Moved a significant portion of machinery processing to on-demand processing, lightening the load on the server."
  - refactor: "Shifted turret targeting and simple mob targeting to use the spatial grid system for searching."
  - bugfix: "Telecomms machines will now once again reboot themselves after being EMPed."
  - bugfix: "Fixed a divide-by-zero runtime with adding reagents to a full container."
  - bugfix: "Fixed an issue with admin proc call failing on unowned procs."