### PR TITLE
Hardsuit Access Disabling

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -182,7 +182,7 @@
 		to_chat(user, SPAN_WARNING("The suit cannot function while the wearer is prone."))
 		return FALSE
 
-	if(holder.security_check_enabled && !holder.check_suit_access(user))
+	if(holder.security_check_enabled && holder.locked && !holder.check_suit_access(user))
 		to_chat(user, SPAN_DANGER("Access denied."))
 		return FALSE
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -569,7 +569,7 @@
 
 /obj/item/rig/proc/check_suit_access(var/mob/living/carbon/human/user)
 
-	if(!security_check_enabled)
+	if(!security_check_enabled || !locked)
 		return 1
 
 	if(istype(user))

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -22,7 +22,7 @@
 			to_chat(user, "<span class='danger'>\The [src] doesn't seem to have a locking mechanism.</span>")
 			return
 
-		if(security_check_enabled && !src.allowed(user))
+		if(security_check_enabled && locked && !src.allowed(user))
 			to_chat(user, "<span class='danger'>Access denied.</span>")
 			return
 

--- a/html/changelogs/geeves-hardsuit_access_disabling.yml
+++ b/html/changelogs/geeves-hardsuit_access_disabling.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Disabling the access lock on a hardsuit maintenance panel now unlocks the hardsuit entirely, meaning anyone can use it."


### PR DESCRIPTION
* Disabling the access lock on a hardsuit maintenance panel now unlocks the hardsuit entirely, meaning anyone can use it.