### PR TITLE
Projectile Duplicate Variable Fix

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -436,7 +436,6 @@
 	anti_materiel_potential = 4
 	embed = FALSE
 	penetrating = FALSE
-	armor_penetration = 10
 	var/heavy_impact_range = 1
 
 /obj/item/projectile/bullet/recoilless_rifle/on_impact(var/atom/A)

--- a/html/changelogs/antitank_warhead_fix.yml
+++ b/html/changelogs/antitank_warhead_fix.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the anti-tank warhead having \"armor_penetration\" defined twice."


### PR DESCRIPTION
this PR fixes the anti-tank warhead having `armor_penetration` defined twice.