### PR TITLE
Industrial Hardsuit Armor Buff

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -71,11 +71,11 @@
 	icon_state = "industrial_rig"
 	icon_supported_species_tags = list("ipc", "skr", "taj", "una")
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT,
+		melee = ARMOR_MELEE_MAJOR,
 		bullet = ARMOR_BALLISTIC_PISTOL,
-		laser = ARMOR_LASER_MINOR,
+		laser = ARMOR_LASER_SMALL,
 		energy = ARMOR_ENERGY_MINOR,
-		bomb = ARMOR_BOMB_PADDED,
+		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
 	)

--- a/html/changelogs/geeves-industrial_hardsuit_armor.yml
+++ b/html/changelogs/geeves-industrial_hardsuit_armor.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Increased the melee, laser, and bomb resistances of the industrial hardsuit."


### PR DESCRIPTION
* Increased the melee, laser, and bomb resistances of the industrial hardsuit.

since simple mobs now go simple saiyan, might as well buff the hardsuit so it's worth using over the standard voidsuit