### PR TITLE
Investigator Gloves Fix

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -170,7 +170,6 @@
 
 	uniform = /obj/item/clothing/under/det
 	shoes = /obj/item/clothing/shoes/laceup/all_species
-	gloves = /obj/item/clothing/gloves/black/forensic
 
 	headset = /obj/item/device/radio/headset/headset_sec
 	bowman = /obj/item/device/radio/headset/headset_sec/alt
@@ -189,6 +188,15 @@
 	backpack_contents = list(
 		/obj/item/storage/box/evidence = 1
 	)
+
+/datum/outfit/job/forensics/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if(istajara(H))
+		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black_leather/tajara(H), slot_gloves)
+	else if(isunathi(H))
+		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black_leather/unathi(H), slot_gloves)
+	else
+		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black_leather(H), slot_gloves)
 
 /datum/job/officer
 	title = "Security Officer"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -279,6 +279,7 @@
 	new /obj/item/clothing/under/det/pmc(src)
 	new /obj/item/clothing/under/det/zavod(src)
 	new /obj/item/clothing/accessory/badge/investigator(src)
+	new/obj/item/clothing/gloves/black/forensic(src)
 	new /obj/item/clothing/shoes/laceup/all_species(src)
 	new /obj/item/clothing/shoes/laceup/all_species(src)
 	//Tools

--- a/html/changelogs/investigloves.yml
+++ b/html/changelogs/investigloves.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Makes investigators spawn with black gloves. Re-adds investigator gloves to their lockers."


### PR DESCRIPTION
this PR fixes investigators choosing custom gloves in the loadout overwriting their otherwise unobtainable investigator gloves.