### PR TITLE
Refactor cell chargers

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -27,6 +27,9 @@
 #define MAINT    0x8  // Under maintenance.
 #define EMPED    0x10 // Temporary broken by EMP pulse.
 
+#define INOPERABLE(machine)  (machine.stat & (BROKEN|NOPOWER|MAINT|EMPED))
+#define OPERABLE(machine)    !INOPERABLE(machine)
+
 // Used by firelocks
 #define FIREDOOR_OPEN 1
 #define FIREDOOR_CLOSED 2

--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -44,6 +44,7 @@
 /obj/item/cell/crap/empty/Initialize()
 	. = ..()
 	charge = 0
+	update_icon()
 
 /obj/item/cell/crap/cig
 	name = "\improper rechargable mini-battery"
@@ -59,6 +60,7 @@
 /obj/item/cell/secborg/empty/Initialize()
 	. = ..()
 	charge = 0
+	update_icon()
 
 /obj/item/cell/apc
 	name = "heavy-duty power cell"
@@ -83,6 +85,7 @@
 /obj/item/cell/high/empty/Initialize()
 	. = ..()
 	charge = 0
+	update_icon()
 
 /obj/item/cell/super
 	name = "super-capacity power cell"
@@ -94,6 +97,7 @@
 /obj/item/cell/super/empty/Initialize()
 	. = ..()
 	charge = 0
+	update_icon()
 
 /obj/item/cell/hyper
 	name = "hyper-capacity power cell"
@@ -105,6 +109,7 @@
 /obj/item/cell/hyper/empty/Initialize()
 	. = ..()
 	charge = 0
+	update_icon()
 
 /obj/item/cell/infinite
 	name = "infinite-capacity power cell!"
@@ -163,6 +168,7 @@
 /obj/item/cell/device/emergency_light/empty/Initialize()
 	. = ..()
 	charge = 0
+	update_icon()
 
 /obj/item/cell/proto
 	name = "proto power cell"
@@ -174,3 +180,4 @@
 /obj/item/cell/proto/empty/Initialize()
 	. = ..()
 	charge = 0
+	update_icon()

--- a/html/changelogs/johnwildkins-chargers.yml
+++ b/html/changelogs/johnwildkins-chargers.yml
@@ -1,0 +1,9 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - refactor: "Cleaned up cell charger interaction and processing code."
+  - bugfix: "Cell chargers no longer send 90 kW into the void every time they're unwrenched and moved."
+  - bugfix: "Fixed empty cells not initializing with the proper icon state."
+  - tweak: "Cell chargers now audibly ping when their attached cell has finished charging."


### PR DESCRIPTION
Fixes #15375

changes:
  - refactor: "Cleaned up cell charger interaction and processing code."
  - bugfix: "Cell chargers no longer send 90 kW into the void every time they're unwrenched and moved."
  - bugfix: "Fixed empty cells not initializing with the proper icon state."
  - tweak: "Cell chargers now audibly ping when their attached cell has finished charging."