### PR TITLE
You Taste Uncooked Dough Fix

### DIFF
--- a/code/modules/cooking/recipes/recipe.dm
+++ b/code/modules/cooking/recipes/recipe.dm
@@ -35,6 +35,7 @@
 /decl/recipe
 	var/display_name
 	var/list/reagents // example: = list(/decl/reagent/drink/berryjuice = 5) // do not list same reagent twice
+	var/list/recipe_taste_override // example: = list("uncooked dough" = "crispy dough")
 	var/list/items    // example: = list(/obj/item/crowbar, /obj/item/welder) // place /foo/bar before /foo
 	var/list/fruit    // example: = list("fruit" = 3)
 	var/coating = null//Required coating on all items in the recipe. The default value of null explitly requires no coating
@@ -226,6 +227,21 @@
 		for (var/r in reagents)
 			//Doesnt matter whether or not there's enough, we assume that check is done before
 			container.reagents.trans_type_to(buffer, r, reagents[r])
+
+	// this is the generic list of reagent tastes to change, but the recipe-specific one override this
+	var/list/taste_replacers = list(
+		"uncooked dough" = "cooked dough"
+	)
+	for(var/reagent in buffer.reagent_data)
+		for(var/taste in buffer.reagent_data[reagent])
+			if(taste in recipe_taste_override)
+				buffer.reagent_data[reagent][recipe_taste_override[taste]] = buffer.reagent_data[reagent][taste]
+				buffer.reagent_data[reagent] -= taste
+				continue
+			if(taste in taste_replacers)
+				buffer.reagent_data[reagent][taste_replacers[taste]] = buffer.reagent_data[reagent][taste]
+				buffer.reagent_data[reagent] -= taste
+				continue
 
 	/*
 	Now we've removed all the ingredients that were used and we have the buffer containing the total of

--- a/code/modules/cooking/recipes/recipes_pastries.dm
+++ b/code/modules/cooking/recipes/recipes_pastries.dm
@@ -154,6 +154,7 @@
 		/obj/item/reagent_containers/food/snacks/sliceable/flatdough,
 		/obj/item/reagent_containers/food/snacks/meat
 	)
+	recipe_taste_override = list("uncooked dough" = "crispy dough")
 	result = /obj/item/reagent_containers/food/snacks/meatpie
 
 /decl/recipe/tofupie

--- a/html/changelogs/geeves-uncooked_dough.yml
+++ b/html/changelogs/geeves-uncooked_dough.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Dough-based pastries no longer have an uncooked dough taste, and meatpies specifically now have a crispy dough taste."


### PR DESCRIPTION
* Dough-based pastries no longer have an uncooked dough taste, and meatpies specifically now have a crispy dough taste.