### PR TITLE
Event Items Framework

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -1545,6 +1545,7 @@
 #include "code\modules\client\preference_setup\loadout\loadout_computer.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_cosmetics.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_ears.dm"
+#include "code\modules\client\preference_setup\loadout\loadout_events.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_eyes.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_factions.dm"
 #include "code\modules\client\preference_setup\loadout\loadout_general.dm"

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -119,10 +119,12 @@
 		query.Execute(list("id" = text2num(pref.current_character)))
 
 		if (query.NextRow())
-			if (text2num(query.item[1]) > 5)
+			var/character_age = text2num(query.item[1])
+			if (character_age > 5)
 				pref.can_edit_name = FALSE
 				if(config.ipc_timelock_active)
 					pref.can_edit_ipc_tag = FALSE
+				pref.days_character_existed = character_age
 		else
 			error("SQL CHARACTER LOAD: Logic error, general/basic/load_special() didn't return any rows when it should have.")
 			log_debug("SQL CHARACTER LOAD: Logic error, general/basic/load_special() didn't return any rows when it should have. Character ID: [pref.current_character].")

--- a/code/modules/client/preference_setup/loadout/loadout_events.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_events.dm
@@ -1,0 +1,14 @@
+/datum/gear/event
+	sort_category = "Event Items"
+	display_name = "Example Entry"
+	header_title = "Example Header"
+	always_use_available_items_list = TRUE
+	hide_if_cant_spawn = TRUE
+	slot = slot_in_backpack
+	cost = 1
+	character_existed_before_date = -1
+	path = /obj/item/gun/energy/lawgiver
+
+/datum/gear/event/yesterday
+	display_name = "Example Entry 2"
+	path = /obj/item/gun/energy/lawgiver

--- a/code/modules/client/preference_setup/loadout/loadout_events.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_events.dm
@@ -9,6 +9,6 @@
 	character_existed_before_date = -1
 	path = /obj/item/gun/energy/lawgiver
 
-/datum/gear/event/yesterday
+/datum/gear/event/another_item
 	display_name = "Example Entry 2"
 	path = /obj/item/gun/energy/lawgiver

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -36,6 +36,7 @@ datum/preferences
 	var/real_name						//our character's name
 	var/can_edit_name = TRUE				//Whether or not a character's name can be edited. Used with SQL saving.
 	var/can_edit_ipc_tag = TRUE
+	var/days_character_existed = INFINITY
 	var/gender = MALE					//gender of character (well duh)
 	var/pronouns = NEUTER				//what the character will appear as to others when examined
 	var/age = 30						//age of character


### PR DESCRIPTION
Made a framework for adding event items to the loadout, but restricting it only to character that could feasibly have been at the event. This is done by adding the date the event was ran into the loadout item, meaning only character created before that date has that item available in the loadout.

![image](https://user-images.githubusercontent.com/22774890/218306335-64a7847c-821e-4fac-a659-d736dddd2915.png)

Also adds an optional header, which you can use to name the group of items, with the event's name or whatever you want.