### PR TITLE
Scapper outpost and mixing bowl icons fixes

### DIFF
--- a/code/modules/cooking/machinery/cooking_machines/container.dm
+++ b/code/modules/cooking/machinery/cooking_machines/container.dm
@@ -301,19 +301,37 @@
 	QDEL_NULL(temp) //delete buffer object
 	return ..()
 
-/obj/item/reagent_containers/cooking_container/board/do_empty(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-
-/obj/item/reagent_containers/cooking_container/board/attackby(obj/item/I, mob/user)
-	. = ..()
-	if(length(contents)) // Only if something was actually added.
-		icon_state = "[initial(icon_state)]_prep"
 
 /obj/item/reagent_containers/cooking_container/board/on_reagent_change()
-	. = ..()
-	if(reagents.total_volume) // Only if something was actually added.
+	update_icon()
+
+/obj/item/reagent_containers/cooking_container/board/pickup(mob/user)
+	..()
+	update_icon()
+
+/obj/item/reagent_containers/cooking_container/board/dropped(mob/user)
+	..()
+	update_icon()
+
+
+/obj/item/reagent_containers/cooking_container/board/attack_hand()
+	..()
+	update_icon()
+
+
+/obj/item/reagent_containers/cooking_container/board/do_empty(mob/user)
+	..()
+	update_icon()
+
+/obj/item/reagent_containers/cooking_container/board/attackby(obj/item/I, mob/user)
+	..()
+	update_icon()
+
+/obj/item/reagent_containers/cooking_container/board/update_icon()
+	if(length(contents)) // Only if something was actually added.
 		icon_state = "[initial(icon_state)]_prep"
+	else
+		icon_state = initial(icon_state)
 
 /obj/item/reagent_containers/cooking_container/board/bowl
 	name = "mixing bowl"
@@ -328,26 +346,6 @@
 	volume = 180
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,25,30,60,180)
-
-
-/obj/item/reagent_containers/cooking_container/board/bowl/on_reagent_change()
-	update_icon()
-
-
-/obj/item/reagent_containers/cooking_container/board/bowl/pickup(mob/user)
-	..()
-	update_icon()
-
-
-/obj/item/reagent_containers/cooking_container/board/bowl/dropped(mob/user)
-	..()
-	update_icon()
-
-
-/obj/item/reagent_containers/cooking_container/board/bowl/attack_hand()
-	..()
-	update_icon()
-
 
 /obj/item/reagent_containers/cooking_container/board/bowl/update_icon()
 	cut_overlays()

--- a/html/changelogs/alberyk-morefixes.yml
+++ b/html/changelogs/alberyk-morefixes.yml
@@ -1,0 +1,7 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed mixing bowls turning invisible."
+  - bugfix: "Fixed the scrapper outpost being invisible."

--- a/maps/away/away_site/tajara/scrapper/scrapper.dm
+++ b/maps/away/away_site/tajara/scrapper/scrapper.dm
@@ -25,6 +25,8 @@
 	)
 	comms_support = TRUE
 	comms_name = "adhomian scrapper"
+
+	icon = 'icons/obj/overmap/overmap_stationary.dmi'
 	icon_state = "outpost"
 	color = "#DAA06D"
 


### PR DESCRIPTION
-fixes #16147
-fixes the scrapper outpost being invisible
