### PR TITLE
Destroys SS13 culture: Bags of Holding no more

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -84,8 +84,8 @@
  */
 
 /obj/item/storage/backpack/holding
-	name = "bag of holding"
-	desc = "A backpack that opens into a localized pocket of Blue Space."
+	name = "portable bluespace pocket"
+	desc = "A backpack that opens into a localized pocket of bluespace. Extremely dangerous, and officially these devices do not exist. Officially."
 	origin_tech = list(TECH_BLUESPACE = 4)
 	icon_state = "holdingpack"
 	item_state = "holdingpack"

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -423,7 +423,6 @@
 	name = "random backpack"
 	problist = list(
 		/obj/item/storage/backpack = 3,
-		/obj/item/storage/backpack/holding = 0.5,
 		/obj/item/storage/backpack/cultpack = 2,
 		/obj/item/storage/backpack/medic = 3,
 		/obj/item/storage/backpack/security = 3,

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -1,10 +1,3 @@
-/datum/bounty/item/science/boh
-	name = "Bag of Holding"
-	description = "%COMPNAME would make good use of a high-capacity backpack. If you have any, please ship them."
-	reward_low = 6000
-	reward_high = 7200
-	wanted_types = list(/obj/item/storage/backpack/holding)
-
 /datum/bounty/item/science/nightvision_goggles
 	name = "Night Vision Goggles"
 	description = "An electrical storm has busted all the lights at %BOSSSHORT. While management is waiting for replacements, perhaps some night vision goggles can be shipped?"

--- a/code/modules/holidays/christmas/props.dm
+++ b/code/modules/holidays/christmas/props.dm
@@ -101,7 +101,6 @@
 		/obj/item/storage/photo_album,
 		/obj/item/storage/box/snappops,
 		/obj/item/storage/box/fancy/crayons,
-		/obj/item/storage/backpack/holding,
 		/obj/item/storage/belt/champion,
 		/obj/item/soap/deluxe,
 		/obj/item/pickaxe/silver,

--- a/code/modules/research/designs/protolathe/tool_designs.dm
+++ b/code/modules/research/designs/protolathe/tool_designs.dm
@@ -30,13 +30,6 @@ datum/design/item/tool/advanced_light_replacer
 	materials = list(DEFAULT_WALL_MATERIAL = 2500, MATERIAL_GLASS = 200)
 	build_path = /obj/item/mop/advanced
 
-/datum/design/item/tool/blutrash
-	name = "Trashbag of Holding"
-	desc = "An advanced trash bag with bluespace properties; capable of holding a plethora of garbage."
-	build_type = PROTOLATHE
-	materials = list(MATERIAL_GOLD = 1500, MATERIAL_URANIUM = 250, MATERIAL_PHORON = 1500)
-	build_path = /obj/item/storage/bag/trash/bluespace
-
 /datum/design/item/tool/mmi
 	name = "Man-Machine Interface"
 	req_tech = list(TECH_DATA = 2, TECH_BIO = 3)
@@ -62,12 +55,6 @@ datum/design/item/tool/advanced_light_replacer
 	req_tech = list(TECH_BLUESPACE = 1)
 	materials = list (DEFAULT_WALL_MATERIAL = 20, MATERIAL_GLASS = 10)
 	build_path = /obj/item/device/radio/beacon
-
-/datum/design/item/tool/bag_holding
-	desc = "Using localized pockets of bluespace, this bag prototype offers incredible storage capacity, while the contents apply no weight to the external user. It's a shame the bag itself is pretty heavy."
-	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 6)
-	materials = list(MATERIAL_GOLD = 3000, MATERIAL_DIAMOND = 1500, MATERIAL_URANIUM = 250)
-	build_path = /obj/item/storage/backpack/holding
 
 /datum/design/item/tool/power_cell_backpack
 	req_tech = list(TECH_MATERIAL = 4, TECH_MAGNET = 2, TECH_POWER = 4)

--- a/html/changelogs/dansemacabre-nomorebags.yml
+++ b/html/changelogs/dansemacabre-nomorebags.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheDanseMacabre
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Bags of holding have been renamed and made adminspawn only."


### PR DESCRIPTION
 Bags of holding (trash and normal) have been made adminspawn only and refluffed to have names that are not outright references. There is still some utility to having them in the game, though, so they are not being outright removed. If I was to get a better sprite I'd be happy to undo some of these changes, but as it is I don't think they should be spawnable.