### PR TITLE
Grenade Manufacturing

### DIFF
--- a/code/game/machinery/autolathe/autolathe_datums.dm
+++ b/code/game/machinery/autolathe/autolathe_datums.dm
@@ -599,3 +599,13 @@
 	path = /obj/item/clothing/gloves/brassknuckles
 	hidden = 1
 	category = "General"
+
+/datum/autolathe/recipe/grenade
+	name = "grenade casing"
+	path = /obj/item/grenade/chem_grenade
+	category = "Arms and Ammunition"
+
+/datum/autolathe/recipe/grenade/large
+	name = "large grenade casing"
+	path = /obj/item/grenade/chem_grenade/large
+	hidden = TRUE

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -15,6 +15,8 @@
 	var/list/allowed_containers = list(/obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle)
 	var/affected_area = 3
 
+	matter = list(DEFAULT_WALL_MATERIAL = 700, MATERIAL_GLASS = 300)
+
 /obj/item/grenade/chem_grenade/Initialize()
 	. = ..()
 	create_reagents(1000)
@@ -189,6 +191,8 @@
 	allowed_containers = list(/obj/item/reagent_containers/glass)
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	affected_area = 4
+
+	matter = list(DEFAULT_WALL_MATERIAL = 1000, MATERIAL_GLASS = 500)
 
 /obj/item/grenade/chem_grenade/metalfoam
 	name = "metal-foam grenade"

--- a/code/modules/research/designs/protolathe/weapon_designs.dm
+++ b/code/modules/research/designs/protolathe/weapon_designs.dm
@@ -40,11 +40,6 @@
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, MATERIAL_GLASS = 500, MATERIAL_SILVER = 3000)
 	build_path = /obj/item/gun/energy/temperature
 
-/datum/design/item/weapon/large_grenade
-	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 3000)
-	build_path = /obj/item/grenade/chem_grenade/large
-
 /datum/design/item/weapon/eglaive
 	req_tech = list(TECH_COMBAT = 6, TECH_PHORON = 4, TECH_MATERIAL = 7, TECH_ILLEGAL = 4, TECH_POWER = 4)
 	materials = list(DEFAULT_WALL_MATERIAL = 10000, MATERIAL_GLASS = 18750, MATERIAL_PHORON = 3000, MATERIAL_SILVER = 7500)

--- a/html/changelogs/geeves-large_grenades.yml
+++ b/html/changelogs/geeves-large_grenades.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Added grenade and large grenade casings to the Autolathe, under the Arms and Ammunition section. Large casings are only available in hacked lathes."
+  - rscdel: "Removed the option to print large grenade casings from Protolathes."


### PR DESCRIPTION
* Added grenade and large grenade casings to the Autolathe, under the Arms and Ammunition section. Large casings are only available in hacked lathes.
* Removed the option to print large grenade casings from Protolathes.