### PR TITLE
Light fixture tweaks

### DIFF
--- a/code/modules/power/lights/fixtures.dm
+++ b/code/modules/power/lights/fixtures.dm
@@ -11,7 +11,7 @@
 	var/base_state = "tube"		// base description and icon_state
 	icon_state = "tube_empty"
 	desc = "A lighting fixture."
-	desc_info = "Use grab intent when interacting with a working light to take it out of it's fixture."
+	desc_info = "Use grab intent when interacting with a working light to take it out of its fixture."
 	anchored = TRUE
 	layer = 5  					// They were appearing under mobs which is a little weird - Ostaf
 	use_power = POWER_USE_ACTIVE

--- a/code/modules/power/lights/fixtures.dm
+++ b/code/modules/power/lights/fixtures.dm
@@ -11,6 +11,7 @@
 	var/base_state = "tube"		// base description and icon_state
 	icon_state = "tube_empty"
 	desc = "A lighting fixture."
+	desc_info = "Use grab intent when interacting with a working light to take it out of it's fixture."
 	anchored = TRUE
 	layer = 5  					// They were appearing under mobs which is a little weird - Ostaf
 	use_power = POWER_USE_ACTIVE
@@ -486,7 +487,7 @@
 				shatter()
 				return
 
-	if(user.a_intent != I_GRAB)
+	if(user.a_intent != I_GRAB && status == LIGHT_OK)
 		return
 
 	// create a light tube/bulb item and put it in the user's hand

--- a/html/changelogs/Afya-lights.yml
+++ b/html/changelogs/Afya-lights.yml
@@ -1,0 +1,7 @@
+author: Afya
+
+delete-after: True
+
+changes:
+  - tweak: "You can pull out broken lights without grab intent."
+  - tweak: "Added mechanics description to light figures mentioning grab intent."


### PR DESCRIPTION
Light fixtures now have a mechanical description about grab intent. Broken lights do not require grab intent.
