### PR TITLE
Crew Armory Fixes And Stuff Thanks!

### DIFF
--- a/html/changelogs/dansemacabre-ammo.yml
+++ b/html/changelogs/dansemacabre-ammo.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "The 10mm pistol and ammo lockers in the crew armory are now properly labelled, and the liquid sandbags and barbed wire will now spawn at the top of the item rack."
+  - bugfix: "The 10mm pistol and ammo lockers in the crew armory are now properly labelled, and the fortification supplies are better organized."

--- a/html/changelogs/dansemacabre-ammo.yml
+++ b/html/changelogs/dansemacabre-ammo.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheDanseMacabre
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The 10mm pistol and ammo lockers in the crew armory are now properly labelled, and the liquid sandbags and barbed wire will now spawn at the top of the item rack."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -1144,7 +1144,7 @@
 /area/horizon/security/meeting_room)
 "aRw" = (
 /obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (.45 Pistol and Holsters)";
+	name = "Weaponry (10mm Pistol and Holsters)";
 	req_access = null;
 	req_one_access = list(3,19)
 	},
@@ -26088,7 +26088,7 @@
 /area/medical/ward/isolation)
 "uUy" = (
 /obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (.45 Magazines)";
+	name = "Weaponry (10mm Ammunition)";
 	req_access = null;
 	req_one_access = list(3,19)
 	},
@@ -30193,14 +30193,14 @@
 /area/horizon/crew_quarters/fitness/lounge)
 "ygT" = (
 /obj/structure/table/rack,
+/obj/item/stack/liquidbags/half_full,
+/obj/item/stack/barbed_wire/half_full,
 /obj/item/stack/material/plasteel{
 	amount = 20
 	},
 /obj/item/stack/material/steel/full,
 /obj/item/stack/material/steel/full,
 /obj/item/stack/material/steel/full,
-/obj/item/stack/liquidbags/half_full,
-/obj/item/stack/barbed_wire/half_full,
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -30193,14 +30193,28 @@
 /area/horizon/crew_quarters/fitness/lounge)
 "ygT" = (
 /obj/structure/table/rack,
-/obj/item/stack/liquidbags/half_full,
-/obj/item/stack/barbed_wire/half_full,
-/obj/item/stack/material/plasteel{
-	amount = 20
+/obj/item/stack/liquidbags/half_full{
+	pixel_x = -5;
+	pixel_y = -3
 	},
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/steel/full,
+/obj/item/stack/barbed_wire/half_full{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/stack/material/plasteel{
+	amount = 20;
+	pixel_y = 3;
+	pixel_x = 5
+	},
+/obj/item/stack/material/steel/full{
+	pixel_x = 5
+	},
+/obj/item/stack/material/steel/full{
+	pixel_x = 5
+	},
+/obj/item/stack/material/steel/full{
+	pixel_x = 5
+	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},


### PR DESCRIPTION
This PR fixes the labels on the pistol and pistol ammo lockers being wrong (Wonder who did that?) and also organizes the fortification equipment so it's easier to parse what is on the rack at a glance.