### PR TITLE
blatant bulwark buffs

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -264,14 +264,8 @@
 	if(prob(25))
 		playsound(user, 'sound/weapons/push_connect.ogg', 50, 1, -1)
 		user.visible_message("<span class='danger'>[user] shoves hard, sending [target] flying!</span>")
-		step_away(target,user,15)
-		sleep(1)
-		step_away(target,user,15)
-		sleep(1)
-		step_away(target,user,15)
-		sleep(1)
-		step_away(target,user,15)
-		sleep(1)
+                var/turf/target_turf = get_ranged_target_turf(target, user.dir, 4)
+                target.throw_at(target_turf, 4, 1, user)
 		target.apply_effect(attack_damage * 0.4, WEAKEN, armor)
 
 /datum/unarmed_attack/bite/warrior

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -264,7 +264,7 @@
 	..()
 	if(prob(25))
 		playsound(user, 'sound/weapons/push_connect.ogg', 50, 1, -1)
-		user.visible_message(SPAN_DANGER([user] shoves hard, sending [target] flying!"))
+		user.visible_message(SPAN_DANGER("[user] shoves hard, sending [target] flying!"))
 		var/turf/target_turf = get_ranged_target_turf(target, user.dir, 4)
 		target.throw_at(target_turf, 4, 1, user)
 		target.apply_effect(attack_damage * 0.4, WEAKEN, armor)

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -258,14 +258,15 @@
 	damage = 10
 	attack_door = 20
 	crowbar_door = TRUE
+	sparring_variant_type = /datum/unarmed_attack/pain_strike/heavy
 
 /datum/unarmed_attack/vaurca_bulwark/apply_effects(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/armor,var/attack_damage,var/zone)
 	..()
 	if(prob(25))
 		playsound(user, 'sound/weapons/push_connect.ogg', 50, 1, -1)
 		user.visible_message("<span class='danger'>[user] shoves hard, sending [target] flying!</span>")
-                var/turf/target_turf = get_ranged_target_turf(target, user.dir, 4)
-                target.throw_at(target_turf, 4, 1, user)
+		var/turf/target_turf = get_ranged_target_turf(target, user.dir, 4)
+		target.throw_at(target_turf, 4, 1, user)
 		target.apply_effect(attack_damage * 0.4, WEAKEN, armor)
 
 /datum/unarmed_attack/bite/warrior

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -245,17 +245,34 @@
 	if(prob(25))
 		target.apply_effect(1, INCINERATE, 0)
 
-/datum/unarmed_attack/claws/vaurca_bulwark
-	attack_verb = list("punched", "clobbered", "lacerated")
-	attack_noun = list("clawed fists")
+/datum/unarmed_attack/vaurca_bulwark
+	attack_verb = list("punched", "pulverized", "hammered")
+	attack_noun = list("fists")
+	desc = "Smash into your opponents with the strength the Queens gave you. Not as sharp as other species' claws, but yours hit a hell of a lot harder"
 	eye_attack_text = "claws"
 	eye_attack_text_victim = "claws"
-	attack_name = "clawed fists"
+	attack_name = "bulwark punch"
+	attack_sound = 'sound/weapons/heavysmash.ogg'
 	shredding = TRUE
 
-	damage = 7.5
+	damage = 10
 	attack_door = 20
 	crowbar_door = TRUE
+
+/datum/unarmed_attack/vaurca_bulwark/apply_effects(var/mob/living/carbon/human/user,var/mob/living/carbon/human/target,var/armor,var/attack_damage,var/zone)
+	..()
+	if(prob(25))
+		playsound(user, 'sound/weapons/push_connect.ogg', 50, 1, -1)
+		user.visible_message("<span class='danger'>[user] shoves hard, sending [target] flying!</span>")
+		step_away(target,user,15)
+		sleep(1)
+		step_away(target,user,15)
+		sleep(1)
+		step_away(target,user,15)
+		sleep(1)
+		step_away(target,user,15)
+		sleep(1)
+		target.apply_effect(attack_damage * 0.4, WEAKEN, armor)
 
 /datum/unarmed_attack/bite/warrior
 	attack_name = "warrior bite"

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -264,7 +264,7 @@
 	..()
 	if(prob(25))
 		playsound(user, 'sound/weapons/push_connect.ogg', 50, 1, -1)
-		user.visible_message("<span class='danger'>[user] shoves hard, sending [target] flying!</span>")
+		user.visible_message(SPAN_DANGER([user] shoves hard, sending [target] flying!"))
 		var/turf/target_turf = get_ranged_target_turf(target, user.dir, 4)
 		target.throw_at(target_turf, 4, 1, user)
 		target.apply_effect(attack_damage * 0.4, WEAKEN, armor)

--- a/code/modules/mob/living/carbon/human/species/species_attack.dm
+++ b/code/modules/mob/living/carbon/human/species/species_attack.dm
@@ -248,7 +248,7 @@
 /datum/unarmed_attack/vaurca_bulwark
 	attack_verb = list("punched", "pulverized", "hammered")
 	attack_noun = list("fists")
-	desc = "Smash into your opponents with the strength the Queens gave you. Not as sharp as other species' claws, but yours hit a hell of a lot harder"
+	desc = "Smash into your opponents with the strength the Queens gave you. Not as sharp as other species' claws, but yours hit a hell of a lot harder."
 	eye_attack_text = "claws"
 	eye_attack_text_victim = "claws"
 	attack_name = "bulwark punch"

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
@@ -220,7 +220,7 @@
 
 	slowdown = 2
 
-	unarmed_types = list(/datum/unarmed_attack/claws/vaurca_bulwark)
+	unarmed_types = list(/datum/unarmed_attack/vaurca_bulwark)
 	maneuvers = list(
 		/singleton/maneuver/leap/bulwark
 	)
@@ -235,8 +235,8 @@
 	radiation_mod = 0
 	toxins_mod = 3
 
-	grab_mod = 0.8
-	resist_mod = 4
+	grab_mod = 0.5 //very big, very easy to grab
+	resist_mod = 14 //also very strong
 
 	mob_size = 28
 	taste_sensitivity = TASTE_DULL

--- a/html/changelogs/RustingWithYou - bigbug.yml
+++ b/html/changelogs/RustingWithYou - bigbug.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Vaurca Bulwark unarmed attacks no longer have a chance to cause bleeding, but deal slightly more brute damage and have a chance to knock back the unfortunate victim."
+  - tweak: "Vaurca Bulwarks are easier to grab and have a higher resist modifier to bring them in line with other large mobs."
+  - tweak: "Vaurca Bulwarks now use the heavy sparring attack instead of the light one, because they are giant bugs."


### PR DESCRIPTION
Vaurca Bulwarks now hit harder, though they no longer inflict bleeding. They now have a chance to knock back when punching.

The grab mod and resist mod of Bulwarks have been tweaked. It is now easier to grab them, and easier for them to resist being grabbed, because they're nine foot tall walking forklifts. 

Vaurca Bulwarks now use the heavy hit sparring attack. This changes practically nothing, because Bulwarks don't really do sparring anyway. 