### PR TITLE
Announcement handling robusting

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -48,7 +48,7 @@
 			var/turf/T = get_turf(M)
 			if(T)
 				to_chat(M, msg)
-				if(message_sound && !isdeaf(M) && (M.client.prefs.sfx_toggles & ASFX_VOX))
+				if(message_sound && !isdeaf(M) && (M.client?.prefs.sfx_toggles & ASFX_VOX))
 					sound_to(M, message_sound)
 	if(do_newscast)
 		NewsCast(message, message_title)

--- a/html/changelogs/fluffyghost-robustmobannouncementshandling.yml
+++ b/html/changelogs/fluffyghost-robustmobannouncementshandling.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Fluffyghost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Makes the announcement handling more robust, avoiding a runtime when it's called and no player is logged in (eg. when a random event triggers)."


### PR DESCRIPTION
Makes the announcement handling more robust, avoiding a runtime when it's called and no player is logged in (eg. when a random event triggers).

Atomized from https://github.com/Aurorastation/Aurora.3/pull/16065