### PR TITLE
Reduce vending spritesheet init time

### DIFF
--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -537,51 +537,61 @@ var/list/asset_datums = list()
 	name = "vending"
 
 /datum/asset/spritesheet/vending/register()
-	var/list/vending_products = list()
-	for(var/v_type in typesof(/obj/machinery/vending))
-		var/obj/machinery/vending/V = new v_type
-		for(var/list/p in list(V.products, V.contraband, V.premium))
-			for(var/k in p)
-				vending_products += k
+	var/vending_products = list()
+	for(var/obj/machinery/vending/vendor as anything in typesof(/obj/machinery/vending))
+		vendor = new vendor()
+		for(var/each in list(vendor.products, vendor.contraband, vendor.premium))
+			vending_products |= each
+		qdel(vendor)
+
 	for(var/path in vending_products)
-		var/obj/O = new path
-		var/icon_file = O.icon
-		var/icon_state = O.icon_state
-		var/icon/I
+		var/atom/item = path
+		if(!ispath(item, /atom))
+			continue
+
+		var/icon_file = initial(item.icon)
+		var/icon_state = initial(item.icon_state)
+
+		#ifdef UNIT_TEST
 		var/icon_states_list = icon_states(icon_file)
-		if(icon_state in icon_states_list)
-			I = icon(icon_file, icon_state, SOUTH)
-			var/c = O.color
-			if(!isnull(c) && c != "#FFFFFF")
-				I.Blend(c, ICON_MULTIPLY)
-		else
+		if(!(icon_state in icon_states_list))
 			var/icon_states_string
 			for(var/s in icon_states_list)
 				if(!icon_states_string)
 					icon_states_string = "[json_encode(s)](\ref[s])"
 				else
 					icon_states_string += ", [json_encode(s)](\ref[s])"
-			log_error("[O] has an invalid icon state, icon=[icon_file], icon_state=[json_encode(icon_state)](\ref[icon_state]), icon_states=[icon_states_string]")
-			I = icon('icons/turf/floors.dmi', "", SOUTH)
 
-		var/imgid = ckey("[path]")
+			stack_trace("[item] has an invalid icon state, icon=[icon_file], icon_state=[json_encode(icon_state)](\ref[icon_state]), icon_states=[icon_states_string]")
+			continue
+		#endif
 
-		if(istype(O, /obj/item/seeds))
+		var/icon/I = icon(icon_file, icon_state, SOUTH)
+		var/c = initial(item.color)
+		if(!isnull(c) && c != "#FFFFFF")
+			I.Blend(c, ICON_MULTIPLY)
+
+		var/imgid = ckey("[item]")
+		item = new item()
+
+		if(ispath(item, /obj/item/seeds))
 			// thanks seeds for being overlays defined at runtime
-			var/obj/item/seeds/S = O
+			var/obj/item/seeds/S = item
 			if(!S.seed && S.seed_type && !isnull(SSplants.seeds) && SSplants.seeds[S.seed_type])
 				S.seed = SSplants.seeds[S.seed_type]
 			I = S.update_appearance(TRUE)
 			Insert(imgid, I, forced=I)
 		else
-			O.update_icon()
-			if(O.overlay_queued)
-				O.compile_overlays()
-			if(O.overlays.len)
-				I = getFlatIcon(O) // forgive me for my performance sins
+			item.update_icon()
+			if(item.overlay_queued)
+				item.compile_overlays()
+			if(item.overlays.len)
+				I = getFlatIcon(item) // forgive me for my performance sins
 				Insert(imgid, I, forced=I)
 			else
 				Insert(imgid, I)
+
+		qdel(item)
 	return ..()
 
 /datum/asset/spritesheet/chem_master

--- a/html/changelogs/johnwildkins-vendingredux.yml
+++ b/html/changelogs/johnwildkins-vendingredux.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - backend: "Slightly reduced init time required to build vending UI spritesheets."


### PR DESCRIPTION
very bad no good coding here
in an ideal world i'd like to not instantiate item ever, but unfortunately between seeds and a half dozen other generated-sprites-on-runtime, we don't really have much of an option