### PR TITLE
Bugfix: Fixes OM/Command's vault access

### DIFF
--- a/html/changelogs/Eyeveri_Vaultbugfix.yml
+++ b/html/changelogs/Eyeveri_Vaultbugfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ReadThisNamePlz
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes overall command access to the vault. Turrets will not shoot command members, and they have panel access now."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -29254,12 +29254,11 @@
 /obj/machinery/light/small/red{
 	dir = 1
 	},
-/obj/machinery/turretid{
-	name = "Vault Turret Control";
-	req_access = list(16,41,19,38);
+/obj/machinery/turretid/lethal{
 	dir = 4;
-	pixel_x = -27;
-	lethal = 1
+	pixel_x = -29;
+	name = "Vault Turret Control Panel";
+	req_access = list(16,41)
 	},
 /turf/simulated/floor/tiled,
 /area/storage/secure)

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -29258,8 +29258,15 @@
 	name = "Vault Turret Control";
 	req_access = list(16,41,19,38);
 	dir = 4;
+<<<<<<< Updated upstream
 	pixel_x = -27;
 	lethal = 1
+=======
+	pixel_x = -29;
+	name = "Vault Turret Control Panel";
+	req_access = null;
+	req_one_access = list(19,20,38,41)
+>>>>>>> Stashed changes
 	},
 /turf/simulated/floor/tiled,
 /area/storage/secure)

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -29256,7 +29256,7 @@
 	pixel_x = -26;
 	name = "Vault Turret Control";
 	check_synth = 1;
-	req_access = list(16,41)
+	req_access = list(16,41,19)
 	},
 /obj/machinery/light/small/red{
 	dir = 1

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -29254,11 +29254,12 @@
 /obj/machinery/light/small/red{
 	dir = 1
 	},
-/obj/machinery/turretid/lethal{
+/obj/machinery/turretid{
+	name = "Vault Turret Control";
+	req_access = list(16,41,19,38);
 	dir = 4;
-	pixel_x = -29;
-	name = "Vault Turret Control Panel";
-	req_access = list(16,41)
+	pixel_x = -27;
+	lethal = 1
 	},
 /turf/simulated/floor/tiled,
 /area/storage/secure)

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -11836,7 +11836,7 @@
 	},
 /obj/machinery/light/small/red,
 /turf/simulated/floor/tiled,
-/area/storage/secure)
+/area/operations/office)
 "fME" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -18154,7 +18154,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/storage/secure)
+/area/operations/office)
 "iGG" = (
 /obj/structure/stairs/north,
 /turf/simulated/floor/tiled/dark,
@@ -29256,13 +29256,13 @@
 	pixel_x = -26;
 	name = "Vault Turret Control";
 	check_synth = 1;
-	req_access = list(16,41,19)
+	req_access = list(16,41,19,38)
 	},
 /obj/machinery/light/small/red{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/storage/secure)
+/area/operations/office)
 "obQ" = (
 /obj/effect/floor_decal/corner_wide/lime{
 	dir = 9

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -20636,7 +20636,7 @@
 /obj/machinery/camera/motion/security{
 	dir = 8;
 	network = list("Command","Security","Operations");
-	c_tag = "Operations - Vault 1" 
+	c_tag = "Operations - Vault 1"
 	},
 /turf/simulated/floor/reinforced,
 /area/storage/secure)
@@ -29255,7 +29255,8 @@
 	dir = 4;
 	pixel_x = -26;
 	name = "Vault Turret Control";
-	check_synth = 1
+	check_synth = 1;
+	req_access = list(16,41)
 	},
 /obj/machinery/light/small/red{
 	dir = 1

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -11836,7 +11836,7 @@
 	},
 /obj/machinery/light/small/red,
 /turf/simulated/floor/tiled,
-/area/operations/office)
+/area/storage/secure)
 "fME" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -18154,7 +18154,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/operations/office)
+/area/storage/secure)
 "iGG" = (
 /obj/structure/stairs/north,
 /turf/simulated/floor/tiled/dark,
@@ -29251,18 +29251,18 @@
 /obj/structure/sign/securearea{
 	pixel_y = 32
 	},
-/obj/machinery/turretid/lethal{
-	dir = 4;
-	pixel_x = -26;
-	name = "Vault Turret Control";
-	check_synth = 1;
-	req_access = list(16,41,19,38)
-	},
 /obj/machinery/light/small/red{
 	dir = 1
 	},
+/obj/machinery/turretid{
+	name = "Vault Turret Control";
+	req_access = list(16,41,19,38);
+	dir = 4;
+	pixel_x = -27;
+	lethal = 1
+	},
 /turf/simulated/floor/tiled,
-/area/operations/office)
+/area/storage/secure)
 "obQ" = (
 /obj/effect/floor_decal/corner_wide/lime{
 	dir = 9


### PR DESCRIPTION
It was intended for command to have access to the vault turret panel, specifically the O.M, but I completely overlooked it. This has since been fixed with this PR. 
