### PR TITLE
Ion Thrusters

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -2637,6 +2637,7 @@
 #include "code\modules\overmap\ships\computers\shuttle.dm"
 #include "code\modules\overmap\ships\engines\engine.dm"
 #include "code\modules\overmap\ships\engines\gas_thruster.dm"
+#include "code\modules\overmap\ships\engines\ion_thruster.dm"
 #include "code\modules\paperwork\carbonpaper.dm"
 #include "code\modules\paperwork\clipboard.dm"
 #include "code\modules\paperwork\faxmachine.dm"

--- a/code/modules/overmap/ships/engines/ion_thruster.dm
+++ b/code/modules/overmap/ships/engines/ion_thruster.dm
@@ -37,7 +37,7 @@
 
 /obj/machinery/ion_engine 
 	name = "ion propulsion device"
-	desc = "An advanced ion propulsion device, using energy and minutes amount of gas to generate thrust."
+	desc = "An advanced ion propulsion device, using energy and minute amount of gas to generate thrust."
 	icon = 'icons/obj/ship_engine.dmi'
 	icon_state = "nozzle"
 	power_channel = ENVIRON

--- a/code/modules/overmap/ships/engines/ion_thruster.dm
+++ b/code/modules/overmap/ships/engines/ion_thruster.dm
@@ -1,4 +1,4 @@
-//electric engine
+//electric engine, should be very rare
 /datum/ship_engine/ion
 	name = "ion thruster"
 	var/obj/machinery/ion_engine/thruster

--- a/code/modules/overmap/ships/engines/ion_thruster.dm
+++ b/code/modules/overmap/ships/engines/ion_thruster.dm
@@ -1,0 +1,87 @@
+//electric engine
+/datum/ship_engine/ion
+	name = "ion thruster"
+	var/obj/machinery/ion_engine/thruster
+
+/datum/ship_engine/ion/New(obj/machinery/_holder)
+	..()
+	thruster = _holder
+
+/datum/ship_engine/ion/Destroy()
+	thruster = null
+	. = ..()
+
+/datum/ship_engine/ion/get_status()
+	return thruster.get_status()
+
+/datum/ship_engine/ion/get_thrust()
+	return thruster.get_thrust()
+
+/datum/ship_engine/ion/burn()
+	return thruster.burn()
+
+/datum/ship_engine/ion/set_thrust_limit(new_limit)
+	thruster.thrust_limit = new_limit
+
+/datum/ship_engine/ion/get_thrust_limit()
+	return thruster.thrust_limit
+
+/datum/ship_engine/ion/is_on()
+	return thruster.on && thruster.powered()
+
+/datum/ship_engine/ion/toggle()
+	thruster.on = !thruster.on
+
+/datum/ship_engine/ion/can_burn()
+	return thruster.on && thruster.powered()
+
+/obj/machinery/ion_engine 
+	name = "ion propulsion device"
+	desc = "An advanced ion propulsion device, using energy and minutes amount of gas to generate thrust."
+	icon = 'icons/obj/ship_engine.dmi'
+	icon_state = "nozzle"
+	power_channel = ENVIRON
+	idle_power_usage = 19600
+	anchored = TRUE
+
+	var/datum/ship_engine/ion/controller
+	var/thrust_limit = 1
+	var/on = 1
+	var/burn_cost = 36000
+	var/generated_thrust = 2.5
+
+/obj/machinery/ion_engine/Initialize()
+	. = ..()
+	controller = new(src)
+
+/obj/machinery/ion_engine/Destroy()
+	QDEL_NULL(controller)
+	. = ..()
+
+/obj/machinery/ion_engine/proc/get_status()
+	. = list()
+	.+= "Location: [get_area(src)]."
+	if(!powered())
+		.+= "Insufficient power to operate."
+
+	. = jointext(.,"<br>")
+
+/obj/machinery/ion_engine/proc/burn()
+	if(!on && !powered())
+		return 0
+	use_power_oneoff(burn_cost) 
+	. = thrust_limit * generated_thrust
+
+/obj/machinery/ion_engine/proc/get_thrust()
+	return thrust_limit * generated_thrust * on
+
+/obj/item/circuitboard/engine/ion
+	name = T_BOARD("ion propulsion device")
+	board_type = "machine"
+	icon_state = "mcontroller"
+	build_path = /obj/machinery/ion_engine
+	origin_tech = list(TECH_POWER = 4, TECH_ENGINEERING = 3)
+	req_components = list(
+							/obj/item/stack/cable_coil = 2,
+							/obj/item/stock_parts/matter_bin = 1,
+							/obj/item/stock_parts/capacitor = 2)

--- a/code/modules/overmap/ships/engines/ion_thruster.dm
+++ b/code/modules/overmap/ships/engines/ion_thruster.dm
@@ -37,7 +37,7 @@
 
 /obj/machinery/ion_engine 
 	name = "ion propulsion device"
-	desc = "An advanced ion propulsion device, using energy and minute amount of gas to generate thrust."
+	desc = "An advanced ion propulsion device, using energy and a minute amount of gas to generate thrust."
 	icon = 'icons/obj/ship_engine.dmi'
 	icon_state = "nozzle"
 	power_channel = ENVIRON

--- a/html/changelogs/wickedcybs_electricthruster.yml
+++ b/html/changelogs/wickedcybs_electricthruster.yml
@@ -1,0 +1,7 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a thruster subtype that only requires electricity to be supplied to it in-game. This is probably something that won't be something that's seen often."
+  - tweak: "The runtime shuttle had its gas thrusters replaced with ion thrusters."

--- a/maps/runtime/runtime-1.dmm
+++ b/maps/runtime/runtime-1.dmm
@@ -1442,7 +1442,7 @@
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "dH" = (
-/obj/machinery/atmospherics/unary/engine{
+/obj/machinery/ion_engine{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -1458,10 +1458,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
-"eQ" = (
-/obj/machinery/atmospherics/binary/pump,
-/turf/simulated/floor/shuttle,
-/area/shuttle/runtime)
 "fq" = (
 /obj/machinery/computer/shuttle_control/explore/runtime,
 /turf/simulated/floor/shuttle,
@@ -1523,11 +1519,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering)
-"lV" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/shuttle,
-/area/shuttle/runtime)
 "mn" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
@@ -1689,12 +1680,6 @@
 /obj/effect/landmark/entry_point/aft,
 /turf/simulated/wall/r_wall,
 /area/maintenance/maintcentral)
-"EN" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/runtime)
 "ES" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/shipsensors,
@@ -1720,12 +1705,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
-"Hn" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/runtime)
 "HB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -1766,12 +1745,6 @@
 /obj/machinery/computer/ship/helm,
 /turf/simulated/floor/shuttle,
 /area/shuttle/runtime)
-"JW" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
-	},
-/turf/simulated/floor/shuttle,
-/area/shuttle/runtime)
 "Kz" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
 	dir = 4
@@ -1806,7 +1779,7 @@
 /turf/simulated/wall/r_wall,
 /area/shuttle/runtime)
 "Qn" = (
-/obj/machinery/atmospherics/unary/engine{
+/obj/machinery/ion_engine{
 	dir = 1
 	},
 /obj/effect/landmark/entry_point/fore,
@@ -2170,9 +2143,9 @@ cK
 de
 qx
 Vm
-lV
-eQ
-Hn
+Vm
+Vm
+Vm
 Qn
 de
 cK
@@ -2239,7 +2212,7 @@ Qe
 Vm
 Jx
 wL
-EN
+Vm
 dH
 de
 cK
@@ -2306,7 +2279,7 @@ qx
 fq
 yE
 Tq
-JW
+Vm
 Qn
 de
 cK


### PR DESCRIPTION
Adds a type of ship thruster that only relies on electricity to work in game. This should be extremely rare to see around, only being available to extremely high tech factions and more than likely only being used during events and such rather than the average round due to how it affects balance. It will never be as fast as a properly fueled gas thruster but it can consistently thrust at 1gm/h and for that reason it should also only really be present on a shuttle and not any "main" ship.

The runtime map had its shuttle gas thrusters switched with ion thrusters to make for easier testing.

The code is from Bay and tweaked slightly to work here. It is not my own.