### PR TITLE
Mapping Fixes

### DIFF
--- a/html/changelogs/giant_mapping_bugfixes.yml
+++ b/html/changelogs/giant_mapping_bugfixes.yml
@@ -1,0 +1,17 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed the atmospherics volume tanks room not having air alarms."
+  - bugfix: "Fixed the atmospherics locker room airlock not having an emergency shutter."
+  - bugfix: "Fixed the security firing range airlock not having an emergency shutter."
+  - bugfix: "Fixed the security firing range not having an air alarm."
+  - bugfix: "Fixed the engineering hard storage not having an air alarm."
+  - bugfix: "Fixed the Intrepid's fuel line being connected to the starboard airlock's air line."
+  - bugfix: "Fixed the Intrepid's medical compartment not having an air alarm."
+  - bugfix: "Fixed the deck 1 substations not having air alarms."
+  - bugfix: "Fixed some parts of deck 1 starboard maintenance not having air alarms."
+  - bugfix: "Fixed some parts of deck 2 security maintenance not having air alarms."
+  - bugfix: "Fixed some subgrids missing powernet sensors."
+  - bugfix: "Fixed the deck 2 civilian subgrid powernet sensor being named wrong."

--- a/maps/sccv_horizon/code/sccv_horizon_areas.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_areas.dm
@@ -283,8 +283,6 @@
 	name = "Intrepid Crew Compartment"
 /area/shuttle/intrepid/cargo_bay
 	name = "Intrepid Cargo Bay"
-/area/shuttle/intrepid/medical_compartment
-	name = "Intrepid Medical Compartment"
 /area/shuttle/intrepid/engine_compartment
 	name = "Engine Compartment"
 /area/shuttle/intrepid/atmos_compartment

--- a/maps/sccv_horizon/code/sccv_horizon_shuttles.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_shuttles.dm
@@ -156,7 +156,7 @@
 /datum/shuttle/autodock/overmap/intrepid
 	name = "Intrepid"
 	move_time = 20
-	shuttle_area = list(/area/shuttle/intrepid/crew_compartment, /area/shuttle/intrepid/cargo_bay, /area/shuttle/intrepid/medical_compartment, /area/shuttle/intrepid/engine_compartment, /area/shuttle/intrepid/atmos_compartment, /area/shuttle/intrepid/cockpit, /area/shuttle/intrepid/rotary)
+	shuttle_area = list(/area/shuttle/intrepid/crew_compartment, /area/shuttle/intrepid/cargo_bay, /area/shuttle/intrepid/engine_compartment, /area/shuttle/intrepid/atmos_compartment, /area/shuttle/intrepid/cockpit, /area/shuttle/intrepid/rotary)
 	dock_target = "intrepid_shuttle"
 	current_location = "nav_hangar_intrepid"
 	landmark_transition = "nav_transit_intrepid"

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -5184,9 +5184,6 @@
 	pixel_x = -24;
 	pixel_y = -10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -26,10 +26,12 @@
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "acn" = (
-/obj/structure/window/shuttle/scc,
-/obj/machinery/door/firedoor,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plating,
-/area/shuttle/intrepid/medical_compartment)
+/area/maintenance/wing/starboard/deck1)
 "acp" = (
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 8
@@ -277,15 +279,15 @@
 /turf/simulated/floor/plating,
 /area/rnd/xenoarch_atrium)
 "aoG" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/obj/machinery/camera/network/intrepid{
+	c_tag = "Intrepid - Medbay"
 	},
-/obj/machinery/hologram/holopad/long_range,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/vending/wallmed1{
+	pixel_y = 32;
+	req_access = null
 	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/intrepid/crew_compartment)
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "aoR" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	frequency = 1441;
@@ -875,11 +877,11 @@
 /area/engineering/atmos/propulsion)
 "aMg" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/intrepid/medical_compartment)
+/area/shuttle/intrepid/crew_compartment)
 "aMh" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -1579,7 +1581,6 @@
 /turf/simulated/floor/tiled,
 /area/operations/loading)
 "blW" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -2717,6 +2718,15 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/crew_compartment)
 "ccU" = (
@@ -2806,6 +2816,10 @@
 "cfS" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Deck 1 Engineering Subgrid";
+	name_tag = "Deck 1 Engineering Subgrid"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/engineering/lower)
@@ -2921,6 +2935,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/sleeper,
 /turf/simulated/floor/plating,
 /area/hangar/intrepid)
 "cne" = (
@@ -4118,13 +4133,11 @@
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos)
 "dnR" = (
-/obj/structure/window/shuttle/scc,
-/obj/machinery/door/firedoor,
-/obj/effect/landmark/entry_point/port{
-	name = "port, medbay"
+/obj/structure/bed/stool/chair/shuttle{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/shuttle/intrepid/medical_compartment)
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/intrepid/crew_compartment)
 "dnX" = (
 /obj/structure/closet/walllocker/emerglocker/east{
 	pixel_x = 0;
@@ -4179,6 +4192,9 @@
 	},
 /obj/structure/railing/mapped{
 	dir = 8
+	},
+/obj/machinery/alarm{
+	pixel_y = 28
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/deck1)
@@ -4572,17 +4588,17 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenoarch_atrium)
 "dER" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/structure/cable/green,
 /obj/machinery/power/apc/low{
 	dir = 8;
 	pixel_x = -24
 	},
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Starboard Hangar Subgrid";
-	name_tag = "Starboard Hangar Subgrid"
+	name = "Powernet Sensor - Deck 2 Civilian Subgrid";
+	name_tag = "Deck 2 Civilian Subgrid"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian_west)
@@ -5078,18 +5094,6 @@
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/tiled,
 /area/shuttle/intrepid/crew_compartment)
-"ebd" = (
-/obj/effect/floor_decal/corner/blue/full{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/intrepid/crew_compartment)
 "ebu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -5180,13 +5184,7 @@
 	pixel_x = -24;
 	pixel_y = -10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /obj/structure/cable/green{
@@ -5222,18 +5220,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "eeD" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = -1;
-	pixel_y = 29;
-	req_access = null
-	},
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/storage/firstaid/o2,
 /obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/camera/network/intrepid{
-	c_tag = "Intrepid - Medbay"
+/obj/item/reagent_containers/inhaler/pneumalin,
+/obj/item/reagent_containers/inhaler/pneumalin,
+/obj/effect/floor_decal/industrial/outline/medical,
+/obj/structure/table/standard,
+/obj/structure/closet/walllocker/medical{
+	pixel_x = 32
 	},
-/obj/machinery/sleeper,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/toxin,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/intrepid/medical_compartment)
+/area/shuttle/intrepid/crew_compartment)
 "eeV" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue,
 /obj/machinery/meter,
@@ -5646,7 +5651,7 @@
 	},
 /obj/machinery/power/apc/intrepid{
 	dir = 1;
-	pixel_y = 30
+	pixel_y = 24
 	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -6013,28 +6018,11 @@
 /area/horizon/custodial)
 "eJu" = (
 /obj/structure/window/reinforced,
-/obj/structure/table/standard,
-/obj/item/storage/box/gloves{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/glass/bottle/inaprovaline{
-	pixel_x = 4;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -6;
-	pixel_y = 12
-	},
 /obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/machinery/iv_drip,
+/obj/effect/floor_decal/industrial/outline/medical,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/intrepid/medical_compartment)
+/area/shuttle/intrepid/crew_compartment)
 "eJG" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6283,7 +6271,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
-	name = "Science Substation";
+	name = "Deck 1 Research Substation";
 	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/plating,
@@ -6699,6 +6687,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/operations)
 "fga" = (
@@ -7198,16 +7189,11 @@
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/power/apc/intrepid{
-	dir = 4;
-	pixel_x = 30
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
 	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/shuttle/intrepid/medical_compartment)
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/intrepid/crew_compartment)
 "fBg" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -8711,6 +8697,10 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "gBw" = (
@@ -9164,7 +9154,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
-	name = "Science Substation";
+	name = "Deck 1 Research Substation";
 	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/plating,
@@ -9290,6 +9280,10 @@
 "haj" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research_sublevel)
@@ -9512,8 +9506,8 @@
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/intrepid/crew_compartment)
@@ -10011,8 +10005,8 @@
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/intrepid/crew_compartment)
@@ -10495,11 +10489,12 @@
 /obj/item/reagent_containers/blood/OMinus,
 /obj/structure/closet/walllocker/medical/secure{
 	name = "blood closet";
-	pixel_x = 30;
+	pixel_x = 32;
 	req_access = null
 	},
+/obj/effect/floor_decal/industrial/outline/medical,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/intrepid/medical_compartment)
+/area/shuttle/intrepid/crew_compartment)
 "hXX" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Xenoarchaeology"
@@ -10793,23 +10788,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "ijn" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/obj/machinery/alarm{
+	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/intrepid/crew_compartment)
+/turf/simulated/floor/plating,
+/area/maintenance/operations)
 "ijU" = (
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
@@ -11028,12 +11011,17 @@
 /area/maintenance/operations)
 "iwX" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/door/window/westright{
+	name = "Medical Compartment"
 	},
-/obj/machinery/door/window/westright,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/intrepid/medical_compartment)
+/area/shuttle/intrepid/crew_compartment)
 "ixm" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -11071,6 +11059,10 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "iAs" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/security)
 "iAL" = (
@@ -12202,21 +12194,14 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/crew_compartment)
 "jwL" = (
@@ -12542,7 +12527,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
-	name = "Hangar Substation";
+	name = "Deck 1 Civilian Substation";
 	req_one_access = list(11,24)
 	},
 /obj/machinery/door/firedoor,
@@ -12737,13 +12722,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/bed/roller,
 /obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/iv_drip{
-	pixel_x = 7
-	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/intrepid/medical_compartment)
+/area/shuttle/intrepid/crew_compartment)
 "jRx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13510,17 +13491,15 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/custodial/disposals)
 "kxl" = (
-/obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/window/westleft,
+/obj/structure/window/reinforced,
+/obj/structure/bed/roller,
+/obj/effect/floor_decal/industrial/outline/medical,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/intrepid/medical_compartment)
+/area/shuttle/intrepid/crew_compartment)
 "kyq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -13764,14 +13743,21 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/crew_compartment)
@@ -14760,6 +14746,10 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Deck 1 Civilian Subgrid";
+	name_tag = "Deck 1 Civilian Subgrid"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/hangar)
 "lyc" = (
@@ -14873,6 +14863,10 @@
 "lDd" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian_west)
@@ -16217,14 +16211,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "mJn" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 5
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/intrepid/crew_compartment)
@@ -16333,6 +16324,9 @@
 	target_pressure = 200
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/deck1)
 "mNH" = (
@@ -18475,10 +18469,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/crew_compartment)
 "ows" = (
@@ -18735,6 +18726,10 @@
 	},
 /obj/machinery/power/apc/low{
 	pixel_y = -24
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Deck 2 and 3 Security Subgrid";
+	name_tag = "Deck 2 and 3 Security Subgrid"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/security)
@@ -19448,19 +19443,21 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "pqh" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc/low{
 	name = "south bump";
 	pixel_y = -24
 	},
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Supply";
-	name_tag = "Supply Subgrid"
+	name = "Powernet Sensor - Operations Subgrid";
+	name_tag = "Operations Subgrid"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/supply)
@@ -19487,10 +19484,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
 "psd" = (
-/obj/structure/closet/walllocker/emerglocker/west{
-	pixel_x = -27;
-	pixel_y = 3
-	},
+/obj/structure/closet/walllocker/emerglocker/west,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -19775,23 +19769,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "pCD" = (
-/obj/structure/closet/walllocker/medical{
-	pixel_y = 31
-	},
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/storage/firstaid/o2,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lime/diagonal,
-/obj/item/reagent_containers/inhaler/pneumalin,
-/obj/item/reagent_containers/inhaler/pneumalin,
+/obj/machinery/sleeper,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/intrepid/medical_compartment)
+/area/shuttle/intrepid/crew_compartment)
 "pEb" = (
 /obj/machinery/body_scanconsole{
 	dir = 8
@@ -20046,7 +20031,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
-	name = "Security Substation";
+	name = "Deck 2 and 3 Security Substation";
 	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/tiled/full,
@@ -20531,7 +20516,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/crew_compartment)
 "qfH" = (
@@ -21934,6 +21918,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/closet/walllocker/emerglocker/east,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/crew_compartment)
 "riL" = (
@@ -22024,8 +22009,13 @@
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
 "rmT" = (
-/turf/simulated/wall/shuttle/scc/cardinal,
-/area/shuttle/intrepid/medical_compartment)
+/obj/structure/window/shuttle/scc,
+/obj/machinery/door/firedoor,
+/obj/effect/landmark/entry_point/port{
+	name = "port, medbay"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/intrepid/crew_compartment)
 "rmY" = (
 /obj/structure/trash_pile,
 /obj/effect/floor_decal/corner/purple/full{
@@ -22514,11 +22504,13 @@
 /turf/simulated/floor/tiled,
 /area/medical/morgue/lower)
 "rHi" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/intrepid/crew_compartment)
 "rHr" = (
@@ -23084,18 +23076,14 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/crew_compartment)
 "seU" = (
@@ -23339,11 +23327,8 @@
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/intrepid/crew_compartment)
@@ -24096,7 +24081,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
-	name = "Hangar Substation";
+	name = "Deck 1 Civilian Substation";
 	req_one_access = list(11,24)
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -24524,23 +24509,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "tkX" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/intrepid/crew_compartment)
+/turf/simulated/floor/plating,
+/area/maintenance/operations)
 "tlt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -24604,6 +24578,10 @@
 "tns" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "tny" = (
@@ -25254,8 +25232,7 @@
 /area/engineering/storage/tech)
 "tNo" = (
 /obj/structure/closet/walllocker/firecloset{
-	pixel_x = 28;
-	pixel_y = -4
+	pixel_x = 32
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -25956,6 +25933,7 @@
 	},
 /obj/machinery/bluespace_beacon,
 /obj/effect/shuttle_landmark/intrepid/hangar,
+/obj/machinery/hologram/holopad/long_range,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/crew_compartment)
 "unS" = (
@@ -26332,9 +26310,6 @@
 /turf/simulated/wall,
 /area/operations/loading)
 "uCq" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/machinery/power/apc/low{
 	dir = 8;
 	name = "west bump";
@@ -26344,8 +26319,11 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Research First Deck Subgrid";
-	name_tag = "Research First Deck Subgrid"
+	name = "Powernet Sensor - Deck 1 Research Subgrid";
+	name_tag = "Deck 1 Research Subgrid"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research_sublevel)
@@ -27308,26 +27286,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/operations)
 "vqV" = (
-/obj/structure/table/standard,
-/obj/item/storage/firstaid/regular{
-	layer = 3.01;
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = -4;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/fire{
-	layer = 3.01
-	},
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/structure/table/standard,
+/obj/item/reagent_containers/glass/bottle/inaprovaline{
+	pixel_x = 4;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/item/roller{
+	pixel_x = -8
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = 5;
+	pixel_y = -1
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/intrepid/medical_compartment)
+/area/shuttle/intrepid/crew_compartment)
 "vqW" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/industrial/warning{
@@ -27806,16 +27788,13 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hydroponics/lower)
 "vMd" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 6
-	},
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 8
 	},
 /obj/machinery/light/small,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/intrepid/crew_compartment)
 "vMB" = (
@@ -28377,16 +28356,16 @@
 	id = "intrepid_inner";
 	name = "inner cargo hold blast doors";
 	pixel_x = -24;
-	pixel_y = 23
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 6
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/crew_compartment)
@@ -28667,6 +28646,10 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 28
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/hangar)
 "wrX" = (
@@ -28916,7 +28899,8 @@
 /area/shuttle/intrepid/cockpit)
 "wGn" = (
 /obj/structure/bed/stool/chair/shuttle,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/spline/plain/cee,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/intrepid/crew_compartment)
 "wHJ" = (
 /obj/effect/landmark/entry_point/fore{
@@ -29097,7 +29081,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
-	name = "Security Substation";
+	name = "Deck 2 and 3 Security Substation";
 	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/tiled/full,
@@ -29961,7 +29945,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "xpT" = (
-/obj/structure/closet/walllocker/emerglocker/north,
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
@@ -29979,6 +29962,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/crew_compartment)
@@ -40560,7 +40546,7 @@ hTk
 hTk
 hTk
 hTk
-fif
+acn
 fif
 fif
 kho
@@ -46422,7 +46408,7 @@ lIg
 lIg
 lIg
 lIg
-vqU
+tkX
 oDv
 tIS
 wkD
@@ -47023,7 +47009,7 @@ rNH
 rNH
 rNH
 nnw
-fCT
+ijn
 fCT
 dWL
 bDl
@@ -50885,7 +50871,7 @@ dSD
 dSD
 dSD
 ccr
-ijn
+xrp
 uSd
 oxX
 aEw
@@ -51087,7 +51073,7 @@ elI
 psd
 dQP
 wjU
-tkX
+xrp
 hhv
 hBV
 aEw
@@ -51289,9 +51275,9 @@ nQH
 brI
 hqg
 rRE
-aoG
+xrp
 spQ
-spQ
+dnR
 nyl
 liI
 djn
@@ -52097,7 +52083,7 @@ gfb
 qeY
 qWV
 jwo
-ebd
+nwF
 uSd
 nwF
 aEw
@@ -52295,7 +52281,7 @@ ghP
 fTb
 tWc
 lXC
-rmT
+clM
 pCD
 jQQ
 iwX
@@ -52497,7 +52483,7 @@ eVn
 dzg
 fQU
 vfk
-rmT
+clM
 eeD
 hXw
 aMg
@@ -52699,9 +52685,9 @@ clM
 clM
 clM
 pkw
-rmT
-acn
-rmT
+clM
+aEw
+aEw
 fAj
 vqV
 eaS
@@ -52901,11 +52887,11 @@ uRt
 uRt
 jgf
 eKr
+aoG
 iRC
-iRC
+aEw
 rmT
-rmT
-dnR
+aEw
 aEw
 aEw
 aEw

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -301,7 +301,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
-	name = "Engineering Substation";
+	name = "Deck 2 Research Substation";
 	req_one_access = list(11,24)
 	},
 /obj/machinery/door/firedoor,
@@ -4126,7 +4126,7 @@
 	},
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Master Grid";
-	name_tag = "Master"
+	name_tag = "Master Grid"
 	},
 /obj/effect/floor_decal/corner/yellow/full,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -11062,6 +11062,11 @@
 /area/horizon/security/armoury)
 "fyU" = (
 /obj/effect/floor_decal/corner/yellow/full,
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - AI Subgrid";
+	name_tag = "AI Subgrid"
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled,
 /area/turret_protected/ai_upload)
 "fyV" = (
@@ -13801,8 +13806,8 @@
 	pixel_y = -24
 	},
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Supermatter Containment";
-	name_tag = "SM Containment"
+	name = "Powernet Sensor - SM Reactor Containment";
+	name_tag = "SM Reactor Containment"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
@@ -15001,6 +15006,10 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 8
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
 /turf/simulated/floor/tiled/full,
 /area/engineering/storage_hard)
 "hlM" = (
@@ -16161,6 +16170,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/break_room)
+"hMd" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/security_starboard)
 "hMm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -17761,11 +17777,14 @@
 /obj/effect/floor_decal/corner/yellow/full{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/turret_protected/ai_upload)
@@ -19285,6 +19304,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/full,
 /area/engineering/atmos/storage)
 "joM" = (
@@ -24046,8 +24066,8 @@
 	pixel_x = 24
 	},
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Engineering Subgrid";
-	name_tag = "Engineering Subgrid"
+	name = "Powernet Sensor - Deck 2 Engineering Subgrid";
+	name_tag = "Deck 2 Engineering Subgrid"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -25773,8 +25793,8 @@
 	pixel_y = -24
 	},
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Research Subgrid";
-	name_tag = "Research Subgrid"
+	name = "Powernet Sensor - Deck 2 Research Subgrid";
+	name_tag = "Deck 2 Research Subgrid"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
@@ -26075,7 +26095,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
-	name = "Medbay Substation";
+	name = "Deck 1, 2, and 3 Medical Substation";
 	req_one_access = list(11,24)
 	},
 /obj/machinery/door/firedoor,
@@ -27336,7 +27356,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/engineering{
-	name = "Medbay Substation";
+	name = "Deck 1, 2, and 3 Medical Substation";
 	req_access = list(66);
 	req_one_access = null
 	},
@@ -28836,6 +28856,9 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "ogV" = (
@@ -30741,7 +30764,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Port Wing Subgrid";
+	name = "Powernet Sensor - Starboard Wing Subgrid";
 	name_tag = "Starboard Wing Subgrid"
 	},
 /turf/simulated/floor/plating,
@@ -31516,7 +31539,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/engineering{
-	name = "Engineering Substation";
+	name = "Deck 2 Research Substation";
 	req_one_access = list(11,24)
 	},
 /obj/machinery/door/firedoor,
@@ -31668,8 +31691,8 @@
 	dir = 4
 	},
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Supermatter Output";
-	name_tag = "SM Output"
+	name = "Powernet Sensor - SM Reactor Output";
+	name_tag = "SM Reactor Output"
 	},
 /obj/machinery/button/remote/blast_door{
 	desc = "A remote control-switch for the engine control room blast doors.";
@@ -48461,8 +48484,8 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Medbay Subgrid";
-	name_tag = "Medbay Subgrid"
+	name = "Powernet Sensor - Deck 1, 2, and 3 Medical Subgrid";
+	name_tag = "Deck 1, 2, and 3 Medical Subgrid"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
@@ -74893,7 +74916,7 @@ qlU
 exu
 jvp
 pMf
-gis
+hMd
 lMO
 xer
 qgN
@@ -75899,7 +75922,7 @@ dTj
 rec
 bzs
 qDh
-gis
+hMd
 gis
 pjs
 gis
@@ -76101,7 +76124,7 @@ mqg
 hsh
 jKb
 qDh
-sKE
+gis
 bDo
 bDo
 bDo

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -4546,6 +4546,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/full,
 /area/horizon/security/firing_range)
 "dVW" = (
@@ -7606,8 +7607,8 @@
 	},
 /obj/machinery/power/sensor{
 	long_range = 1;
-	name = "Powernet Sensor - Shields Subgrid";
-	name_tag = "Shields Subgrid"
+	name = "Powernet Sensor - Shield Subgrid";
+	name_tag = "Shield Subgrid"
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -20664,9 +20665,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/nosmoking_2{
-	pixel_y = 32
-	},
 /obj/item/gun/energy/disruptorpistol/practice{
 	pixel_y = -4
 	},
@@ -20680,6 +20678,10 @@
 /obj/item/gun/energy/rifle/laser/practice,
 /obj/item/gun/energy/rifle/laser/practice{
 	pixel_y = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 28;
+	req_one_access = list(24,11,55)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/firing_range)
@@ -21568,10 +21570,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/power/sensor{
-	name = "Powernet Sensor - Command Subgrid";
-	name_tag = "Command Subgrid"
-	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
@@ -22012,6 +22010,10 @@
 /obj/structure/cable/green,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Deck 3 Command Subgrid";
+	name_tag = "Deck 3 Command Subgrid"
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/command)
@@ -27801,8 +27803,11 @@
 "vSg" = (
 /obj/effect/floor_decal/spline/plain/cee,
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Telecommunications Subgrid";
-	name_tag = "Telecommunications Subgrid"
+	name = "Powernet Sensor - Deck 3 Telecommunications Subgrid";
+	name_tag = "Deck 3 Telecommunications Subgrid"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"


### PR DESCRIPTION
this PR fixes a lot of mapping issues.
fixes #15992.

## changelog
- fixed the atmospherics volume tanks room not having air alarms.
- fixed the atmospherics locker room airlock not having an emergency shutter.
- fixed the security firing range airlock not having an emergency shutter.
- fixed the security firing range not having an air alarm.
- fixed the engineering hard storage not having an air alarm.
- fixed the Intrepid's fuel line being connected to the starboard airlock's air line.
- fixed the Intrepid's medical compartment not having an air alarm.
- fixed the deck 1 substations not having air alarms.
- fixed some parts of deck 1 starboard maintenance not having air alarms.
- fixed some parts of deck 2 security maintenance not having air alarms.
- fixed some subgrids missing powernet sensors.
- fixed the deck 2 civilian subgrid powernet sensor being named wrong.