### PR TITLE
Fix IFF swapping destroying away ship radios

### DIFF
--- a/code/__defines/lists.dm
+++ b/code/__defines/lists.dm
@@ -13,6 +13,7 @@
 #define LAZYADDASSOCLIST(L, K, V) if(!L) { L = list(); } L[K] += list(V);
 #define LAZYREMOVEASSOC(L, K, V) if(L) { if(L[K]) { L[K] -= V; if(!length(L[K])) L -= K; } if(!length(L)) L = null; }
 #define LAZYACCESSASSOC(L, I, K) L ? L[I] ? L[I][K] ? L[I][K] : null : null : null
+#define LAZYREPLACEKEY(L, K, NK) if(L) { if(L[K]) { L[NK] = L[K] } else {L += NK} L -= K; }
 
 /// Performs an insertion on the given lazy list with the given key and value. If the value already exists, a new one will not be made.
 #define LAZYORASSOCLIST(lazy_list, key, value) \

--- a/code/controllers/subsystems/radio.dm
+++ b/code/controllers/subsystems/radio.dm
@@ -217,6 +217,34 @@ var/datum/controller/subsystem/radio/SSradio
 
 	return "radio"
 
+/proc/update_away_freq(old_channel, new_channel)
+	if(!old_channel || !new_channel || !(old_channel in AWAY_FREQS_ASSIGNED))
+		return FALSE
+
+	var/freq = AWAY_FREQS_ASSIGNED[old_channel]
+	var/datum/radio_frequency/RF = SSradio.return_frequency(freq)
+
+	if(old_channel == new_channel)
+		return istype(RF) ? RF : assign_away_freq(new_channel)
+
+	LAZYREPLACEKEY(AWAY_FREQS_ASSIGNED, old_channel, new_channel)
+	LAZYREPLACEKEY(radiochannels, old_channel, new_channel)
+	LAZYREPLACEKEY(ALL_RADIO_CHANNELS, old_channel, new_channel)
+	reverseradiochannels["[freq]"] = new_channel
+
+	for(var/obj/item/device/radio/R in RF.devices[RADIO_CHAT])
+		var/obj/item/device/radio/headset/H = R
+		if(istype(H))
+			for(var/obj/item/device/encryptionkey/EK in list(H.keyslot1, H.keyslot2))
+				if(old_channel in EK.channels)
+					LAZYREPLACEKEY(EK.channels, old_channel, new_channel)
+
+			H.recalculateChannels(TRUE)
+
+		else if(old_channel in R.channels)
+			LAZYREPLACEKEY(R.channels, old_channel, new_channel)
+			LAZYREPLACEKEY(R.secure_radio_connections, old_channel, new_channel)
+
 /proc/assign_away_freq(channel)
 	if (!AWAY_FREQS_UNASSIGNED.len)
 		return FALSE

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -50,7 +50,7 @@
 		id = "[preset_name] Receiver"
 		network = "tcomm_[name_lower]"
 		freq_listening += list(assign_away_freq(preset_name), HAIL_FREQ)
-		if (use_common)
+		if (use_common || linked.use_common)
 			freq_listening += PUB_FREQ
 		autolinkers = list(
 			"[name_lower]_receiver"
@@ -94,7 +94,7 @@
 		id = "[preset_name] Bus"
 		network = "tcomm_[name_lower]"
 		freq_listening += list(assign_away_freq(preset_name), HAIL_FREQ)
-		if (use_common)
+		if (use_common || linked.use_common)
 			freq_listening += PUB_FREQ
 		autolinkers = list(
 			"[name_lower]_processor",
@@ -205,7 +205,7 @@
 			assign_away_freq(preset_name),
 			HAIL_FREQ
 		)
-		if(use_common)
+		if(use_common || linked.use_common)
 			freq_listening += PUB_FREQ
 		autolinkers = list(
 			"[name_lower]_server"

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -36,7 +36,7 @@
 		)
 
 	if(use_common)
-		channels += list(CHANNEL_COMMON, TRUE)
+		channels += list(CHANNEL_COMMON = TRUE)
 
 /obj/item/device/encryptionkey/ship/common
 	use_common = TRUE

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -34,8 +34,12 @@ var/global/area/overmap/map_overmap // Global object used to locate the overmap 
 	var/obj/machinery/leviathan_safeguard/levi_safeguard
 	var/obj/machinery/gravity_generator/main/gravity_generator
 
-	var/comms_support = FALSE		// Whether ghostroles attached to this overmap object spawn with comms
-	var/comms_name = "shipboard"	// Snowflake name to apply to comms equipment ("shipboard radio headset", "intercom (shipboard)", "shipboard telecommunications mainframe"), etc.
+	/// Whether ghostroles attached to this overmap object spawn with comms
+	var/comms_support = FALSE
+	/// Snowflake name to apply to comms equipment ("shipboard radio headset", "intercom (shipboard)", "shipboard telecommunications mainframe"), etc.
+	var/comms_name = "shipboard"
+	/// Whether away ship comms have access to the common channel / PUB_FREQ
+	var/use_common = FALSE
 
 /obj/effect/overmap/visitable/Initialize()
 	. = ..()
@@ -158,6 +162,8 @@ var/global/area/overmap/map_overmap // Global object used to locate the overmap 
 		return
 	if(obfuscated)
 		return
+	if(comms_support)
+		update_away_freq(name, get_real_name())
 	name = get_real_name()
 
 /obj/effect/overmap/visitable/proc/get_real_name()

--- a/html/changelogs/johnwildkins-fixradio2.yml
+++ b/html/changelogs/johnwildkins-fixradio2.yml
@@ -1,0 +1,8 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Changing the IFF on an away ship no longer bricks comms for any late-joiners."
+  - bugfix: "Away ships with access to the Common channel (casino, etc.) now properly broadcast that channel to crew."
+  - tweak: "Capitalized 'Grand Romanovich Casino' when used as a proper noun (e.g., as a radio channel)."

--- a/maps/away/away_site/romanovich/grand_romanovich.dm
+++ b/maps/away/away_site/romanovich/grand_romanovich.dm
@@ -1,5 +1,5 @@
 /datum/map_template/ruin/away_site/grand_romanovich
-	name = "grand romanovich casino"
+	name = "Grand Romanovich Casino"
 	description = "An adhomian style casino in Tau Ceti's space."
 	suffix = "away_site/romanovich/grand_romanovich.dmm"
 	sectors = list(SECTOR_ROMANOVICH)
@@ -8,15 +8,16 @@
 	id = "grand_romanovich"
 
 /decl/submap_archetype/grand_romanovich
-	map = "grand romanovich casino"
+	map = "Grand Romanovich Casino"
 	descriptor = "An adhomian style casino in Tau Ceti's space."
 
 /obj/effect/overmap/visitable/sector/grand_romanovich
-	name = "grand romanovich casino"
+	name = "Grand Romanovich Casino"
 	desc = "An adhomian style casino in Tau Ceti's space."
 
 	comms_support = TRUE
-	comms_name = "grand romanovich"
+	comms_name = "casino"
+	use_common = TRUE
 
 /area/grand_romanovich
 	flags = HIDE_FROM_HOLOMAP

--- a/maps/away/away_site/space_bar/space_bar.dm
+++ b/maps/away/away_site/space_bar/space_bar.dm
@@ -16,6 +16,7 @@
 	desc = "A cozy meeting place floating on space."
 	comms_support = TRUE
 	comms_name = "station"
+	use_common = TRUE
 
 /area/space_bar
 	name = "Spacer Bar"


### PR DESCRIPTION
changes:
  - bugfix: "Changing the IFF on an away ship no longer bricks comms for any late-joiners."
  - bugfix: "Away ships with access to the Common channel (casino, etc.) now properly broadcast that channel to crew."
  - tweak: "Capitalized 'Grand Romanovich Casino' when used as a proper noun (e.g., as a radio channel)."

Fixes #15402