### PR TITLE
Movable Overmap Events

### DIFF
--- a/code/modules/overmap/events/event.dm
+++ b/code/modules/overmap/events/event.dm
@@ -176,10 +176,61 @@
 	var/list/victims //basically cached events on which Z level
 	var/can_be_destroyed = TRUE //Can this event be destroyed by ship guns?
 
+	// Vars that determine movability, current moving direction, and moving speed //
+	/// Whether this event can move or not
+	var/movable_event = FALSE
+	/// The percentage chance that this event will turn itself into a mobile version
+	var/movable_event_chance = 0
+	/// In which direction this event is currently planning on moving, will select a random dir if null
+	var/moving_dir = null
+	/// How many times the event has to process before moving (2 seconds per)
+	var/movable_speed = 60
+	/// Ticks up each process until move speed is matched, at which point the event will move
+	var/move_counter = 0
+	/// Percentage chance that the event changes direction
+	var/dir_change_chance = 25
+	/// How long to delay the next move counter if there's a ship in our loc, this gives bad events some time to happen
+	var/ship_delay_time = 2
+	/// Ticks up each process until move speed is matched, at which point the event will move
+	var/ship_delay_counter = 0
+
 /obj/effect/overmap/event/Initialize()
 	. = ..()
 	icon_state = pick(event_icon_states)
 	overmap_event_handler.update_hazards(loc)
+	if(movable_event)
+		start_moving()
+	else if(prob(movable_event_chance))
+		make_movable()
+
+/obj/effect/overmap/event/proc/make_movable()
+	movable_event = TRUE
+	start_moving()
+
+/obj/effect/overmap/event/proc/start_moving()
+	if(!moving_dir) moving_dir = pick(alldirs)
+	START_PROCESSING(SSprocessing, src)
+
+/obj/effect/overmap/event/process()
+	if(locate(/obj/effect/overmap/visitable/ship) in loc)
+		ship_delay_counter++
+		if(ship_delay_counter < ship_delay_time)
+			return
+	ship_delay_counter = 0
+	move_counter++
+	if(move_counter >= movable_speed)
+		handle_move()
+		move_counter = 0
+
+/obj/effect/overmap/event/proc/handle_move()
+	Move(get_step(src, moving_dir))
+	if(prob(dir_change_chance))
+		moving_dir = turn(moving_dir, pick(45, -45))
+
+/obj/effect/overmap/event/Bump(var/atom/A)
+	if(istype(A,/turf/unsimulated/map/edge))
+		handle_wraparound()
+	..()
 
 /obj/effect/overmap/event/Move()
 	var/turf/old_loc = loc
@@ -196,6 +247,8 @@
 		overmap_event_handler.update_hazards(loc)
 
 /obj/effect/overmap/event/Destroy()//takes a look at this one as well, make sure everything is A-OK
+	if(movable_event)
+		STOP_PROCESSING(SSprocessing, src)
 	var/turf/T = loc
 	. = ..()
 	overmap_event_handler.update_hazards(T)
@@ -234,6 +287,7 @@
 	opacity = 0
 	difficulty = EVENT_LEVEL_MODERATE
 	event_icon_states = list("carp")
+	movable_event_chance = 5
 
 /obj/effect/overmap/event/carp/major
 	name = "carp school"

--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -17,11 +17,32 @@
 /obj/effect/overmap/proc/get_scan_data(mob/user)
 	return desc
 
+/obj/effect/overmap/proc/handle_wraparound()
+	var/nx = x
+	var/ny = y
+	var/low_edge = 1
+	var/high_edge = current_map.overmap_size - 1
+
+	if((dir & WEST) && x == low_edge)
+		nx = high_edge
+	else if((dir & EAST) && x == high_edge)
+		nx = low_edge
+	if((dir & SOUTH)  && y == low_edge)
+		ny = high_edge
+	else if((dir & NORTH) && y == high_edge)
+		ny = low_edge
+	if((x == nx) && (y == ny))
+		return //we're not flying off anywhere
+
+	var/turf/T = locate(nx,ny,z)
+	if(T)
+		forceMove(T)
+
 /obj/effect/overmap/Initialize()
 	. = ..()
 	if(!current_map.use_overmap)
 		return INITIALIZE_HINT_QDEL
-	
+
 	if(known)
 		layer = EFFECTS_ABOVE_LIGHTING_LAYER
 		for(var/obj/machinery/computer/ship/helm/H in SSmachinery.machinery)

--- a/code/modules/overmap/ship_weaponry/projectiles/_overmap_projectiles.dm
+++ b/code/modules/overmap/ship_weaponry/projectiles/_overmap_projectiles.dm
@@ -11,7 +11,7 @@
 	var/range = OVERMAP_PROJECTILE_RANGE_MEDIUM
 	var/current_range_counter = 0
 	var/speed = 0 //A projectile with 0 speed does not move. Note that this is the 'lag' variable on walk_towards! Lower speed is better.
-	
+
 	var/moving = FALSE //Is the projectile actively moving on the overmap?
 	var/entering = FALSE //Are we entering an entry point?
 
@@ -27,7 +27,7 @@
 		handle_wraparound()
 	..()
 
-/obj/effect/overmap/projectile/proc/handle_wraparound()
+/obj/effect/overmap/projectile/handle_wraparound()
 	var/nx = x
 	var/ny = y
 	var/low_edge = 1

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -209,27 +209,6 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 		. = 0
 	. = max(CEILING(., 1),0)
 
-/obj/effect/overmap/visitable/ship/proc/handle_wraparound()
-	var/nx = x
-	var/ny = y
-	var/low_edge = 1
-	var/high_edge = current_map.overmap_size - 1
-
-	if((dir & WEST) && x == low_edge)
-		nx = high_edge
-	else if((dir & EAST) && x == high_edge)
-		nx = low_edge
-	if((dir & SOUTH)  && y == low_edge)
-		ny = high_edge
-	else if((dir & NORTH) && y == high_edge)
-		ny = low_edge
-	if((x == nx) && (y == ny))
-		return //we're not flying off anywhere
-
-	var/turf/T = locate(nx,ny,z)
-	if(T)
-		forceMove(T)
-
 /obj/effect/overmap/visitable/ship/proc/halt()
 	adjust_speed(-speed[1], -speed[2])
 	halted = 1

--- a/html/changelogs/geeves-movable_overmap_events.yml
+++ b/html/changelogs/geeves-movable_overmap_events.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Carp shoals and schools now a 5 percent to be a movable event, which means it'll move across the overmap."


### PR DESCRIPTION
* Carp shoals and schools now a 5 percent to be a movable event, which means it'll move across the overmap.