### PR TITLE
Security Map QoL and Tweaks

### DIFF
--- a/html/changelogs/security_tweaks.yml
+++ b/html/changelogs/security_tweaks.yml
@@ -1,0 +1,13 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - maptweak: "Tweaked the armoury and made it more walkable."
+  - maptweak: "Expanded the security equipment room and made it more walkable. Made the wall behind the lockers empty to allow hanging banners/flags on it."
+  - maptweak: "Tweaked the holding cells layout."
+  - maptweak: "Shrinked the brig communal a little and tweaked its layout."
+  - maptweak: "Tweaked the security washroom on deck 3 and connected its door to the hallway instead."
+  - maptweak: "Expanded the speakeasy area behind security."
+  - maptweak: "Fixed various mapping issues in security, such as wiring, piping, disposals, decals, and similarly."
+  - bugfix: "Fixed wrong IDs on objects in the brig cells."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -1561,7 +1561,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_b)
 "aHk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -2202,7 +2202,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_a)
 "aVo" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2756,7 +2756,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_a)
 "bkv" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -3404,7 +3404,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/maintenance/security_starboard)
+/area/horizon/security/equipment)
 "bzH" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/dark,
@@ -3470,7 +3470,7 @@
 	},
 /obj/structure/trash_pile,
 /turf/simulated/floor/plating,
-/area/horizon/security/equipment)
+/area/maintenance/wing/port)
 "bBO" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/engineering/aft_airlock)
@@ -4252,7 +4252,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_a)
+/area/horizon/security/equipment)
 "bSz" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 1
@@ -4387,7 +4387,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_a)
+/area/horizon/security/equipment)
 "bUN" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/polarized/firedoor{
 	id = "polarized_deck2_workshop"
@@ -4962,7 +4962,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_a)
+/area/horizon/security/equipment)
 "cjD" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/xenobiology/xenoflora_hazard)
@@ -6353,17 +6353,10 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "dbd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -6993,7 +6986,7 @@
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/horizon/security/equipment)
+/area/maintenance/wing/port)
 "dsj" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7726,7 +7719,7 @@
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_a)
 "dLn" = (
 /obj/machinery/light{
 	dir = 1
@@ -7930,7 +7923,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_a)
 "dQZ" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /obj/machinery/door/blast/shutters/open{
@@ -8009,7 +8002,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor/tiled,
-/area/maintenance/security_starboard)
+/area/horizon/security/equipment)
 "dTI" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -9588,7 +9581,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
+/area/horizon/security/equipment)
 "eMi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/brown,
@@ -11128,7 +11121,7 @@
 /area/storage/primary)
 "fzF" = (
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
+/area/horizon/security/equipment)
 "fzI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -13837,7 +13830,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/full,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_a)
 "gFT" = (
 /obj/structure/cable/orange{
 	icon_state = "0-4"
@@ -13931,13 +13924,14 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -15405,7 +15399,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
+/area/horizon/security/equipment)
 "hst" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
@@ -16267,7 +16261,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_b)
 "hPC" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -16863,7 +16857,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_a)
+/area/horizon/security/equipment)
 "ieM" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -19049,7 +19043,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_a)
+/area/horizon/security/equipment)
 "jjF" = (
 /obj/machinery/firealarm/east,
 /obj/effect/floor_decal/spline/fancy/wood/cee{
@@ -19278,7 +19272,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_a)
 "jnF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19834,7 +19828,7 @@
 	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/horizon/security/equipment)
+/area/maintenance/wing/port)
 "jBu" = (
 /obj/machinery/light{
 	dir = 8
@@ -20203,7 +20197,7 @@
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
+/area/horizon/security/equipment)
 "jKd" = (
 /obj/structure/bed/stool/chair/sofa/corner/brown{
 	dir = 1
@@ -21013,7 +21007,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_b)
 "kfE" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -21452,7 +21446,7 @@
 "ktc" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
-/area/horizon/security/holding_cell_a)
+/area/horizon/security/equipment)
 "ktC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -23741,7 +23735,7 @@
 /obj/random/loot,
 /obj/structure/table/rack,
 /turf/simulated/floor/plating,
-/area/horizon/security/equipment)
+/area/maintenance/wing/port)
 "lFP" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 8
@@ -24373,7 +24367,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_a)
 "lUA" = (
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d3-4"
@@ -24803,8 +24797,11 @@
 /area/template_noop)
 "mfV" = (
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/horizon/security/holding_cell_b)
+/area/maintenance/security_starboard)
 "mfX" = (
 /obj/structure/cable/green,
 /obj/effect/map_effect/window_spawner/full/reinforced/polarized/grille/firedoor{
@@ -25158,7 +25155,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_a)
+/area/horizon/security/equipment)
 "mqj" = (
 /obj/structure/closet/secure_closet/hangar_tech,
 /obj/machinery/light{
@@ -26570,20 +26567,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "mWT" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
+/turf/simulated/floor/tiled/dark/full,
+/area/horizon/security/holding_cell_b)
 "mWY" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset{
@@ -27552,7 +27541,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
+/area/horizon/security/equipment)
 "nry" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/wood,
@@ -27647,7 +27636,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/full,
-/area/horizon/security/holding_cell_b)
+/area/horizon/security/equipment)
 "nvq" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/polarized/firedoor{
 	id = "psych"
@@ -29983,12 +29972,9 @@
 /turf/simulated/floor/carpet/rubber,
 /area/hallway/primary/central_one)
 "oFx" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/horizon/security/holding_cell_b)
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled,
+/area/horizon/security/holding_cell_a)
 "oGp" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 1
@@ -30712,7 +30698,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_a)
 "oZI" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -31997,7 +31983,7 @@
 	},
 /obj/structure/closet/secure_closet/brig,
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_a)
 "pJK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -33031,7 +33017,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_b)
 "qjl" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -34888,7 +34874,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
-/area/maintenance/security_starboard)
+/area/horizon/security/equipment)
 "reo" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -38834,7 +38820,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_b)
 "tdO" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/disposalpipe/segment{
@@ -38954,7 +38940,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_a)
 "tgT" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -39368,7 +39354,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_a)
+/area/horizon/security/equipment)
 "tsA" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -41380,7 +41366,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_b)
 "uoj" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -41763,7 +41749,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_a)
+/area/horizon/security/equipment)
 "uvM" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -42775,7 +42761,7 @@
 	},
 /obj/structure/closet/secure_closet/brig,
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_b)
 "uUJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -42963,7 +42949,7 @@
 	req_access = list(63)
 	},
 /turf/simulated/floor/tiled/full,
-/area/horizon/security/holding_cell_b)
+/area/horizon/security/hallway)
 "uZH" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -42994,7 +42980,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
+/area/horizon/security/equipment)
 "vbc" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -45625,7 +45611,7 @@
 	},
 /obj/structure/reagent_dispensers/extinguisher,
 /turf/simulated/floor/plating,
-/area/horizon/security/equipment)
+/area/maintenance/wing/port)
 "wnc" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -46737,7 +46723,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/full,
-/area/horizon/security/holding_cell_a)
+/area/horizon/security/equipment)
 "wMg" = (
 /obj/structure/curtain/black{
 	icon_state = "open";
@@ -47558,7 +47544,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/full,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_b)
 "xhf" = (
 /obj/effect/floor_decal/corner/lime/full{
 	dir = 8
@@ -47647,7 +47633,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/maintenance/security_starboard)
+/area/horizon/security/equipment)
 "xio" = (
 /obj/machinery/atmospherics/unary/freezer{
 	dir = 1;
@@ -47751,7 +47737,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_a)
+/area/horizon/security/equipment)
 "xkS" = (
 /obj/machinery/computer/rdconsole/robotics{
 	dir = 8
@@ -48750,7 +48736,7 @@
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_b)
 "xNn" = (
 /obj/machinery/computer/shuttle_control/lift{
 	pixel_y = -1;
@@ -48924,7 +48910,7 @@
 "xQz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/holding_cell_b)
 "xQB" = (
 /obj/machinery/iv_drip,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -74672,12 +74658,12 @@ ayF
 ykd
 ayF
 ayF
-qDh
-qDh
+nUN
+bHb
 dLe
 dQR
 bkn
-qDh
+bHb
 lFP
 feO
 pIn
@@ -74875,9 +74861,9 @@ dev
 kaT
 cNU
 jBq
-qDh
+bHb
 tgp
-xQz
+oFx
 oZB
 lUi
 xIH
@@ -75077,7 +75063,7 @@ uTr
 uTr
 emN
 wmZ
-qDh
+bHb
 pJE
 aVf
 jno
@@ -75279,11 +75265,11 @@ bAZ
 uTr
 kaT
 drT
-qDh
-qDh
-qDh
-qDh
-qDh
+bHb
+bHb
+bHb
+bHb
+bHb
 jfu
 uJa
 tJr
@@ -75481,7 +75467,7 @@ dYe
 uTr
 kaT
 lFG
-qDh
+ePb
 uUz
 unV
 aHj
@@ -75683,11 +75669,11 @@ dYe
 uTr
 tCY
 bBu
-qDh
+ePb
 kfw
 xQz
 qjh
-lUi
+mWT
 xIH
 ycF
 aNB
@@ -75885,11 +75871,11 @@ oGK
 uTr
 veG
 bBu
-qDh
+ePb
 xMV
 hPx
 tdv
-qDh
+ePb
 wdY
 iIM
 iqu
@@ -76086,22 +76072,22 @@ drw
 tYa
 uTr
 kaT
-qDh
-qDh
-qDh
-qDh
-qDh
-qDh
+hps
+hps
+hps
+hps
+hps
+hps
 yci
 vtf
 wLk
-ubq
+qDh
 xik
 rec
 dTj
 rec
 bzs
-wAm
+qDh
 gis
 gis
 pjs
@@ -76303,9 +76289,9 @@ xkQ
 mqg
 hsh
 jKb
-ePb
-oFx
-ePb
+qDh
+sKE
+bDo
 bDo
 bDo
 bDo
@@ -76506,8 +76492,8 @@ bUm
 fzF
 eMf
 nuF
-mfV
-ePb
+gis
+bDo
 pBA
 rWG
 jzV
@@ -76701,15 +76687,15 @@ hps
 tuD
 rXd
 nrr
-bHb
+qDh
 jju
 cjC
 iet
 vaR
 nru
-ePb
+qDh
 mfV
-ePb
+bDo
 pTf
 gEa
 rGx
@@ -76903,15 +76889,15 @@ hsy
 vYv
 ggC
 qtN
-bHb
-bHb
-bHb
-bHb
-ePb
-ePb
-ePb
+qDh
+qDh
+qDh
+qDh
+qDh
+qDh
+qDh
 uZD
-ePb
+bDo
 kRr
 uiH
 bDo
@@ -77107,11 +77093,11 @@ gqy
 dhZ
 gem
 oaX
-mWT
+dKi
 lZD
 gAN
 dKi
-mWT
+dKi
 dKi
 xxc
 fuJ

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -4253,22 +4253,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
-"bSz" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 1
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Holding Cell B"
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/computer/sentencing/courtroom{
-	pixel_y = 32
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled,
-/area/template_noop)
 "bSD" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /turf/simulated/floor/tiled/dark/full,
@@ -7708,10 +7692,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
-"dLc" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/template_noop)
 "dLe" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 8
@@ -10792,23 +10772,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
-"fri" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/glass_security{
-	name = "Holding Cell B";
-	req_one_access = list(2,4)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/full,
-/area/template_noop)
 "frL" = (
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 1
@@ -11333,15 +11296,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/telesci)
-"fFV" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	req_access = list(63)
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/full,
-/area/template_noop)
 "fGi" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
@@ -18790,24 +18744,6 @@
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white,
 /area/operations/break_room)
-"jcz" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 8
-	},
-/obj/structure/bed/stool/chair,
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/sign/nosmoking_1{
-	pixel_y = 32
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled,
-/area/template_noop)
 "jcK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19342,21 +19278,6 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/engineering/atmos/storage)
-"joH" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 4
-	},
-/obj/structure/table/steel,
-/obj/item/device/flashlight/lamp,
-/obj/item/paper/sentencing{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/template_noop)
 "joM" = (
 /obj/effect/landmark{
 	name = "Revenant"
@@ -23009,19 +22930,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
-"ljZ" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/firealarm/west,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/template_noop)
 "lkt" = (
 /obj/machinery/camera/network/security{
 	c_tag = "Security - Lobby Desk"
@@ -25964,13 +25872,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/stairwell/central)
-"mJJ" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/template_noop)
 "mKw" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -34855,11 +34756,6 @@
 	},
 /turf/simulated/open/airless,
 /area/template_noop)
-"rdP" = (
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/full,
-/area/template_noop)
 "rdZ" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -35918,19 +35814,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/horizon/crew_quarters/lounge/bar)
-"rDK" = (
-/obj/effect/floor_decal/corner/paleblue/full,
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/machinery/alarm{
-	pixel_x = -28;
-	dir = 4
-	},
-/obj/structure/sign/nosmoking_1{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled,
-/area/template_noop)
 "rEk" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
@@ -36457,22 +36340,6 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/library)
-"rQr" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 1
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Holding Cell A"
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/computer/sentencing/courtroom{
-	pixel_y = 32
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled,
-/area/template_noop)
 "rQB" = (
 /obj/effect/floor_decal/sign/icu,
 /obj/structure/cable/green{
@@ -43435,27 +43302,6 @@
 /obj/structure/grille,
 /turf/simulated/open/airless,
 /area/horizon/exterior)
-"vrr" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled,
-/area/template_noop)
 "vrC" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -44734,23 +44580,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/conference)
-"vVW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/airlock/glass_security{
-	name = "Holding Cell A";
-	req_one_access = list(2,4)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/full,
-/area/template_noop)
 "vWt" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/green{
@@ -48693,9 +48522,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/template_noop)
-"xLZ" = (
-/turf/simulated/wall/r_wall,
-/area/template_noop)
 "xMm" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -49060,13 +48886,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room/tesla)
-"xVl" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light/small/emergency{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/template_noop)
 "xVu" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced/airless,
@@ -77109,14 +76928,14 @@ kuh
 fdj
 qgN
 qgN
-fFV
-dLc
-xVl
-dLc
-rdP
-dLc
-dLc
-dLc
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
 qgN
 qgN
 qgN
@@ -77311,14 +77130,14 @@ dUw
 fdj
 qgN
 qgN
-xLZ
-xLZ
-xLZ
-xLZ
-xLZ
-xLZ
-xLZ
-xLZ
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
 qgN
 qgN
 qgN
@@ -77513,14 +77332,14 @@ kuh
 fdj
 qgN
 qgN
-xLZ
-jcz
-ljZ
-rDK
-xLZ
-jcz
-ljZ
-rDK
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
 qgN
 qgN
 qgN
@@ -77715,14 +77534,14 @@ kuh
 fdj
 qgN
 qgN
-xLZ
-rQr
-vrr
-joH
-xLZ
-bSz
-vrr
-joH
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
 qgN
 qgN
 qgN
@@ -77917,14 +77736,14 @@ nJQ
 opx
 qgN
 qgN
-xLZ
-mJJ
-vVW
-mJJ
-xLZ
-mJJ
-fri
-mJJ
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
+qgN
 qgN
 qgN
 qgN

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -688,15 +688,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "arb" = (
@@ -1550,11 +1549,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "aHj" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+/obj/effect/floor_decal/corner/paleblue/full,
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/computer/sentencing/courtroom{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
@@ -2187,10 +2191,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
 "aVf" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/computer/sentencing/courtroom{
+	pixel_x = 32
+	},
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -2738,10 +2746,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
 "bkn" = (
+/obj/machinery/firealarm/south,
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
+	},
 /obj/effect/floor_decal/corner/paleblue/full,
-/obj/machinery/light,
-/obj/machinery/vending/security,
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "bkv" = (
@@ -3383,6 +3396,15 @@
 	},
 /turf/simulated/floor/lino/grey,
 /area/horizon/bar)
+"bzs" = (
+/obj/structure/closet/secure_closet/security,
+/obj/effect/floor_decal/corner/paleblue/full,
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/security_starboard)
 "bzH" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/dark,
@@ -3443,22 +3465,12 @@
 /turf/simulated/floor/tiled,
 /area/operations/break_room)
 "bBu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/airlock/glass_security{
-	name = "Holding Cell A";
-	req_one_access = list(2,4)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/full,
-/area/horizon/security/holding_cell_a)
+/obj/structure/trash_pile,
+/turf/simulated/floor/plating,
+/area/horizon/security/equipment)
 "bBO" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/engineering/aft_airlock)
@@ -4230,6 +4242,33 @@
 	},
 /turf/simulated/floor/wood,
 /area/medical/psych)
+"bSl" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/horizon/security/holding_cell_a)
+"bSz" = (
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 1
+	},
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Holding Cell B"
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/computer/sentencing/courtroom{
+	pixel_y = 32
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/template_noop)
 "bSD" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /turf/simulated/floor/tiled/dark/full,
@@ -4281,6 +4320,8 @@
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 4
 	},
+/obj/structure/closet/walllocker/emerglocker/east,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "bTz" = (
@@ -4342,15 +4383,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "bUm" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/firealarm/west,
-/obj/structure/cable/green{
-	icon_state = "1-4"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/holding_cell_a)
@@ -4915,17 +4949,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "cjC" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/obj/structure/table/steel,
-/obj/item/device/flashlight/lamp,
-/obj/item/paper/sentencing{
-	pixel_x = 6;
-	pixel_y = 6
+/obj/structure/table/standard,
+/obj/item/storage/box/fancy/donut,
+/obj/item/storage/box/fancy/donut{
+	pixel_y = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/item/device/radio/intercom{
+	pixel_x = 24;
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/holding_cell_a)
@@ -6953,6 +6987,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/turret_protected/ai_upload_foyer)
+"drT" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/horizon/security/equipment)
 "dsj" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7675,95 +7716,15 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "dLc" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	req_access = list(63)
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/full,
-/area/horizon/security/hallway)
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
+/area/template_noop)
 "dLe" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 8
 	},
-/obj/structure/table/rack,
-/obj/item/device/radio/sec{
-	pixel_x = -7
-	},
-/obj/item/device/radio/sec{
-	pixel_x = -7
-	},
-/obj/item/device/radio/sec{
-	pixel_x = -7
-	},
-/obj/item/device/radio/sec{
-	pixel_x = -7
-	},
-/obj/item/device/radio/sec{
-	pixel_x = -7
-	},
-/obj/item/device/radio/sec{
-	pixel_x = -7
-	},
-/obj/item/device/radio/sec{
-	pixel_x = -7
-	},
-/obj/item/crowbar/red{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/obj/item/crowbar/red{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/obj/item/crowbar/red{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/obj/item/crowbar/red{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/obj/item/crowbar/red{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/obj/item/crowbar/red{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/obj/item/device/flashlight/maglight{
-	pixel_y = -7
-	},
-/obj/item/device/flashlight/maglight{
-	pixel_y = -7
-	},
-/obj/item/device/flashlight/maglight{
-	pixel_y = -7
-	},
-/obj/item/device/flashlight/maglight{
-	pixel_y = -7
-	},
-/obj/item/device/flashlight/maglight{
-	pixel_y = -7
-	},
-/obj/item/device/flashlight/maglight{
-	pixel_y = -7
-	},
-/obj/item/device/hand_labeler{
-	pixel_y = 10;
-	pixel_x = 7
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/firealarm/north,
-/obj/machinery/alarm{
-	pixel_x = -28;
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/security,
+/obj/structure/table/reinforced,
+/obj/item/device/flashlight/lamp,
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "dLn" = (
@@ -7961,16 +7922,13 @@
 /turf/simulated/floor/lino/grey,
 /area/chapel/main)
 "dQR" = (
+/obj/structure/bed/stool/chair{
+	dir = 4
+	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/machinery/power/apc/low{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "dQZ" = (
@@ -8041,18 +7999,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "dTj" = (
-/obj/effect/floor_decal/corner/paleblue/full,
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/security,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
 /obj/effect/floor_decal/industrial/outline/security,
 /obj/machinery/alarm{
-	pixel_x = -28;
-	dir = 4
-	},
-/obj/structure/sign/nosmoking_1{
-	pixel_y = -32
+	dir = 4;
+	pixel_x = -28
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
+/area/maintenance/security_starboard)
 "dTI" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -9627,20 +9584,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hor)
 "eMf" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 8
-	},
-/obj/structure/bed/stool/chair,
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/sign/nosmoking_1{
-	pixel_y = 32
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/holding_cell_b)
@@ -10854,6 +10799,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
+"fri" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_security{
+	name = "Holding Cell B";
+	req_one_access = list(2,4)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/full,
+/area/template_noop)
 "frL" = (
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 1
@@ -11164,6 +11126,9 @@
 "fzh" = (
 /turf/simulated/wall,
 /area/storage/primary)
+"fzF" = (
+/turf/simulated/floor/tiled,
+/area/horizon/security/holding_cell_b)
 "fzI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -11375,6 +11340,15 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/telesci)
+"fFV" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	req_access = list(63)
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
+/area/template_noop)
 "fGi" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
@@ -12496,18 +12470,18 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/main_storage)
 "gem" = (
-/obj/effect/floor_decal/corner/paleblue/full,
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/machinery/alarm{
-	pixel_x = -28;
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
 	},
-/obj/structure/sign/nosmoking_1{
-	pixel_y = -32
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_a)
+/area/horizon/security/hallway)
 "gfj" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -13569,10 +13543,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -28
-	},
 /obj/machinery/camera/network/security{
 	c_tag = "Security - Corridor Camera 4";
 	dir = 4
@@ -13854,6 +13824,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
+"gFP" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/glass_security{
+	name = "Holding Cell A";
+	req_one_access = list(2,4)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/full,
+/area/horizon/security/equipment)
 "gFT" = (
 /obj/structure/cable/orange{
 	icon_state = "0-4"
@@ -15417,12 +15401,11 @@
 /turf/simulated/floor/tiled,
 /area/engineering/storage_eva)
 "hsh" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/structure/cable/green{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/full,
-/area/horizon/security/holding_cell_a)
+/turf/simulated/floor/tiled,
+/area/horizon/security/holding_cell_b)
 "hst" = (
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
@@ -16123,10 +16106,13 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/structure/closet/secure_closet/security,
-/obj/effect/floor_decal/industrial/outline/security,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/hallway)
 "hHM" = (
 /obj/structure/ladder{
 	pixel_y = 4
@@ -16273,9 +16259,13 @@
 /turf/simulated/wall,
 /area/medical/psych)
 "hPx" = (
+/obj/structure/bed/stool/chair{
+	dir = 8
+	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "hPC" = (
@@ -16798,6 +16788,82 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
+"iet" = (
+/obj/structure/table/rack,
+/obj/item/device/radio/sec{
+	pixel_x = -7
+	},
+/obj/item/device/radio/sec{
+	pixel_x = -7
+	},
+/obj/item/device/radio/sec{
+	pixel_x = -7
+	},
+/obj/item/device/radio/sec{
+	pixel_x = -7
+	},
+/obj/item/device/radio/sec{
+	pixel_x = -7
+	},
+/obj/item/device/radio/sec{
+	pixel_x = -7
+	},
+/obj/item/device/radio/sec{
+	pixel_x = -7
+	},
+/obj/item/crowbar/red{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/obj/item/crowbar/red{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/obj/item/crowbar/red{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/obj/item/crowbar/red{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/obj/item/crowbar/red{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/obj/item/crowbar/red{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/obj/item/device/flashlight/maglight{
+	pixel_y = -7
+	},
+/obj/item/device/flashlight/maglight{
+	pixel_y = -7
+	},
+/obj/item/device/flashlight/maglight{
+	pixel_y = -7
+	},
+/obj/item/device/flashlight/maglight{
+	pixel_y = -7
+	},
+/obj/item/device/flashlight/maglight{
+	pixel_y = -7
+	},
+/obj/item/device/flashlight/maglight{
+	pixel_y = -7
+	},
+/obj/item/device/hand_labeler{
+	pixel_y = 10;
+	pixel_x = 7
+	},
+/obj/machinery/firealarm/east,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/security,
+/turf/simulated/floor/tiled,
+/area/horizon/security/holding_cell_a)
 "ieM" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -18731,8 +18797,23 @@
 /turf/simulated/floor/tiled/white,
 /area/operations/break_room)
 "jcz" = (
-/turf/simulated/wall,
-/area/horizon/security/office)
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 8
+	},
+/obj/structure/bed/stool/chair,
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled,
+/area/template_noop)
 "jcK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18847,12 +18928,17 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/hologram/holopad,
+/obj/structure/closet/walllocker/medical{
+	pixel_y = 32
 	},
-/obj/structure/disposalpipe/segment,
+/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline,
+/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline,
+/obj/effect/floor_decal/industrial/outline/medical,
+/obj/item/stack/medical/ointment,
+/obj/item/stack/medical/ointment,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/bruise_pack,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "jfH" = (
@@ -18957,15 +19043,10 @@
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 1
 	},
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Holding Cell A"
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/computer/sentencing/courtroom{
-	pixel_y = 32
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/machinery/vending/security,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/holding_cell_a)
@@ -19186,16 +19267,16 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/lobby)
 "jno" = (
-/obj/effect/floor_decal/corner/paleblue{
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/table/steel,
-/obj/machinery/recharger{
-	pixel_x = -6
-	},
-/obj/machinery/recharger{
-	pixel_x = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "jnF" = (
@@ -19268,26 +19349,20 @@
 /turf/simulated/floor/tiled/full,
 /area/engineering/atmos/storage)
 "joH" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/corner/paleblue/full{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/table/steel,
+/obj/item/device/flashlight/lamp,
+/obj/item/paper/sentencing{
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_a)
+/area/template_noop)
 "joM" = (
 /obj/effect/landmark{
 	name = "Revenant"
@@ -19447,6 +19522,10 @@
 /area/rnd/xenobiology/xenoflora)
 "jrz" = (
 /obj/effect/floor_decal/corner/paleblue/full,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/investigations_hallway)
 "jrH" = (
@@ -19750,16 +19829,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "jBq" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
 /area/horizon/security/equipment)
 "jBu" = (
 /obj/machinery/light{
@@ -20120,6 +20194,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/armoury)
+"jKb" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/machinery/power/apc{
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled,
+/area/horizon/security/holding_cell_b)
 "jKd" = (
 /obj/structure/bed/stool/chair/sofa/corner/brown{
 	dir = 1
@@ -20726,6 +20810,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "kaz" = (
@@ -20819,17 +20906,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "kbZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -20909,17 +20999,19 @@
 /area/horizon/crew_quarters/lounge/bar)
 "kfw" = (
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/structure/table/reinforced,
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Holding Cell B"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/item/paper/pamphlet{
+	pixel_y = 8;
+	pixel_x = -8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "kfE" = (
@@ -21357,6 +21449,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
+"ktc" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
+/area/horizon/security/holding_cell_a)
 "ktC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -22919,6 +23015,19 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
+"ljZ" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/firealarm/west,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/template_noop)
 "lkt" = (
 /obj/machinery/camera/network/security{
 	c_tag = "Security - Lobby Desk"
@@ -23625,21 +23734,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"lFG" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/random/loot,
+/obj/structure/table/rack,
+/turf/simulated/floor/plating,
+/area/horizon/security/equipment)
 "lFP" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 8
 	},
-/obj/structure/table/steel,
-/obj/item/storage/box/fancy/donut{
-	pixel_y = 13
-	},
-/obj/item/storage/box/fancy/donut,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/alarm{
-	pixel_y = 28
+/obj/structure/bed/stool/chair,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -24
 	},
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "lFU" = (
@@ -24253,7 +24368,10 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/lobby)
 "lUi" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/equipment)
 "lUA" = (
@@ -24684,19 +24802,8 @@
 /turf/space/dynamic,
 /area/template_noop)
 "mfV" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 4
-	},
-/obj/structure/table/steel,
-/obj/item/device/flashlight/lamp,
-/obj/item/paper/sentencing{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
 /area/horizon/security/holding_cell_b)
 "mfX" = (
 /obj/structure/cable/green,
@@ -25044,18 +25151,14 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
 "mqg" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/firealarm/west,
 /obj/structure/cable/green{
-	icon_state = "1-4"
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
+/area/horizon/security/holding_cell_a)
 "mqj" = (
 /obj/structure/closet/secure_closet/hangar_tech,
 /obj/machinery/light{
@@ -25865,8 +25968,12 @@
 /turf/simulated/floor/tiled,
 /area/horizon/stairwell/central)
 "mJJ" = (
-/turf/simulated/wall,
-/area/horizon/security/equipment)
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/template_noop)
 "mKw" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -26771,21 +26878,6 @@
 "ncR" = (
 /turf/simulated/wall/r_wall,
 /area/horizon/security/lobby)
-"ndk" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/structure/closet/walllocker/medical{
-	pixel_y = -32
-	},
-/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/stack/medical/ointment,
-/obj/item/stack/medical/ointment,
-/obj/effect/floor_decal/industrial/outline/medical,
-/turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
 "ndn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -27451,18 +27543,13 @@
 /turf/simulated/floor/tiled/full,
 /area/horizon/security/hallway)
 "nru" = (
+/obj/structure/closet/secure_closet/security_cadet,
 /obj/effect/floor_decal/corner/paleblue/full{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Holding Cell B"
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/computer/sentencing/courtroom{
-	pixel_y = 32
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/holding_cell_b)
@@ -27553,14 +27640,14 @@
 /turf/simulated/floor/carpet,
 /area/horizon/crew_quarters/lounge/bar)
 "nuF" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	req_access = list(63)
 	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/full,
+/area/horizon/security/holding_cell_b)
 "nvq" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/polarized/firedoor{
 	id = "psych"
@@ -28663,6 +28750,16 @@
 /obj/structure/disposalpipe/junction/yjunction,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
+"oaX" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/hallway)
 "obd" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 9
@@ -29885,6 +29982,13 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/hallway/primary/central_one)
+"oFx" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/horizon/security/holding_cell_b)
 "oGp" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 1
@@ -30601,8 +30705,12 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/structure/closet/wardrobe/red,
-/obj/effect/floor_decal/industrial/outline/security,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "oZI" = (
@@ -31479,17 +31587,6 @@
 	},
 /turf/simulated/open,
 /area/hallway/primary/central_one)
-"pyA" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/security_cadet,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
 "pyJ" = (
 /obj/machinery/shower{
 	dir = 1
@@ -31887,6 +31984,18 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/conference)
 "pJE" = (
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/obj/structure/closet/secure_closet/brig,
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "pJK" = (
@@ -32915,9 +33024,11 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/machinery/disposal/small/north,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
@@ -34759,20 +34870,10 @@
 /turf/simulated/open/airless,
 /area/template_noop)
 "rdP" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	req_access = list(1);
-	name = "Equipment Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/multi_tile,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
-/area/horizon/security/equipment)
+/area/template_noop)
 "rdZ" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -34781,15 +34882,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/zta)
 "rec" = (
+/obj/structure/closet/secure_closet/security,
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 5
+	dir = 9
 	},
-/obj/structure/table/steel,
-/obj/item/deck/cards{
-	pixel_y = 12
-	},
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
+/area/maintenance/security_starboard)
 "reo" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -35834,8 +35933,18 @@
 /turf/simulated/floor/wood,
 /area/horizon/crew_quarters/lounge/bar)
 "rDK" = (
-/turf/simulated/wall,
-/area/horizon/security/lobby)
+/obj/effect/floor_decal/corner/paleblue/full,
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/machinery/alarm{
+	pixel_x = -28;
+	dir = 4
+	},
+/obj/structure/sign/nosmoking_1{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/template_noop)
 "rEk" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
@@ -36362,6 +36471,22 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/library)
+"rQr" = (
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 1
+	},
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Holding Cell A"
+	},
+/obj/machinery/hologram/holopad,
+/obj/machinery/computer/sentencing/courtroom{
+	pixel_y = 32
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/template_noop)
 "rQB" = (
 /obj/effect/floor_decal/sign/icu,
 /obj/structure/cable/green{
@@ -37197,6 +37322,17 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room)
+"smt" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/horizon/security/hallway)
 "snt" = (
 /turf/simulated/floor/wood,
 /area/medical/psych)
@@ -37759,20 +37895,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/telesci)
-"sEc" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
 "sEu" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/junk,
@@ -37821,9 +37943,6 @@
 /obj/machinery/disposal/small/west,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/hor)
-"sGm" = (
-/turf/simulated/wall,
-/area/horizon/security/investigations_hallway)
 "sGn" = (
 /turf/simulated/open,
 /area/horizon/stairwell/bridge)
@@ -38703,10 +38822,17 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "tdv" = (
+/obj/machinery/firealarm/south,
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "tdO" = (
@@ -38813,22 +38939,22 @@
 /turf/simulated/floor/wood,
 /area/horizon/security/head_of_security)
 "tgp" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
 	},
-/obj/machinery/door/airlock/glass_security{
-	name = "Holding Cell B";
-	req_one_access = list(2,4)
+/obj/structure/table/reinforced,
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Holding Cell A"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/paper/pamphlet{
+	pixel_y = 8;
+	pixel_x = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/full,
-/area/horizon/security/holding_cell_b)
+/turf/simulated/floor/tiled,
+/area/horizon/security/equipment)
 "tgT" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -39238,20 +39364,8 @@
 /turf/simulated/floor/tiled/dark/airless,
 /area/horizon/exterior)
 "tsy" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 8
-	},
-/obj/structure/bed/stool/chair,
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/sign/nosmoking_1{
-	pixel_y = 32
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/holding_cell_a)
@@ -39388,6 +39502,17 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/smes/tesla)
+"txr" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/machinery/light,
+/obj/machinery/alarm{
+	pixel_y = -28;
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/hallway)
 "txy" = (
 /turf/simulated/floor/tiled/dark,
 /area/rnd/hallway)
@@ -40680,18 +40805,6 @@
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
-"ucD" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	req_access = list(1);
-	name = "Equipment Room";
-	dir = 1
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 2
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/full,
-/area/horizon/security/equipment)
 "ucI" = (
 /obj/effect/floor_decal/corner_wide/paleblue/full{
 	dir = 8
@@ -41259,8 +41372,12 @@
 /turf/simulated/open/airless,
 /area/template_noop)
 "unV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
@@ -41641,6 +41758,12 @@
 /obj/effect/floor_decal/industrial/outline/medical,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
+"uvC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/holding_cell_a)
 "uvM" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -42639,10 +42762,18 @@
 /turf/simulated/floor/tiled,
 /area/horizon/kitchen/freezer)
 "uUz" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -24
 	},
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/obj/structure/closet/secure_closet/brig,
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "uUJ" = (
@@ -42825,11 +42956,13 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/smes/tesla)
 "uZD" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	req_access = list(63)
 	},
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/holding_cell_b)
 "uZH" = (
 /obj/machinery/light/small{
@@ -42855,16 +42988,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "vaR" = (
+/obj/structure/closet/secure_closet/security_cadet,
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+	dir = 6
 	},
-/obj/item/device/radio/intercom{
-	pixel_y = -24;
-	dir = 1
-	},
-/obj/machinery/light,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
+/area/horizon/security/holding_cell_b)
 "vbc" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
@@ -43319,6 +43449,27 @@
 /obj/structure/grille,
 /turf/simulated/open/airless,
 /area/horizon/exterior)
+"vrr" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/template_noop)
 "vrC" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -44597,6 +44748,23 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/conference)
+"vVW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/glass_security{
+	name = "Holding Cell A";
+	req_one_access = list(2,4)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/full,
+/area/template_noop)
 "vWt" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/green{
@@ -45040,6 +45208,7 @@
 	dir = 5
 	},
 /obj/structure/bed/stool/chair,
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "weh" = (
@@ -45450,6 +45619,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
+"wmZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/extinguisher,
+/turf/simulated/floor/plating,
+/area/horizon/security/equipment)
 "wnc" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -45927,6 +46103,20 @@
 /obj/structure/flora/pottedplant/random,
 /turf/simulated/floor/wood,
 /area/hallway/engineering)
+"wzM" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/horizon/security/hallway)
 "wzN" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -46424,6 +46614,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "wLz" = (
@@ -46528,6 +46721,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/office)
+"wLZ" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	req_access = list(1);
+	name = "Equipment Room";
+	dir = 8
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/full,
+/area/horizon/security/holding_cell_a)
 "wMg" = (
 /obj/structure/curtain/black{
 	icon_state = "open";
@@ -47337,6 +47547,16 @@
 /area/engineering/engine_room/tesla)
 "xgZ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/glass_security{
+	name = "Holding Cell B";
+	req_one_access = list(2,4)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/full,
 /area/horizon/security/equipment)
 "xhf" = (
@@ -47417,6 +47637,17 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
+"xik" = (
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 8
+	},
+/obj/structure/closet/wardrobe/red,
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/security_starboard)
 "xio" = (
 /obj/machinery/atmospherics/unary/freezer{
 	dir = 1;
@@ -47511,6 +47742,16 @@
 "xkH" = (
 /turf/simulated/open,
 /area/turret_protected/ai_upload)
+"xkQ" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/holding_cell_a)
 "xkS" = (
 /obj/machinery/computer/rdconsole/robotics{
 	dir = 8
@@ -48331,9 +48572,11 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/structure/bed/stool/chair{
-	dir = 4
+/obj/structure/bed/stool/chair,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "xIJ" = (
@@ -48465,13 +48708,8 @@
 /turf/simulated/floor/reinforced/airless,
 /area/template_noop)
 "xLZ" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/structure/closet/secure_closet/security_cadet,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/turf/simulated/wall/r_wall,
+/area/template_noop)
 "xMm" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -48506,13 +48744,11 @@
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "xMV" = (
-/obj/item/device/radio/intercom{
-	pixel_x = 24;
-	dir = 8
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
+/obj/structure/table/reinforced,
+/obj/item/device/flashlight/lamp,
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "xNn" = (
@@ -48686,9 +48922,7 @@
 /turf/simulated/floor/tiled/full,
 /area/engineering/engine_waste)
 "xQz" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "xQB" = (
@@ -48826,6 +49060,7 @@
 	c_tag = "Security - Corridor Camera 3";
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "xVf" = (
@@ -48840,26 +49075,12 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room/tesla)
 "xVl" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency{
+	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
+/turf/simulated/floor/plating,
+/area/template_noop)
 "xVu" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced/airless,
@@ -49199,9 +49420,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/structure/bed/stool/chair{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "yct" = (
@@ -49233,6 +49451,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"ycF" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/hallway)
 "ycL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -72422,7 +72658,7 @@ dLu
 pTQ
 txW
 lZu
-rDK
+ncR
 jOv
 wvn
 efA
@@ -73230,7 +73466,7 @@ gny
 dkp
 tWx
 mLN
-jcz
+hnD
 fLB
 rBL
 efA
@@ -74040,7 +74276,7 @@ wQi
 fAC
 qlV
 wCZ
-qtN
+txr
 pMf
 vCs
 nDx
@@ -74236,11 +74472,11 @@ nfs
 uoU
 cHM
 hnD
-jcz
-jcz
-jcz
-jcz
-jcz
+hnD
+hnD
+hnD
+hnD
+hnD
 eIt
 nrr
 pMf
@@ -74441,7 +74677,7 @@ qDh
 dLe
 dQR
 bkn
-mJJ
+qDh
 lFP
 feO
 pIn
@@ -74638,13 +74874,13 @@ kaT
 dev
 kaT
 cNU
+jBq
 qDh
-hHJ
-pJE
-uUz
+tgp
+xQz
 oZB
 lUi
-wdY
+xIH
 kat
 pIn
 vCs
@@ -74840,13 +75076,13 @@ uTr
 uTr
 uTr
 emN
+wmZ
 qDh
-hHJ
 pJE
 aVf
 jno
-lUi
-wdY
+gFP
+hHJ
 aqZ
 mOt
 glv
@@ -75042,14 +75278,14 @@ vPg
 bAZ
 uTr
 kaT
+drT
 qDh
-hHJ
-pJE
-jBq
-kfw
-rdP
+qDh
+qDh
+qDh
+qDh
 jfu
-sEc
+uJa
 tJr
 pMf
 iWm
@@ -75244,15 +75480,15 @@ ncx
 dYe
 uTr
 kaT
+lFG
 qDh
-hHJ
-pJE
+uUz
 unV
 aHj
 xgZ
-lCC
-uJa
-aNB
+hHJ
+wzM
+pIn
 pMf
 wiB
 kvE
@@ -75446,15 +75682,15 @@ ncx
 dYe
 uTr
 tCY
+bBu
 qDh
-xLZ
-pJE
+kfw
 xQz
 qjh
 lUi
 xIH
-gqy
-ndk
+ycF
+aNB
 pMf
 nqE
 ijp
@@ -75648,13 +75884,13 @@ uxf
 oGK
 uTr
 veG
+bBu
 qDh
-pyA
 xMV
 hPx
 tdv
-lUi
-rec
+qDh
+wdY
 iIM
 iqu
 pMf
@@ -75851,21 +76087,21 @@ tYa
 uTr
 kaT
 qDh
-mJJ
-mJJ
-xgZ
-ucD
-mJJ
+qDh
+qDh
+qDh
+qDh
+qDh
 yci
 vtf
 wLk
-dLc
-gis
-pjs
-gis
-sKE
-gis
-gis
+ubq
+xik
+rec
+dTj
+rec
+bzs
+wAm
 gis
 gis
 pjs
@@ -76060,15 +76296,15 @@ jrz
 qUt
 lCC
 kbZ
-nuF
-bHb
-bHb
-bHb
-bHb
+smt
+wLZ
+bSl
+xkQ
+mqg
+hsh
+jKb
 ePb
-ePb
-ePb
-ePb
+oFx
 ePb
 bDo
 bDo
@@ -76263,14 +76499,14 @@ oqW
 lCC
 eJW
 pIn
-bHb
+ktc
 tsy
+uvC
 bUm
-gem
-ePb
+fzF
 eMf
-mqg
-dTj
+nuF
+mfV
 ePb
 pBA
 rWG
@@ -76457,21 +76693,21 @@ kGX
 wUS
 wwR
 hps
-sGm
-sGm
-sGm
-sGm
-sGm
+hps
+hps
+hps
+hps
+hps
 tuD
 rXd
 nrr
 bHb
 jju
-joH
 cjC
-ePb
+iet
+vaR
 nru
-xVl
+ePb
 mfV
 ePb
 pTf
@@ -76666,14 +76902,14 @@ vCM
 hsy
 vYv
 ggC
-vaR
+qtN
 bHb
-hsh
-bBu
-hsh
+bHb
+bHb
+bHb
 ePb
-uZD
-tgp
+ePb
+ePb
 uZD
 ePb
 kRr
@@ -76869,8 +77105,8 @@ edD
 lCC
 gqy
 dhZ
-xxc
-dKi
+gem
+oaX
 mWT
 lZD
 gAN
@@ -76887,14 +77123,14 @@ kuh
 fdj
 qgN
 qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
+fFV
+dLc
+xVl
+dLc
+rdP
+dLc
+dLc
+dLc
 qgN
 qgN
 qgN
@@ -77089,14 +77325,14 @@ dUw
 fdj
 qgN
 qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
+xLZ
+xLZ
+xLZ
+xLZ
+xLZ
+xLZ
+xLZ
+xLZ
 qgN
 qgN
 qgN
@@ -77291,14 +77527,14 @@ kuh
 fdj
 qgN
 qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
+xLZ
+jcz
+ljZ
+rDK
+xLZ
+jcz
+ljZ
+rDK
 qgN
 qgN
 qgN
@@ -77493,14 +77729,14 @@ kuh
 fdj
 qgN
 qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
+xLZ
+rQr
+vrr
+joH
+xLZ
+bSz
+vrr
+joH
 qgN
 qgN
 qgN
@@ -77695,14 +77931,14 @@ nJQ
 opx
 qgN
 qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
-qgN
+xLZ
+mJJ
+vVW
+mJJ
+xLZ
+mJJ
+fri
+mJJ
 qgN
 qgN
 qgN

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -1,10 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aae" = (
-/obj/machinery/recharge_station,
-/obj/effect/floor_decal/industrial/hatch/grey,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/seed_storage,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
+/obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "aal" = (
@@ -94,24 +94,19 @@
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/warden{
-	pixel_x = 8
-	},
-/obj/structure/coatrack{
-	pixel_x = -6
-	},
-/obj/item/device/eftpos{
-	eftpos_name = "Brig EFTPOS scanner"
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 36
+	pixel_y = 28
 	},
-/obj/machinery/firealarm/east{
-	pixel_x = 27
+/obj/structure/filingcabinet/filingcabinet{
+	pixel_x = 9
+	},
+/obj/machinery/papershredder{
+	pixel_x = -6;
+	pixel_y = -1
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 28;
+	pixel_x = 36
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/warden)
@@ -487,19 +482,15 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_two/fore)
 "amI" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/flasher{
+	id = "permflash";
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/horizon/security/brig)
 "ang" = (
 /obj/effect/shuttle_landmark/horizon/decktwo/port_fore,
@@ -520,24 +511,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/zta)
-"anU" = (
-/obj/structure/window/shuttle/scc_space_ship,
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Security Lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
 "aob" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -715,14 +688,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "arb" = (
@@ -735,12 +709,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "aru" = (
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/machinery/flasher{
-	id = "permflash"
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "arG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -777,12 +748,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/operations/office)
 "arV" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/hullbeacon/red,
-/turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port/far)
 "ask" = (
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d3-4"
@@ -1054,23 +1031,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room/tesla)
 "avW" = (
-/obj/structure/window/shuttle/scc_space_ship,
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Security Lockdown";
-	name = "Security Blast Door";
-	opacity = 0
+/obj/structure/toilet{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
+/obj/effect/floor_decal/corner/green/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/horizon/security/brig)
 "aww" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
@@ -1144,29 +1110,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "aya" = (
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/outline/security,
 /obj/structure/closet/secure_closet/guncabinet{
 	name = "Weaponry (Anti-Materiel)"
 	},
-/obj/item/gun/projectile/peac,
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/item/ammo_casing/peac,
+/obj/item/ammo_casing/peac,
+/obj/item/ammo_casing/peac,
+/obj/item/gun/projectile/peac,
+/obj/machinery/alarm{
+	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/sign/flag/scc/left{
-	pixel_y = 32
-	},
-/obj/machinery/light/colored/red{
-	dir = 1
-	},
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "ayc" = (
@@ -1590,11 +1547,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "aHj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
@@ -1653,10 +1610,16 @@
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "aIH" = (
+/obj/machinery/camera/network/prison{
+	c_tag = "Security - Brig Communal Fore";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/paleblue,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "aIP" = (
@@ -1704,20 +1667,11 @@
 /turf/simulated/floor/wood,
 /area/hallway/engineering)
 "aKO" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -28
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -1734,29 +1688,28 @@
 /area/maintenance/wing/starboard)
 "aLq" = (
 /obj/structure/table/rack,
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 8;
-	name = "Riot Armour and Gear Storage";
-	req_access = list(3)
-	},
-/obj/item/clothing/suit/armor/carrier/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/shield/riot,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 6
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/sign/flag/scc/left{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = -16
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/clothing/suit/armor/carrier/riot,
+/obj/item/clothing/suit/armor/carrier/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/machinery/door/window/brigdoor/southright{
+	req_access = list(3);
+	name = "Riot Armour"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
@@ -1889,8 +1842,18 @@
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "aOz" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -1960,22 +1923,24 @@
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)
 "aQR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/glass_security{
+	autoclose = 0;
+	id_tag = "cell_1";
+	name = "Cell A";
+	req_access = list(2)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Brig Lockdown";
-	name = "Brig Lockdown Blast Door";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/brig)
 "aRr" = (
 /obj/structure/cable{
@@ -2165,10 +2130,9 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
-/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
 /area/horizon/security/armoury)
 "aTO" = (
@@ -2220,7 +2184,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
 "aVf" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "aVo" = (
@@ -2239,17 +2208,9 @@
 "aVX" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/brig)
 "aWi" = (
 /obj/structure/railing/mapped,
@@ -2484,20 +2445,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_waste)
 "baJ" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
+/obj/machinery/computer/cryopod{
+	pixel_x = 32
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -32
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "bbI" = (
@@ -2702,10 +2654,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner_wide/paleblue{
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -2782,24 +2735,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
 "bkn" = (
-/obj/machinery/firealarm/south,
 /obj/effect/floor_decal/corner/paleblue/full,
-/obj/machinery/power/apc/low{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/table/steel,
-/obj/machinery/recharger{
-	pixel_x = -6
-	},
-/obj/machinery/recharger{
-	pixel_x = 6
-	},
+/obj/machinery/light,
+/obj/machinery/vending/security,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "bkv" = (
@@ -2825,13 +2764,6 @@
 /obj/machinery/porta_turret,
 /turf/simulated/floor/reinforced,
 /area/turret_protected/ai)
-"blC" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/tiled/dark/full,
-/area/horizon/security/armoury)
 "blJ" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
@@ -2986,17 +2918,12 @@
 	pixel_x = 6;
 	pixel_y = -4
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = -32
 	},
-/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
 /area/horizon/security/armoury)
 "bnQ" = (
@@ -3513,21 +3440,21 @@
 /turf/simulated/floor/tiled,
 /area/operations/break_room)
 "bBu" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/glass_security{
+	name = "Holding Cell A";
+	req_one_access = list(2,4)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_security{
-	name = "Holding Cell A";
-	req_one_access = list(2,4)
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/holding_cell_a)
 "bBO" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
@@ -3718,20 +3645,20 @@
 /turf/simulated/floor/carpet/rubber,
 /area/engineering/engine_monitoring)
 "bFU" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
+/area/horizon/security/armoury)
 "bGg" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3804,17 +3731,7 @@
 /turf/simulated/floor/wood,
 /area/chapel/office)
 "bHb" = (
-/obj/machinery/computer/sentencing/courtroom{
-	pixel_y = -29
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Processing 1";
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/wall/r_wall,
 /area/horizon/security/holding_cell_a)
 "bHe" = (
 /turf/simulated/floor/tiled,
@@ -3959,9 +3876,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/zta)
 "bKu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/emergency{
-	dir = 8
+/obj/structure/lattice/catwalk/indoor/grate/damaged,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
@@ -3984,10 +3904,10 @@
 /turf/simulated/floor/lino/grey,
 /area/horizon/bar)
 "bLu" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "bLB" = (
@@ -4024,11 +3944,16 @@
 /turf/simulated/floor/tiled,
 /area/medical/gen_treatment)
 "bOe" = (
+/obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 4
 	},
-/obj/structure/bed/stool/chair/plastic{
-	dir = 8
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -4078,11 +4003,19 @@
 /turf/simulated/floor/plating,
 /area/horizon/maintenance/deck_two/fore/starboard)
 "bOR" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/central_one)
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Brig Lockdown";
+	name = "Brig Lockdown Blast Door";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/horizon/security/brig)
 "bOV" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4325,20 +4258,11 @@
 /turf/simulated/floor/tiled,
 /area/turret_protected/ai_upload_foyer)
 "bTy" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
 	id = "isolation_a_lockdown";
 	name = "Isolation Cell A Blastdoors";
 	pixel_y = -33
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
 	},
 /obj/machinery/button/remote/airlock{
 	dir = 1;
@@ -4347,6 +4271,9 @@
 	pixel_y = -25;
 	req_access = list(19);
 	specialfunctions = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -4409,9 +4336,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "bUm" = (
-/obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/firealarm/west,
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/holding_cell_a)
@@ -4645,8 +4578,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/main_storage)
 "bZE" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "caj" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -4969,7 +4904,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "cjC" = (
-/turf/simulated/wall,
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 4
+	},
+/obj/structure/table/steel,
+/obj/item/device/flashlight/lamp,
+/obj/item/paper/sentencing{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
 /area/horizon/security/holding_cell_a)
 "cjD" = (
 /turf/simulated/wall/r_wall,
@@ -5292,13 +5239,13 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "cww" = (
@@ -5379,13 +5326,10 @@
 /area/maintenance/wing/starboard/far)
 "czL" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "czP" = (
@@ -5438,11 +5382,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_quarters/lounge/bar)
 "cAx" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/wing/port)
 "cBq" = (
@@ -5600,30 +5541,34 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "cIx" = (
-/obj/structure/table/rack,
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 8;
-	name = "Bulletproof Armour Storage";
-	req_access = list(3)
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Ammunition (Rifles and Shotguns)"
 	},
-/obj/item/clothing/suit/armor/carrier/ballistic,
-/obj/item/clothing/suit/armor/carrier/ballistic,
-/obj/item/clothing/head/helmet/ballistic,
-/obj/item/clothing/head/helmet/ballistic,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/item/storage/box/stunshells,
+/obj/item/storage/box/flashshells{
+	pixel_x = -2;
+	pixel_y = 2
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/item/storage/box/beanbags{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/obj/effect/floor_decal/industrial/outline/security,
+/obj/item/storage/box/beanbags{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/trackingslugs,
+/obj/item/storage/box/shotgunshells,
+/obj/item/storage/box/shotgunshells,
+/obj/item/ammo_magazine/a556/carbine/polymer,
+/obj/item/ammo_magazine/a556/carbine/polymer,
+/obj/item/ammo_magazine/a556/carbine/polymer,
+/obj/item/ammo_magazine/a556/carbine/polymer,
+/obj/machinery/light,
 /obj/effect/floor_decal/corner_wide/paleblue/full{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 6
-	},
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "cIz" = (
@@ -5869,19 +5814,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "cOj" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
 /obj/machinery/door/blast/regular{
-	density = 0;
 	dir = 4;
-	icon_state = "pdoor0";
-	id = "Brig Lockdown";
-	name = "Brig Lockdown Blast Door";
-	opacity = 0
+	id = "shutters_deck1_security_cell_2";
+	name = "Cell B Blast Door"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/brig)
 "cOk" = (
 /obj/effect/floor_decal/corner/green{
@@ -5953,21 +5894,16 @@
 /turf/simulated/open/airless,
 /area/template_noop)
 "cQd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32
+	},
+/obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "cQw" = (
@@ -6366,8 +6302,17 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "dbd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -6396,13 +6341,11 @@
 /turf/simulated/floor/tiled,
 /area/operations/break_room)
 "dcN" = (
+/obj/structure/foamedmetal,
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d2-1-f"
 	},
-/obj/effect/floor_decal/corner_wide/red/full{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/horizon/security/brig)
 "dcT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -6436,20 +6379,18 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room/tesla)
 "ddH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port/far)
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "ddX" = (
 /obj/structure/reagent_dispensers/cookingoil,
 /turf/simulated/floor/tiled/freezer{
@@ -6537,13 +6478,12 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/structure/cable/green,
+/obj/structure/table/standard,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/armoury)
@@ -6768,7 +6708,12 @@
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "dlR" = (
-/obj/effect/floor_decal/corner/paleblue/full,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "dlT" = (
@@ -6944,14 +6889,13 @@
 /turf/simulated/floor/wood,
 /area/chapel/office)
 "dqy" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 5
+/obj/effect/floor_decal/corner/paleblue/full,
+/obj/machinery/power/apc/critical{
+	pixel_y = -24
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/cable/green,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -7171,8 +7115,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint2)
 "dwK" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "dwP" = (
@@ -7412,29 +7359,15 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "dDo" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/paleblue,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door_timer/cell_2{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Corridor Camera 4";
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "dDp" = (
@@ -7672,12 +7605,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/hallway)
 "dKi" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -7725,31 +7658,94 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "dLc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	req_access = list(63)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door_timer/cell_1{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/hallway)
 "dLe" = (
-/obj/item/device/radio/intercom{
-	pixel_y = 24
-	},
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/security,
+/obj/structure/table/rack,
+/obj/item/device/radio/sec{
+	pixel_x = -7
+	},
+/obj/item/device/radio/sec{
+	pixel_x = -7
+	},
+/obj/item/device/radio/sec{
+	pixel_x = -7
+	},
+/obj/item/device/radio/sec{
+	pixel_x = -7
+	},
+/obj/item/device/radio/sec{
+	pixel_x = -7
+	},
+/obj/item/device/radio/sec{
+	pixel_x = -7
+	},
+/obj/item/device/radio/sec{
+	pixel_x = -7
+	},
+/obj/item/crowbar/red{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/obj/item/crowbar/red{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/obj/item/crowbar/red{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/obj/item/crowbar/red{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/obj/item/crowbar/red{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/obj/item/crowbar/red{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/obj/item/device/flashlight/maglight{
+	pixel_y = -7
+	},
+/obj/item/device/flashlight/maglight{
+	pixel_y = -7
+	},
+/obj/item/device/flashlight/maglight{
+	pixel_y = -7
+	},
+/obj/item/device/flashlight/maglight{
+	pixel_y = -7
+	},
+/obj/item/device/flashlight/maglight{
+	pixel_y = -7
+	},
+/obj/item/device/flashlight/maglight{
+	pixel_y = -7
+	},
+/obj/item/device/hand_labeler{
+	pixel_y = 10;
+	pixel_x = 7
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm/north,
+/obj/machinery/alarm{
+	pixel_x = -28;
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
@@ -7947,38 +7943,16 @@
 	},
 /turf/simulated/floor/lino/grey,
 /area/chapel/main)
-"dPZ" = (
-/obj/structure/window/shuttle/scc_space_ship,
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Brig Lockdown";
-	name = "Brig Lockdown Blast Door";
-	opacity = 0
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Security Lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
 "dQR" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/power/apc/low{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/structure/sign/nosmoking_2{
-	pixel_x = -32
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
@@ -8050,12 +8024,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "dTj" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/effect/floor_decal/corner/paleblue/full,
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/machinery/alarm{
+	pixel_x = -28;
+	dir = 4
 	},
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
+/obj/structure/sign/nosmoking_1{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/holding_cell_b)
 "dTI" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -8076,12 +8056,6 @@
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 8;
@@ -8098,6 +8072,7 @@
 	name = "Brig Lockdown Blast Door";
 	opacity = 0
 	},
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/horizon/security/brig)
 "dVt" = (
@@ -8154,13 +8129,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "dVE" = (
-/obj/structure/sign/securearea{
-	desc = "A caution sign which reads 'CAUTION: BRIG COMMUNAL AREA' and 'SECURE AREA'.";
-	name = "\improper BRIG COMMUNAL AREA sign";
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/railing/mapped{
+	dir = 4
+	},
 /obj/item/hullbeacon/red,
 /turf/simulated/floor/reinforced/airless,
 /area/template_noop)
@@ -8255,28 +8227,27 @@
 /turf/simulated/floor/tiled/full,
 /area/hallway/engineering)
 "dXx" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
+/obj/structure/closet/secure_closet/marooning_equipment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/light{
+/obj/machinery/door/window/southright{
+	name = "Marooning Equipment Access";
+	req_one_access = list(1,19)
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/hallway)
 "dXD" = (
 /obj/effect/shuttle_landmark/horizon/decktwo/port_aft,
 /turf/template_noop,
 /area/template_noop)
-"dXF" = (
-/obj/effect/floor_decal/corner/paleblue/full,
-/obj/structure/table/steel,
-/obj/item/paper/sentencing{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/device/flashlight/lamp,
-/turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
 "dYe" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 10
@@ -8319,17 +8290,15 @@
 /area/horizon/zta)
 "dYr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/stool/bar/padded/red,
+/obj/structure/table/wood/gamblingtable,
 /turf/simulated/floor/wood,
 /area/maintenance/wing/port)
 "dYR" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
+/obj/machinery/door/airlock{
+	name = "Brig Showers"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/brig)
 "dZG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8424,26 +8393,25 @@
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
 "ebT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/airlock/glass_security{
+	autoclose = 0;
+	id_tag = "cell_2";
+	name = "Cell B";
+	req_access = list(2)
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Brig Lockdown";
-	name = "Brig Lockdown Blast Door";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/brig)
 "ebY" = (
 /obj/structure/railing/mapped{
@@ -8452,7 +8420,10 @@
 /obj/machinery/alarm{
 	pixel_y = 28
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "ecx" = (
@@ -8470,25 +8441,22 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_monitoring/tesla)
 "edD" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
+/obj/structure/closet/secure_closet/marooning_equipment,
+/obj/machinery/door/window/southleft{
+	name = "Marooning Equipment";
+	req_one_access = list(1,19)
+	},
+/obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/hallway)
 "eew" = (
 /obj/machinery/power/apc/low{
@@ -8528,10 +8496,17 @@
 /turf/simulated/floor/reinforced,
 /area/horizon/grauwolf)
 "efz" = (
+/obj/item/hullbeacon/red,
+/obj/structure/sign/securearea{
+	desc = "A caution sign which reads 'CAUTION: BRIG COMMUNAL AREA' and 'SECURE AREA'.";
+	name = "\improper BRIG COMMUNAL AREA sign";
+	pixel_y = 32;
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/item/hullbeacon/red,
 /turf/simulated/floor/reinforced/airless,
 /area/template_noop)
 "efA" = (
@@ -8696,7 +8671,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
 /area/maintenance/wing/port)
 "elz" = (
 /obj/structure/cable{
@@ -8708,11 +8684,11 @@
 /turf/simulated/floor/tiled/full,
 /area/engineering/lobby)
 "elL" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
+/obj/machinery/light/small/emergency{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "ema" = (
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d3-6"
@@ -8940,11 +8916,36 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "eqS" = (
-/obj/structure/shuttle_part/scc_space_ship{
-	icon_state = "d2-1-f"
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
-/turf/simulated/wall,
-/area/maintenance/wing/port)
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "Security Lockdown";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "cell_isolation";
+	name = "Isolation Cell Blast Door";
+	opacity = 0;
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	name = "Viewing Shutter";
+	id = "cell_isolation_viewing"
+	},
+/obj/structure/grille,
+/obj/structure/window/shuttle/scc_space_ship,
+/turf/simulated/floor/plating,
+/area/horizon/security/brig)
 "eqX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -8967,6 +8968,7 @@
 /turf/simulated/floor/reinforced,
 /area/horizon/zta)
 "erY" = (
+/obj/structure/table/wood/gamblingtable,
 /turf/simulated/floor/tiled,
 /area/maintenance/wing/port)
 "esy" = (
@@ -9133,10 +9135,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "exu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "exw" = (
 /obj/machinery/light/small/red{
@@ -9467,18 +9466,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "eGh" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Brig Lockdown";
+	name = "Brig Lockdown Blast Door";
+	opacity = 0;
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/brig)
 "eGl" = (
 /obj/structure/railing/mapped,
@@ -9548,16 +9546,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/hallway)
 "eIE" = (
 /obj/machinery/door/airlock{
@@ -9616,8 +9610,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/hor)
 "eMf" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 8
+	},
+/obj/structure/bed/stool/chair,
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/holding_cell_b)
@@ -9669,14 +9675,10 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
 "eNZ" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/obj/random/junk,
+/obj/structure/table/wood,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "eOl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -9693,16 +9695,7 @@
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/horizon/zta)
 "ePb" = (
-/obj/machinery/computer/sentencing/courtroom{
-	pixel_y = 29
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Processing 2"
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/wall/r_wall,
 /area/horizon/security/holding_cell_b)
 "ePc" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -9804,11 +9797,11 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -10009,39 +10002,24 @@
 	dir = 5
 	},
 /obj/machinery/power/apc{
-	pixel_y = 24;
 	dir = 1;
-	pixel_x = 4
+	pixel_y = 24
 	},
-/obj/structure/table/standard,
-/obj/item/paper/sentencing,
-/obj/item/paper/sentencing,
+/obj/structure/closet/secure_closet/warden,
+/obj/item/device/eftpos{
+	eftpos_name = "Brig EFTPOS scanner"
+	},
 /obj/item/stamp/warden,
-/obj/item/folder/sec,
-/obj/item/folder/sec,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/machinery/button/flasher{
-	id = "permflash";
-	name = "brig flashes";
-	req_access = list(2);
-	pixel_y = 24;
-	pixel_x = -8
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/warden)
 "eXU" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 2;
-	icon_state = "pdoor0";
-	id = "isolation_a_lockdown";
-	name = "Isolation_a_lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/obj/random/junk,
+/turf/simulated/floor/wood,
+/area/maintenance/wing/port)
 "eYp" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Port Wing"
@@ -10168,21 +10146,10 @@
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "eZZ" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
+/obj/structure/table/wood,
+/obj/structure/reagent_dispensers/keg/xuizikeg,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "fai" = (
 /obj/structure/bed/handrail{
 	buckle_dir = 8;
@@ -10573,7 +10540,15 @@
 /turf/simulated/floor/tiled/full,
 /area/operations/lobby)
 "fin" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "fjc" = (
@@ -10829,25 +10804,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "fqS" = (
-/obj/machinery/firealarm/east{
-	pixel_x = 0;
-	pixel_y = 33;
-	dir = 1
-	},
-/obj/machinery/disposal/small/north,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/button/flasher{
 	id = "permflash";
 	name = "brig flashes";
 	req_access = list(2);
-	pixel_y = -24;
-	pixel_x = 8
+	pixel_y = 24;
+	pixel_x = 23;
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/firealarm/north,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -10943,10 +10923,28 @@
 /turf/simulated/floor/tiled/full,
 /area/hallway/engineering/tesla)
 "ftz" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/structure/cable/green,
+/obj/machinery/camera/network/prison{
+	c_tag = "Security - Cell A";
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "cell_1"
+	},
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
 /obj/structure/cable/green{
-	icon_state = "0-2"
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -10967,18 +10965,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
-"fum" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/machinery/firealarm/east{
-	pixel_x = 0;
-	pixel_y = 33;
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
 "fuu" = (
 /turf/simulated/wall,
 /area/maintenance/wing/port/far)
@@ -10989,12 +10975,15 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
 /obj/machinery/door_timer/isolation_cell{
 	pixel_x = -32;
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -11120,11 +11109,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "fyO" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
+/turf/simulated/floor/tiled/dark/full,
+/area/horizon/security/armoury)
 "fyU" = (
 /obj/effect/floor_decal/corner/yellow/full,
 /turf/simulated/floor/tiled,
@@ -11225,17 +11214,14 @@
 /area/crew_quarters/heads/chief)
 "fBN" = (
 /obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (Burst Rifle)"
+	name = "Weaponry (Energy Carbines)"
 	},
-/obj/item/gun/projectile/automatic/rifle/jingya,
-/obj/effect/floor_decal/corner_wide/paleblue/full{
-	dir = 4
+/obj/item/gun/energy/gun,
+/obj/item/gun/energy/gun,
+/obj/effect/floor_decal/corner_wide/paleblue{
+	dir = 10
 	},
 /obj/effect/floor_decal/industrial/outline/security,
-/obj/item/gun/projectile/automatic/rifle/jingya,
-/obj/structure/sign/flag/scc/left{
-	pixel_y = -32
-	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "fCd" = (
@@ -11608,7 +11594,6 @@
 "fKG" = (
 /obj/structure/closet/crate,
 /obj/random/loot,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "fKH" = (
@@ -11742,14 +11727,11 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/storage_hard)
 "fNx" = (
-/obj/structure/sink{
-	pixel_y = 21
+/obj/machinery/shower{
+	dir = 8
 	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/random/soap,
+/turf/simulated/floor/tiled/freezer,
 /area/horizon/security/brig)
 "fOj" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -11780,7 +11762,7 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/hallway)
 "fOp" = (
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
@@ -12162,10 +12144,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/strongroom)
 "fYW" = (
-/obj/machinery/door/airlock{
-	name = "Brig Showers"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/flasher{
+	id = "permflash";
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/corner/green/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/horizon/security/brig)
 "fZk" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
@@ -12278,19 +12265,42 @@
 /area/rnd/hallway)
 "gaA" = (
 /obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (Energy Carbines)"
+	name = "Ammunition (SMGs and Pistols)"
 	},
-/obj/item/gun/energy/gun,
-/obj/item/gun/energy/gun,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/mc9mmt,
+/obj/item/ammo_magazine/mc9mmt,
+/obj/item/ammo_magazine/mc9mmt/rubber,
+/obj/item/ammo_magazine/mc9mmt/rubber,
+/obj/item/ammo_magazine/mc9mmt/rubber,
+/obj/item/ammo_magazine/mc9mmt/rubber,
+/obj/item/ammo_magazine/mc9mmt/rubber,
+/obj/item/ammo_magazine/mc9mmt/rubber,
+/obj/item/ammo_magazine/mc9mmt,
+/obj/item/ammo_magazine/mc9mmt,
+/obj/item/ammo_magazine/mc9mmt,
+/obj/item/ammo_magazine/mc9mmt,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
+/obj/item/ammo_magazine/c45m/rubber,
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/outline/security,
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = -32
-	},
-/obj/machinery/light/colored/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "gbk" = (
@@ -12438,12 +12448,18 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/main_storage)
 "gem" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/paleblue/full,
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/machinery/alarm{
+	pixel_x = -28;
+	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
+/obj/structure/sign/nosmoking_1{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/holding_cell_a)
 "gfj" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -12553,34 +12569,29 @@
 "ggA" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 4;
-	id = "isolation_b_lockdown";
-	name = "Isolation Cell B Lockdown";
+	id = "cell_isolation";
+	name = "Isolation Cell Blast Door";
 	pixel_x = -35;
-	pixel_y = 7
+	pixel_y = 7;
+	req_access = list(2)
 	},
 /obj/machinery/button/remote/airlock{
 	dir = 4;
-	id = "cell_isolation_b";
-	name = "Isolation Cell Bolts";
+	id = "cell_isolation";
+	name = "Isolation Cell Door Bolts";
 	pixel_x = -25;
 	pixel_y = 7;
-	req_access = list(19);
+	req_access = list(2);
 	specialfunctions = 4
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Corridor Camera 7";
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/machinery/button/flasher{
-	pixel_y = -7;
-	dir = 4;
-	pixel_x = -25;
-	id = "cell_isolation"
+/obj/effect/floor_decal/corner/paleblue/full,
+/obj/machinery/firealarm/south,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -12764,21 +12775,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "glv" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
 	},
-/obj/structure/bed/stool/chair{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+/obj/machinery/door/airlock/glass_security{
+	name = "Armoury Foyer";
+	req_access = list(3)
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_a)
+/turf/simulated/floor/tiled/full,
+/area/horizon/security/armoury)
 "glx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
@@ -13082,13 +13095,11 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "gqI" = (
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "shutters_deck1_security_cell_3";
-	name = "Cell Door"
+/obj/machinery/vending/hydronutrients,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "gqP" = (
@@ -13205,7 +13216,13 @@
 	req_access = list(3)
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/warden)
 "gtw" = (
 /obj/structure/cable/green{
@@ -13227,10 +13244,10 @@
 /area/horizon/stairwell/central)
 "gud" = (
 /obj/effect/landmark/entry_point/fore{
-	name = "fore, security"
+	name = "fore, brig communal"
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/industrial/warning,
-/obj/item/hullbeacon/red,
 /turf/simulated/floor/reinforced/airless,
 /area/template_noop)
 "guj" = (
@@ -13504,12 +13521,13 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Corridor Camera 4";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -13569,24 +13587,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/central_one)
-"gBH" = (
-/obj/effect/floor_decal/corner_wide/red/full{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/pen{
-	pixel_x = 8;
-	pixel_y = 3
-	},
-/obj/item/paper_bin{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
 "gBK" = (
 /obj/structure/bed/stool/chair/sofa/right/brown{
 	dir = 4
@@ -13731,17 +13731,20 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "gEa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/corner/red{
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -13894,13 +13897,15 @@
 /area/horizon/hydroponics)
 "gGX" = (
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -14019,6 +14024,7 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/horizon/security/hallway)
 "gKC" = (
@@ -14100,9 +14106,6 @@
 	name = "Brig Lockdown Blast Door";
 	opacity = 0
 	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
 /obj/machinery/door/blast/regular{
 	density = 0;
 	dir = 8;
@@ -14111,14 +14114,8 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
-/area/horizon/security/brig)
-"gNk" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/turf/simulated/floor/tiled/white,
 /area/horizon/security/brig)
 "gNm" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -14394,18 +14391,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smes)
-"gSY" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 5
-	},
-/obj/structure/bed/stool/chair/office/light{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
 "gTy" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
@@ -14623,12 +14608,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room/tesla)
 "haI" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -14960,10 +14945,10 @@
 /turf/simulated/open/airless,
 /area/template_noop)
 "hjo" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "hjG" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -15266,16 +15251,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/pharmacy)
 "hpY" = (
-/obj/machinery/cryopod,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/turf/simulated/floor/tiled/dark/full,
+/area/horizon/security/armoury)
 "hqd" = (
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d2-2-f"
@@ -15322,23 +15302,40 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical)
 "hrC" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
+/obj/effect/floor_decal/corner_wide/paleblue{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "armory";
+	name = "Armoury Blast Doors";
+	pixel_x = -25;
+	req_access = list(3);
+	pixel_y = 7
 	},
-/obj/structure/closet/secure_closet/security,
-/obj/effect/floor_decal/industrial/outline/security,
-/turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Armoury Starboard";
+	network = list("Security","Armory");
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/horizon/security/armoury)
 "hrG" = (
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d2-3-f"
 	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/item/hullbeacon/red,
+/obj/structure/sign/securearea{
+	desc = "A caution sign which reads 'CAUTION: BRIG COMMUNAL AREA' and 'SECURE AREA'.";
+	name = "\improper BRIG COMMUNAL AREA sign";
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/template_noop)
 "hrN" = (
@@ -15373,14 +15370,10 @@
 /area/engineering/storage_eva)
 "hsh" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/holding_cell_a)
 "hst" = (
 /turf/simulated/wall/r_wall,
@@ -15391,17 +15384,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sortjunction/flipped{
 	name = "Security";
 	sortType = "Security";
 	dir = 2
 	},
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "hsA" = (
@@ -15656,14 +15644,15 @@
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 9
 	},
-/obj/machinery/button/remote/blast_door{
-	dir = 4;
-	id = "armory";
-	name = "Armoury Shutters";
-	pixel_x = -25;
-	req_access = list(3)
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -28;
+	pixel_y = 2
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -28;
+	pixel_y = -9
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "hAh" = (
 /obj/structure/cable/green{
@@ -15761,8 +15750,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
 /area/maintenance/wing/port)
 "hCe" = (
 /obj/machinery/camera/network/reactor{
@@ -16087,9 +16077,13 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical)
 "hHJ" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/horizon/security/brig)
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/security,
+/obj/effect/floor_decal/industrial/outline/security,
+/turf/simulated/floor/tiled,
+/area/horizon/security/equipment)
 "hHM" = (
 /obj/structure/ladder{
 	pixel_y = 4
@@ -16149,23 +16143,14 @@
 /area/operations/office)
 "hLh" = (
 /obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (SMGs and Pistols)"
+	name = "Weaponry (Shotguns)"
 	},
-/obj/item/gun/projectile/sec,
-/obj/item/gun/projectile/sec,
-/obj/item/gun/projectile/automatic/wt550,
-/obj/item/gun/projectile/automatic/wt550,
-/obj/item/gun/projectile/sec,
-/obj/item/gun/projectile/sec,
-/obj/effect/floor_decal/corner_wide/paleblue/full,
+/obj/item/gun/projectile/shotgun/pump,
+/obj/item/gun/projectile/shotgun/pump,
+/obj/effect/floor_decal/corner_wide/paleblue{
+	dir = 10
+	},
 /obj/effect/floor_decal/industrial/outline/security,
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (Laser Rifles)"
-	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = -32
-	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "hLJ" = (
@@ -16774,15 +16759,6 @@
 "ifm" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/turret_protected/ai_upload)
-"ifF" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
 "ifK" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -16790,18 +16766,11 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/turbolift/scc_ship/morgue_lift)
 "ifO" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/light/small/emergency{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
+/area/maintenance/wing/port)
 "ifP" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 8
@@ -16906,6 +16875,7 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/security_starboard)
 "iji" = (
@@ -16917,29 +16887,22 @@
 /turf/simulated/floor/tiled/full,
 /area/engineering/lobby)
 "ijp" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/blue,
-/obj/machinery/flasher{
-	id = "cell_2";
-	pixel_y = -32
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 36;
+	pixel_y = 2
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 36;
+	pixel_y = -9
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/area/horizon/security/armoury)
 "ijD" = (
 /obj/machinery/button/remote/blast_door{
 	id = "seconddeckdockint";
@@ -17120,7 +17083,12 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "ini" = (
@@ -17198,32 +17166,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_waste)
 "ioW" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Ammunition (Rifles and Shotguns)"
-	},
-/obj/item/storage/box/stunshells,
-/obj/item/storage/box/flashshells{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/beanbags{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/beanbags{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/trackingslugs,
-/obj/item/storage/box/shotgunshells,
-/obj/item/storage/box/shotgunshells,
-/obj/item/ammo_magazine/a556/carbine/polymer,
-/obj/item/ammo_magazine/a556/carbine/polymer,
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/item/ammo_magazine/a556/carbine/polymer,
-/obj/item/ammo_magazine/a556/carbine/polymer,
-/turf/simulated/floor/tiled/dark/full,
-/area/horizon/security/armoury)
+/obj/machinery/door/window/northleft,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "ioX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17360,11 +17305,12 @@
 /turf/simulated/floor/tiled,
 /area/engineering/lobby)
 "isO" = (
+/obj/structure/foamedmetal,
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d2-1-f"
 	},
-/turf/simulated/wall/r_wall,
-/area/horizon/security/brig)
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "itS" = (
 /obj/machinery/porta_turret/sniper,
 /obj/effect/floor_decal/industrial/warning/full,
@@ -17694,28 +17640,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_quarters/lounge/bar)
 "iDH" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/structure/foamedmetal,
+/obj/structure/shuttle_part/scc_space_ship{
+	icon_state = "d2-2-f"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "iEd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18200,12 +18130,9 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical)
 "iOg" = (
-/obj/machinery/washing_machine,
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/effect/floor_decal/spline/plain/cee{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/cryopod,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "iOD" = (
 /obj/structure/cable/green{
@@ -18253,13 +18180,26 @@
 /turf/simulated/floor/lino/grey,
 /area/horizon/crew_quarters/lounge/bar)
 "iQK" = (
-/obj/effect/floor_decal/corner/paleblue/full{
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/light/colored/red{
-	dir = 1
+/obj/item/clothing/suit/armor/carrier/ablative,
+/obj/item/clothing/suit/armor/carrier/ablative,
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/head/helmet/ablative,
+/obj/machinery/door/window/brigdoor/southright{
+	req_access = list(3);
+	name = "Ablative Armour"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "iRb" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -18360,17 +18300,6 @@
 /obj/structure/bed/stool/chair/office/dark,
 /turf/simulated/floor/carpet/rubber,
 /area/crew_quarters/heads/hor)
-"iTL" = (
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/structure/closet/secure_closet/security,
-/obj/effect/floor_decal/industrial/outline/security,
-/turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
 "iUg" = (
 /obj/structure/table/standard,
 /obj/item/stamp/rd{
@@ -18467,11 +18396,27 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/wing/starboard)
 "iWm" = (
+/obj/structure/table/rack,
+/obj/item/stack/liquidbags/half_full{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/stack/barbed_wire/half_full{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/device/magnetic_lock/security{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/device/magnetic_lock/security{
+	pixel_x = -6;
+	pixel_y = 2
+	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/structure/closet/bombclosetsecurity,
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled,
 /area/horizon/security/armoury)
 "iWp" = (
@@ -18672,6 +18617,15 @@
 /turf/simulated/floor/carpet/rubber,
 /area/engineering/engine_monitoring)
 "jbo" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "jbB" = (
@@ -18728,9 +18682,20 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -18826,6 +18791,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "jfH" = (
@@ -18897,34 +18866,15 @@
 /area/template_noop)
 "jih" = (
 /obj/structure/table/reinforced/steel,
-/obj/machinery/door/window/brigdoor/northleft{
-	name = "Warden's Desk";
-	req_access = null;
-	dir = 8
-	},
-/obj/machinery/door/window/brigdoor/southright{
-	name = "Warden's Desk";
+/obj/machinery/door/window/eastright{
 	req_access = list(3);
-	dir = 4
+	name = "Warden's Office"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/window/westleft{
+	req_access = list(1);
+	name = "Warden's Office"
 	},
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/warden)
 "jjl" = (
 /obj/structure/bed/stool/chair/office/light,
@@ -18949,19 +18899,16 @@
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	pixel_y = 24;
-	dir = 1
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Holding Cell A"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/hologram/holopad,
+/obj/machinery/computer/sentencing/courtroom{
+	pixel_y = 32
 	},
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "2-4"
 	},
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
 /area/horizon/security/holding_cell_a)
 "jjF" = (
@@ -19022,18 +18969,10 @@
 /turf/simulated/floor/tiled/full,
 /area/engineering/engine_airlock)
 "jki" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/sign/securearea{
-	desc = "A caution sign which reads 'CAUTION: BRIG COMMUNAL AREA' and 'SECURE AREA'.";
-	name = "\improper BRIG COMMUNAL AREA sign";
-	pixel_y = 32
-	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/item/hullbeacon/red,
-/turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/stool/bar/padded/red,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "jko" = (
 /obj/machinery/light{
 	dir = 4
@@ -19189,13 +19128,16 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/lobby)
 "jno" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/structure/closet/wardrobe/red,
+/obj/structure/table/steel,
+/obj/machinery/recharger{
+	pixel_x = -6
+	},
+/obj/machinery/recharger{
+	pixel_x = 6
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "jnF" = (
@@ -19271,14 +19213,20 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/holding_cell_a)
@@ -19333,14 +19281,13 @@
 /turf/simulated/floor/carpet/rubber,
 /area/engineering/engine_monitoring/tesla)
 "jpB" = (
+/obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/structure/table/reinforced,
-/obj/item/deck/cards,
-/obj/item/storage/pill_bottle/dice,
-/obj/item/board{
-	pixel_y = 4
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -19546,17 +19493,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_quarters/lounge/bar)
-"jup" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "cell_isolation"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
 "juH" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -19576,15 +19512,15 @@
 /area/turret_protected/ai)
 "jvp" = (
 /obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (Shotguns)"
+	name = "Weaponry (Laser Rifles)"
 	},
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/gun/projectile/shotgun/pump,
+/obj/item/gun/energy/rifle/laser,
+/obj/item/gun/energy/rifle/laser,
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/outline/security,
-/obj/structure/sign/flag/scc/right{
+/obj/structure/sign/nosmoking_1{
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -19681,36 +19617,14 @@
 /turf/simulated/floor/tiled,
 /area/engineering/lobby)
 "jzv" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/shuttle/scc_space_ship,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Brig Lockdown";
-	name = "Brig Lockdown Blast Door";
-	opacity = 0
+/obj/effect/floor_decal/corner/paleblue/diagonal{
+	dir = 4
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Security Lockdown";
-	name = "Security Blast Door";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/door/blast/shutters/open{
-	dir = 2;
-	id = "shutters_deck1_security_cell_isolation";
-	name = "Isolation Cell Window Shutter"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark/full,
-/area/maintenance/security_starboard)
+/area/horizon/security/armoury)
 "jzV" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -19721,13 +19635,7 @@
 	pixel_x = 8;
 	pixel_y = 3
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/effect/floor_decal/corner_wide/red/full,
+/obj/effect/floor_decal/corner/paleblue/full,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "jAo" = (
@@ -19740,7 +19648,10 @@
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "jAS" = (
 /obj/structure/railing/mapped{
@@ -19777,7 +19688,15 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "jBq" = (
-/obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "jBu" = (
@@ -19865,6 +19784,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -20090,32 +20012,14 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "jJa" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/blue,
-/obj/machinery/flasher{
-	id = "cell_2";
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/brig)
 "jJw" = (
 /obj/structure/cable/yellow{
@@ -20139,33 +20043,19 @@
 /turf/simulated/floor/tiled/ramp,
 /area/maintenance/wing/starboard)
 "jJY" = (
-/obj/structure/table/rack,
-/obj/item/stack/liquidbags/half_full{
-	pixel_x = 6;
-	pixel_y = -6
-	},
-/obj/item/stack/barbed_wire/half_full{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/device/magnetic_lock/security{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/device/magnetic_lock/security{
-	pixel_x = -6;
-	pixel_y = 2
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/security,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/armoury)
 "jKd" = (
@@ -20256,26 +20146,25 @@
 /turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "jMB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/airlock/glass_security{
+	autoclose = 0;
+	id_tag = "cell_3";
+	name = "Cell C";
+	req_access = list(2)
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Brig Lockdown";
-	name = "Brig Lockdown Blast Door";
-	opacity = 0
-	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/plating,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/brig)
 "jMO" = (
 /obj/machinery/door/airlock/glass_security{
@@ -20326,7 +20215,21 @@
 /turf/simulated/floor/reinforced,
 /area/storage/secure)
 "jNY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 4
+	},
+/obj/machinery/disposal/small/west,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -20526,17 +20429,9 @@
 /turf/simulated/floor/plating,
 /area/medical/cryo)
 "jUx" = (
-/obj/structure/window/shuttle/scc_space_ship,
-/obj/structure/grille,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/green,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Brig Lockdown";
-	name = "Brig Lockdown Blast Door";
-	opacity = 0
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -20546,6 +20441,21 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "cell_isolation";
+	name = "Isolation Cell Blast Door";
+	opacity = 0;
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	name = "Viewing Shutter";
+	id = "cell_isolation_viewing"
+	},
+/obj/structure/grille,
+/obj/structure/window/shuttle/scc_space_ship,
 /turf/simulated/floor/plating,
 /area/horizon/security/brig)
 "jUB" = (
@@ -20708,10 +20618,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room)
 "jYJ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "jZB" = (
 /obj/machinery/light,
@@ -20751,9 +20663,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -20830,16 +20739,13 @@
 /area/operations/lower/machinist)
 "kbL" = (
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
@@ -20876,15 +20782,28 @@
 /turf/simulated/floor/carpet,
 /area/hallway/primary/central_two)
 "kcO" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
+/obj/machinery/camera/network/prison{
+	c_tag = "Security - Cell C";
+	dir = 1
 	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
+/obj/structure/closet/secure_closet/brig{
+	id = "cell_isolation"
+	},
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_a)
+/area/horizon/security/brig)
 "kdr" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green,
 /turf/simulated/floor/plating,
@@ -20918,18 +20837,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
-"kep" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/structure/closet/secure_closet/security_cadet,
-/turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
 "keG" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/machinery/door/firedoor,
@@ -20942,12 +20849,15 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "kfE" = (
@@ -21064,9 +20974,7 @@
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 8
 	},
-/obj/item/modular_computer/console/preset/security{
-	dir = 1
-	},
+/obj/item/modular_computer/console/preset/security,
 /obj/machinery/requests_console{
 	department = "Warden's Desk";
 	departmentType = 5;
@@ -21148,24 +21056,11 @@
 	},
 /turf/simulated/floor/lino/grey,
 /area/horizon/bar)
-"kjs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
 "kjO" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/light/small/emergency{
+	dir = 4
 	},
-/obj/structure/trash_pile,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/maintenance/wing/port)
 "kkb" = (
 /obj/structure/disposalpipe/segment,
@@ -21186,25 +21081,28 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/zta)
 "kkW" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/machinery/firealarm/west,
+/obj/effect/floor_decal/corner/paleblue/full,
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/horizon/security/armoury)
 "kkY" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -21216,9 +21114,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/recharger/wallcharger{
-	pixel_y = -28;
-	pixel_x = 4
+/obj/machinery/firealarm/south,
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/warden)
@@ -21287,22 +21185,15 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical)
 "kqz" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -21465,13 +21356,14 @@
 /turf/simulated/floor/wood,
 /area/horizon/library)
 "kuS" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/recharge_station,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/machinery/camera/network/prison{
-	c_tag = "Security - Communal Brig Fore"
-	},
+/obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "kvc" = (
@@ -21704,13 +21596,13 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/exam)
 "kCr" = (
-/obj/machinery/flasher{
-	id = "permflash"
+/obj/machinery/camera/network/prison{
+	c_tag = "Security - Brig Communal Port";
+	dir = 8
 	},
-/obj/machinery/flasher{
-	id = "permflash"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "kCV" = (
@@ -21822,8 +21714,6 @@
 /turf/simulated/wall/r_wall,
 /area/rnd/strongroom)
 "kHb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/bed/stool/chair/plastic{
 	dir = 4
 	},
@@ -22169,16 +22059,15 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 2;
 	icon_state = "pdoor0";
-	id = "isolation_b_lockdown";
-	name = "Isolation_b_lockdown";
+	id = "cell_isolation";
+	name = "Isolation Cell Blast Door";
 	opacity = 0
 	},
 /obj/structure/cable/green{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/brig)
 "kRz" = (
 /obj/machinery/door/firedoor,
@@ -22286,8 +22175,12 @@
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "kSM" = (
-/obj/machinery/vending/hydronutrients,
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "kUc" = (
@@ -22327,8 +22220,21 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance_hatch,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/maintenance{
+	name = "Security Maintenance";
+	req_access = list(63)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 8;
+	icon_state = "pdoor0";
+	id = "Security Lockdown";
+	name = "Security Blast Door";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
 /area/maintenance/security_starboard)
 "kUz" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
@@ -22412,27 +22318,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "kXs" = (
-/obj/structure/table/rack,
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 8;
-	name = "Ablative Armour Storage";
-	req_access = list(3)
-	},
-/obj/item/clothing/suit/armor/carrier/ablative,
-/obj/item/clothing/suit/armor/carrier/ablative,
-/obj/item/clothing/head/helmet/ablative,
-/obj/item/clothing/head/helmet/ablative,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/security,
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 6
 	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "kXO" = (
@@ -22895,19 +22784,31 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)
 "ljm" = (
-/obj/machinery/light{
+/obj/structure/closet/secure_closet/brig{
+	id = "cell_isolation"
+	},
+/obj/machinery/camera/network/prison{
+	c_tag = "Security - Cell B";
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet/security,
 /obj/effect/floor_decal/industrial/outline/security,
-/obj/structure/sign/flag/scc{
-	pixel_y = 32
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
+/area/horizon/security/brig)
 "ljp" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -22933,17 +22834,11 @@
 /turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_one)
 "ljx" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/railing/mapped{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/wing/port/far)
 "ljF" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
@@ -23220,42 +23115,13 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room/tesla)
 "lrQ" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Ammunition (SMGs and Pistols)"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/mc9mmt,
-/obj/item/ammo_magazine/mc9mmt,
-/obj/item/ammo_magazine/mc9mmt/rubber,
-/obj/item/ammo_magazine/mc9mmt/rubber,
-/obj/item/ammo_magazine/mc9mmt/rubber,
-/obj/item/ammo_magazine/mc9mmt/rubber,
-/obj/item/ammo_magazine/mc9mmt/rubber,
-/obj/item/ammo_magazine/mc9mmt/rubber,
-/obj/item/ammo_magazine/mc9mmt,
-/obj/item/ammo_magazine/mc9mmt,
-/obj/item/ammo_magazine/mc9mmt,
-/obj/item/ammo_magazine/mc9mmt,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/item/ammo_magazine/c45m/rubber,
-/obj/effect/floor_decal/industrial/outline/security,
-/turf/simulated/floor/tiled/dark/full,
-/area/horizon/security/armoury)
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "lrS" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -23400,22 +23266,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
-"lvT" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/structure/bed/stool/chair{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
 "lwD" = (
 /turf/simulated/floor/carpet,
 /area/horizon/security/head_of_security)
@@ -23453,20 +23303,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
 "lzq" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/door_timer/cell_1{
+	pixel_x = 32
+	},
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "lzC" = (
@@ -23491,19 +23337,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/engineering/engine_monitoring/tesla)
-"lAv" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
 "lAx" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -23731,6 +23564,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "lFU" = (
@@ -23789,17 +23625,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering)
 "lGQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -23972,86 +23809,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
-"lLj" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/structure/table/rack,
-/obj/item/device/radio/sec{
-	pixel_x = -7
-	},
-/obj/item/device/radio/sec{
-	pixel_x = -7
-	},
-/obj/item/device/radio/sec{
-	pixel_x = -7
-	},
-/obj/item/device/radio/sec{
-	pixel_x = -7
-	},
-/obj/item/device/radio/sec{
-	pixel_x = -7
-	},
-/obj/item/device/radio/sec{
-	pixel_x = -7
-	},
-/obj/item/device/radio/sec{
-	pixel_x = -7
-	},
-/obj/item/crowbar/red{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/obj/item/crowbar/red{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/obj/item/crowbar/red{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/obj/item/crowbar/red{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/obj/item/crowbar/red{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/obj/item/crowbar/red{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/obj/item/device/hand_labeler{
-	pixel_y = 10;
-	pixel_x = 7
-	},
-/obj/item/device/flashlight/maglight{
-	pixel_y = -7
-	},
-/obj/item/device/flashlight/maglight{
-	pixel_y = -7
-	},
-/obj/item/device/flashlight/maglight{
-	pixel_y = -7
-	},
-/obj/item/device/flashlight/maglight{
-	pixel_y = -7
-	},
-/obj/item/device/flashlight/maglight{
-	pixel_y = -7
-	},
-/obj/item/device/flashlight/maglight{
-	pixel_y = -7
-	},
-/obj/structure/sign/flag/scc{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
 "lLn" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -24278,18 +24035,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
 "lRO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -24433,11 +24180,8 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/lobby)
 "lUi" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/equipment)
 "lUA" = (
 /obj/structure/shuttle_part/scc_space_ship{
@@ -24479,6 +24223,7 @@
 	dir = 8;
 	pixel_x = 28
 	},
+/obj/machinery/light/small/emergency,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port/far)
 "lWf" = (
@@ -24505,13 +24250,21 @@
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "lWF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/junk,
-/obj/machinery/light/small/emergency{
-	dir = 8
+/obj/structure/bed/padded,
+/obj/item/bedsheet/blue,
+/obj/effect/floor_decal/corner/paleblue/full,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
+/obj/machinery/flasher{
+	id = "cell_2";
+	pixel_y = -32
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "lWJ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -24599,8 +24352,20 @@
 /turf/simulated/floor/tiled,
 /area/horizon/stairwell/bridge)
 "lZp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/r_wall,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
 /area/maintenance/wing/port/far)
 "lZu" = (
 /obj/structure/sign/nosmoking_2{
@@ -24621,12 +24386,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "lZP" = (
@@ -24687,8 +24449,8 @@
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/armoury)
@@ -24705,15 +24467,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "mbF" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/closet/emcloset/communal,
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "mbH" = (
@@ -24749,6 +24507,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/horizon/security/lobby)
 "mdn" = (
@@ -24784,16 +24543,10 @@
 /turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
 "mdB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/board{
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/flasher{
-	id = "permflash"
-	},
-/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "mdR" = (
@@ -24858,26 +24611,20 @@
 /turf/space/dynamic,
 /area/template_noop)
 "mfV" = (
-/obj/structure/window/shuttle/scc_space_ship,
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Security Lockdown";
-	name = "Security Blast Door";
-	opacity = 0
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/structure/table/steel,
+/obj/item/device/flashlight/lamp,
+/obj/item/paper/sentencing{
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/green,
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
+/turf/simulated/floor/tiled,
+/area/horizon/security/holding_cell_b)
 "mfX" = (
 /obj/structure/cable/green,
 /obj/effect/map_effect/window_spawner/full/reinforced/polarized/grille/firedoor{
@@ -25159,16 +24906,10 @@
 "mns" = (
 /obj/effect/floor_decal/corner/paleblue/full,
 /obj/structure/bed/stool/chair/office/dark{
-	dir = 1
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/warden)
@@ -25230,12 +24971,18 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
 "mqg" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/firealarm/west,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/holding_cell_b)
 "mqj" = (
 /obj/structure/closet/secure_closet/hangar_tech,
 /obj/machinery/light{
@@ -25692,10 +25439,13 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "cell_isolation_viewing";
+	name = "Isolation Cell Viewing Shutters";
+	pixel_x = -57;
+	pixel_y = -4;
+	req_access = list(2)
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -25833,6 +25583,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/wing/port)
 "mFs" = (
@@ -25852,25 +25603,10 @@
 /turf/simulated/open/airless,
 /area/horizon/exterior)
 "mFD" = (
-/obj/machinery/door/airlock/glass_security{
-	autoclose = 0;
-	id_tag = "cell_2";
-	name = "Cell B";
-	req_access = list(2)
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Brig Lockdown";
-	name = "Brig Lockdown Blast Door";
-	opacity = 0
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/dark/full,
+/area/horizon/security/armoury)
 "mFJ" = (
 /obj/structure/foamedmetal,
 /obj/structure/shuttle_part/scc_space_ship{
@@ -25879,13 +25615,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "mFQ" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/green{
+/obj/machinery/firealarm/east,
+/obj/effect/floor_decal/corner/green/full{
 	dir = 4
 	},
-/obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "mFX" = (
@@ -26272,17 +26005,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "mOt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/door/firedoor,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "mOu" = (
@@ -26290,13 +26020,20 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "mOy" = (
@@ -26565,25 +26302,20 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "mUL" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -26610,10 +26342,12 @@
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "mVb" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/disposal/small/south,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "mVw" = (
@@ -26659,12 +26393,14 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -26711,11 +26447,11 @@
 	name = "HoS Office";
 	sortType = "HoS Office"
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -26735,13 +26471,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -26753,10 +26487,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/wing/port)
 "mYp" = (
@@ -27157,19 +26888,15 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/lobby)
 "ngj" = (
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "ngA" = (
@@ -27194,35 +26921,9 @@
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "ngB" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "cell_isolation"
-	},
-/obj/machinery/camera/network/prison{
-	c_tag = "Security - Brig Cell 2";
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/maintenance/wing/port)
 "ngC" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -27613,9 +27314,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "noZ" = (
-/obj/effect/floor_decal/corner/paleblue/full,
-/obj/structure/bed/stool/chair/plastic{
-	dir = 4
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -27654,51 +27359,35 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "nqE" = (
-/obj/structure/table/standard,
-/obj/structure/bedsheetbin,
-/obj/effect/floor_decal/corner/green/diagonal,
-/obj/effect/floor_decal/spline/plain/cee{
-	dir = 4
+/obj/structure/closet/bombclosetsecurity,
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/horizon/security/brig)
+/obj/effect/floor_decal/industrial/outline/security,
+/turf/simulated/floor/tiled,
+/area/horizon/security/armoury)
 "nrr" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/machinery/light,
-/obj/structure/closet/secure_closet/marooning_equipment,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	layer = 5;
-	name = "adjusted reinforced window"
-	},
-/obj/machinery/door/window/southright{
-	name = "Marooning Equipment Access";
-	req_one_access = list(1,19);
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/hallway)
 "nru" = (
 /obj/effect/floor_decal/corner/paleblue/full{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/power/apc{
-	pixel_y = -24
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Holding Cell B
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/hologram/holopad,
+/obj/machinery/computer/sentencing/courtroom{
+	pixel_y = 32
 	},
-/obj/structure/cable/green,
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/floor_decal/industrial/outline/security,
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/holding_cell_b)
 "nry" = (
@@ -27789,10 +27478,13 @@
 /area/horizon/crew_quarters/lounge/bar)
 "nuF" = (
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 4
+	dir = 10
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/area/horizon/security/hallway)
 "nvq" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/polarized/firedoor{
 	id = "psych"
@@ -28014,33 +27706,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "nCg" = (
-/obj/structure/table/rack,
-/obj/machinery/door/window/brigdoor/eastleft{
-	dir = 8;
-	name = "Riot Armour and Gear Storage";
-	req_access = list(3)
+/obj/machinery/anti_bluespace{
+	density = 0;
+	pixel_x = 32
 	},
-/obj/item/clothing/suit/armor/carrier/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/shield/riot,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/security,
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 6
 	},
-/obj/structure/sign/flag/scc/right{
-	dir = 4;
-	pixel_x = 32;
-	pixel_y = -16
-	},
-/obj/machinery/light/colored/red{
-	dir = 4
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Armoury Port";
+	network = list("Security","Armory");
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
@@ -28098,34 +27774,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hydroponics)
-"nDd" = (
-/obj/machinery/door/airlock/glass_security{
-	autoclose = 0;
-	id_tag = "cell_3";
-	name = "Cell C";
-	req_access = list(2)
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Brig Lockdown";
-	name = "Brig Lockdown Blast Door";
-	opacity = 0
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
 "nDx" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/obj/machinery/vending/cola,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/horizon/security/armoury)
 "nDC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28186,13 +27847,8 @@
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 8;
 	icon_state = "pdoor0";
 	id = "Security Lockdown";
 	name = "Security Blast Door";
@@ -28200,11 +27856,13 @@
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 4;
 	icon_state = "pdoor0";
 	id = "Brig Lockdown";
 	name = "Brig Lockdown Blast Door";
 	opacity = 0
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/horizon/security/brig)
@@ -28376,6 +28034,10 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/ladder/up{
 	pixel_y = 16
+	},
+/obj/item/hullbeacon/red,
+/obj/structure/railing/mapped{
+	dir = 8
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/template_noop)
@@ -28682,9 +28344,6 @@
 /area/hallway/primary/central_one)
 "nUP" = (
 /obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/railing/mapped{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -28781,13 +28440,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/machinery/papershredder{
-	pixel_x = 7
-	},
-/obj/structure/filingcabinet/filingcabinet{
-	pixel_x = -9;
-	pixel_y = 1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -28822,6 +28474,12 @@
 	pixel_y = 25;
 	req_access = list(3)
 	},
+/obj/structure/table/steel,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/folder/sec,
+/obj/item/paper/sentencing,
+/obj/item/book/manual/wiki/security_space_law,
 /turf/simulated/floor/tiled,
 /area/horizon/security/warden)
 "nZj" = (
@@ -28905,11 +28563,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
-"oaA" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
 "oaQ" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 5
@@ -29236,22 +28889,16 @@
 /turf/simulated/floor/carpet,
 /area/hallway/primary/central_two)
 "oiD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
+/obj/machinery/door_timer/cell_2{
+	pixel_x = 32
 	},
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "oiJ" = (
@@ -29450,15 +29097,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai)
 "oou" = (
-/obj/random/soap,
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	pixel_y = 20
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/mapped{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/horizon/security/brig)
+/obj/structure/railing/mapped,
+/turf/simulated/open/airless,
+/area/template_noop)
 "opb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29550,6 +29195,7 @@
 /turf/simulated/floor/wood,
 /area/horizon/library)
 "oqW" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/horizon/security/investigations_hallway)
 "ord" = (
@@ -29656,14 +29302,15 @@
 /turf/simulated/floor/wood,
 /area/rnd/conference)
 "ouo" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/washing_machine,
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
 /area/horizon/security/brig)
 "ouK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -29894,21 +29541,13 @@
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "oAs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/obj/machinery/door_timer/isolation_cell{
-	pixel_x = 32
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/light{
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -30108,6 +29747,7 @@
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d2-4-f"
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -30375,14 +30015,19 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/warden)
@@ -30535,17 +30180,26 @@
 /turf/simulated/floor/lino/grey,
 /area/horizon/kitchen/hallway)
 "oRF" = (
-/obj/effect/floor_decal/corner_wide/red/full,
-/obj/structure/bed/padded,
-/obj/item/bedsheet/blue,
-/turf/simulated/floor/tiled,
+/obj/structure/foamedmetal,
+/turf/simulated/floor/plating,
 /area/horizon/security/brig)
 "oRT" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "oSj" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -30736,24 +30390,13 @@
 /turf/simulated/floor/wood,
 /area/chapel/main)
 "oWW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "oXd" = (
@@ -30810,8 +30453,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/starboard)
 "oYc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -30823,21 +30469,16 @@
 /area/engineering/storage_hard)
 "oYH" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -30878,11 +30519,8 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/machinery/vending/security,
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/closet/wardrobe/red,
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "oZI" = (
@@ -30978,17 +30616,17 @@
 /area/medical/ors)
 "pbM" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
-/area/maintenance/wing/port/far)
+/area/maintenance/wing/port)
 "pbN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -31038,26 +30676,9 @@
 /area/maintenance/substation/wing_starboard)
 "pcJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
-"pdg" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/machinery/vending/snack,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/camera/network/prison{
-	c_tag = "Security - Communal Brig Aft";
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
 "pdv" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
@@ -31071,6 +30692,9 @@
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -31385,12 +31009,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora_hazard)
 "plb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/contraband,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/armoury)
@@ -31597,12 +31222,14 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/wing/starboard)
 "psg" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/armoury)
@@ -31771,14 +31398,16 @@
 /turf/simulated/open,
 /area/hallway/primary/central_one)
 "pyA" = (
-/obj/effect/floor_decal/corner_wide/red/full{
-	dir = 8
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/closet/secure_closet/security_cadet,
+/obj/machinery/light{
+	dir = 1
 	},
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/area/horizon/security/equipment)
 "pyJ" = (
 /obj/machinery/shower{
 	dir = 1
@@ -31855,12 +31484,13 @@
 	id = "cell_isolation"
 	},
 /obj/machinery/camera/network/prison{
-	c_tag = "Security - Isolation Cell";
+	c_tag = "Security - Cell ISO";
 	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/red/full{
+/obj/effect/floor_decal/corner/paleblue/full{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "pCf" = (
@@ -31889,11 +31519,18 @@
 /turf/simulated/floor/carpet,
 /area/hallway/primary/central_two)
 "pDh" = (
-/obj/structure/shuttle_part/scc_space_ship{
-	icon_state = "d2-1-f"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/wall/shuttle/scc_space_ship/cardinal,
-/area/horizon/security/brig)
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/machinery/alarm{
+	pixel_y = -28;
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/hallway)
 "pDn" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -32065,18 +31702,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/kitchen)
 "pGJ" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/sign/securearea{
-	desc = "A caution sign which reads 'CAUTION: BRIG COMMUNAL AREA' and 'SECURE AREA'.";
-	name = "\improper BRIG COMMUNAL AREA sign";
-	pixel_y = 32
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/railing/mapped{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/obj/item/hullbeacon/red,
-/turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "pGX" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/disposalpipe/segment,
@@ -32251,16 +31885,12 @@
 /turf/simulated/floor/wood,
 /area/chapel/main)
 "pLX" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small/emergency{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate/damaged,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "pMf" = (
@@ -32272,7 +31902,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora_hazard)
 "pMz" = (
-/turf/simulated/wall,
+/obj/effect/floor_decal/corner/green/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/horizon/security/brig)
 "pMB" = (
 /obj/structure/cable/green{
@@ -32381,11 +32012,10 @@
 /turf/simulated/floor/lino/grey,
 /area/horizon/kitchen/hallway)
 "pNG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "pNX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -32534,29 +32164,6 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/open,
 /area/engineering/atmos/storage)
-"pSv" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle/scc_space_ship,
-/obj/structure/cable/green,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 8;
-	icon_state = "pdoor0";
-	id = "Security Lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Brig Lockdown";
-	name = "Brig Lockdown Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
 "pSI" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -32587,8 +32194,13 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room)
 "pTf" = (
-/obj/effect/floor_decal/corner_wide/red/full{
+/obj/structure/bed/padded,
+/obj/item/bedsheet/blue,
+/obj/effect/floor_decal/corner/paleblue/full{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -32625,13 +32237,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/starboard/far)
 "pUn" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/cans/root_beer{
+	pixel_x = 6;
+	pixel_y = 4
 	},
-/obj/structure/closet/emcloset/communal,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/obj/item/reagent_containers/food/drinks/cans/root_beer,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "pUI" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -32725,11 +32338,11 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "pWx" = (
@@ -32822,32 +32435,17 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "pZV" = (
-/obj/machinery/camera/network/prison{
-	c_tag = "Security - Brig Cell 3";
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "cell_isolation"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -33081,14 +32679,19 @@
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
 "qfR" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Brig Lockdown";
+	name = "Brig Lockdown Blast Door";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/horizon/security/warden)
 "qgf" = (
 /obj/structure/closet/crate/freezer{
 	name = "Fridge"
@@ -33127,17 +32730,30 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room)
 "qgK" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/structure/cable/green{
-	icon_state = "0-2"
+/obj/structure/closet/crate/trashcart,
+/obj/item/storage/bag/trash{
+	pixel_x = -9;
+	pixel_y = 2
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 2;
-	icon_state = "pdoor0";
-	id = "isolation_a_lockdown";
-	name = "Isolation_a_lockdown";
-	opacity = 0
+/obj/item/storage/bag/trash{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash{
+	pixel_x = 4
+	},
+/obj/item/storage/bag/trash{
+	pixel_x = 8
+	},
+/obj/item/storage/bag/trash{
+	pixel_x = 12
+	},
+/obj/item/toy/figure/secofficer,
+/obj/effect/floor_decal/corner/paleblue/full,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -33214,12 +32830,13 @@
 /turf/simulated/floor/tiled,
 /area/engineering/lobby)
 "qjh" = (
-/obj/machinery/light,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
 /obj/machinery/disposal/small/north,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "qjl" = (
@@ -33301,10 +32918,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint2)
 "qlU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/anti_bluespace,
-/obj/effect/floor_decal/industrial/hatch/red,
-/turf/simulated/floor/tiled,
+/obj/structure/bed/stool/padded/black,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "qlV" = (
 /obj/machinery/door/airlock/glass_security{
@@ -33363,11 +32979,14 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -33483,6 +33102,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/wing/port)
 "qsj" = (
@@ -33673,8 +33293,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/warden)
@@ -33745,35 +33374,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "qxp" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 35;
-	pixel_y = 2
+/obj/structure/bed/padded,
+/obj/item/bedsheet/blue,
+/obj/effect/floor_decal/corner/paleblue/full,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
 	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 35;
-	pixel_y = -8
+/obj/machinery/flasher{
+	id = "cell_3";
+	pixel_y = -32
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/armoury)
-"qxq" = (
-/obj/machinery/door/blast/regular{
-	dir = 1;
-	id = "shutters_deck1_security_cell_1";
-	name = "Cell A Blast Door"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -34318,15 +33930,16 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical)
 "qLd" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/closet/hazmat/security,
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light/small/emergency{
-	dir = 1
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/nosmoking_1{
+	pixel_y = -32
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
+/turf/simulated/floor/tiled,
+/area/horizon/security/armoury)
 "qLj" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
@@ -34412,9 +34025,10 @@
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "qOt" = (
-/obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor,
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
 /area/maintenance/wing/port/far)
 "qOM" = (
 /turf/simulated/floor/plating,
@@ -34472,14 +34086,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/zta)
 "qPP" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
-/obj/item/material/shard{
-	icon_state = "small"
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Brig Lockdown";
+	name = "Brig Lockdown Blast Door";
+	opacity = 0
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
+/turf/simulated/floor/tiled/dark/full,
+/area/horizon/security/brig)
 "qPY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -34492,29 +34111,10 @@
 /area/maintenance/wing/port/far)
 "qQt" = (
 /obj/machinery/camera/network/prison{
-	c_tag = "Security - Brig Cell 1";
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "cell_isolation"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
+	c_tag = "Security - Brig Communal Starboard"
 	},
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -34637,15 +34237,24 @@
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "qSH" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+/obj/structure/bed/padded,
+/obj/item/bedsheet/blue,
+/obj/machinery/light/small/emergency{
+	dir = 8
 	},
-/obj/machinery/status_display{
-	layer = 4;
+/obj/effect/floor_decal/corner/paleblue/full,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "cell_1";
 	pixel_y = -32
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
+/area/horizon/security/brig)
 "qSN" = (
 /turf/simulated/floor/tiled/dark,
 /area/horizon/zta)
@@ -34666,12 +34275,11 @@
 "qSY" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/blast/regular{
-	dir = 1;
 	id = "armory";
-	name = "Emergency Access"
+	name = "Armoury Blast Door"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/armoury)
 "qTB" = (
 /obj/effect/floor_decal/industrial/loading/yellow{
@@ -34710,6 +34318,7 @@
 "qUt" = (
 /obj/machinery/door/airlock/multi_tile/glass,
 /obj/machinery/door/firedoor/multi_tile,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/horizon/security/investigations_hallway)
 "qUz" = (
@@ -34903,14 +34512,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
-"qZI" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/librarycomp/public,
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
 "qZM" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -35012,12 +34613,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/zta)
 "rcH" = (
-/obj/structure/foamedmetal,
-/obj/structure/shuttle_part/scc_space_ship{
-	icon_state = "d2-1-f"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/r_wall,
-/area/maintenance/wing/port)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
+/area/maintenance/wing/port/far)
 "rcR" = (
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -35059,7 +34663,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor/multi_tile,
-/turf/simulated/floor/tiled,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/equipment)
 "rdZ" = (
 /obj/machinery/alarm{
@@ -35069,14 +34678,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/zta)
 "rec" = (
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Corridor Camera 2"
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
 /obj/structure/table/steel,
-/obj/item/deck/cards,
+/obj/item/deck/cards{
+	pixel_y = 12
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "reo" = (
@@ -35147,6 +34755,9 @@
 	dir = 8
 	},
 /obj/structure/trash_pile,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "rfG" = (
@@ -35214,13 +34825,12 @@
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "rhz" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/template_noop)
 "rhC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -35322,11 +34932,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room/tesla)
-"rkZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/keg/mead,
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
 "rlf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/camera/network/reactor{
@@ -35621,34 +35226,6 @@
 	dir = 1
 	},
 /area/maintenance/wing/starboard/far)
-"rqZ" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/storage/bag/trash{
-	pixel_x = -9;
-	pixel_y = 2
-	},
-/obj/item/storage/bag/trash{
-	pixel_x = -4;
-	pixel_y = -2
-	},
-/obj/item/storage/bag/trash,
-/obj/item/storage/bag/trash{
-	pixel_x = 4
-	},
-/obj/item/storage/bag/trash{
-	pixel_x = 8
-	},
-/obj/item/storage/bag/trash{
-	pixel_x = 12
-	},
-/obj/item/toy/figure/secofficer,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
 "rrq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -35970,14 +35547,10 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/lobby)
 "rzC" = (
-/obj/machinery/computer/cryopod{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "rzD" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -36125,14 +35698,13 @@
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)
 "rDE" = (
-/obj/machinery/door_timer/cell_1{
-	pixel_y = -32
+/obj/effect/floor_decal/corner/paleblue,
+/obj/machinery/flasher{
+	id = "permflash"
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/loading/yellow{
-	dir = 4
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -36223,15 +35795,12 @@
 /area/horizon/kitchen)
 "rGx" = (
 /obj/structure/bed/stool/chair/office/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 8
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner_wide/red/full{
+/obj/effect/floor_decal/corner/paleblue/full{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -36331,6 +35900,7 @@
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/loading/yellow,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "rIN" = (
@@ -36410,14 +35980,24 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "rKv" = (
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 5
-	},
+/obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/security,
-/obj/structure/closet/secure_closet/contraband,
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Armoury";
-	network = list("Security","Armory")
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/clothing/suit/armor/carrier/ballistic,
+/obj/item/clothing/suit/armor/carrier/ballistic,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/machinery/door/window/brigdoor/southright{
+	req_access = list(3);
+	name = "Ballistic Armour"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
@@ -36570,16 +36150,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "rOt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/stool/chair/plastic{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/area/horizon/security/hallway)
 "rOw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -36700,12 +36284,11 @@
 /turf/simulated/floor/carpet,
 /area/horizon/security/head_of_security)
 "rQJ" = (
-/obj/structure/shuttle_part/scc_space_ship{
-	icon_state = "d2-4-f"
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/turf/simulated/floor/tiled,
+/area/horizon/security/armoury)
 "rQO" = (
 /obj/structure/bed/stool/chair/padded/red{
 	dir = 4
@@ -36776,7 +36359,8 @@
 /area/rnd/hallway)
 "rSE" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/tiled,
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/warden)
 "rSG" = (
 /turf/simulated/open,
@@ -36936,11 +36520,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/medical/pharmacy)
 "rWG" = (
-/obj/structure/bed/padded,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/item/bedsheet/blue,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -36948,7 +36527,10 @@
 	id = "cell_isolation";
 	pixel_x = -32
 	},
-/obj/effect/floor_decal/corner/red{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
@@ -36966,18 +36548,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/hallway)
 "rXh" = (
-/obj/machinery/portable_atmospherics/hydroponics,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
+/obj/machinery/camera/network/prison{
+	c_tag = "Security - Brig Communal Aft"
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/table/standard,
+/obj/structure/bedsheetbin,
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
 /area/horizon/security/brig)
 "rXm" = (
 /obj/effect/floor_decal/industrial/warning/full,
@@ -37256,22 +36847,29 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "sgl" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/structure/closet/crate,
-/obj/random/loot,
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
-"sgp" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
+"sgp" = (
+/obj/structure/table/wood,
+/obj/structure/reagent_dispensers/keg/beerkeg,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "sgQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37295,15 +36893,6 @@
 	},
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/maintenance/wing/starboard/far)
-"shI" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
 "shR" = (
 /obj/machinery/camera/network/reactor{
 	c_tag = "Engineering - Tesla Room 2"
@@ -37330,16 +36919,9 @@
 	name = "Security Maintenance";
 	req_access = list(63)
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 8;
-	icon_state = "pdoor0";
-	id = "Security Lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/hallway)
 "siL" = (
 /obj/structure/railing/mapped,
@@ -37645,23 +37227,24 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/sign/securearea{
+	pixel_x = 32;
+	desc = "A warning sign which reads 'WARNING' and 'ARMOURY'.";
+	name = "\improper WARNING: ARMOURY sign"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "sqE" = (
+/obj/structure/foamedmetal,
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d2-2-f"
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/horizon/security/brig)
 "srn" = (
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced,
@@ -37862,17 +37445,20 @@
 /area/engineering/engine_monitoring/tesla)
 "swz" = (
 /obj/structure/closet/secure_closet/guncabinet{
+	name = "Weaponry (SMGs and Pistols)"
+	},
+/obj/item/gun/projectile/sec,
+/obj/item/gun/projectile/sec,
+/obj/item/gun/projectile/automatic/wt550,
+/obj/item/gun/projectile/automatic/wt550,
+/obj/item/gun/projectile/sec,
+/obj/item/gun/projectile/sec,
+/obj/structure/closet/secure_closet/guncabinet{
 	name = "Weaponry (Laser Rifles)"
 	},
-/obj/item/gun/energy/rifle/laser,
-/obj/item/gun/energy/rifle/laser,
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 10
-	},
+/obj/machinery/light,
+/obj/effect/floor_decal/corner_wide/paleblue/full,
 /obj/effect/floor_decal/industrial/outline/security,
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "swH" = (
@@ -37929,23 +37515,20 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "syI" = (
-/obj/machinery/flasher{
-	id = "cell_2";
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/structure/bed/padded,
-/obj/item/bedsheet/blue,
-/obj/machinery/light/small/emergency{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -38068,11 +37651,14 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "sEu" = (
@@ -38279,23 +37865,9 @@
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/horizon/hydroponics)
 "sKE" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	req_access = list(63)
-	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 8;
-	icon_state = "pdoor0";
-	id = "Security Lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
 /area/maintenance/security_starboard)
 "sKJ" = (
 /turf/simulated/wall,
@@ -38383,19 +37955,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "sNx" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id = "Brig Lockdown";
+	name = "Brig Lockdown Blast Door";
+	opacity = 0
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 28
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Brig Lockdown";
+	name = "Brig Lockdown Blast Door";
+	opacity = 0
 	},
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/brig)
 "sNJ" = (
 /obj/structure/cable/green{
@@ -39015,6 +38594,7 @@
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "tdO" = (
@@ -39121,21 +38701,22 @@
 /turf/simulated/floor/wood,
 /area/horizon/security/head_of_security)
 "tgp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass_security{
+	name = "Holding Cell B";
+	req_one_access = list(2,4)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
+/turf/simulated/floor/tiled/full,
+/area/horizon/security/holding_cell_b)
 "tgT" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -39238,10 +38819,13 @@
 /turf/simulated/floor/lino/grey,
 /area/horizon/kitchen/hallway)
 "tiG" = (
+/obj/machinery/flasher{
+	id = "permflash"
+	},
+/obj/effect/floor_decal/industrial/outline/security,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "tiJ" = (
@@ -39386,11 +38970,9 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "tmb" = (
-/obj/structure/sign/nosmoking_2{
-	pixel_x = 32
-	},
-/turf/simulated/wall,
-/area/horizon/security/brig)
+/obj/structure/foamedmetal,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "tmG" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -39425,21 +39007,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room)
-"tne" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
 "tnq" = (
 /obj/machinery/body_scanconsole{
 	dir = 8
@@ -39550,13 +39117,20 @@
 /turf/simulated/floor/tiled/dark/airless,
 /area/horizon/exterior)
 "tsy" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 8
 	},
-/obj/machinery/firealarm/east{
-	pixel_x = 0;
-	pixel_y = 33;
-	dir = 1
+/obj/structure/bed/stool/chair,
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/holding_cell_a)
@@ -39602,35 +39176,19 @@
 /turf/simulated/floor/wood,
 /area/horizon/crew_quarters/lounge/bar)
 "tuD" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/item/device/radio/intercom{
-	pixel_y = 24
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
-"tuH" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 8
-	},
-/obj/structure/table/steel,
-/obj/item/device/flashlight/lamp,
-/obj/item/paper/sentencing{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_a)
-"tvc" = (
-/obj/machinery/seed_storage,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/full,
+/area/horizon/security/hallway)
+"tvc" = (
+/obj/item/hullbeacon/red,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced/airless,
+/area/template_noop)
 "tvk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -39964,12 +39522,13 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "tEq" = (
-/obj/effect/floor_decal/industrial/warning,
 /obj/structure/sign/securearea{
-	desc = "A caution sign which reads 'CAUTION: BRIG COMMUNAL AREA' and 'SECURE AREA'.";
-	name = "\improper BRIG COMMUNAL AREA sign";
+	desc = "A caution sign which reads 'CAUTION: BRIG AREA' and 'SECURE AREA'.";
+	name = "\improper BRIG AREA sign";
 	pixel_y = 32
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced/airless,
 /area/template_noop)
 "tEs" = (
@@ -40003,15 +39562,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "tFx" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
 	},
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/machinery/flasher{
-	id = "permflash"
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port/far)
 "tFy" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -40033,14 +39588,13 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical)
 "tFA" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/structure/cable{
 	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
@@ -40264,19 +39818,16 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/medical/pharmacy)
 "tJr" = (
-/obj/machinery/flasher{
-	id = "permflash";
-	pixel_y = -32
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/bed/handrail{
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Corridor Camera 2";
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/horizon/security/brig)
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled,
+/area/horizon/security/hallway)
 "tJB" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Locker Room Maintenance";
@@ -40577,10 +40128,6 @@
 /obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/tiled/dark/full,
 /area/operations/mail_room)
-"tQA" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
-/turf/simulated/floor/tiled,
-/area/horizon/security/equipment)
 "tQB" = (
 /obj/machinery/door/airlock/hatch{
 	id_tag = "bolts_cannon_external";
@@ -40681,16 +40228,15 @@
 "tTM" = (
 /obj/machinery/door/window/brigdoor/southright{
 	dir = 1;
-	name = "Armoury Lobby Exterior Access";
-	req_access = list(63)
+	name = "Armoury Foyer"
 	},
 /obj/structure/table/reinforced/steel,
 /obj/machinery/door/window/brigdoor/southright{
-	name = "Armoury Lobby Interior Access";
+	name = "Armoury Foyer";
 	req_access = list(3)
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "tTW" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -40854,11 +40400,20 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "tYB" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "shutters_deck1_security_cell_1";
+	name = "Cell A Blast Door"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/brig)
 "tZr" = (
 /obj/structure/cable/orange{
@@ -40994,21 +40549,12 @@
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "ucq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/machinery/firealarm/east,
+/obj/machinery/light{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled,
@@ -41022,7 +40568,8 @@
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 2
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/equipment)
 "ucI" = (
 /obj/effect/floor_decal/corner_wide/paleblue/full{
@@ -41082,7 +40629,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "ueC" = (
-/obj/effect/floor_decal/corner/paleblue,
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/floor_decal/corner/paleblue/full{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "ueF" = (
@@ -41122,11 +40673,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "ufU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/bed/stool/chair/plastic{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -41230,27 +40781,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/bar/backroom)
 "uhE" = (
-/obj/machinery/door/airlock/glass_security{
-	autoclose = 0;
-	id_tag = "cell_isolation_a";
-	name = "Isolation Cell A";
-	req_access = list(2)
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/railing/mapped{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 2;
-	icon_state = "pdoor0";
-	id = "isolation_a_lockdown";
-	name = "Isolation_a_lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/port)
 "uhP" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -41297,19 +40837,11 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
 	autoclose = 0;
-	id_tag = "cell_isolation_b";
+	id_tag = "cell_isolation";
 	name = "Isolation Cell B";
 	req_access = list(2)
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 2;
-	icon_state = "pdoor0";
-	id = "isolation_b_lockdown";
-	name = "Isolation_b_lockdown";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/brig)
 "uiL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -41606,7 +41138,9 @@
 /turf/simulated/open/airless,
 /area/template_noop)
 "unV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "uoj" = (
@@ -41787,7 +41321,7 @@
 /turf/simulated/floor,
 /area/maintenance/wing/port/far)
 "uqi" = (
-/obj/structure/reagent_dispensers/keg/xuizikeg,
+/obj/structure/reagent_dispensers/keg/mead,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "ura" = (
@@ -41965,8 +41499,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room/tesla)
 "uvd" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/reagent_dispensers/extinguisher,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port/far)
 "uvo" = (
@@ -42777,11 +42310,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "uPP" = (
-/obj/machinery/power/apc/low{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -42795,6 +42323,10 @@
 	icon_state = "2-8"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "uPW" = (
@@ -42878,6 +42410,9 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/secure_ammunition_storage)
 "uRu" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
@@ -42983,13 +42518,12 @@
 /turf/simulated/floor/tiled,
 /area/horizon/kitchen/freezer)
 "uUz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/machinery/light/small/emergency,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/maintenance/wing/port)
+/turf/simulated/floor/tiled,
+/area/horizon/security/equipment)
 "uUJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -43170,13 +42704,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/smes/tesla)
 "uZD" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	req_access = list(63)
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
+/turf/simulated/floor/tiled/dark/full,
+/area/horizon/security/holding_cell_b)
 "uZH" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -43190,6 +42723,11 @@
 /area/hallway/medical)
 "vaj" = (
 /obj/structure/table/reinforced,
+/obj/item/storage/pill_bottle/dice,
+/obj/item/deck/cards,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_y = -16
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "vaL" = (
@@ -43199,23 +42737,11 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/structure/closet/secure_closet/marooning_equipment,
-/obj/structure/window/reinforced{
-	layer = 5;
-	name = "adjusted reinforced window"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/southright{
-	name = "Marooning Equipment Access";
-	req_one_access = list(1,19);
+/obj/item/device/radio/intercom{
+	pixel_y = -24;
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "vbc" = (
@@ -43383,14 +42909,14 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/pharmacy)
 "vgg" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
 	dir = 1;
 	id = "armory";
-	name = "Emergency Access"
+	name = "Armoury Blast Door"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/armoury)
 "vgh" = (
 /obj/structure/window/shuttle/scc_space_ship,
@@ -43418,21 +42944,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
-"vgz" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
 "vgZ" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -43746,8 +43257,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -43986,16 +43497,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
-"vAr" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/structure/bed/handrail{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/horizon/security/brig)
 "vAw" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/closet/walllocker/firecloset{
@@ -44100,17 +43601,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
 "vCs" = (
-/obj/machinery/door/airlock/glass_security{
-	name = "Armoury Lobby";
-	req_access = list(3)
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "vCM" = (
 /obj/structure/cable/green{
@@ -44124,6 +43619,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/horizon/security/hallway)
 "vCQ" = (
@@ -44598,12 +44094,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "vOL" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/structure/closet/crate,
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/loot,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "vOS" = (
@@ -45039,9 +44534,6 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -45097,7 +44589,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 1
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -45175,40 +44667,20 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "vYW" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/firingpins{
-	pixel_x = 12;
-	pixel_y = -6
-	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = 12;
-	pixel_y = 6
-	},
-/obj/item/storage/box/teargas{
-	pixel_y = -6
-	},
-/obj/item/storage/box/teargas{
-	pixel_y = 6
-	},
-/obj/item/storage/box/flashbangs{
-	pixel_x = -12;
-	pixel_y = -6
-	},
-/obj/item/storage/box/flashbangs{
-	pixel_x = -12;
-	pixel_y = 6
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/power/apc/critical{
+	pixel_y = -24
 	},
 /obj/machinery/light,
-/obj/effect/floor_decal/industrial/outline/security,
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled,
 /area/horizon/security/armoury)
 "vZr" = (
@@ -45438,21 +44910,15 @@
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "wdY" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
+/obj/structure/bed/stool/chair,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "weh" = (
@@ -45662,14 +45128,32 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hydroponics)
 "wiB" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 1
+/obj/structure/table/rack,
+/obj/item/storage/box/firingpins{
+	pixel_x = 12;
+	pixel_y = -6
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Armoury Foyer"
+/obj/item/storage/box/handcuffs{
+	pixel_x = 12;
+	pixel_y = 6
 	},
-/obj/structure/closet/hazmat/security,
+/obj/item/storage/box/teargas{
+	pixel_y = -6
+	},
+/obj/item/storage/box/teargas{
+	pixel_y = 6
+	},
+/obj/item/storage/box/flashbangs{
+	pixel_x = -12;
+	pixel_y = -6
+	},
+/obj/item/storage/box/flashbangs{
+	pixel_x = -12;
+	pixel_y = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/armoury)
 "wiD" = (
@@ -45680,18 +45164,20 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/wing/starboard)
 "wjU" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -45968,19 +45454,19 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "wpq" = (
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 9
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 5
+/obj/effect/floor_decal/corner_wide/paleblue/full{
+	dir = 8
 	},
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 24
-	},
-/obj/machinery/recharger/wallcharger{
+/obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "wpz" = (
 /obj/effect/floor_decal/industrial/warning/full,
@@ -46100,12 +45586,8 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/aux_atmospherics/deck_2/starboard/wing)
 "wsF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -46152,23 +45634,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/wing_starboard)
 "wtV" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/light{
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -46576,22 +46045,18 @@
 /turf/simulated/floor,
 /area/maintenance/wing/port/far)
 "wFe" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/obj/machinery/door/airlock/glass_security{
-	name = "Holding Cell B";
-	req_one_access = list(2,4)
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
-/area/horizon/security/holding_cell_b)
+/area/horizon/security/brig)
 "wFh" = (
 /turf/simulated/wall,
 /area/maintenance/aft)
@@ -46810,12 +46275,14 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology)
 "wLk" = (
-/obj/structure/foamedmetal,
-/obj/structure/shuttle_part/scc_space_ship{
-	icon_state = "d2-1-f"
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
-/turf/simulated/wall/r_wall,
-/area/horizon/security/brig)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/hallway)
 "wLz" = (
 /obj/item/device/radio/intercom{
 	listening = 0;
@@ -46978,16 +46445,9 @@
 /turf/simulated/floor/lino/grey,
 /area/horizon/bar)
 "wNQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "wOd" = (
@@ -47094,32 +46554,15 @@
 /turf/simulated/floor/carpet/rubber,
 /area/engineering/engine_monitoring/tesla)
 "wRd" = (
-/obj/item/clothing/suit/armor/carrier/heavy/sec,
-/obj/item/clothing/suit/armor/carrier/heavy/sec,
-/obj/item/clothing/head/helmet/security/heavy,
-/obj/item/clothing/head/helmet/security/heavy,
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/brigdoor/eastright{
-	name = "Heavy Armour Storage";
-	req_access = list(3);
-	dir = 2
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/floor/tiled,
 /area/horizon/security/armoury)
 "wRk" = (
 /obj/machinery/light/small{
@@ -47196,21 +46639,6 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_two)
-"wTm" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
 "wTD" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -47649,9 +47077,13 @@
 /turf/simulated/floor/tiled,
 /area/turret_protected/ai_upload)
 "xdA" = (
-/obj/structure/table/wood/gamblingtable,
-/turf/simulated/floor/wood,
-/area/maintenance/wing/port)
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/random/loot,
+/turf/simulated/floor/tiled/dark,
+/area/maintenance/wing/port/far)
 "xea" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -47761,13 +47193,9 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room/tesla)
 "xgZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
-/area/horizon/security/hallway)
+/turf/simulated/floor/tiled/full,
+/area/horizon/security/equipment)
 "xhf" = (
 /obj/effect/floor_decal/corner/lime/full{
 	dir = 8
@@ -47913,6 +47341,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/horizon/maintenance/deck_two/fore/port)
 "xki" = (
@@ -47923,20 +47352,12 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Brig Lockdown";
-	name = "Brig Lockdown Blast Door";
-	opacity = 0
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
 	name = "Brig Interior";
 	req_access = list(2)
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/brig)
 "xkH" = (
 /turf/simulated/open,
@@ -48187,28 +47608,7 @@
 "xsp" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille/diagonal,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/green,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 8;
-	icon_state = "pdoor0";
-	id = "Security Lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Brig Lockdown";
-	name = "Brig Lockdown Blast Door";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/reinforced,
 /area/horizon/security/brig)
 "xsH" = (
 /obj/effect/floor_decal/spline/fancy/wood/full,
@@ -48351,17 +47751,26 @@
 /turf/simulated/floor/plating,
 /area/horizon/maintenance/deck_two/fore/port)
 "xxa" = (
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 5
-	},
+/obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/security,
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (Anti-Materiel Ammunition)"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/item/ammo_casing/peac,
-/obj/item/ammo_casing/peac,
-/obj/item/ammo_casing/peac,
-/obj/structure/sign/flag/scc/right{
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	req_access = list(3);
+	name = "Heavy Armour"
+	},
+/obj/item/clothing/suit/armor/carrier/heavy/sec,
+/obj/item/clothing/suit/armor/carrier/heavy/sec,
+/obj/item/clothing/head/helmet/security/heavy,
+/obj/item/clothing/head/helmet/security/heavy,
+/obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -48373,8 +47782,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "xxm" = (
@@ -48417,14 +47824,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
-"xzb" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/plating,
-/area/horizon/security/holding_cell_b)
 "xzd" = (
 /obj/structure/closet/radiation,
 /obj/effect/floor_decal/corner/mauve/full,
@@ -48482,9 +47881,9 @@
 /turf/simulated/floor/plating,
 /area/horizon/zta)
 "xzV" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "xBv" = (
@@ -48611,8 +48010,10 @@
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/research)
 "xED" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/light/small/emergency,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "xEF" = (
@@ -48657,11 +48058,12 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/hor)
 "xFZ" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_y = -16
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 13
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/green/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/horizon/security/brig)
 "xGc" = (
 /obj/structure/table/stone/marble,
@@ -48780,8 +48182,9 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/structure/bed/stool/bar/padded/red,
-/obj/structure/disposalpipe/segment,
+/obj/structure/bed/stool/chair{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "xIJ" = (
@@ -48905,23 +48308,21 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "xLY" = (
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "shutters_deck1_security_cell_2";
-	name = "Cell B Blast Door"
-	},
-/obj/machinery/door/firedoor,
+/obj/item/hullbeacon/red,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled,
-/area/horizon/security/brig)
-"xLZ" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light/small/emergency{
-	dir = 1
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/security_starboard)
+/turf/simulated/floor/reinforced/airless,
+/area/template_noop)
+"xLZ" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/security_cadet,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled,
+/area/horizon/security/equipment)
 "xMm" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -48956,11 +48357,13 @@
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "xMV" = (
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 1
+/obj/item/device/radio/intercom{
+	pixel_x = 24;
+	dir = 8
 	},
-/obj/structure/closet/secure_closet/security_cadet,
-/obj/effect/floor_decal/industrial/outline/security,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/equipment)
 "xNn" = (
@@ -49134,30 +48537,11 @@
 /turf/simulated/floor/tiled/full,
 /area/engineering/engine_waste)
 "xQz" = (
-/obj/machinery/door/firedoor,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Brig Lockdown";
-	name = "Brig Lockdown Blast Door";
-	opacity = 0
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/glass_security{
-	autoclose = 0;
-	id_tag = "cell_1";
-	name = "Cell A";
-	req_access = list(2)
-	},
-/turf/simulated/floor/plating,
-/area/horizon/security/brig)
+/turf/simulated/floor/tiled,
+/area/horizon/security/equipment)
 "xQB" = (
 /obj/machinery/iv_drip,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -49236,11 +48620,14 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "xSM" = (
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "shutters_deck1_security_cell_3";
+	name = "Cell C Blast Door"
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/brig)
 "xSP" = (
 /obj/structure/railing/mapped{
@@ -49281,19 +48668,15 @@
 /turf/simulated/floor/reinforced/reactor,
 /area/engineering/engine_room)
 "xUW" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/machinery/firealarm/west,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/paleblue/full,
+/obj/structure/closet/walllocker/emerglocker/west,
 /obj/machinery/camera/network/security{
 	c_tag = "Security - Corridor Camera 3";
-	dir = 4
+	dir = 1
 	},
-/obj/structure/closet/walllocker/emerglocker/south,
-/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "xVf" = (
@@ -49308,39 +48691,26 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room/tesla)
 "xVl" = (
-/turf/simulated/wall,
-/area/horizon/security/holding_cell_b)
-"xVp" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/shuttle/scc_space_ship,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Brig Lockdown";
-	name = "Brig Lockdown Blast Door";
-	opacity = 0
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "Security Lockdown";
-	name = "Security Blast Door";
-	opacity = 0
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/machinery/door/blast/shutters/open{
-	dir = 2;
-	id = "shutters_deck1_security_cell_isolation";
-	name = "Isolation Cell Window Shutter"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/dark/full,
-/area/maintenance/security_starboard)
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/holding_cell_b)
 "xVu" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced/airless,
@@ -49352,10 +48722,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_waste)
 "xVB" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port/far)
@@ -49490,11 +48856,8 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_two/fore)
 "xYO" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/light/small/emergency{
+	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
@@ -49603,15 +48966,16 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_monitoring/tesla)
 "ybf" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Weaponry (Burst Rifle)"
 	},
-/obj/machinery/light/colored/red,
-/obj/effect/floor_decal/corner/paleblue/full{
-	dir = 4
+/obj/item/gun/projectile/automatic/rifle/jingya,
+/obj/item/gun/projectile/automatic/rifle/jingya,
+/obj/effect/floor_decal/corner_wide/paleblue{
+	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/security,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
 "ybh" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -49686,7 +49050,9 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/structure/bed/stool/bar/padded/red,
+/obj/structure/bed/stool/chair{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "yct" = (
@@ -49868,7 +49234,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
 /area/horizon/security/brig)
 "yeY" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -72898,8 +72267,8 @@ dza
 ayF
 uXq
 eNj
-bOR
-ncR
+pdv
+acz
 dLu
 pTQ
 txW
@@ -73100,7 +72469,7 @@ jWF
 jWF
 tZV
 eNj
-bOR
+pdv
 acz
 tIQ
 ukV
@@ -73512,7 +72881,7 @@ ini
 wYe
 tGX
 gNq
-sIR
+pDh
 efA
 eCR
 sBr
@@ -74120,18 +73489,18 @@ flb
 lKH
 gDT
 fOn
-dKi
+mPq
 vMF
 jmH
 pdz
 haI
-mPq
+dKi
 xUW
 ubq
 ogR
 rfi
 vOL
-avW
+jfH
 xer
 uGh
 gTy
@@ -74332,8 +73701,8 @@ mOu
 siD
 vXy
 bLu
-ifO
-mfV
+gis
+jfH
 xer
 kUf
 ryR
@@ -74524,18 +73893,18 @@ qlV
 wCZ
 qtN
 pMf
-pMf
-pMf
-pMf
+vCs
+nDx
+mFD
 pMf
 qSY
 vgg
-qSY
+pMf
 pMf
 pMf
 pMf
 sKE
-anU
+jfH
 xer
 nIX
 cPB
@@ -74724,19 +74093,19 @@ jcz
 jcz
 jcz
 eIt
-czL
-blC
+nrr
+pMf
 mbi
 dgw
 kkW
 pMf
 wpq
 jAp
-jAp
+hrC
 hzZ
 swz
 pMf
-gem
+gis
 jfH
 xer
 qgN
@@ -74918,7 +74287,7 @@ ayF
 ykd
 ayF
 ayF
-ayF
+qDh
 qDh
 dLe
 dQR
@@ -74929,7 +74298,7 @@ feO
 pIn
 tTM
 gdW
-jYJ
+rQJ
 wJh
 hIK
 wdF
@@ -74939,7 +74308,7 @@ hjo
 gaA
 pMf
 xYO
-jzv
+jfH
 xer
 qgN
 qgN
@@ -75120,15 +74489,15 @@ kaT
 dev
 kaT
 cNU
-sgl
 qDh
-hrC
+hHJ
 pJE
+uUz
 oZB
 lUi
 wdY
 kat
-kjs
+pIn
 vCs
 plb
 psg
@@ -75140,8 +74509,8 @@ qlU
 exu
 fBN
 pMf
-xYO
-xVp
+gis
+jfH
 xer
 qgN
 qgN
@@ -75322,27 +74691,27 @@ uTr
 uTr
 uTr
 emN
-sgl
 qDh
-ljm
+hHJ
+pJE
 aVf
 jno
-tQA
-rhz
+lUi
+wdY
 aqZ
 mOt
-pMf
+glv
 wRd
-mGr
+bFU
 vYW
 pMf
 xxa
-kvE
-ioW
-kvE
+pNG
+qlU
+exu
 jvp
 pMf
-qLd
+gis
 lMO
 xer
 qgN
@@ -75524,31 +74893,31 @@ vPg
 bAZ
 uTr
 kaT
-dTj
 qDh
-iTL
+hHJ
+pJE
 jBq
 kfw
 rdP
 jfu
 sEc
-pIn
+tJr
 pMf
 iWm
-kvE
+mGr
 bmY
 pMf
 rKv
-kvE
-lrQ
-kvE
+pNG
+qlU
+exu
 hLh
 pMf
-gem
+gis
 jfH
-jki
-nJQ
-mnU
+xer
+qgN
+qgN
 qgN
 qgN
 qgN
@@ -75726,31 +75095,31 @@ ncx
 dYe
 uTr
 kaT
-qPP
 qDh
-lLj
+hHJ
+pJE
 unV
 aHj
-pJE
+xgZ
 lCC
 uJa
 aNB
 pMf
 wiB
-qxp
+kvE
 aTI
 pMf
 iQK
-kvE
-kvE
-kvE
+jzv
+fyO
+hpY
 ybf
 pMf
-gem
+xYO
 jfH
-jPc
-kuh
-fdj
+xer
+qgN
+qgN
 qgN
 qgN
 qgN
@@ -75928,31 +75297,31 @@ ncx
 dYe
 uTr
 tCY
-kjO
 qDh
-kep
+xLZ
 pJE
+xQz
 qjh
-oaA
+lUi
 xIH
-bFU
+gqy
 ndk
 pMf
-pMf
-pMf
-pMf
-pMf
+nqE
+ijp
+qLd
 pMf
 aLq
+kXs
 nCg
 kXs
 cIx
 pMf
-mqg
-dPZ
-jPc
-dUw
-fdj
+gis
+jfH
+xer
+qgN
+qgN
 qgN
 qgN
 qgN
@@ -76130,12 +75499,12 @@ uxf
 oGK
 uTr
 veG
-kjO
 qDh
+pyA
 xMV
 hPx
 tdv
-tQA
+lUi
 rec
 iIM
 iqu
@@ -76150,11 +75519,11 @@ pMf
 pMf
 pMf
 pMf
-xLZ
+sKE
 jfH
-jPc
-kuh
-fdj
+xer
+qgN
+qgN
 qgN
 qgN
 qgN
@@ -76332,31 +75701,31 @@ drw
 tYa
 uTr
 kaT
-hps
 qDh
 mJJ
-pJE
+mJJ
+xgZ
 ucD
 mJJ
 yci
 vtf
-qtN
-cjC
-tuH
-glv
-cjC
-lvT
-dXF
-xVl
+wLk
+dLc
+gis
 pjs
 gis
+sKE
 gis
+gis
+gis
+gis
+pjs
 gis
 gis
 jfH
 dVE
-kuh
-fdj
+nJQ
+oou
 qgN
 qgN
 qgN
@@ -76542,21 +75911,21 @@ jrz
 qUt
 lCC
 kbZ
-pIn
-cjC
-kcO
+nuF
 bHb
-cjC
+bHb
+bHb
+bHb
 ePb
-qSH
-xVl
-gis
-bDo
+ePb
+ePb
+ePb
+ePb
 bDo
 bDo
 bDo
 uan
-jPc
+tEq
 kuh
 fdj
 qgN
@@ -76745,21 +76114,21 @@ oqW
 lCC
 eJW
 pIn
-cjC
+bHb
 tsy
 bUm
-cjC
-fum
+gem
+ePb
 eMf
-xVl
-gis
-bDo
+mqg
+dTj
+ePb
 pBA
 rWG
 jzV
 jUx
 jPc
-dUw
+kuh
 fdj
 qgN
 qgN
@@ -76947,21 +76316,21 @@ sGm
 tuD
 rXd
 nrr
-cjC
+bHb
 jju
 joH
 cjC
-tne
+ePb
 nru
 xVl
-gis
-bDo
+mfV
+ePb
 pTf
 gEa
 rGx
-uan
+eqS
 jPc
-kuh
+dUw
 fdj
 qgN
 qgN
@@ -77149,22 +76518,22 @@ hsy
 vYv
 ggC
 vaR
-cjC
+bHb
 hsh
 bBu
-cjC
-wFe
-xzb
-xVl
+hsh
+ePb
 uZD
-bDo
+tgp
+uZD
+ePb
 kRr
 uiH
 bDo
 uan
-pGJ
-nJQ
-hod
+jPc
+kuh
+fdj
 qgN
 qgN
 qgN
@@ -77348,25 +76717,25 @@ wAm
 ijc
 ubq
 edD
-jbo
+lCC
 gqy
 dhZ
 xxc
-ifF
+dKi
 mWT
 lZD
 gAN
-sgp
-eZZ
 dKi
+mWT
 dKi
+xxc
 fuJ
 eQD
 ggA
 oJm
-xer
-qgN
-qgN
+jPc
+kuh
+fdj
 qgN
 qgN
 qgN
@@ -77547,28 +76916,28 @@ kaT
 cAx
 kaT
 kaT
-uUz
+uXV
 ubq
 dXx
-jbo
+lCC
 lGQ
+sgl
+dwK
+czL
+gGX
 jbo
 dwK
-jbo
-gGX
-xgZ
-fyO
-jbo
+rOt
 dbd
-jbo
-jbo
+dwK
+rOt
 jbo
 ngj
 mBy
 iSD
-xer
-qgN
-qgN
+jPc
+dUw
+fdj
 qgN
 qgN
 qgN
@@ -77747,7 +77116,7 @@ kGX
 wUS
 uUR
 wsW
-mEc
+hSG
 dSI
 nTF
 ubq
@@ -77755,12 +77124,12 @@ mVb
 lRO
 ucq
 oYH
-dLc
+wtV
 lzq
 wjU
 dDo
 oiD
-iDH
+mUL
 wtV
 cQd
 mUL
@@ -77768,9 +77137,9 @@ oAs
 oWW
 bTy
 oJm
-xer
-qgN
-qgN
+jPc
+kuh
+fdj
 qgN
 qgN
 qgN
@@ -77949,30 +77318,30 @@ kGX
 dVy
 eUp
 wsW
-hSG
+mEc
 dSI
-nTF
+uhE
 uOB
 vnC
 jih
 uOB
 yeT
+jJa
 bDo
-xQz
 aQR
+qPP
 bDo
-mFD
 ebT
+qPP
 bDo
-nDd
 jMB
+qPP
 bDo
-uhE
-eXU
+bDo
 uan
 tEq
-qgN
-qgN
+kuh
+fdj
 qgN
 qgN
 qgN
@@ -78159,22 +77528,22 @@ khi
 mns
 rSE
 jcK
+dqy
 bDo
-amI
 syI
+qSH
 bDo
-shI
-ijp
+syI
+lWF
 bDo
-shI
-jJa
+syI
+qxp
 bDo
-pyA
 oRF
 uan
 nKA
-qgN
-qgN
+nJQ
+opx
 qgN
 qgN
 qgN
@@ -78362,19 +77731,19 @@ oLB
 gtk
 kkY
 fin
-wTm
-qQt
-ftz
 eGh
-ngB
+pZV
 ftz
 eGh
 pZV
+ljm
+eGh
+pZV
+kcO
 bDo
-dqy
-jup
-pSv
-arV
+oRF
+uan
+uhP
 qgN
 qgN
 qgN
@@ -78563,17 +77932,17 @@ eWX
 qvO
 rSE
 mXO
+ddH
 bDo
-qxq
 tYB
+bOR
 bDo
-xLY
 cOj
+sNx
 bDo
-gqI
 xSM
+bOR
 bDo
-gSY
 sqE
 mfN
 qgN
@@ -78765,17 +78134,17 @@ abz
 klv
 uOB
 fqS
-bDo
-ljx
+jNY
+eGh
+oYc
+aKO
 aOz
-baJ
-aOz
-aOz
-lAv
+dlR
+aKO
 aOz
 dlR
 qgK
-gBH
+bDo
 dcN
 kmx
 qgN
@@ -78964,21 +78333,21 @@ sYc
 gEB
 uOB
 uOB
-rSE
+qfR
 uOB
 xki
+bOR
 bDo
-vgz
-huP
-jcc
-huP
+qQt
+eUB
 huP
 huP
+eUB
 huP
-rqZ
-bDo
+eUB
+gqI
 hqd
-rQJ
+mfN
 qgN
 qgN
 qgN
@@ -79172,14 +78541,14 @@ qni
 aKO
 kqz
 wsF
-rOt
+huP
 kHb
-ufU
+kHb
+yef
 huP
 huP
-oRT
 aae
-pDh
+uan
 hrG
 qgN
 qgN
@@ -79369,20 +78738,20 @@ wLJ
 bDo
 bDo
 ouo
-huP
 eUB
-huP
 jcc
+huP
 eUB
-xFZ
+huP
+eUB
 vaj
 mdB
-oYc
+fGs
 huP
-tFx
+huP
 noZ
 gMP
-xer
+tvc
 qgN
 qgN
 qgN
@@ -79572,19 +78941,19 @@ jqD
 bDo
 rXh
 huP
-yef
-tvc
 jcc
 huP
+huP
+huP
+huP
 lBc
 lBc
-jNY
 xzV
 huP
-huP
+eUB
 jpB
 dVc
-xer
+jPc
 qgN
 qgN
 qgN
@@ -79773,15 +79142,15 @@ iwo
 ryu
 bDo
 kuS
-huP
-fGs
-kSM
+eUB
 waU
 vPH
 tiG
 vPH
-qfR
+tiG
 vPH
+vPH
+rDE
 aIH
 uRu
 bOe
@@ -79975,20 +79344,20 @@ iwo
 ryu
 bDo
 mbF
-nuF
-eUB
-huP
-huP
+hrP
+hrP
+wFe
+hrP
 kCr
-huP
-huP
-eUB
+kSM
+ufU
+pGJ
 ueC
-qZI
+bDo
 uan
 nFs
 xsp
-xer
+jPc
 qgN
 qgN
 qgN
@@ -80175,22 +79544,22 @@ jpO
 vIz
 iwo
 hBQ
-bzh
+bDo
 bDo
 iOg
-huP
-ueC
+baJ
+bDo
 dYR
-hrP
-pUn
-sNx
-nDx
-pdg
+bDo
+bDo
+bDo
+bDo
+bDo
 hqd
 oDg
 efz
-rVv
-uhP
+rhz
+xLY
 qgN
 qgN
 qgN
@@ -80379,16 +79748,16 @@ iwo
 uPP
 gBa
 bDo
-nqE
-huP
-oRT
+bDo
+bDo
+bDo
 pMz
 fYW
-pMz
-pMz
-pMz
+dYR
+amI
+bDo
 tmb
-wLk
+isO
 kmx
 qgN
 qgN
@@ -80580,16 +79949,16 @@ eWw
 iwo
 iwo
 ryu
-bDo
+ioW
 elL
 aru
-rDE
-pMz
+bDo
+xFZ
 fNx
-hHJ
-fYW
-gNk
-hqd
+bDo
+avW
+bDo
+iDH
 mfN
 qgN
 qgN
@@ -80781,16 +80150,16 @@ vCl
 oyD
 pEh
 iwo
-lvq
-bDo
+ryu
+lrQ
 eNZ
 rzC
-hpY
-pMz
-oou
-tJr
-pMz
-vAr
+bDo
+bDo
+bDo
+bDo
+bDo
+bDo
 isO
 kmx
 qgN
@@ -80984,15 +80353,15 @@ qsw
 uFm
 iwo
 ryu
-bDo
-bDo
-bDo
-bDo
-bDo
-bDo
-bDo
-bDo
-hqd
+tXR
+ngB
+tXR
+tXR
+elL
+pUn
+wsW
+tmb
+iDH
 mfN
 qgN
 qgN
@@ -81185,16 +80554,16 @@ wye
 aUQ
 fLi
 iwo
-tgp
-wWx
-wWx
-wWx
-wWx
-tXR
-tXR
-tXR
+lvq
+eXU
+mmS
+mmS
+mmS
+aru
+sgp
 wsW
-rcH
+tmb
+isO
 kmx
 qgN
 qgN
@@ -81389,13 +80758,13 @@ vXB
 iwo
 ryu
 wWx
-mmS
+nvF
 dYr
 erY
-lWF
-tXR
-tXR
-lVg
+oiY
+eZZ
+wsW
+iDH
 mfN
 qgN
 qgN
@@ -81589,15 +80958,15 @@ rCL
 nKc
 cJU
 iwo
-lvq
+ryu
 wWx
-nvF
-xdA
-oiY
-rkZ
+mmS
+mmS
+jki
+aru
 uqi
 wsW
-eqS
+isO
 kmx
 qgN
 qgN
@@ -81793,11 +81162,11 @@ iwo
 iwo
 ryu
 wWx
-mmS
-mmS
+kjO
+wWx
 oyi
-wsW
-wsW
+ifO
+uqi
 lVg
 mfN
 qgN
@@ -81992,7 +81361,7 @@ pnj
 feC
 vIz
 iwo
-yka
+oRT
 pbM
 fuu
 fuu
@@ -82195,7 +81564,7 @@ jpO
 vIz
 iwo
 lZp
-ddH
+fuu
 fuu
 xVB
 jIj
@@ -82399,7 +81768,7 @@ iwo
 bKu
 pLX
 fuu
-lBd
+ljx
 nUP
 ueH
 fuu
@@ -82598,10 +81967,10 @@ iwo
 iwo
 iwo
 iwo
-pVs
-pbM
-hnN
+arV
 lBd
+hnN
+ueH
 xpX
 lVn
 svf
@@ -82797,14 +82166,14 @@ wrc
 jmj
 egt
 wrc
-wrc
+rcH
 emT
 wrc
 tFA
-pbM
+tFx
 fuu
-fuu
-fuu
+ueH
+xdA
 fuu
 agG
 kmx
@@ -83004,8 +82373,8 @@ fuu
 fuu
 kbL
 wNQ
-hnN
-lBd
+fuu
+ueH
 fKG
 svf
 mfN
@@ -83205,7 +82574,7 @@ fuu
 kDg
 qZj
 bUk
-lBd
+wNQ
 yka
 yka
 yka

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -37573,9 +37573,6 @@
 /obj/item/gun/projectile/automatic/wt550,
 /obj/item/gun/projectile/sec,
 /obj/item/gun/projectile/sec,
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Weaponry (Laser Rifles)"
-	},
 /obj/machinery/light,
 /obj/effect/floor_decal/corner_wide/paleblue/full,
 /obj/effect/floor_decal/industrial/outline/security,

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -15692,13 +15692,8 @@
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 9
 	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -28;
-	pixel_y = 2
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -28;
-	pixel_y = -9
+/obj/structure/fireaxecabinet{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)
@@ -45597,11 +45592,16 @@
 /obj/effect/floor_decal/corner_wide/paleblue/full{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 32
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 23
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 34
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/armoury)

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -27379,7 +27379,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/network/security{
-	c_tag = "Security - Holding Cell B
+	c_tag = "Security - Holding Cell B"
 	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/computer/sentencing/courtroom{

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -758,6 +758,9 @@
 	pixel_y = 28
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "ask" = (
@@ -3883,6 +3886,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
 "bKR" = (
@@ -4565,6 +4571,11 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
+"bZz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "bZD" = (
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/regular{
@@ -5255,6 +5266,12 @@
 	},
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/maintenance/wing/starboard)
+"cwH" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "cwO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/shuttle/scc_space_ship,
@@ -10829,6 +10846,12 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "frL" = (
@@ -11927,6 +11950,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/chief)
+"fSy" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "fSA" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/stack/material/graphite/full,
@@ -12113,6 +12142,12 @@
 "fWI" = (
 /turf/simulated/floor/lino/grey,
 /area/chapel/main)
+"fXA" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "fYi" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 10
@@ -12327,6 +12362,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/lobby)
+"gbJ" = (
+/obj/machinery/flasher{
+	id = "permflash"
+	},
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "gbT" = (
 /turf/simulated/floor/tiled,
 /area/engineering/lobby)
@@ -16179,6 +16227,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/break_room)
+"hMm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "hMt" = (
 /turf/simulated/floor/plating,
 /area/engineering/engine_room/tesla)
@@ -18662,6 +18719,12 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "jck" = (
@@ -19461,6 +19524,10 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/engineering/engine_airlock)
+"jtQ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "jtR" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -21195,6 +21262,8 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "kqM" = (
@@ -21710,6 +21779,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
+"kGc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "kGX" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/strongroom)
@@ -26477,6 +26555,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "mXS" = (
@@ -30480,6 +30561,12 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "oYM" = (
@@ -32988,6 +33075,12 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "qnl" = (
@@ -33516,6 +33609,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/horizon/grauwolf)
+"qBg" = (
+/obj/machinery/flasher{
+	id = "permflash"
+	},
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "qBt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -34115,6 +34217,12 @@
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -35226,6 +35334,18 @@
 	dir = 1
 	},
 /area/maintenance/wing/starboard/far)
+"rrf" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "rrq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -39036,6 +39156,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/storage_eva)
+"tnX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "toe" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -45453,6 +45582,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"wpd" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "wpq" = (
 /obj/machinery/light{
 	dir = 1
@@ -45588,6 +45728,12 @@
 "wsF" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
@@ -47356,6 +47502,12 @@
 /obj/machinery/door/airlock/glass_security{
 	name = "Brig Interior";
 	req_access = list(2)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/full,
 /area/horizon/security/brig)
@@ -78339,12 +78491,12 @@ xki
 bOR
 bDo
 qQt
-eUB
-huP
-huP
-eUB
-huP
-eUB
+qBg
+bZz
+bZz
+qBg
+bZz
+gbJ
 gqI
 hqd
 mfN
@@ -78538,15 +78690,15 @@ aVX
 rIM
 jDA
 qni
-aKO
+wpd
 kqz
 wsF
 huP
 kHb
 kHb
 yef
-huP
-huP
+cwH
+tnX
 aae
 uan
 hrG
@@ -78747,8 +78899,8 @@ eUB
 vaj
 mdB
 fGs
-huP
-huP
+kGc
+hMm
 noZ
 gMP
 tvc
@@ -78940,16 +79092,16 @@ xiu
 jqD
 bDo
 rXh
-huP
-jcc
-huP
+jtQ
+rrf
+fSy
 huP
 huP
 huP
 lBc
 lBc
 xzV
-huP
+fXA
 eUB
 jpB
 dVc

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -131,8 +131,20 @@
 /turf/simulated/floor/tiled/full,
 /area/horizon/hallway/deck_three/primary/central)
 "adv" = (
-/turf/simulated/wall,
-/area/horizon/security/investigations_hallway)
+/obj/machinery/door/airlock{
+	name = "Washroom"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
+/area/horizon/security/washroom)
 "adQ" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -850,6 +862,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/investigations_hallway)
@@ -3878,12 +3893,6 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/blue,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /turf/simulated/floor/plating,
 /area/horizon/security/meeting_room)
 "dre" = (
@@ -6098,12 +6107,12 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "fhs" = (
@@ -6673,8 +6682,8 @@
 /turf/simulated/floor/plating,
 /area/medical/washroom)
 "fxm" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/meeting_room)
@@ -7280,20 +7289,21 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "fWH" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/horizon/security/meeting_room)
+/obj/structure/disposalpipe/junction,
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/investigations_hallway)
 "fWT" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
@@ -11707,6 +11717,9 @@
 	pixel_y = 28;
 	req_one_access = list(24,11,55)
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/horizon/security/meeting_room)
 "jzc" = (
@@ -11937,7 +11950,7 @@
 	},
 /obj/structure/window/shuttle/scc_space_ship/cardinal,
 /turf/simulated/floor/plating,
-/area/template_noop)
+/area/horizon/security/meeting_room)
 "jJH" = (
 /obj/structure/table/wood,
 /obj/machinery/photocopier/faxmachine{
@@ -12185,9 +12198,6 @@
 /area/horizon/crew_quarters/fitness/changing)
 "jUg" = (
 /obj/structure/railing/mapped,
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -12200,6 +12210,8 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "jUp" = (
@@ -15463,7 +15475,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/window/shuttle/scc_space_ship/cardinal,
 /turf/simulated/floor/plating,
-/area/template_noop)
+/area/horizon/security/meeting_room)
 "mrU" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
@@ -15525,7 +15537,7 @@
 /area/template_noop)
 "muG" = (
 /turf/simulated/wall/r_wall,
-/area/maintenance/security_starboard)
+/area/horizon/security/washroom)
 "muO" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
@@ -15819,19 +15831,16 @@
 /turf/simulated/floor/carpet/art,
 /area/horizon/crew_quarters/fitness/lounge)
 "mNY" = (
-/obj/structure/window/reinforced/tinted{
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/structure/bed/handrail{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/freezer,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/white,
 /area/horizon/security/washroom)
 "mOc" = (
 /obj/machinery/door/airlock/glass{
@@ -16354,10 +16363,6 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 28
-	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/investigations_hallway)
 "nhL" = (
@@ -16747,7 +16752,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
 "nAf" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/power/apc{
 	dir = 4;
 	pixel_x = 24
@@ -16755,6 +16759,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "nAM" = (
@@ -18424,10 +18429,10 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "oLM" = (
@@ -18440,13 +18445,18 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/port/docks)
 "oMf" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
-/obj/structure/flora/pottedplant/random,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/investigations_hallway)
 "oMk" = (
@@ -19479,16 +19489,14 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/crew_quarters/fitness/showers)
 "pMu" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/white,
 /area/horizon/security/washroom)
 "pML" = (
@@ -19929,8 +19937,6 @@
 /obj/effect/landmark/start{
 	name = "Investigator"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/meeting_room)
 "qeu" = (
@@ -20531,13 +20537,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "qzR" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "qAq" = (
@@ -23213,27 +23219,22 @@
 	pixel_x = 5;
 	pixel_y = 4
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/investigations_hallway)
 "sGQ" = (
-/obj/structure/sink{
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/westright{
+	name = "Shower"
+	},
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
 	pixel_y = 24
 	},
-/obj/structure/mirror{
-	pixel_y = 35
-	},
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/freezer,
 /area/horizon/security/washroom)
 "sHy" = (
 /obj/effect/floor_decal/corner/green/full{
@@ -23430,8 +23431,6 @@
 /obj/effect/landmark/start{
 	name = "Investigator"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/meeting_room)
 "sNZ" = (
@@ -24004,16 +24003,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/evidence_storage)
 "tni" = (
-/obj/machinery/door/airlock{
-	name = "Restroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/wall,
 /area/horizon/security/washroom)
 "tnA" = (
 /obj/machinery/power/apc/low{
@@ -24545,18 +24535,8 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "tGG" = (
-/obj/structure/window/shuttle/scc_space_ship/cardinal,
-/obj/structure/grille,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "Security Lockdown";
-	name = "Security Blast Door";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/template_noop)
+/turf/simulated/wall/shuttle/scc_space_ship/cardinal,
+/area/horizon/security/washroom)
 "tHh" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -25117,9 +25097,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/meeting_room)
 "tZR" = (
@@ -25379,14 +25356,20 @@
 /turf/simulated/floor/carpet,
 /area/lawoffice/representative)
 "uks" = (
-/obj/machinery/shower{
+/obj/machinery/power/apc{
+	pixel_y = -24
+	},
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/curtain/open/shower,
-/obj/structure/bed/handrail{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/tiled/white,
 /area/horizon/security/washroom)
 "ulh" = (
 /obj/machinery/alarm{
@@ -25396,10 +25379,10 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "uly" = (
@@ -25623,10 +25606,18 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/hallway/deck_three/primary/port/docks)
 "uzK" = (
-/obj/machinery/door/window{
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer,
+/obj/machinery/door/window/westleft{
+	name = "Toilet"
+	},
+/obj/structure/curtain/open/shower,
+/turf/simulated/floor/tiled/white,
 /area/horizon/security/washroom)
 "uAr" = (
 /obj/structure/railing/mapped{
@@ -25691,17 +25682,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/command)
-"uBz" = (
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/blast/shutters/open{
-	dir = 8;
-	id = "shutters_deck3_cafedesk";
-	name = "Cafe Desk Shutter"
-	},
-/obj/structure/table/stone/marble,
-/turf/simulated/floor/tiled,
-/area/horizon/cafeteria)
 "uBG" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/effect/floor_decal/spline/plain{
@@ -25795,14 +25775,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/meeting_room)
@@ -27278,15 +27255,19 @@
 /turf/simulated/wall,
 /area/horizon/hallway/deck_three/primary/central)
 "vGh" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/structure/mirror{
+	pixel_y = 32
 	},
-/obj/machinery/firealarm/south{
-	pixel_y = 24
+/obj/structure/sink{
+	pixel_y = 28
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/white,
 /area/horizon/security/washroom)
@@ -27826,9 +27807,6 @@
 /turf/simulated/floor/plating,
 /area/bridge/minibar)
 "wbp" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	pixel_y = 24
@@ -53631,7 +53609,7 @@ lbi
 evE
 gDe
 ofx
-uBz
+gDe
 aLA
 lbi
 hNj
@@ -55881,8 +55859,8 @@ cPq
 cPq
 mKC
 slH
-slH
-slH
+dSF
+dSF
 dSF
 dSF
 dSF
@@ -56083,8 +56061,8 @@ cPq
 cPq
 mKC
 slH
-slH
-slH
+dSF
+dSF
 dSF
 dSF
 dSF
@@ -56285,8 +56263,8 @@ cPq
 oRi
 mKC
 slH
-slH
-slH
+dSF
+dSF
 dSF
 dSF
 dSF
@@ -56487,8 +56465,8 @@ nsP
 uKB
 eIz
 slH
-slH
-slH
+dSF
+dSF
 dSF
 dSF
 dSF
@@ -56866,7 +56844,7 @@ two
 dOH
 bqQ
 gOz
-dal
+fWH
 hQh
 cru
 xwm
@@ -57268,10 +57246,10 @@ aQk
 lnI
 xGF
 xGF
-lnI
+tni
+tni
 adv
-adv
-nSp
+muG
 dBS
 nSp
 nSp
@@ -57470,7 +57448,7 @@ uCm
 sNN
 qdz
 dqT
-lnI
+tni
 vGh
 uks
 muG
@@ -57669,9 +57647,9 @@ lnI
 jzb
 sLg
 tZE
-fxm
-fxm
-fWH
+kxs
+kxs
+dAI
 tni
 pMu
 mNY
@@ -57699,8 +57677,8 @@ nmh
 tXQ
 avR
 slH
-dSF
-dSF
+slH
+slH
 dSF
 dSF
 dSF
@@ -57873,8 +57851,8 @@ iVD
 fyZ
 gTO
 kxs
-dAI
-lnI
+fxm
+tni
 sGQ
 uzK
 muG
@@ -57901,8 +57879,8 @@ kHa
 oty
 ntv
 slH
-dSF
-dSF
+slH
+slH
 dSF
 dSF
 dSF
@@ -58076,14 +58054,14 @@ fyZ
 kxs
 kxs
 xJq
-oIR
-rRe
+tGG
+tGG
+tGG
 tGG
 rRe
 rRe
 rRe
 rRe
-wGH
 wGH
 wGH
 wGH
@@ -58103,8 +58081,8 @@ nsP
 oty
 ntv
 slH
-dSF
-dSF
+slH
+slH
 dSF
 dSF
 dSF
@@ -58306,7 +58284,7 @@ nSj
 kZs
 jBu
 slH
-dSF
+slH
 dSF
 dSF
 dSF
@@ -58508,7 +58486,7 @@ cBs
 mKC
 vtk
 uRs
-dSF
+slH
 dSF
 dSF
 dSF
@@ -58878,13 +58856,13 @@ nlv
 nlv
 nlv
 pbx
-rRe
+oIR
 mrA
 jJs
 mrA
 mrA
-rRe
-rRe
+oIR
+oIR
 wGH
 wGH
 wGH

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -132,7 +132,8 @@
 /area/horizon/hallway/deck_three/primary/central)
 "adv" = (
 /obj/machinery/door/airlock{
-	name = "Washroom"
+	name = "Washroom";
+	id_tag = "sec_deck3_toilet"
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -23226,13 +23227,11 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/investigations_hallway)
 "sGQ" = (
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/westright{
-	name = "Shower"
-	},
-/obj/structure/curtain/open/shower,
 /obj/machinery/shower{
 	pixel_y = 24
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/horizon/security/washroom)
@@ -25610,13 +25609,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/green/diagonal,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/westleft{
-	name = "Toilet"
-	},
-/obj/structure/curtain/open/shower,
 /turf/simulated/floor/tiled/white,
 /area/horizon/security/washroom)
 "uAr" = (
@@ -27265,9 +27257,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/item/device/radio/intercom{
+/obj/machinery/button/remote/airlock{
 	dir = 4;
-	pixel_x = -24
+	id = "sec_deck3_toilet";
+	name = "Door Bolt Control";
+	pixel_x = -25;
+	specialfunctions = 4;
+	pixel_y = -7
 	},
 /turf/simulated/floor/tiled/white,
 /area/horizon/security/washroom)


### PR DESCRIPTION
this PR tweaks security in the map to improve QoL and to fix some issues.

## changelog
- tweaked the armoury and made it more walkable.
- expanded the security equipment room and made it more walkable. made the wall behind the lockers empty to allow hanging banners/flags on it.
- tweaked the holding cells layout.
- shrinked the brig communal a little and tweaked its layout.
- tweaked the security washroom on deck 3 and connected its door to the hallway instead.
- expanded the speakeasy area behind security.
- fixed various mapping issues in security, such as wiring, piping, disposals, decals, and similarly.
- fixed wrong IDs on objects in the brig cells.

## screenshots
<details>
<summary>🖼️ click to view</summary>

![image](https://user-images.githubusercontent.com/99297919/222571070-7916ddec-6681-4ffd-aad4-3f82ed78aa6f.png)
**figure 1:** deck 2 security.

![image](https://user-images.githubusercontent.com/99297919/222570035-8a484522-e544-4b1b-84bf-af4d1504586a.png)
**figure 2:** deck 3 security washroom.
</details>