### PR TITLE
Exosuit weapon circuit can now be built round start

### DIFF
--- a/code/modules/research/designs/circuit/exosuit_circuits.dm
+++ b/code/modules/research/designs/circuit/exosuit_circuits.dm
@@ -30,5 +30,5 @@
 
 /datum/design/circuit/exosuit/weapons
 	name = "Basic Weapon Control"
-	req_tech = list(TECH_DATA = 4)
+	req_tech = list(TECH_DATA = 3)
 	build_path = /obj/item/circuitboard/exosystem/weapons

--- a/html/changelogs/Ben10083-WepCircuit.yml
+++ b/html/changelogs/Ben10083-WepCircuit.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Exosuit weapon system circuit can now be build roundstart."


### PR DESCRIPTION
Weapon circuit for exosuits can be constructed without research, like the others.

Since taser for exosuit can be done round start, making it unusable since it's circuit requirement isn't buildable is not good.