### PR TITLE
Exosuit Weapon Refactors

### DIFF
--- a/code/modules/heavy_vehicle/equipment/combat.dm
+++ b/code/modules/heavy_vehicle/equipment/combat.dm
@@ -80,7 +80,7 @@
 	use_external_power = TRUE
 	self_recharge = TRUE
 	has_safety = FALSE
-	projectile_type = /obj/item/projectile/beam/midlaser/mech
+	projectile_type = /obj/item/projectile/beam/heavylaser/mech
 
 /obj/item/gun/energy/pulse/mounted/mech
 	use_external_power = TRUE

--- a/code/modules/heavy_vehicle/equipment/combat.dm
+++ b/code/modules/heavy_vehicle/equipment/combat.dm
@@ -40,6 +40,11 @@
 	icon_state = "mecha_ballistic"
 	holding_type = /obj/item/gun/energy/mountedsmg/mech
 
+/obj/item/mecha_equipment/mounted_system/combat/smg/attack_self(mob/user)
+	if(owner && istype(holding, /obj/item/gun/energy/mountedsmg/mech))
+		var/obj/item/gun/energy/mountedsmg/mech/R = holding
+		R.toggle_firing_mode(user)
+
 /obj/item/mecha_equipment/mounted_system/combat/pulse
 	name = "heavy pulse cannon"
 	desc = "A weapon for combat exosuits. The eZ-13 mk2 heavy pulse rifle shoots powerful pulse-based beams, capable of destroying structures."

--- a/code/modules/mob/living/silicon/robot/syndicate_robot.dm
+++ b/code/modules/mob/living/silicon/robot/syndicate_robot.dm
@@ -80,7 +80,12 @@
 	has_safety = FALSE
 
 /obj/item/gun/energy/mountedsmg/mech
+	max_shots = 30
 	projectile_type = /obj/item/projectile/bullet/pistol/medium/mech
+	firemodes = list(
+	list(mode_name="semiauto",       burst=1, fire_delay=0,    move_delay=null, burst_accuracy=null, dispersion=list(0)),
+	list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=4,    burst_accuracy=list(0,-1,-1),       dispersion=list(0, 15, 15)),
+)
 
 /obj/item/gun/energy/crossbow/cyborg
 	name = "mounted energy-crossbow"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -75,9 +75,6 @@
 	damage = 25
 	armor_penetration = 10
 
-/obj/item/projectile/beam/midlaser/mech
-	armor_penetration = 35
-
 /obj/item/projectile/beam/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
@@ -87,6 +84,10 @@
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
 	tracer_type = /obj/effect/projectile/tracer/heavy_laser
 	impact_type = /obj/effect/projectile/impact/heavy_laser
+
+/obj/item/projectile/beam/heavylaser/mech
+	damage = 35
+	armor_penetration = 35
 
 /obj/item/projectile/beam/xray
 	name = "xray beam"

--- a/html/changelogs/Ben10083 - Exosuit-Weps.yml
+++ b/html/changelogs/Ben10083 - Exosuit-Weps.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Exosuit laser gun now uses heavy laser beams, purely aesthetic."
+  - rscdel: "Killed innocent kittens."

--- a/html/changelogs/Ben10083 - Exosuit-Weps.yml
+++ b/html/changelogs/Ben10083 - Exosuit-Weps.yml
@@ -38,5 +38,6 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Exosuit laser gun now uses heavy laser beams, purely aesthetic."
-  - rscdel: "Killed innocent kittens."
+  - balance: "Exosuit laser gun now uses heavy laser beams, damage set to be between a medium and heavy laser."
+  - rscadd: "Exosuit mounted smg now can switch between semi-auto and 3-round burst"
+  - tweak: "Exosuit mounted smg now has a ammo capacity of 30 rounds."


### PR DESCRIPTION
General buffs to exosuit weapons, with QoL changes in between
* exosuit laser now is considered a heavy laser, set to do 35 damage instead of usual 45 damage of heavy
* mounted smg now can change firemodes
* capacity set to 30 rounds to allow either 30 semiauto shots or 10 3-round bursts