### PR TITLE
Simplified the bloom effect for screen overlays

### DIFF
--- a/code/_helpers/overlay.dm
+++ b/code/_helpers/overlay.dm
@@ -42,15 +42,11 @@
 	target.add_overlay(list(multiply, overlay))
 
 /proc/make_screen_overlay(icon, icon_state, brightness_factor = null, glow_radius = 1)
-	var/icon/base = new(icon, icon_state) // forgive us, but this is to get the width/height.
-	var/height = base.Height() // at least this is cached in most use cases
-	var/width = base.Width()
 	var/image/overlay = image(icon, icon_state)
 	overlay.layer = EFFECTS_ABOVE_LIGHTING_LAYER
 	var/image/underlay = image(overlay)
 	underlay.alpha = 128
-	underlay.transform = underlay.transform.Scale((width + glow_radius*2)/width, (height+glow_radius*2)/height)
-	underlay.filters = filter(type="blur", size=glow_radius)
+	underlay.filters = filter(type="bloom", offset=glow_radius, size=glow_radius*2, threshold="#000")
 	overlay.underlays += underlay
 	if (brightness_factor)
 		overlay.color = list(

--- a/html/changelogs/GeneralCamo - Better Bloom.yml
+++ b/html/changelogs/GeneralCamo - Better Bloom.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - refactor: "Simplified screen overlay/bloom code."


### PR DESCRIPTION
Previously, the bloom effect required creating a new icon, for the sole purpose of getting the height and width of the icon in question. This simplifies it to use Byond's bloom filter, introduced in 514.