### PR TITLE
Goonchat cookie namespacing.

### DIFF
--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -440,16 +440,18 @@ function runByond(uri) {
 	window.location = uri;
 }
 
+var cookieNamespace = "nss_aurora_";
+
 function setCookie(cname, cvalue, exdays) {
 	cvalue = escaper(cvalue);
 	var d = new Date();
 	d.setTime(d.getTime() + (exdays*24*60*60*1000));
 	var expires = 'expires='+d.toUTCString();
-	document.cookie = cname + '=' + cvalue + '; ' + expires + "; path=/";
+	document.cookie = cookieNamespace + cname + '=' + cvalue + '; ' + expires + "; path=/";
 }
 
 function getCookie(cname) {
-	var name = cname + '=';
+	var name = cookieNamespace + cname + '=';
 	var ca = document.cookie.split(';');
 	for(var i=0; i < ca.length; i++) {
 	var c = ca[i];

--- a/html/changelogs/DreamySkrell-goonchat-cookie-namespacing-347637.yml
+++ b/html/changelogs/DreamySkrell-goonchat-cookie-namespacing-347637.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Goonchat cookie namespacing."


### PR DESCRIPTION
Currently cookies are not namespaced.
This means you get the same chat settings on every goonchat server, like for example, bay.
Settings like chat string highlighting.