### PR TITLE
fixes medical computers lacking the download program

### DIFF
--- a/code/modules/modular_computers/file_system/programs/app_presets.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets.dm
@@ -102,6 +102,7 @@
 
 /datum/modular_computer_app_presets/medical/return_install_programs(obj/item/modular_computer/comp)
 	var/list/_prg_list = list(
+		new /datum/computer_file/program/ntnetdownload(comp),
 		new /datum/computer_file/program/filemanager(comp),
 		new /datum/computer_file/program/newsbrowser(comp),
 		new /datum/computer_file/program/manifest(comp),

--- a/html/changelogs/anconfuzedrock-medicaldownloads.yml
+++ b/html/changelogs/anconfuzedrock-medicaldownloads.yml
@@ -1,0 +1,7 @@
+
+author: anconfuzedrock
+
+delete-after: True
+
+changes:
+  - rscadd: "Medical computers can now download other programs."

--- a/html/changelogs/anconfuzedrock-medicaldownloads.yml
+++ b/html/changelogs/anconfuzedrock-medicaldownloads.yml
@@ -1,7 +1,6 @@
-
 author: anconfuzedrock
 
 delete-after: True
 
 changes:
-  - rscadd: "Medical computers can now download other programs."
+  - bugfix: "Medical computers can now download other programs."


### PR DESCRIPTION
The fact this hasn't been fixed before is so incredible to me that I'd be hesitant to call this a bug, but I could find no mention of it being noticed or even intentional. Currently medical PDAs, laptops, etc, all can't download other programs. they're the only computer missing this functionality; even the CMO computer has it, just not the basic medical one. This gives it the download program.