### PR TITLE
Get_area_turf explicit background

### DIFF
--- a/code/_helpers/areas.dm
+++ b/code/_helpers/areas.dm
@@ -12,6 +12,8 @@
 			. += A
 
 /proc/get_area_turfs(var/area/A, var/list/predicates)
+	set background=1
+
 	. = new/list()
 	A = istype(A) ? A : locate(A)
 	if(!A)

--- a/html/changelogs/fluffyghost-getareaturfexplicitbackground.yml
+++ b/html/changelogs/fluffyghost-getareaturfexplicitbackground.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Fluffyghost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Set background=1 in get_area_turf, byond consider the proc too long and automatically switch it in background already, but prints a warning about it, this suppress the warning."


### PR DESCRIPTION
Set background=1 in get_area_turf, byond consider the proc too long and automatically switch it in background already, but prints a warning about it, this suppress the warning.

I don't know if it's possible to rewrite this function any differently, but it's something worth looking into in the future, if that's called often, my tests suggests that it's not called by many other places, however.

Atomized from https://github.com/Aurorastation/Aurora.3/pull/16065