### PR TITLE
Away map fixes: north pole and hailstorm

### DIFF
--- a/code/game/objects/structures/geyser.dm
+++ b/code/game/objects/structures/geyser.dm
@@ -20,7 +20,7 @@
 	..()
 
 /obj/structure/geyser/proc/trigger(mob/living/carbon/human/L)
-	visible_message(SPAN_WARNING("The [src] spews a cloud of hot steam!"))
+	visible_message(SPAN_WARNING("\The [src] spews a cloud of hot steam!"))
 	flick("geyser_fire", src)
 	var/steam_temperature = pick(10,50,100,500)
 	L.bodytemperature += steam_temperature

--- a/html/changelogs/alberyk-mapbugfix.yml
+++ b/html/changelogs/alberyk-mapbugfix.yml
@@ -1,0 +1,7 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed some access problems in the hailstorm ship."
+  - bugfix: "Fixed the glacier worm carcass having no name."

--- a/maps/away/ships/dpra/hailstorm/hailstorm_ship.dmm
+++ b/maps/away/ships/dpra/hailstorm/hailstorm_ship.dmm
@@ -308,7 +308,7 @@
 	master_tag = "hailstorm_shuttle";
 	name = "exterior access button";
 	pixel_y = -23;
-	req_access = list(113);
+	req_access = list(214);
 	pixel_x = -8
 	},
 /turf/simulated/floor/plating{
@@ -464,7 +464,7 @@
 /area/hailstorm_ship/eva)
 "bS" = (
 /obj/machinery/vending/tool{
-	req_access = list(209)
+	req_access = list(214)
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/firealarm/east,
@@ -1379,7 +1379,7 @@
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
 	id_tag = "hailstorm_shuttle_sensor";
-	req_access = list(113);
+	req_access = list(214);
 	pixel_y = 25
 	},
 /obj/structure/lattice/catwalk/indoor,

--- a/maps/random_ruins/exoplanets/adhomai/north_pole_worm.dmm
+++ b/maps/random_ruins/exoplanets/adhomai/north_pole_worm.dmm
@@ -14,7 +14,9 @@
 /obj/effect/decal/fake_object{
 	icon = 'icons/effects/adhomai_worm.dmi';
 	icon_state = "skeleton";
-	layer = 4.5
+	layer = 4.5;
+	name = "glacier worm carcass";
+	desc = "A massive carcass of an Adhomian aquatic creature."
 	},
 /obj/effect/decal/fake_object{
 	icon = 'icons/effects/adhomai_worm.dmi';


### PR DESCRIPTION
-fixes the glacier worm object not having a set name and description
-fixes some messed up access in the hailstorm ship
-fixes a geyser message