### PR TITLE
Update Zo'ra and K'lax Ta citizenship for Consular

### DIFF
--- a/code/modules/background/citizenship/human.dm
+++ b/code/modules/background/citizenship/human.dm
@@ -45,6 +45,18 @@
 		/obj/item/gun/energy/blaster/revolver = 1
 	)
 
+/datum/outfit/job/representative/consular/ceti/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(H && !visualsOnly)
+		if(isvaurca(H))
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/gearharness(H), slot_w_uniform)
+			H.equip_to_slot_or_del(new /obj/item/clothing/head/vaurca_breeder(H), slot_head)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/vaurca/breeder(H), slot_shoes)
+			H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/vaurca/breeder(H), slot_wear_suit)
+			H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec(H), slot_back)
+		else
+			addtimer(CALLBACK(src, .proc/send_representative_mission, H), 5 MINUTES)
+	return TRUE
 
 /datum/citizenship/sol_alliance
 	name = CITIZENSHIP_SOL

--- a/code/modules/background/citizenship/unathi.dm
+++ b/code/modules/background/citizenship/unathi.dm
@@ -67,3 +67,16 @@
 	suit = /obj/item/clothing/accessory/poncho/unathimantle
 	backpack_contents = list(/obj/item/device/camera = 1)
 	belt = /obj/item/gun/energy/pistol/hegemony
+
+/datum/outfit/job/representative/consular/izweski/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(H && !visualsOnly)
+		if(isvaurca(H))
+			H.equip_to_slot_or_del(new /obj/item/clothing/under/gearharness(H), slot_w_uniform)
+			H.equip_to_slot_or_del(new /obj/item/clothing/head/vaurca_breeder/klax(H), slot_head)
+			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/vaurca/breeder/klax(H), slot_shoes)
+			H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+			H.equip_to_slot_or_del(new /obj/item/clothing/suit/vaurca/breeder/klax(H), slot_wear_suit)
+			H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec/klax(H), slot_back)
+		else
+			addtimer(CALLBACK(src, .proc/send_representative_mission, H), 5 MINUTES)
+	return TRUE

--- a/code/modules/background/origins/origins/vaurca/breeder/klax.dm
+++ b/code/modules/background/origins/origins/vaurca/breeder/klax.dm
@@ -12,26 +12,26 @@
 	name = "Zkaii Brood"
 	desc = "The new High Queen of the K'lax, the Zkaii Brood is often mocked for their eccentric Mother Dream religion. Many still remain within Tret and other Izweski territories."
 	possible_accents = list(ACCENT_KLAX, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_KLAX)
+	possible_citizenships = list(CITIZENSHIP_KLAX, CITIZENSHIP_IZWESKI)
 	possible_religions = list(RELIGION_PILOTDREAM)
 
 /singleton/origin_item/origin/leto_b
 	name = "Leto Brood" //jared?
 	desc = "The brood is mostly known for their archeological work and their production of k'ois in Pid, a moon near Tret."
 	possible_accents = list(ACCENT_KLAX, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_KLAX)
+	possible_citizenships = list(CITIZENSHIP_KLAX, CITIZENSHIP_IZWESKI)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_PILOTDREAM, RELIGION_NONE)
 
 /singleton/origin_item/origin/vedhra_b
 	name = "Vedhra Brood"
 	desc = "One of the youngest Vaurca Queens, Vedhra wishes to unite the Vaurca civilization under Preimminence. The brood is also known for their augments and fascination with the Unathi culture. As with most K'lax broods, they mainly reside in Tret."
 	possible_accents = list(ACCENT_KLAX, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_KLAX)
+	possible_citizenships = list(CITIZENSHIP_KLAX, CITIZENSHIP_IZWESKI)
 	possible_religions = list(RELIGION_PREIMMINENNCE)
 
 /singleton/origin_item/origin/tupii_b
 	name = "Tupii-K'lax Brood"
 	desc = "The old K'lax brood, reinvigorated by the newly elected Queen Tupii. While older generations retain many customs of Mother K'lax, Tupii has attempted to modernize the brood and prove their loyalty."
 	possible_accents = list(ACCENT_KLAX, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_KLAX)
+	possible_citizenships = list(CITIZENSHIP_KLAX, CITIZENSHIP_IZWESKI)
 	possible_religions = list(RELIGION_PREIMMINENNCE, RELIGION_HIVEPANTHEON)

--- a/code/modules/background/origins/origins/vaurca/breeder/zora.dm
+++ b/code/modules/background/origins/origins/vaurca/breeder/zora.dm
@@ -13,7 +13,7 @@
 	name = "Zoleth Brood"
 	desc = "The Warrior brood of the Zo'ra, Zoleth is established in Caprice, Tau Ceti. Although feared as a warmonger, the Zoleth Brood is known for their diplomacy."
 	possible_accents = list(ACCENT_ZORA, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_BIESEL, CITIZENSHIP_BIESEL)
+	possible_citizenships = list(CITIZENSHIP_ZORA, CITIZENSHIP_BIESEL)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)
 
 /singleton/origin_item/origin/scay_b

--- a/code/modules/background/origins/origins/vaurca/breeder/zora.dm
+++ b/code/modules/background/origins/origins/vaurca/breeder/zora.dm
@@ -13,33 +13,33 @@
 	name = "Zoleth Brood"
 	desc = "The Warrior brood of the Zo'ra, Zoleth is established in Caprice, Tau Ceti. Although feared as a warmonger, the Zoleth Brood is known for their diplomacy."
 	possible_accents = list(ACCENT_ZORA, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_ZORA)
+	possible_citizenships = list(CITIZENSHIP_BIESEL, CITIZENSHIP_BIESEL)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)
 
 /singleton/origin_item/origin/scay_b
 	name = "Scay Brood"
 	desc = "The scientific brood of the Zo'ra, Scay is established in the Xerxes Biodome, New Gibson. The Queen is reluctant and eccentric, qualities shared with her brood."
 	possible_accents = list(ACCENT_ZORA, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_ZORA)
+	possible_citizenships = list(CITIZENSHIP_ZORA, CITIZENSHIP_BIESEL)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)
 
 /singleton/origin_item/origin/vaur_b
 	name = "Vaur Brood"
 	desc = "The brood of the current High Queen. While Queen Vaur now resides in Caprice, most of her subjects remain in Flagsdale, Mendell City."
 	possible_accents = list(ACCENT_ZORA, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_ZORA)
+	possible_citizenships = list(CITIZENSHIP_ZORA, CITIZENSHIP_BIESEL)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)
 
 /singleton/origin_item/origin/xakt_b
 	name = "Xakt Brood"
 	desc = "Located in Luthien, Tau Ceti, the brood is mostly Bound Workers in industrial roles."
 	possible_accents = list(ACCENT_ZORA, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_ZORA)
+	possible_citizenships = list(CITIZENSHIP_ZORA, CITIZENSHIP_BIESEL)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)
 
 /singleton/origin_item/origin/athvur_b
 	name = "Athvur"
 	desc = "Athvur is a unique brood, as it has assimilated plenty of human customs. While the brood originally resided in Phoenixport, Biesel, they have relocated to Belle Côte."
 	possible_accents = list(ACCENT_ZORA, ACCENT_TTS)
-	possible_citizenships = list(CITIZENSHIP_ZORA)
+	possible_citizenships = list(CITIZENSHIP_ZORA, CITIZENSHIP_BIESEL)
 	possible_religions = list(RELIGION_HIVEPANTHEON, RELIGION_PREIMMINENNCE, RELIGION_NONE)

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Connorjg1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added the ability for Zo'ra and K'lax Ta to take their respective host nation's citizenship as consular."
+

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added the ability for Zo'ra and K'lax Ta to take their respective host nation's citizenship as Consular officers."
+  - rscadd: "Added the ability for Zo'ra and K'lax Ta to take their respective host nation's citizenship as Consular officer."
 

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added the ability for Zo'ra and K'lax Ta to take their respective host nation's citizenship as Consular officer."
+  - rscadd: "Added the ability for Zo'ra and K'lax Ta to take their respective host nation's citizenship as Consular officers."
 

--- a/html/changelogs/connorjg1.yml
+++ b/html/changelogs/connorjg1.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added the ability for Zo'ra and K'lax Ta to take their respective host nation's citizenship as consular."
+  - rscadd: "Added the ability for Zo'ra and K'lax Ta to take their respective host nation's citizenship as Consular officers."
 


### PR DESCRIPTION
The citizenships available to Zo'ra and K'lax Ta have now been updated to match the lore. 

With this, they can be Biesel/Hegemony consuls directly instead of through Zo'ra/K'lax "citizenship" which is now reserved for Ta who are representing the Hive instead of their host nation. 

Clothing is coming later in the week. 

Lore approved. 
