### PR TITLE
Fix cleanable fuel decal initialize

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -130,11 +130,15 @@
 			has_spread = 1
 			break
 
+	initialized = TRUE
+
 	if(!has_spread)
 		Spread()
 		QDEL_IN(src, 2 MINUTES)
+		return INITIALIZE_HINT_NORMAL
 	else
-		qdel(src)
+		return INITIALIZE_HINT_QDEL
+
 
 /obj/effect/decal/cleanable/foam/proc/Spread(exclude=list())
 	if(amount < 15) return

--- a/html/changelogs/fluffyghost-fixcleanablefueldecalinit.yml
+++ b/html/changelogs/fluffyghost-fixcleanablefueldecalinit.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Fluffyghost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes cleanable fuel decal initialize, they now return the correct hint."


### PR DESCRIPTION
Fixes cleanable fuel decal initialize, they now return the correct hint.

Atomized from https://github.com/Aurorastation/Aurora.3/pull/16065