### PR TITLE
Adjusts NanoMed Plus stock list

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -521,6 +521,7 @@
 		/obj/item/reagent_containers/glass/bottle/inaprovaline = 4,
 		/obj/item/reagent_containers/glass/bottle/perconol = 3,
 		/obj/item/reagent_containers/glass/bottle/toxin = 1,
+		/obj/item/reagent_containers/glass/bottle/stoxin = 1,
 		/obj/item/reagent_containers/glass/bottle/coagzolug = 2,
 		/obj/item/reagent_containers/glass/bottle/thetamycin = 1,
 		/obj/item/reagent_containers/syringe = 12,
@@ -541,10 +542,10 @@
 		/obj/item/reagent_containers/spray/sterilizine = 2
 	)
 	contraband = list(
-		/obj/item/reagent_containers/inhaler/space_drugs = 2,
-		/obj/item/reagent_containers/pill/tox = 3,
-		/obj/item/reagent_containers/pill/stox = 4
-	)
+		/obj/item/reagent_containers/glass/bottle/dermaline = 2,
+		/obj/item/reagent_containers/glass/bottle/butazoline = 2,
+		/obj/item/reagent_containers/glass/bottle/mortaphenyl = 2
+	) //Actually unlocks the good stuff when hacked. No dexalin plus because phoron shortage.
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 	random_itemcount = 0
 	temperature_setting = -1

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -522,7 +522,7 @@
 		/obj/item/reagent_containers/glass/bottle/perconol = 3,
 		/obj/item/reagent_containers/glass/bottle/dermaline = 2,
 		/obj/item/reagent_containers/glass/bottle/butazoline = 2,
-		/obj/item/reagent_containers/glass/bottle/mortaphenyl = 2
+		/obj/item/reagent_containers/glass/bottle/mortaphenyl = 2,
 		/obj/item/reagent_containers/glass/bottle/coagzolug = 2,
 		/obj/item/reagent_containers/glass/bottle/toxin = 1,
 		/obj/item/reagent_containers/glass/bottle/thetamycin = 1,

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -520,9 +520,11 @@
 		/obj/item/reagent_containers/glass/bottle/antitoxin = 4,
 		/obj/item/reagent_containers/glass/bottle/inaprovaline = 4,
 		/obj/item/reagent_containers/glass/bottle/perconol = 3,
-		/obj/item/reagent_containers/glass/bottle/toxin = 1,
-		/obj/item/reagent_containers/glass/bottle/stoxin = 1,
+		/obj/item/reagent_containers/glass/bottle/dermaline = 2,
+		/obj/item/reagent_containers/glass/bottle/butazoline = 2,
+		/obj/item/reagent_containers/glass/bottle/mortaphenyl = 2
 		/obj/item/reagent_containers/glass/bottle/coagzolug = 2,
+		/obj/item/reagent_containers/glass/bottle/toxin = 1,
 		/obj/item/reagent_containers/glass/bottle/thetamycin = 1,
 		/obj/item/reagent_containers/syringe = 12,
 		/obj/item/device/healthanalyzer = 5,
@@ -542,10 +544,10 @@
 		/obj/item/reagent_containers/spray/sterilizine = 2
 	)
 	contraband = list(
-		/obj/item/reagent_containers/glass/bottle/dermaline = 2,
-		/obj/item/reagent_containers/glass/bottle/butazoline = 2,
-		/obj/item/reagent_containers/glass/bottle/mortaphenyl = 2
-	) //Actually unlocks the good stuff when hacked. No dexalin plus because phoron shortage.
+		/obj/item/reagent_containers/inhaler/space_drugs = 2,
+		/obj/item/reagent_containers/pill/tox = 3,
+		/obj/item/reagent_containers/pill/stox = 4
+	)
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 	random_itemcount = 0
 	temperature_setting = -1

--- a/html/changelogs/UponASeaOfStars-PR-NanoMedPlus.yml
+++ b/html/changelogs/UponASeaOfStars-PR-NanoMedPlus.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: UponASeaOfStars
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "NanoMed Plus vendors now provide two bottles each of dermaline, mortaphenyl and butazoline when hacked, as well as one bottle of soporific normally."
+  - rscdel: "NanoMed Plus vendors no longer provide soporific and toxin pills and drug syringes when hacked."

--- a/html/changelogs/UponASeaOfStars-PR-NanoMedPlus.yml
+++ b/html/changelogs/UponASeaOfStars-PR-NanoMedPlus.yml
@@ -38,5 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "NanoMed Plus vendors now provide two bottles each of dermaline, mortaphenyl and butazoline when hacked, as well as one bottle of soporific normally."
-  - rscdel: "NanoMed Plus vendors no longer provide soporific and toxin pills and drug syringes when hacked."
+  - rscadd: "NanoMed Plus vendors now provide two bottles each of dermaline, mortaphenyl and butazoline. Your cries have been answered, medics."


### PR DESCRIPTION
* Adds dermaline, butazoline and mortaphenyl bottles (2 each).

If there's a pharmacist: nothing changes, because medical still needs a bunch of other meds, and two bottles in each vendor won't last long with a full team.
If there's no pharmacist: medbay is now slightly less fucked. They're still missing alkysine, oculine, dexplus, peridaxon, clonexadone and all the other fancy chems, but they at least have the basics.

This means that, on the many, _many_ rounds where there's no Pharmacist present, medical will survive. It won't replace the need for a Pharmacist (especially on busier rounds!), but it will help them get by in the meantime.

This is also a slight antag buff; by emagging or hacking a NanoMed Plus (of which there's usually at least one unattended on Deck 3 medical), an injured antag can grab themselves some basic medicine in an emergency - not enough to fix their sixteen bullet wounds, but enough to keep them alive while they come up with a plan.

EDIT: Adjusted to move the meds to regular stock and readd the contraband stock, because apparently it's unironically useful for dealing with grem bites? And some people had objections to the term contraband, so let's avoid that altogether.