### PR TITLE
Removes VueUI Client-State-Sync from UIs

### DIFF
--- a/code/modules/economy/quikpay.dm
+++ b/code/modules/economy/quikpay.dm
@@ -155,13 +155,10 @@
 
 	VUEUI_SET_CHECK_IFNOTSET(data["items"], items, ., data)
 	VUEUI_SET_CHECK_IFNOTSET(data["price"], items, ., data)
-	VUEUI_SET_CHECK_IFNOTSET(data["tmp_name"], "", ., data)
-	VUEUI_SET_CHECK_IFNOTSET(data["tmp_price"], 0, ., data)
 	VUEUI_SET_CHECK(data["tmp_price"], max(0, data["tmp_price"]), ., data)
 	if(data["tmp_price"] < 0)
 		data["tmp_price"] = 0
 		. = data
-	VUEUI_SET_CHECK_IFNOTSET(data["selection"], list("_" = 0), ., data)
 	VUEUI_SET_CHECK(data["editmode"], editmode, ., data)
 	VUEUI_SET_CHECK(data["destinationact"], destinationact, ., data)
 
@@ -187,7 +184,7 @@
 		ui.data["items"] -= href_list["remove"]
 		. = TRUE
 	if(href_list["confirm"])
-		var/selection = ui.data["selection"]
+		var/selection = href_list["confirm"]
 		var/items = ui.data["items"]
 		for(var/name in selection)
 			if(items[name] && selection[name])

--- a/vueui/src/components/view/console/atmocontrol/supermatter.vue
+++ b/vueui/src/components/view/console/atmocontrol/supermatter.vue
@@ -7,17 +7,15 @@
         <span v-else>On Hold</span>&nbsp;
         <vui-button :params="{ in_toggle_injector: 1 }" icon="power-off">Toggle Power</vui-button>
       </vui-item>
-      <vui-item label="Flow Rate Limit:">{{ state['input'].rate }} L/s</vui-item>
+      <vui-item label="Flow Rate Limit:">{{ inputRate }} L/s</vui-item>
       <vui-item label="Command:">
         <vui-input-numeric
-          @keypress.enter="$toTopic({ in_set_flowrate: state['input'].setrate })"
           width="3em"
           :button-count="3"
-          v-model="state['input'].setrate"
+          v-model="inputRate"
           :max="state.maxrate"
         />
         <br>
-        <vui-button push-state :params="{ in_set_flowrate: state['input'].setrate }">Set Flow Rate</vui-button>
       </vui-item>
     </div>
     <vui-button v-else :params="{ in_refresh_status: 1 }">Search for input port</vui-button>
@@ -27,21 +25,16 @@
         <span v-else>On Hold</span>&nbsp;
         <vui-button :params="{ out_toggle_power: 1 }" icon="power-off">Toggle Power</vui-button>
       </vui-item>
-      <vui-item label="Min Core Pressure:">{{ state['output'].pressure }} kPa</vui-item>
+      <vui-item label="Min Core Pressure:">{{ outputPressure }} kPa</vui-item>
       <vui-item label="Command:">
         <vui-input-numeric
-          @keypress.enter="$toTopic({ out_set_pressure: state['output'].setpressure })"
           width="5em"
           :button-count="3"
           :decimal-places="2"
-          v-model="state['output'].setpressure"
+          v-model="outputPressure"
           :max="state.maxpressure"
         />
         <br>
-        <vui-button
-          push-state
-          :params="{ out_set_pressure: state['output'].setpressure }"
-        >Set Pressure</vui-button>
       </vui-item>
     </div>
     <vui-button v-else :params="{ out_refresh_status: 1 }">Search for output port</vui-button>
@@ -52,6 +45,24 @@
 export default {
   data() {
     return this.$root.$data
-  }
+  },
+  computed: {
+    inputRate: {
+      get() {
+        return this.state['input'].setrate
+      },
+      set(value) {
+        this.$toTopic({ in_set_flowrate: value })
+      }
+    },
+    outputPressure: {
+      get() {
+        return this.state['output'].setpressure
+      },
+      set(value) {
+        this.$toTopic({ out_set_pressure: value })
+      }
+    }
+  },
 };
 </script>

--- a/vueui/src/components/view/console/atmocontrol/tank.vue
+++ b/vueui/src/components/view/console/atmocontrol/tank.vue
@@ -7,13 +7,12 @@
         <span v-else>On Hold</span>&nbsp;
         <vui-button :params="{ in_toggle_injector: 1 }" icon="power-off">Toggle Power</vui-button>
       </vui-item>
-      <vui-item :balance="0.65" label="Flow Rate Limit:">{{ state['input'].rate }} L/s</vui-item>
+      <vui-item :balance="0.65" label="Flow Rate Limit:">{{ inputRate }} L/s</vui-item>
       <vui-item :balance="0.65" label="Command:">
         <vui-input-numeric
-          @keypress.enter="$toTopic({ in_set_flowrate: state['input'].setrate })"
           width="3em"
           :button-count="3"
-          v-model="state['input'].setrate"
+          v-model="inputRate"
           :max="state.maxrate"
         />
         <br >
@@ -27,21 +26,16 @@
         <span v-else>On Hold</span>&nbsp;
         <vui-button :params="{ out_toggle_power: 1 }" icon="power-off">Toggle Power</vui-button>
       </vui-item>
-      <vui-item :balance="0.65" label="Max Output Pressure:">{{ state['output'].pressure }} kPa</vui-item>
+      <vui-item :balance="0.65" label="Max Output Pressure:">{{ outputPressure }} kPa</vui-item>
       <vui-item :balance="0.65" label="Command:">
         <vui-input-numeric
-          @keypress.enter="$toTopic({ out_set_pressure: state['output'].setpressure })"
           width="5em"
           :button-count="4"
           :decimal-places="2"
-          v-model="state['output'].setpressure"
+          v-model="outputPressure"
           :max="state.maxpressure"
         />
         <br >
-        <vui-button
-          push-state
-          :params="{ out_set_pressure: state['output'].setpressure }"
-        >Set Pressure</vui-button>
       </vui-item>
     </div>
     <vui-button v-else :params="{ out_refresh_status: 1 }">Search for output port</vui-button>
@@ -52,6 +46,24 @@
 export default {
   data() {
     return this.$root.$data
+  },
+  computed: {
+    inputRate: {
+      get() {
+        return this.state['input'].setrate
+      },
+      set(value) {
+        this.$toTopic({ in_set_flowrate: value })
+      }
+    },
+    outputPressure: {
+      get() {
+        return this.state['output'].setpressure
+      },
+      set(value) {
+        this.$toTopic({ out_set_pressure: value })
+      }
+    }
   }
 };
 </script>

--- a/vueui/src/components/view/devices/gps/gps.vue
+++ b/vueui/src/components/view/devices/gps/gps.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <!-- Controls -->
-    <input v-model="new_own_tag" :placeholder="own_tag"><vui-button :params="{ tag: new_own_tag }">Set GPS Tag</vui-button><br>
-    <input v-model="add_track_tag"><vui-button :params="{ add_tag: add_track_tag }">Track New Tag</vui-button><br>
+    <input type="text" v-model="new_own_tag" :placeholder="s,own_tag"><vui-button :params="{ tag: new_own_tag }">Set GPS Tag</vui-button><br>
+    <input type="text" v-model="add_track_tag"><vui-button :params="{ add_tag: add_track_tag }">Track New Tag</vui-button><br>
     <vui-button :params="{ add_all: 1 }">Track All</vui-button>
     <vui-button :params="{ clear_all: 1 }">Untrack All</vui-button>
     <hr>
@@ -16,14 +16,14 @@
         <th>Remove</th>
         <th>C-Track</th>
       </tr>
-      <tr v-for="gps in tracking_list" :key="gps.tag">
+      <tr v-for="gps in s.tracking_list" :key="gps.tag">
         <td> {{ gps.tag }} </td>
         <td> {{ gps.pos_x }}, {{ gps.pos_y }}, {{ gps.pos_z }} </td>
         <td> {{ gps.area }} </td>
-        <td v-if="gps.tag != own_tag"><vui-button :params="{ remove_tag: gps.tag }">Untrack</vui-button></td>
-        <td v-else/>
-        <td v-if="gps.tag != own_tag"><vui-button :class="{selected: compass_list && compass_list.includes(gps.tag)}" :params="{ compass: gps.tag }">Compass</vui-button></td>
-        <td v-else/>
+        <td v-if="gps.tag != s.own_tag"><vui-button :params="{ remove_tag: gps.tag }">Untrack</vui-button></td>
+        <td v-else />
+        <td v-if="gps.tag != s.own_tag"><vui-button :class="{selected: s.compass_list && s.compass_list.includes(gps.tag)}" :params="{ compass: gps.tag }">Compass</vui-button></td>
+        <td v-else />
       </tr>
     </table>
   </div>
@@ -32,7 +32,11 @@
 <script>
 export default {
   data() {
-    return this.$root.$data.state;
-  }
+    return {
+      s: this.$root.$data.state,
+      new_own_tag: '',
+      add_track_tag: '',
+    }
+  },
 }
 </script>

--- a/vueui/src/components/view/devices/gps/gps.vue
+++ b/vueui/src/components/view/devices/gps/gps.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <!-- Controls -->
-    <input type="text" v-model="new_own_tag" :placeholder="s,own_tag"><vui-button :params="{ tag: new_own_tag }">Set GPS Tag</vui-button><br>
+    <input type="text" v-model="new_own_tag" :placeholder="s.own_tag"><vui-button :params="{ tag: new_own_tag }">Set GPS Tag</vui-button><br>
     <input type="text" v-model="add_track_tag"><vui-button :params="{ add_tag: add_track_tag }">Track New Tag</vui-button><br>
     <vui-button :params="{ add_all: 1 }">Track All</vui-button>
     <vui-button :params="{ clear_all: 1 }">Untrack All</vui-button>

--- a/vueui/src/components/view/devices/quikpay/main.vue
+++ b/vueui/src/components/view/devices/quikpay/main.vue
@@ -1,14 +1,14 @@
 <template>
   <div>
-    <div v-for="(price, name) in items" :key="name" style="clear: both;">
+    <div v-for="(price, name) in s.items" :key="name" style="clear: both;">
       {{ name }}: {{ price }} Credits
       <div style="float: right;">
-        <vui-input-numeric v-model="selection[name]" width="2em"/>
-        <vui-button v-if="editmode == 1" :params="{ remove: name }" width="3em">Delete</vui-button>
+        <vui-input-numeric @input="setSelection(name, $event)" :value="getSelection(name)" width="2em"/>
+        <vui-button v-if="s.editmode == 1" :params="{ remove: name }" width="3em">Delete</vui-button>
       </div>
     </div>
 
-    <div v-if="editmode == 1">
+    <div v-if="s.editmode == 1">
       <input v-model="tmp_name">
       <vui-input-numeric v-model="tmp_price" width="3em" :button-count="2"/>
       <vui-button :params="{ add: {name: tmp_name, price: tmp_price }}">Add</vui-button>
@@ -23,7 +23,20 @@
 <script>
 export default {
   data() {
-    return this.$root.$data.state;
+    return {
+      s: this.$root.$data.state,
+      selection: {},
+      tmp_name: '',
+      tmp_price: 0,
+    }
+  },
+  methods: {
+    getSelection(name) {
+      return this.selection[name] || 0
+    },
+    setSelection(name, value) {
+      this.$set(this.selection, name, value)
+    },
   }
 }
 </script>

--- a/vueui/src/components/view/machinery/atmospherics/canister.vue
+++ b/vueui/src/components/view/machinery/atmospherics/canister.vue
@@ -33,7 +33,7 @@
       <vui-group-item label="Release Pressure:">
         <vui-progress style="width: 100%;" :value="releasePressure" :min="minReleasePressure" :max="maxReleasePressure"/>
         <div style="clear: both; padding-top: 4px;">
-          <vui-input-numeric width="5em" v-model="releasePressure" :button-count="4" :min="minReleasePressure" :max="maxReleasePressure" @input="$toTopic({pressure_set : releasePressure})">{{releasePressure}} kPa&nbsp;</vui-input-numeric>
+          <vui-input-numeric width="5em" v-model="releasePressure" :button-count="4" :min="minReleasePressure" :max="maxReleasePressure">{{releasePressure}} kPa&nbsp;</vui-input-numeric>
         </div>
       </vui-group-item>
 
@@ -49,6 +49,17 @@
 export default {
 	data() {
 		return this.$root.$data.state;
-  }
+  },
+  computed: {
+    releasePressure: {
+      get() {
+        return this.$data.releasePressure;
+      },
+      set(value) {
+        this.$data.releasePressure = value;
+        this.$toTopic({pressure_set : value});
+      }
+    },
+  },
 }
 </script>

--- a/vueui/src/components/view/machinery/atmospherics/portpump.vue
+++ b/vueui/src/components/view/machinery/atmospherics/portpump.vue
@@ -31,7 +31,7 @@
     <vui-group-item label="Target Pressure:">
       <vui-progress :value="targetpressure" :min="minpressure" :max="maxpressure"/>
       <div style="float: left; clear: both; padding-top: 4px; text-align: center;">
-        <vui-input-numeric v-model="targetpressure" :min="minpressure" :max="maxpressure" min-button max-button width="4em" :button-count="0" @input="s({pressure_set : targetpressure})"/>
+        <vui-input-numeric v-model="targetpressure" :min="minpressure" :max="maxpressure" min-button max-button width="4em" :button-count="0"/>
       </div>
     </vui-group-item>
 
@@ -46,16 +46,21 @@
 </template>
 
 <script>
-import Utils from "../../../../utils.js";
 export default {
 	data() {
 		return this.$root.$data.state;
   },
-	methods: {
-    s(parameters) {
-      Utils.sendToTopic(parameters);
-    }
-	}
+  computed: {
+    targetpressure: {
+      get() {
+        return this.$data.targetpressure;
+      },
+      set(value) {
+        this.$data.targetpressure = value;
+        this.$toTopic({pressure_set : targetpressure})
+      },
+    },
+  },
 }
 </script>
 

--- a/vueui/src/components/view/machinery/chemdisp.vue
+++ b/vueui/src/components/view/machinery/chemdisp.vue
@@ -4,7 +4,7 @@
       <vui-button v-for="n in [5, 10, 20, 30, 40]" icon="cog" :params="{ amount : n }" :class="{selected : (state.amount == n)}" :key="amount-button-n">{{n}}</vui-button>
       <br><br>
       <div style="text-align:center">
-        <vui-input-numeric width="2.5em" v-model="state.amount" @input="$toTopic({amount : state.amount})" :button-count="2" :min="1" :max="state.beakerMaxVolume || 120"/>
+        <vui-input-numeric width="2.5em" :value="state.amount" @input="$toTopic({amount : $event})" :button-count="2" :min="1" :max="state.beakerMaxVolume || 120"/>
       </div>
     </div>
     <div style="clear:both;">&nbsp;</div>

--- a/vueui/src/components/view/machinery/orderterminal/ordering.vue
+++ b/vueui/src/components/view/machinery/orderterminal/ordering.vue
@@ -1,14 +1,14 @@
 <template>
   <div>
-    <div v-for="(price, name) in items" :key="name" style="clear: both;">
+    <div v-for="(price, name) in s.items" :key="name" style="clear: both;">
       {{ name }}: {{ price }} Credits
       <div style="float: right;">
         <vui-button :params="{ buy: {name: name, price: price, amount: 1 } }" width="2em">Buy</vui-button>
-        <vui-button v-if="editmode == 1" :params="{ remove: name }" width="3em">Delete</vui-button>
+        <vui-button v-if="s.editmode == 1" :params="{ remove: name }" width="3em">Delete</vui-button>
       </div>
     </div>
 
-    <div v-if="editmode == 1">
+    <div v-if="s.editmode == 1">
       <input v-model="tmp_name">
       <vui-input-numeric v-model="tmp_price" width="3em" :button-count="2"/>
       <vui-button :params="{ add: {name: tmp_name, price: tmp_price }}">Add</vui-button>
@@ -18,9 +18,9 @@
     <vui-button :params="{ clear: 1 }">Clear selection</vui-button>
 
     <h4> Selected Products:</h4>
-    <div v-for="(price, name) in buying" :key="name" style="clear: both;">
-      <span v-if="buying[name] && buying[name] >= 0">
-        {{buying[name] }}x  {{ name }}: at {{ price * items[name] }} Credits
+    <div v-for="(price, name) in s.buying" :key="name" style="clear: both;">
+      <span v-if="s.buying[name] && s.buying[name] >= 0">
+        {{s.buying[name] }}x  {{ name }}: at {{ price * s.items[name] }} Credits
         <div style="float: right;">
           <vui-button :params="{ removal: {name: name, price: price, amount: 1 }}" width="2em">Remove</vui-button>
         </div>
@@ -32,7 +32,11 @@
 <script>
 export default {
   data() {
-    return this.$root.$data.state;
-  }
+    return {
+      s: this.$root.$data.state,
+      tmp_name: '',
+      tmp_price: 0,
+    }
+  },
 }
 </script>

--- a/vueui/src/components/view/machinery/power/smes.vue
+++ b/vueui/src/components/view/machinery/power/smes.vue
@@ -36,9 +36,9 @@
       </vui-group-item>
 
       <vui-group-item label="Input Level:">
-        <vui-progress :value="state.chargeLevel" :min="0" :max="state.chargeMax"/>
+        <vui-progress :value="chargeLevel" :min="0" :max="state.chargeMax"/>
         <div style="clear: both; padding-top: 4px; text-align:center;">
-          <vui-input-numeric width="100px" v-model="state.chargeLevel" min-button max-button :button-count="0" :min="0" :max="state.chargeMax" @input="s({input : state.chargeLevel})">&nbsp;{{state.chargeLevel}} W&nbsp;</vui-input-numeric>
+          <vui-input-numeric width="100px" v-model="chargeLevel" min-button max-button :button-count="0" :min="0" :max="state.chargeMax"></vui-input-numeric>
         </div>
       </vui-group-item>
 
@@ -57,9 +57,9 @@
       </vui-group-item>
 
       <vui-group-item label="Output Level:">
-        <vui-progress :value="state.outputLevel" :min="0" :max="state.outputMax"/>
+        <vui-progress :value="outputLevel" :min="0" :max="state.outputMax"/>
         <div style="clear: both; padding-top: 4px; text-align: center;">
-          <vui-input-numeric width="100px" v-model="state.outputLevel" min-button max-button :button-count="0" :min="0" :max="state.outputMax" @input="s({output : state.outputLevel})">&nbsp;{{state.outputLevel}} W&nbsp;</vui-input-numeric>
+          <vui-input-numeric width="100px" v-model="outputLevel" min-button max-button :button-count="0" :min="0" :max="state.outputMax"></vui-input-numeric>
         </div>
       </vui-group-item>
 
@@ -74,17 +74,32 @@
 </template>
 
 <script>
-import Utils from "../../../../utils.js";
 export default {
   data() {
-    return this.$root.$data; // Make data more easily accessible
-  },
-  methods: {
-    s(parameters) {
-      Utils.sendToTopic(parameters)
-    },
+    return {
+      state: this.$root.$data.state,
+
+    }
   },
   computed: {
+    chargeLevel: {
+      get() {
+        return this.state.chargeLevel
+      },
+      set(value) {
+        this.state.chargeLevel = value
+        this.$toTopic({input : value})
+      }
+    },
+    outputLevel: {
+      get() {
+        return this.state.outputLevel
+      },
+      set(value) {
+        this.state.outputLevel = value
+        this.$toTopic({output : value})
+      }
+    },
     chargeClass() {
       switch(this.state.chargeMode){
         case 2: return 'good';
@@ -114,7 +129,7 @@ export default {
       }
     },
     timeRemaining() {
-      var timeleft = (this.state.time - this.wtime)/10 // deciseconds
+      var timeleft = (this.state.time - this.$root.$data.wtime)/10 // deciseconds
       var hours = Math.round(timeleft / 3600)
       var minutes = Math.round(timeleft % 3600 / 60)
       var seconds = Math.round(timeleft % 60)


### PR DESCRIPTION
Attempts to remove Client to Server state sync from UIs. 
Why? Client to Server state sync is buggy, unintuitive and just underused. Also it's main cause for `VUEUI_SET_CHECK` macro polution.

This is one of many SRPR series to achieve vueui2

Testing:
 - [ ] Quikpay
 - [ ] atmocontrol/supermatter.vue
 - [ ] atmocontrol/tank.vue
 - [ ] devices/gps/gps.vue
 - [ ] atmospherics/canister.vue
 - [ ] atmospherics/portpump.vue
 - [ ] machinery/chemdisp.vue
 - [ ] orderterminal/ordering.vue
 - [ ] power/smes.vue