### PR TITLE
Xenoarch Initialize Explicit Background

### DIFF
--- a/code/controllers/subsystems/initialization/xenoarch.dm
+++ b/code/controllers/subsystems/initialization/xenoarch.dm
@@ -18,6 +18,8 @@ var/datum/controller/subsystem/xenoarch/SSxenoarch
 	NEW_SS_GLOBAL(SSxenoarch)
 
 /datum/controller/subsystem/xenoarch/Initialize(timeofday)
+	set background=1
+
 	//create digsites
 	for(var/turf/simulated/mineral/M in turfs)
 		CHECK_TICK

--- a/html/changelogs/fluffyghost-xenoarchinitializeexplicitbackground.yml
+++ b/html/changelogs/fluffyghost-xenoarchinitializeexplicitbackground.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Fluffyghost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Set background=1 in xenoarch Initialize(), byond consider the proc too long and automatically switch it in background already, but prints a warning about it, this suppress the warning."


### PR DESCRIPTION
Set background=1 in xenoarch Initialize(), byond consider the proc too long and automatically switch it in background already, but prints a warning about it, this suppress the warning.

Atomized from https://github.com/Aurorastation/Aurora.3/pull/16065