### PR TITLE
Overmap object fixes

### DIFF
--- a/code/modules/maps/planet_types/lore/srandmarr.dm
+++ b/code/modules/maps/planet_types/lore/srandmarr.dm
@@ -62,8 +62,8 @@
 /obj/effect/overmap/visitable/sector/exoplanet/lava/sahul
 	name = "Sahul"
 	desc = "Az'mar's moon is a celestial body composed primarily of molten metals."
-	color = "#cf1020"
 	icon_state = "globe1"
+	color = "#cf1020"
 	generated_name = FALSE
 	ring_chance = 0
 

--- a/code/modules/maps/planet_types/lore/srandmarr.dm
+++ b/code/modules/maps/planet_types/lore/srandmarr.dm
@@ -62,6 +62,7 @@
 /obj/effect/overmap/visitable/sector/exoplanet/lava/sahul
 	name = "Sahul"
 	desc = "Az'mar's moon is a celestial body composed primarily of molten metals."
+	color = "#cf1020"
 	icon_state = "globe1"
 	generated_name = FALSE
 	ring_chance = 0

--- a/html/changelogs/alberyk-overmapfixes.yml
+++ b/html/changelogs/alberyk-overmapfixes.yml
@@ -1,0 +1,8 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed Sahul not having a proper color."
+  - bugfix: "Fixed the NKA merchant ship spawning even if no one joined as its crew."
+  - bugfix: "Fixed the scrapper outpost using the wrong icon."

--- a/maps/away/away_site/tajara/scrapper/scrapper.dm
+++ b/maps/away/away_site/tajara/scrapper/scrapper.dm
@@ -25,6 +25,7 @@
 	)
 	comms_support = TRUE
 	comms_name = "adhomian scrapper"
+	icon_state = "outpost"
 	color = "#DAA06D"
 
 /obj/effect/shuttle_landmark/tajara_scrapper

--- a/maps/away/ships/nka/nka_merchant/nka_merchant.dm
+++ b/maps/away/ships/nka/nka_merchant/nka_merchant.dm
@@ -33,6 +33,8 @@
 		"Her Majesty's Mercantile Flotilla Shuttle" = list("nav_nka_merchant_shuttle")
 	)
 
+	invisible_until_ghostrole_spawn = TRUE
+
 /obj/effect/overmap/visitable/ship/nka_merchant/New()
 	designation = "[pick("Minharrzka's Daughter", "Her Majesty's Merchant", "Vahzirthaamro", "Azunja's Favorite", "Wealth-Beyond-Measure", "Miran'mir", "Crown Traveller", "Space Monarch")]"
 	..()


### PR DESCRIPTION
- fixed Sahul using the old grey color since I forgot to give it a better color
- fixed the NKA merchant ship spawning even if no one joined as its crew
- fixed the scrapper outpost using the wrong icon
