### PR TITLE
Adds git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Ignores big formatting commits when checking blame.
+# To make use of this file by default, run 'git config blame.ignoreRevsFile .git-blame-ignore-revs'
+# in the project folder
+
+# Enforces Lineendings and adds Editorconfig
+cb4a7128515170ad7f8fbe3032e6c2810d481322
+# Removes Weapons
+af16a489a6b6ba790a04d2fde4cb1ae527ba13ca


### PR DESCRIPTION
no player facing changes
adds git-blame-ignore-revs which will ignore any commits listed in the file by default when using github blame, or locally if you set your config via the command listed in the file

right now I've only selected two commits, both of which touch an obscene amount of files and make git blaming slightly more arduous