### PR TITLE
Adds first aid kits and welding helmets to the PRA Mining Camp

### DIFF
--- a/html/changelogs/praminingtweaks.yml
+++ b/html/changelogs/praminingtweaks.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - maptweak: adds welding helmets and first aid kits to the PRA mining camp away site
+  - maptweak: "Adds welding helmets and first aid kits to the PRA mining camp away site."

--- a/html/changelogs/praminingtweaks.yml
+++ b/html/changelogs/praminingtweaks.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: adds welding helmets and first aid kits to the PRA mining camp away site

--- a/maps/random_ruins/exoplanets/adhomai/pra_mining_camp.dmm
+++ b/maps/random_ruins/exoplanets/adhomai/pra_mining_camp.dmm
@@ -221,6 +221,15 @@
 	temperature = 268.15
 	},
 /area/pra_mining_camp)
+"um" = (
+/obj/structure/closet/crate/plastic,
+/obj/item/storage/firstaid,
+/obj/item/storage/firstaid,
+/obj/item/storage/firstaid,
+/turf/simulated/floor/concrete{
+	temperature = 268.15
+	},
+/area/pra_mining_camp)
 "up" = (
 /obj/machinery/light{
 	dir = 8
@@ -614,6 +623,8 @@
 /obj/item/device/analyzer,
 /obj/item/device/analyzer,
 /obj/item/device/analyzer,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
 /turf/simulated/floor/concrete{
 	temperature = 268.15
 	},
@@ -1140,7 +1151,7 @@ Hg
 Hg
 Hg
 Mq
-zx
+um
 uN
 ct
 Gq


### PR DESCRIPTION
The welding helmets are so that the Tesla suits can get fixed up without eye damage, and the first aid kits are just so one hostile mob doesn't absolutely gamer the mining team.