### PR TITLE
Fix two implanters Initialize()

### DIFF
--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -144,7 +144,7 @@
 
 /obj/item/implanter/freedom/Initialize()
 	imp = new /obj/item/implant/freedom( src )
-	..()
+	. = ..()
 	update()
 
 /obj/item/implanter/uplink
@@ -152,7 +152,7 @@
 
 /obj/item/implanter/uplink/Initialize()
 	imp = new /obj/item/implant/uplink( src )
-	..()
+	. = ..()
 	update()
 
 /obj/item/implanter/anti_augment

--- a/html/changelogs/fluffyghost-fiximplanterinitialize.yml
+++ b/html/changelogs/fluffyghost-fiximplanterinitialize.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Fluffyghost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fix two implanters Initialize() that didn't return an hint to SSAtoms."


### PR DESCRIPTION
Fix two implanters Initialize() that didn't return an hint to SSAtoms.

Atomized from https://github.com/Aurorastation/Aurora.3/pull/16065