### PR TITLE
Makes some overmap items less generic

### DIFF
--- a/code/modules/maps/planet_types/barren.dm
+++ b/code/modules/maps/planet_types/barren.dm
@@ -59,10 +59,6 @@
 	if(prob(20))
 		overlays += image('icons/turf/decals/decals.dmi', "asteroid[rand(0,9)]")
 
-/obj/effect/overmap/visitable/sector/exoplanet/barren/Initialize()
-  . = ..()
-  icon_state = "asteroid[rand(1,3)]"
-
 /turf/simulated/floor/exoplanet/barren/Initialize()
 	. = ..()
 	update_icon()
@@ -98,6 +94,9 @@
 		/datum/map_template/ruin/exoplanet/carp_nest,
 		/datum/map_template/ruin/exoplanet/drill_site)
 	place_near_main = list(1, 1)
+
+/obj/effect/overmap/visitable/sector/exoplanet/barren/asteroid/update_icon()
+  icon_state = "asteroid[rand(1,3)]"
 
 /obj/effect/overmap/visitable/sector/exoplanet/barren/asteroid/generate_planet_image()
 	skybox_image = image('icons/skybox/skybox_rock_128.dmi', "bigrock")

--- a/code/modules/maps/planet_types/lore/srandmarr.dm
+++ b/code/modules/maps/planet_types/lore/srandmarr.dm
@@ -3,6 +3,7 @@
 	name = "Ae'themir"
 	desc = "A planet comprised mainly of solid common minerals and silicate."
 	color = "#B1A69B"
+	icon_state = "globe1"
 	rock_colors = list(COLOR_GRAY80)
 	possible_themes = list(/datum/exoplanet_theme/mountains)
 	map_generators = list(/datum/random_map/noise/exoplanet/barren, /datum/random_map/noise/ore)
@@ -21,11 +22,15 @@
 /obj/effect/overmap/visitable/sector/exoplanet/barren/aethemir/get_surface_color()
 	return "#B1A69B"
 
+/obj/effect/overmap/visitable/sector/exoplanet/barren/aethemir/update_icon()
+	return
+
 //Az'Mar
 /obj/effect/overmap/visitable/sector/exoplanet/barren/azmar
 	name = "Az'Mar"
 	desc = "A small planet with a caustic shale crust. The surface is extremely hot and dense."
 	color = "#4a3f41"
+	icon_state = "globe2"
 	rock_colors = null
 	plant_colors = null
 	rock_colors = list("#4a3f41")
@@ -50,17 +55,25 @@
 		atmosphere.temperature = T0C + 500
 		atmosphere.update_values()
 
+/obj/effect/overmap/visitable/sector/exoplanet/barren/azmar/update_icon()
+	return
+
 //Sahul
 /obj/effect/overmap/visitable/sector/exoplanet/lava/sahul
 	name = "Sahul"
 	desc = "Az'mar's moon is a celestial body composed primarily of molten metals."
+	icon_state = "globe1"
 	generated_name = FALSE
 	ring_chance = 0
+
+/obj/effect/overmap/visitable/sector/exoplanet/lava/sahul/update_icon()
+	return
 
 //Raskara
 /obj/effect/overmap/visitable/sector/exoplanet/barren/raskara
 	name = "Raskara"
 	desc = "A barren moon orbiting Adhomai."
+	icon_state = "globe1"
 	color = "#373737"
 	rock_colors = list("#373737")
 	planetary_area = /area/exoplanet/barren/raskara
@@ -75,6 +88,9 @@
 
 /obj/effect/overmap/visitable/sector/exoplanet/barren/raskara/get_surface_color()
 	return "#373737"
+
+/obj/effect/overmap/visitable/sector/exoplanet/barren/raskara/update_icon()
+	return
 
 /obj/effect/overmap/visitable/sector/exoplanet/barren/raskara/generate_planet_image()
 	skybox_image = image('icons/skybox/lore_planets.dmi', "raskara")
@@ -102,7 +118,8 @@
 /obj/effect/overmap/visitable/sector/exoplanet/adhomai
 	name = "Adhomai"
 	desc = "The Tajaran homeworld. Adhomai is a cold and icy world, suffering from almost perpetual snowfall and extremely low temperatures."
-	color = "#dcdcdc"
+	icon_state = "globe2"
+	color = "#b5dfeb"
 	planetary_area = /area/exoplanet/adhomai
 	rock_colors = null
 	plant_colors = null
@@ -163,6 +180,9 @@
 	if(atmosphere)
 		atmosphere.temperature = T0C - 5
 		atmosphere.update_values()
+
+/obj/effect/overmap/visitable/sector/exoplanet/adhomai/update_icon()
+	return
 
 /datum/random_map/noise/exoplanet/snow/adhomai
 	descriptor = "Adhomai"

--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -63,7 +63,10 @@
 
 /obj/effect/overmap/visitable/sector/exoplanet/Initialize()
   . = ..()
-  icon_state = "globe[rand(1,3)]"
+  update_icon()
+
+/obj/effect/overmap/visitable/sector/exoplanet/update_icon()
+	icon_state = "globe[rand(1,3)]"
 
 /obj/effect/overmap/visitable/sector/exoplanet/New(nloc, max_x, max_y)
 	if(!current_map.use_overmap)

--- a/html/changelogs/alberyk-overmapcolors.yml
+++ b/html/changelogs/alberyk-overmapcolors.yml
@@ -1,0 +1,7 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - tweak: "Some away sites have different sprites and colors."
+  - tweak: "S'rand'marr overmap planet objects now have lore accurate icons."

--- a/maps/away/away_site/tajara/mining_jack/mining_jack.dm
+++ b/maps/away/away_site/tajara/mining_jack/mining_jack.dm
@@ -29,7 +29,7 @@
 		"Mining Jack" = list("nav_hangar_tajara_mining_jack")
 	)
 	comms_support = TRUE
-	comms_name = "adhomian"
+	comms_name = "adhomian mining"
 
 /obj/effect/shuttle_landmark/tajara_mining_jack
 	base_turf = /turf/space
@@ -54,8 +54,9 @@
 	class = "ACV"
 	desc = "A modified skipjack used by Tajaran miners. These models have been modified to mine as much as possible with a small crew. Due to its limited fuel supply, it usually does not go too far from its home base."
 	shuttle = "Mining Jack"
-	icon_state = "shuttle_grey"
-	moving_state = "shuttle_grey_moving"
+	icon_state = "shuttle"
+	moving_state = "shuttle_moving"
+	colors = list("#DAA06D")
 	max_speed = 1/(3 SECONDS)
 	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod

--- a/maps/away/away_site/tajara/mining_jack/mining_jack.dm
+++ b/maps/away/away_site/tajara/mining_jack/mining_jack.dm
@@ -15,6 +15,11 @@
 /obj/effect/overmap/visitable/sector/tajara_mining_jack
 	name = "adhomian mining outpost"
 	desc = "An outpost used by the crew of adhomian mining jacks."
+
+	icon = 'icons/obj/overmap/overmap_stationary.dmi'
+	icon_state = "outpost"
+	color = "#DAA06D"
+
 	initial_generic_waypoints = list(
 		"nav_tajara_mining_jack_1",
 		"nav_tajara_mining_jack_2",

--- a/maps/away/away_site/tajara/peoples_station/peoples_station.dm
+++ b/maps/away/away_site/tajara/peoples_station/peoples_station.dm
@@ -15,6 +15,11 @@
 /obj/effect/overmap/visitable/sector/peoples_station
 	name = "People's Space Station"
 	desc = "Built in the interwar period, the People's Space Station bears the prestige of being the first space installation designed, constructed, and manned by Tajara."
+
+	icon = 'icons/obj/overmap/overmap_stationary.dmi'
+	icon_state = "battlestation"
+	color = "#8A3324"
+
 	initial_generic_waypoints = list(
 		"nav_peoples_station_ship_1",
 		"nav_peoples_station_ship_1",

--- a/maps/away/away_site/tajara/peoples_station/peoples_station.dm
+++ b/maps/away/away_site/tajara/peoples_station/peoples_station.dm
@@ -57,7 +57,7 @@
 	desc = "An interceptor used by the Orbital Fleet in its carriers and stations."
 	shuttle = "Orbital Fleet Fang"
 	icon_state = "shuttle"
-	moving_state = "shuttle_red_moving"
+	moving_state = "shuttle_moving"
 	max_speed = 1/(1 SECONDS)
 	burn_delay = 1 SECONDS
 	vessel_mass = 3000

--- a/maps/away/away_site/tajara/saniorios_smuggler/saniorios_smuggler.dm
+++ b/maps/away/away_site/tajara/saniorios_smuggler/saniorios_smuggler.dm
@@ -14,7 +14,7 @@
 /obj/effect/overmap/visitable/sector/saniorios_smuggler
 	name = "Sani'Orios"
 	desc = "A gas giant composed of ammonia. Its planetary ring is home to several spaceship wrecks and hidden smuggler bases."
-	icon_state = "globe"
+	icon_state = "globe3"
 	color = COLOR_DARK_BLUE_GRAY
 
 /obj/effect/overmap/visitable/sector/saniorios_smuggler/get_skybox_representation()

--- a/maps/away/away_site/tajara/scrapper/scrapper.dm
+++ b/maps/away/away_site/tajara/scrapper/scrapper.dm
@@ -24,7 +24,8 @@
 		"Scrapper Ship" = list("nav_hangar_tajara_scrapper")
 	)
 	comms_support = TRUE
-	comms_name = "adhomian"
+	comms_name = "adhomian scrapper"
+	color = "#DAA06D"
 
 /obj/effect/shuttle_landmark/tajara_scrapper
 	base_turf = /turf/space
@@ -49,8 +50,9 @@
 	class = "ACV"
 	desc = "A horseshoe-shaped ship used by Adhomian Scrappers. Frequently used in repairs and scrapping operations."
 	shuttle = "Scrapper Ship"
-	icon_state = "shuttle_grey"
-	moving_state = "shuttle_grey_moving"
+	icon_state = "skipjack"
+	moving_state = "skipjack_moving"
+	colors = list("#DAA06D")
 	max_speed = 1/(3 SECONDS)
 	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod

--- a/maps/away/away_site/tajara/taj_safehouse/tajara_safehouse.dm
+++ b/maps/away/away_site/tajara/taj_safehouse/tajara_safehouse.dm
@@ -48,8 +48,9 @@
 	designation = "Civilian Shuttle"
 	desc = "A civilian shuttle without any kind of identification."
 	shuttle = "Unmarked Civilian Shuttle"
-	icon_state = "shuttle_grey"
-	moving_state = "shuttle_grey_moving"
+	icon_state = "shuttle"
+	moving_state = "shuttle_moving"
+	colors = list("#CD4A4C")
 	max_speed = 1/(3 SECONDS)
 	burn_delay = 2 SECONDS
 	vessel_mass = 3000 //very inefficient pod

--- a/maps/away/away_site/tajara/taj_safehouse/tajara_safehouse.dm
+++ b/maps/away/away_site/tajara/taj_safehouse/tajara_safehouse.dm
@@ -15,6 +15,11 @@
 /obj/effect/overmap/visitable/sector/tajara_safehouse
 	name = "abandoned outpost"
 	desc = "A derelict space outpost."
+
+	icon = 'icons/obj/overmap/overmap_stationary.dmi'
+	icon_state = "outpost"
+	color = "#CD4A4C"
+
 	initial_restricted_waypoints = list(
 		"Unmarked Civilian Shuttle" = list("nav_hangar_tajara_safehouse")
 	)

--- a/maps/away/away_site/unathi_pirate/unathi_pirate_izharshan.dm
+++ b/maps/away/away_site/unathi_pirate/unathi_pirate_izharshan.dm
@@ -76,8 +76,9 @@
 	shuttle = "Izharshan Freighter"
 	designation = "Anvil"
 	desc = "Though the sensors identify the engine signature and overall rough profile of the signal as being from an older Hegemonic Brick-class civilian freight shuttle, many modifications are detected, such as possible anti-ship weaponry onboard."
-	icon_state = "shuttle_green"
-	moving_state = "shuttle_green_moving"
+	icon_state = "generic"
+	moving_state = "generic_moving"
+	colors = list("#95de9c")
 	max_speed = 1/(2 SECONDS)
 	burn_delay = 2 SECONDS
 	vessel_mass = 7500 //This truck is too damn big

--- a/maps/away/ships/dpra/hailstorm/hailstorm_ship.dm
+++ b/maps/away/ships/dpra/hailstorm/hailstorm_ship.dm
@@ -18,7 +18,7 @@
 	class = "DPRAMV" //Democratic People's Republic of Adhomai Vessel
 	icon_state = "hailstorm"
 	moving_state = "hailstorm_moving"
-	colors = list("#f0d295", "#ecb037")
+	colors = list("B9BDC4")
 	vessel_mass = 10000
 	max_speed = 1/(2 SECONDS)
 	fore_dir = NORTH
@@ -64,7 +64,7 @@
 	desc = "A simple and reliable shuttle design used by the Spacer Militia Shuttle."
 	icon_state = "shuttle"
 	moving_state = "shuttle_moving"
-	colors = list("#f0d295", "#ecb037")
+	colors = list("B9BDC4")
 	class = "DPRAMV"
 	designation = "Yve'kha"
 	shuttle = "Spacer Militia Shuttle"

--- a/maps/away/ships/pra/database_freighter/database_freighter.dm
+++ b/maps/away/ships/pra/database_freighter/database_freighter.dm
@@ -18,7 +18,7 @@
 	class = "PRAMV" //People's Republic of Adhomai Vessel
 	icon_state = "tramp"
 	moving_state = "tramp_moving"
-	colors = list("#fad89f", "#f1d378")
+	colors = list("#8A3324")
 	vessel_mass = 10000
 	max_speed = 1/(2 SECONDS)
 	fore_dir = NORTH
@@ -66,7 +66,7 @@
 	desc = "A simple and reliable shuttle design used by the Orbital Fleet."
 	icon_state = "shuttle"
 	moving_state = "shuttle_moving"
-	colors = list("#fad89f", "#f1d378")
+	colors = list("#8A3324")
 	class = "PRAMV"
 	designation = "Yve'kha"
 	shuttle = "Database Freighter Shuttle"

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dm
@@ -18,7 +18,7 @@
 	class = "PRAMV" //People's Republic of Adhomai Vessel
 	icon_state = "headmaster"
 	moving_state = "headmaster_moving"
-	colors = list("#fad89f", "#f1d378")
+	colors = list("#8A3324")
 	vessel_mass = 10000
 	max_speed = 1/(2 SECONDS)
 	fore_dir = NORTH
@@ -66,7 +66,7 @@
 	desc = "A simple and reliable shuttle design used by the Orbital Fleet."
 	icon_state = "shuttle"
 	moving_state = "shuttle_moving"
-	colors = list("#fad89f", "#f1d378")
+	colors = list("#8A3324")
 	class = "PRAMV"
 	designation = "Yve'kha"
 	shuttle = "Orbital Fleet Shuttle"


### PR DESCRIPTION
This pr makes it so that you can control more the overmap icon of the planets.

All S'rand'marr planets had their icon set to something more lore accurate.
Some away sites got the new icons that were not used anywhere.
-fixes #15792