### PR TITLE
Main Elevator Escape Hatch

### DIFF
--- a/html/changelogs/elevator_escape.yml
+++ b/html/changelogs/elevator_escape.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - maptweak: "Adds an emergency escape hatch to the main elevator on deck 1."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -1987,7 +1987,7 @@
 	input_tag = "ph_in";
 	name = "Phoron Supply Monitor";
 	output_tag = "ph_out";
-	sensors = list("ph_sensor" = "Tank")
+	sensors = list("ph_sensor"="Tank")
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 1
@@ -11318,7 +11318,7 @@
 	frequency = 1442;
 	input_tag = "port_prop_in";
 	output_tag = "port_prop_out";
-	sensors = list("port_prop_sensor" = "Port Propulsion Sensor")
+	sensors = list("port_prop_sensor"="Port Propulsion Sensor")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -12943,7 +12943,7 @@
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Monitor";
 	output_tag = "co2_out";
-	sensors = list("co2_sensor" = "Tank")
+	sensors = list("co2_sensor"="Tank")
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 1
@@ -14508,7 +14508,7 @@
 	input_tag = "h_in";
 	name = "Hydrogen Supply Monitor";
 	output_tag = "h_out";
-	sensors = list("h_sensor" = "Tank")
+	sensors = list("h_sensor"="Tank")
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 1
@@ -14580,7 +14580,7 @@
 	name = "Nitrogen Supply Monitor";
 	output_tag = "n_out";
 	pixel_x = -32;
-	sensors = list("n_sensor" = "Tank")
+	sensors = list("n_sensor"="Tank")
 	},
 /obj/machinery/light{
 	dir = 8
@@ -14799,7 +14799,7 @@
 	frequency = 1442;
 	input_tag = "starboard_prop_in";
 	output_tag = "starboard_prop_out";
-	sensors = list("starboard_prop_sensor" = "Starboard Propulsion Sensor")
+	sensors = list("starboard_prop_sensor"="Starboard Propulsion Sensor")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
@@ -16774,7 +16774,7 @@
 	name = "Air Supply Monitor";
 	output_tag = "air_out";
 	pixel_x = 32;
-	sensors = list("air_sensor" = "Tank")
+	sensors = list("air_sensor"="Tank")
 	},
 /obj/machinery/light{
 	dir = 4
@@ -19310,7 +19310,7 @@
 	name = "Nitrous Oxide Supply Monitor";
 	output_tag = "n2o_out";
 	pixel_x = 32;
-	sensors = list("n2o_sensor" = "Tank")
+	sensors = list("n2o_sensor"="Tank")
 	},
 /obj/machinery/light{
 	dir = 4
@@ -19999,7 +19999,7 @@
 	input_tag = null;
 	name = "Phoron Supply Monitor";
 	output_tag = "ph_out_engines";
-	sensors = list("ph_sensor" = "Tank")
+	sensors = list("ph_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -23489,6 +23489,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/rotary)
+"sza" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Elevator Emergency Escape Hatch";
+	req_one_access = list(11,24,67)
+	},
+/obj/effect/map_effect/door_helper/unres{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
+/area/hallway/primary/aft)
 "szM" = (
 /turf/simulated/floor/reinforced{
 	blocks_air = 1;
@@ -27757,7 +27767,7 @@
 	name = "Oxygen Supply Monitor";
 	output_tag = "o2_out";
 	pixel_x = -32;
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /obj/machinery/light{
 	dir = 8
@@ -29110,7 +29120,7 @@
 	name = "Mixed Gas Tank Monitor";
 	output_tag = "mixed_out";
 	pixel_y = -3;
-	sensors = list("mixed_sensor" = "Tank")
+	sensors = list("mixed_sensor"="Tank")
 	},
 /turf/simulated/wall/r_wall,
 /area/engineering/atmos)
@@ -51313,7 +51323,7 @@ tny
 tny
 tny
 tny
-tny
+sza
 tny
 jvl
 wLL


### PR DESCRIPTION
this PR adds a emergency escape hatch to the main elevator on deck 1, to allow people to avoid being crushed.
engineers, atmos. technicians, and first responders have access. the inside is one-way access.