### PR TITLE
Brings back the skybox icon color

### DIFF
--- a/code/controllers/subsystems/skybox.dm
+++ b/code/controllers/subsystems/skybox.dm
@@ -56,7 +56,7 @@ var/datum/controller/subsystem/skybox/SSskybox
 	res.appearance_flags = KEEP_TOGETHER
 
 	var/sector_icon = SSatlas.current_sector.skybox_icon
-	var/image/base = overlay_image(skybox_icon, sector_icon, background_color)
+	var/image/base = overlay_image(skybox_icon, sector_icon)
 
 	if(use_stars)
 		var/image/stars = overlay_image(skybox_icon, star_state, flags = RESET_COLOR)

--- a/html/changelogs/alberyk-skyboxcolor.yml
+++ b/html/changelogs/alberyk-skyboxcolor.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - tweak: "Skybox icon should now have their original colors while keeping their light color."


### PR DESCRIPTION
This items removed the tint from the skybox icon without removing the starlight color
