### PR TITLE
Many minor rewrites and spellchecks for accent descs

### DIFF
--- a/code/modules/background/accent/diona.dm
+++ b/code/modules/background/accent/diona.dm
@@ -1,11 +1,11 @@
 /datum/accent/rootsong
 	name = ACCENT_ROOTSONG
-	description = "An accent native to the Dionae born within atmospheric conditions, more specifically that of planets. More commonly found in Dionae that were exposed to non-ionising or trace amounts of radiation during their formative years. To non-Dionae, this accent is akin to that of singing - a high pitched voice that has various rises and falls between Soprano and Mezzo-soprano."
+	description = "An accent native to the Dionae born within atmospheric conditions, more specifically that of planets. More commonly found in Dionae that were exposed to non-ionising or trace amounts of radiation during their formative years. To non-Dionae, this accent is akin to singing - a high pitched voice that has various rises and falls between Soprano and Mezzo-soprano."
 	tag_icon = "dionae_rootsong"
 	text_tag = "RTS"
 
 /datum/accent/voidsong
 	name = ACCENT_VOIDSONG
-	description = "An innate accent spoken by Dionae that were born within the vacuum of space, or near extreme amounts of ionising radiation. The accent is said to be incredibly deep, and some have said that the Dionae that have the accent sound extremely similar to Baritones -  a type of voice whose vocals differ between basslike and tenorlike."
+	description = "An innate accent spoken by Dionae that were born within the vacuum of space, or near extreme amounts of ionising radiation. The accent is said to be incredibly deep, and some have said that the Dionae that have the accent sound extremely similar to Baritones - varying between basslike and tenorlike."
 	tag_icon = "dionae_voidsong"
 	text_tag = "VDS"

--- a/code/modules/background/accent/diona.dm
+++ b/code/modules/background/accent/diona.dm
@@ -1,6 +1,6 @@
 /datum/accent/rootsong
 	name = ACCENT_ROOTSONG
-	description = "An accent native to the Dionae born within atmospheric conditions, more specifically that of planets. More commonly found in Dionae that were exposed to non-ionising or trace amounts of radiation during their formative years. To non-Dionae, this accent is akin to singing - a high pitched voice that has various rises and falls between Soprano and Mezzo-soprano."
+	description = "An accent native to the Dionae born within atmospheric conditions, more specifically that of planets. More commonly found in Dionae that were exposed to non-ionising or trace amounts of radiation during their formative years. To non-Dionae, this accent is akin to singing - a high pitched voice that has various rises and falls between soprano and mezzo-soprano."
 	tag_icon = "dionae_rootsong"
 	text_tag = "RTS"
 

--- a/code/modules/background/accent/diona.dm
+++ b/code/modules/background/accent/diona.dm
@@ -6,6 +6,6 @@
 
 /datum/accent/voidsong
 	name = ACCENT_VOIDSONG
-	description = "An innate accent spoken by Dionae that were born within the vacuum of space, or near extreme amounts of ionising radiation. The accent is said to be incredibly deep, and some have said that the Dionae that have the accent sound extremely similar to Baritones - varying between basslike and tenorlike."
+	description = "An innate accent spoken by Dionae that were born within the vacuum of space, or near extreme amounts of ionising radiation. The accent is said to be incredibly deep, and some have said that the Dionae that have the accent sound extremely similar to baritones, varying between basslike and tenorlike."
 	tag_icon = "dionae_voidsong"
 	text_tag = "VDS"

--- a/code/modules/background/accent/diona.dm
+++ b/code/modules/background/accent/diona.dm
@@ -6,6 +6,6 @@
 
 /datum/accent/voidsong
 	name = ACCENT_VOIDSONG
-	description = "An innate accent spoken by Dionae that were born within the vacuum of space, or near extreme amounts of ionising radiation. The accent is said to be incredibly deep, and some have said that the Dionae that have the accent sound extremely similar to baritones, varying between basslike and tenorlike."
+	description = "An innate accent spoken by Dionae that were born within the vacuum of space, or near extreme amounts of ionising radiation. The accent is said to be incredibly deep, and some have said that the Dionae that have the accent sound extremely similar to baritone, varying between basslike and tenorlike."
 	tag_icon = "dionae_voidsong"
 	text_tag = "VDS"

--- a/code/modules/background/accent/human.dm
+++ b/code/modules/background/accent/human.dm
@@ -180,7 +180,7 @@
 
 /datum/accent/dominia_frontier
 	name = ACCENT_DOMINIA_FRONTIER
-	description = "Resembling  Freespeak more than the Vulgar Morozi dialect found in more civilised regions of the Empire, most accents of the Imperial Frontier are looked down upon by those from the Core Worlds. \
+	description = "Resembling Freespeak more than the Vulgar Morozi dialect found in more civilised regions of the Empire, most accents of the Imperial Frontier are looked down upon by those from the Core Worlds. \
 	Many Primaries and Secondaries look down upon the dialects of the Imperial Frontier as rogue, coarse, and often grating to hear compared to their Common-descended dialects. Many from this region who wish to rise \
 	through the ranks of the Empire’s Ma'zals spend great amounts of time learning an ersatz Solarian Common dialect based upon this one which is known as the Refined Imperial Frontier Dialect. While not nearly as \
 	prestigious as its counterparts the Refined Frontier dialect is often viewed as a mark of loyalty and dedication to the Empire."

--- a/code/modules/background/accent/human.dm
+++ b/code/modules/background/accent/human.dm
@@ -180,10 +180,10 @@
 
 /datum/accent/dominia_frontier
 	name = ACCENT_DOMINIA_FRONTIER
-	description = "Resembling more Freespeak than the Vulgar Morozi dialect found in more civilised regions of the Empire, most accents of the Imperial Frontier are looked down upon by those from the Core Worlds. \
+	description = "Resembling  Freespeak more than the Vulgar Morozi dialect found in more civilised regions of the Empire, most accents of the Imperial Frontier are looked down upon by those from the Core Worlds. \
 	Many Primaries and Secondaries look down upon the dialects of the Imperial Frontier as rogue, coarse, and often grating to hear compared to their Common-descended dialects. Many from this region who wish to rise \
 	through the ranks of the Empire’s Ma'zals spend great amounts of time learning an ersatz Solarian Common dialect based upon this one which is known as the Refined Imperial Frontier Dialect. While not nearly as \
-	prestigious see its counterparts the Refined Frontier dialect is often viewed as a mark of loyalty and dedication to the Empire."
+	prestigious as its counterparts the Refined Frontier dialect is often viewed as a mark of loyalty and dedication to the Empire."
 	tag_icon = "dominia_frontier"
 	text_tag = "IFR"
 
@@ -192,7 +192,7 @@
 	description = "Much like the planet itself, the Jadranic dialect of Solarian Common sits between standard Solarian Common-influenced Vulgar Morozi and the more Freespeak-derived accents of the Imperial Frontier. \
 	The dialect possesses grammar and pronunciation similar to Vulgar Morozi but possesses multiple loan words from Freespeak which make it distinct from its Morozian counterpart. Jadraners are valued highly for their \
 	loyalty and this dialect is often regarded as the most common accent of the Imperial Army. More educated Jadraners, such as those from the planet's few urban centers, will often leave the dialect's Freespeak \
-	loan words our while talking with Morozians or other Dominians."
+	loan words out while talking with Morozians or other Dominians."
 	tag_icon = "dominia_novijadran"
 	text_tag = "NOV"
 
@@ -239,7 +239,7 @@
 /datum/accent/xanu
 	name = ACCENT_XANU
 	description = "The Xanu Standard dialect is arguably the most notable Freespeak dialect. Xanu Standard first emerged as an informal creole designed to make communication between the various nationalities \
-	who settled the planet more easily and possessed loan words from upwards of a half-dozen languages during this early period. Over time this creole would morph into the Xanu Standard dialect of Freespeak \
+	who settled the planet easier and used loan words from upwards of a half-dozen languages during this early period. Over time this creole would morph into the Xanu Standard dialect of Freespeak \
 	and is arguably the oldest and most widespread of the 25th century's common Freespeak dialects. Freespeak taught abroad, such as in the Serene Republic of Elyra and Republic of Biesel, is most often based upon the Xanu Standard dialect."
 	tag_icon = "xanu"
 	text_tag = "XAN"
@@ -253,7 +253,7 @@
 
 /datum/accent/fisanduh
 	name = ACCENT_FISANDUH
-	description = "While it is similar to the typical Morozian accent, to those not familiar with it; or not from the Empire of Dominia, the standard Fisanduhian accent has some variations that mark it as distinctive. \
+	description = "While it is similar to the typical Morozian accent to those not familiar with it, the standard Fisanduhian accent has some variations that mark it as distinctive. \
 	The accent is higher pitched than its Dominian counterpart, and has been described as more tonal. Members of the Fisanduh Freedom Front will often go to great lengths to disguise this accent, \
 	though most will slip back into it when off-world."
 	tag_icon = "fisanduh"
@@ -269,16 +269,16 @@
 
 /datum/accent/pluto
 	name = ACCENT_PLUTO
-	description = "The Plutonian accent is one of many Sol Common accents found throughout the Sol System itself, though it is almost undoubtedly the furthest one out from the Sun itself. Rooted in a combination \
+	description = "The Plutonian accent is one of many Sol Common accents found throughout the Sol System. Rooted in a combination \
 	of Central Asian and Eastern European dialects, the Plutonian accent is notable for its slow, methodical method of speech. Very few positronics can be found with this accent, due to Pluto's unusual relationship with corporations."
 	tag_icon = "pluto"
 	text_tag = "PLU"
 
 /datum/accent/assunzione
 	name = ACCENT_ASSUNZIONE
-	description = "The Assunzionii accent is one of the most unusual found in the Coalition of Colonies, due to the planet's colonial roots in the Mediterranean. Heavily influenced by Romance languages the Assunzionii dialect is \
-	most notable for its elegant-sounding and evenly-paced method of speaking compared to rougher-sounding Coalition and frontier dialects. Liturgical Assunzionii is a small subset of this dialect, and is generally only spoken during \
-	Luceian services and can be distinguished by its use of archaic language."
+	description = "The Assunzionii accent is one of the most unusual found in the Coalition of Colonies, due to the planet's colonial roots in the Mediterranean. Heavily influenced by Romance languages, the Assunzionii dialect is \
+	most notable for its elegant-sounding and evenly-paced method of speaking compared to rougher-sounding Coalition and frontier dialects. Liturgical Assunzionii, distinguished by its use of archaic language, is a small subset of this dialect, \
+	and is generally only spoken during Luceian services."
 	tag_icon = "assunzione"
 	text_tag = "ASU"
 
@@ -313,13 +313,14 @@
 
 /datum/accent/antillia
 	name = ACCENT_ANTILLIA
-	description = "There are two distinct dialects present on the planet: one that sees heavy lifting from Tradeband and the other more influenced by Solarian Common. It is relatively easy to identify the differences between the two: Antilleans influenced by Tradeband sound more nasal and rhythmic, whereas those that grew up in regions where Solarian Common is the dominant language are more soft-spoken and enunciated."
+	description = "There are two distinct dialects present on the planet: one that sees heavy lifting from Tradeband, and another more influenced by Solarian Common. It is relatively easy to identify the differences between \
+	the two: Antilleans influenced by Tradeband sound more nasal and rhythmic, whereas those that grew up in regions where Solarian Common is the dominant language are more soft-spoken and enunciated."
 	tag_icon = "antillia"
 	text_tag = "PRT"
 
 /datum/accent/persepolis
 	name = ACCENT_PERSEPOLIS
-	description = "Well-known across Elyra for its rapid-fire, energetic cadence, the Persepolitian accent is characterised by a vibrant and fast-paced nature that represents the New Ankaran Jewel's cosmopolitan nature. \
+	description = "Well-known across Elyra for its rapid-fire, energetic cadence, the Persepolitian accent is characterised by a vibrant and fast-paced nature that represents the New Ankaran Jewel's cosmopolitanism. \
 	Speakers of this variant of Elyran Standard tend to be affluent and well-cultured, in keeping with the Elyran capital's general prosperity."
 	tag_icon = "persepolis"
 	text_tag = "PER"

--- a/code/modules/background/accent/human.dm
+++ b/code/modules/background/accent/human.dm
@@ -269,16 +269,16 @@
 
 /datum/accent/pluto
 	name = ACCENT_PLUTO
-	description = "Rooted in a combination of Central Asian and Eastern European dialects, the Plutonian accent is notable for its slow, methodical method of speech. \
-	Very few positronics can be found with this accent, due to Pluto's unusual relationship with corporations."
+	description = "The Plutonian accent is one of many Sol Common accents found throughout the Sol System itself, though it is almost undoubtedly the furthest one out from the Sun itself. Rooted in a combination \
+	of Central Asian and Eastern European dialects, the Plutonian accent is notable for its slow, methodical method of speech. Very few positronics can be found with this accent, due to Pluto's unusual relationship with corporations."
 	tag_icon = "pluto"
 	text_tag = "PLU"
 
 /datum/accent/assunzione
 	name = ACCENT_ASSUNZIONE
-	description = "The Assunzionii accent is one of the most unusual found in the Coalition of Colonies, due to the planet's colonial roots in the Mediterranean. Heavily influenced by Romance languages, the Assunzionii dialect is \
-	most notable for its elegant-sounding and evenly-paced method of speaking compared to rougher-sounding Coalition and frontier dialects. Liturgical Assunzionii, distinguished by its use of archaic language, is a small subset of this dialect, \
-	and is generally only spoken during Luceian services."
+	description = "The Assunzionii accent is one of the most unusual found in the Coalition of Colonies, due to the planet's colonial roots in the Mediterranean. Heavily influenced by Romance languages the Assunzionii dialect is \
+	most notable for its elegant-sounding and evenly-paced method of speaking compared to rougher-sounding Coalition and frontier dialects. Liturgical Assunzionii is a small subset of this dialect, and is generally only spoken during \
+	Luceian services and can be distinguished by its use of archaic language."
 	tag_icon = "assunzione"
 	text_tag = "ASU"
 
@@ -320,7 +320,7 @@
 
 /datum/accent/persepolis
 	name = ACCENT_PERSEPOLIS
-	description = "Well-known across Elyra for its rapid-fire, energetic cadence, the Persepolitian accent is characterised by a vibrant and fast-paced nature that represents the New Ankaran Jewel's cosmopolitanism. \
+	description = "Well-known across Elyra for its rapid-fire, energetic cadence, the Persepolitian accent is characterised by a vibrant and fast-paced nature that represents the New Ankaran Jewel's cosmopolitan nature. \
 	Speakers of this variant of Elyran Standard tend to be affluent and well-cultured, in keeping with the Elyran capital's general prosperity."
 	tag_icon = "persepolis"
 	text_tag = "PER"

--- a/code/modules/background/accent/human.dm
+++ b/code/modules/background/accent/human.dm
@@ -183,7 +183,7 @@
 	description = "Resembling Freespeak more than the Vulgar Morozi dialect found in more civilised regions of the Empire, most accents of the Imperial Frontier are looked down upon by those from the Core Worlds. \
 	Many Primaries and Secondaries look down upon the dialects of the Imperial Frontier as rogue, coarse, and often grating to hear compared to their Common-descended dialects. Many from this region who wish to rise \
 	through the ranks of the Empire’s Ma'zals spend great amounts of time learning an ersatz Solarian Common dialect based upon this one which is known as the Refined Imperial Frontier Dialect. While not nearly as \
-	prestigious as its counterparts the Refined Frontier dialect is often viewed as a mark of loyalty and dedication to the Empire."
+	prestigious as its counterparts, the Refined Frontier dialect is often viewed as a mark of loyalty and dedication to the Empire."
 	tag_icon = "dominia_frontier"
 	text_tag = "IFR"
 

--- a/code/modules/background/accent/human.dm
+++ b/code/modules/background/accent/human.dm
@@ -269,8 +269,8 @@
 
 /datum/accent/pluto
 	name = ACCENT_PLUTO
-	description = "The Plutonian accent is one of many Sol Common accents found throughout the Sol System. Rooted in a combination \
-	of Central Asian and Eastern European dialects, the Plutonian accent is notable for its slow, methodical method of speech. Very few positronics can be found with this accent, due to Pluto's unusual relationship with corporations."
+	description = "Rooted in a combination of Central Asian and Eastern European dialects, the Plutonian accent is notable for its slow, methodical method of speech. \
+	Very few positronics can be found with this accent, due to Pluto's unusual relationship with corporations."
 	tag_icon = "pluto"
 	text_tag = "PLU"
 

--- a/code/modules/background/accent/skrell.dm
+++ b/code/modules/background/accent/skrell.dm
@@ -1,13 +1,13 @@
 /datum/accent/skrell
 	name = ACCENT_SKRELL
-	description = "In the Nralakk Federation, the typical skrellian accent has dozens of minute and tiny variations and can be found across a multitude of planets (and their colonies) \
-	and in a wide range of sectors. Its generality has resulted in the belief that it is the 'standard' accent for all Skrell. "
+	description = "In the Nralakk Federation, the typical skrellian accent has dozens of minute variations and can be found across a multitude of planets (and their colonies). \
+	Its generality has resulted in the belief that it is the 'standard' accent for all Skrell. "
 	tag_icon = "skrell"
 	text_tag = "NRA"
 
 /datum/accent/skrell/homeworld
 	name = ACCENT_HOMEWORLD
-	description = "The typical accent of the Homeworld (or Qerrbalak), is very much more distinct and enunciated than other variations of Nral'Malic. It puts specific emphasis on a \
+	description = "The typical accent of the Homeworld (or Qerrbalak), is very distinct for being much more enunciated than other variations of Nral'Malic. It puts specific emphasis on a \
 	melodious manner of speaking, their tones often jumping out of the standard human hearing range."
 	tag_icon = "skrell_homeworld"
 	text_tag = "QER"
@@ -15,7 +15,7 @@
 /datum/accent/skrell/qerrmalic
 	name = ACCENT_QERRMALIC
 	description = "The Qerr'Malic accent is known for being rather soft, even hushed at some points. Because of the moon's tourist industry, it borrows elements from other accents to \
-	form a rather unique mixture that makes specific reference to keeping low tones accessible to non-Skrell, further cementing the overall 'quietness' to other Skrell as their sentences \
+	form a unique mixture designed to emphasize low tones so that the accent is more comfortable to non-Skrell, further cementing the overall 'quietness' to other Skrell as their sentences \
 	sound half-finished."
 	tag_icon = "skrell_qerrmalic"
 	text_tag = "QRM"
@@ -29,7 +29,7 @@
 
 /datum/accent/skrell/aweiji
 	name = ACCENT_AWEIJI
-	description = "This type of accent emphasizes on a balance of highs and lows. It uses the nasal canal to further produce a harmonic pattern of speech. Idols are often found replicating \
+	description = "This type of accent emphasizes a balance of highs and lows. It uses the nasal canal to further produce a harmonic pattern of speech. Idols are often found replicating \
 	this accent due to how gentle it is on both Skrell and non-Skrell."
 	tag_icon = "skrell_aweiji"
 	text_tag = "AWE"

--- a/code/modules/background/accent/skrell.dm
+++ b/code/modules/background/accent/skrell.dm
@@ -7,7 +7,7 @@
 
 /datum/accent/skrell/homeworld
 	name = ACCENT_HOMEWORLD
-	description = "The typical accent of the Homeworld (or Qerrbalak), is very distinct for being much more enunciated than other variations of Nral'Malic. It puts specific emphasis on a \
+	description = "The typical accent of the Homeworld (or Qerrbalak) is very distinct for being much more enunciated than other variations of Nral'Malic. It puts specific emphasis on a \
 	melodious manner of speaking, their tones often jumping out of the standard human hearing range."
 	tag_icon = "skrell_homeworld"
 	text_tag = "QER"

--- a/code/modules/background/accent/tajara.dm
+++ b/code/modules/background/accent/tajara.dm
@@ -1,7 +1,7 @@
 /datum/accent/republican_siik
 	name = ACCENT_REPUBICLANSIIK
 	description = "The dialect of central Ras'nrr. It was spoken by the Hadii dynasty and its subjects before being adopted as the official version of the People's Republic \
-	Siik'maas. This variation is taught in all Republican schools since the end of the first revolution and is considered as the most pure and correct form. PRA citizens are encouraged \
+	Siik'maas. This variation is taught in all Republican schools since the end of the first revolution and is considered the most pure and correct form. PRA citizens are encouraged \
 	to learn and adopt it, as speaking another accent is frowned upon. It is notable for its unusually rigid grammatical construction as opposed to most other Adhomian dialects. \
 	Republican Siik'maas is the language of Hadiist loyalists, both in and outside of S'rand'marr."
 	tag_icon = "tajara"
@@ -34,14 +34,14 @@
 /datum/accent/high_harr_siik
 	name = ACCENT_HIGHHARRSIIK
 	description = "Used by the natives of northern Harr'masir. It is deemed to be a rustic and harsh-sounding form of siik'maas; the accent is associated with peasants and uneducated \
-	Tajara. It is the most common dialect among New Kingdom's commoners. The nobility usually attempts to mask this accent due to its relationship with the common people. It is also \
+	Tajara. It is the most common dialect among the New Kingdom's commoners. The nobility usually attempts to mask this accent due to its relationship with the common people. It is also \
 	spoken by the New Kingdom population living in Tau Ceti."
 	tag_icon = "tajara_high_harr"
 	text_tag = "HHA"
 
 /datum/accent/low_harr_siik
 	name = ACCENT_LOWHARRSIIK
-	description = "Native to the southern area of Harr'masir. In comparison to other Siik'maas dialects - it is the one that deviates the most from the standard version. Thanks to Republican \
+	description = "Native to the southern area of Harr'masir. In comparison to other Siik'maas dialects, it is the one that deviates the most from the standard. Thanks to Republican \
 	propaganda, it has gained the fame of being the tongue of criminals and guerrilla fighters. Most speakers are Democratic People's Republic citizens. Its words are spoken in a hushed \
 	manner."
 	tag_icon = "tajara_low_harr"
@@ -49,7 +49,7 @@
 
 /datum/accent/amohda_siik
 	name = ACCENT_AMOHDASIIK
-	description = "Spoken by the Tajara from the island of Amohda. Despite past Republican attempts to destroy this dialect; it survived and is now undergoing a period of revival by Amohdan \
+	description = "Spoken by the Tajara from the island of Amohda. Despite past Republican attempts to destroy this dialect, it survived and is now undergoing a period of revival by Amohdan \
 	nationalists. It can also be found in the New Kingdom because of the Amohda Exiles. Due to royalist influence, it has many Ya'ssa loan words. Amohdan Siik'maas has a characteristic \
 	drawl tone to it."
 	tag_icon = "tajara_amohda"
@@ -57,7 +57,7 @@
 
 /datum/accent/rural_delvahhi
 	name = ACCENT_RURALDELVAHHI
-	description = "The form  of Delvahhi spoken by settled zhan communities. It has been heavily influenced by Siik'maas. It is also used as the liturgical language by some Ma'ta'ke \
+	description = "The form  of Delvahhi spoken by settled Zhan communities. It has been heavily influenced by Siik'maas. It is also used as the liturgical language by some Ma'ta'ke \
 	priests. Rural Delvahhi speakers usually speak siik'maas with a slower and throaty tone."
 	tag_icon = "tajara_rural"
 	text_tag = "DEL"
@@ -72,7 +72,7 @@
 /datum/accent/old_yassa
 	name = ACCENT_OLDYASSA
 	description = "The tongue of the old Tajaran nobility, spoken by those who were born before the first revolution. It differs from the modern Ya'ssa by having a far more complex set \
-	of rules, long-drawn-out sentences and compound words. Old Ya'ssa is a dying tongue; as the version taught by the New Kingdom of Adhomai has mostly replaced it in the post-revolution \
+	of rules, long-drawn-out sentences and compound words. Old Ya'ssa is a dying tongue, as the version taught by the New Kingdom of Adhomai has mostly replaced it in the post-revolution \
 	noble generation."
 	tag_icon = "tajara_oldyassa"
 	text_tag = "YSA"
@@ -86,7 +86,7 @@
 
 /datum/accent/dinakk
 	name = ACCENT_DINAKK
-	description = "Found in the isolated valleys of the Din'akk Mountains, little has changed in this accent since the first contact. It still clings to words and grammatical \
+	description = "Found in the isolated valleys of the Din'akk Mountains, little has changed in this accent since first contact. It still clings to words and grammatical \
 	structures that have long since fallen out of use by other Siik'maas speakers. It is described as strong and abrupt by other Tajara."
 	tag_icon = "tajara_dinaak"
 	text_tag = "DIN"
@@ -99,7 +99,7 @@
 
 /datum/accent/zarrjiri
 	name = ACCENT_ZARRJIRI
-	description = "Zarr'jiri Siik'mas: Located only in the Zarr'jirah mountain range, this accent is rarity outside of the New Kingdom. Speakers of it are often noted for a soft, almost sing-song \
+	description = "Located only in the Zarr'jirah mountain range, this accent is rarity outside of the New Kingdom. Speakers of it are often noted for a soft, almost sing-song \
 	voice and hand gestures which carry over from Nal'rasan."
 	tag_icon = "tajara_zarrjiri"
 	text_tag = "ZAR"

--- a/code/modules/background/accent/unathi.dm
+++ b/code/modules/background/accent/unathi.dm
@@ -17,8 +17,8 @@
 /datum/accent/trad_noble
 	name = ACCENT_TRAD_NOBLE
 	description = "A more guttural, droning accent - although one that would demand respect on Moghes before the Contact War, and still demands it in the Wasteland. Primarily born from the \
-	guttural intonations and physical movement required to communicate in Sinta'Azaziba, this Noble Traditional accent requires clan-training from a family member or shaman - and has \
-	become either a sign of survival or defeat to most who see this ancient accent fading from existence."
+	guttural intonations and physical movement required to communicate in Sinta'Azaziba, this Noble Traditional accent requires clan-training from a family member or shaman - and as \
+	this accent fades from existence, it has taken on a dual symbol of either survival or defeat."
 	tag_icon = "trad_noble"
 	text_tag = "TRN"
 

--- a/code/modules/background/accent/vaurca.dm
+++ b/code/modules/background/accent/vaurca.dm
@@ -9,7 +9,7 @@
 
 /datum/accent/klax
     name = ACCENT_KLAX
-    description = "K'laxane is the modern day dialect of the K'lax Hive. Primitive modulators, even among K'lax standards, manage to capture a similarity to the \
+    description = "K'laxane is the modern day dialect of the K'lax Hive. Primitive modulators manage to capture a similarity to the \
     peasantry of the Izweski Hegemony on Moghes - however, they do not fully replicate it, retaining a more drawn out and dreamy tone. To other vaurcae, this is \
     a more subservient manner of speaking, akin to how Bound tend to draw out their thoughts - a common trait instilled in most vassal hives as a brand. Their \
     vocal augments stereotypically have difficulty, typically when producing sounds related to the letter 's', instead substituting with a harsh buzzing in the \
@@ -20,10 +20,10 @@
 
 /datum/accent/cthur
     name = ACCENT_CTHUR
-    description = "C'thuric is the modern day dialect of the C'thur Hive, a sly and sneering take on the unyielding Nral'Malic. Modulators are unfortunately \
-    still cheap, capturing a very monotone and unchanging method of speaking. Voices are warped into being clear and concise, many C'thur adopting a blunt and \
-    to-the-point method of speaking - yet, when needed to be verbose, delivery is often swift and intelligible. Other vaurcae would recognize this tone as being \
-    infamous of the C'thur's past deeds. Their vocal augments stereotypically have difficulty, typically when producing sounds related to the letter 's', instead \
+    description = "C'thuric is the modern day dialect of the C'thur Hive, a sly and sneering take on the unyielding Nral'Malic. Other vaurcae would associate this tone with \
+	C'thur's infamous past deeds. Modulators are unfortunately still cheap, creating a monotone method of speaking. \
+	Voices are also warped into being clear and concise, many C'thur adopting a blunt and to-the-point style when speaking casually. \
+	Their vocal augments stereotypically have difficulty, typically when producing sounds related to the letter 's', instead \
     substituting with a harsh buzzing in the throat."
     tag_icon = "cthur"
     text_tag = "CTH"
@@ -31,9 +31,9 @@
 /datum/accent/liidra
     name = ACCENT_LIIDRA
     description = "The Lii'dra speech, as understood by those that have heard the Hivemind and live to tell, is characterized by a monotonous voice that sounds \
-    even more robotical than the rest of the modulators used by the other Hives. It is believed to be a modified technology reverse engineered from stolen \
+    even more robotic than the modulators used by other Hives. It is believed to be a modified technology reverse engineered from stolen \
     Zo'rane modulators. While, with its flaws, the Zo'ra accent might sound quirky to some, it is often said that this is to add more personality to each \
-    individual. Since the Lii'dra do not think of themselves as such, these variations were deemed useless. The Connected individuals will often speak in plural, while the Disconnected \
-    are prone to use the first person when referring to others."
+    individual. Since the Lii'dra do not think of themselves as individuals, these variations were deemed useless. The Connected will often speak of themselves in plural, while the Disconnected \
+    are prone to using the first person when referring to others."
     tag_icon = "liidra"
     text_tag = "LII"

--- a/code/modules/background/accent/vaurca.dm
+++ b/code/modules/background/accent/vaurca.dm
@@ -21,7 +21,7 @@
 /datum/accent/cthur
     name = ACCENT_CTHUR
     description = "C'thuric is the modern day dialect of the C'thur Hive, a sly and sneering take on the unyielding Nral'Malic. Other vaurcae would associate this tone with \
-	C'thur's infamous past deeds. Modulators are unfortunately still cheap, creating a monotone method of speaking. \
+	C'thur's infamous past deeds. Modulators are unfortunately still cheap, leading to a monotone method of speaking. \
 	Voices are also warped into being clear and concise, many C'thur adopting a blunt and to-the-point style when speaking casually. \
 	Their vocal augments stereotypically have difficulty, typically when producing sounds related to the letter 's', instead \
     substituting with a harsh buzzing in the throat."

--- a/code/modules/clothing/under/xenos/tajara.dm
+++ b/code/modules/clothing/under/xenos/tajara.dm
@@ -303,7 +303,7 @@
 
 /obj/item/clothing/under/tajaran/nka_merchant_navy
 	name = "her majesty's mercantile flotilla crew uniform"
-	desc = "An uniform used by the crew of the New Kingdom's merchant space ships. It is clearly inspired on the ones used back in Adhomai."
+	desc = "An uniform used by the crew of the New Kingdom's merchant space ships. It is clearly inspired by the ones used back on Adhomai."
 	icon_state = "nka_merchant_navy"
 	item_state = "nka_merchant_navy"
 

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -563,7 +563,7 @@
 	icon_state = "messa_mead"
 	center_of_mass = list("x" = 16,"y" = 5)
 	desc_extended = "A fermented alcoholic drink made from earthen-root juice and Messa's tears leaves. It has a relatively low alcohol content and characteristic honey flavor. \
-	Messa's Mead is one of the most popular alcoholic drinks in Adhomai; it is consumed both during celebrations and daily meals. Any proper Adhomian bar will have at least a keg or \
+	Messa's Mead is one of the most popular alcoholic drinks on Adhomai; it is consumed both during celebrations and daily meals. Any proper Adhomian bar will have at least a keg or \
 	some bottles of the mead."
 	reagents_to_add = list(/singleton/reagent/alcohol/messa_mead = 100)
 

--- a/html/changelogs/sniblet-our.yml
+++ b/html/changelogs/sniblet-our.yml
@@ -1,0 +1,6 @@
+author: ChangeMe
+
+delete-after: True
+
+changes:
+  - spellcheck: "A whole lot of spellchecks and clarity/brevity/grammatical rewrites in accent description texts for all races."

--- a/html/changelogs/sniblet-our.yml
+++ b/html/changelogs/sniblet-our.yml
@@ -1,4 +1,4 @@
-author: ChangeMe
+author: Sniblet
 
 delete-after: True
 


### PR DESCRIPTION
The branch was named for a spelling error I found in Novi Jandranic and I was going to leave it at that, but then I decided to go over all the others and so ensued 20 minutes of copyediting and "why didn't I correct that before"s.
The goal is to reduce spelling and usage errors, redundancies, and in Plutonian's case, a weird aside noting that the accent is - _most likely_ from the most distant inhabited body in the Sol System? I don't know what this means, but it's not really making a point anyway. So I also cut out stuff like that.

There may be small lore implications for some of these:

- I cut out an "even among K'lax standards" in the K'lax accent because it made it sound like K'lax engineering standards are low, and unless I'm mistaken that's the opposite of true? But I just play here.
- In C'thuric, I guessed that "sly and sneering" is what's being associated with C'thur's past deeds, as opposed to "blunt and to the point." I've not exactly studied vaurca history, but from single reads of each page, C'thur's role reads to me as more rogue than barbarian.
- In rewriting the Qerr'Malic description, I had to make an assumption about what it was trying to say. I don't think it's right to say that any Nral'Malic dialect is "accessible" to other natural species, given nobody else can speak or understand it without synthetic help, so I guessed that the pitching was for comfort instead.
- Capitalized Zhan in Rural Delvahhi. I couldn't think of a reason why it should be lowercase, but somebody can check me on that.