### PR TITLE
Fixes overmap hazards not spawning correctly, fixes overmap being smaller by 15 tiles.

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -349,7 +349,7 @@ var/const/enterloopsanity = 100
 
 /turf/proc/AdjacentTurfs(var/check_blockage = TRUE)
 	. = list()
-	for(var/turf/t in oview(src,1))
+	for(var/turf/t in orange(src,1))
 		if(check_blockage)
 			if(!t.density)
 				if(!LinkBlocked(src, t) && !TurfBlockedNonWindow(t))

--- a/code/modules/overmap/events/event.dm
+++ b/code/modules/overmap/events/event.dm
@@ -57,7 +57,7 @@
 	if(continuous)
 		fitting_turfs = origin_turf.CardinalTurfs(FALSE)
 	else
-		fitting_turfs = oview(range, origin_turf)
+		fitting_turfs = orange(range, origin_turf)
 	fitting_turfs = shuffle(fitting_turfs)
 	for(var/turf/T in fitting_turfs)
 		if(T in candidate_turfs)

--- a/html/changelogs/mattatlas-overmapfix.yml
+++ b/html/changelogs/mattatlas-overmapfix.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed the Overmap being 15 tiles smaller than it should be."
+  - bugfix: "Fixed overmap hazards not spawning correctly. There are now MANY more hazards."

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -37,6 +37,7 @@
 
 	use_overmap = TRUE
 	num_exoplanets = 2
+	overmap_size = 35
 	overmap_event_areas = 34
 	planet_size = list(255,255)
 


### PR DESCRIPTION
![dreamseeker_VGlfzFE6zs](https://user-images.githubusercontent.com/13016572/210642609-34acb9b6-6612-4fe5-8d55-0af6f2d60b6a.png)
Overmap looks like this now.