### PR TITLE
Lowers Physician slots to 2 and Medical Intern to 2.

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -67,8 +67,8 @@
 	departments = SIMPLEDEPT(DEPARTMENT_MEDICAL)
 	department_flag = MEDSCI
 	faction = "Station"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "the chief medical officer"
 	selection_color = "#15903a"
 	economic_modifier = 7
@@ -320,8 +320,8 @@
 	department_flag = MEDSCI
 	faction = "Station"
 	alt_titles = list("First Responder Intern", "Surgeon Intern")
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 1
+	spawn_positions = 1
 	supervisors = "the Chief Medical Officer"
 	selection_color = "#15903a"
 	access = list(access_medical, access_medical_equip)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -320,8 +320,8 @@
 	department_flag = MEDSCI
 	faction = "Station"
 	alt_titles = list("First Responder Intern", "Surgeon Intern")
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "the Chief Medical Officer"
 	selection_color = "#15903a"
 	access = list(access_medical, access_medical_equip)

--- a/html/changelogs/mattatlas-toomanycooks.yml
+++ b/html/changelogs/mattatlas-toomanycooks.yml
@@ -39,4 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - tweak: "Lowered Physician slots to 2."
-  - tweak: "Lowered Medical Intern slots to 1."
+  - tweak: "Lowered Medical Intern slots to 2."

--- a/html/changelogs/mattatlas-toomanycooks.yml
+++ b/html/changelogs/mattatlas-toomanycooks.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Lowered Physician slots to 2."
+  - tweak: "Lowered Medical Intern slots to 1."


### PR DESCRIPTION
There are way too many cooks in the kitchen in medical, which leads to stupid shit like patient stealing. Also, four physicians is a frankly insane number.

Also lowers medical intern slots to 2, because as it is medical interns act like younger doctors. And you can also focus on actually teaching them, since there aren't 3 of the fuckers.