### PR TITLE
Replaces mentions of the genophage and the Jargon Federation with their superseded names

### DIFF
--- a/code/modules/background/religion/diona.dm
+++ b/code/modules/background/religion/diona.dm
@@ -24,7 +24,7 @@
   on the planet intentionally, granting them a blissful haven via the use of technology. Once the prominent and only religion on the planet, Shrkh-ism was quickly displaced when \
   Skrell explorers crashlanded and their memories, thoughts, emotions, everything was consumed, and doubt was first seeded in the minds of all Dionae on Xrim. The premise \
   behind the religion itself is simple; revere, help sustain and maintain synthetic life. As synthetic life brought dionae into this haven, so too shall it be preserved. In the \
-  minds of the Shrkh worshippers, the Skrell that brought Ksshr to the planet were misguided. To the Shrkh, the genophage was something that never happened, a myth made up by \
+  minds of the Shrkh worshippers, the Skrell that brought Ksshr to the planet were misguided. To the Shrkh, the X'Lu'oa was something that never happened, a myth made up by \
   the Federation to indoctrinate its population into its anti-synthetic and authoritarian beliefs. \
   \
   Note that due to their beliefs, those that are openly members of the faith are barred from command, machinist, and chaplain positions. They are also completely barred from \

--- a/code/modules/clothing/spacesuits/rig/suits/skrell.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/skrell.dm
@@ -52,7 +52,7 @@
 
 /obj/item/rig/skrell/tup
 	name = "outdated tupkala suit control module"
-	desc = "A suit control module designed by the Jargon Federation for Tup operations. The best of the best, albeit outdated now."
+	desc = "A suit control module designed by the Nralakk Federation for Tup operations. The best of the best, albeit outdated now."
 	icon = 'icons/clothing/rig/tup.dmi'
 	icon_state = "tup_rig"
 	suit_type = "tup suit"

--- a/code/modules/clothing/spacesuits/void/alien/skrell.dm
+++ b/code/modules/clothing/spacesuits/void/alien/skrell.dm
@@ -50,7 +50,7 @@
 
 /obj/item/clothing/suit/space/void/kala
 	name = "qukala voidsuit"
-	desc = "A sleek skrell voidsuit that slightly shimmers as it moves. This one has a Jargon Federation emblem on it."
+	desc = "A sleek skrell voidsuit that slightly shimmers as it moves. This one has a Nralakk Federation emblem on it."
 	icon = 'icons/clothing/kit/skrell_armor.dmi'
 	icon_state = "kala_suit"
 	item_state = "kala_suit"
@@ -68,7 +68,7 @@
 
 /obj/item/clothing/head/helmet/space/void/kala
 	name = "qukala voidsuit helmet"
-	desc = "A sleek skrell voidsuit helmet that slightly shimmers as it moves. This one has a Jargon Federation emblem on it."
+	desc = "A sleek skrell voidsuit helmet that slightly shimmers as it moves. This one has a Nralakk Federation emblem on it."
 	icon = 'icons/clothing/kit/skrell_armor.dmi'
 	icon_state = "kala_helm"
 	item_state = "kala_helm"
@@ -86,36 +86,36 @@
 
 /obj/item/clothing/suit/space/void/kala/med
 	name = "qukala medical voidsuit"
-	desc = "A sleek skrell voidsuit that slightly shimmers as it moves. This one has a Jargon Federation emblem on it. This one belongs to a Qukala medic."
+	desc = "A sleek skrell voidsuit that slightly shimmers as it moves. This one has a Nralakk Federation emblem on it. This one belongs to a Qukala medic."
 	icon_state = "kala_med"
 	item_state = "kala_med"
 
 /obj/item/clothing/head/helmet/space/void/kala/med
 	name = "qukala medical voidsuit helmet"
-	desc = "A sleek skrell voidsuit helmet that slightly shimmers as it moves. This one has a Jargon Federation emblem on it. This one belongs to a Qukala medic."
+	desc = "A sleek skrell voidsuit helmet that slightly shimmers as it moves. This one has a Nralakk Federation emblem on it. This one belongs to a Qukala medic."
 	icon_state = "kala_helm_med"
 	item_state = "kala_helm_med"
 
 /obj/item/clothing/suit/space/void/kala/leader
 	name = "qukala leader voidsuit"
-	desc = "A sleek skrell voidsuit that slightly shimmers as it moves. This one has a Jargon Federation emblem on it. This one belongs to a Qukala leader."
+	desc = "A sleek skrell voidsuit that slightly shimmers as it moves. This one has a Nralakk Federation emblem on it. This one belongs to a Qukala leader."
 	icon_state = "kala_leader"
 	item_state = "kala_leader"
 
 /obj/item/clothing/head/helmet/space/void/kala/leader
 	name = "qukala leader voidsuit helmet"
-	desc = "A sleek skrell voidsuit helmet that slightly shimmers as it moves. This one has a Jargon Federation emblem on it. This one belongs to a Qukala leader."
+	desc = "A sleek skrell voidsuit helmet that slightly shimmers as it moves. This one has a Nralakk Federation emblem on it. This one belongs to a Qukala leader."
 	icon_state = "kala_leader_helm"
 	item_state = "kala_leader_helm"
 
 /obj/item/clothing/suit/space/void/kala/engineering
 	name = "qukala engineer voidsuit"
-	desc = "A sleek skrell voidsuit that slightly shimmers as it moves. This one has a Jargon Federation emblem on it. This one belongs to a Qukala engineer."
+	desc = "A sleek skrell voidsuit that slightly shimmers as it moves. This one has a Nralakk Federation emblem on it. This one belongs to a Qukala engineer."
 	icon_state = "kala_eng"
 	item_state = "kala_eng"
 
 /obj/item/clothing/head/helmet/space/void/kala/engineering
 	name = "qukala engineer voidsuit helmet"
-	desc = "A sleek skrell voidsuit helmet that slightly shimmers as it moves. This one has a Jargon Federation emblem on it. This one belongs to a Qukala engineer."
+	desc = "A sleek skrell voidsuit helmet that slightly shimmers as it moves. This one has a Nralakk Federation emblem on it. This one belongs to a Qukala engineer."
 	icon_state = "kala_helm_eng"
 	item_state = "kala_helm_eng"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -4469,7 +4469,7 @@
 	color = "#1936a0"
 	strength = 10
 	description = "A controversial drink popular with the punk youth of the Nralakk Federation. Represents blood, eggs, and tears."
-	taste_description = "genophage sadness"
+	taste_description = "X'Lu'oa sadness"
 
 	glass_icon_state = "thirdincident"
 	glass_name = "glass of the Third Incident"

--- a/html/changelogs/lly - genophage removal.yml
+++ b/html/changelogs/lly - genophage removal.yml
@@ -1,0 +1,6 @@
+author: Llywelwyn
+
+delete-after: True
+
+changes:
+  - tweak: "Replaces all mentions of 'genophage' with 'X'Lu'oa'."

--- a/html/changelogs/lly - genophage removal.yml
+++ b/html/changelogs/lly - genophage removal.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - tweak: "Replaces all mentions of 'genophage' with 'X'Lu'oa'."
+  - tweak: "Replaces all remaining mentions of 'Jargon Federation' with 'Nralakk Federation'."


### PR DESCRIPTION
  - tweak: "Replaces all mentions of 'genophage' with 'X'Lu'oa'."
  - tweak: "Replaces all remaining mentions of 'Jargon Federation' with 'Nralakk Federation'."