### PR TITLE
Fixes psi-ping sprites lingering

### DIFF
--- a/code/modules/psionics/faculties/coercion.dm
+++ b/code/modules/psionics/faculties/coercion.dm
@@ -307,7 +307,7 @@
 			var/image/ping_image = image(icon = 'icons/effects/effects.dmi', icon_state = "sonar_ping", loc = our_turf, layer = OBFUSCATION_LAYER + 0.1)
 			pixel_shift_to_turf(ping_image, our_turf, T)
 			user << ping_image
-			addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, ping_image), 8)
+			QDEL_IN(ping_image, 8)
 			var/direction = num2text(get_dir(user, L))
 			var/dist
 			if(text2num(direction))

--- a/html/changelogs/meep109_psibugfix.yml
+++ b/html/changelogs/meep109_psibugfix.yml
@@ -1,0 +1,8 @@
+author: meep109
+
+
+delete-after: True
+
+
+changes:
+  - bugfix: "Fixes psi-ping sprites not disappearing."


### PR DESCRIPTION
Right now, psi ping circles stay on the screen until you restart the client. This should fix it. My first PR please tell me if I messed up
