### PR TITLE
Offship Pop Requirements

### DIFF
--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -126,6 +126,9 @@
 		VUEUI_SET_CHECK(data["spawners"][G.short_name]["name"], G.name, ., data)
 		if(cant_spawn)
 			VUEUI_SET_CHECK(data["spawners"][G.short_name]["desc"], "[G.desc] ([cant_spawn])", ., data)
+		else if(G.hor_crew_needed_to_spawn || G.hor_crew_needed_per_slot)
+			var/crew_needed = (G.count + 1) * G.hor_crew_needed_per_slot
+			VUEUI_SET_CHECK(data["spawners"][G.short_name]["desc"], "[G.desc] ([crew_needed > G.hor_crew_needed_to_spawn ? crew_needed : G.hor_crew_needed_to_spawn] Horizon Crew Members Required)", ., data)
 		else
 			VUEUI_SET_CHECK(data["spawners"][G.short_name]["desc"], G.desc, ., data)
 		VUEUI_SET_CHECK(data["spawners"][G.short_name]["cant_spawn"], cant_spawn, ., data)
@@ -146,9 +149,9 @@
 		var/datum/ghostspawner/S = spawners[spawner]
 		if(!S)
 			return
-		var/cant_spawn = S.cant_spawn(usr)
+		var/cant_spawn = S.cant_spawn(usr, TRUE)
 		if(cant_spawn)
-			to_chat(usr, "Unable to spawn: [cant_spawn]")
+			alert(usr, "Unable to spawn: [cant_spawn]", "Unable to Spawn")
 			return
 		if(isnewplayer(usr))
 			var/mob/abstract/new_player/N = usr

--- a/html/changelogs/geeves-ship_pop_requirement.yml
+++ b/html/changelogs/geeves-ship_pop_requirement.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "There now needs to be at least 10 crewmembers active on the Horizon before ghosts can spawn into other ship."
+  - rscadd: "Ghostspawner Ship roles require 3 Horizon crew per slot in addition to the 10 crewmember limit, so to fill 5 slots, there has to be 15 Horizon crew."

--- a/maps/away/ships/coc_ranger/coc_ship_ghostroles.dm
+++ b/maps/away/ships/coc_ranger/coc_ship_ghostroles.dm
@@ -17,6 +17,9 @@
 	special_role = "Coalition Ranger"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/ranger
 	name = "Coalition Ranger"

--- a/maps/away/ships/dominia/dominian_corvette_ghostroles.dm
+++ b/maps/away/ships/dominia/dominian_corvette_ghostroles.dm
@@ -18,6 +18,9 @@
 	special_role = "Imperial Fleet Voidsman"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/imperial_fleet_voidsman
 	name = "Imperial Fleet Voidsman"
@@ -50,6 +53,9 @@
 	assigned_role = "Imperial Fleet Officer"
 	special_role = "Imperial Fleet Officer"
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/imperial_fleet_voidsman/officer
 	name = "Imperial Fleet Officer"
@@ -71,6 +77,9 @@
 	assigned_role = "Imperial Fleet Armsman"
 	special_role = "Imperial Fleet Armsman"
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/imperial_fleet_voidsman/armsman
 	name = "Imperial Fleet Armsman"
@@ -90,6 +99,9 @@
 
 	assigned_role = "Imperial Fleet Priest"
 	special_role = "Imperial Fleet Priest"
+
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
 
 
 /datum/outfit/admin/imperial_fleet_voidsman/priest

--- a/maps/away/ships/einstein/ee_spy_ship_ghostroles.dm
+++ b/maps/away/ships/einstein/ee_spy_ship_ghostroles.dm
@@ -15,6 +15,9 @@
 	special_role = "Einstein Engines Crewman"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/ee_crewman
 	name = "Einstein Engines Crewman"
@@ -50,6 +53,9 @@
 	assigned_role = "Einstein Engines Research Officer"
 	special_role = "Einstein Engines Research Officer"
 	respawn_flag = null
+
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
 
 
 /datum/outfit/admin/ee_research_officer

--- a/maps/away/ships/elyra/elyra_strike_craft_ghostroles.dm
+++ b/maps/away/ships/elyra/elyra_strike_craft_ghostroles.dm
@@ -18,6 +18,9 @@
 	special_role = "Elyran Naval Infantryman"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/elyran_naval_infantry
 	name = "Elyran Naval Infantryman"

--- a/maps/away/ships/iac/iac_rescue_ship_ghostroles.dm
+++ b/maps/away/ships/iac/iac_rescue_ship_ghostroles.dm
@@ -17,6 +17,9 @@
 	special_role = "IAC Volunteer"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/iac_volunteer
 	name = "IAC Volunteer"

--- a/maps/away/ships/kataphracts/kataphract_ship_ghostroles.dm
+++ b/maps/away/ships/kataphracts/kataphract_ship_ghostroles.dm
@@ -22,6 +22,9 @@
 	extra_languages = list(LANGUAGE_UNATHI, LANGUAGE_AZAZIBA)
 	away_site = TRUE
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 /datum/ghostspawner/human/kataphract/klax
 	short_name = "kataphract_hop_klax"
 	name = "Kataphract-Hopeful Klaxan"
@@ -47,7 +50,7 @@
 	spawnpoints = list("kataphract_knight")
 
 	outfit = /datum/outfit/admin/kataphract/knight
-	
+
 
 	assigned_role = "Kataphract Knight Captain"
 	special_role = "Kataphract Knight Captain"
@@ -129,14 +132,14 @@
 
 	suit = /obj/item/clothing/accessory/poncho/red
 	back = /obj/item/storage/backpack/satchel/hegemony
-	
+
 
 /datum/outfit/admin/kataphract/knight/get_id_access()
 	return list(access_kataphract, access_kataphract_knight, access_external_airlocks)
 
 /datum/outfit/admin/kataphract/specialist
 	name = "Kataphract Specialist"
-	
+
 	back = /obj/item/storage/backpack/satchel/hegemony
 
 /datum/outfit/admin/kataphract/quartermaster/get_id_access()

--- a/maps/away/ships/orion/orion_express_ship_ghostroles.dm
+++ b/maps/away/ships/orion/orion_express_ship_ghostroles.dm
@@ -17,6 +17,9 @@
 	special_role = "Orion Express Courier"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/orion_express_courier
 	name = "Orion Express Courier"

--- a/maps/away/ships/pra/database_freighter/database_freighter_ghostroles.dm
+++ b/maps/away/ships/pra/database_freighter/database_freighter_ghostroles.dm
@@ -17,6 +17,9 @@
 	special_role = "Database Freighter Surveyor"
 	extra_languages = list(LANGUAGE_SIIK_MAAS)
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 /datum/outfit/admin/database_freighter_crew
 	name = "Database Freighter Surveyor"
 

--- a/maps/away/ships/pra/headmaster/headmaster_ghostroles.dm
+++ b/maps/away/ships/pra/headmaster/headmaster_ghostroles.dm
@@ -17,6 +17,9 @@
 	special_role = "Headmaster Kosmostrelki"
 	extra_languages = list(LANGUAGE_SIIK_MAAS)
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 /datum/outfit/admin/headmaster_kosmostrelki
 	name = "Kosmostrelki"
 

--- a/maps/away/ships/skrell_smuggler/tirakqi_freighter_ghostroles.dm
+++ b/maps/away/ships/skrell_smuggler/tirakqi_freighter_ghostroles.dm
@@ -17,6 +17,9 @@
 
 	uses_species_whitelist = FALSE
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 /datum/outfit/admin/tirakqi_crew
 	name = "Ti'Rakqi Qu'fup"
 
@@ -123,6 +126,9 @@
 
 	uses_species_whitelist = TRUE
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 /datum/outfit/admin/tirakqi_crew/captain
 	name = "Ti'Rakqi Qu'fup"
 
@@ -157,6 +163,9 @@
 
 	uses_species_whitelist = TRUE
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 /datum/outfit/admin/tirakqi_crew/medic
 	name = "Ti'Rakqi Medic"
 
@@ -183,6 +192,9 @@
 	respawn_flag = null
 
 	uses_species_whitelist = TRUE
+
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
 
 /datum/outfit/admin/tirakqi_crew/engineer
 	name = "Ti'Rakqi Engineer"

--- a/maps/away/ships/sol_merc/fsf_patrol_ship_ghostroles.dm
+++ b/maps/away/ships/sol_merc/fsf_patrol_ship_ghostroles.dm
@@ -16,6 +16,9 @@
 	special_role = "FSF Navy Crewman"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/fsf_navy_crewman
 	name = "FSF Navy Crewman"
@@ -53,6 +56,9 @@
 	assigned_role = "FSF Navy Officer"
 	special_role = "FSF Navy Officer"
 	respawn_flag = null
+
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
 
 
 /datum/outfit/admin/fsf_navy_officer

--- a/maps/away/ships/sol_pirate/sfa_patrol_ship_ghostroles.dm
+++ b/maps/away/ships/sol_pirate/sfa_patrol_ship_ghostroles.dm
@@ -16,6 +16,9 @@
 	special_role = "SFA Navy Crewman"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/sfa_navy_crewman
 	name = "SFA Navy Crewman"
@@ -54,6 +57,9 @@
 	special_role = "SFA Navy Officer"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/sfa_navy_officer
 	name = "SFA Navy Officer"
@@ -90,6 +96,9 @@
 	assigned_role = "SFA Marine"
 	special_role = "SFA Marine"
 	respawn_flag = null
+
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
 
 
 /datum/outfit/admin/sfa_marine

--- a/maps/away/ships/sol_ssmd/ssmd_ship_ghostroles.dm
+++ b/maps/away/ships/sol_ssmd/ssmd_ship_ghostroles.dm
@@ -16,6 +16,9 @@
 	special_role = "SSMD Navy Crewman"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/ssmd_navy_crewman
 	name = "SSMD Navy Crewman"
@@ -53,6 +56,9 @@
 	assigned_role = "SSMD Navy Officer"
 	special_role = "SSMD Navy Officer"
 	respawn_flag = null
+
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
 
 
 /datum/outfit/admin/ssmd_navy_officer
@@ -103,6 +109,9 @@
 	special_role = "SSMD Marine Exosuit Pilot"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/ssmd_marine_pilot
 	name = "SSMD Marine Exosuit Pilot"
@@ -140,6 +149,9 @@
 	assigned_role = "SSMD Military Synthetic"
 	special_role = "SSMD Military Synthetic"
 	respawn_flag = null
+
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
 
 
 /datum/outfit/admin/ssmd_ipc

--- a/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler_ghostroles.dm
+++ b/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler_ghostroles.dm
@@ -20,6 +20,9 @@
 	special_role = "Tajaran Smuggler"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 /datum/outfit/admin/tajaran_smuggler
 	name = "Tajaran Smuggler"
 

--- a/maps/away/ships/tcfl_patrol/tcfl_peacekeeper_ship_ghostroles.dm
+++ b/maps/away/ships/tcfl_patrol/tcfl_peacekeeper_ship_ghostroles.dm
@@ -18,6 +18,9 @@
 	special_role = "TCFL Peacekeeper"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/tcfl_peacekeeper
 	name = "TCFL Peacekeeper"

--- a/maps/away/ships/tramp_freighter/tramp_freighter_ghostroles.dm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter_ghostroles.dm
@@ -15,6 +15,9 @@
 	special_role = "Freighter Crewman"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/freighter_crew
 	name = "Freighter Crewman"

--- a/maps/away/ships/wildlands_militia/militia_ship_ghostroles.dm
+++ b/maps/away/ships/wildlands_militia/militia_ship_ghostroles.dm
@@ -15,6 +15,9 @@
 	special_role = "Militiaman"
 	respawn_flag = null
 
+	hor_crew_needed_to_spawn = 10
+	hor_crew_needed_per_slot = 3
+
 
 /datum/outfit/admin/militia_crew
 	name = "Militiaman"


### PR DESCRIPTION
* There now needs to be at least 10 crewmembers active on the Horizon before ghosts can spawn into other ship.
* Ghostspawner Ship roles require 3 Horizon crew per slot in addition to the 10 crewmember limit, so to fill 5 slots, there has to be 15 Horizon crew.