### PR TITLE
adds gpses to literally every ghostrole ship + sfa powerloader

### DIFF
--- a/code/modules/heavy_vehicle/premade/powerloader.dm
+++ b/code/modules/heavy_vehicle/premade/powerloader.dm
@@ -25,6 +25,10 @@
 	name = "solarian powerloader"
 	e_color = COLOR_DARK_GREEN_GRAY
 
+/mob/living/heavy_vehicle/premade/ripley/loader/sol/fucked
+	name = "damaged solarian powerloader"
+	h_l_hand = null
+
 /mob/living/heavy_vehicle/premade/ripley/janitorial
 	name = "janitorial power loader"
 	desc = "A standard cargo-handling power loader converted into a cleaning machine."

--- a/code/modules/heavy_vehicle/premade/powerloader.dm
+++ b/code/modules/heavy_vehicle/premade/powerloader.dm
@@ -25,7 +25,7 @@
 	name = "solarian powerloader"
 	e_color = COLOR_DARK_GREEN_GRAY
 
-/mob/living/heavy_vehicle/premade/ripley/loader/sol/fucked
+/mob/living/heavy_vehicle/premade/ripley/loader/sol/damaged
 	name = "damaged solarian powerloader"
 	h_l_hand = null
 

--- a/html/changelogs/rustingwithyou - offshipgps.yml
+++ b/html/changelogs/rustingwithyou - offshipgps.yml
@@ -38,6 +38,6 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - maptweak: "all ghost ships now have GPS units"
+  - maptweak: "All ghost ships now have GPSes."
   - maptweak: "Adds a damaged Solarian powerloader and adds it to the SFA away ship."
   - maptweak: "Replaces the FSF corvette's powerloader with a Solarian powerloader."

--- a/html/changelogs/rustingwithyou - offshipgps.yml
+++ b/html/changelogs/rustingwithyou - offshipgps.yml
@@ -39,5 +39,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - maptweak: "all ghost ships now have GPS units"
-  - maptweak: "adds a amaged solarian powerloader and adds it to the sfa ship"
+  - maptweak: "Adds a damaged Solarian powerloader and adds it to the SFA away ship."
   - maptweak: "Replaces the FSF corvette's powerloader with a Solarian powerloader."

--- a/html/changelogs/rustingwithyou - offshipgps.yml
+++ b/html/changelogs/rustingwithyou - offshipgps.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "all ghost ships now have GPS units"
+  - maptweak: "adds a amaged solarian powerloader and adds it to the sfa ship"
+  - maptweak: "replaces the FSF corvette's powerloader with a solarian powerloader"

--- a/html/changelogs/rustingwithyou - offshipgps.yml
+++ b/html/changelogs/rustingwithyou - offshipgps.yml
@@ -40,4 +40,4 @@ delete-after: True
 changes:
   - maptweak: "all ghost ships now have GPS units"
   - maptweak: "adds a amaged solarian powerloader and adds it to the sfa ship"
-  - maptweak: "replaces the FSF corvette's powerloader with a solarian powerloader"
+  - maptweak: "Replaces the FSF corvette's powerloader with a Solarian powerloader."

--- a/maps/away/away_site/tajara/mining_jack/mining_jack.dmm
+++ b/maps/away/away_site/tajara/mining_jack/mining_jack.dmm
@@ -783,6 +783,7 @@
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/void/mining,
 /obj/item/clothing/head/helmet/space/void/mining,
+/obj/item/device/gps/mining,
 /turf/simulated/floor/tiled/steel{
 	temperature = 278.15
 	},
@@ -1035,6 +1036,7 @@
 /obj/item/clothing/suit/space/void/mining,
 /obj/item/clothing/head/helmet/space/void/mining,
 /obj/machinery/light,
+/obj/item/device/gps/mining,
 /turf/simulated/floor/tiled/steel{
 	temperature = 278.15
 	},

--- a/maps/away/away_site/tajara/scrapper/scrapper.dmm
+++ b/maps/away/away_site/tajara/scrapper/scrapper.dmm
@@ -584,6 +584,7 @@
 /obj/item/clothing/suit/space/void/engineering,
 /obj/item/clothing/head/helmet/space/void/engineering,
 /obj/item/clothing/mask/breath,
+/obj/item/device/gps/engineering,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -811,6 +812,7 @@
 /obj/item/clothing/suit/space/void/engineering,
 /obj/item/clothing/head/helmet/space/void/engineering,
 /obj/item/clothing/mask/breath,
+/obj/item/device/gps/engineering,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -2261,6 +2263,7 @@
 /obj/item/clothing/suit/space/void/engineering,
 /obj/item/clothing/head/helmet/space/void/engineering,
 /obj/item/clothing/mask/breath,
+/obj/item/device/gps/engineering,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},

--- a/maps/away/away_site/unathi_pirate/unathi_pirate_izharshan.dmm
+++ b/maps/away/away_site/unathi_pirate/unathi_pirate_izharshan.dmm
@@ -1415,6 +1415,10 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "VS" = (

--- a/maps/away/ships/coc_ranger/coc_ship.dmm
+++ b/maps/away/ships/coc_ranger/coc_ship.dmm
@@ -377,6 +377,7 @@
 /obj/item/clothing/suit/space/void/coalition,
 /obj/item/clothing/head/helmet/space/void/coalition,
 /obj/item/tank/emergency_oxygen/double,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/ranger_corvette/voidsuits)
 "bIQ" = (
@@ -898,6 +899,7 @@
 	req_one_access = null
 	},
 /obj/item/tank/emergency_oxygen/double,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/ranger_corvette/voidsuits)
 "eFH" = (
@@ -1488,6 +1490,7 @@
 	icon_state = "tube1"
 	},
 /obj/item/tank/emergency_oxygen/double,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/ranger_corvette/voidsuits)
 "hwT" = (

--- a/maps/away/ships/dominia/dominian_corvette.dmm
+++ b/maps/away/ships/dominia/dominian_corvette.dmm
@@ -2763,6 +2763,7 @@
 	icon_state = "tube1";
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_corvette/engineering)
 "kAt" = (
@@ -3215,6 +3216,7 @@
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/void/dominia/voidsman,
 /obj/item/clothing/head/helmet/space/void/dominia/voidsman,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/dominian_corvette/engineering)
 "mcE" = (

--- a/maps/away/ships/dpra/hailstorm/hailstorm_ship.dmm
+++ b/maps/away/ships/dpra/hailstorm/hailstorm_ship.dmm
@@ -114,6 +114,7 @@
 /obj/item/clothing/suit/space/void/dpra,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/void/dpra,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},

--- a/maps/away/ships/einstein/ee_spy_ship.dmm
+++ b/maps/away/ships/einstein/ee_spy_ship.dmm
@@ -80,6 +80,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/clothing/suit/space/void/einstein,
 /obj/item/clothing/head/helmet/space/void/einstein,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/ee_spy_ship)
 "aHs" = (
@@ -1247,6 +1248,7 @@
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/void/einstein,
 /obj/item/clothing/head/helmet/space/void/einstein,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/ee_spy_ship)
 "wZf" = (

--- a/maps/away/ships/elyra/elyran_strike_craft.dmm
+++ b/maps/away/ships/elyra/elyran_strike_craft.dmm
@@ -488,6 +488,7 @@
 /obj/item/tank/oxygen,
 /obj/item/clothing/suit/space/void/valkyrie,
 /obj/item/clothing/head/helmet/space/void/valkyrie,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled,
 /area/ship/elyran_strike_craft)
 "cWy" = (
@@ -531,6 +532,7 @@
 /obj/item/ammo_magazine/c45m,
 /obj/item/gun/projectile/plasma/bolter,
 /obj/item/ammo_magazine/plasma/light,
+/obj/item/device/gps,
 /turf/simulated/floor/carpet,
 /area/ship/elyran_strike_craft)
 "dqM" = (
@@ -1783,6 +1785,7 @@
 /obj/structure/sign/securearea{
 	pixel_y = -32
 	},
+/obj/item/device/gps,
 /turf/simulated/floor/tiled,
 /area/ship/elyran_strike_craft)
 "rBF" = (

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -6852,6 +6852,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
 "pf" = (
@@ -8121,6 +8122,7 @@
 /obj/item/clothing/head/helmet/unathi/klax,
 /obj/item/clothing/shoes/magboots/hegemony,
 /obj/item/clothing/glasses/sunglasses/blinders,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
 "AG" = (
@@ -10258,6 +10260,7 @@
 	dir = 4;
 	pixel_x = 32
 	},
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
 "TP" = (
@@ -10373,6 +10376,7 @@
 /obj/item/clothing/head/helmet/space/void/kataphract,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/shoes/magboots/hegemony,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
 "VG" = (

--- a/maps/away/ships/nka/nka_merchant/nka_merchant.dmm
+++ b/maps/away/ships/nka/nka_merchant/nka_merchant.dmm
@@ -1144,6 +1144,7 @@
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/void/nka,
 /obj/item/clothing/head/helmet/space/void/nka,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1863,6 +1864,7 @@
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/void/security,
 /obj/item/clothing/head/helmet/space/void/security,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2027,6 +2029,7 @@
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/void/nka,
 /obj/item/clothing/head/helmet/space/void/nka,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -2575,6 +2575,8 @@
 /obj/item/clothing/suit/space/void/engineering,
 /obj/item/clothing/head/helmet/space/void/engineering,
 /obj/item/clothing/head/helmet/space/void/engineering,
+/obj/item/device/gps/engineering,
+/obj/item/device/gps/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion_express_ship)
 "sJD" = (
@@ -2895,6 +2897,8 @@
 /obj/item/clothing/suit/space/void/engineering,
 /obj/item/clothing/head/helmet/space/void/engineering,
 /obj/item/clothing/head/helmet/space/void/engineering,
+/obj/item/device/gps/engineering,
+/obj/item/device/gps/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion_express_ship)
 "uzX" = (

--- a/maps/away/ships/pra/database_freighter/database_freighter.dmm
+++ b/maps/away/ships/pra/database_freighter/database_freighter.dmm
@@ -3923,6 +3923,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
+/obj/item/device/gps/science,
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dmm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dmm
@@ -454,6 +454,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/clothing/mask/breath,
 /obj/machinery/light,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -2249,6 +2250,7 @@
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/clothing/mask/breath,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -3223,6 +3225,7 @@
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/clothing/mask/breath,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -3936,6 +3939,7 @@
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/clothing/mask/breath,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},

--- a/maps/away/ships/skrell_smuggler/tirakqi_freighter.dmm
+++ b/maps/away/ships/skrell_smuggler/tirakqi_freighter.dmm
@@ -447,6 +447,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/device/gps,
+/obj/item/device/gps,
 /turf/simulated/floor,
 /area/ship/tirakqi_freighter)
 "eMT" = (
@@ -1807,6 +1809,10 @@
 	},
 /turf/simulated/floor,
 /area/ship/tirakqi_freighter)
+"rQN" = (
+/obj/item/device/gps,
+/turf/space/transit/north,
+/area/space)
 "rXT" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack,
@@ -2144,6 +2150,8 @@
 /obj/item/clothing/suit/space/void/skrell/black,
 /obj/item/clothing/head/helmet/space/void/skrell/black,
 /obj/item/clothing/head/helmet/space/void/skrell/black,
+/obj/item/device/gps,
+/obj/item/device/gps,
 /turf/simulated/floor,
 /area/ship/tirakqi_freighter)
 "yiR" = (
@@ -7024,7 +7032,7 @@ etL
 etL
 etL
 etL
-etL
+rQN
 que
 etL
 etL

--- a/maps/away/ships/sol_merc/fsf_patrol_ship.dmm
+++ b/maps/away/ships/sol_merc/fsf_patrol_ship.dmm
@@ -660,6 +660,7 @@
 	icon_state = "tube1";
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/fsf_patrol_ship)
 "eTq" = (
@@ -1342,6 +1343,7 @@
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/clothing/suit/space/void/sol/fsf,
 /obj/item/clothing/head/helmet/space/void/sol/fsf,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/fsf_patrol_ship)
 "iQy" = (
@@ -1675,6 +1677,7 @@
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/clothing/suit/space/void/sol/fsf,
 /obj/item/clothing/head/helmet/space/void/sol/fsf,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/fsf_patrol_ship)
 "lBQ" = (
@@ -2563,7 +2566,7 @@
 "uvX" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/outline/red,
-/mob/living/heavy_vehicle/premade/ripley/loader,
+/mob/living/heavy_vehicle/premade/ripley/loader/sol,
 /turf/simulated/floor,
 /area/ship/fsf_patrol_ship)
 "uBC" = (
@@ -2619,6 +2622,7 @@
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/clothing/suit/space/void/sol/fsf,
 /obj/item/clothing/head/helmet/space/void/sol/fsf,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/fsf_patrol_ship)
 "vgc" = (

--- a/maps/away/ships/sol_pirate/sfa_patrol_ship.dmm
+++ b/maps/away/ships/sol_pirate/sfa_patrol_ship.dmm
@@ -1874,7 +1874,7 @@
 	pixel_x = 24;
 	req_access = list(113)
 	},
-/mob/living/heavy_vehicle/premade/ripley/loader/sol/fucked,
+/mob/living/heavy_vehicle/premade/ripley/loader/sol/damaged,
 /turf/simulated/floor/tiled/dark,
 /area/ship/sfa_patrol_ship/Ammo_Closet)
 "hnw" = (

--- a/maps/away/ships/sol_pirate/sfa_patrol_ship.dmm
+++ b/maps/away/ships/sol_pirate/sfa_patrol_ship.dmm
@@ -1198,6 +1198,7 @@
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
 /obj/item/device/radio/off,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/sfa_patrol_ship/Suit_Storage)
 "eLQ" = (
@@ -1873,6 +1874,7 @@
 	pixel_x = 24;
 	req_access = list(113)
 	},
+/mob/living/heavy_vehicle/premade/ripley/loader/sol/fucked,
 /turf/simulated/floor/tiled/dark,
 /area/ship/sfa_patrol_ship/Ammo_Closet)
 "hnw" = (

--- a/maps/away/ships/sol_ssmd/ssmd_ship.dmm
+++ b/maps/away/ships/sol_ssmd/ssmd_ship.dmm
@@ -231,6 +231,7 @@
 /obj/machinery/light/colored/blue{
 	dir = 8
 	},
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/dorms)
 "aHC" = (
@@ -471,6 +472,7 @@
 /obj/machinery/light/colored/blue{
 	dir = 8
 	},
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/dorms)
 "bdq" = (
@@ -2640,6 +2642,7 @@
 /obj/item/clothing/suit/space/void/sol/ssmd,
 /obj/item/clothing/head/helmet/space/void/sol/ssmd,
 /obj/item/tank/emergency_oxygen/double,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/dorms)
 "gKp" = (
@@ -2883,6 +2886,7 @@
 /obj/machinery/light/colored/blue{
 	dir = 4
 	},
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/dorms)
 "hBs" = (

--- a/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dmm
+++ b/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dmm
@@ -2514,6 +2514,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/device/gps/engineering,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -2956,6 +2957,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/item/device/gps/engineering,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -3799,6 +3801,7 @@
 	req_one_access = null;
 	pixel_y = 32
 	},
+/obj/item/device/gps/engineering,
 /turf/simulated/floor{
 	temperature = 278.15
 	},

--- a/maps/away/ships/tcfl_patrol/tcfl_peacekeeper_ship.dmm
+++ b/maps/away/ships/tcfl_patrol/tcfl_peacekeeper_ship.dmm
@@ -475,6 +475,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/item/device/gps,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/tcfl_peacekeeper_ship)
 "ehg" = (
@@ -3770,6 +3772,8 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
+/obj/item/device/gps,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/tcfl_peacekeeper_ship)
 "yiy" = (

--- a/maps/away/ships/tramp_freighter/tramp_freighter.dmm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter.dmm
@@ -524,6 +524,8 @@
 /obj/item/device/suit_cooling_unit,
 /obj/item/clothing/head/helmet/space/void/mining/fluff,
 /obj/item/device/suit_cooling_unit,
+/obj/item/device/gps/mining,
+/obj/item/device/gps/mining,
 /turf/simulated/floor/tiled/dark,
 /area/ship/tramp_freighter)
 "dmm" = (
@@ -595,6 +597,8 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
+/obj/item/device/gps/mining,
+/obj/item/device/gps/mining,
 /turf/simulated/floor/tiled/dark,
 /area/ship/tramp_freighter)
 "dGM" = (

--- a/maps/away/ships/wildlands_militia/militia_ship.dmm
+++ b/maps/away/ships/wildlands_militia/militia_ship.dmm
@@ -64,6 +64,7 @@
 	},
 /obj/item/clothing/suit/space/void/freelancer,
 /obj/item/clothing/head/helmet/space/void/freelancer,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/militia_ship)
 "atj" = (
@@ -693,6 +694,7 @@
 	},
 /obj/item/clothing/suit/space/void/freelancer,
 /obj/item/clothing/head/helmet/space/void/freelancer,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/militia_ship)
 "hQA" = (
@@ -1431,6 +1433,7 @@
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/void/freelancer,
 /obj/item/clothing/head/helmet/space/void/freelancer,
+/obj/item/device/gps,
 /turf/simulated/floor/tiled/dark,
 /area/ship/militia_ship)
 "uYP" = (


### PR DESCRIPTION
Most ghost role ships now have GPSes, to make exoplanet navigation easier.

The SFA now has a new variant of the solarian powerloader, missing one of its clamps due to damage. In addition, the power loader aboard the FSF corvette has been replaced with a solarian power loader.