### PR TITLE
Cheaper Aut'akh Augments

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_xeno/unathi.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/unathi.dm
@@ -133,7 +133,7 @@
 	path = /obj/item/organ/external/hand/right/autakh/tool
 	whitelisted = list(SPECIES_UNATHI)
 	sort_category = "Xenowear - Unathi"
-	cost = 3
+	cost = 2
 	allowed_roles = list("Engineer", "Chief Engineer", "Atmospheric Technician", "Engineering Apprentice", "Machinist")
 	flags = GEAR_NO_SELECTION
 
@@ -143,7 +143,7 @@
 	path = /obj/item/organ/external/hand/right/autakh/tool/mining
 	whitelisted = list(SPECIES_UNATHI)
 	sort_category = "Xenowear - Unathi"
-	cost = 3
+	cost = 2
 	allowed_roles = list("Shaft Miner")
 	flags = GEAR_NO_SELECTION
 
@@ -153,7 +153,7 @@
 	path = /obj/item/organ/external/hand/right/autakh/medical
 	whitelisted = list(SPECIES_UNATHI)
 	sort_category = "Xenowear - Unathi"
-	cost = 3
+	cost = 2
 	allowed_roles = list("Chief Medical Officer", "Physician", "Surgeon", "First Responder", "Medical Intern", "Psychiatrist", "Chemist")
 	flags = GEAR_NO_SELECTION
 
@@ -163,7 +163,7 @@
 	path = /obj/item/organ/external/hand/right/autakh/security
 	whitelisted = list(SPECIES_UNATHI)
 	sort_category = "Xenowear - Unathi"
-	cost = 3
+	cost = 2
 	allowed_roles = list("Security Officer", "Head of Security", "Warden")
 	flags = GEAR_NO_SELECTION
 
@@ -228,7 +228,7 @@
 	description = "A rune inscribed mirror or piece of glass placed behind the eyes. Believed to \
 	be the 'Window to the Soul' and house the concentrated spirit of an individual."
 	path = /obj/item/organ/internal/anchor
-	cost = 1
+	cost = 0
 	whitelisted = list(SPECIES_UNATHI)
 	sort_category = "Xenowear - Unathi"
 
@@ -237,23 +237,27 @@
 	description = "An Aut'akh augment that allows the user to run at high speeds without the cost \
 	of stamina, causes damage to the lower body when used."
 	path = /obj/item/organ/internal/augment/calf_override
+	cost = 1
 
 /datum/gear/augment/autakh/protein_valve
 	display_name = "protein breakdown valve"
 	description = "An aut'akh valve on the chest that releases a dangerous chemical into the \
 	stomach, forcing rapid digestion for immediate adrenal stimulation. Causes long-term damage."
 	path = /obj/item/organ/internal/augment/protein_valve
+	cost = 1
 
 /datum/gear/augment/autakh/venomous_rest
 	display_name = "venomous rest implant"
 	description = "An aut'akh compartment connected to the blood system that administers a \
 	traditional Unathi healing agent."
 	path = /obj/item/organ/internal/augment/venomous_rest
+	cost = 1
 
 /datum/gear/augment/autakh/eyes
 	display_name = "eye augment selection"
 	description = "A selection of au'takh eye augments."
 	path = /obj/item/organ/internal/augment/farseer_eye
+	cost = 1
 
 /datum/gear/augment/autakh/eyes/New()
 	..()

--- a/html/changelogs/geeves-cheaper_autments.yml
+++ b/html/changelogs/geeves-cheaper_autments.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Reduced the price of Aut'akh Soul Anchors to 0, and the price of the various specialized graspers to 2."


### PR DESCRIPTION
* Reduced the price of Aut'akh Soul Anchors to 0, and the price of the various specialized graspers to 2.

The idea behind the price drops is: The Soul Anchor doesn't really do anything, it's just lore fluff hidden inside your head. As for the graspers, they're generally weaker than their standard counterparts, which the roles they're restricted to get for free anyway.