### PR TITLE
Bugfix: Adds OM to turret panel for vault

### DIFF
--- a/html/changelogs/Eyeveri_FixesVaultAccess.yml
+++ b/html/changelogs/Eyeveri_FixesVaultAccess.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ReadThisNamePlz
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes vault access for OM. Also adds access requirements to the Vault door."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -20536,7 +20536,7 @@
 /obj/machinery/camera/motion/security{
 	dir = 8;
 	network = list("Command","Security","Operations");
-	c_tag = "Operations - Vault 1" 
+	c_tag = "Operations - Vault 1"
 	},
 /turf/simulated/floor/reinforced,
 /area/storage/secure)
@@ -29140,7 +29140,9 @@
 	dir = 4;
 	pixel_x = -26;
 	name = "Vault Turret Control";
-	check_synth = 1
+	check_synth = 1;
+	req_access = null;
+	req_one_access = list(16,20,41)
 	},
 /obj/machinery/light/small/red{
 	dir = 1
@@ -46822,7 +46824,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/vault/bolted{
-	id_tag = "Vault_Airlock"
+	id_tag = "Vault_Airlock";
+	req_one_access = list(16,20,41)
 	},
 /turf/simulated/floor/reinforced,
 /area/storage/secure)


### PR DESCRIPTION
As intended, this adds the OM and RD to the vault turret controls, and locks the vault door behind their access requirements.