### PR TITLE
Leg Actuator Tweaks

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -640,9 +640,6 @@
 	return T.name
 
 /obj/item/rig_module/actuators/engage(atom/target, mob/user)
-	if (!..())
-		return FALSE
-
 	// This is for when you toggle it on or off. Why do they both run the same
 	// proc chain ...? :l
 	if (!target)
@@ -669,12 +666,16 @@
 			if (combatType && ismob(aa))
 				continue
 
-			if (aa.density)
+			if (aa.density && NOT_FLAG(aa.flags, ON_BORDER))
 				to_chat(user, SPAN_WARNING("You cannot leap at a location with solid objects on it!"))
 				return FALSE
 
 	if (T.z != H.z || dist > leapDistance)
 		to_chat(user, SPAN_WARNING("You cannot leap at such a distant object!"))
+		return FALSE
+
+	. = ..()
+	if(!.)
 		return FALSE
 
 	// Handle leaping at targets with a combat capable version here.

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -493,8 +493,7 @@
 	if (istype(rig))
 		for (var/obj/item/rig_module/actuators/A in rig.installed_modules)
 			if (A.active && rig.check_power_cost(src, 10, A, 0))
-				visible_message(SPAN_NOTICE("\The [src] lands flawlessly with [src.get_pronoun("his")] [rig]."),
-					SPAN_NOTICE("You hear an electric <i>*whirr*</i> right after the slam!"))
+				visible_message(SPAN_NOTICE("\The [src] lands flawlessly with [src.get_pronoun("his")] [rig.name]."), SPAN_NOTICE("You land flawlessly with your [rig.name]."), SPAN_NOTICE("You hear an electric <i>*whirr*</i> right after a loud slam!"))
 				return FALSE
 
 	if(status_flags & GODMODE) // Godmode

--- a/code/modules/research/designs/mechfab/hardsuit/modules.dm
+++ b/code/modules/research/designs/mechfab/hardsuit/modules.dm
@@ -84,7 +84,7 @@
 	name = "Leg Actuators"
 	desc = "A set of electromechanical actuators, for safe traversal of multilevelled areas."
 	req_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 4, TECH_POWER = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 85000, MATERIAL_GLASS = 1250, MATERIAL_SILVER = 5250, MATERIAL_GOLD = 2750)
+	materials = list(DEFAULT_WALL_MATERIAL = 85000, MATERIAL_GLASS = 1250)
 	build_path = /obj/item/rig_module/actuators
 
 /datum/design/hardsuitmodules/taser_module

--- a/html/changelogs/geeves-leg_actuator_price_tweak.yml
+++ b/html/changelogs/geeves-leg_actuator_price_tweak.yml
@@ -1,0 +1,9 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "There's no longer a power cost or delay when you fail to use leg actuators."
+  - tweak: "You can now jump to a location that contains railings with leg actuators."
+  - tweak: "Removed the silver and gold cost for leg actuators in the mechfab, it just costs steel and glass now."
+  - tweak: "Tweaked the leg actuator landing messages to make more grammatical sense, and adds a self message to them."


### PR DESCRIPTION
* There's no longer a power cost or delay when you fail to use leg actuators.
* You can now jump to a location that contains railings with leg actuators.
* Removed the silver and gold cost for leg actuators in the mechfab, it just costs steel and glass now.
* Tweaked the leg actuator landing messages to make more grammatical sense, and adds a self message to them.