### PR TITLE
Francisca Fragmentation Ammo

### DIFF
--- a/code/modules/overmap/ship_weaponry/weaponry/francisca.dm
+++ b/code/modules/overmap/ship_weaponry/weaponry/francisca.dm
@@ -33,13 +33,13 @@
 	impact_type = SHIP_AMMO_IMPACT_AP
 	projectile_type_override = /obj/item/projectile/ship_ammo/francisca/ap
 
-/obj/item/ship_ammunition/francisca/he
-	name = "40mm HE ammunition box"
-	name_override = "40mm HE burst"
-	desc = "A box of HE shells for use in a Francisca rotary gun."
+/obj/item/ship_ammunition/francisca/frag
+	name = "40mm fragmentation ammunition box"
+	name_override = "40mm FRAG burst"
+	desc = "A box of fragmentation shells for use in a Francisca rotary gun."
 	icon_state = "box_inc"
-	impact_type = SHIP_AMMO_IMPACT_AP
-	projectile_type_override = /obj/item/projectile/ship_ammo/francisca/he
+	impact_type = SHIP_AMMO_IMPACT_HE
+	projectile_type_override = /obj/item/projectile/ship_ammo/francisca/frag
 
 /obj/item/projectile/ship_ammo/francisca
 	name = "40mm FMJ shell"
@@ -54,13 +54,13 @@
 	armor_penetration = 100
 	penetrating = 4
 
-/obj/item/projectile/ship_ammo/francisca/he
-	name = "40mm HE shell"
-	damage = 50
+/obj/item/projectile/ship_ammo/francisca/frag
+	name = "40mm FRAG shell"
+	damage = 30
 	armor_penetration = 50
 	penetrating = 1
 
 
-/obj/item/projectile/ship_ammo/francisca/he/on_impact(var/atom/A)
-	explosion(A, -1, 0, 2)
+/obj/item/projectile/ship_ammo/francisca/frag/on_impact(var/atom/A)
+	fragem(src, 70, 70, 1, 2, 10, 4,TRUE)
 	..()

--- a/code/modules/overmap/ship_weaponry/weaponry/francisca.dm
+++ b/code/modules/overmap/ship_weaponry/weaponry/francisca.dm
@@ -61,5 +61,5 @@
 	penetrating = 1
 
 /obj/item/projectile/ship_ammo/francisca/frag/on_impact(var/atom/A)
-	fragem(src, 70, 70, 1, 2, 10, 4,TRUE)
+	fragem(src, 70, 70, 1, 2, 10, 4, TRUE)
 	..()

--- a/code/modules/overmap/ship_weaponry/weaponry/francisca.dm
+++ b/code/modules/overmap/ship_weaponry/weaponry/francisca.dm
@@ -15,7 +15,7 @@
 /obj/item/ship_ammunition/francisca
 	name = "40mm FMJ ammunition box"
 	name_override = "40mm FMJ burst"
-	desc = "A box of FMJ bullets for use in a Francisca rotary gun."
+	desc = "A box of FMJ shells for use in a Francisca rotary gun."
 	icon = 'icons/obj/guns/ship/ship_ammo_rotary.dmi'
 	icon_state = "box_fmj"
 	overmap_icon_state = "cannon_salvo"
@@ -28,20 +28,39 @@
 /obj/item/ship_ammunition/francisca/ap
 	name = "40mm AP ammunition box"
 	name_override = "40mm AP burst"
-	desc = "A box of AP bullets for use in a Francisca rotary gun."
+	desc = "A box of AP shells for use in a Francisca rotary gun."
 	icon_state = "box_ap"
 	impact_type = SHIP_AMMO_IMPACT_AP
 	projectile_type_override = /obj/item/projectile/ship_ammo/francisca/ap
 
+/obj/item/ship_ammunition/francisca/he
+	name = "40mm HE ammunition box"
+	name_override = "40mm HE burst"
+	desc = "A box of HE shells for use in a Francisca rotary gun."
+	icon_state = "box_inc"
+	impact_type = SHIP_AMMO_IMPACT_AP
+	projectile_type_override = /obj/item/projectile/ship_ammo/francisca/he
+
 /obj/item/projectile/ship_ammo/francisca
-	name = "40mm FMJ bullet"
+	name = "40mm FMJ shell"
 	icon_state = "small"
 	damage = 50
 	armor_penetration = 50
 	penetrating = 2
 
 /obj/item/projectile/ship_ammo/francisca/ap
-	name = "40mm AP bullet"
+	name = "40mm AP shell"
 	damage = 30
 	armor_penetration = 100
 	penetrating = 4
+
+/obj/item/projectile/ship_ammo/francisca/he
+	name = "40mm HE shell"
+	damage = 50
+	armor_penetration = 50
+	penetrating = 1
+
+
+/obj/item/projectile/ship_ammo/francisca/he/on_impact(var/atom/A)
+	explosion(A, -1, 0, 2)
+	..()

--- a/code/modules/overmap/ship_weaponry/weaponry/francisca.dm
+++ b/code/modules/overmap/ship_weaponry/weaponry/francisca.dm
@@ -60,7 +60,6 @@
 	armor_penetration = 50
 	penetrating = 1
 
-
 /obj/item/projectile/ship_ammo/francisca/frag/on_impact(var/atom/A)
 	fragem(src, 70, 70, 1, 2, 10, 4,TRUE)
 	..()

--- a/html/changelogs/dansemacabre-frannyhe.yml
+++ b/html/changelogs/dansemacabre-frannyhe.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheDanseMacabre
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added 40mm fragmentation ammo for the Francisca, and gives a few boxes to all ships with one."

--- a/maps/away/away_site/tajara/peoples_station/peoples_station.dmm
+++ b/maps/away/away_site/tajara/peoples_station/peoples_station.dmm
@@ -1380,6 +1380,12 @@
 	dir = 1;
 	icon_state = "rwindow"
 	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 5
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -1828,6 +1834,12 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 8
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 5
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -8357,11 +8369,11 @@
 	dir = 1;
 	icon_state = "rwindow"
 	},
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca/frag,
+/obj/item/ship_ammunition/francisca/frag,
+/obj/item/ship_ammunition/francisca/frag,
+/obj/item/ship_ammunition/francisca/frag,
+/obj/item/ship_ammunition/francisca/frag,
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -9830,6 +9842,11 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},

--- a/maps/away/ships/coc_ranger/coc_ship.dmm
+++ b/maps/away/ships/coc_ranger/coc_ship.dmm
@@ -4177,12 +4177,18 @@
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
-/obj/item/grenade/frag{
-	desc = "A military fragmentation grenade, designed to explode in a deadly shower of fragments. This one has the word 'CATCH!!' written on it in white paint."
-	},
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/ship/ranger_corvette/munitions)
@@ -4310,6 +4316,9 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
+	},
+/obj/item/grenade/frag{
+	desc = "A military fragmentation grenade, designed to explode in a deadly shower of fragments. This one has the word 'CATCH!!' written on it in white paint."
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/ranger_corvette/gunnery)

--- a/maps/away/ships/dominia/dominian_corvette.dmm
+++ b/maps/away/ships/dominia/dominian_corvette.dmm
@@ -978,6 +978,12 @@
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_corvette/franny)
 "dBq" = (
@@ -4071,6 +4077,12 @@
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_corvette/franny)
 "oYG" = (

--- a/maps/away/ships/dpra/hailstorm/hailstorm_ship.dmm
+++ b/maps/away/ships/dpra/hailstorm/hailstorm_ship.dmm
@@ -14,6 +14,9 @@
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -30,6 +33,9 @@
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -50,6 +56,9 @@
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -69,6 +78,9 @@
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -85,6 +97,9 @@
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -105,6 +120,9 @@
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},

--- a/maps/away/ships/elyra/elyran_strike_craft.dmm
+++ b/maps/away/ships/elyra/elyran_strike_craft.dmm
@@ -1840,6 +1840,15 @@
 /obj/item/ship_ammunition/francisca/ap{
 	pixel_y = 8
 	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor,
 /area/ship/elyran_strike_craft)
 "rWk" = (

--- a/maps/away/ships/sol_merc/fsf_patrol_ship.dmm
+++ b/maps/away/ships/sol_merc/fsf_patrol_ship.dmm
@@ -422,6 +422,15 @@
 /obj/item/ship_ammunition/francisca/ap{
 	pixel_y = 8
 	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor,
 /area/ship/fsf_patrol_ship)
 "cdD" = (

--- a/maps/away/ships/sol_pirate/sfa_patrol_ship.dmm
+++ b/maps/away/ships/sol_pirate/sfa_patrol_ship.dmm
@@ -3266,6 +3266,15 @@
 	pixel_y = 8
 	},
 /obj/structure/table/rack,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor,
 /area/ship/sfa_patrol_ship/Ammo_Closet)
 "nnv" = (

--- a/maps/away/ships/sol_ssmd/ssmd_ship.dmm
+++ b/maps/away/ships/sol_ssmd/ssmd_ship.dmm
@@ -4391,6 +4391,9 @@
 /obj/machinery/light/colored/red,
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/reinforced,
 /area/ship/ssmd_corvette/francisca)
 "mqW" = (
@@ -5348,6 +5351,9 @@
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/reinforced,
 /area/ship/ssmd_corvette/francisca)
 "pwR" = (
@@ -5634,6 +5640,9 @@
 /obj/item/ship_ammunition/francisca,
 /obj/machinery/light/colored/red{
 	dir = 1
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/ship/ssmd_corvette/francisca)
@@ -6599,6 +6608,9 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/reinforced,
 /area/ship/ssmd_corvette/francisca)
 "uew" = (

--- a/maps/away/ships/tcfl_patrol/tcfl_peacekeeper_ship.dmm
+++ b/maps/away/ships/tcfl_patrol/tcfl_peacekeeper_ship.dmm
@@ -2914,6 +2914,15 @@
 /obj/item/ship_ammunition/francisca/ap{
 	pixel_y = 5
 	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/tcfl_peacekeeper_ship)
 "rlW" = (

--- a/maps/away/ships/tramp_freighter/tramp_freighter.dmm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter.dmm
@@ -1731,6 +1731,12 @@
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor,
 /area/ship/tramp_freighter)
 "qpg" = (
@@ -1979,6 +1985,12 @@
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor,
 /area/ship/tramp_freighter)
 "uCl" = (

--- a/maps/away/ships/wildlands_militia/militia_ship.dmm
+++ b/maps/away/ships/wildlands_militia/militia_ship.dmm
@@ -37,6 +37,12 @@
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
 /obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/militia_ship)
 "ajL" = (
@@ -1473,6 +1479,12 @@
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/militia_ship)
 "vwF" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -42194,6 +42194,15 @@
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
 /obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/secure_ammunition_storage)
 "uRu" = (


### PR DESCRIPTION
Adds a type of Francisca ammo that has lower penetration and individual damage compared to FMJ and AP Francisca ammo, but spawns the equivalent of a frag grenade's explosion on impact.