### PR TITLE
The horizon is now the default map if no map is set

### DIFF
--- a/code/controllers/subsystems/initialization/atlas.dm
+++ b/code/controllers/subsystems/initialization/atlas.dm
@@ -255,9 +255,9 @@ var/datum/controller/subsystem/atlas/SSatlas
 			log_ss("atlas", "Using configured map.")
 		else
 			log_ss("atlas", "-- WARNING: CONFIGURED MAP DOES NOT EXIST, IGNORING! --")
-			. = "aurora"
+			. = "sccv_horizon"
 	else
-		. = "aurora"
+		. = "sccv_horizon"
 
 /datum/controller/subsystem/atlas/proc/load_map_meta()
 	// This needs to be done after current_map is set, but before mapload.


### PR DESCRIPTION
What it says in the title. Way easier for testing stuff. No changelog because no real player facing changes.