### PR TITLE
Fix windoors playing a closed deny animation when open

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -65,7 +65,7 @@
 
 /obj/machinery/door/window/allowed(mob/M)
 	. = ..()
-	if(inoperable()) // Unpowered windoors can just be slid open
+	if(inoperable() || !density) // Unpowered windoors can just be slid open, open windoors can always be closed
 		return TRUE
 	use_power_oneoff(50) // Just powering the RFID and maybe a weak motor
 	if(operable() && . == FALSE)

--- a/html/changelogs/johnwildkins-fixdoors.yml
+++ b/html/changelogs/johnwildkins-fixdoors.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Windoors no longer play a closed deny animation when interacted with while open without access."


### PR DESCRIPTION
see title
now anyone can close windoors even if they don't have access (powercreep)