### PR TITLE
Machinist Workshop Expansion and Fixes

### DIFF
--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -224,7 +224,7 @@
 		/obj/item/surgery/surgicaldrill = 1,
 		/obj/item/surgery/bone_gel = 1,
 		/obj/item/surgery/fix_o_vein = 1,
-		/obj/item/stack/medical/advanced/bruise_pack = 1,
+		/obj/item/stack/medical/advanced/bruise_pack = 1
 	)
 
 /obj/item/storage/box/fancy/tray/update_icon()
@@ -326,20 +326,23 @@
 	)
 
 /obj/item/storage/box/fancy/tray/robotics
-	starts_with = list(
-		/obj/item/surgery/circular_saw = 1,
-		/obj/item/surgery/hemostat = 1,
-		/obj/item/surgery/retractor = 1,
-		/obj/item/surgery/scalpel = 1,
-		/obj/item/surgery/surgicaldrill = 1,
-		/obj/item/surgery/cautery,
-	)
-
 	can_hold = list(
-		/obj/item/surgery/circular_saw,
+		/obj/item/surgery/bonesetter,
+		/obj/item/surgery/cautery,
 		/obj/item/surgery/circular_saw,
 		/obj/item/surgery/hemostat,
 		/obj/item/surgery/retractor,
 		/obj/item/surgery/scalpel,
-		/obj/item/surgery/surgicaldrill
+		/obj/item/surgery/surgicaldrill,
+		/obj/item/surgery/bone_gel
+		)
+
+	starts_with = list(
+		/obj/item/surgery/bonesetter = 1,
+		/obj/item/surgery/cautery = 1,
+		/obj/item/surgery/circular_saw = 1,
+		/obj/item/surgery/hemostat = 1,
+		/obj/item/surgery/retractor = 1,
+		/obj/item/surgery/scalpel = 1,
+		/obj/item/surgery/surgicaldrill = 1
 	)

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -212,7 +212,7 @@
 		/obj/item/surgery/fix_o_vein,
 		/obj/item/stack/medical/advanced/bruise_pack,
 		/obj/item/stack/nanopaste
-		)
+	)
 
 	starts_with = list(
 		/obj/item/surgery/bonesetter = 1,
@@ -326,12 +326,15 @@
 	)
 
 /obj/item/storage/box/fancy/tray/machinist
+	name = "machinist operation tray"
+	desc = "A tray of various tools for use by machinists in repairing robots."
 	can_hold = list(
 		/obj/item/surgery/cautery,
 		/obj/item/surgery/circular_saw,
 		/obj/item/surgery/hemostat,
 		/obj/item/surgery/retractor,
-		/obj/item/surgery/scalpel
+		/obj/item/surgery/scalpel,
+		/obj/item/stack/nanopaste
 		)
 
 	starts_with = list(

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -325,24 +325,19 @@
 		/obj/item/reagent_containers/syringe
 	)
 
-/obj/item/storage/box/fancy/tray/robotics
+/obj/item/storage/box/fancy/tray/machinist
 	can_hold = list(
-		/obj/item/surgery/bonesetter,
 		/obj/item/surgery/cautery,
 		/obj/item/surgery/circular_saw,
 		/obj/item/surgery/hemostat,
 		/obj/item/surgery/retractor,
-		/obj/item/surgery/scalpel,
-		/obj/item/surgery/surgicaldrill,
-		/obj/item/surgery/bone_gel
+		/obj/item/surgery/scalpel
 		)
 
 	starts_with = list(
-		/obj/item/surgery/bonesetter = 1,
 		/obj/item/surgery/cautery = 1,
 		/obj/item/surgery/circular_saw = 1,
 		/obj/item/surgery/hemostat = 1,
 		/obj/item/surgery/retractor = 1,
-		/obj/item/surgery/scalpel = 1,
-		/obj/item/surgery/surgicaldrill = 1
+		/obj/item/surgery/scalpel = 1
 	)

--- a/html/changelogs/machinist_workshop_tweaks.yml
+++ b/html/changelogs/machinist_workshop_tweaks.yml
@@ -1,0 +1,7 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - maptweak: "Expands the machinist workshop. Gives the machinist workshop a welder fuel tank and tinting windows."
+  - bugfix: "Fixes the machinist workshop ringer terminal not being mounted on the wall."

--- a/maps/away/away_site/racers/racers.dmm
+++ b/maps/away/away_site/racers/racers.dmm
@@ -3158,7 +3158,7 @@
 /area/racers)
 "pvh" = (
 /obj/structure/table/steel,
-/obj/item/storage/box/fancy/tray/robotics,
+/obj/item/storage/box/fancy/tray/machinist,
 /obj/item/stack/medical/bruise_pack,
 /obj/item/tank/anesthetic,
 /obj/item/clothing/mask/breath/medical,

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -49178,7 +49178,7 @@
 /area/operations/office)
 "yhR" = (
 /obj/structure/table/standard,
-/obj/item/storage/box/fancy/tray/robotics,
+/obj/item/storage/box/fancy/tray/machinist,
 /obj/effect/floor_decal/spline/plain{
 	dir = 9
 	},

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -1313,12 +1313,6 @@
 "aAx" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/rnd/xenobiology/xenoflora)
-"aBa" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
 "aBn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2223,15 +2217,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "aWN" = (
-/obj/machinery/conveyor{
-	dir = 6;
-	id = "Robocompo"
-	},
-/obj/effect/floor_decal/spline/plain{
+/obj/effect/floor_decal/corner/black{
 	dir = 10
 	},
-/obj/structure/plasticflaps,
-/turf/simulated/floor/carpet/rubber,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
 "aXf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3372,15 +3369,9 @@
 /turf/simulated/floor/wood,
 /area/horizon/library)
 "bAZ" = (
-/obj/machinery/mecha_part_fabricator,
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/railing/mapped,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/rubber,
+/obj/machinery/recharge_station,
+/obj/effect/floor_decal/corner/black/full,
+/turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
 "bBh" = (
 /obj/effect/floor_decal/corner/brown/full{
@@ -4077,16 +4068,16 @@
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced/steel,
 /obj/machinery/door/window/eastleft{
-	name = "Machinist Workshop Desk Interior Access";
+	name = "Machinist Workshop Desk";
 	req_access = list(29)
 	},
 /obj/machinery/door/window/westright{
-	name = "Machinist Workshop Desk Exterior Access"
+	name = "Machinist Workshop Desk"
 	},
-/obj/machinery/door/blast/shutters/open{
-	dir = 8;
-	id = "shutters_deck1_workshopdesk";
-	name = "Workshop Desk Shutter"
+/obj/machinery/door/blast/shutters{
+	id = "shutters_deck2_workshopdesk";
+	name = "Machinist Workshop Desk Shutter";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/operations/lower/machinist)
@@ -4254,8 +4245,10 @@
 /turf/simulated/floor/tiled,
 /area/security/main)
 "bUN" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/turf/simulated/floor/tiled,
+/obj/effect/map_effect/window_spawner/full/reinforced/polarized/firedoor{
+	id = "polarized_deck2_workshop"
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/operations/lower/machinist)
 "bVc" = (
 /obj/structure/disposalpipe/segment{
@@ -6853,14 +6846,13 @@
 /area/security/security_office)
 "drw" = (
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 1;
 	id = "Robocompo"
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 6
-	},
-/obj/machinery/light,
 /obj/structure/plasticflaps,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/operations/lower/machinist)
 "drB" = (
@@ -7169,9 +7161,16 @@
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "dzI" = (
-/obj/machinery/mecha_part_fabricator,
-/obj/structure/railing/mapped,
+/obj/machinery/mecha_part_fabricator{
+	dir = 4
+	},
 /obj/effect/floor_decal/spline/plain{
+	dir = 9
+	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/structure/railing/mapped{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/rubber,
@@ -7888,6 +7887,8 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/structure/closet/crate,
+/obj/random/loot,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "dTI" = (
@@ -10554,16 +10555,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/security_office)
-"fqa" = (
-/obj/effect/floor_decal/industrial/loading/yellow{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/spline/plain{
-	dir = 9
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/operations/lower/machinist)
 "fqg" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/effect/decal/cleanable/dirt,
@@ -10874,12 +10865,6 @@
 /obj/random/loot,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/aux_atmospherics/deck_2/starboard)
-"fxD" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/machinery/recharge_station,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
-/area/operations/lower/machinist)
 "fyi" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
@@ -12720,10 +12705,23 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/table/rack,
 /obj/effect/floor_decal/corner/black/full{
 	dir = 1
 	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/southright{
+	name = "Welding Fuel Tank Storage"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
 "gnD" = (
@@ -13059,13 +13057,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/security/armory)
-"guh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/closet/crate,
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
 "guj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
@@ -13117,17 +13108,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
-"guA" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/machinist,
-/obj/effect/floor_decal/corner/black{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/operations/lower/machinist)
 "guQ" = (
 /obj/effect/floor_decal/corner/green/full,
 /turf/simulated/floor/tiled,
@@ -15705,7 +15685,7 @@
 /obj/structure/table/standard,
 /obj/machinery/button/remote/blast_door{
 	dir = 4;
-	id = "shutters_deck1_workshopdesk";
+	id = "shutters_deck2_workshopdesk";
 	name = "Machinist Workshop Desk Shutters";
 	pixel_x = -25;
 	pixel_y = -7;
@@ -17935,18 +17915,6 @@
 	},
 /turf/simulated/floor/lino/grey,
 /area/horizon/crew_quarters/lounge/bar)
-"iPi" = (
-/obj/machinery/conveyor_switch/oneway{
-	desc = "A conveyor control switch. It appears to only go in one direction. Controls the components conveyor belt.";
-	id = "Robocompo";
-	pixel_x = -13;
-	pixel_y = -6
-	},
-/obj/effect/floor_decal/corner/black{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/operations/lower/machinist)
 "iQK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20439,6 +20407,9 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/operations/lower/machinist)
 "kbL" = (
@@ -20765,7 +20736,9 @@
 /turf/simulated/floor/tiled,
 /area/security/prison)
 "kjO" = (
-/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /obj/structure/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
@@ -20817,12 +20790,9 @@
 /turf/space/dynamic,
 /area/template_noop)
 "knA" = (
-/obj/machinery/light,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28
+/obj/effect/floor_decal/corner/black{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/black/diagonal,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
@@ -25258,16 +25228,6 @@
 /obj/machinery/computer/ship/navigation,
 /turf/simulated/floor/reinforced,
 /area/horizon/zta)
-"mDi" = (
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/full,
-/area/maintenance/wing/port)
 "mDD" = (
 /obj/machinery/light{
 	dir = 1
@@ -27917,6 +27877,9 @@
 	opacity = 0
 	},
 /obj/structure/table/reinforced,
+/obj/machinery/door/window/southright{
+	name = "Research Desk"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/rnd/research)
 "nRF" = (
@@ -29506,11 +29469,17 @@
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
 "oGK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/trash_pile,
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
+/obj/machinery/mecha_part_fabricator{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
+	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/operations/lower/machinist)
 "oGR" = (
 /obj/machinery/r_n_d/protolathe,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -33974,7 +33943,10 @@
 /turf/simulated/floor/tiled,
 /area/security/brig)
 "qTB" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/loading/yellow{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/spline/plain/cee{
 	dir = 1
 	},
@@ -36127,23 +36099,18 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room)
 "rUh" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/plasticflaps/mining,
-/obj/machinery/door/blast/shutters/open{
-	dir = 2
-	},
 /obj/machinery/conveyor{
 	dir = 1;
-	id = "rnd";
-	layer = 2.9
+	id = "rnd"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/spline/plain/cee,
+/obj/structure/plasticflaps/mining,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "shutters_deck2_rescon";
+	name = "Conveyor Shutter"
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/research)
 "rUu" = (
@@ -37787,6 +37754,12 @@
 /area/security/brig)
 "sRC" = (
 /obj/effect/floor_decal/spline/plain,
+/obj/machinery/button/switch/windowtint{
+	pixel_x = -25;
+	dir = 4;
+	pixel_y = -4;
+	id = "polarized_deck2_workshop"
+	},
 /turf/simulated/floor/tiled/white,
 /area/operations/lower/machinist)
 "sSY" = (
@@ -38928,11 +38901,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/strongroom)
 "twc" = (
-/obj/machinery/mecha_part_fabricator,
-/obj/structure/railing/mapped,
 /obj/effect/floor_decal/spline/plain{
 	dir = 5
 	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "Robocompo"
+	},
+/obj/structure/plasticflaps,
 /turf/simulated/floor/carpet/rubber,
 /area/operations/lower/machinist)
 "two" = (
@@ -39740,6 +39716,7 @@
 /obj/effect/floor_decal/corner/black{
 	dir = 6
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
 "tPU" = (
@@ -40043,13 +40020,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "tYa" = (
-/obj/machinery/ringer{
-	department = "Machinist Workshop";
-	id = "robo_ringer";
-	pixel_y = -32;
-	req_access = list(29)
+/obj/machinery/light,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "Robocompo"
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/plasticflaps,
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/operations/lower/machinist)
 "tYj" = (
 /turf/simulated/wall/r_wall,
@@ -40797,10 +40777,10 @@
 	c_tag = "Operations -  Machinist Workshop Starboard";
 	dir = 4
 	},
-/obj/machinery/firealarm/west,
 /obj/machinery/vending/robotics,
 /obj/effect/floor_decal/corner/black/full,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
 "uoq" = (
@@ -41222,12 +41202,15 @@
 /turf/simulated/floor/wood,
 /area/horizon/crew_quarters/lounge/bar)
 "uxf" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "Robocompo"
+/obj/machinery/mecha_part_fabricator{
+	dir = 4
 	},
-/obj/effect/floor_decal/spline/plain,
-/obj/structure/plasticflaps,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/operations/lower/machinist)
 "uxn" = (
@@ -43919,11 +43902,12 @@
 /turf/simulated/floor/tiled/full,
 /area/engineering/engine_airlock)
 "vPg" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/corner/black{
+	dir = 9
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
+/turf/simulated/floor/tiled,
+/area/operations/lower/machinist)
 "vPj" = (
 /turf/simulated/wall/r_wall,
 /area/security/armory)
@@ -44078,7 +44062,7 @@
 	input_tag = "cooling_in";
 	name = "Engine Cooling Control";
 	output_tag = "cooling_out";
-	sensors = list("engine_sensor" = "Engine Core")
+	sensors = list("engine_sensor"="Engine Core")
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering - Supermatter Reactor Monitoring";
@@ -45880,6 +45864,13 @@
 	name = "Research Shutters";
 	pixel_x = 8
 	},
+/obj/machinery/button/remote/blast_door{
+	desc = "It controls the research shutters.";
+	id = "shutters_deck2_rescon";
+	name = "Research Conveyor Shutter";
+	pixel_x = 8;
+	pixel_y = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "wGT" = (
@@ -46728,11 +46719,16 @@
 	},
 /obj/item/device/floor_painter,
 /obj/item/reagent_containers/weldpack,
-/obj/machinery/light,
 /obj/effect/floor_decal/corner/black{
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/ringer{
+	department = "Machinist Workshop";
+	id = "robo_ringer";
+	pixel_y = -32;
+	req_access = list(29)
+	},
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
 "wZF" = (
@@ -47211,6 +47207,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
 "xlQ" = (
@@ -48182,7 +48179,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/corner/black{
-	dir = 10
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
@@ -48320,9 +48317,19 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/east,
-/obj/effect/floor_decal/corner/black/full{
-	dir = 4
+/obj/machinery/conveyor_switch/oneway{
+	desc = "A conveyor control switch. It appears to only go in one direction. Controls the components conveyor belt.";
+	id = "Robocompo";
+	pixel_x = -13;
+	pixel_y = -6
 	},
+/obj/effect/floor_decal/corner/black{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/loading/yellow{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
 "xQj" = (
@@ -73873,9 +73880,9 @@ ulB
 kXY
 qsj
 uTr
-guA
+ntg
 ncx
-tYa
+ncx
 wZw
 uTr
 xmw
@@ -74281,8 +74288,8 @@ kbF
 oUZ
 ukT
 jPr
-bUN
 cHz
+kaT
 kaT
 kaT
 cNU
@@ -74482,11 +74489,11 @@ uTr
 tld
 xkS
 kur
-jPr
-fxD
+aWN
 uTr
-aBa
-vPg
+uTr
+uTr
+uTr
 emN
 mia
 ibU
@@ -74686,9 +74693,9 @@ goQ
 aCP
 xMm
 knA
+vPg
+bAZ
 uTr
-uTr
-guh
 kaT
 dTj
 vNG
@@ -74882,15 +74889,15 @@ cer
 vBO
 qhA
 qUz
-nCG
+bUN
 yhR
 qdf
 qfP
+ncx
+ncx
+ncx
 dYe
-fqa
-aWN
 uTr
-wUS
 kaT
 mia
 vNG
@@ -75084,17 +75091,17 @@ qrx
 taf
 fKk
 rnA
-nCG
+bUN
 aTp
 sRC
 qfP
-iPi
-bAZ
-uxf
+ncx
+ncx
+ncx
+dYe
 uTr
-oGK
 kaT
-mia
+kjO
 vNG
 kep
 cQu
@@ -75286,17 +75293,17 @@ hfv
 pZQ
 wEq
 rnA
-nCG
+bUN
 xdr
 tSJ
 qfP
-dYe
+ncx
 dzI
 uxf
+oGK
 uTr
-kjO
 kaT
-mia
+kjO
 vNG
 xMV
 fpj
@@ -75495,9 +75502,9 @@ opW
 xQg
 twc
 drw
+tYa
 uTr
-wsW
-mDi
+kaT
 hps
 vNG
 sEk
@@ -75698,8 +75705,8 @@ kGX
 kGX
 kGX
 kGX
-pyV
-kaT
+uTr
+iYf
 hps
 elh
 qPI
@@ -76102,8 +76109,8 @@ cdv
 nOJ
 smn
 kGX
-wsW
-iYf
+pyV
+kaT
 hps
 sGm
 sGm

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -3371,6 +3371,7 @@
 "bAZ" = (
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/corner/black/full,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
 "bBh" = (
@@ -6303,6 +6304,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical)
+"dev" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "dex" = (
 /obj/effect/floor_decal/spline/fancy/wood/cee{
 	dir = 1
@@ -7887,8 +7895,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/closet/crate,
-/obj/random/loot,
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "dTI" = (
@@ -33773,6 +33780,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/zta)
+"qPP" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/item/material/shard{
+	icon_state = "small"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "qPY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -36519,6 +36535,14 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
+"sgl" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "sgp" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -42500,6 +42524,11 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/horizon/exterior)
+"veG" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "veO" = (
 /obj/structure/bed/stool/chair/padded/black{
 	dir = 1
@@ -43906,6 +43935,7 @@
 /obj/effect/floor_decal/corner/black{
 	dir = 9
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
 "vPj" = (
@@ -74290,10 +74320,10 @@ ukT
 jPr
 cHz
 kaT
-kaT
+dev
 kaT
 cNU
-mia
+sgl
 ibU
 hrC
 erH
@@ -74495,7 +74525,7 @@ uTr
 uTr
 uTr
 emN
-mia
+sgl
 ibU
 ljm
 aVf
@@ -74899,7 +74929,7 @@ ncx
 dYe
 uTr
 kaT
-mia
+qPP
 vNG
 lLj
 unV
@@ -75302,7 +75332,7 @@ dzI
 uxf
 oGK
 uTr
-kaT
+veG
 kjO
 vNG
 xMV

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -427,16 +427,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/stairwell/central)
-"alr" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/template_noop)
 "amf" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 6
@@ -3389,9 +3379,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
-"bBf" = (
-/turf/simulated/wall/r_wall,
-/area/template_noop)
 "bBh" = (
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 8
@@ -4519,17 +4506,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
-"bZP" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "caj" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -5102,16 +5078,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
-"crB" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/machinery/door/window/northright{
-	name = "Secure Storage";
-	req_access = list(7)
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/template_noop)
 "crP" = (
 /obj/effect/floor_decal/corner/yellow/full{
 	dir = 1
@@ -5736,16 +5702,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
-"cOh" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 6
-	},
-/obj/machinery/firealarm/east,
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "cOj" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6576,17 +6532,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port/far)
-"dkr" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 6
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/empty/oxygen,
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "dkz" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -7740,14 +7685,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/horizon/crew_quarters/lounge/bar)
-"dLT" = (
-/obj/structure/closet/secure_closet/guncabinet/sci,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/spline/plain{
-	dir = 6
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/template_noop)
 "dLX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -8896,14 +8833,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/smes/tesla)
-"esY" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 10;
-	req_access = list(55)
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "etv" = (
 /obj/machinery/autolathe,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -11251,12 +11180,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
-"fEY" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/spline/plain,
-/obj/structure/table/reinforced/glass,
-/turf/simulated/floor/carpet/rubber,
-/area/template_noop)
 "fFx" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -13149,19 +13072,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)
-"gtq" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Aft Research Hallway Maintenance";
-	req_one_access = list(12,47)
-	},
-/turf/simulated/floor/tiled/full,
-/area/template_noop)
 "gtw" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -16727,19 +16637,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/aux_atmospherics/deck_2/starboard/wing)
-"iic" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 5
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/firealarm/east,
-/turf/simulated/floor/carpet/rubber,
-/area/template_noop)
 "iid" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/spline/plain{
@@ -16908,19 +16805,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/horizon/kitchen/freezer)
-"ilu" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/floor_decal/corner/mauve/full{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "ily" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/black,
 /obj/machinery/meter,
@@ -19097,16 +18981,6 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/engineering/atmos/storage)
-"joE" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/machinery/door/window/northleft{
-	name = "Secure Storage";
-	req_access = list(47)
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/template_noop)
 "joH" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -19245,14 +19119,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room/tesla)
-"jra" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/spline/plain{
-	dir = 10
-	},
-/obj/structure/closet/secure_closet/guncabinet/sci,
-/turf/simulated/floor/carpet/rubber,
-/area/template_noop)
 "jri" = (
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_upload)
@@ -19964,30 +19830,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
-"jKU" = (
-/obj/machinery/door/blast/regular{
-	closed_layer = 3.5;
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "RDStorage";
-	name = "Storage Lockdown Blast Door";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/glass_research{
-	name = "Research Storage";
-	req_access = list(47)
-	},
-/obj/effect/map_effect/door_helper/unres,
-/turf/simulated/floor/tiled/dark/full,
-/area/template_noop)
 "jKV" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -23916,16 +23758,6 @@
 "lPd" = (
 /turf/simulated/floor,
 /area/maintenance/wing/port/far)
-"lPk" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "lPn" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -24682,12 +24514,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/lobby)
-"mhv" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "mia" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -25404,25 +25230,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/main_storage)
-"mCb" = (
-/obj/machinery/camera/network/research{
-	c_tag = "Research - Research Storage";
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 9
-	},
-/obj/structure/closet/radiation,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "mCC" = (
 /obj/effect/floor_decal/corner_wide/orange{
 	dir = 10
@@ -26331,15 +26138,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
-"mWe" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "mWs" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
@@ -27308,22 +27106,6 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/wood,
 /area/operations/qm)
-"nrM" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 9
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/template_noop)
 "nsn" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -30282,12 +30064,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/operations/qm)
-"oVo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "oWm" = (
 /obj/structure/table/reinforced/steel,
 /obj/machinery/door/window/southleft{
@@ -31428,14 +31204,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/engineering/engine_airlock)
-"pyV" = (
-/obj/effect/floor_decal/corner/mauve/full{
-	dir = 8
-	},
-/obj/structure/closet/hazmat/research,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "pzc" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 5
@@ -33981,14 +33749,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/horizon/zta)
-"qNa" = (
-/obj/structure/closet/secure_closet/scientist,
-/obj/effect/floor_decal/corner/mauve{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/outline/research,
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "qNd" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/floor_decal/industrial/loading/yellow{
@@ -35654,13 +35414,6 @@
 /obj/effect/floor_decal/corner/yellow/diagonal,
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
-"rBb" = (
-/obj/structure/closet/radiation,
-/obj/effect/floor_decal/corner/mauve/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "rBh" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
@@ -37494,14 +37247,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"szD" = (
-/obj/structure/closet/secure_closet/scientist,
-/obj/effect/floor_decal/corner/mauve/full{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/research,
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "sAT" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/closet/walllocker/firecloset{
@@ -43965,21 +43710,6 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /turf/simulated/floor/tiled/dark/full,
 /area/medical/reception)
-"vJh" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/structure/closet/hazmat/research,
-/turf/simulated/floor/tiled/dark,
-/area/template_noop)
 "vJu" = (
 /obj/machinery/shower{
 	dir = 1;
@@ -79711,13 +79441,13 @@ qgN
 qgN
 qgN
 qgN
-bBf
-pyV
-vJh
-mCb
-rBb
-nrM
-jra
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
 qgN
 qgN
 qgN
@@ -79913,13 +79643,13 @@ qgN
 qgN
 qgN
 qgN
-jKU
-bZP
-lPk
-mWe
-esY
-joE
-fEY
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
 qgN
 qgN
 qgN
@@ -80115,13 +79845,13 @@ qgN
 qgN
 qgN
 qgN
-bBf
-qNa
-oVo
-mhv
-esY
-crB
-fEY
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
 qgN
 qgN
 qgN
@@ -80317,13 +80047,13 @@ qgN
 qgN
 qgN
 qgN
-bBf
-szD
-cOh
-dkr
-ilu
-iic
-dLT
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
 qgN
 qgN
 qgN
@@ -80519,13 +80249,13 @@ qgN
 qgN
 qgN
 qgN
-bBf
-bBf
-bBf
-bBf
-bBf
-bBf
-bBf
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
 qgN
 qgN
 qgN
@@ -80721,13 +80451,13 @@ qgN
 qgN
 qgN
 qgN
-gtq
-alr
-alr
-alr
-alr
-alr
-alr
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
 qgN
 qgN
 qgN

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -428,16 +428,15 @@
 /turf/simulated/floor/tiled,
 /area/horizon/stairwell/central)
 "alr" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/mauve{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/strongroom)
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
+/area/template_noop)
 "amf" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 6
@@ -536,14 +535,17 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
@@ -1511,6 +1513,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/horizon/library)
+"aGx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "aHj" = (
 /obj/machinery/computer/sentencing/courtroom{
 	pixel_x = -29
@@ -3374,6 +3389,9 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
+"bBf" = (
+/turf/simulated/wall/r_wall,
+/area/template_noop)
 "bBh" = (
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 8
@@ -4501,6 +4519,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"bZP" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/template_noop)
 "caj" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -4565,20 +4594,21 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "cda" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/mauve{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/junction/yjunction,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
@@ -5072,6 +5102,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
+"crB" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/door/window/northright{
+	name = "Secure Storage";
+	req_access = list(7)
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/template_noop)
 "crP" = (
 /obj/effect/floor_decal/corner/yellow/full{
 	dir = 1
@@ -5304,15 +5344,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_quarters/lounge/bar)
 "cAx" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/strongroom)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/full,
+/area/maintenance/wing/port)
 "cBq" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/industrial/warning{
@@ -5698,6 +5736,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
+"cOh" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
+	},
+/obj/machinery/firealarm/east,
+/turf/simulated/floor/tiled/dark,
+/area/template_noop)
 "cOj" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6529,11 +6577,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port/far)
 "dkr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/empty/oxygen,
 /turf/simulated/floor/tiled/dark,
-/area/rnd/strongroom)
+/area/template_noop)
 "dkz" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -7687,6 +7740,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/horizon/crew_quarters/lounge/bar)
+"dLT" = (
+/obj/structure/closet/secure_closet/guncabinet/sci,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/template_noop)
 "dLX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -7891,7 +7952,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "dTj" = (
-/obj/machinery/light/small/emergency,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -7972,6 +8032,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
+"dVy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "dVE" = (
 /obj/structure/sign/securearea{
 	desc = "A caution sign which reads 'CAUTION: BRIG COMMUNAL AREA' and 'SECURE AREA'.";
@@ -8817,6 +8896,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/smes/tesla)
+"esY" = (
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10;
+	req_access = list(55)
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/dark,
+/area/template_noop)
 "etv" = (
 /obj/machinery/autolathe,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -9757,6 +9844,15 @@
 "eVu" = (
 /turf/simulated/wall,
 /area/horizon/stairwell/bridge)
+"eWb" = (
+/obj/structure/closet/secure_closet/scientist,
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/research,
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/tiled/dark,
+/area/rnd/strongroom)
 "eWm" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -10518,8 +10614,23 @@
 /turf/simulated/wall,
 /area/engineering/atmos/storage)
 "fns" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/reagent_dispensers/extinguisher,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "fnP" = (
@@ -11141,11 +11252,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "fEY" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/rnd/strongroom)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/table/reinforced/glass,
+/turf/simulated/floor/carpet/rubber,
+/area/template_noop)
 "fFx" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -11862,6 +11973,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
+"fVz" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/strongroom)
 "fVL" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -11954,6 +12074,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/full,
 /area/horizon/stairwell/central)
+"fYN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/strongroom)
 "fYW" = (
 /obj/structure/table/rack,
 /obj/machinery/door/window/brigdoor/eastleft{
@@ -12227,14 +12357,9 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 10
 	},
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "RDStorage";
-	name = "Storage Lockdown";
-	pixel_x = 7;
-	pixel_y = -25;
-	req_access = list(30)
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "gei" = (
@@ -13024,6 +13149,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)
+"gtq" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Aft Research Hallway Maintenance";
+	req_one_access = list(12,47)
+	},
+/turf/simulated/floor/tiled/full,
+/area/template_noop)
 "gtw" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -13437,13 +13575,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/wing_port)
 "gBT" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/mauve{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/strongroom)
 "gCj" = (
@@ -13848,7 +13982,7 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_two/fore)
 "gKG" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
@@ -16594,13 +16728,18 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/aux_atmospherics/deck_2/starboard/wing)
 "iic" = (
-/obj/structure/closet/secure_closet/scientist,
-/obj/effect/floor_decal/corner/mauve{
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
 	dir = 5
 	},
-/obj/effect/floor_decal/industrial/outline/research,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/strongroom)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/firealarm/east,
+/turf/simulated/floor/carpet/rubber,
+/area/template_noop)
 "iid" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/spline/plain{
@@ -16769,6 +16908,19 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/horizon/kitchen/freezer)
+"ilu" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/template_noop)
 "ily" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/black,
 /obj/machinery/meter,
@@ -17830,6 +17982,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/security/prison)
+"iNl" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "iNu" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -17877,21 +18036,20 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical)
 "iOD" = (
-/obj/structure/disposalpipe/junction/yjunction,
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
@@ -18211,6 +18369,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
+"iYo" = (
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/rnd/strongroom)
 "iYu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18928,6 +19097,16 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/engineering/atmos/storage)
+"joE" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/door/window/northleft{
+	name = "Secure Storage";
+	req_access = list(47)
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/template_noop)
 "joH" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -19066,6 +19245,14 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room/tesla)
+"jra" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
+	},
+/obj/structure/closet/secure_closet/guncabinet/sci,
+/turf/simulated/floor/carpet/rubber,
+/area/template_noop)
 "jri" = (
 /turf/simulated/floor/plating,
 /area/turret_protected/ai_upload)
@@ -19777,6 +19964,30 @@
 	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
+"jKU" = (
+/obj/machinery/door/blast/regular{
+	closed_layer = 3.5;
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "RDStorage";
+	name = "Storage Lockdown Blast Door";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/glass_research{
+	name = "Research Storage";
+	req_access = list(47)
+	},
+/obj/effect/map_effect/door_helper/unres,
+/turf/simulated/floor/tiled/dark/full,
+/area/template_noop)
 "jKV" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -21919,12 +22130,14 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "RDStorage";
+	name = "Storage Lockdown";
+	pixel_x = -7;
+	pixel_y = -25;
+	req_access = list(30)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "kVm" = (
@@ -22629,6 +22842,13 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/horizon/kitchen)
+"lmZ" = (
+/obj/random/junk,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "lng" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23697,22 +23917,15 @@
 /turf/simulated/floor,
 /area/maintenance/wing/port/far)
 "lPk" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/template_noop)
 "lPn" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -24469,6 +24682,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/lobby)
+"mhv" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/template_noop)
 "mia" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -25185,6 +25404,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/main_storage)
+"mCb" = (
+/obj/machinery/camera/network/research{
+	c_tag = "Research - Research Storage";
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve{
+	dir = 9
+	},
+/obj/structure/closet/radiation,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/template_noop)
 "mCC" = (
 /obj/effect/floor_decal/corner_wide/orange{
 	dir = 10
@@ -26093,6 +26331,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
+"mWe" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/template_noop)
 "mWs" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
@@ -26165,6 +26412,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
+"mXS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/full,
+/area/maintenance/wing/port)
 "mYp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -27047,6 +27308,22 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/wood,
 /area/operations/qm)
+"nrM" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/template_noop)
 "nsn" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -29743,6 +30020,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
+"oPk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
+	},
+/obj/structure/closet/secure_closet/scientist,
+/obj/effect/floor_decal/industrial/outline/research,
+/turf/simulated/floor/tiled/dark,
+/area/rnd/strongroom)
 "oPC" = (
 /obj/machinery/firealarm/west,
 /obj/effect/floor_decal/corner/yellow{
@@ -29994,6 +30282,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/operations/qm)
+"oVo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/template_noop)
 "oWm" = (
 /obj/structure/table/reinforced/steel,
 /obj/machinery/door/window/southleft{
@@ -31135,10 +31429,13 @@
 /turf/simulated/floor/tiled/full,
 /area/engineering/engine_airlock)
 "pyV" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 8
+	},
+/obj/structure/closet/hazmat/research,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/template_noop)
 "pzc" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 5
@@ -33684,6 +33981,14 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/horizon/zta)
+"qNa" = (
+/obj/structure/closet/secure_closet/scientist,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/research,
+/turf/simulated/floor/tiled/dark,
+/area/template_noop)
 "qNd" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/floor_decal/industrial/loading/yellow{
@@ -34458,12 +34763,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "rfO" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
+/turf/simulated/wall/r_wall,
+/area/operations/lower/machinist)
 "rgc" = (
 /obj/structure/flora/pottedplant/random,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -35353,6 +35654,13 @@
 /obj/effect/floor_decal/corner/yellow/diagonal,
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
+"rBb" = (
+/obj/structure/closet/radiation,
+/obj/effect/floor_decal/corner/mauve/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/tiled/dark,
+/area/template_noop)
 "rBh" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
@@ -37186,6 +37494,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"szD" = (
+/obj/structure/closet/secure_closet/scientist,
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/research,
+/turf/simulated/floor/tiled/dark,
+/area/template_noop)
 "sAT" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/closet/walllocker/firecloset{
@@ -39158,6 +39474,13 @@
 	},
 /turf/simulated/floor/tiled/ramp,
 /area/turret_protected/ai_upload_foyer)
+"tCY" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "tDc" = (
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/research)
@@ -41747,6 +42070,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 10
 	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "uKV" = (
@@ -42119,6 +42443,14 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "RDStorage";
+	name = "Storage Lockdown";
+	pixel_x = 7;
+	pixel_y = -25;
+	req_access = list(30)
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
@@ -43633,6 +43965,21 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /turf/simulated/floor/tiled/dark/full,
 /area/medical/reception)
+"vJh" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/mauve{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/structure/closet/hazmat/research,
+/turf/simulated/floor/tiled/dark,
+/area/template_noop)
 "vJu" = (
 /obj/machinery/shower{
 	dir = 1;
@@ -44165,6 +44512,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/lino/grey,
 /area/horizon/bar)
+"vUK" = (
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
+/turf/simulated/floor/tiled/dark/full,
+/area/rnd/strongroom)
 "vUO" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 1
@@ -45443,6 +45794,13 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hos)
+"wwR" = (
+/obj/structure/reagent_dispensers/extinguisher,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "wxr" = (
 /turf/simulated/wall,
 /area/medical/or1)
@@ -46521,7 +46879,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/gen_treatment)
 "wUS" = (
-/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "wUU" = (
@@ -47930,11 +48300,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "xGz" = (
-/obj/structure/closet/secure_closet/scientist,
-/obj/effect/floor_decal/corner/mauve/full{
-	dir = 1
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
 	},
-/obj/effect/floor_decal/industrial/outline/research,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/strongroom)
 "xGM" = (
@@ -48265,9 +48633,19 @@
 /obj/machinery/alarm{
 	pixel_y = 28
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate/old,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "xNO" = (
@@ -48472,17 +48850,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/mauve{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
@@ -75130,7 +75505,7 @@ ncx
 ncx
 dYe
 uTr
-kaT
+tCY
 kjO
 vNG
 kep
@@ -75727,14 +76102,14 @@ rbK
 iRq
 wpb
 kZL
-kGX
-kGX
-kGX
-kGX
-kGX
-kGX
-kGX
-kGX
+rfO
+rfO
+rfO
+rfO
+rfO
+rfO
+rfO
+rfO
 uTr
 iYf
 hps
@@ -75929,14 +76304,14 @@ cer
 gFa
 cda
 gec
-kGX
-fEO
-wou
-tjP
-xzd
-rom
-rgR
-kGX
+xWb
+hiq
+aGx
+hiq
+hiq
+hiq
+hiq
+mXS
 fns
 kaT
 hps
@@ -76130,17 +76505,17 @@ gYm
 cer
 hIj
 xSA
-vEg
-goc
-alr
-cAx
-rUZ
-cdv
-nOJ
-smn
+rnA
 kGX
-pyV
-kaT
+kGX
+kGX
+kGX
+kGX
+kGX
+kGX
+kGX
+wUS
+wwR
 hps
 sGm
 sGm
@@ -76334,15 +76709,15 @@ vBO
 oOi
 gUA
 kGX
-iic
-dkr
-fEY
-cdv
-sHY
-smn
+fEO
+wou
+tjP
+xzd
+rom
+rgR
 kGX
 wUS
-kaT
+iNl
 wAm
 cRr
 mst
@@ -76535,16 +76910,16 @@ sig
 lKI
 nZu
 rnA
-kGX
+vUK
 xGz
 gBT
-urh
-tvX
-qzF
-vLu
+fVz
+cdv
+nOJ
+smn
 kGX
 xNJ
-kaT
+lmZ
 wAm
 wAm
 wAm
@@ -76736,18 +77111,18 @@ jxs
 mdR
 pBn
 aov
-lcG
+vEg
+goc
+iYo
+fYN
+rUZ
+cdv
+sHY
+smn
 kGX
-kGX
-kGX
-kGX
-kGX
-kGX
-kGX
-kGX
+wUS
 kaT
-kaT
-kaT
+cAx
 kaT
 kaT
 uUz
@@ -76939,15 +77314,15 @@ sig
 dZU
 iOD
 kVk
-xWb
-hiq
-hiq
-hiq
-hiq
-hiq
-hiq
-hiq
-lPk
+kGX
+eWb
+oPk
+urh
+tvX
+qzF
+vLu
+kGX
+wUS
 uUR
 wsW
 mEc
@@ -77140,16 +77515,16 @@ weq
 sig
 kXY
 nnr
-rnA
-dOi
-dOi
-dOi
-dOi
-dOi
-dOi
-dOi
-rfO
-bGp
+lcG
+kGX
+kGX
+kGX
+kGX
+kGX
+kGX
+kGX
+kGX
+dVy
 eUp
 wsW
 hSG
@@ -79336,13 +79711,13 @@ qgN
 qgN
 qgN
 qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
+bBf
+pyV
+vJh
+mCb
+rBb
+nrM
+jra
 qgN
 qgN
 qgN
@@ -79538,13 +79913,13 @@ qgN
 qgN
 qgN
 qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
+jKU
+bZP
+lPk
+mWe
+esY
+joE
+fEY
 qgN
 qgN
 qgN
@@ -79740,13 +80115,13 @@ qgN
 qgN
 qgN
 qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
+bBf
+qNa
+oVo
+mhv
+esY
+crB
+fEY
 qgN
 qgN
 qgN
@@ -79942,13 +80317,13 @@ qgN
 qgN
 qgN
 qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
+bBf
+szD
+cOh
+dkr
+ilu
+iic
+dLT
 qgN
 qgN
 qgN
@@ -80144,13 +80519,13 @@ qgN
 qgN
 qgN
 qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
+bBf
+bBf
+bBf
+bBf
+bBf
+bBf
+bBf
 qgN
 qgN
 qgN
@@ -80346,13 +80721,13 @@ qgN
 qgN
 qgN
 qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
+gtq
+alr
+alr
+alr
+alr
+alr
+alr
 qgN
 qgN
 qgN

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -42189,14 +42189,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "RDStorage";
-	name = "Storage Lockdown";
-	pixel_x = 7;
-	pixel_y = -25;
-	req_access = list(30)
-	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "uTn" = (


### PR DESCRIPTION
this PR expands the machinist workshop a bit and fixes some mapping oversights.

## changes
- expands the machinist workshop.
- gives the workshop a welder fuel tank.
- gives the workshop tinting windows.
- fixes the machinist workshop ringer terminal not being mounted on the wall.
- makes the machinist desk shutter spawn closed.
- makes the RnD conveyor shutter spawn closed.