### PR TITLE
Fixes IAC off-ship spawner

### DIFF
--- a/html/changelogs/iacbugfix.yml
+++ b/html/changelogs/iacbugfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Nope63
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes an overlap between the IAC Technician and Coordinator roles that should allow proper spawning."

--- a/maps/away/ships/iac/iac_rescue_ship_ghostroles.dm
+++ b/maps/away/ships/iac/iac_rescue_ship_ghostroles.dm
@@ -9,7 +9,7 @@
 	spawnpoints = list("iac_volunteer")
 	max_count = 2
 
-	outfit = /datum/outfit/admin/freighter_crew
+	outfit = /datum/outfit/admin/iac_volunteer
 	possible_species = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_MSAI, SPECIES_TAJARA_ZHAN, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_UNATHI, SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_WORKER)
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 
@@ -59,21 +59,21 @@
 	name = "IAC Technician"
 	desc = "Crew the IAC Rescue Ship. Act as one of the ship's engineering or medical personnel. Help those in need and respond to medical emergencies or distress calls. Try to raise funds and donations while staying out of trouble."
 
-	spawnpoints = list("iac_coordinator")
+	spawnpoints = list("iac_technician")
 	max_count = 2
 
 	outfit = /datum/outfit/admin/iac_volunteer/technician
 	possible_species = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_TAJARA, SPECIES_TAJARA_MSAI, SPECIES_TAJARA_ZHAN, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_UNATHI, SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL)
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 
-	assigned_role = "IAC Coordinator"
-	special_role = "IAC Coordinator"
+	assigned_role = "IAC Technician"
+	special_role = "IAC Technician"
 
 
 /datum/outfit/admin/iac_volunteer/technician
-	name = "IAC Coordinator"
+	name = "IAC Technician"
 
-	suit= /obj/item/clothing/suit/storage/hazardvest/iac
+	suit = /obj/item/clothing/suit/storage/hazardvest/iac
 
 	species_shoes = list(
 		SPECIES_UNATHI = /obj/item/clothing/shoes/workboots/toeless/grey,
@@ -85,7 +85,7 @@
 /datum/ghostspawner/human/iac_volunteer/coordinator
 	short_name = "iac_coordinator"
 	name = "IAC Coordinator"
-	desc = "Captain the IAC Rescue Ship. Act as the ship's chief doctor. Train your volunteers. Help those in need and respond to medical emergencies or distress calls. Try to raise funds and donations while staying out of trouble."
+	desc = "Command the IAC Rescue Ship. Act as the ship's chief doctor. Train your volunteers. Help those in need and respond to medical emergencies or distress calls. Try to raise funds and donations while staying out of trouble."
 
 	spawnpoints = list("iac_coordinator")
 	max_count = 1
@@ -101,7 +101,7 @@
 /datum/outfit/admin/iac_volunteer/coordinator
 	name = "IAC Coordinator"
 
-	suit= /obj/item/clothing/suit/storage/toggle/labcoat/iac
+	suit = /obj/item/clothing/suit/storage/toggle/labcoat/iac
 
 	species_shoes = list(
 		SPECIES_UNATHI = /obj/item/clothing/shoes/workboots/toeless/grey,
@@ -109,6 +109,8 @@
 		SPECIES_TAJARA_MSAI = /obj/item/clothing/shoes/workboots/toeless/grey,
 		SPECIES_TAJARA_ZHAN = /obj/item/clothing/shoes/workboots/toeless/grey
 	)
+
+//items
 
 /obj/item/card/id/iac_rescue_ship
 	name = "iac ship id"


### PR DESCRIPTION
Fixes a writing mistake in the IAC ghost roles that made the Technician and Coordinator roles overlap on the same spawn point.
(i hate byond)