### PR TITLE
Raises maximum health and break threshold of hearts, nerfs the heart damage component of adrenaline

### DIFF
--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -7,8 +7,8 @@
 	robotic_name = "circulatory pump"
 	toxin_type = CE_CARDIOTOXIC
 
-	max_damage = 45
-	min_broken_damage = 25
+	max_damage = 60
+	min_broken_damage = 45
 	relative_size = 5
 	damage_reduction = 0.7
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -1490,7 +1490,7 @@
 		remove_self(5, holder)
 		if(M.resuscitate())
 			var/obj/item/organ/internal/heart = M.internal_organs_by_name[BP_HEART]
-			M.add_chemical_effect(CE_CARDIOTOXIC, heart.max_damage * 0.15)
+			M.add_chemical_effect(CE_CARDIOTOXIC, heart.max_damage * 0.05)
 
 //Secret Chems
 /decl/reagent/elixir

--- a/html/changelogs/sheeplets.yml
+++ b/html/changelogs/sheeplets.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - balance: "Buffed the maximum health of hearts to 60, and the break point to 45."
+  - balance: "Reduced the amount of heart damage that hands-free adrenaline revives do, to a third of the original value."

--- a/html/changelogs/sheeplets.yml
+++ b/html/changelogs/sheeplets.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Sheeplets
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Buffed the maximum health of hearts to 60, and the break point to 45."


### PR DESCRIPTION
Hopefully this stops people from getting tapped in the chest by a stray bullet and instantly dying. Affects all species.

- Maximum health up from 45 -> 60.
- Break threshold up from 25 -> 45.
- Hands-free adrenaline revives now do a third of the damage they used to, with the new numbers they do 6 damage, down from 18.