### PR TITLE
Fix telescience stationary GPS Initialize

### DIFF
--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -351,6 +351,9 @@ var/list/GPS_list = list()
 
 	START_PROCESSING(SSprocessing, src)
 
+	initialized = TRUE
+	return INITIALIZE_HINT_NORMAL
+
 /obj/item/device/gps/stationary/attack_hand() // Don't let users pick it up.
 	return
 

--- a/html/changelogs/fluffyghost-fixstationarygpsinitialize.yml
+++ b/html/changelogs/fluffyghost-fixstationarygpsinitialize.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: Fluffyghost
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/fluffyghost-fixstationarygpsinitialize.yml
+++ b/html/changelogs/fluffyghost-fixstationarygpsinitialize.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fix telescience stationary GPS Initialize() not setting the initialize variable nor returning an hint to SSAtoms."


### PR DESCRIPTION
Fix telescience stationary GPS Initialize() not setting the initialize variable nor returning an hint to SSAtoms.

Atomized from https://github.com/Aurorastation/Aurora.3/pull/16065