### PR TITLE
Adds a Button Inside the Armoury That Controls the Blast Doors

### DIFF
--- a/html/changelogs/wickedcybs_armoury.yml
+++ b/html/changelogs/wickedcybs_armoury.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - maptweak: "Added a button inside the armoury that controls the blast doors. The warden and the HoS can use this. It replaces the bottom wall charger."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -24293,10 +24293,6 @@
 	pixel_x = 4;
 	pixel_y = 34
 	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 4;
-	pixel_y = 23
-	},
 /obj/machinery/camera/network/security{
 	c_tag = "Security - Armoury";
 	network = list("Security","Armory")
@@ -24306,6 +24302,12 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "armory";
+	name = "Armory Blast Doors";
+	pixel_y = 26;
+	req_access = list(3)
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/security/armory)


### PR DESCRIPTION
I have been asking myself for a while what the point is really of having the only means to open the armoury blast doors be from within the HoS's office. Suppose it was halfway fine on the station map, but the HoS's office is a world away now and wardens simply just let officers through the airlock and in from the side in a situation where everyone needs gear.

The button replaces the bottom wall charger inside the armoury and the warden can use it.