### PR TITLE
Bugfix: Fixes HT's not having access to ammo storage turret controls

### DIFF
--- a/html/changelogs/eyeveri_changelog.yml
+++ b/html/changelogs/eyeveri_changelog.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ReadThisNamePlz
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes Ammunition storage turret control access"

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -7754,8 +7754,9 @@
 /obj/machinery/turretid{
 	name = "\improper Secure Ammunition Storage Turret Control Console";
 	pixel_x = -26;
-	req_access = list(19);
-	dir = 4
+	dir = 4;
+	req_access = null;
+	req_one_access = list(11,19,20,24,31,41)
 	},
 /turf/simulated/floor/tiled,
 /area/operations/lobby)


### PR DESCRIPTION
Fixes the ammunition storage controls for HTs, general command and engineers. 

Bugfix for [Issue 16166](https://github.com/Aurorastation/Aurora.3/issues/16166)
