### PR TITLE
Tactical/Welding Goggles Layer Above Hair by Default

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -574,6 +574,7 @@ BLIND     // can't see anything
 	item_flags = THICKMATERIAL
 	flash_protection = FLASH_PROTECTION_MAJOR
 	tint = TINT_HEAVY
+	normal_layer = FALSE
 
 /obj/item/clothing/glasses/welding/attack_self()
 	toggle()

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -303,6 +303,7 @@ BLIND     // can't see anything
 	var/sprite_state = "security_goggles"
 	contained_sprite = TRUE
 	change_item_state_on_flip = TRUE
+	normal_layer = FALSE
 
 /obj/item/clothing/glasses/safety/goggles/goon/Initialize(mapload, material_key)
 	icon_state = sprite_state

--- a/html/changelogs/wickedcybs_goggles.yml
+++ b/html/changelogs/wickedcybs_goggles.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - bugfix: "LARP has been enhanced. The tactical goggles layer above hair as they likely should."

--- a/html/changelogs/wickedcybs_goggles.yml
+++ b/html/changelogs/wickedcybs_goggles.yml
@@ -3,4 +3,4 @@ author: WickedCybs
 delete-after: True
 
 changes:
-  - bugfix: "LARP has been enhanced. The tactical goggles layer above hair as they likely should."
+  - bugfix: "LARP has been enhanced. The tactical goggles and welding goggles layer above hair as they likely should."


### PR DESCRIPTION
It doesn't really look right when it layers underneath hair and it completely goes underneath it for most hairstyles sans bald if you adjust them upwards.

The goggles can all still have the adjust verb used to let hair cover them again though. This essentially just reverses it for the tac and welding goggles.