### PR TITLE
Tail Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1478,6 +1478,8 @@
 	if(change_hair)
 		species.set_default_hair(src)
 
+	species.set_default_tail(src)
+
 	if(species)
 		return 1
 	else

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -710,6 +710,9 @@
 	H.g_style = H.species.default_g_style
 	H.update_hair()
 
+/datum/species/proc/set_default_tail(var/mob/living/carbon/human/H)
+	H.set_tail_style(H.species.tail)
+
 /datum/species/proc/get_species_tally(var/mob/living/carbon/human/H)
 	return 0
 

--- a/html/changelogs/ramke-tail_bugfix.yml
+++ b/html/changelogs/ramke-tail_bugfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ramke
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Tails will now appear on ghost roles and spawned mobs that are meant to have a tail."


### PR DESCRIPTION
After Tail Overhaul 2 was merged, mobs that are meant to have tails (Tajara, Unathi, etc.) did not get them when they were spawned in (either ghost roles, commands or proto). 

This PR fixes it by adding a proc to set_species to force it on.