### PR TITLE
Runtime Killer PR 3000

### DIFF
--- a/code/_helpers/atmospherics.dm
+++ b/code/_helpers/atmospherics.dm
@@ -1,14 +1,15 @@
-/obj/proc/analyze_gases(var/obj/A, var/mob/user)
+/obj/proc/analyze_gases(var/atom/A, var/mob/user)
 	if(src != A)
 		user.visible_message("<span class='notice'>\The [user] has used \an [src] on \the [A]</span>")
 
-	A.add_fingerprint(user)
-	var/list/result = A.atmosanalyze(user)
-	if(result && result.len)
-		to_chat(user, "<span class='notice'>Results of the analysis[src == A ? "" : " of [A]"]</span>")
-		for(var/line in result)
-			to_chat(user, "<span class='notice'>[line]</span>")
-		return 1
+	if(istype(A))
+		A.add_fingerprint(user)
+		var/list/result = A.atmosanalyze(user)
+		if(result && result.len)
+			to_chat(user, "<span class='notice'>Results of the analysis[src == A ? "" : " of [A]"]</span>")
+			for(var/line in result)
+				to_chat(user, "<span class='notice'>[line]</span>")
+			return 1
 
 	to_chat(user, "<span class='warning'>Your [src] flashes a red light as it fails to analyze \the [A].</span>")
 	return 0
@@ -29,7 +30,7 @@
 
 	return results
 
-/obj/proc/atmosanalyze(var/mob/user)
+/atom/proc/atmosanalyze(var/mob/user)
 	return
 
 /obj/item/tank/atmosanalyze(var/mob/user)

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -880,7 +880,8 @@
 /proc/fade_location_blurb(client/C, obj/T)
 	animate(T, alpha = 0, time = 5)
 	sleep(5)
-	C.screen -= T
+	if(C)
+		C.screen -= T
 	qdel(T)
 
 /datum/controller/subsystem/jobs/proc/UniformReturn(mob/living/carbon/human/H, datum/preferences/prefs, datum/job/job)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -392,6 +392,9 @@
 			for (var/atom/movable/location as anything in nested_locs)
 				LAZYREMOVEASSOC(location.important_recursive_contents, channel, gone.important_recursive_contents[channel])
 
+	if(LAZYLEN(gone.stored_chat_text))
+		return_floating_text(gone)
+
 /atom/movable/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 
@@ -400,6 +403,9 @@
 		for (var/channel in arrived.important_recursive_contents)
 			for (var/atom/movable/location as anything in nested_locs)
 				LAZYORASSOCLIST(location.important_recursive_contents, channel, arrived.important_recursive_contents[channel])
+
+	if (LAZYLEN(arrived.stored_chat_text))
+		give_floating_text(arrived)
 
 //allows this movable to hear and adds itself to the important_recursive_contents list of itself and every movable loc its in
 /atom/movable/proc/become_hearing_sensitive(trait_source = TRAIT_GENERIC)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -146,7 +146,7 @@
 		return SPACE
 	else
 		var/area/A = get_area(src)
-		return A.sound_env
+		return A ? A.sound_env : STANDARD_STATION
 
 /mob/living/playsound_get_environment(pressure_factor = 1.0)
 	if (hallucination)

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -103,7 +103,7 @@ var/savefile/iconCache = new("data/tmp/iconCache.sav") //Cache of icons for the 
 
 //Called on chat output done-loading by JS.
 /datum/chatOutput/proc/doneLoading()
-	if(loaded)
+	if(loaded || !owner)
 		return
 
 	loaded = TRUE

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -172,9 +172,9 @@
 			last_biolum = null
 
 /obj/effect/plant/proc/refresh_icon()
-	if(!growth_threshold)
-		growth_threshold = max_health/seed.growth_stages
-	var/growth = min(max_growth,round(health/growth_threshold))
+	var/growth = 0
+	if(growth_threshold)
+		growth = min(max_growth,round(health/growth_threshold))
 	var/at_fringe = get_dist(src,parent)
 	if(spread_distance > 5)
 		if(at_fringe >= (spread_distance-3))

--- a/code/modules/mob/floating_messages.dm
+++ b/code/modules/mob/floating_messages.dm
@@ -72,32 +72,25 @@ var/list/floating_chat_colors = list()
 		animate(old, 2, pixel_y = old.pixel_y + 8)
 	LAZYADD(holder.stored_chat_text, I)
 
-	if(attached_holder != holder)
-		attached_holder.RegisterSignal(holder, COMSIG_MOVABLE_MOVED, /atom/movable/proc/give_floating_text)
-		addtimer(CALLBACK(attached_holder, /atom/movable/proc/drop_floating_signal, holder), duration + 2)
-
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/remove_floating_text, holder, I), duration)
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/remove_images_from_clients, I, show_to), duration + 2)
 
 	return I
 
+/// Gives floating text to src upon holder entering
 /atom/movable/proc/give_floating_text(atom/movable/holder)
 	if(!holder)
 		return
 	for(var/image/I in holder.stored_chat_text)
-		if(I.loc == src)
-			I.loc = holder
+		I.loc = src
 
-/atom/movable/proc/drop_floating_signal(atom/movable/holder)
+/// Returns floating text to holder upon leaving src
+/atom/movable/proc/return_floating_text(atom/movable/holder)
 	if(!holder)
 		return
 	for(var/image/I in holder.stored_chat_text)
-		if(I.loc == src)
-			return
-	UnregisterSignal(holder, COMSIG_MOVABLE_MOVED)
+		I.loc = holder
 
 /proc/remove_floating_text(atom/movable/holder, image/I)
 	animate(I, 2, pixel_y = I.pixel_y + 10, alpha = 0)
 	LAZYREMOVE(holder.stored_chat_text, I)
-	if(!length(holder.stored_chat_text))
-		holder.UnregisterSignal(holder, COMSIG_MOVABLE_MOVED)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -695,7 +695,7 @@
 	M.adjustHydrationLoss(2*removed)
 
 /singleton/reagent/sodiumchloride/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	overdose(M, alien, holder)
+	overdose(M, alien, removed, holder)
 
 /singleton/reagent/sodiumchloride/overdose(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	M.intoxication -= min(M.intoxication,removed*20)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -320,7 +320,7 @@
 			M.losebreath++
 
 	if(REAGENT_VOLUME(M.reagents, /singleton/reagent/oxycomorphine)) //Straight to overdose.
-		overdose(M, alien, holder)
+		overdose(M, alien, removed, holder)
 
 /singleton/reagent/mortaphenyl/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)
 	..()

--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -151,6 +151,9 @@
 
 		average_field_strength = 0 //recalculate the average field strength
 		for(var/obj/effect/energy_field/E as anything in field)
+			if(!E)
+				field -= E
+				continue
 			var/amount_to_strengthen = renwick_increase_per_field - renwick_upkeep_per_field
 			if(E.ticks_recovering > 0 && amount_to_strengthen > 0)
 				E.Strengthen( min(amount_to_strengthen / 10, 0.1) )

--- a/html/changelogs/johnwildkins-runtimekill3000.yml
+++ b/html/changelogs/johnwildkins-runtimekill3000.yml
@@ -1,0 +1,8 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - tweak: "Floating chat messages now follow you in -and- out of the closet! (And all other 'enterable' objects.)."
+  - bugfix: "Sodium chloride now overdoses properly."
+  - backend: "Cleaned up a whole mess of runtime errors related to bad clients, null objects, etc."


### PR DESCRIPTION
player-facing: floating chat messages now follow you in and out of the closet
sodium chloride now overdoses properly

backend: killed off a bunch of runtimes related to clients (people disconnecting before deferred stuff like chat loading finished) and things like the shield generator constantly checking null fields every tick