### PR TITLE
Zo'ra and K'lax Bound for ops are now from Scay and Vedhra

### DIFF
--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -74,11 +74,11 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	var/list/hive = splittext(name, " ")
 	switch(hive[length(hive)])
 		if("K'lax")
-			change_skin_color(20, 170, 20) //vedhra does bio-research
+			change_skin_color(20, 170, 20) // Vedhra does bioresearch.
 		if("C'thur")
-			change_skin_color(10, 35, 55) //vytel tolerates the scc the most
+			change_skin_color(10, 35, 55) // Vytel tolerates the SCC the most.
 		if("Zo'ra")
-			change_skin_color(71 ,11, 51) //scay does bio-research
+			change_skin_color(71 ,11, 51) // Scay does bioresearch.
 
 /mob/living/carbon/human/type_b/Initialize(mapload)
 	h_style = "Classic Antennae"

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -74,11 +74,11 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	var/list/hive = splittext(name, " ")
 	switch(hive[length(hive)])
 		if("K'lax")
-			change_skin_color(33, 63, 33)
+			change_skin_color(20, 170, 20) //vedhra does bio-research
 		if("C'thur")
-			change_skin_color(10, 35, 55)
+			change_skin_color(10, 35, 55) //vytel tolerates the scc the most
 		if("Zo'ra")
-			change_skin_color(111, 21, 21)
+			change_skin_color(71 ,11, 51) //scay does bio-research
 
 /mob/living/carbon/human/type_b/Initialize(mapload)
 	h_style = "Classic Antennae"

--- a/html/changelogs/sniblet-bound_donors.yml
+++ b/html/changelogs/sniblet-bound_donors.yml
@@ -1,0 +1,6 @@
+author: Sniblet
+
+delete-after: True
+
+changes:
+  - tweak: "Instead of Zoleth and Vetju, Scay and Vedhra are the new Bound donors for Horizon biological testing. This means the bugs you buy come in new colors."


### PR DESCRIPTION
Previously, their colors indicated Zoleth (why) and Vetju (_big_ why). Now, each hive is represented by the Queen most likely to actually invest their Bound in the SCC's research. I didn't change Vytel because she still makes the most sense for C'thur.
Have a bug report while I'm here: sometimes, the bound workers that ops gets are named Za and/or Akaix, because every bug uses the same random-naming scheme regardless of type and origin. And I don't know how to fix this.