### PR TITLE
Vaurcae aren't slowed by cold

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -13,10 +13,11 @@
 #define NO_ARTERIES         BITFLAG(12)   // This species does not have arteries.
 #define PHORON_IMMUNE       BITFLAG(13)   // species doesn't suffer the negative effects of phoron contamination
 #define CAN_SWEAT           BITFLAG(14)   // Forgive me.
+#define NO_COLD_SLOWDOWN	BITFLAG(15)		//Doesn't slow down in the cold.
 // unused: 0x8000(32768) - higher than this will overflow
 
 // Base flags for IPCs.
-#define IS_IPC (NO_BREATHE|NO_SCAN|NO_BLOOD|NO_PAIN|NO_POISON|IS_MECHANICAL|NO_CHUBBY|PHORON_IMMUNE)
+#define IS_IPC (NO_BREATHE|NO_SCAN|NO_BLOOD|NO_PAIN|NO_POISON|IS_MECHANICAL|NO_CHUBBY|PHORON_IMMUNE|NO_COLD_SLOWDOWN)
 
 // Species spawn flags
 #define IS_WHITELISTED    0x1    // Must be whitelisted to play.

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -40,7 +40,7 @@
 	if (is_drowsy())
 		tally += 6
 
-	if (!(species.flags & IS_MECHANICAL))	// Machines don't move slower when cold.
+	if (!(species.flags & NO_COLD_SLOWDOWN))	// Bugs and machines don't move slower when cold.
 		if(HAS_FLAG(mutations, FAT))
 			tally += 1.5
 		if (bodytemperature < 283.222)
@@ -55,7 +55,7 @@
 	var/obj/item/I = get_active_hand()
 	if(istype(I))
 		tally += I.slowdown
-	
+
 	if(isitem(pulling))
 		var/obj/item/P = pulling
 		tally += P.slowdown

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -71,7 +71,7 @@
 	heat_level_1 = 330 //Default 360
 	heat_level_2 = 380 //Default 400
 	heat_level_3 = 600 //Default 1000
-	flags = NO_SLIP | NO_CHUBBY | NO_ARTERIES | PHORON_IMMUNE
+	flags = NO_SLIP | NO_CHUBBY | NO_ARTERIES | PHORON_IMMUNE | NO_COLD_SLOWDOWN
 	spawn_flags = CAN_JOIN | IS_WHITELISTED | NO_AGE_MINIMUM
 	appearance_flags = HAS_SKIN_COLOR | HAS_HAIR_COLOR
 	blood_color = COLOR_VAURCA_BLOOD // dark yellow

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
@@ -91,7 +91,7 @@
 	sprint_cost_factor = 0.80
 	stamina_recovery = 3
 
-	flags =  NO_SLIP | NO_ARTERIES | PHORON_IMMUNE
+	flags =  NO_SLIP | NO_ARTERIES | PHORON_IMMUNE | NO_COLD_SLOWDOWN
 
 	possible_cultures = list(
 		/singleton/origin_item/culture/zora_breeder,
@@ -164,7 +164,7 @@
 	warning_high_pressure = 3250 //Default 325
 
 	spawn_flags = IS_RESTRICTED
-	flags = NO_SCAN | NO_SLIP | NO_PAIN | NO_BREATHE | NO_ARTERIES | PHORON_IMMUNE
+	flags = NO_SCAN | NO_SLIP | NO_PAIN | NO_BREATHE | NO_ARTERIES | PHORON_IMMUNE | NO_COLD_SLOWDOWN
 
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/rebel_yell,

--- a/html/changelogs/sniblet-coldbugs.yml
+++ b/html/changelogs/sniblet-coldbugs.yml
@@ -1,0 +1,9 @@
+# Your name.
+author: Sniblet
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - tweak: "Vaurcae aren't slowed by cold."
+  - backend: "Adds the NO_COLD_SLOWDOWN species flag, only used by IPCs and vaurcae."


### PR DESCRIPTION
changes:
  - tweak: "Vaurcae aren't slowed by cold."
  - backend: "Adds the NO_COLD_SLOWDOWN species flag, only used by IPCs and vaurcae."

This is because mining on planets like Raskara causes unplayable slowdown.