### PR TITLE
Aiming Now Allows Movement By Default.

### DIFF
--- a/code/_onclick/hud/gun_mode.dm
+++ b/code/_onclick/hud/gun_mode.dm
@@ -11,7 +11,7 @@
 
 /obj/screen/gun/move
 	name = "Allow Movement"
-	icon_state = "no_walk0"
+	icon_state = "no_walk1"
 	screen_loc = ui_gun2
 
 /obj/screen/gun/move/Click(location, control, params)
@@ -25,7 +25,7 @@
 
 /obj/screen/gun/item
 	name = "Allow Item Use"
-	icon_state = "no_item0"
+	icon_state = "no_item1"
 	screen_loc = ui_gun1
 
 /obj/screen/gun/item/Click(location, control, params)
@@ -53,7 +53,7 @@
 
 /obj/screen/gun/radio
 	name = "Allow Radio Use"
-	icon_state = "no_radio0"
+	icon_state = "no_radio1"
 	screen_loc = ui_gun4
 
 /obj/screen/gun/radio/Click(location, control, params)

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -17,7 +17,7 @@
 	var/locked =    0          // Have we locked on?
 	var/lock_time = 0          // When -will- we lock on?
 	var/active =    0          // Is our owner intending to take hostages?
-	var/target_permissions = 0 // Permission bitflags.
+	var/target_permissions = TARGET_CAN_MOVE | TARGET_CAN_CLICK | TARGET_CAN_RADIO // Permission bitflags.
 	var/aimcooldown			   // How long untill we can re-aim?
 /obj/aiming_overlay/New(var/newowner)
 	..()

--- a/html/changelogs/purplepineapple-aimfix.yml
+++ b/html/changelogs/purplepineapple-aimfix.yml
@@ -1,0 +1,6 @@
+author: ChangeMe
+
+delete-after: True
+
+changes:
+  - tweak: "Aim mode now does not restrict movement, radio, or item use by default. You can set it yourself instead of accidentally shooting people because you forgot."


### PR DESCRIPTION
A simple change to make the default option for aiming to be "Allowed" for movement, radios, and item use. This way, antagonists may have better luck not accidentally shooting their targets and security might not accidentally shoot the people they're halting in maintenance.

You can still of course toggle the setting on, if you require.