### PR TITLE
Independent Assistants Fix

### DIFF
--- a/code/__defines/jobs.dm
+++ b/code/__defines/jobs.dm
@@ -24,6 +24,9 @@
 // Singular Roles
 #define VISITOR_ROLE /datum/job/visitor
 #define REPRESENTATIVE_ROLE /datum/job/representative
+#define CONSULAR_ROLE /datum/job/consular
+#define JOURNALIST_ROLE /datum/job/journalist
+#define CHAPLAIN_ROLE /datum/job/chaplain
 
 // Factions
 // Used to know what what roles are allowed to play as which factions.
@@ -36,4 +39,4 @@
 #define ZENG_ROLES list(SCIENCE_ROLES, MEDICAL_ROLES, CIVILIAN_ROLES, REPRESENTATIVE_ROLE)
 #define HEPH_ROLES list(OPERATIONS_ROLES, ENGINEERING_ROLES, CIVILIAN_ROLES, REPRESENTATIVE_ROLE)
 #define ORION_ROLES list(OPERATIONS_ROLES, CIVILIAN_ROLES)
-#define INDEP_ROLES list(NON_CREW_CIVILIAN_ROLES, /datum/job/consular, /datum/job/journalist, /datum/job/chaplain)
+#define INDEP_ROLES list(NON_CREW_CIVILIAN_ROLES, CONSULAR_ROLE, JOURNALIST_ROLE, CHAPLAIN_ROLE)

--- a/code/__defines/jobs.dm
+++ b/code/__defines/jobs.dm
@@ -13,23 +13,27 @@
 #define MEDICAL_ROLES list(/datum/job/doctor, /datum/job/surgeon, /datum/job/pharmacist, /datum/job/psychiatrist, /datum/job/med_tech, /datum/job/intern_med)
 #define ENGINEERING_ROLES list(/datum/job/engineer, /datum/job/atmos, /datum/job/intern_eng)
 #define SERVICE_ROLES list(/datum/job/chaplain, /datum/job/bartender, /datum/job/chef, /datum/job/hydro, /datum/job/janitor, /datum/job/journalist, /datum/job/librarian)
-#define CIVILIAN_ROLES list(/datum/job/assistant, /datum/job/visitor, /datum/job/passenger)
+#define CIVILIAN_ROLES list(/datum/job/assistant, /datum/job/visitor)
+#define NON_CREW_CIVILIAN_ROLES list(/datum/job/passenger, /datum/job/merchant)
 #define SECURITY_ROLES list(/datum/job/warden, /datum/job/investigator, /datum/job/officer, /datum/job/intern_sec)
 #define OPERATIONS_ROLES list(/datum/job/hangar_tech, /datum/job/mining, /datum/job/machinist)
 #define EQUIPMENT_ROLES list(/datum/job/ai, /datum/job/cyborg)
 
-#define ALL_ROLES list(COMMAND_ROLES, COMMAND_SUPPORT_ROLES, ENGINEERING_ROLES, SERVICE_ROLES, CIVILIAN_ROLES, OPERATIONS_ROLES, MEDICAL_ROLES, SCIENCE_ROLES, SECURITY_ROLES, EQUIPMENT_ROLES)
-#define ALL_FACTION_ROLES list(/datum/job/representative, /datum/job/assistant, /datum/job/visitor)
+#define ALL_ROLES list(COMMAND_ROLES, COMMAND_SUPPORT_ROLES, ENGINEERING_ROLES, SERVICE_ROLES, CIVILIAN_ROLES, NON_CREW_CIVILIAN_ROLES, OPERATIONS_ROLES, MEDICAL_ROLES, SCIENCE_ROLES, SECURITY_ROLES, EQUIPMENT_ROLES)
+
+// Singular Roles
+#define VISITOR_ROLE /datum/job/visitor
+#define REPRESENTATIVE_ROLE /datum/job/representative
 
 // Factions
 // Used to know what what roles are allowed to play as which factions.
 // Note that independent isn't a faction by itself, as faction in this case means a megacorporation.
-#define SCC_ROLES list(COMMAND_ROLES, COMMAND_SUPPORT_ROLES, EQUIPMENT_ROLES, /datum/job/visitor)
-#define NT_ROLES list(SCIENCE_ROLES, MEDICAL_ROLES, SERVICE_ROLES, ALL_FACTION_ROLES)
-#define PMC_ROLES list(SECURITY_ROLES, MEDICAL_ROLES, ALL_FACTION_ROLES)
-#define IDRIS_ROLES list(SECURITY_ROLES, SERVICE_ROLES, ALL_FACTION_ROLES)
-#define ZAVOD_ROLES list(SECURITY_ROLES, SCIENCE_ROLES, ENGINEERING_ROLES, ALL_FACTION_ROLES)
-#define ZENG_ROLES list(SCIENCE_ROLES, MEDICAL_ROLES, ALL_FACTION_ROLES)
-#define HEPH_ROLES list(OPERATIONS_ROLES, ENGINEERING_ROLES, ALL_FACTION_ROLES)
-#define ORION_ROLES list(OPERATIONS_ROLES, ALL_FACTION_ROLES)
-#define INDEP_ROLES list(CIVILIAN_ROLES, /datum/job/merchant, /datum/job/consular, /datum/job/journalist, /datum/job/chaplain)
+#define SCC_ROLES list(COMMAND_ROLES, COMMAND_SUPPORT_ROLES, EQUIPMENT_ROLES, VISITOR_ROLE)
+#define NT_ROLES list(SCIENCE_ROLES, MEDICAL_ROLES, SERVICE_ROLES, CIVILIAN_ROLES, REPRESENTATIVE_ROLE)
+#define PMC_ROLES list(SECURITY_ROLES, MEDICAL_ROLES, CIVILIAN_ROLES, REPRESENTATIVE_ROLE)
+#define IDRIS_ROLES list(SECURITY_ROLES, SERVICE_ROLES, CIVILIAN_ROLES, REPRESENTATIVE_ROLE)
+#define ZAVOD_ROLES list(SECURITY_ROLES, SCIENCE_ROLES, ENGINEERING_ROLES, CIVILIAN_ROLES, REPRESENTATIVE_ROLE)
+#define ZENG_ROLES list(SCIENCE_ROLES, MEDICAL_ROLES, CIVILIAN_ROLES, REPRESENTATIVE_ROLE)
+#define HEPH_ROLES list(OPERATIONS_ROLES, ENGINEERING_ROLES, CIVILIAN_ROLES, REPRESENTATIVE_ROLE)
+#define ORION_ROLES list(OPERATIONS_ROLES, CIVILIAN_ROLES)
+#define INDEP_ROLES list(NON_CREW_CIVILIAN_ROLES, /datum/job/consular, /datum/job/journalist, /datum/job/chaplain)

--- a/code/__defines/jobs.dm
+++ b/code/__defines/jobs.dm
@@ -1,9 +1,16 @@
 //
-// Role Groups and Faction Groups Defines
+// Role and Faction Defines
 //
 
-// Groups
-// Used to know what roles are part of which department or group.
+// Singular Roles
+#define VISITOR_ROLE /datum/job/visitor
+#define REPRESENTATIVE_ROLE /datum/job/representative
+#define CONSULAR_ROLE /datum/job/consular
+#define JOURNALIST_ROLE /datum/job/journalist
+#define CHAPLAIN_ROLE /datum/job/chaplain
+
+// Departments
+// Used to know what roles are part of which department.
 // Notes on COMMAND_SUPPORT_ROLES: HRA is an admin job. Representative is under ALL_FACTION_ROLES. Consular intentionally not included as they are independent.
 #define ADMIN_ROLES list(/datum/job/hra)
 
@@ -21,17 +28,9 @@
 
 #define ALL_ROLES list(COMMAND_ROLES, COMMAND_SUPPORT_ROLES, ENGINEERING_ROLES, SERVICE_ROLES, CIVILIAN_ROLES, NON_CREW_CIVILIAN_ROLES, OPERATIONS_ROLES, MEDICAL_ROLES, SCIENCE_ROLES, SECURITY_ROLES, EQUIPMENT_ROLES)
 
-// Singular Roles
-#define VISITOR_ROLE /datum/job/visitor
-#define REPRESENTATIVE_ROLE /datum/job/representative
-#define CONSULAR_ROLE /datum/job/consular
-#define JOURNALIST_ROLE /datum/job/journalist
-#define CHAPLAIN_ROLE /datum/job/chaplain
-
 // Factions
 // Used to know what what roles are allowed to play as which factions.
-// Note that independent isn't a faction by itself, as faction in this case means a megacorporation.
-#define SCC_ROLES list(COMMAND_ROLES, COMMAND_SUPPORT_ROLES, EQUIPMENT_ROLES, VISITOR_ROLE)
+#define SCC_ROLES list(ADMIN_ROLES, COMMAND_ROLES, COMMAND_SUPPORT_ROLES, EQUIPMENT_ROLES, VISITOR_ROLE)
 #define NT_ROLES list(SCIENCE_ROLES, MEDICAL_ROLES, SERVICE_ROLES, CIVILIAN_ROLES, REPRESENTATIVE_ROLE)
 #define PMC_ROLES list(SECURITY_ROLES, MEDICAL_ROLES, CIVILIAN_ROLES, REPRESENTATIVE_ROLE)
 #define IDRIS_ROLES list(SECURITY_ROLES, SERVICE_ROLES, CIVILIAN_ROLES, REPRESENTATIVE_ROLE)

--- a/html/changelogs/independent_assistants_oversight.yml
+++ b/html/changelogs/independent_assistants_oversight.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes assistants being able to be independent."


### PR DESCRIPTION
this PR fixes assistants being able to be independent.

## changes
- splits the civilian roles define into a crew and non-crew variant respectively.
- adds a visitor and representative singular role define to make the faction defines clearer.