### PR TITLE
Ai Core and Solar Panels Build Fix

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -94,7 +94,7 @@
 					A.amount = 5
 				return TRUE
 
-			if(istype(P, /obj/item/stack/material) && P.get_material_name() == "rglass")
+			if(istype(P, /obj/item/stack/material) && P.get_material_name() == MATERIAL_GLASS_REINFORCED)
 				var/obj/item/stack/RG = P
 				if (RG.get_amount() < 2)
 					to_chat(user, "<span class='warning'>You need two sheets of glass to put in the glass panel.</span>")

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -235,7 +235,7 @@
 			playsound(src.loc, W.usesound, 75, 1)
 			return 1
 
-		if(istype(W, /obj/item/stack/material) && (W.get_material_name() == "glass" || W.get_material_name() == "rglass"))
+		if(istype(W, /obj/item/stack/material) && (W.get_material_name() == "glass" || W.get_material_name() == MATERIAL_GLASS_REINFORCED))
 			var/obj/item/stack/material/S = W
 			if(S.use(2))
 				glass_type = W.type

--- a/html/changelogs/Ben10083 - Core Fix.yml
+++ b/html/changelogs/Ben10083 - Core Fix.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Ai cores and Solar Panels can now be built again."


### PR DESCRIPTION
Fixes #15479
AI core and Solar now can be build again, they were looking for 'rglass' when path has changed, it now looks for the Reinforced glass define.