### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,7 +51,7 @@
 
 # ZAS, the dreaded and esoteric atmos system, since Matt is the last to have touched it and
 # all others I can find are long gone...
-/code/__defines/ZAS.dm
+/code/__defines/ZAS.dm @NonQueueingMatt
 /code/ZAS/ @NonQueueingMatt
 
 # Matt is also the implementer/porter of the observable design pattern

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,10 +34,10 @@
 /code/__defines/organs.dm @NonQueueingMatt
 /code/modules/organs/ @NonQueueingMatt
 
-# VueUI
-/code/modules/vueui/ @Karolis2011
-/vueui/ @Karolis2011
-/code/__defines/vueui.dm @Karolis2011
+# VueUI, it would be @Karolis2011 but no repo write access
+/code/modules/vueui/ @NonQueueingMatt
+/vueui/ @NonQueueingMatt
+/code/__defines/vueui.dm @NonQueueingMatt
 
 # Tools, often binary in nature, let arrow and alb know
 /tools/ @Arrow768 @Alberyk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,10 +42,6 @@
 # Tools, often binary in nature, let arrow and alb know
 /tools/ @Arrow768 @Alberyk
 
-# Sounds and images often requires licensing reviews, alb seems the best suited for it
-/sound/ @Alberyk
-/icons/ @Alberyk
-
 # Pipeline/CI stuffs, arrow
 /scripts/ @Arrow768
 /.github/ @Arrow768
@@ -61,10 +57,15 @@
 # Matt is also the implementer/porter of the observable design pattern
 /code/datums/observation/ @NonQueueingMatt
 
-# Spatial gridmap, Windinks
+# Spatial gridmap, Wildkins
 /code/__defines/spatial_gridmap.dm @JohnWildkins
 /code/_helpers/spatial_info.dm @JohnWildkins
 /controllers/subsystems/spatial_gridmap.dm @JohnWildkins
+
+# Tcomms and radios, Wildkins
+/code/game/machinery/telecomms/ @JohnWildkins
+/code/game/objects/items/devices/radio/ @JohnWildkins
+
 # Whatever else
 /code/controllers/subsystems/cargo.dm @Arrow768
 /code/datums/cargo.dm @Arrow768

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,23 +5,74 @@
 # If you want to be added, make a PR that adds you to it.
 # If you are added, then you are expected to review PRs in a timely manner.
 
+
+# This code requires the host/head dev to know of changes, therefore it's places in
+# this dedicated section
+/code/__defines/master_controller.dm @Arrow768
+/code/controllers/master @Arrow768
+/code/controllers/subsystems/fail2topic.dm @Arrow768
 /code/world.dm @Arrow768
-/code/controllers/subsystems/cargo.dm @Arrow768
+/code/modules/admin/ @Arrow768
+/code/modules/web_interface/ @Arrow768
+/code/modules/world_api/ @Arrow768
+/code/datums/discord/ @Arrow768
+/code/modules/udp/ @Arrow768
+/code/defines/procs/dbcore.dm @Arrow768
+/SQL/ @Arrow768
+/code/modules/http/ @Arrow768
 /code/datums/api.dm @Arrow768
-/code/datums/cargo.dm @Arrow768
-/code/datums/discord/ @Skull132
-/code/defines/procs/dbcore.dm @Skull132
-/code/modules/http/ @Arrow768 @Skull132
-/code/modules/client/preference_setup/ @Skull132
+
+# Custom items, alb
 /code/modules/customitems/item_defines.dm @Alberyk
+
+# Overmap, away sites and organs (brainmed), matt's expertise
+/code/__defines/overmap.dm @NonQueueingMatt
+/code/_helpers/overmap.dm @NonQueueingMatt
+/code/modules/overmap/ @NonQueueingMatt
+/maps/away/ @NonQueueingMatt
+
+/code/__defines/organs.dm @NonQueueingMatt
+/code/modules/organs/ @NonQueueingMatt
+
+# VueUI
+/code/modules/vueui/ @Karolis2011
+/vueui/ @Karolis2011
+/code/__defines/vueui.dm @Karolis2011
+
+# Tools, often binary in nature, let arrow and alb know
+/tools/ @Arrow768 @Alberyk
+
+# Sounds and images often requires licensing reviews, alb seems the best suited for it
+/sound/ @Alberyk
+/icons/ @Alberyk
+
+# Pipeline/CI stuffs, arrow
+/scripts/ @Arrow768
+/.github/ @Arrow768
+/.travis.yml @Arrow768
+/.drone.yml @Arrow768
+/flyway.conf @Arrow768
+
+# ZAS, the dreaded and esoteric atmos system, since Matt is the last to have touched it and
+# all others I can find are long gone...
+/code/__defines/ZAS.dm
+/code/ZAS/ @NonQueueingMatt
+
+# Matt is also the implementer/porter of the observable design pattern
+/code/datums/observation/ @NonQueueingMatt
+
+# Spatial gridmap, Windinks
+/code/__defines/spatial_gridmap.dm @JohnWildkins
+/code/_helpers/spatial_info.dm @JohnWildkins
+/controllers/subsystems/spatial_gridmap.dm @JohnWildkins
+# Whatever else
+/code/controllers/subsystems/cargo.dm @Arrow768
+/code/datums/cargo.dm @Arrow768
+/code/modules/client/preference_setup/ @Arrow768
 /code/modules/item_worth/ @Arrow768
 /code/modules/modular_computers/ @Arrow768
 /code/modules/telesci/ @Arrow768
 /code/modules/cargo/ @Arrow768
-/code/modules/udp/ @Arrow768
-/code/modules/vueui/ @Karolis2011
-/code/modules/web_interface/ @Arrow768
-/lib/ @Skull132
 /nano/templates/ @Arrow768
-/SQL/ @Arrow768
-/vueui/ @Karolis2011
+
+

--- a/html/changelogs/fluffyghost-modernizecodeowners.yml
+++ b/html/changelogs/fluffyghost-modernizecodeowners.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Fluffyghost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Modernized our codeowners template for PRs pings, added some additional ones, reassigned away from skull to currently-in-team devs."


### PR DESCRIPTION
Modernized our codeowners template for PRs pings, added some additional ones, reassigned away from skull to currently-in-team devs.