### PR TITLE
Fix headset channel resetting

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -141,6 +141,7 @@
 
 
 /obj/item/device/radio/headset/proc/recalculateChannels(var/setDescription = FALSE)
+	var/list/old_channel_settings = channels.Copy()
 	channels = list()
 	translate_binary = FALSE
 	translate_hivenet = FALSE
@@ -176,6 +177,8 @@
 			independent = TRUE
 
 	for (var/ch_name in channels)
+		if(ch_name in old_channel_settings)
+			channels[ch_name] = old_channel_settings[ch_name]
 		secure_radio_connections[ch_name] = SSradio.add_object(src, radiochannels[ch_name], RADIO_CHAT)
 
 	if(setDescription)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -487,13 +487,13 @@ var/global/list/default_medbay_channels = list(
 	if ((input_frequency in ANTAG_FREQS) && !syndie) //Checks to see if it's allowed on that frequency, based on the encryption keys
 		return FALSE
 
-	if (input_frequency == frequency)
-		return TRUE
-
 	for (var/ch_name in channels)
 		var/datum/radio_frequency/RF = secure_radio_connections[ch_name]
-		if (RF.frequency == input_frequency && (channels[ch_name] & FREQ_LISTENING))
-			return TRUE
+		if (RF.frequency == input_frequency)
+			return channels[ch_name]
+
+	if (input_frequency == frequency)
+		return TRUE
 
 	return FALSE
 

--- a/html/changelogs/johnwildkins-headsets.yml
+++ b/html/changelogs/johnwildkins-headsets.yml
@@ -1,0 +1,7 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - tweak: "Headsets no longer reset channel settings when moving them between inventory slots."
+  - bugfix: "Headset channel on/off settings now are taken into account over the frequency of the radio when determining if a radio should hear a channel."


### PR DESCRIPTION
changes:
  - tweak: "Headsets no longer reset channel settings when moving them between inventory slots."
  - bugfix: "Headset channel on/off settings now are taken into account over the frequency of the radio when determining if a radio should hear a channel."
