### PR TITLE
Allows unathi to take modified evening gloves and colorable leather gloves

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_xeno/unathi.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/unathi.dm
@@ -69,6 +69,22 @@
 	un_gloves["black leather gloves"] = /obj/item/clothing/gloves/black_leather/unathi
 	gear_tweaks += new /datum/gear_tweak/path(un_gloves)
 
+/datum/gear/gloves/unathi_full_leather
+	display_name = "full leather gloves (colourable)"
+	path = /obj/item/clothing/gloves/black_leather/colour/unathi
+	cost = 1
+	whitelisted = list(SPECIES_UNATHI)
+	sort_category = "Xenowear - Unathi"
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
+
+/datum/gear/gloves/unathi_evening
+	display_name = "evening gloves"
+	path = /obj/item/clothing/gloves/evening/unathi
+	cost = 1
+	whitelisted = list(SPECIES_UNATHI)
+	sort_category = "Xenowear - Unathi"
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
+
 /datum/gear/gloves/unathi_handwraps
 	display_name = "cloth handwraps"
 	path = /obj/item/clothing/gloves/unathi

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -162,6 +162,11 @@
 	desc = "A pair of gloves that reach past the elbow."
 	icon_state = "evening_gloves"
 
+/obj/item/clothing/gloves/evening/unathi
+	name = "evening gloves"
+	desc = "A pair of gloves that reach past the elbow. These ones are designed for Unathi."
+	species_restricted = list(BODYTYPE_UNATHI)
+
 /obj/item/clothing/gloves/black_leather
 	name = "black leather gloves"
 	desc = "A pair of tight-fitting synthleather gloves."
@@ -176,6 +181,10 @@
 /obj/item/clothing/gloves/black_leather/colour
 	icon_state = "full_leather_colour"
 	item_state = "full_leather_colour"
+
+/obj/item/clothing/gloves/black_leather/colour/unathi
+	species_restricted = list(BODYTYPE_UNATHI)
+	desc = "Leather gloves made for Unathi use."
 
 /obj/item/clothing/gloves/fingerless
 	name = "fingerless gloves"

--- a/html/changelogs/anconfuzedrock-unatgloves.yml
+++ b/html/changelogs/anconfuzedrock-unatgloves.yml
@@ -1,0 +1,7 @@
+
+author: anconfuzedrock
+
+delete-after: True
+changes:
+  - rscadd: "modifiedEvening gloves and colorable gloves are now available for unathi."
+

--- a/html/changelogs/anconfuzedrock-unatgloves.yml
+++ b/html/changelogs/anconfuzedrock-unatgloves.yml
@@ -3,5 +3,5 @@ author: anconfuzedrock
 
 delete-after: True
 changes:
-  - rscadd: "modifiedEvening gloves and colorable gloves are now available for unathi."
+  - rscadd: "Modified evening gloves and colorable gloves are now available for unathi."
 


### PR DESCRIPTION
This lets unathi take modified versions of colorable leather gloves and colorable evening gloves, as those were the gloves that unathi can take unmodified, but not modified, and both have valid use- saves a trip to the wirecutters with no real balance implication. 

I got approval from petrichor, as minute as this is.