### PR TITLE
Adds k'ois contaminated phoron (1)

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -200,9 +200,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		playsound(src, 'sound/items/cigs_lighters/cig_light.ogg', 75, 1, -1)
 		src.reagents.set_temperature(T0C + 45)
 		damtype = "fire"
-		if(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron/base)) // the phoron explodes when exposed to fire
+		if(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron/pure)) // the phoron explodes when exposed to fire
 			var/datum/effect/effect/system/reagents_explosion/e = new()
-			e.set_up(round(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron/base) / 2.5, 1), get_turf(src), 0, 0)
+			e.set_up(round(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron/pure) / 2.5, 1), get_turf(src), 0, 0)
 			e.start()
 			qdel(src)
 			return

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -200,9 +200,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		playsound(src, 'sound/items/cigs_lighters/cig_light.ogg', 75, 1, -1)
 		src.reagents.set_temperature(T0C + 45)
 		damtype = "fire"
-		if(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron)) // the phoron explodes when exposed to fire
+		if(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron/base)) // the phoron explodes when exposed to fire
 			var/datum/effect/effect/system/reagents_explosion/e = new()
-			e.set_up(round(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron) / 2.5, 1), get_turf(src), 0, 0)
+			e.set_up(round(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron/base) / 2.5, 1), get_turf(src), 0, 0)
 			e.start()
 			qdel(src)
 			return
@@ -300,7 +300,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	w_class = ITEMSIZE_TINY
 	slot_flags = SLOT_EARS | SLOT_MASK
 	attack_verb = list("burnt", "singed")
-	icon_on = "cigon" 
+	icon_on = "cigon"
 	icon_off = "cigoff"
 	has_blood_overlay = FALSE
 	type_butt = /obj/item/trash/cigbutt

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -224,7 +224,7 @@
 
 	B1.reagents.add_reagent(/singleton/reagent/aluminum, 15)
 	B1.reagents.add_reagent(/singleton/reagent/fuel,20)
-	B2.reagents.add_reagent(/singleton/reagent/toxin/phoron/base, 15)
+	B2.reagents.add_reagent(/singleton/reagent/toxin/phoron/pure, 15)
 	B2.reagents.add_reagent(/singleton/reagent/acid, 15)
 	B1.reagents.add_reagent(/singleton/reagent/fuel,20)
 

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -224,7 +224,7 @@
 
 	B1.reagents.add_reagent(/singleton/reagent/aluminum, 15)
 	B1.reagents.add_reagent(/singleton/reagent/fuel,20)
-	B2.reagents.add_reagent(/singleton/reagent/toxin/phoron, 15)
+	B2.reagents.add_reagent(/singleton/reagent/toxin/phoron/base, 15)
 	B2.reagents.add_reagent(/singleton/reagent/acid, 15)
 	B1.reagents.add_reagent(/singleton/reagent/fuel,20)
 

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -319,7 +319,7 @@
 		list("synaptizine",		"synaptizine",		/singleton/reagent/synaptizine,		30),
 		list("hyperzine",		"hyperzine",		/singleton/reagent/hyperzine,		30),
 		list("oxycomorphine",	"oxycomorphine",	/singleton/reagent/oxycomorphine,	30),
-		list("phoron",			"phoron",			/singleton/reagent/toxin/phoron,	60),
+		list("phoron",			"phoron",			/singleton/reagent/toxin/phoron/base,	60),
 		list("kois",			"k'ois paste",		/singleton/reagent/kois,			80)
 		)
 

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -319,7 +319,7 @@
 		list("synaptizine",		"synaptizine",		/singleton/reagent/synaptizine,		30),
 		list("hyperzine",		"hyperzine",		/singleton/reagent/hyperzine,		30),
 		list("oxycomorphine",	"oxycomorphine",	/singleton/reagent/oxycomorphine,	30),
-		list("phoron",			"phoron",			/singleton/reagent/toxin/phoron/base,	60),
+		list("phoron",			"phoron",			/singleton/reagent/toxin/phoron/pure,	60),
 		list("kois",			"k'ois paste",		/singleton/reagent/kois,			80)
 		)
 

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -228,10 +228,10 @@
 		return
 
 	//also copied from matches
-	if(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron)) // the phoron explodes when exposed to fire
+	if(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron/base)) // the phoron explodes when exposed to fire
 		visible_message(SPAN_DANGER("\The [src] conflagrates violently!"))
 		var/datum/effect/effect/system/reagents_explosion/e = new()
-		e.set_up(round(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron) / 2.5, 1), get_turf(src), 0, 0)
+		e.set_up(round(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron/base) / 2.5, 1), get_turf(src), 0, 0)
 		e.start()
 		qdel(src)
 		return

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -228,10 +228,10 @@
 		return
 
 	//also copied from matches
-	if(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron/base)) // the phoron explodes when exposed to fire
+	if(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron/pure)) // the phoron explodes when exposed to fire
 		visible_message(SPAN_DANGER("\The [src] conflagrates violently!"))
 		var/datum/effect/effect/system/reagents_explosion/e = new()
-		e.set_up(round(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron/base) / 2.5, 1), get_turf(src), 0, 0)
+		e.set_up(round(REAGENT_VOLUME(reagents, /singleton/reagent/toxin/phoron/pure) / 2.5, 1), get_turf(src), 0, 0)
 		e.start()
 		qdel(src)
 		return

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -440,7 +440,7 @@
 			/singleton/reagent/mindbreaker,
 			/singleton/reagent/inaprovaline,
 			/singleton/reagent/peridaxon,
-			/singleton/reagent/toxin/phoron,
+			/singleton/reagent/toxin/phoron/kois,
 			/singleton/reagent/toxin/plasticide,
 			/singleton/reagent/potassium,
 			/singleton/reagent/radium,

--- a/code/modules/hydroponics/seed_datums/mushrooms.dm
+++ b/code/modules/hydroponics/seed_datums/mushrooms.dm
@@ -35,7 +35,7 @@
 	display_name = "k'ois spores"
 	chems = list(
 				/singleton/reagent/kois = list(4),
-				/singleton/reagent/toxin/phoron = list(8))
+				/singleton/reagent/toxin/phoron/kois = list(8))
 	splat_type = /obj/effect/plant
 	kitchen_tag = "koisspore"
 	mutants = null
@@ -68,7 +68,7 @@
 	mutants = null
 	chems = list(
 				/singleton/reagent/kois/black = list(4),
-				/singleton/reagent/toxin/phoron = list(2))
+				/singleton/reagent/toxin/phoron/kois/black = list(2))
 
 /datum/seed/koisspore/black/setup_traits()
 	..()

--- a/code/modules/integrated_electronics/passive/power.dm
+++ b/code/modules/integrated_electronics/passive/power.dm
@@ -130,7 +130,7 @@
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2, TECH_BIO = 2)
 	var/volume = 60
-	var/list/fuel = list(/singleton/reagent/toxin/phoron = 50000, /singleton/reagent/slimejelly = 25000, /singleton/reagent/fuel = 15000, /singleton/reagent/carbon = 10000, /singleton/reagent/alcohol = 10000, /singleton/reagent/nutriment = 8000, /singleton/reagent/blood = 5000)
+	var/list/fuel = list(/singleton/reagent/toxin/phoron/base = 50000, /singleton/reagent/slimejelly = 25000, /singleton/reagent/fuel = 15000, /singleton/reagent/carbon = 10000, /singleton/reagent/alcohol = 10000, /singleton/reagent/nutriment = 8000, /singleton/reagent/blood = 5000)
 
 /obj/item/integrated_circuit/passive/power/chemical_cell/New()
 	..()

--- a/code/modules/integrated_electronics/passive/power.dm
+++ b/code/modules/integrated_electronics/passive/power.dm
@@ -130,7 +130,7 @@
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2, TECH_BIO = 2)
 	var/volume = 60
-	var/list/fuel = list(/singleton/reagent/toxin/phoron/base = 50000, /singleton/reagent/slimejelly = 25000, /singleton/reagent/fuel = 15000, /singleton/reagent/carbon = 10000, /singleton/reagent/alcohol = 10000, /singleton/reagent/nutriment = 8000, /singleton/reagent/blood = 5000)
+	var/list/fuel = list(/singleton/reagent/toxin/phoron/pure = 50000, /singleton/reagent/slimejelly = 25000, /singleton/reagent/fuel = 15000, /singleton/reagent/carbon = 10000, /singleton/reagent/alcohol = 10000, /singleton/reagent/nutriment = 8000, /singleton/reagent/blood = 5000)
 
 /obj/item/integrated_circuit/passive/power/chemical_cell/New()
 	..()

--- a/code/modules/item_worth/reagents.dm
+++ b/code/modules/item_worth/reagents.dm
@@ -81,6 +81,9 @@
 /singleton/reagent/kois
 	value = 0.5
 
+/singleton/reagent/phoron/kois
+	value = 0.5
+
 /singleton/reagent/nutriment
 	value = 0.1
 
@@ -723,7 +726,7 @@
 /singleton/reagent/toxin/carpotoxin
 	value = 3
 
-/singleton/reagent/toxin/phoron
+/singleton/reagent/toxin/phoron/base
 	value = 10
 
 /singleton/reagent/toxin/cyanide

--- a/code/modules/item_worth/reagents.dm
+++ b/code/modules/item_worth/reagents.dm
@@ -726,7 +726,7 @@
 /singleton/reagent/toxin/carpotoxin
 	value = 3
 
-/singleton/reagent/toxin/phoron/base
+/singleton/reagent/toxin/phoron/pure
 	value = 10
 
 /singleton/reagent/toxin/cyanide

--- a/code/modules/makeshift/makeshift_reagents.dm
+++ b/code/modules/makeshift/makeshift_reagents.dm
@@ -17,7 +17,7 @@
 	var/list/sheet_reagents = list( //have a number of reagents which is a factor of REAGENTS_PER_SHEET (default 20) unless you like decimals
 		/obj/item/stack/material/iron = list(/singleton/reagent/iron),
 		/obj/item/stack/material/uranium = list(/singleton/reagent/uranium),
-		/obj/item/stack/material/phoron = list(/singleton/reagent/toxin/phoron/base),
+		/obj/item/stack/material/phoron = list(/singleton/reagent/toxin/phoron/pure),
 		/obj/item/stack/material/gold = list(/singleton/reagent/gold),
 		/obj/item/stack/material/silver = list(/singleton/reagent/silver),
 		/obj/item/stack/material/steel = list(/singleton/reagent/iron, /singleton/reagent/carbon),

--- a/code/modules/makeshift/makeshift_reagents.dm
+++ b/code/modules/makeshift/makeshift_reagents.dm
@@ -17,7 +17,7 @@
 	var/list/sheet_reagents = list( //have a number of reagents which is a factor of REAGENTS_PER_SHEET (default 20) unless you like decimals
 		/obj/item/stack/material/iron = list(/singleton/reagent/iron),
 		/obj/item/stack/material/uranium = list(/singleton/reagent/uranium),
-		/obj/item/stack/material/phoron = list(/singleton/reagent/toxin/phoron),
+		/obj/item/stack/material/phoron = list(/singleton/reagent/toxin/phoron/base),
 		/obj/item/stack/material/gold = list(/singleton/reagent/gold),
 		/obj/item/stack/material/silver = list(/singleton/reagent/silver),
 		/obj/item/stack/material/steel = list(/singleton/reagent/iron, /singleton/reagent/carbon),

--- a/code/modules/organs/subtypes/parasite.dm
+++ b/code/modules/organs/subtypes/parasite.dm
@@ -25,7 +25,7 @@
 		return
 
 	if(stage < max_stage)
-		stage_ticker += infection_speed 
+		stage_ticker += infection_speed
 
 	if(stage_ticker >= stage*stage_interval)
 		stage = min(stage+1,max_stage)
@@ -87,7 +87,7 @@
 		set_light(1, l_color = "#E6E600")
 		if(prob(10))
 			to_chat(owner, "<span class='warning'>You feel something squirming inside of you!</span>")
-			owner.reagents.add_reagent(/singleton/reagent/toxin/phoron, 8)
+			owner.reagents.add_reagent(/singleton/reagent/toxin/phoron/kois, 8)
 			owner.reagents.add_reagent(/singleton/reagent/kois, 5)
 
 	if(stage >= 4)
@@ -99,7 +99,7 @@
 
 			var/datum/reagents/R = new/datum/reagents(100)
 			R.add_reagent(/singleton/reagent/kois,10)
-			R.add_reagent(/singleton/reagent/toxin/phoron,10)
+			R.add_reagent(/singleton/reagent/toxin/phoron/kois,10)
 			var/datum/effect/effect/system/smoke_spread/chem/spores/S = new("koisspore")
 
 			S.attach(T)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -97,7 +97,7 @@
 
 		to_chat(user, "You inject the solution into the power cell.")
 
-		if(S.reagents.has_reagent(/singleton/reagent/toxin/phoron, 5))
+		if(S.reagents.has_reagent(/singleton/reagent/toxin/phoron/base, 5))
 
 			rigged = 1
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -97,7 +97,7 @@
 
 		to_chat(user, "You inject the solution into the power cell.")
 
-		if(S.reagents.has_reagent(/singleton/reagent/toxin/phoron/base, 5))
+		if(S.reagents.has_reagent(/singleton/reagent/toxin/phoron/pure, 5))
 
 			rigged = 1
 

--- a/code/modules/power/lights/bulbs.dm
+++ b/code/modules/power/lights/bulbs.dm
@@ -66,7 +66,7 @@
 
 		to_chat(user, SPAN_NOTICE("You inject the solution into \the [src]."))
 
-		if(S.reagents.has_reagent(/singleton/reagent/toxin/phoron, 5))
+		if(S.reagents.has_reagent(/singleton/reagent/toxin/phoron/base, 5))
 
 			log_admin("LOG: [user.name] ([user.ckey]) injected a light with phoron, rigging it to explode.",ckey=key_name(user))
 			message_admins("LOG: [user.name] ([user.ckey]) injected a light with phoron, rigging it to explode.")

--- a/code/modules/power/lights/bulbs.dm
+++ b/code/modules/power/lights/bulbs.dm
@@ -66,7 +66,7 @@
 
 		to_chat(user, SPAN_NOTICE("You inject the solution into \the [src]."))
 
-		if(S.reagents.has_reagent(/singleton/reagent/toxin/phoron/base, 5))
+		if(S.reagents.has_reagent(/singleton/reagent/toxin/phoron/pure, 5))
 
 			log_admin("LOG: [user.name] ([user.ckey]) injected a light with phoron, rigging it to explode.",ckey=key_name(user))
 			message_admins("LOG: [user.name] ([user.ckey]) injected a light with phoron, rigging it to explode.")

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -327,7 +327,7 @@
 	var/list/sheet_reagents = list( //have a number of reagents which is a factor of REAGENTS_PER_SHEET (default 20) unless you like decimals
 		/obj/item/stack/material/iron = list(/singleton/reagent/iron),
 		/obj/item/stack/material/uranium = list(/singleton/reagent/uranium),
-		/obj/item/stack/material/phoron = list(/singleton/reagent/toxin/phoron/base),
+		/obj/item/stack/material/phoron = list(/singleton/reagent/toxin/phoron/pure),
 		/obj/item/stack/material/gold = list(/singleton/reagent/gold),
 		/obj/item/stack/material/silver = list(/singleton/reagent/silver),
 		/obj/item/stack/material/platinum = list(/singleton/reagent/platinum),

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -327,7 +327,7 @@
 	var/list/sheet_reagents = list( //have a number of reagents which is a factor of REAGENTS_PER_SHEET (default 20) unless you like decimals
 		/obj/item/stack/material/iron = list(/singleton/reagent/iron),
 		/obj/item/stack/material/uranium = list(/singleton/reagent/uranium),
-		/obj/item/stack/material/phoron = list(/singleton/reagent/toxin/phoron),
+		/obj/item/stack/material/phoron = list(/singleton/reagent/toxin/phoron/base),
 		/obj/item/stack/material/gold = list(/singleton/reagent/gold),
 		/obj/item/stack/material/silver = list(/singleton/reagent/silver),
 		/obj/item/stack/material/platinum = list(/singleton/reagent/platinum),

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -161,7 +161,7 @@
 /singleton/reagent/toxin/phoron/kois
 	name = "Phoron"
 	description = "Phoron in its liquid form. Twice as potent when breathed in. Contains biological traces."
-	fallback_specific_heat = 1 //contaminated phoron acts more like k'ois than phoron
+	fallback_specific_heat = 0.75 //contaminated phoron acts more like k'ois than phoron
 	var/kois_type = 1
 
 /singleton/reagent/toxin/phoron/kois/black

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -158,6 +158,15 @@
 	T.assume_gas(GAS_PHORON, amount, T20C)
 	remove_self(amount, holder)
 
+/singleton/reagent/toxin/phoron/kois
+	name = "Phoron"
+	description = "Phoron in its liquid form. Twice as potent when breathed in. Contains biological traces."
+	fallback_specific_heat = 1 //Contaminated phoron loses its cool energetic properties.
+
+/singleton/reagent/toxin/phoron/kois/black
+	name = "Phoron"
+	description = "Phoron in its liquid form. Twice as potent when breathed in. Contains exotic biological traces."
+
 /singleton/reagent/toxin/cardox
 	name = "Cardox"
 	description = "Cardox is a mildly toxic, expensive, NanoTrasen designed cleaner intended to eliminate liquid phoron stains from suits."

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -161,11 +161,43 @@
 /singleton/reagent/toxin/phoron/kois
 	name = "Phoron"
 	description = "Phoron in its liquid form. Twice as potent when breathed in. Contains biological traces."
-	fallback_specific_heat = 1 //Contaminated phoron loses its cool energetic properties.
+	fallback_specific_heat = 1 //contaminated phoron acts more like k'ois than phoron
+	var/kois_type = 1
 
 /singleton/reagent/toxin/phoron/kois/black
 	name = "Phoron"
 	description = "Phoron in its liquid form. Twice as potent when breathed in. Contains exotic biological traces."
+	fallback_specific_heat = 0.5 //same as black k'ois
+	var/kois_type = 2
+
+/decl/reagent/toxin/phoron/kois/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
+	if(ishuman(M))
+		infect(M, alien, removed)
+
+/decl/reagent/toxin/phoron/kois/affect_chem_effect(mob/living/carbon/M, alien, removed, datum/reagents/holder)
+	var/is_vaurcalike = (alien == IS_VAURCA)
+	if(!is_vaurcalike)
+		var/obj/item/organ/internal/parasite/P = M.internal_organs_by_name["blackkois"]
+		if(istype(P) && P.stage >= 3)
+			is_vaurcalike = TRUE
+	if(is_vaurcalike)
+		M.add_chemical_effect(CE_BLOODRESTORE, 6 * removed)
+
+/decl/reagent/toxin/phoron/kois/proc/infect(var/mob/living/carbon/human/H, var/alien, var/removed)
+	var/obj/item/organ/internal/parasite/P = H.internal_organs_by_name["blackkois"]
+	if((alien != IS_VAURCA) && !(istype(P) && P.stage >= 3))
+		H.adjustToxLoss(1 * removed)
+		switch(kois_type)
+			if(1) //Normal
+				if(!H.internal_organs_by_name["kois"] && prob(5*removed))
+					var/obj/item/organ/external/affected = H.get_organ(BP_CHEST)
+					var/obj/item/organ/internal/parasite/kois/infest = new()
+					infest.replaced(H, affected)
+			if(2) //Modified
+				if(!H.internal_organs_by_name["blackkois"] && prob(10*removed))
+					var/obj/item/organ/external/affected = H.get_organ(BP_HEAD)
+					var/obj/item/organ/internal/parasite/blackkois/infest = new()
+					infest.replaced(H, affected)
 
 /singleton/reagent/toxin/cardox
 	name = "Cardox"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -170,11 +170,24 @@
 	fallback_specific_heat = 0.5 //same as black k'ois
 	var/kois_type = 2
 
-/decl/reagent/toxin/phoron/kois/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
+/singleton/reagent/toxin/phoron/kois/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(ishuman(M))
 		infect(M, alien, removed)
 
-/decl/reagent/toxin/phoron/kois/affect_chem_effect(mob/living/carbon/M, alien, removed, datum/reagents/holder)
+/singleton/reagent/toxin/phoron/kois/affect_blood(var/mob/living/carbon/human/M, var/alien, var/removed, var/datum/reagents/holder)
+	if(!ishuman(M))
+		return
+	var/is_vaurcalike = (alien == IS_VAURCA)
+	if(!is_vaurcalike)
+		var/obj/item/organ/internal/parasite/P = M.internal_organs_by_name["blackkois"]
+		if(istype(P) && P.stage >= 3)
+			is_vaurcalike = TRUE
+	if(is_vaurcalike)
+		return
+	else
+		infect(M, alien, removed)
+
+/singleton/reagent/toxin/phoron/kois/affect_chem_effect(mob/living/carbon/M, alien, removed, datum/reagents/holder)
 	var/is_vaurcalike = (alien == IS_VAURCA)
 	if(!is_vaurcalike)
 		var/obj/item/organ/internal/parasite/P = M.internal_organs_by_name["blackkois"]
@@ -183,7 +196,7 @@
 	if(is_vaurcalike)
 		M.add_chemical_effect(CE_BLOODRESTORE, 6 * removed)
 
-/decl/reagent/toxin/phoron/kois/proc/infect(var/mob/living/carbon/human/H, var/alien, var/removed)
+/singleton/reagent/toxin/phoron/kois/proc/infect(var/mob/living/carbon/human/H, var/alien, var/removed)
 	var/obj/item/organ/internal/parasite/P = H.internal_organs_by_name["blackkois"]
 	if((alien != IS_VAURCA) && !(istype(P) && P.stage >= 3))
 		H.adjustToxLoss(1 * removed)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -187,8 +187,6 @@
 		var/obj/item/organ/internal/parasite/P = M.internal_organs_by_name["blackkois"]
 		if(istype(P) && P.stage >= 3)
 			is_vaurcalike = TRUE
-	if(is_vaurcalike)
-		M.add_chemical_effect(CE_BLOODRESTORE, 6 * removed)
 
 /singleton/reagent/toxin/phoron/kois/proc/infect(var/mob/living/carbon/human/H, var/alien, var/removed)
 	var/obj/item/organ/internal/parasite/P = H.internal_organs_by_name["blackkois"]

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -168,7 +168,7 @@
 	name = "Phoron"
 	description = "Phoron in its liquid form. Twice as potent when breathed in. Contains exotic biological traces."
 	fallback_specific_heat = 0.5 //same as black k'ois
-	var/kois_type = 2
+	kois_type = 2
 
 /singleton/reagent/toxin/phoron/kois/affect_blood(var/mob/living/carbon/human/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(!ishuman(M))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -170,10 +170,6 @@
 	fallback_specific_heat = 0.5 //same as black k'ois
 	var/kois_type = 2
 
-/singleton/reagent/toxin/phoron/kois/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	if(ishuman(M))
-		infect(M, alien, removed)
-
 /singleton/reagent/toxin/phoron/kois/affect_blood(var/mob/living/carbon/human/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(!ishuman(M))
 		return
@@ -182,8 +178,6 @@
 		var/obj/item/organ/internal/parasite/P = M.internal_organs_by_name["blackkois"]
 		if(istype(P) && P.stage >= 3)
 			is_vaurcalike = TRUE
-	if(is_vaurcalike)
-		return
 	else
 		infect(M, alien, removed)
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -176,7 +176,7 @@
 	id = "oxycomorphine"
 	result = /singleton/reagent/oxycomorphine
 	required_reagents = list(/singleton/reagent/alcohol = 1, /singleton/reagent/mortaphenyl = 1)
-	catalysts = list(/singleton/reagent/toxin/phoron = 5)
+	catalysts = list(/singleton/reagent/toxin/phoron/base = 5)
 	result_amount = 1
 
 /datum/chemical_reaction/sterilizine
@@ -269,7 +269,7 @@
 	id = "peridaxon"
 	result = /singleton/reagent/peridaxon
 	required_reagents = list(/singleton/reagent/bicaridine = 1, /singleton/reagent/clonexadone = 1)
-	catalysts = list(/singleton/reagent/toxin/phoron = 5)
+	catalysts = list(/singleton/reagent/toxin/phoron/base = 5)
 	result_amount = 1
 
 /datum/chemical_reaction/virus_food
@@ -284,7 +284,7 @@
 	id = "leporazine"
 	result = /singleton/reagent/leporazine
 	required_reagents = list(/singleton/reagent/silicon = 1, /singleton/reagent/copper = 1)
-	catalysts = list(/singleton/reagent/toxin/phoron = 5)
+	catalysts = list(/singleton/reagent/toxin/phoron/base = 5)
 	result_amount = 2
 
 /datum/chemical_reaction/cryptobiolin
@@ -313,7 +313,7 @@
 	id = "dexalin"
 	result = /singleton/reagent/dexalin
 	required_reagents = list(/singleton/reagent/acetone = 2, /singleton/reagent/toxin/phoron = 0.1)
-	catalysts = list(/singleton/reagent/toxin/phoron = 1)
+	catalysts = list(/singleton/reagent/toxin/phoron/base = 1)
 	inhibitors = list(/singleton/reagent/water = 1) // Messes with cryox
 	result_amount = 1
 
@@ -371,8 +371,8 @@
 	name = "Clonexadone"
 	id = "clonexadone"
 	result = /singleton/reagent/clonexadone
-	required_reagents = list(/singleton/reagent/cryoxadone = 1, /singleton/reagent/sodium = 1, /singleton/reagent/toxin/phoron = 0.1)
-	catalysts = list(/singleton/reagent/toxin/phoron = 5)
+	required_reagents = list(/singleton/reagent/cryoxadone = 1, /singleton/reagent/sodium = 1, /singleton/reagent/toxin/phoron/base = 0.1)
+	catalysts = list(/singleton/reagent/toxin/phoron/base = 5)
 	result_amount = 2
 
 /datum/chemical_reaction/thetamycin
@@ -458,7 +458,7 @@
 	name = "Potassium Chlorophoride"
 	id = "potassium_chlorophoride"
 	result = /singleton/reagent/toxin/potassium_chlorophoride
-	required_reagents = list(/singleton/reagent/toxin/potassium_chloride = 1, /singleton/reagent/toxin/phoron = 1, /singleton/reagent/polysomnine = 1)
+	required_reagents = list(/singleton/reagent/toxin/potassium_chloride = 1, /singleton/reagent/toxin/phoron/base = 1, /singleton/reagent/polysomnine = 1)
 	result_amount = 4
 
 /datum/chemical_reaction/zombiepowder
@@ -472,7 +472,7 @@
 	name = "Dextrotoxin"
 	id = "dextrotoxin"
 	result = /singleton/reagent/toxin/dextrotoxin
-	required_reagents = list(/singleton/reagent/toxin/carpotoxin = 3, /singleton/reagent/soporific = 10, /singleton/reagent/toxin/phoron = 5)
+	required_reagents = list(/singleton/reagent/toxin/carpotoxin = 3, /singleton/reagent/soporific = 10, /singleton/reagent/toxin/phoron/base = 5)
 	result_amount = 5
 
 /datum/chemical_reaction/mindbreaker
@@ -574,7 +574,7 @@
 	id = "condensedcapsaicin"
 	result = /singleton/reagent/capsaicin/condensed
 	required_reagents = list(/singleton/reagent/capsaicin = 2)
-	catalysts = list(/singleton/reagent/toxin/phoron = 5)
+	catalysts = list(/singleton/reagent/toxin/phoron/base = 5)
 	result_amount = 1
 
 /datum/chemical_reaction/coolant
@@ -597,7 +597,7 @@
 	id = "lexorin"
 	result = /singleton/reagent/lexorin
 	required_reagents = list(/singleton/reagent/tungsten = 1, /singleton/reagent/hydrazine = 1, /singleton/reagent/ammonia = 1)
-	catalysts = list(/singleton/reagent/toxin/phoron = 5)
+	catalysts = list(/singleton/reagent/toxin/phoron/base = 5)
 	result_amount = 3
 
 /datum/chemical_reaction/fluvectionem
@@ -655,14 +655,14 @@
 	id = "saline"
 	result = /singleton/reagent/saline
 	required_reagents = list(/singleton/reagent/water = 2, /singleton/reagent/sugar = 0.5, /singleton/reagent/sodiumchloride = 1)
-	catalysts = list(/singleton/reagent/toxin/phoron = 5)
+	catalysts = list(/singleton/reagent/toxin/phoron/base = 5)
 	result_amount = 2
 
 /datum/chemical_reaction/cataleptinol
 	name = "Cataleptinol"
 	id = "cataleptinol"
 	result = /singleton/reagent/cataleptinol
-	required_reagents = list(/singleton/reagent/toxin/phoron = 0.1, /singleton/reagent/alkysine = 1, /singleton/reagent/cryoxadone = 0.1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 0.1, /singleton/reagent/alkysine = 1, /singleton/reagent/cryoxadone = 0.1)
 	result_amount = 1
 
 /datum/chemical_reaction/coughsyrup
@@ -747,7 +747,7 @@
 	name = "Truthserum"
 	id = "truthserum"
 	result = /singleton/reagent/mental/truthserum
-	required_reagents = list(/singleton/reagent/mindbreaker = 1, /singleton/reagent/synaptizine = 1, /singleton/reagent/toxin/phoron = 0.1)
+	required_reagents = list(/singleton/reagent/mindbreaker = 1, /singleton/reagent/synaptizine = 1, /singleton/reagent/toxin/phoron/base = 0.1)
 	result_amount = 2
 
 /datum/chemical_reaction/pacifier
@@ -761,7 +761,7 @@
 	name = "Red Nightshade"
 	id = "berserk"
 	result = /singleton/reagent/toxin/berserk
-	required_reagents = list(/singleton/reagent/toxin/stimm = 1, /singleton/reagent/synaptizine = 1, /singleton/reagent/toxin/phoron = 0.1)
+	required_reagents = list(/singleton/reagent/toxin/stimm = 1, /singleton/reagent/synaptizine = 1, /singleton/reagent/toxin/phoron/base = 0.1)
 	result_amount = 1
 
 /datum/chemical_reaction/joy
@@ -824,7 +824,7 @@
 	name = "Solid Phoron"
 	id = "solidphoron"
 	result = null
-	required_reagents = list(/singleton/reagent/iron = 5, /singleton/reagent/frostoil = 5, /singleton/reagent/toxin/phoron = 20)
+	required_reagents = list(/singleton/reagent/iron = 5, /singleton/reagent/frostoil = 5, /singleton/reagent/toxin/phoron/base = 20)
 	result_amount = 1
 
 /datum/chemical_reaction/phoronsolidification/on_reaction(var/datum/reagents/holder, var/created_volume)
@@ -922,7 +922,7 @@
 	name = "Napalm"
 	id = "napalm"
 	result = null
-	required_reagents = list(/singleton/reagent/aluminum = 1, /singleton/reagent/toxin/phoron = 1, /singleton/reagent/acid = 1 )
+	required_reagents = list(/singleton/reagent/aluminum = 1, /singleton/reagent/toxin/phoron/base = 1, /singleton/reagent/acid = 1 )
 	result_amount = 1
 
 /datum/chemical_reaction/napalm/on_reaction(var/datum/reagents/holder, var/created_volume)
@@ -944,7 +944,7 @@
 	name = "Zo'rane Fire"
 	id = "greekfire"
 	result = /singleton/reagent/fuel/napalm
-	required_reagents = list(/singleton/reagent/nitroglycerin = 2, /singleton/reagent/pyrosilicate = 2, /singleton/reagent/toxin/phoron = 3, /singleton/reagent/fuel/zoragel = 3)
+	required_reagents = list(/singleton/reagent/nitroglycerin = 2, /singleton/reagent/pyrosilicate = 2, /singleton/reagent/toxin/phoron/base = 3, /singleton/reagent/fuel/zoragel = 3)
 	result_amount = 1
 	log_is_important = 1
 
@@ -1066,7 +1066,7 @@
 	name = "Slime Spawn"
 	id = "m_spawn"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/grey
 
@@ -1091,7 +1091,7 @@
 /datum/chemical_reaction/slime/teleportation
 	name = "Slime Teleportation"
 	id = "slimeteleportation"
-	required_reagents = list(/singleton/reagent/toxin/phoron = 5)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 5)
 	result_amount = 1
 	required = /obj/item/slime_extract/green
 
@@ -1130,7 +1130,7 @@
 	name = "Slime Metal"
 	id = "m_metal"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/metal
 
@@ -1203,7 +1203,7 @@
 	name = "Slime Bork"
 	id = "m_tele2"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/silver
 
@@ -1300,7 +1300,7 @@
 	name = "Slime fire"
 	id = "m_fire"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/orange
 	mix_message = "The slime extract begins to vibrate violently!"
@@ -1360,7 +1360,7 @@
 	name = "Slime Steroid"
 	id = "m_steroid"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/purple
 
@@ -1382,7 +1382,7 @@
 	name = "Slime Rare Metal"
 	id = "rm_metal"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/darkpurple
 
@@ -1417,7 +1417,7 @@
 	name = "Slime Nightshade"
 	id = "slime_nightshade"
 	result = /singleton/reagent/toxin/berserk
-	required_reagents = list(/singleton/reagent/toxin/phoron = 10)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 10)
 	result_amount = 1
 	required = /obj/item/slime_extract/red
 
@@ -1426,7 +1426,7 @@
 	name = "Docility Serum"
 	id = "docility_serum"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/pink
 
@@ -1447,7 +1447,7 @@
 	name = "Advanced Mutation Toxin"
 	id = "mutationtoxin2"
 	result = /singleton/reagent/aslimetoxin
-	required_reagents = list(/singleton/reagent/toxin/phoron = 5)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 5)
 	result_amount = 1
 	required = /obj/item/slime_extract/black
 
@@ -1456,7 +1456,7 @@
 	name = "Slime Explosion"
 	id = "m_explosion"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/oil
 	mix_message = "The slime extract begins to vibrate violently!"
@@ -1484,7 +1484,7 @@
 	result = null
 	result_amount = 1
 	required = /obj/item/slime_extract/lightpink
-	required_reagents = list(/singleton/reagent/toxin/phoron = 5)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 5)
 
 /datum/chemical_reaction/slime/advanced_docility_serum/on_reaction(var/datum/reagents/holder)
 	..()
@@ -1495,7 +1495,7 @@
 	name = "Slime Golem"
 	id = "m_golem"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron = 5)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 5)
 	result_amount = 1
 	required = /obj/item/slime_extract/adamantine
 	mix_message = "A soft fizzle is heard within the slime extract, and mystic runes suddenly appear on the floor beneath it!"
@@ -1626,7 +1626,7 @@
 	name = "Extract Enhancer"
 	id = "extract_enhancer"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/cerulean
 
@@ -2141,7 +2141,7 @@
 	name = "Toxins Special"
 	id = "phoronspecial"
 	result = /singleton/reagent/alcohol/toxins_special
-	required_reagents = list(/singleton/reagent/alcohol/rum = 2, /singleton/reagent/alcohol/vermouth = 2, /singleton/reagent/toxin/phoron = 2)
+	required_reagents = list(/singleton/reagent/alcohol/rum = 2, /singleton/reagent/alcohol/vermouth = 2, /singleton/reagent/toxin/phoron/base = 2)
 	result_amount = 6
 
 /datum/chemical_reaction/drink/beepsky_smash

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -176,7 +176,7 @@
 	id = "oxycomorphine"
 	result = /singleton/reagent/oxycomorphine
 	required_reagents = list(/singleton/reagent/alcohol = 1, /singleton/reagent/mortaphenyl = 1)
-	catalysts = list(/singleton/reagent/toxin/phoron/base = 5)
+	catalysts = list(/singleton/reagent/toxin/phoron/pure = 5)
 	result_amount = 1
 
 /datum/chemical_reaction/sterilizine
@@ -269,7 +269,7 @@
 	id = "peridaxon"
 	result = /singleton/reagent/peridaxon
 	required_reagents = list(/singleton/reagent/bicaridine = 1, /singleton/reagent/clonexadone = 1)
-	catalysts = list(/singleton/reagent/toxin/phoron/base = 5)
+	catalysts = list(/singleton/reagent/toxin/phoron/pure = 5)
 	result_amount = 1
 
 /datum/chemical_reaction/virus_food
@@ -284,7 +284,7 @@
 	id = "leporazine"
 	result = /singleton/reagent/leporazine
 	required_reagents = list(/singleton/reagent/silicon = 1, /singleton/reagent/copper = 1)
-	catalysts = list(/singleton/reagent/toxin/phoron/base = 5)
+	catalysts = list(/singleton/reagent/toxin/phoron/pure = 5)
 	result_amount = 2
 
 /datum/chemical_reaction/cryptobiolin
@@ -313,7 +313,7 @@
 	id = "dexalin"
 	result = /singleton/reagent/dexalin
 	required_reagents = list(/singleton/reagent/acetone = 2, /singleton/reagent/toxin/phoron = 0.1)
-	catalysts = list(/singleton/reagent/toxin/phoron/base = 1)
+	catalysts = list(/singleton/reagent/toxin/phoron/pure = 1)
 	inhibitors = list(/singleton/reagent/water = 1) // Messes with cryox
 	result_amount = 1
 
@@ -371,8 +371,8 @@
 	name = "Clonexadone"
 	id = "clonexadone"
 	result = /singleton/reagent/clonexadone
-	required_reagents = list(/singleton/reagent/cryoxadone = 1, /singleton/reagent/sodium = 1, /singleton/reagent/toxin/phoron/base = 0.1)
-	catalysts = list(/singleton/reagent/toxin/phoron/base = 5)
+	required_reagents = list(/singleton/reagent/cryoxadone = 1, /singleton/reagent/sodium = 1, /singleton/reagent/toxin/phoron/pure = 0.1)
+	catalysts = list(/singleton/reagent/toxin/phoron/pure = 5)
 	result_amount = 2
 
 /datum/chemical_reaction/thetamycin
@@ -458,7 +458,7 @@
 	name = "Potassium Chlorophoride"
 	id = "potassium_chlorophoride"
 	result = /singleton/reagent/toxin/potassium_chlorophoride
-	required_reagents = list(/singleton/reagent/toxin/potassium_chloride = 1, /singleton/reagent/toxin/phoron/base = 1, /singleton/reagent/polysomnine = 1)
+	required_reagents = list(/singleton/reagent/toxin/potassium_chloride = 1, /singleton/reagent/toxin/phoron/pure = 1, /singleton/reagent/polysomnine = 1)
 	result_amount = 4
 
 /datum/chemical_reaction/zombiepowder
@@ -472,7 +472,7 @@
 	name = "Dextrotoxin"
 	id = "dextrotoxin"
 	result = /singleton/reagent/toxin/dextrotoxin
-	required_reagents = list(/singleton/reagent/toxin/carpotoxin = 3, /singleton/reagent/soporific = 10, /singleton/reagent/toxin/phoron/base = 5)
+	required_reagents = list(/singleton/reagent/toxin/carpotoxin = 3, /singleton/reagent/soporific = 10, /singleton/reagent/toxin/phoron/pure = 5)
 	result_amount = 5
 
 /datum/chemical_reaction/mindbreaker
@@ -574,7 +574,7 @@
 	id = "condensedcapsaicin"
 	result = /singleton/reagent/capsaicin/condensed
 	required_reagents = list(/singleton/reagent/capsaicin = 2)
-	catalysts = list(/singleton/reagent/toxin/phoron/base = 5)
+	catalysts = list(/singleton/reagent/toxin/phoron/pure = 5)
 	result_amount = 1
 
 /datum/chemical_reaction/coolant
@@ -597,7 +597,7 @@
 	id = "lexorin"
 	result = /singleton/reagent/lexorin
 	required_reagents = list(/singleton/reagent/tungsten = 1, /singleton/reagent/hydrazine = 1, /singleton/reagent/ammonia = 1)
-	catalysts = list(/singleton/reagent/toxin/phoron/base = 5)
+	catalysts = list(/singleton/reagent/toxin/phoron/pure = 5)
 	result_amount = 3
 
 /datum/chemical_reaction/fluvectionem
@@ -655,14 +655,14 @@
 	id = "saline"
 	result = /singleton/reagent/saline
 	required_reagents = list(/singleton/reagent/water = 2, /singleton/reagent/sugar = 0.5, /singleton/reagent/sodiumchloride = 1)
-	catalysts = list(/singleton/reagent/toxin/phoron/base = 5)
+	catalysts = list(/singleton/reagent/toxin/phoron/pure = 5)
 	result_amount = 2
 
 /datum/chemical_reaction/cataleptinol
 	name = "Cataleptinol"
 	id = "cataleptinol"
 	result = /singleton/reagent/cataleptinol
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 0.1, /singleton/reagent/alkysine = 1, /singleton/reagent/cryoxadone = 0.1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 0.1, /singleton/reagent/alkysine = 1, /singleton/reagent/cryoxadone = 0.1)
 	result_amount = 1
 
 /datum/chemical_reaction/coughsyrup
@@ -747,7 +747,7 @@
 	name = "Truthserum"
 	id = "truthserum"
 	result = /singleton/reagent/mental/truthserum
-	required_reagents = list(/singleton/reagent/mindbreaker = 1, /singleton/reagent/synaptizine = 1, /singleton/reagent/toxin/phoron/base = 0.1)
+	required_reagents = list(/singleton/reagent/mindbreaker = 1, /singleton/reagent/synaptizine = 1, /singleton/reagent/toxin/phoron/pure = 0.1)
 	result_amount = 2
 
 /datum/chemical_reaction/pacifier
@@ -761,7 +761,7 @@
 	name = "Red Nightshade"
 	id = "berserk"
 	result = /singleton/reagent/toxin/berserk
-	required_reagents = list(/singleton/reagent/toxin/stimm = 1, /singleton/reagent/synaptizine = 1, /singleton/reagent/toxin/phoron/base = 0.1)
+	required_reagents = list(/singleton/reagent/toxin/stimm = 1, /singleton/reagent/synaptizine = 1, /singleton/reagent/toxin/phoron/pure = 0.1)
 	result_amount = 1
 
 /datum/chemical_reaction/joy
@@ -824,7 +824,7 @@
 	name = "Solid Phoron"
 	id = "solidphoron"
 	result = null
-	required_reagents = list(/singleton/reagent/iron = 5, /singleton/reagent/frostoil = 5, /singleton/reagent/toxin/phoron/base = 20)
+	required_reagents = list(/singleton/reagent/iron = 5, /singleton/reagent/frostoil = 5, /singleton/reagent/toxin/phoron/pure = 20)
 	result_amount = 1
 
 /datum/chemical_reaction/phoronsolidification/on_reaction(var/datum/reagents/holder, var/created_volume)
@@ -922,7 +922,7 @@
 	name = "Napalm"
 	id = "napalm"
 	result = null
-	required_reagents = list(/singleton/reagent/aluminum = 1, /singleton/reagent/toxin/phoron/base = 1, /singleton/reagent/acid = 1 )
+	required_reagents = list(/singleton/reagent/aluminum = 1, /singleton/reagent/toxin/phoron/pure = 1, /singleton/reagent/acid = 1 )
 	result_amount = 1
 
 /datum/chemical_reaction/napalm/on_reaction(var/datum/reagents/holder, var/created_volume)
@@ -944,7 +944,7 @@
 	name = "Zo'rane Fire"
 	id = "greekfire"
 	result = /singleton/reagent/fuel/napalm
-	required_reagents = list(/singleton/reagent/nitroglycerin = 2, /singleton/reagent/pyrosilicate = 2, /singleton/reagent/toxin/phoron/base = 3, /singleton/reagent/fuel/zoragel = 3)
+	required_reagents = list(/singleton/reagent/nitroglycerin = 2, /singleton/reagent/pyrosilicate = 2, /singleton/reagent/toxin/phoron/pure = 3, /singleton/reagent/fuel/zoragel = 3)
 	result_amount = 1
 	log_is_important = 1
 
@@ -1066,7 +1066,7 @@
 	name = "Slime Spawn"
 	id = "m_spawn"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/grey
 
@@ -1091,7 +1091,7 @@
 /datum/chemical_reaction/slime/teleportation
 	name = "Slime Teleportation"
 	id = "slimeteleportation"
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 5)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 5)
 	result_amount = 1
 	required = /obj/item/slime_extract/green
 
@@ -1130,7 +1130,7 @@
 	name = "Slime Metal"
 	id = "m_metal"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/metal
 
@@ -1203,7 +1203,7 @@
 	name = "Slime Bork"
 	id = "m_tele2"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/silver
 
@@ -1300,7 +1300,7 @@
 	name = "Slime fire"
 	id = "m_fire"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/orange
 	mix_message = "The slime extract begins to vibrate violently!"
@@ -1360,7 +1360,7 @@
 	name = "Slime Steroid"
 	id = "m_steroid"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/purple
 
@@ -1382,7 +1382,7 @@
 	name = "Slime Rare Metal"
 	id = "rm_metal"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/darkpurple
 
@@ -1417,7 +1417,7 @@
 	name = "Slime Nightshade"
 	id = "slime_nightshade"
 	result = /singleton/reagent/toxin/berserk
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 10)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 10)
 	result_amount = 1
 	required = /obj/item/slime_extract/red
 
@@ -1426,7 +1426,7 @@
 	name = "Docility Serum"
 	id = "docility_serum"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/pink
 
@@ -1447,7 +1447,7 @@
 	name = "Advanced Mutation Toxin"
 	id = "mutationtoxin2"
 	result = /singleton/reagent/aslimetoxin
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 5)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 5)
 	result_amount = 1
 	required = /obj/item/slime_extract/black
 
@@ -1456,7 +1456,7 @@
 	name = "Slime Explosion"
 	id = "m_explosion"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/oil
 	mix_message = "The slime extract begins to vibrate violently!"
@@ -1484,7 +1484,7 @@
 	result = null
 	result_amount = 1
 	required = /obj/item/slime_extract/lightpink
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 5)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 5)
 
 /datum/chemical_reaction/slime/advanced_docility_serum/on_reaction(var/datum/reagents/holder)
 	..()
@@ -1495,7 +1495,7 @@
 	name = "Slime Golem"
 	id = "m_golem"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 5)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 5)
 	result_amount = 1
 	required = /obj/item/slime_extract/adamantine
 	mix_message = "A soft fizzle is heard within the slime extract, and mystic runes suddenly appear on the floor beneath it!"
@@ -1626,7 +1626,7 @@
 	name = "Extract Enhancer"
 	id = "extract_enhancer"
 	result = null
-	required_reagents = list(/singleton/reagent/toxin/phoron/base = 1)
+	required_reagents = list(/singleton/reagent/toxin/phoron/pure = 1)
 	result_amount = 1
 	required = /obj/item/slime_extract/cerulean
 
@@ -2141,7 +2141,7 @@
 	name = "Toxins Special"
 	id = "phoronspecial"
 	result = /singleton/reagent/alcohol/toxins_special
-	required_reagents = list(/singleton/reagent/alcohol/rum = 2, /singleton/reagent/alcohol/vermouth = 2, /singleton/reagent/toxin/phoron/base = 2)
+	required_reagents = list(/singleton/reagent/alcohol/rum = 2, /singleton/reagent/alcohol/vermouth = 2, /singleton/reagent/toxin/phoron/pure = 2)
 	result_amount = 6
 
 /datum/chemical_reaction/drink/beepsky_smash

--- a/code/modules/reagents/reagent_containers/food/cans.dm
+++ b/code/modules/reagents/reagent_containers/food/cans.dm
@@ -337,7 +337,7 @@
 	icon_state = "phoron_punch"
 	center_of_mass = list("x"=16, "y"=8)
 	can_size_overrides = list("x" = 1)
-	reagents_to_add = list(/singleton/reagent/kois/clean = 10, /singleton/reagent/toxin/phoron/base = 5)
+	reagents_to_add = list(/singleton/reagent/kois/clean = 10, /singleton/reagent/toxin/phoron/pure = 5)
 
 /obj/item/reagent_containers/food/drinks/cans/root_beer
 	name = "\improper RnD Root Beer"

--- a/code/modules/reagents/reagent_containers/food/cans.dm
+++ b/code/modules/reagents/reagent_containers/food/cans.dm
@@ -337,7 +337,7 @@
 	icon_state = "phoron_punch"
 	center_of_mass = list("x"=16, "y"=8)
 	can_size_overrides = list("x" = 1)
-	reagents_to_add = list(/singleton/reagent/kois/clean = 10, /singleton/reagent/toxin/phoron = 5)
+	reagents_to_add = list(/singleton/reagent/kois/clean = 10, /singleton/reagent/toxin/phoron/base = 5)
 
 /obj/item/reagent_containers/food/drinks/cans/root_beer
 	name = "\improper RnD Root Beer"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -438,7 +438,7 @@
 	trash = /obj/item/trash/koisbar
 	filling_color = "#dcd9cd"
 	bitesize = 5
-	reagents_to_add = list(/singleton/reagent/kois/clean = 10, /singleton/reagent/toxin/phoron/base = 15)
+	reagents_to_add = list(/singleton/reagent/kois/clean = 10, /singleton/reagent/toxin/phoron/pure = 15)
 
 /obj/item/reagent_containers/food/snacks/koisbar
 	name = "organic k'ois bar"
@@ -656,7 +656,7 @@
 		if(4)
 			reagents.add_reagent(/singleton/reagent/nutriment/sprinkles, 3)
 		if(5)
-			reagents.add_reagent(/singleton/reagent/toxin/phoron/base, 3)
+			reagents.add_reagent(/singleton/reagent/toxin/phoron/pure, 3)
 		if(6)
 			reagents.add_reagent(/singleton/reagent/nutriment/coco, 3)
 		if(7)
@@ -5563,7 +5563,7 @@
 	desc = "Rock candy popular in Flagsdale. Actually contains phoron."
 	icon_state = "rock_candy"
 	filling_color = "#ff22d9"
-	reagents_to_add = list(/singleton/reagent/toxin/phoron/base = 25)
+	reagents_to_add = list(/singleton/reagent/toxin/phoron/pure = 25)
 	bitesize = 5
 	trash = /obj/item/trash/phoroncandy
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -438,7 +438,7 @@
 	trash = /obj/item/trash/koisbar
 	filling_color = "#dcd9cd"
 	bitesize = 5
-	reagents_to_add = list(/singleton/reagent/kois/clean = 10, /singleton/reagent/toxin/phoron = 15)
+	reagents_to_add = list(/singleton/reagent/kois/clean = 10, /singleton/reagent/toxin/phoron/base = 15)
 
 /obj/item/reagent_containers/food/snacks/koisbar
 	name = "organic k'ois bar"
@@ -447,7 +447,7 @@
 	trash = /obj/item/trash/koisbar
 	filling_color = "#dcd9cd"
 	bitesize = 5
-	reagents_to_add = list(/singleton/reagent/kois = 10, /singleton/reagent/toxin/phoron = 15)
+	reagents_to_add = list(/singleton/reagent/kois = 10, /singleton/reagent/toxin/phoron/kois = 15)
 
 /obj/item/reagent_containers/food/snacks/salad/aesirsalad
 	name = "aesir salad"
@@ -656,7 +656,7 @@
 		if(4)
 			reagents.add_reagent(/singleton/reagent/nutriment/sprinkles, 3)
 		if(5)
-			reagents.add_reagent(/singleton/reagent/toxin/phoron, 3)
+			reagents.add_reagent(/singleton/reagent/toxin/phoron/base, 3)
 		if(6)
 			reagents.add_reagent(/singleton/reagent/nutriment/coco, 3)
 		if(7)
@@ -4094,7 +4094,7 @@
 	icon_state = "friedkois"
 	filling_color = "#E6E600"
 	bitesize = 5
-	reagents_to_add = list(/singleton/reagent/kois = 6, /singleton/reagent/toxin/phoron = 9)
+	reagents_to_add = list(/singleton/reagent/kois = 6, /singleton/reagent/toxin/phoron/kois = 9)
 
 /obj/item/reagent_containers/food/snacks/friedkois/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/stack/rods))
@@ -4114,7 +4114,7 @@
 	trash = /obj/item/stack/rods
 	filling_color = "#E6E600"
 	bitesize = 3
-	reagents_to_add = list(/singleton/reagent/kois = 8, /singleton/reagent/toxin/phoron = 12)
+	reagents_to_add = list(/singleton/reagent/kois = 8, /singleton/reagent/toxin/phoron/kois = 12)
 
 /obj/item/reagent_containers/food/snacks/koiskebab1/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/reagent_containers/food/snacks/friedkois))
@@ -4130,7 +4130,7 @@
 	trash = /obj/item/stack/rods
 	filling_color = "#E6E600"
 	bitesize = 6
-	reagents_to_add = list(/singleton/reagent/kois = 12, /singleton/reagent/toxin/phoron = 16)
+	reagents_to_add = list(/singleton/reagent/kois = 12, /singleton/reagent/toxin/phoron/kois = 16)
 
 /obj/item/reagent_containers/food/snacks/koiskebab2/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/reagent_containers/food/snacks/friedkois))
@@ -4146,7 +4146,7 @@
 	trash = /obj/item/stack/rods
 	filling_color = "#E6E600"
 	bitesize = 9
-	reagents_to_add = list(/singleton/reagent/kois = 16, /singleton/reagent/toxin/phoron = 20)
+	reagents_to_add = list(/singleton/reagent/kois = 16, /singleton/reagent/toxin/phoron/kois = 20)
 
 /obj/item/reagent_containers/food/snacks/soup/kois
 	name = "k'ois paste"
@@ -4155,7 +4155,7 @@
 	filling_color = "#4E6E600"
 	bitesize = 6
 
-	reagents_to_add = list(/singleton/reagent/kois = 15, /singleton/reagent/toxin/phoron = 15)
+	reagents_to_add = list(/singleton/reagent/kois = 15, /singleton/reagent/toxin/phoron/kois = 15)
 
 /obj/item/reagent_containers/food/snacks/koiswaffles
 	name = "k'ois waffles"
@@ -4165,7 +4165,7 @@
 	drop_sound = /singleton/sound_category/tray_hit_sound
 	filling_color = "#E6E600"
 	bitesize = 8
-	reagents_to_add = list(/singleton/reagent/kois = 25, /singleton/reagent/toxin/phoron = 15)
+	reagents_to_add = list(/singleton/reagent/kois = 25, /singleton/reagent/toxin/phoron/kois = 15)
 
 /obj/item/reagent_containers/food/snacks/koisjelly
 	name = "k'ois jelly"
@@ -4173,7 +4173,7 @@
 	icon_state = "koisjelly"
 	filling_color = "#E6E600"
 	bitesize = 10
-	reagents_to_add = list(/singleton/reagent/kois = 25, /singleton/reagent/oculine = 20, /singleton/reagent/toxin/phoron = 25)
+	reagents_to_add = list(/singleton/reagent/kois = 25, /singleton/reagent/oculine = 20, /singleton/reagent/toxin/phoron/kois = 25)
 
 //unathi snacks - sprites by Araskael
 
@@ -5435,7 +5435,7 @@
 	desc = "Some well-done k'ois, grilled to perfection."
 	icon_state = "kois_steak"
 	filling_color = "#dcd9cd"
-	reagents_to_add = list(/singleton/reagent/kois = 20, /singleton/reagent/toxin/phoron = 15)
+	reagents_to_add = list(/singleton/reagent/kois = 20, /singleton/reagent/toxin/phoron/kois = 15)
 	bitesize = 7
 
 /obj/item/reagent_containers/food/snacks/donut/kois
@@ -5444,7 +5444,7 @@
 	icon_state = "kois_donut"
 	filling_color = "#dcd9cd"
 	overlay_state = "box-kois_donut"
-	reagents_to_add = list(/singleton/reagent/kois = 15, /singleton/reagent/toxin/phoron = 10)
+	reagents_to_add = list(/singleton/reagent/kois = 15, /singleton/reagent/toxin/phoron/kois = 10)
 	bitesize = 5
 
 /obj/item/reagent_containers/food/snacks/koismuffin
@@ -5452,7 +5452,7 @@
 	desc = "Baked k'ois goop, molded into a little cake."
 	icon_state = "kois_muffin"
 	filling_color = "#dcd9cd"
-	reagents_to_add = list(/singleton/reagent/kois = 10, /singleton/reagent/toxin/phoron = 15)
+	reagents_to_add = list(/singleton/reagent/kois = 10, /singleton/reagent/toxin/phoron/kois = 15)
 	bitesize = 5
 
 /obj/item/reagent_containers/food/snacks/koisburger
@@ -5460,7 +5460,7 @@
 	desc = "K'ois inside k'ois. Peak Vaurcesian cuisine."
 	icon_state = "kois_burger"
 	filling_color = "#dcd9cd"
-	reagents_to_add = list(/singleton/reagent/kois = 20, /singleton/reagent/toxin/phoron = 20)
+	reagents_to_add = list(/singleton/reagent/kois = 20, /singleton/reagent/toxin/phoron/kois = 20)
 	bitesize = 8
 
 /obj/item/storage/box/fancy/vkrexitaffy
@@ -5563,7 +5563,7 @@
 	desc = "Rock candy popular in Flagsdale. Actually contains phoron."
 	icon_state = "rock_candy"
 	filling_color = "#ff22d9"
-	reagents_to_add = list(/singleton/reagent/toxin/phoron = 25)
+	reagents_to_add = list(/singleton/reagent/toxin/phoron/base = 25)
 	bitesize = 5
 	trash = /obj/item/trash/phoroncandy
 

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -30,7 +30,7 @@
 
 /obj/item/reagent_containers/food/snacks/meat/bug
 	filling_color = "#E6E600"
-	reagents_to_add = list(/singleton/reagent/nutriment/protein = 6, /singleton/reagent/nutriment/triglyceride = 2, /singleton/reagent/toxin/phoron = 27)
+	reagents_to_add = list(/singleton/reagent/nutriment/protein = 6, /singleton/reagent/nutriment/triglyceride = 2, /singleton/reagent/toxin/phoron/base = 27)
 	bitesize = 1.5
 
 /obj/item/reagent_containers/food/snacks/meat/monkey

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -30,7 +30,7 @@
 
 /obj/item/reagent_containers/food/snacks/meat/bug
 	filling_color = "#E6E600"
-	reagents_to_add = list(/singleton/reagent/nutriment/protein = 6, /singleton/reagent/nutriment/triglyceride = 2, /singleton/reagent/toxin/phoron/base = 27)
+	reagents_to_add = list(/singleton/reagent/nutriment/protein = 6, /singleton/reagent/nutriment/triglyceride = 2, /singleton/reagent/toxin/phoron/pure = 27)
 	bitesize = 1.5
 
 /obj/item/reagent_containers/food/snacks/meat/monkey

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -207,7 +207,7 @@
 
 /obj/item/reagent_containers/inhaler/phoron/Initialize()
 	. =..()
-	reagents.add_reagent(/singleton/reagent/toxin/phoron/base, volume)
+	reagents.add_reagent(/singleton/reagent/toxin/phoron/pure, volume)
 	update_icon()
 	return
 
@@ -221,7 +221,7 @@
 
 /obj/item/reagent_containers/inhaler/phoron_special/Initialize()
 	. =..()
-	reagents.add_reagent(/singleton/reagent/toxin/phoron/base, volume)
+	reagents.add_reagent(/singleton/reagent/toxin/phoron/pure, volume)
 	update_icon()
 	return
 

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -207,7 +207,7 @@
 
 /obj/item/reagent_containers/inhaler/phoron/Initialize()
 	. =..()
-	reagents.add_reagent(/singleton/reagent/toxin/phoron, volume)
+	reagents.add_reagent(/singleton/reagent/toxin/phoron/base, volume)
 	update_icon()
 	return
 
@@ -221,7 +221,7 @@
 
 /obj/item/reagent_containers/inhaler/phoron_special/Initialize()
 	. =..()
-	reagents.add_reagent(/singleton/reagent/toxin/phoron, volume)
+	reagents.add_reagent(/singleton/reagent/toxin/phoron/base, volume)
 	update_icon()
 	return
 

--- a/html/changelogs/Sniblet-PR-15644.yml
+++ b/html/changelogs/Sniblet-PR-15644.yml
@@ -4,5 +4,5 @@ delete-after: True
 
 changes:
   - backend: "/reagent/toxin/phoron no longer spawns in-game, replaced with three new types."
-  - rscadd: "Phoron can be phoron/base, which is the one the SCC is looking for, phoron/kois, which spawns in unfiltered k'ois bars and k'ois fungus and is only useful for Vaurca, or phoron/kois/black, which is useful for bioterrorism."
+  - rscadd: "Phoron can be phoron/base, which is the one the SCC is looking for, phoron/kois, which spawns in unfiltered k'ois bars and k'ois fungus and is only useful for poisoning, causing mycosis, and vaurca respiration, or phoron/kois/black, which is useful for bioterrorism."
   - bugfix: "This means that you can no longer solve the phoron crisis with k'ois. For now?"

--- a/html/changelogs/Sniblet-PR-15644.yml
+++ b/html/changelogs/Sniblet-PR-15644.yml
@@ -1,0 +1,8 @@
+author: Sniblet
+
+delete-after: True
+
+changes:
+  - backend: "/reagent/toxin/phoron no longer spawns in-game, replaced with three new types."
+  - rscadd: "Phoron can be phoron/base, which is the one the SCC is looking for, phoron/kois, which spawns in unfiltered k'ois bars and k'ois fungus and is only useful for Vaurca, or phoron/kois/black, which is useful for bioterrorism."
+  - bugfix: "This means that you can no longer solve the phoron crisis with k'ois. For now?"

--- a/html/changelogs/Sniblet-PR-15644.yml
+++ b/html/changelogs/Sniblet-PR-15644.yml
@@ -4,5 +4,5 @@ delete-after: True
 
 changes:
   - backend: "/reagent/toxin/phoron no longer spawns in-game, replaced with three new types."
-  - rscadd: "Phoron can be phoron/base, which is the one the SCC is looking for, phoron/kois, which spawns in unfiltered k'ois bars and k'ois fungus and is only useful for poisoning, causing mycosis, and vaurca respiration, or phoron/kois/black, which is useful for bioterrorism."
+  - rscadd: "Phoron can be phoron/pure, which is the one the SCC is looking for, phoron/kois, which spawns in unfiltered k'ois bars and k'ois fungus and is only useful for poisoning, causing mycosis, and vaurca respiration, or phoron/kois/black, which is useful for bioterrorism."
   - bugfix: "This means that you can no longer solve the phoron crisis with k'ois. For now?"


### PR DESCRIPTION
#15418

> Wow! My very first PR here and it's kinda big! I'm a bad coder and phoron is important so please review a lot!!
> 
> This splits reagent-form phoron into four types:
> toxin/phoron, which is now abstract and does not appear ingame;
> toxin/phoron/base, which does all the normal unobtanium things that phoron does and is what you get from grinding it/injecting with a vaurca hardsuit/eating filtered k'ois bars/etc;
> toxin/phoron/kois, which is only good as phoron for vaurca consumption (no chemical reactions except sedantian firestorm, doesn't work for sabotaging light tubes or whatever, etc), works as a secondary mycosis vector, and spawns in unclean k'ois snacks, k'ois mycosis procs, and the plant itself;
> toxin/phoron/kois/black, which spawns in black k'ois and does black k'ois things.
> 
> All of these will show as "Phoron" to most chemical machines, but if analyzed by a chemmaster, k'ois variants will have a bonus description sentence about biological traces. Don't drink phoron! You can never be sure that it's safe- wait.
> 
> This doesn't add gaseous k'ois phoron, partly because oh my god that's a lot of work and I'm GOING to break something trying that, partly because it'd need separate art that looks less energetic, and partly because people who're playing with k'ois phoron aren't really talking to atmos that much. If you spill phoron/kois into the air you get "safe" and functional phoron gas.
> Look.
> This is an improvement.
> I mean, if it works.
> 😩