### PR TITLE
Tracy verb to proc

### DIFF
--- a/code/__defines/profiler_tracy.dm
+++ b/code/__defines/profiler_tracy.dm
@@ -8,7 +8,7 @@
 // 	prof_init()
 // 	. = ..()
 
-/client/verb/profiler_start()
+/client/proc/profiler_start()
 	set name = "Start Tracy Profiler"
 	set category = "Debug"
 	set desc = "Starts the tracy profiler, which will await the client connection."

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -226,7 +226,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/disconnect_ntsl,
 	/turf/proc/view_chunk,
 	/turf/proc/update_chunk,
-	/client/verb/profiler_start
+	/client/proc/profiler_start
 	)
 
 var/list/admin_verbs_paranoid_debug = list(
@@ -400,7 +400,7 @@ var/list/admin_verbs_hideable = list(
 	/proc/possess,
 	/proc/release,
 	/client/proc/force_away_mission,
-	/client/verb/profiler_start
+	/client/proc/profiler_start
 	)
 var/list/admin_verbs_mod = list(
 	/client/proc/cmd_admin_pm_context,	// right-click adminPM interface,
@@ -464,7 +464,7 @@ var/list/admin_verbs_dev = list( //will need to be altered - Ryan784
 	/client/proc/cmd_display_del_log,
 	/client/proc/cmd_display_init_log,
 	/client/proc/create_poll, //Allows to create polls
-	/client/verb/profiler_start
+	/client/proc/profiler_start
 )
 var/list/admin_verbs_cciaa = list(
 	/client/proc/cmd_admin_pm_panel,	/*admin-pm list*/

--- a/html/changelogs/Fluffyghost-tracyverbtoproc.yml
+++ b/html/changelogs/Fluffyghost-tracyverbtoproc.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - security: "Made the Tracy profiler verb into a proc from a verb, this should (hopefully) correctly hide it now, as it's the only difference I found from others in its category."
+  - security: "Made the Tracy profiler verb into a proc, this should (hopefully) correctly hide it now, as it's the only difference I found from others in its category."

--- a/html/changelogs/Fluffyghost-tracyverbtoproc.yml
+++ b/html/changelogs/Fluffyghost-tracyverbtoproc.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - security: "Made the Tracy profiler verb into a proc, this should (hopefully) correctly hide it now, as it's the only difference I found from others in its category."
+  - security: "Made the Tracy profiler verb into a proc."

--- a/html/changelogs/Fluffyghost-tracyverbtoproc.yml
+++ b/html/changelogs/Fluffyghost-tracyverbtoproc.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Fluffyghost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - security: "Made the Tracy profiler verb into a proc from a verb, this should (hopefully) correctly hide it now, as it's the only difference I found from others in its category."


### PR DESCRIPTION
Made the Tracy profiler verb into a proc, this should (hopefully) correctly hide it now, as it's the only difference I found from others in its category.

Security/Bugfix.