### PR TITLE
Fixes ships being in the away site spawn pool

### DIFF
--- a/html/changelogs/shipcost.yml
+++ b/html/changelogs/shipcost.yml
@@ -1,0 +1,6 @@
+author: listerla
+
+delete-after: True
+
+changes:
+  - bugfix: "Dionae ships, the SSMD ship, and the IAC ship now are in the ship pool rather than away site pool."

--- a/maps/away/ships/dionae/diona_rokz_ship/diona_rokz_ship.dm
+++ b/maps/away/ships/dionae/diona_rokz_ship/diona_rokz_ship.dm
@@ -4,7 +4,7 @@
 	suffixes = list("ships/dionae/diona_rokz_ship/diona_rokz_ship.dmm")
 	sectors = list(SECTOR_BADLANDS, SECTOR_GAKAL, SECTOR_UUEOAESA)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "diona_rokz"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/diona_rokz_ship_shuttle)
 

--- a/maps/away/ships/dionae/diona_serz_ship/diona_serz_ship.dm
+++ b/maps/away/ships/dionae/diona_serz_ship/diona_serz_ship.dm
@@ -4,7 +4,7 @@
 	suffixes = list("ships/dionae/diona_serz_ship/diona_serz_ship.dmm")
 	sectors = list(SECTOR_BADLANDS, SECTOR_GAKAL, SECTOR_UUEOAESA)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "diona_serz"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/diona_serz_ship_shuttle)
 

--- a/maps/away/ships/iac/iac_rescue_ship.dm
+++ b/maps/away/ships/iac/iac_rescue_ship.dm
@@ -4,7 +4,7 @@
 	suffixes = list("ships/iac/iac_rescue_ship.dmm")
 	sectors = list(SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "iac_rescue_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/iac_shuttle)
 
@@ -17,43 +17,43 @@
 /area/ship/iac_rescue_ship
 	name = "IAC Rescue Ship"
 	requires_power = TRUE
-	
+
 /area/ship/iac_rescue_ship/bridge
 	name = "IAC Rescue Ship Bridge"
-	
+
 /area/ship/iac_rescue_ship/hangar
 	name = "IAC Rescue Ship Hangar"
-	
+
 /area/ship/iac_rescue_ship/starboardengine
 	name = "IAC Rescue Ship Starboard Engine"
-	
+
 /area/ship/iac_rescue_ship/portengine
 	name = "IAC Rescue Ship Port Engine"
-	
+
 /area/ship/iac_rescue_ship/bathroom
 	name = "IAC Rescue Ship Bathroom"
-	
+
 /area/ship/iac_rescue_ship/mainstorage
 	name = "IAC Rescue Ship Main Storage"
-	
+
 /area/ship/iac_rescue_ship/medical
 	name = "IAC Rescue Ship Medical"
-	
+
 /area/ship/iac_rescue_ship/surgery
 	name = "IAC Rescue Ship Surgery Room"
 
 /area/ship/iac_rescue_ship/pharmacy
 	name = "IAC Rescue Ship Pharmacy"
-	
+
 /area/ship/iac_rescue_ship/dorms
 	name = "IAC Rescue Ship Dorms"
-	
+
 /area/ship/iac_rescue_ship/coord
 	name = "IAC Rescue Ship Coordinator's Office"
-	
+
 /area/ship/iac_rescue_ship/hallway
 	name = "IAC Rescue Ship Hallway"
-	
+
 /area/shuttle/iac_shuttle
 	name = "IAC Ambulance Shuttle"
 	icon_state = "shuttle2"
@@ -98,19 +98,19 @@
 	landmark_tag = "nav_iac_rescue_ship_2"
 	base_turf = /turf/space/dynamic
 	base_area = /area/space
-	
+
 /obj/effect/shuttle_landmark/iac_rescue_ship/nav3
 	name = "IAC Rescue Ship - Starboard Side"
 	landmark_tag = "nav_iac_rescue_ship_3"
 	base_turf = /turf/space/dynamic
 	base_area = /area/space
-	
+
 /obj/effect/shuttle_landmark/iac_rescue_ship/nav4
 	name = "IAC Rescue Ship - Aft Side"
 	landmark_tag = "nav_iac_rescue_ship_4"
 	base_turf = /turf/space/dynamic
 	base_area = /area/space
-	
+
 /obj/effect/shuttle_landmark/iac_rescue_ship/nav5
 	name = "IAC Rescue Ship - Fore Side"
 	landmark_tag = "nav_iac_rescue_ship_5"

--- a/maps/away/ships/sol_ssmd/ssmd_ship.dm
+++ b/maps/away/ships/sol_ssmd/ssmd_ship.dm
@@ -5,7 +5,7 @@
 	suffixes = list("ships/sol_ssmd/ssmd_ship.dmm")
 	sectors = list(SECTOR_BADLANDS)
 	spawn_weight = 1
-	spawn_cost = 1
+	ship_cost = 1
 	id = "ssmd_corvette"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/ssmd_shuttle)
 


### PR DESCRIPTION
SSMD, IAC, and the new Dionae ships used spawn_cost instead of ship_cost, meaning they used the away site spawn pool instead of the ghost role spawn pool.

I also noticed the Hadiist satellite uses spawn_cost instead of ship_cost, but it's not well-documented whether its intended for all ghostroles or just ships, so I left it.