### PR TITLE
Fix hivebot beacon initialize

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_beacon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_beacon.dm
@@ -66,7 +66,7 @@
 		addtimer(CALLBACK(src, PROC_REF(activate_beacon)), 450)
 	latest_area = get_area(src)
 	icon_state = "hivebotbeacon_off"
-	generate_warp_destinations()
+	addtimer(CALLBACK(src, PROC_REF(generate_warp_destinations)), 10) //So we don't sleep during init
 	set_light(6,0.5,LIGHT_COLOR_GREEN)
 
 /mob/living/simple_animal/hostile/hivebotbeacon/proc/generate_warp_destinations()

--- a/html/changelogs/fluffyghost-fixhivebotbeaconinitialize.yml
+++ b/html/changelogs/fluffyghost-fixhivebotbeaconinitialize.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed hivebot beacon Initialize() being so heavy that BYOND sended it in background, thus sleeping, thus making SSAtom not happy."

--- a/html/changelogs/fluffyghost-fixhivebotbeaconinitialize.yml
+++ b/html/changelogs/fluffyghost-fixhivebotbeaconinitialize.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: Fluffyghost
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
Fixed hivebot beacon Initialize() being so heavy that BYOND sended it in background, thus sleeping, thus making SSAtom not happy.

Atomized from https://github.com/Aurorastation/Aurora.3/pull/16065