### PR TITLE
Fix map lattices, removes a vendor from the old Aurora map that have shitcode in it.

### DIFF
--- a/html/changelogs/fluffyghost-fixmaplattices.yml
+++ b/html/changelogs/fluffyghost-fixmaplattices.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Fluffyghost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes duplicate lattices in our maps."
+  - bugfix: "Resolves some startup runtimes/harddels."
+  - maptweak: "Removes minor objects from the old Aurora map that implement shitcode."

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -179,7 +179,6 @@
 /area/maintenance/security_starboard)
 "aaz" = (
 /obj/structure/lattice,
-/obj/structure/lattice,
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine/unexplored)
 "aaA" = (
@@ -244,8 +243,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
 "aaH" = (
-/obj/structure/grille/broken,
-/obj/structure/lattice,
 /obj/structure/grille/broken,
 /obj/structure/lattice,
 /turf/unsimulated/floor/asteroid/ash/rocky,
@@ -50684,7 +50681,6 @@
 /obj/machinery/newscaster{
 	pixel_y = -30
 	},
-/obj/machinery/vending/battlemonsters,
 /turf/simulated/floor/wood,
 /area/library)
 "bQR" = (

--- a/maps/away/away_site/blueriver/blueriver.dm
+++ b/maps/away/away_site/blueriver/blueriver.dm
@@ -84,10 +84,9 @@
 	dynamic_lighting = 0
 
 /turf/unsimulated/wall/supermatter/no_spread/blueriver/Initialize()
-	.=..()
+	. = ..()
 	icon_state = "bluespacecrystal[rand(1,3)]"
 	set_light(0.7, 1, 5, l_color = "#0066ff")
-	return PROCESS_KILL
 
 /obj/structure/deity
 	name = "crystal altar"

--- a/maps/away/away_site/racers/racers.dmm
+++ b/maps/away/away_site/racers/racers.dmm
@@ -814,15 +814,6 @@
 /obj/structure/bed/stool/bar/padded,
 /turf/simulated/floor/plating,
 /area/racers)
-"dtM" = (
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 8
-	},
-/obj/structure/window/reinforced/tinted/frosted,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/racers)
 "dtY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -2732,6 +2723,14 @@
 /obj/machinery/portable_atmospherics/canister/empty/hydrogen,
 /turf/simulated/floor/tiled/white/airless,
 /area/racers)
+"nqE" = (
+/obj/structure/window/reinforced/tinted/frosted,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/racers)
 "nrP" = (
 /obj/structure/girder/displaced,
 /obj/item/reagent_containers/food/drinks/bottle/small/beer,
@@ -3633,12 +3632,6 @@
 	},
 /turf/template_noop,
 /area/space)
-"rHx" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/plating,
-/area/racers)
 "rIG" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/plating,
@@ -40164,7 +40157,7 @@ jyq
 jyq
 jyq
 jyq
-dtM
+nqE
 xRX
 xRX
 xRX
@@ -43228,7 +43221,7 @@ vLM
 wiz
 bVv
 vLM
-rHx
+vLM
 xjB
 sae
 xjB
@@ -44256,7 +44249,7 @@ vLM
 vLM
 bhm
 lwM
-rHx
+vLM
 lsG
 dsR
 xjB

--- a/maps/away/away_site/romanovich/grand_romanovich.dm
+++ b/maps/away/away_site/romanovich/grand_romanovich.dm
@@ -92,7 +92,7 @@
 	return
 
 /obj/item/storage/bag/money/casino/Initialize()
-	..()
+	. = ..()
 	new /obj/item/coin/casino(src)
 	new /obj/item/coin/casino(src)
 	new /obj/item/coin/casino(src)

--- a/maps/away/away_site/shady/shady.dmm
+++ b/maps/away/away_site/shady/shady.dmm
@@ -287,12 +287,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/asteroid,
 /area/hideout)
-"dP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/turf/simulated/floor/plating,
-/area/hideout)
 "ed" = (
 /turf/simulated/floor/holofloor/tiled/dark,
 /area/hideout)
@@ -35203,7 +35197,7 @@ fV
 eu
 ci
 hg
-dP
+GO
 lf
 lf
 lf

--- a/maps/away/away_site/tajara/saniorios_smuggler/saniorios_smuggler.dmm
+++ b/maps/away/away_site/tajara/saniorios_smuggler/saniorios_smuggler.dmm
@@ -1165,13 +1165,6 @@
 /obj/item/material/shard/shrapnel,
 /turf/simulated/floor/airless,
 /area/saniorios_smuggler)
-"WZ" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/saniorios_smuggler)
 "Yj" = (
 /turf/simulated/wall,
 /area/saniorios_smuggler)
@@ -25713,7 +25706,7 @@ SL
 SL
 AW
 AW
-WZ
+Nt
 Nt
 Nt
 Nt
@@ -29054,7 +29047,6 @@ SL
 SL
 AW
 AW
-WZ
 Nt
 Nt
 Nt
@@ -29062,7 +29054,8 @@ Nt
 Nt
 Nt
 Nt
-WZ
+Nt
+Nt
 AW
 AW
 SL

--- a/maps/away/away_site/tajara/scrapper/scrapper.dmm
+++ b/maps/away/away_site/tajara/scrapper/scrapper.dmm
@@ -1616,12 +1616,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/scrapper_ship/bridge)
-"ua" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/obj/item/hullbeacon/red,
-/turf/template_noop,
-/area/scrapper_base)
 "ud" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -3555,11 +3549,6 @@
 	temperature = 278.15
 	},
 /area/shuttle/scrapper_ship/power_station)
-"RJ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/space)
 "RK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -37946,7 +37935,7 @@ Uk
 OZ
 mx
 JU
-RJ
+Ng
 Ng
 Ng
 Ng
@@ -40010,7 +39999,7 @@ Iu
 Iu
 Iu
 Iu
-RJ
+Ng
 Ng
 Ng
 Ng
@@ -45142,7 +45131,7 @@ Uk
 cD
 mx
 JU
-RJ
+Ng
 Ng
 Ng
 Ng
@@ -46453,7 +46442,7 @@ Ng
 Ng
 Ng
 Ng
-ua
+CO
 Kn
 Kn
 Kn

--- a/maps/away/ships/iac/iac_rescue_ship.dmm
+++ b/maps/away/ships/iac/iac_rescue_ship.dmm
@@ -643,7 +643,6 @@
 	icon_state = "2-4"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -297,7 +297,6 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/structure/railing/mapped,
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
@@ -604,11 +603,6 @@
 	tag_interior_door = "orion_traveler_n_in"
 	},
 /turf/simulated/floor,
-/area/ship/orion_express_ship)
-"dHA" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
 /area/ship/orion_express_ship)
 "dLy" = (
 /turf/simulated/floor/shuttle/black,
@@ -31366,7 +31360,7 @@ xRX
 xRX
 xRX
 bex
-dHA
+soM
 xnk
 xRX
 xRX

--- a/maps/away/ships/sol_merc/fsf_patrol_ship.dmm
+++ b/maps/away/ships/sol_merc/fsf_patrol_ship.dmm
@@ -710,11 +710,6 @@
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/fsf_patrol_ship)
-"fji" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/ship/fsf_patrol_ship)
 "fjy" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -33765,7 +33760,7 @@ sSs
 bcf
 jmA
 yjk
-fji
+hBs
 hBs
 sSs
 sSs

--- a/maps/away/ships/sol_ssmd/ssmd_ship.dmm
+++ b/maps/away/ships/sol_ssmd/ssmd_ship.dmm
@@ -96,7 +96,6 @@
 /area/ship/ssmd_corvette/starboardengine)
 "aow" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
@@ -3232,11 +3231,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/bridge)
-"iwS" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/ship/ssmd_corvette/hangar)
 "ixt" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -41869,9 +41863,9 @@ wgj
 aSi
 aSi
 hoJ
-iwS
-iwS
-iwS
+aMB
+aMB
+aMB
 rtf
 aMB
 qZm

--- a/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dmm
+++ b/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dmm
@@ -2036,7 +2036,6 @@
 /area/tajaran_smuggler)
 "kpn" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/railing/mapped{
 	dir = 1
 	},

--- a/maps/away/ships/tramp_freighter/tramp_freighter.dmm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter.dmm
@@ -1052,14 +1052,6 @@
 /obj/machinery/hologram/holopad/long_range,
 /turf/simulated/floor/tiled/dark,
 /area/ship/tramp_freighter)
-"gIU" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/ship/tramp_freighter)
 "gMq" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -1905,14 +1897,6 @@
 	},
 /obj/structure/railing/mapped{
 	dir = 4
-	},
-/turf/simulated/floor,
-/area/ship/tramp_freighter)
-"sLk" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/railing/mapped{
-	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/tramp_freighter)
@@ -32616,7 +32600,7 @@ cVA
 nty
 nty
 nty
-gIU
+cVA
 dbx
 bci
 pUv
@@ -32876,7 +32860,7 @@ aSJ
 aSJ
 aSJ
 jqx
-sLk
+hQL
 cVA
 dbx
 nty

--- a/maps/runtime/runtime-2.dmm
+++ b/maps/runtime/runtime-2.dmm
@@ -1190,11 +1190,6 @@
 	temperature = 278
 	},
 /area/tcommsat/chamber)
-"Wz" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/simulated/open,
-/area/construction/storage)
 "Xd" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -5614,12 +5609,12 @@ ki
 wx
 zQ
 zQ
-Wz
 zQ
 zQ
 zQ
 zQ
-Wz
+zQ
+zQ
 zQ
 zQ
 Vd
@@ -6899,12 +6894,12 @@ Nz
 wf
 zQ
 zQ
-Wz
 zQ
 zQ
 zQ
 zQ
-Wz
+zQ
+zQ
 zQ
 zQ
 Vd

--- a/maps/runtime/runtime-3.dmm
+++ b/maps/runtime/runtime-3.dmm
@@ -95,17 +95,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction/hallway)
-"o" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/simulated/open,
-/area/construction/hallway)
-"p" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/simulated/open,
-/area/construction/hallway)
 "q" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
@@ -4851,11 +4840,11 @@ g
 k
 k
 k
-o
 k
 k
-o
-o
+k
+k
+k
 k
 k
 v
@@ -5622,10 +5611,10 @@ g
 k
 k
 k
-o
 k
 k
-o
+k
+k
 k
 k
 k
@@ -5882,7 +5871,7 @@ j
 k
 j
 j
-p
+k
 j
 j
 j

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -2802,7 +2802,6 @@
 	dir = 5
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "bkQ" = (
@@ -19520,14 +19519,6 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/far)
-"jmm" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/simulated/open/airless,
-/area/horizon/exterior)
 "jmE" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -22321,12 +22312,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/wing_starboard)
-"kHS" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/simulated/open/airless,
-/area/horizon/exterior)
 "kIp" = (
 /turf/simulated/floor/tiled,
 /area/operations/break_room)
@@ -26255,14 +26240,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_one)
-"mFz" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
-	},
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/simulated/open/airless,
-/area/horizon/exterior)
 "mFJ" = (
 /obj/structure/foamedmetal,
 /obj/structure/shuttle_part/scc_space_ship{
@@ -32836,14 +32813,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/mail_room)
-"pQg" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/simulated/open/airless,
-/area/horizon/exterior)
 "pQj" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -35277,7 +35246,6 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hydroponics)
 "qZj" = (
-/obj/structure/lattice,
 /obj/structure/cable{
 	icon_state = "11-2"
 	},
@@ -37415,12 +37383,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"sau" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/simulated/open/airless,
-/area/horizon/exterior)
 "saJ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
@@ -62709,7 +62671,7 @@ avu
 avu
 avu
 avu
-sau
+avu
 bxp
 bxp
 bxp
@@ -63309,10 +63271,10 @@ avu
 avu
 avu
 avu
-sau
+avu
 bxp
-pQg
-jmm
+oSQ
+lVd
 gmo
 gmo
 gmo
@@ -63715,7 +63677,7 @@ gmo
 gmo
 gmo
 gmo
-mFz
+xPj
 oSQ
 bxp
 sSY
@@ -63917,7 +63879,7 @@ lVd
 gmo
 gmo
 gmo
-kHS
+gmo
 xPj
 bxp
 sSY

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -23829,11 +23829,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass/alt,
 /area/horizon/hallway/deck_three/primary/starboard)
-"sXr" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/simulated/open,
-/area/horizon/hallway/deck_three/primary/central)
 "sXJ" = (
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 10
@@ -51619,7 +51614,7 @@ iHA
 hOw
 lrF
 tlL
-sXr
+isT
 nez
 isT
 kzM
@@ -51627,7 +51622,7 @@ kzM
 kzM
 isT
 nez
-sXr
+isT
 tlL
 ykD
 eod
@@ -52023,7 +52018,7 @@ fDJ
 hOw
 lrF
 tlL
-sXr
+isT
 ocK
 isT
 gcR
@@ -52031,7 +52026,7 @@ gcR
 gcR
 isT
 ocK
-sXr
+isT
 tlL
 ykD
 rIg


### PR DESCRIPTION
Fixes duplicate lattices in our maps.
Resolves some startup runtimes/harddels.
Removes minor objects from the old Aurora map that implement shitcode.

This is atomized from https://github.com/Aurorastation/Aurora.3/pull/16065