### PR TITLE
Cozy Time Enabler

### DIFF
--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -10,6 +10,7 @@ var/global/list/total_active_bonfires = list()
 	anchored = TRUE
 	density = FALSE
 	light_color = LIGHT_COLOR_FIRE
+	build_amt = 20
 	var/fuel = 2000
 	var/max_fuel = 2000
 	var/on_fire = FALSE
@@ -65,7 +66,7 @@ var/global/list/total_active_bonfires = list()
 	var/mob/living/carbon/human/H = user
 	if(use_check_and_message(H))
 		return
-	if(fuel >= max(max_fuel * 0.1, 50))
+	if(fuel >= max(max_fuel * 0.1, 50) && on_fire)
 		to_chat(H, SPAN_NOTICE("You grab a burning stick from the fire."))
 		fuel -= 40
 		var/obj/item/device/flashlight/flare/torch/stick/torch = new(get_turf(user))

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -160,6 +160,7 @@
 	recipes += new /datum/stack_recipe_list("[display_name] recipes",
 		list(
 			new /datum/stack_recipe("wooden barricade", /obj/structure/barricade/wooden, BUILD_AMT, time = 5 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
+			new /datum/stack_recipe("bonfire", /obj/structure/bonfire, BUILD_AMT, time = 30 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
 			new /datum/stack_recipe("wooden sandals", /obj/item/clothing/shoes/sandal, 1),
 			new /datum/stack_recipe("wood circlet", /obj/item/woodcirclet, 1),
 			new /datum/stack_recipe("wood floor tile", /obj/item/stack/tile/wood, 1, 4, 20),

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -160,7 +160,7 @@
 	recipes += new /datum/stack_recipe_list("[display_name] recipes",
 		list(
 			new /datum/stack_recipe("wooden barricade", /obj/structure/barricade/wooden, BUILD_AMT, time = 5 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
-			new /datum/stack_recipe("bonfire", /obj/structure/bonfire, BUILD_AMT, time = 30 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
+			new /datum/stack_recipe("bonfire", /obj/structure/bonfire, BUILD_AMT, time = 10 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
 			new /datum/stack_recipe("wooden sandals", /obj/item/clothing/shoes/sandal, 1),
 			new /datum/stack_recipe("wood circlet", /obj/item/woodcirclet, 1),
 			new /datum/stack_recipe("wood floor tile", /obj/item/stack/tile/wood, 1, 4, 20),

--- a/html/changelogs/ramke - bonfiretime.yml
+++ b/html/changelogs/ramke - bonfiretime.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ramke
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Wood can now be used to craft bonfires."
+  - bugfix: "Can no longer take burning sticks from unlit bonfires."


### PR DESCRIPTION
Bonfires can now be crafted using 20 wood planks. Become cozy on your expedition trips! Probably don't make one in the supermatter chamber.

Also small bugfix so you can't take burning sticks from an unlit bonfire anymore.