### PR TITLE
Vaurca Bulwarks and Workers can now select the integrated drill augment

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_augments.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_augments.dm
@@ -203,6 +203,14 @@
 	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician", "Engineering Apprentice", "Machinist")
 	cost = 2
 
+/datum/gear/augment/drill
+	display_name = "integrated drill"
+	description = "A mining drill integrated in the hand. The drill is heavy, so only industrial IPCs and Vaurca Bulwarks can use it."
+	path = /obj/item/organ/internal/augment/tool/drill
+	whitelisted = list(SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_VAURCA_BULWARK)
+	allowed_roles = list("Shaft Miner")
+	cost = 5
+
 /datum/gear/augment/head_fluff
 	display_name = "custom head augmentation"
 	description = "A fluff based augmentation that can be renamed/redescribed to appear as something else for RP purposes."

--- a/code/modules/client/preference_setup/loadout/loadout_augments.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_augments.dm
@@ -205,7 +205,7 @@
 
 /datum/gear/augment/drill
 	display_name = "integrated drill"
-	description = "A mining drill integrated in the hand. The drill is heavy enough that it is only usable by industrial IPCs, as well as Vaurca Bulwarks and Bound Workers"
+	description = "A mining drill integrated in the hand. The drill is heavy enough that it is only usable by industrial IPCs, as well as Vaurca bulwarks and bound workers."
 	path = /obj/item/organ/internal/augment/tool/drill
 	whitelisted = list(SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_WORKER)
 	allowed_roles = list("Shaft Miner")

--- a/code/modules/client/preference_setup/loadout/loadout_augments.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_augments.dm
@@ -205,7 +205,7 @@
 
 /datum/gear/augment/drill
 	display_name = "integrated drill"
-	description = "A mining drill integrated in the hand. The drill is heavy enough that it is only usable by industrial IPCs, as well as Vaurca bulwarks and bound workers."
+	description = "A mining drill integrated in the hand. The drill is heavy enough that it is only usable by industrial IPCs, as well as Vaurca Bulwarks and Bound Workers."
 	path = /obj/item/organ/internal/augment/tool/drill
 	whitelisted = list(SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_WORKER)
 	allowed_roles = list("Shaft Miner")

--- a/code/modules/client/preference_setup/loadout/loadout_augments.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_augments.dm
@@ -205,9 +205,9 @@
 
 /datum/gear/augment/drill
 	display_name = "integrated drill"
-	description = "A mining drill integrated in the hand. The drill is heavy, so only industrial IPCs and Vaurca Bulwarks can use it."
+	description = "A mining drill integrated in the hand. The drill is heavy enough that it is only usable by industrial IPCs, as well as Vaurca Bulwarks and Bound Workers"
 	path = /obj/item/organ/internal/augment/tool/drill
-	whitelisted = list(SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_VAURCA_BULWARK)
+	whitelisted = list(SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_WORKER)
 	allowed_roles = list("Shaft Miner")
 	cost = 5
 

--- a/code/modules/client/preference_setup/loadout/loadout_xeno/machine.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/machine.dm
@@ -161,15 +161,6 @@
 	handies["gustatorial centre (left hand)"] = /obj/item/organ/internal/augment/gustatorial/hand/left
 	gear_tweaks += new /datum/gear_tweak/path(handies)
 
-/datum/gear/augment/drill
-	display_name = "integrated drill"
-	description = "A mining drill integrated in the hand. The drill is heavy, so only industrial IPCs can use it."
-	path = /obj/item/organ/internal/augment/tool/drill
-	whitelisted = list(SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION)
-	allowed_roles = list("Shaft Miner")
-	cost = 5
-	sort_category = "Xenowear - IPC"
-
 /datum/gear/augment/drill/New()
 	..()
 	var/list/augs = list()

--- a/code/modules/client/preference_setup/loadout/loadout_xeno/vaurca.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/vaurca.dm
@@ -219,13 +219,3 @@
 	sort_category = "Xenowear - Vaurca"
 	whitelisted = list(SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_BREEDER, SPECIES_VAURCA_BULWARK)
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
-
-/datum/gear/augment/bulwark_mining
-	display_name = "integrated mining drill"
-	description = "A mining drill integrated into the hand. This drill is so heavy, only Vaurca Bulwarks are capable of handling it."
-	cost = 5
-	path = /obj/item/organ/internal/augment/tool/drill
-	sort_category = "Xenowear - Vaurca"
-	whitelisted = list(SPECIES_VAURCA_BULWARK)
-	allowed_roles = list("Shaft Miner")
-	flags = GEAR_NO_SELECTION

--- a/code/modules/client/preference_setup/loadout/loadout_xeno/vaurca.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/vaurca.dm
@@ -219,3 +219,13 @@
 	sort_category = "Xenowear - Vaurca"
 	whitelisted = list(SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_BREEDER, SPECIES_VAURCA_BULWARK)
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
+
+/datum/gear/augment/bulwark_mining
+	display_name = "integrated mining drill"
+	description = "A mining drill integrated into the hand. This drill is so heavy, only Vaurca Bulwarks are capable of handling it."
+	cost = 5
+	path = /obj/item/organ/internal/augment/tool/drill
+	sort_category = "Xenowear - Vaurca"
+	whitelisted = list(SPECIES_VAURCA_BULWARK)
+	allowed_roles = list("Shaft Miner")
+	flags = GEAR_NO_SELECTION

--- a/html/changelogs/RustingWithYou - striketheearth.yml
+++ b/html/changelogs/RustingWithYou - striketheearth.yml
@@ -33,4 +33,4 @@ author: RustingWithYou
 delete-after: True
 
 changes:
-  - tweak: Integrated mining drills can now be taken by Vaurca Bulwarks and Workers. The integrated drill has been moved from Xenowear - IPC to Augments in the loadout menu
+  - tweak: "Integrated mining drills can now be taken by Vaurca bulwarks and workers. The integrated drill has been moved from xenowear to augments in the loadout menu."

--- a/html/changelogs/RustingWithYou - striketheearth.yml
+++ b/html/changelogs/RustingWithYou - striketheearth.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - tweak: Integrated mining drills can now be taken by Vaurca Bulwarks. The integrated drill has been moved from Xenowear - IPC to Augments in the loadout menu

--- a/html/changelogs/RustingWithYou - striketheearth.yml
+++ b/html/changelogs/RustingWithYou - striketheearth.yml
@@ -33,4 +33,4 @@ author: RustingWithYou
 delete-after: True
 
 changes:
-  - tweak: Integrated mining drills can now be taken by Vaurca Bulwarks. The integrated drill has been moved from Xenowear - IPC to Augments in the loadout menu
+  - tweak: Integrated mining drills can now be taken by Vaurca Bulwarks and Workers. The integrated drill has been moved from Xenowear - IPC to Augments in the loadout menu


### PR DESCRIPTION
Vaurca Bulwarks can now take integrated drills in loadout, like industrial frame IPCs.

As the augment is now multi-species, it's been moved to the Augments category from Xenowear - IPC.

By Vaurca team request, this has been added to Workers as well