### PR TITLE
The lazarus injector can no longer revive mobs that are not tameable.

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -825,7 +825,7 @@
 	if(isliving(target) && proximity_flag)
 		if(istype(target, /mob/living/simple_animal))
 			var/mob/living/simple_animal/M = target
-			if(!(M.find_type() & revive_type))
+			if(!(M.find_type() & revive_type) || !(M.tameable))
 				to_chat(user, SPAN_INFO("\The [src] does not work on this sort of creature."))
 				return
 			if(M.stat == DEAD)

--- a/html/changelogs/alberyk-lazarustweak.yml
+++ b/html/changelogs/alberyk-lazarustweak.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - tweak: "The Lazarus injector can no longer revive mobs that are not tameable."


### PR DESCRIPTION
What it says in the title.
