### PR TITLE
Single Dispenser Rows Begone

### DIFF
--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -144,7 +144,7 @@
 /obj/machinery/chemical_dispenser/ui_interact(mob/user)
 	var/datum/vueui/ui = SSvueui.get_open_ui(user, src)
 	if(!ui)
-		ui = new(user, src, "machinery-chemdisp", 390, 680, ui_title, state = interactive_state)
+		ui = new(user, src, "machinery-chemdisp", 400, 680, ui_title, state = interactive_state)
 	ui.open()
 
 /obj/machinery/chemical_dispenser/Topic(href, href_list)

--- a/html/changelogs/ramke_single-rows-begone.yml
+++ b/html/changelogs/ramke_single-rows-begone.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ramke
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Dispenser (coffee, chem, alcohol, etc.) UIs no longer open with a single row of reagents."


### PR DESCRIPTION
At some point the vueUI chem dispenser windows changed in width to only show one row because it was a few pixels off from being able to display two like before, forcing you to manually resize it every time.

This fixes it.