### PR TITLE
Removes devastation from fuel tank explosions 

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -204,11 +204,11 @@
 		return
 
 	if (reagents.total_volume > 500)
-		explosion(src.loc,1,2,4)
+		explosion(src.loc,0,3,6)
 	else if (reagents.total_volume > 100)
-		explosion(src.loc,0,1,3)
+		explosion(src.loc,0,2,4)
 	else if (reagents.total_volume > 50)
-		explosion(src.loc,-1,1,2)
+		explosion(src.loc,-1,1,3)
 
 	..()
 

--- a/html/changelogs/fueltankantigrief.yml
+++ b/html/changelogs/fueltankantigrief.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Scheveningen
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Removes the devastation range on half full or greater fuel tanks when exploded. Increases the range of the lesser explosion damage types for a detonated fuel tank. More concussion, less explosion."


### PR DESCRIPTION
saltpr

Fuel tank detonations are excessively easy to do. Just wrench it, light a fire trail on the fuel and the welding tank goes off without a hitch once the fire catches up to it. Or just shoot it. As all fuel tanks start the round full with more than 500 units (engineers are not expected to deplete welders frequently), every single fuel tank is a near guaranteed candidate to blow a hole in the floor, instantly causing a breach and sucking anyone down into the space z-level instantly. Atmos griefing to this extent - or blowing a hole in the floor intentionally - should not be so easy. Devastation range has been set to 0 for all fuel levels for every fuel tank.

On the other hand, the lighter end of fuel tank explosions have a bit more range to compensate. Get concussed!

Notably, due to no longer venting an entire room instantly anymore, fuel tank fires can actually grow to be a substantial atmospheric threat that requires a more complex solution than simply patching the floor over.