### PR TITLE
Fix slot machines init

### DIFF
--- a/code/game/machinery/computer/slotmachine.dm
+++ b/code/game/machinery/computer/slotmachine.dm
@@ -47,9 +47,7 @@
 	toggle_reel_spin(FALSE)
 
 	for(cointype in typesof(/obj/item/coin))
-		var/obj/item/coin/C = new cointype
-		coinvalues["[cointype]"] = get_value(C)
-		qdel(C) //Sigh
+		coinvalues["[cointype]"] = get_value(cointype)
 
 /obj/machinery/computer/slot_machine/Destroy()
 	if(balance)
@@ -249,7 +247,9 @@
 /obj/machinery/computer/slot_machine/proc/toggle_reel_spin(value, delay = 0) //value is 1 or 0 aka on or off
 	for(var/list/reel in reels)
 		reels[reel] = value
-		sleep(delay)
+
+		if(delay)
+			sleep(delay)
 
 /obj/machinery/computer/slot_machine/proc/randomize_reels()
 	for(var/reel in reels)

--- a/html/changelogs/fluffyghost-fixslotmachinesinit.yml
+++ b/html/changelogs/fluffyghost-fixslotmachinesinit.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Fluffyghost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fix slot machines init, they were unnecessarily creating the coins to add and then immediately QDELing them, making SSAtoms angry. They were also sleeping during init, making SSAtoms doubly angry."


### PR DESCRIPTION
Fix slot machines init, they were unnecessarily creating the coins to add and then immediately QDELing them, making SSAtoms angry. They were also sleeping during init, making SSAtoms doubly angry.

Please test that the slot machines keeps working, while the code suggests they should still work perfectly fine, my faith in the code I have seen in this file makes me wary.

Atomized from https://github.com/Aurorastation/Aurora.3/pull/16065