### PR TITLE
Removes access requirement on bridge hallway doors

### DIFF
--- a/html/changelogs/anconfuzedrock-bridgedoortime.yml
+++ b/html/changelogs/anconfuzedrock-bridgedoortime.yml
@@ -1,0 +1,9 @@
+
+# Your name.
+author: anconfuzedrock
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - tweak: "The bridge outer hallway no longer requires access to enter."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -6587,11 +6587,9 @@
 /area/bridge/aibunker)
 "fxj" = (
 /obj/machinery/door/firedoor,
-/obj/effect/map_effect/door_helper/unres,
 /obj/machinery/door/airlock/glass_command{
 	id_tag = "sbridgedoor";
-	name = "Bridge";
-	req_one_access = list(19,38,72)
+	name = "Bridge"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6696,11 +6694,9 @@
 /area/horizon/crew_quarters/fitness/hallway)
 "fBZ" = (
 /obj/machinery/door/firedoor,
-/obj/effect/map_effect/door_helper/unres,
 /obj/machinery/door/airlock/glass_command{
 	id_tag = "sbridgedoor";
-	name = "Bridge";
-	req_one_access = list(19,38,72)
+	name = "Bridge"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
@@ -16897,10 +16893,8 @@
 "nLc" = (
 /obj/machinery/door/airlock/glass_command{
 	id_tag = "sbridgedoor";
-	name = "Bridge";
-	req_one_access = list(19,38,72)
+	name = "Bridge"
 	},
-/obj/effect/map_effect/door_helper/unres,
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,


### PR DESCRIPTION
This allows people without bridge access to enter the hallway where the stargazer is. 
Why it's good:
-Bridge crew are incredibly isolated from the rest of the crew if they stay in the bridge. They're like little elves up at the north pole, I'm not even sure they're real if they're doing their job. You can't even visit 'em. Every time bridge crew want to let people in to the bridge they have to walk down this big purposeless hallway. This cuts down on the walking.
-This lets the hallway actually matter. it has a buncha chairs in it that never get used, it's a big nothing room right now.
-This actually makes the bridge MORE SECURE. right now most breakins don't go through these front two doors, and anyone responding has to get through four doors total. these 2 doors before u can even see the bridge don't make it any more fun.

Why it isn't bad:
-No security is lost by making this hallway public. If you know baddies are coming you can press the button to lock it down. If you DON'T know baddies are coming, you won't even hear them breaking in these doors, because they're in the hallway. they do nothing for security. The meeting room nearby has tinted windows, too. At worst this makes it easier to break into tcomms, but it also makes it easier to keep an eye on people breaking into tcomms.
-This doesn't really disrupt the privacy of the bridge much, either. Even the second set of bridge double-doors isolates it from the rest of the ship, enough that you can't see most of the bridge proper.
