### PR TITLE
Implement auxtools_expr_stub, used by auxtools during debugging

### DIFF
--- a/code/__defines/auxtools.dm
+++ b/code/__defines/auxtools.dm
@@ -1,6 +1,9 @@
 /proc/auxtools_stack_trace(msg)
 	CRASH(msg)
 
+/proc/auxtools_expr_stub()
+	CRASH("auxtools not loaded")
+
 /proc/enable_debugging(mode, port)
 	CRASH("auxtools not loaded")
 

--- a/html/changelogs/fluffyghost-auxtoolexprstub.yml
+++ b/html/changelogs/fluffyghost-auxtoolexprstub.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Fluffyghost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Implements auxtools_expr_stub, used by auxtools (the debugger dll) to get expressions with the debug console."
+  - bugfix: "Fixes the issues found during debugging of not being able to copy values from the variables panel, debug console, or conditional breakpoints expressions."


### PR DESCRIPTION
Implements auxtools_expr_stub, used by auxtools (the debugger dll) to get expressions with the debug console.
Fixes the issues found during debugging of not being able to copy values from the variables panel, debug console, or conditional breakpoints expressions.

Atomized from https://github.com/Aurorastation/Aurora.3/pull/16065