### PR TITLE
Tweaks Some Recipes

### DIFF
--- a/code/modules/cooking/recipes/recipes_baked.dm
+++ b/code/modules/cooking/recipes/recipes_baked.dm
@@ -16,8 +16,6 @@
 	items = list(
 		/obj/item/reagent_containers/food/snacks/sliceable/flatdough,
 		/obj/item/reagent_containers/food/snacks/meat,
-		/obj/item/reagent_containers/food/snacks/meat,
-		/obj/item/reagent_containers/food/snacks/meat,
 		/obj/item/reagent_containers/food/snacks/cheesewedge
 	)
 	result = /obj/item/reagent_containers/food/snacks/sliceable/pizza/meatpizza

--- a/code/modules/cooking/recipes/recipes_breakfast.dm
+++ b/code/modules/cooking/recipes/recipes_breakfast.dm
@@ -98,14 +98,13 @@
 /singleton/recipe/pancakes
 	appliance = SKILLET
 	items = list(
-		/obj/item/reagent_containers/food/snacks/sliceable/flatdough,
 		/obj/item/reagent_containers/food/snacks/sliceable/flatdough
 		)
 	result = /obj/item/reagent_containers/food/snacks/pancakes
-	result_quantity = 2
+	result_quantity = 1
 
 /singleton/recipe/pancakes/berry
-	fruit = list("berries" = 2)
+	fruit = list("berries" = 1)
 	result = /obj/item/reagent_containers/food/snacks/pancakes/berry
 
 /singleton/recipe/waffles

--- a/code/modules/cooking/recipes/recipes_fryer.dm
+++ b/code/modules/cooking/recipes/recipes_fryer.dm
@@ -146,7 +146,6 @@
 	items = list(
 		/obj/item/reagent_containers/food/snacks/sausage
 	)
-	fruit = list("corn" = 1)
 	coating = /singleton/reagent/nutriment/coating/batter
 	result = /obj/item/reagent_containers/food/snacks/corn_dog
 

--- a/code/modules/cooking/recipes/recipes_mix.dm
+++ b/code/modules/cooking/recipes/recipes_mix.dm
@@ -257,10 +257,10 @@
 
 /singleton/recipe/donerkebab
 	fruit = list("tomato" = 1, "cabbage" = 1)
-	reagents = list(/singleton/reagent/sodiumchloride = 1)
+	reagents = list(/singleton/reagent/sodiumchloride = 1, /singleton/reagent/spacespice = 1)
 	items = list(
-		/obj/item/reagent_containers/food/snacks/meatsteak,
-		/obj/item/reagent_containers/food/snacks/sliceable/flatdough
+		/obj/item/reagent_containers/food/snacks/sliceable/flatdough,
+		/obj/item/reagent_containers/food/snacks/cutlet
 	)
 	result = /obj/item/reagent_containers/food/snacks/donerkebab
 

--- a/html/changelogs/recipes.yml
+++ b/html/changelogs/recipes.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - tweak: "Made the meat pizza recipe cost less meat."
-  - tweak: "Made the pancakes recipe give you 1 pancake instead of 2. Reflected by the ingredient cost as well."
+  - tweak: "Made the pancakes recipe give you 1 pancake instead of 2. Lowered the ingredients cost from 2 to 1."

--- a/html/changelogs/recipes.yml
+++ b/html/changelogs/recipes.yml
@@ -5,3 +5,5 @@ delete-after: True
 changes:
   - tweak: "Made the meat pizza recipe cost less meat."
   - tweak: "Made the pancakes recipe give you 1 pancake instead of 2. Lowered the ingredients cost from 2 to 1."
+  - tweak: "Made the döner kebab cost 1 cutlet instead of 1 steak. Made it also cost 1 spice."
+  - bugfix: "Fixed the corn dog recipe."

--- a/html/changelogs/recipes.yml
+++ b/html/changelogs/recipes.yml
@@ -1,0 +1,7 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - tweak: "Made the meat pizza recipe cost less meat."
+  - tweak: "Made the pancakes recipe give you 1 pancake instead of 2. Reflected by the ingredient cost as well."


### PR DESCRIPTION
this PR tweaks some recipes to make more sense.
fixes #11905.

## changelog
- made the meat pizza recipe cost 1 meat instead of 3.
- made the pancake recipe only give 1 pancake instead of 2. lowered the ingredient count from 2 to 1 as well.
- fixed the corn dog recipe requiring a ear of corn.
- made the döner kebab cost 1 cutlet instead of 1 steak. also made it cost 1 space spice.