### PR TITLE
Lowers fire delay for guns across the board

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -64,7 +64,7 @@
 
 	var/burst = 1
 	var/can_autofire = FALSE
-	var/fire_delay = 6 	//delay after shooting before the gun can be used again
+	var/fire_delay = 3 	//delay after shooting before the gun can be used again
 	var/burst_delay = 1	//delay between shots, if firing in bursts
 	var/move_delay = 0
 	var/fire_sound = 'sound/weapons/gunshot/gunshot1.ogg'


### PR DESCRIPTION
The delay between shooting is now half of what it was for most guns. This may be too strong: it may be necessary to make it so rifles have the same fire delay as before, with only pistols and other weaker guns having the fire delay increase. In either case, this needs a test merge.