### PR TITLE
Examine Message Order Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -86,10 +86,6 @@
 		else
 			msg += "[get_pronoun("He")] [get_pronoun("is")] wearing [icon2html(w_uniform, user)] <a href='?src=\ref[src];lookitem_desc_only=\ref[w_uniform]'>\a [w_uniform]</a>[tie_msg].\n"
 
-	//when the player is winded by an admin
-	if(paralysis > 6000)
-		msg += "<span><font color='#002eb8'><b>OOC Information:</b></font> <font color='red'>This player has been winded by a member of staff! Please freeze all roleplay involving their character until the matter is resolved! Adminhelp if you have further questions.</font></span>\n"
-
 	//head
 	if(head)
 		if(head.blood_color)
@@ -161,18 +157,6 @@
 	else if(blood_color)
 		msg += "<span class='warning'>[get_pronoun("He")] [get_pronoun("has")] [fluid_color_type_map(hand_blood_color)]-stained hands!</span>\n"
 
-	//handcuffed?
-	if(handcuffed)
-		msg += "<span class='warning'>[get_pronoun("He")] [get_pronoun("is")] [icon2html(handcuffed, user)] handcuffed!</span>\n"
-
-	//handcuffed?
-	if(legcuffed)
-		msg += "<span class='warning'>[get_pronoun("He")] [get_pronoun("is")] [icon2html(legcuffed, user)] legcuffed!</span>\n"
-
-	//buckled_to
-	if(buckled_to)
-		msg += "<span class='warning'>[get_pronoun("He")] [get_pronoun("is")] [icon2html(buckled_to, user)] buckled to [buckled_to]!</span>\n"
-
 	//belt
 	if(belt)
 		if(belt.blood_color)
@@ -229,10 +213,6 @@
 		else if(jitteriness >= 100)
 			msg += "<span class='warning'>[get_pronoun("He")] [get_pronoun("is")] twitching ever so slightly.</span>\n"
 
-	//Red Nightshade
-	if(is_berserk())
-		msg += "<span class='warning'><B>[get_pronoun("He")] [get_pronoun("has")] engorged veins which appear a vibrant red.</B></span>\n"
-
 	//splints
 	for(var/organ in list(BP_L_LEG,BP_R_LEG,BP_L_ARM,BP_R_ARM,BP_L_HAND,BP_R_HAND,BP_R_FOOT,BP_L_FOOT))
 		var/obj/item/organ/external/o = get_organ(organ)
@@ -244,6 +224,22 @@
 
 	if(HAS_FLAG(mutations, mSmallsize))
 		msg += "[get_pronoun("He")] [get_pronoun("is")] small halfling!\n"
+
+	//buckled_to
+	if(buckled_to)
+		msg += "[get_pronoun("He")] [get_pronoun("is")] buckled to [icon2html(buckled_to, user)] [buckled_to].\n"
+
+	//handcuffed?
+	if(handcuffed)
+		msg += "<span class='warning'>[get_pronoun("He")] [get_pronoun("has")] [icon2html(handcuffed, user)] cuffs around [get_pronoun("his")] wrists!</span>\n"
+
+	//handcuffed?
+	if(legcuffed)
+		msg += "<span class='warning'>[get_pronoun("He")] [get_pronoun("has")] [icon2html(legcuffed, user)] cuffs around [get_pronoun("his")] ankles!</span>\n"
+
+	//Red Nightshade
+	if(is_berserk())
+		msg += "<span class='warning'><B>[get_pronoun("He")] [get_pronoun("has")] engorged veins, which appear a vibrant red!</B></span>\n"
 
 	var/distance = get_dist(user,src)
 	if(istype(user, /mob/abstract/observer) || user.stat == 2) // ghosts can see anything
@@ -259,8 +255,14 @@
 
 	if(fire_stacks)
 		msg += "[get_pronoun("He")] [get_pronoun("is")] covered in some liquid.\n"
+
 	if(on_fire)
 		msg += "<span class='danger'>[get_pronoun("He")] [get_pronoun("is")] on fire!</span>\n"
+
+	//when the player is winded by an admin
+	if(paralysis > 6000)
+		msg += "<span><font size='3'><font color='#002eb8'><b>OOC Information:</b></font> <font color='red'>This player has been winded by a member of staff! Please freeze all roleplay involving their character until the matter is resolved! Adminhelp if you have further questions.</font></font></span>\n"
+
 	msg += "<span class='warning'>"
 
 	msg += "</span>"
@@ -399,7 +401,7 @@
 	var/datum/vampire/V = get_antag_datum(MODE_VAMPIRE)
 	if(V && (V.status & VAMP_DRAINING))
 		var/obj/item/grab/G = get_active_hand()
-		msg += SPAN_ALERT("\n[get_pronoun("He")] is biting [G.affecting]'[G.affecting.get_pronoun("end")] neck!")
+		msg += SPAN_ALERT(FONT_LARGE("\n[get_pronoun("He")] is biting [G.affecting]'[G.affecting.get_pronoun("end")] neck!"))
 
 	if (pose)
 		if( findtext(pose,".",length(pose)) == 0 && findtext(pose,"!",length(pose)) == 0 && findtext(pose,"?",length(pose)) == 0 )

--- a/html/changelogs/examine_tweaks.yml
+++ b/html/changelogs/examine_tweaks.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Tweaked the order some messages appear when examining a character."


### PR DESCRIPTION
this PR tweaks the order some messages appear when examining someone. i.e. clothes go up top, status messages go on the bottom.