### PR TITLE
Fix turrets shooting brains out of cyborgs

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -592,6 +592,9 @@
 	if(!emagged && !target_borgs && issilicon(L))	// Don't target silica
 		return TURRET_NOT_TARGET
 
+	if(isbrain(L) && !isturf(L.loc)) // Don't target cyborg brains / MMIs
+		return TURRET_NOT_TARGET
+
 	if(L.stat && !emagged)		//if the perp is dead/dying, no need to bother really
 		return TURRET_NOT_TARGET	//move onto next potential victim!
 

--- a/html/changelogs/johnwildkins-fixborg.yml
+++ b/html/changelogs/johnwildkins-fixborg.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Fix AI turrets trying to shoot the brains out of cyborgs."


### PR DESCRIPTION
Fix #15430
Not a joke title, the refactor didn't cause the AI turrets to start shooting borgs, but instead target the /mob/living/carbon/brain located inside the MMI located inside the cyborg.

lmao.