### PR TITLE
Fix vending product New()

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -13,7 +13,7 @@
 	var/icon/icon_state
 
 /datum/data/vending_product/New(var/path, var/name = null, var/amount = 1, var/price = 0, var/color = null, var/category = CAT_NORMAL)
-	..()
+	. = ..()
 
 	product_path = path
 	var/atom/A = new path(null)
@@ -33,6 +33,7 @@
 		product_icon = S.update_appearance(TRUE)
 	else
 		product_icon = new /icon(A.icon, A.icon_state)
+
 	icon_state = product_icon
 	QDEL_NULL(A)
 

--- a/html/changelogs/fluffyghost-fixvendingproductnew.yml
+++ b/html/changelogs/fluffyghost-fixvendingproductnew.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Fluffyghost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed vending_product New() so that it assigns the parent return value to itself."


### PR DESCRIPTION
Fixed vending_product New() so that it assigns the parent return value to itself.

Atomized from https://github.com/Aurorastation/Aurora.3/pull/16065