### PR TITLE
Fixes a Loadout Entry Description

### DIFF
--- a/code/controllers/subsystems/sunlight.dm
+++ b/code/controllers/subsystems/sunlight.dm
@@ -55,7 +55,7 @@
 
 /atom/movable/sunobj
 	name = "sunlight emitter"
-	desc = "Weren't you told to never look directly at the sun? (but seriously, you shouldn't see this)"
+	desc = DESC_PARENT
 	light_novis = TRUE
 	light_range = 16
 	simulated = FALSE

--- a/code/game/machinery/abstract/intercom_listener.dm
+++ b/code/game/machinery/abstract/intercom_listener.dm
@@ -1,6 +1,6 @@
 /obj/machinery/abstract/intercom_listener
 	name = "intercom power interface"
-	desc = "You shouldn't see this."
+	desc = DESC_PARENT
 	power_channel = EQUIP
 
 	var/obj/item/device/radio/intercom/master

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -10,7 +10,7 @@
  */
 /obj/item/surgery
 	name = "surgery tool parent item"
-	desc = "This is a parent item. If you have this, please submit an issue report."
+	desc = DESC_PARENT
 	icon = 'icons/obj/surgery.dmi'
 	w_class = ITEMSIZE_SMALL
 	drop_sound = 'sound/items/drop/weldingtool.ogg'

--- a/code/modules/background/origins/_origins.dm
+++ b/code/modules/background/origins/_origins.dm
@@ -1,6 +1,6 @@
 /singleton/origin_item
 	var/name = "generic origin item"
-	var/desc = "You shouldn't be seeing this."
+	var/desc = DESC_PARENT
 	var/important_information //Big red text. Should only be used if not following it would incur a bwoink.
 	var/list/origin_traits = list()
 	/// Format for the following list: "Characters from this origin: [list entry], [list entry]."
@@ -9,12 +9,12 @@
 
 /singleton/origin_item/culture
 	name = "generic culture"
-	desc = "You shouldn't be seeing this."
+	desc = DESC_PARENT
 	var/list/singleton/origin_item/origin/possible_origins = list()
 
 /singleton/origin_item/origin
 	name = "generic origin"
-	desc = "You shouldn't be seeing this."
+	desc = DESC_PARENT
 	var/list/datum/accent/possible_accents = list()
 	var/list/datum/citizenship/possible_citizenships = list()
 	var/list/datum/religion/possible_religions = list()

--- a/code/modules/background/origins/_origins.dm
+++ b/code/modules/background/origins/_origins.dm
@@ -9,12 +9,10 @@
 
 /singleton/origin_item/culture
 	name = "generic culture"
-	desc = DESC_PARENT
 	var/list/singleton/origin_item/origin/possible_origins = list()
 
 /singleton/origin_item/origin
 	name = "generic origin"
-	desc = DESC_PARENT
 	var/list/datum/accent/possible_accents = list()
 	var/list/datum/citizenship/possible_citizenships = list()
 	var/list/datum/religion/possible_religions = list()

--- a/code/modules/client/preference_setup/loadout/loadout_accessories.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_accessories.dm
@@ -94,6 +94,7 @@
 
 /datum/gear/accessory/neck_accessories_colourable
 	display_name = "neck accessories selection (colourable)"
+	description = "A selection of various neck accessories, such as ribbons and bows."
 	path = /obj/item/clothing/accessory/tie/ribbon
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
 

--- a/code/modules/cooking/machinery/cooking_machines/_appliance.dm
+++ b/code/modules/cooking/machinery/cooking_machines/_appliance.dm
@@ -7,7 +7,7 @@
 // Root type for cooking machines. See following files for specific implementations.
 /obj/machinery/appliance
 	name = "cooker"
-	desc = "You shouldn't be seeing this!"
+	desc = DESC_PARENT
 	desc_info = "Control-click this to change its temperature."
 	icon = 'icons/obj/cooking_machines.dmi'
 	var/appliancetype = 0

--- a/code/modules/heavy_vehicle/equipment/combat.dm
+++ b/code/modules/heavy_vehicle/equipment/combat.dm
@@ -2,7 +2,7 @@
 
 /obj/item/mecha_equipment/mounted_system/combat
 	name = "combat thing"
-	desc = "You shouldn't be seeing this."
+	desc = DESC_PARENT
 	icon_state = "mecha_taser"
 	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND, HARDPOINT_LEFT_SHOULDER, HARDPOINT_RIGHT_SHOULDER)
 	restricted_software = list(MECH_SOFTWARE_WEAPONS)

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -3,7 +3,7 @@ var/list/holder_mob_icon_cache = list()
 //Helper object for picking dionaea (and other creatures) up.
 /obj/item/holder
 	name = "holder"
-	desc = "You shouldn't ever see this."
+	desc = DESC_PARENT
 	icon = 'icons/mob/npc/held_mobs.dmi'
 	randpixel = 0
 	center_of_mass = null

--- a/code/modules/modular_computers/computers/modular_computer/variables.dm
+++ b/code/modules/modular_computers/computers/modular_computer/variables.dm
@@ -2,7 +2,7 @@
 
 /obj/item/modular_computer
 	name = "Modular Computer"
-	desc = "A modular computer. You shouldn't see this."
+	desc = DESC_PARENT
 
 	var/lexical_name = "computer"
 	var/enabled = FALSE										// Whether the computer is turned on.

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -77,7 +77,7 @@
 // Holder object used for dimming openspaces & copying lighting of below turf.
 /atom/movable/openspace/multiplier
 	name = "openspace multiplier"
-	desc = "You shouldn't see this."
+	desc = DESC_PARENT
 	icon = 'icons/effects/lighting_overlay.dmi'
 	icon_state = "dark"
 	plane = OPENTURF_MAX_PLANE

--- a/code/modules/overmap/ship_weaponry/_ship_gun.dm
+++ b/code/modules/overmap/ship_weaponry/_ship_gun.dm
@@ -1,6 +1,6 @@
 /obj/machinery/ship_weapon
 	name = "ship weapon"
-	desc = "You shouldn't be seeing this."
+	desc = DESC_PARENT
 	icon = 'icons/obj/machinery/ship_guns/longbow.dmi'
 	idle_power_usage = 1500
 	active_power_usage = 50000

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/projectile/shotgun
 	name = "strange shotgun"
-	desc = "A strange shotgun that doesn't seem to belong anywhere. You feel like you shouldn't be able to see this and should... submit an issue?"
+	desc = DESC_PARENT
 	var/can_sawoff = FALSE
 	var/sawnoff_workmsg
 	var/sawing_in_progress = FALSE

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -117,7 +117,7 @@
 
 /singleton/reagent/alcohol //Parent class for all alcoholic reagents, though this one shouldn't be used anywhere.
 	name = null	// This null name should prevent alcohol from being added to global lists.
-	description = "An abstract type you shouldn't be able to see."
+	description = DESC_PARENT
 	reagent_state = LIQUID
 	color = "#404030"
 	ingest_met = REM * 5

--- a/code/modules/supermatter/setup_supermatter.dm
+++ b/code/modules/supermatter/setup_supermatter.dm
@@ -182,7 +182,7 @@
 
 /obj/effect/landmark/engine_setup
 	name = "Engine Setup Marker"
-	desc = "You shouldn't see this."
+	desc = DESC_PARENT
 	invisibility = 101
 	anchored = 1
 	density = 0

--- a/code/modules/xgm/xgm_gas_data.dm
+++ b/code/modules/xgm/xgm_gas_data.dm
@@ -57,7 +57,7 @@
 
 /obj/effect/gas_overlay
 	name = "gas"
-	desc = "You shouldn't be clicking this."
+	desc = DESC_PARENT
 	icon = 'icons/effects/tile_effects.dmi'
 	icon_state = "generic"
 	layer = LIGHTING_LAYER - 1

--- a/html/changelogs/neck_acc_fix.yml
+++ b/html/changelogs/neck_acc_fix.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Adds missing description for the \"neck accessories selection (colourable)\" entry in the loadout."


### PR DESCRIPTION
this PR adds the missing description for the "neck accessories selection (colourable)" entry in the loadout. also updates some other descriptions to use the DESC_PARENT macro.