### PR TITLE
Adds tricordrazine to sleeper injection options.

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -24,7 +24,8 @@
 		/singleton/reagent/soporific,
 		/singleton/reagent/perconol,
 		/singleton/reagent/dylovene,
-		/singleton/reagent/dexalin
+		/singleton/reagent/dexalin,
+		/singleton/reagent/tricordrazine
 		)
 	var/obj/item/reagent_containers/glass/beaker = null
 	var/filtering = FALSE

--- a/html/changelogs/anconfuzedrock-tricordnapper.yml
+++ b/html/changelogs/anconfuzedrock-tricordnapper.yml
@@ -1,0 +1,7 @@
+
+author: anconfuzedrock
+
+delete-after: True
+
+changes:
+  - rscadd: "Sleepers can now inject people with tricordrazine."


### PR DESCRIPTION
A recent PR changed the recipe for tricordrazine by adding water to it, with the stated intent of avoiding accidentally mixing tricordrazine. Well, now it's harder to intentionally mix it, most egregiously meaning you can't insta-mix it in sleepers. this lets sleepers inject tricordrazine directly to fix this.