### PR TITLE
Engineering/Atmospherics Map Updates

### DIFF
--- a/html/changelogs/Huntime-EngineeringUpdates.yml
+++ b/html/changelogs/Huntime-EngineeringUpdates.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Huntime
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Modified the starboard & port thrusters, adding a Hydrogen line for new combustion/burn opportunities; modifies the atmospherics locker room, adds additional scrubber/pump connectors."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -139,12 +139,11 @@
 /turf/simulated/floor/tiled/full,
 /area/security/checkpoint)
 "aix" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos)
+/turf/simulated/wall/shuttle/scc_space_ship/cardinal,
+/area/horizon/custodial/disposals)
 "aiG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -188,10 +187,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload)
 "akw" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/turf/space/dynamic,
-/area/horizon/exterior)
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos/propulsion/starboard)
 "akC" = (
 /obj/structure/lattice/catwalk/indoor/grate/damaged,
 /obj/item/stack/rods,
@@ -312,12 +321,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "apQ" = (
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion/starboard)
+/area/engineering/atmos/propulsion)
 "aqc" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 6
@@ -325,8 +337,8 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/railing/mapped,
 /obj/structure/reagent_dispensers/watertank,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
@@ -515,16 +527,16 @@
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/cargo_bay)
 "azl" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/bed/stool/chair/office/dark{
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 10
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion/starboard)
@@ -577,6 +589,9 @@
 "aBy" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
@@ -875,9 +890,12 @@
 /turf/simulated/floor/plating,
 /area/rnd/xenoarch_atrium)
 "aLK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
 /obj/machinery/door/firedoor,
-/obj/structure/grille,
 /obj/structure/window/shuttle/scc_space_ship,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "aMg" = (
@@ -1183,9 +1201,6 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 5
-	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "aWx" = (
@@ -1351,20 +1366,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/operations)
 "bbY" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 6
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "Propulsion";
-	req_one_access = list(11,24)
-	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion)
+/turf/space/dynamic,
+/area/horizon/exterior)
 "bcj" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 1
 	},
@@ -1411,12 +1418,19 @@
 /turf/simulated/floor/reinforced,
 /area/turret_protected/ai)
 "beu" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
 	},
-/turf/space/dynamic,
-/area/horizon/exterior)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch{
+	name = "Propulsion";
+	req_one_access = list(11,24)
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos/propulsion/starboard)
 "beF" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -1633,18 +1647,18 @@
 	name = "Starboard Propulsion";
 	req_one_access = list(11,24)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/full,
 /area/engineering/atmos/propulsion/starboard)
 "boC" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/space/dynamic,
 /area/horizon/exterior)
 "boH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
 /turf/space/dynamic,
 /area/horizon/exterior)
 "boN" = (
@@ -1820,7 +1834,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "bvv" = (
@@ -1874,11 +1887,14 @@
 	req_access = list(10);
 	specialfunctions = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_wide/black{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 6
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
@@ -1902,18 +1918,16 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "bxw" = (
-/obj/structure/lattice/catwalk/indoor,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/door/firedoor,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "bxJ" = (
@@ -2101,12 +2115,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/structure/cable/green{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
@@ -2399,9 +2407,17 @@
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/horizon/stairwell/bridge)
 "bLu" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/manifold/hidden/purple,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4;
+	layer = 2.8
+	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "bLO" = (
 /obj/structure/disposalpipe/trunk{
@@ -2495,12 +2511,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "bQb" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 28
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -2521,11 +2537,20 @@
 /obj/machinery/power/apc/super/critical{
 	pixel_y = -24
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/table/steel,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "bRg" = (
 /obj/random/junk,
@@ -2703,13 +2728,8 @@
 /turf/simulated/floor/tiled/airless,
 /area/hangar/operations)
 "bZU" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible/purple,
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "caN" = (
@@ -2969,18 +2989,14 @@
 /turf/simulated/floor/plating,
 /area/hangar/intrepid)
 "cne" = (
-/obj/machinery/sparker{
-	id = "port_prop_igni";
-	pixel_x = 22
-	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion)
 "cnx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/horizon/exterior)
 "cnE" = (
@@ -3019,7 +3035,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "cpf" = (
@@ -3203,22 +3221,17 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 9
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "cwa" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/table/steel,
-/obj/random/tech_supply,
 /obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion/starboard)
 "cwc" = (
 /obj/structure/sign/securearea,
@@ -3442,8 +3455,9 @@
 /area/rnd/xenoarch_atrium)
 "cHK" = (
 /obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
+	dir = 4
 	},
 /turf/space/dynamic,
 /area/horizon/exterior)
@@ -3464,10 +3478,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/rotary)
 "cIU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/machinery/door/airlock/hatch{
+	name = "Propulsion";
+	req_one_access = list(11,24)
 	},
-/obj/machinery/light,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "cIW" = (
@@ -3731,9 +3747,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
 "cSw" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -3742,6 +3755,9 @@
 	},
 /obj/item/modular_computer/telescreen/preset/trashcompactor{
 	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
@@ -3871,8 +3887,16 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenoarch_atrium)
 "cWX" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/black,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 9
+	},
 /obj/machinery/meter,
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "cYs" = (
@@ -3882,12 +3906,6 @@
 "cYS" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /obj/effect/floor_decal/corner/yellow{
@@ -4007,14 +4025,11 @@
 /turf/simulated/floor/tiled,
 /area/hangar/operations)
 "dgC" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 6
 	},
-/obj/structure/sign/nosmoking_1{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion/starboard)
+/turf/simulated/wall/r_wall,
+/area/engineering/atmos)
 "dgD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -4286,8 +4301,9 @@
 /area/engineering/atmos/air)
 "dpF" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
 	},
 /turf/space/dynamic,
 /area/horizon/exterior)
@@ -4442,24 +4458,26 @@
 	},
 /obj/effect/floor_decal/corner/yellow/diagonal,
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "dvT" = (
 /turf/simulated/wall,
 /area/assembly/chargebay)
 "dwr" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 10
-	},
 /obj/machinery/button/ignition{
 	id = "starboard_prop_igni";
 	pixel_y = 26
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/black/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "dwt" = (
 /obj/structure/window/shuttle/scc,
@@ -4546,22 +4564,18 @@
 /turf/simulated/floor/reinforced/hydrogen,
 /area/engineering/atmos)
 "dBG" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/alarm{
 	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "dCC" = (
-/obj/machinery/sparker{
-	id = "starboard_prop_igni";
-	pixel_x = -16
-	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion/starboard)
 "dDq" = (
@@ -4602,7 +4616,6 @@
 /obj/structure/tank_wall/hydrogen{
 	icon_state = "h14"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
@@ -4657,6 +4670,9 @@
 	},
 /obj/structure/tank_wall/phoron{
 	icon_state = "ph8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
@@ -4787,11 +4803,23 @@
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
 "dKM" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner_wide/black/full{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -4880,9 +4908,13 @@
 /turf/simulated/floor/grass/alt,
 /area/horizon/hydroponics/lower)
 "dNa" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/black,
+/obj/machinery/light,
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion)
+/area/engineering/atmos/propulsion/starboard)
 "dNk" = (
 /turf/simulated/wall,
 /area/outpost/mining_main/refinery)
@@ -5095,11 +5127,10 @@
 /area/horizon/crew_quarters/cryo/living_quarters_lift)
 "dZQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 4
+	dir = 5
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -5359,9 +5390,6 @@
 /turf/simulated/floor/tiled,
 /area/operations/loading)
 "ehH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/firealarm/south,
 /obj/effect/floor_decal/corner/yellow,
 /obj/effect/floor_decal/corner/blue{
@@ -5504,8 +5532,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/binary/passive_gate/on{
 	name = "Reactor Waste to Mix"
 	},
@@ -5517,6 +5543,12 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
@@ -5561,7 +5593,6 @@
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid/interstitial)
 "err" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/yellow,
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -5621,7 +5652,7 @@
 /area/horizon/hydroponics/lower)
 "etT" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/space/dynamic,
 /area/horizon/exterior)
 "euj" = (
@@ -5813,9 +5844,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/deck1)
 "ezt" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -5827,6 +5855,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
@@ -5859,13 +5890,6 @@
 "eBb" = (
 /obj/effect/map_effect/airlock/s_to_n,
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
-/area/engineering/atmos/propulsion/starboard)
-"eBf" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 5
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "eBj" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/atmos{
@@ -5964,7 +5988,18 @@
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "eET" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "eFe" = (
@@ -6123,12 +6158,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "eKg" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
+	dir = 10
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "eKi" = (
@@ -6348,24 +6381,23 @@
 /turf/template_noop,
 /area/template_noop)
 "eTi" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 28;
 	req_one_access = list(24,11,55)
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "eTJ" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion/starboard)
 "eVn" = (
@@ -6903,10 +6935,10 @@
 "fkH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
@@ -6968,11 +7000,14 @@
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid/interstitial)
 "fnB" = (
-/obj/structure/sign/nosmoking_1{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 9
 	},
-/obj/machinery/atmospherics/tvalve/digital/bypass{
-	dir = 4
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -6987,7 +7022,6 @@
 	name = "Port Propulsion";
 	req_one_access = list(11,24)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
@@ -7009,6 +7043,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
 "fpp" = (
@@ -7148,22 +7183,19 @@
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "fvq" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
 	},
-/obj/structure/sign/nosmoking_1{
-	pixel_x = -32
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "fvy" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 5
+	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9
-	},
 /turf/space/dynamic,
 /area/horizon/exterior)
 "fwA" = (
@@ -7191,7 +7223,6 @@
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /turf/simulated/floor/plating,
 /area/hallway/engineering)
 "fyb" = (
@@ -7251,9 +7282,6 @@
 	desc = "A warning sign which reads 'DANGER: MASS DRIVER'.";
 	name = "\improper DANGER: MASS DRIVER sign";
 	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
@@ -7324,6 +7352,9 @@
 "fCv" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
@@ -7502,12 +7533,17 @@
 	},
 /area/hangar/auxiliary)
 "fKe" = (
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 4;
-	layer = 2.8
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -7714,20 +7750,24 @@
 /turf/simulated/open/airless,
 /area/template_noop)
 "fRj" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner_wide/black{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/full,
-/area/maintenance/engineering)
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos/propulsion/starboard)
 "fRu" = (
 /obj/structure/tank_wall{
 	icon_state = "m-13"
@@ -7760,9 +7800,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/atmospherics/binary/passive_gate/on/output/max{
+	dir = 8
 	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "fTy" = (
@@ -7829,6 +7873,9 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/custodial/disposals)
@@ -8355,14 +8402,12 @@
 /turf/simulated/floor/tiled/full,
 /area/hangar/control)
 "gnP" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	layer = 2.8
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/black{
+/obj/machinery/atmospherics/valve/open{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion)
+/obj/structure/lattice,
+/turf/space/dynamic,
+/area/horizon/exterior)
 "goO" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -8600,10 +8645,12 @@
 /turf/simulated/wall,
 /area/operations/loading)
 "gwg" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 9
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "gwz" = (
@@ -8677,10 +8724,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "gya" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion)
+/obj/structure/window/shuttle/scc_space_ship,
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/engineering/atmos)
 "gye" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -8769,15 +8820,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/engine_compartment)
 "gAK" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
 /obj/structure/sign/fire{
 	name = "\improper DANGER: COMBUSTION CHAMBER sign";
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
@@ -8895,12 +8949,17 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner_wide/black/full{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "gFI" = (
@@ -8943,11 +9002,18 @@
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "gGE" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -9019,7 +9085,7 @@
 	id = "shutters_disposals";
 	name = "\improper Viewing Shutter"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -9060,8 +9126,8 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
@@ -9270,13 +9336,19 @@
 /area/maintenance/research_port)
 "gVu" = (
 /obj/machinery/atmospherics/binary/passive_gate{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion)
+/area/engineering/atmos/propulsion/starboard)
 "gVx" = (
 /obj/machinery/crusher_base,
 /turf/simulated/floor/plating,
@@ -9435,9 +9507,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/full,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "hcD" = (
@@ -9534,14 +9603,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
 "hfR" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "hgn" = (
@@ -9570,9 +9639,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
@@ -9627,9 +9693,6 @@
 /area/outpost/mining_main/refinery)
 "hhS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -9728,6 +9791,9 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/custodial/disposals)
 "hnS" = (
@@ -9776,12 +9842,6 @@
 "hpU" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -9888,6 +9948,11 @@
 	icon_state = "h6";
 	layer = 10.1;
 	opacity = 0
+	},
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	dir = 1;
+	frequency = 1441;
+	id_tag = "H2_out_portthruster"
 	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/engineering/atmos)
@@ -10071,15 +10136,19 @@
 /turf/simulated/floor/carpet/rubber,
 /area/assembly/chargebay)
 "hAU" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/hatch{
+	name = "Propulsion";
+	req_one_access = list(11,24)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/plating,
-/area/engineering/atmos/air)
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos/propulsion)
 "hAY" = (
 /obj/structure/table/standard,
 /obj/item/book/manual/gravitygenerator,
@@ -10555,6 +10624,12 @@
 /area/hallway/engineering)
 "hVE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "hVL" = (
@@ -10730,12 +10805,15 @@
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
 "iei" = (
-/obj/structure/table/steel,
-/obj/random/tech_supply,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/computer/general_air_control/large_tank_control{
+	input_tag = null;
+	name = "Phoron Supply Monitor";
+	output_tag = "ph_out_starboardthruster";
+	sensors = list("ph_sensor"="Tank")
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion/starboard)
 "ieu" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -11070,15 +11148,13 @@
 /turf/simulated/floor/reinforced/airmix,
 /area/engineering/atmos/air)
 "itD" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/atmospherics/binary/passive_gate/on/output/max{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 8
-	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "itT" = (
@@ -11498,19 +11574,17 @@
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "iNX" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 6
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 1442;
 	input_tag = "port_prop_in";
 	output_tag = "port_prop_out";
 	sensors = list("port_prop_sensor"="Port Propulsion Sensor")
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "iOn" = (
 /obj/structure/cable/green{
@@ -11581,23 +11655,28 @@
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "iQM" = (
-/obj/structure/sign/nosmoking_1{
-	pixel_y = 32
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
+/obj/machinery/firealarm/north,
 /obj/machinery/meter,
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "iQR" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 5
 	},
-/turf/space/dynamic,
-/area/horizon/exterior)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos/propulsion/starboard)
 "iRq" = (
 /obj/effect/floor_decal/corner_wide/purple/full,
 /obj/effect/floor_decal/corner_wide/purple{
@@ -11652,6 +11731,9 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/isolation_c)
 "iTW" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
@@ -11788,16 +11870,17 @@
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "jaP" = (
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 10
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 1442;
 	input_tag = "starboard_prop_in";
 	output_tag = "starboard_prop_out";
 	sensors = list("starboard_prop_sensor"="Starboard Propulsion Sensor")
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion/starboard)
 "jbm" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -12080,7 +12163,8 @@
 	frequency = 1441;
 	id = "ph_in";
 	name = "phoron injector";
-	use_power = 1
+	use_power = 1;
+	dir = 8
 	},
 /turf/simulated/floor/reinforced/phoron,
 /area/engineering/atmos)
@@ -12173,14 +12257,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
 "jsq" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
@@ -12197,17 +12281,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/deck1)
 "jtI" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4;
+	layer = 2.8
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner_wide/black/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "jue" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "juI" = (
@@ -12278,6 +12367,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
 "jvF" = (
@@ -12423,11 +12513,10 @@
 /turf/simulated/floor/tiled,
 /area/hangar/operations)
 "jyY" = (
-/obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/structure/lattice/catwalk/indoor,
 /turf/space,
 /area/horizon/exterior)
 "jzw" = (
@@ -12437,7 +12526,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 1
 	},
@@ -12827,11 +12915,11 @@
 /turf/simulated/wall/r_wall,
 /area/rnd/isolation_c)
 "jQh" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "jQQ" = (
@@ -12894,15 +12982,20 @@
 /turf/space/dynamic,
 /area/engineering/atmos/propulsion)
 "jSF" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	pixel_y = 28
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /obj/machinery/meter,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "jTl" = (
 /obj/effect/floor_decal/corner/lime{
@@ -12953,12 +13046,6 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/binary/pump{
@@ -13257,8 +13344,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
 "kka" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
 	},
 /turf/space,
 /area/horizon/exterior)
@@ -13403,14 +13490,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/deck1)
 "koH" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/machinery/alarm{
+	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	pixel_y = 28
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
@@ -13614,6 +13704,9 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/custodial/disposals)
 "kxl" = (
@@ -13745,11 +13838,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/cockpit)
-"kBt" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/lattice,
-/turf/space/dynamic,
-/area/horizon/exterior)
 "kBF" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -13795,12 +13883,17 @@
 /turf/simulated/floor/tiled/ramp,
 /area/maintenance/engineering)
 "kCG" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 6
 	},
-/obj/structure/lattice,
-/turf/space/dynamic,
-/area/horizon/exterior)
+/obj/effect/floor_decal/corner_wide/black/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos/propulsion/starboard)
 "kDf" = (
 /obj/structure/railing/mapped,
 /obj/effect/decal/cleanable/dirt,
@@ -13855,9 +13948,6 @@
 	tag_east = 3;
 	tag_north = 1;
 	tag_south = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
 	},
 /obj/effect/floor_decal/corner/yellow,
 /obj/effect/floor_decal/corner/blue{
@@ -14245,8 +14335,8 @@
 /area/storage/eva)
 "kSb" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
 	},
 /turf/space/dynamic,
 /area/horizon/exterior)
@@ -14275,8 +14365,8 @@
 /obj/structure/tank_wall/hydrogen{
 	icon_state = "h16"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
 "kTC" = (
@@ -14804,10 +14894,18 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/test_range)
 "lrd" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 9
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
 	},
-/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner_wide/black/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "lrg" = (
@@ -14828,6 +14926,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
 "lsd" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
@@ -15027,16 +15128,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/deck1)
 "lEw" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "Propulsion";
-	req_one_access = list(11,24)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion/starboard)
+/area/engineering/atmos)
 "lEN" = (
 /obj/structure/stairs/east,
 /turf/simulated/floor/tiled/dark,
@@ -15054,11 +15153,14 @@
 /turf/simulated/floor/plating,
 /area/shuttle/mining)
 "lFS" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/table/steel,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion/starboard)
 "lFU" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -15140,9 +15242,14 @@
 /area/shuttle/escape_pod/pod2)
 "lJB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner_wide/black/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "lJK" = (
@@ -15187,9 +15294,11 @@
 /turf/simulated/floor/shuttle/dark_blue,
 /area/shuttle/escape_pod/pod4)
 "lMv" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/floor_decal/corner_wide/black/full{
 	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -15270,12 +15379,10 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/storage/eva)
 "lOi" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
+	dir = 6
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "lOn" = (
@@ -15346,16 +15453,21 @@
 	layer = 10.1;
 	opacity = 0
 	},
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	dir = 1;
+	frequency = 1441;
+	id_tag = "H2_out_starboardthruster"
+	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/engineering/atmos)
 "lPW" = (
 /turf/simulated/wall,
 /area/hangar/auxiliary)
 "lQF" = (
-/obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 9
+	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/horizon/exterior)
 "lQI" = (
@@ -15391,7 +15503,9 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/custodial/disposals)
 "lRu" = (
@@ -15402,6 +15516,12 @@
 "lRH" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
@@ -15432,10 +15552,10 @@
 /turf/simulated/floor/tiled,
 /area/hangar/operations)
 "lSx" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
+/obj/structure/lattice,
 /turf/space/dynamic,
 /area/horizon/exterior)
 "lSy" = (
@@ -15532,9 +15652,6 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
 "lVN" = (
@@ -15621,11 +15738,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
 "lYV" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
 	},
-/obj/structure/sign/nosmoking_1{
-	pixel_x = -32
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
@@ -15669,10 +15786,14 @@
 /turf/simulated/floor/tiled,
 /area/operations/loading)
 "mbI" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/table/steel,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion/starboard)
 "mdH" = (
 /obj/structure/cable{
@@ -15808,20 +15929,17 @@
 	name = "wooden plaque";
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
 "mil" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 9
 	},
-/obj/structure/sign/nosmoking_1{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion)
+/turf/simulated/wall/shuttle/scc_space_ship/cardinal,
+/area/engineering/atmos/air)
 "mio" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 6
@@ -15882,9 +16000,6 @@
 	name = "Engineering Maintenance";
 	req_access = list(10)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/full,
 /area/hallway/engineering)
 "mlL" = (
@@ -15900,6 +16015,9 @@
 /obj/structure/closet/walllocker/emerglocker/south,
 /obj/effect/floor_decal/corner/purple/full{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
@@ -16017,10 +16135,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/port)
 "mqI" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 9
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "msd" = (
@@ -16286,8 +16406,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "mDH" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "mDT" = (
 /obj/structure/railing/mapped{
@@ -16356,9 +16485,6 @@
 /area/engineering/atmos/propulsion)
 "mJk" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "mJn" = (
@@ -16396,12 +16522,15 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/structure/sign/fire{
 	name = "\improper DANGER: COMBUSTION CHAMBER sign";
 	pixel_x = 32
+	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -16754,11 +16883,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "mUj" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 8
+	},
+/obj/machinery/meter,
+/obj/effect/floor_decal/corner_wide/black{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "mUk" = (
 /turf/simulated/wall/shuttle/scc,
@@ -16892,11 +17027,11 @@
 /turf/simulated/floor/plating,
 /area/rnd/xenoarch_atrium)
 "mYb" = (
-/obj/machinery/atmospherics/binary/passive_gate{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion/starboard)
+/turf/space/dynamic,
+/area/horizon/exterior)
 "mYX" = (
 /obj/machinery/camera/network/first_deck{
 	c_tag = "First Deck - EVA Storage 1";
@@ -17265,7 +17400,8 @@
 "nnh" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	frequency = 1441;
-	id_tag = "h_out"
+	id_tag = "h_out";
+	dir = 4
 	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/engineering/atmos)
@@ -17345,15 +17481,20 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
 "nrY" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 6
-	},
 /obj/machinery/button/ignition{
 	id = "port_prop_igni";
 	pixel_y = 26
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/black/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "nsg" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -17386,10 +17527,11 @@
 /turf/simulated/floor/reinforced/n20,
 /area/engineering/atmos/air)
 "nto" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 10
-	},
 /obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
 /turf/space/dynamic,
 /area/horizon/exterior)
 "ntJ" = (
@@ -18003,12 +18145,12 @@
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/engineering/atmos)
 "nSi" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/shuttle/scc_space_ship,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/window/shuttle/scc_space_ship,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "nSt" = (
@@ -18490,18 +18632,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/deck1)
 "onN" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/industrial/warning,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "onU" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/black,
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
 	},
 /turf/space/dynamic,
@@ -18699,6 +18840,9 @@
 	},
 /obj/structure/table/steel,
 /obj/item/toy/figure/janitor,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
 "oxX" = (
@@ -18725,6 +18869,7 @@
 /obj/effect/floor_decal/corner/purple{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
 "ozA" = (
@@ -18743,9 +18888,6 @@
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/rnd/test_range)
 "ozF" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 5
-	},
 /turf/space,
 /area/space)
 "oAi" = (
@@ -19084,9 +19226,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "oTX" = (
@@ -19107,18 +19246,24 @@
 /turf/simulated/wall/r_wall,
 /area/rnd/test_range)
 "oWe" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
 /obj/machinery/firealarm/north,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "oWg" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -19159,10 +19304,14 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
@@ -19174,7 +19323,9 @@
 /area/storage/eva)
 "oYG" = (
 /obj/effect/floor_decal/corner/purple,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
 "oYP" = (
@@ -19323,6 +19474,9 @@
 	pixel_y = -32
 	},
 /obj/machinery/firealarm/west,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
 "pes" = (
@@ -19684,10 +19838,14 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/intrepid/cargo_bay)
 "psr" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 5
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Starboard Propulsion";
+	dir = 1
 	},
-/obj/machinery/meter,
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "psB" = (
@@ -19726,11 +19884,11 @@
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/cargo_bay)
 "pvO" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion)
+/turf/simulated/wall/shuttle/scc_space_ship/cardinal,
+/area/engineering/atmos)
 "pwd" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -19803,9 +19961,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "pyd" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Port Propulsion";
+	dir = 1
 	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "pyh" = (
@@ -19869,13 +20032,10 @@
 /turf/simulated/wall,
 /area/maintenance/substation/hangar)
 "pzY" = (
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Starboard Propulsion";
-	dir = 1
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 10
 	},
-/obj/machinery/atmospherics/binary/passive_gate/on/output/max{
-	dir = 8
-	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "pAp" = (
@@ -20149,6 +20309,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/custodial/disposals)
 "pLU" = (
@@ -20219,6 +20382,9 @@
 	secured_wires = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/custodial/disposals)
 "pNv" = (
@@ -20304,13 +20470,18 @@
 /turf/space/dynamic,
 /area/template_noop)
 "pSk" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/machinery/computer/general_air_control/large_tank_control{
 	input_tag = null;
-	name = "Phoron Supply Monitor";
-	output_tag = "ph_out_portthruster";
-	sensors = list("ph_sensor"="Tank")
+	name = "Hydrogen Supply Monitor";
+	output_tag = "H2_out_portthruster";
+	sensors = list("h_sensor"="Tank")
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "pSx" = (
 /obj/structure/table/standard,
@@ -20359,11 +20530,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/cargo_bay)
 "pTF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
-/area/horizon/custodial/disposals)
+/obj/structure/lattice/catwalk/indoor,
+/turf/space/dynamic,
+/area/horizon/exterior)
 "pTP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -20503,9 +20675,6 @@
 /area/hangar/auxiliary)
 "pZd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -20651,6 +20820,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
 "qdE" = (
@@ -20757,10 +20929,15 @@
 /turf/space/dynamic,
 /area/horizon/exterior)
 "qhz" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
-/obj/machinery/meter,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion/starboard)
+/area/engineering/atmos/propulsion)
 "qhG" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -20926,6 +21103,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
+/obj/machinery/sparker{
+	id = "port_prop_igni";
+	pixel_x = -15
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion)
 "qnt" = (
@@ -21044,14 +21225,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
 "qrh" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -28;
-	req_one_access = list(24,11,55)
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 8
 	},
-/obj/structure/foamedmetal,
-/turf/simulated/floor/plating,
-/area/engineering/atmos/propulsion/starboard)
+/turf/simulated/wall/shuttle/scc_space_ship/cardinal,
+/area/horizon/custodial/disposals)
 "qri" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 8
@@ -21066,11 +21244,11 @@
 /turf/simulated/floor/reinforced/nitrogen,
 /area/engineering/atmos/air)
 "qsn" = (
-/obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/horizon/exterior)
 "qsq" = (
@@ -21895,8 +22073,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
 "qZc" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible/purple{
+	dir = 8
 	},
 /turf/space/dynamic,
 /area/horizon/exterior)
@@ -22574,12 +22752,11 @@
 /turf/simulated/floor/tiled,
 /area/medical/emergency_storage)
 "rzT" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 8;
-	layer = 2.8
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion/starboard)
+/turf/space/dynamic,
+/area/horizon/exterior)
 "rAa" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -22676,20 +22853,22 @@
 /turf/template_noop,
 /area/template_noop)
 "rDE" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "Propulsion";
-	req_one_access = list(11,24)
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/obj/machinery/meter,
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "rDP" = (
-/obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/horizon/exterior)
 "rEl" = (
@@ -22850,9 +23029,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "rNH" = (
@@ -23049,14 +23225,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
@@ -23263,17 +23436,6 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/white,
 /area/rnd/test_range)
-"scL" = (
-/obj/machinery/atmospherics/omni/mixer{
-	active_power_usage = 7500;
-	tag_north = 1;
-	tag_north_con = 0.8;
-	tag_south = 1;
-	tag_south_con = 0.2;
-	tag_west = 2
-	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion/starboard)
 "scW" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /turf/simulated/floor/tiled/dark/full,
@@ -23316,8 +23478,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/crew_compartment)
 "seU" = (
-/obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/horizon/exterior)
 "sfh" = (
@@ -23400,12 +23565,17 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenoarch_atrium)
 "siF" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/tank_wall/hydrogen{
 	density = 0;
 	icon_state = "h12";
 	layer = 10.1;
 	opacity = 0
+	},
+/obj/machinery/atmospherics/unary/outlet_injector{
+	frequency = 1441;
+	id = "h_in";
+	name = "hydrogen injector";
+	use_power = 1
 	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/engineering/atmos)
@@ -23442,7 +23612,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/yellow,
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -23585,11 +23754,11 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/test_range)
 "srw" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/visible/purple{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion/starboard)
+/turf/space/dynamic,
+/area/horizon/exterior)
 "srC" = (
 /obj/machinery/conveyor{
 	id = "cargo_1"
@@ -23758,20 +23927,26 @@
 /turf/simulated/floor/tiled/white,
 /area/storage/eva)
 "swv" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 9
 	},
-/obj/machinery/atmospherics/binary/passive_gate/on/output/max{
-	dir = 4
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 10
 	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "swD" = (
-/obj/structure/table/steel,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/computer/general_air_control/large_tank_control{
+	input_tag = null;
+	name = "Phoron Supply Monitor";
+	output_tag = "ph_out_portthruster";
+	sensors = list("ph_sensor"="Tank")
+	},
+/turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "sxc" = (
 /obj/structure/railing/mapped{
@@ -24141,6 +24316,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/custodial/disposals)
 "sNH" = (
@@ -24212,9 +24390,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "sQT" = (
@@ -24238,13 +24413,11 @@
 	},
 /area/medical/morgue/lower)
 "sRM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 9
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "sRX" = (
@@ -24668,6 +24841,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/custodial/disposals)
 "thU" = (
@@ -24756,8 +24933,13 @@
 /turf/simulated/wall/shuttle/scc/cardinal,
 /area/shuttle/mining)
 "tkS" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/black,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 6
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -24886,6 +25068,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/custodial/disposals)
 "tri" = (
@@ -24897,13 +25082,6 @@
 	},
 /turf/simulated/floor/reinforced/nitrogen,
 /area/engineering/atmos/air)
-"trT" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion)
 "trW" = (
 /obj/machinery/light/spot/weak{
 	dir = 1
@@ -25016,20 +25194,27 @@
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
 "twQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -25217,9 +25402,6 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "tFd" = (
@@ -25289,6 +25471,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
 "tHg" = (
@@ -25618,12 +25803,14 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9
+	dir = 5
 	},
+/obj/machinery/meter,
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "tSX" = (
@@ -25656,9 +25843,6 @@
 /area/hangar/intrepid)
 "tTl" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "tTT" = (
@@ -25789,7 +25973,10 @@
 	layer = 10.1;
 	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	frequency = 1441;
+	id_tag = "ph_out_starboardthruster"
+	},
 /turf/simulated/floor/reinforced/phoron,
 /area/engineering/atmos)
 "tYB" = (
@@ -26174,10 +26361,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/eva)
 "uni" = (
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Port Propulsion";
-	dir = 1
+/obj/machinery/light,
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 10
 	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "unm" = (
@@ -26499,19 +26687,18 @@
 	},
 /area/horizon/custodial/disposals)
 "uzj" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/structure/lattice/catwalk/indoor,
 /turf/space,
 /area/horizon/exterior)
 "uzB" = (
 /turf/simulated/floor/plating,
 /area/operations/loading)
 "uzC" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 10
 	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "uzZ" = (
@@ -26605,12 +26792,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research_sublevel)
 "uCr" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/obj/machinery/meter,
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 5
 	},
-/turf/space/dynamic,
-/area/horizon/exterior)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos/propulsion/starboard)
 "uCw" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -26750,10 +26941,8 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenoarch_atrium)
 "uIN" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/purple,
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion/starboard)
 "uJE" = (
@@ -26867,6 +27056,10 @@
 "uPX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
+	},
+/obj/machinery/sparker{
+	id = "starboard_prop_igni";
+	pixel_x = 19
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion/starboard)
@@ -26997,6 +27190,9 @@
 	dir = 5
 	},
 /obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 10
+	},
 /turf/space/dynamic,
 /area/horizon/exterior)
 "uVF" = (
@@ -27168,9 +27364,6 @@
 	},
 /obj/structure/tank_wall/phoron{
 	icon_state = "ph4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
@@ -27447,6 +27640,12 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "vnJ" = (
@@ -27460,9 +27659,7 @@
 /turf/simulated/floor/tiled/full,
 /area/maintenance/research_port)
 "vnK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/space/dynamic,
 /area/horizon/exterior)
 "voa" = (
@@ -27599,8 +27796,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
@@ -27712,11 +27909,6 @@
 	layer = 10.1;
 	opacity = 0
 	},
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
-	dir = 8;
-	frequency = 1441;
-	id_tag = "ph_out_starboardthruster"
-	},
 /turf/simulated/floor/reinforced/phoron,
 /area/engineering/atmos)
 "vuG" = (
@@ -27775,7 +27967,6 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenoarch_atrium)
 "vBr" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/tank_wall/hydrogen{
 	density = 0;
 	icon_state = "h11";
@@ -28111,25 +28302,18 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
-"vPf" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	layer = 2.8
+"vPo" = (
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/black{
+/obj/effect/floor_decal/corner_wide/black{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion/starboard)
-"vPo" = (
-/obj/machinery/atmospherics/tvalve/mirrored/digital/bypass{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
-/obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "vPu" = (
@@ -28158,12 +28342,8 @@
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "vRX" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 10
-	},
+/obj/structure/lattice,
+/obj/machinery/atmospherics/valve/open,
 /turf/space,
 /area/horizon/exterior)
 "vSF" = (
@@ -28288,7 +28468,9 @@
 /obj/structure/tank_wall/phoron{
 	icon_state = "ph14"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 9
+	},
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
 "vWL" = (
@@ -28296,6 +28478,9 @@
 	icon_state = "h9"
 	},
 /obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
 /turf/simulated/floor/airless,
@@ -28491,9 +28676,12 @@
 /turf/simulated/floor/tiled,
 /area/hangar/auxiliary)
 "wfg" = (
-/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/corner_wide/black/full,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion)
+/area/engineering/atmos/propulsion/starboard)
 "wfo" = (
 /obj/effect/floor_decal/corner_wide/purple{
 	dir = 8
@@ -28744,19 +28932,18 @@
 /turf/simulated/floor/tiled,
 /area/operations/loading)
 "wlT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/computer/general_air_control/large_tank_control{
-	input_tag = null;
-	name = "Phoron Supply Monitor";
-	output_tag = "ph_out_starboardthruster";
-	sensors = list("ph_sensor"="Tank")
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/computer/general_air_control/large_tank_control{
+	input_tag = null;
+	name = "Hydrogen Supply Monitor";
+	output_tag = "H2_out_starboardthruster";
+	sensors = list("h_sensor"="Tank")
+	},
+/turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion/starboard)
 "wmD" = (
 /obj/structure/railing/mapped,
@@ -28878,16 +29065,12 @@
 /turf/simulated/floor/tiled,
 /area/hangar/operations)
 "wpM" = (
-/obj/machinery/atmospherics/omni/mixer{
-	active_power_usage = 7500;
-	tag_east = 2;
-	tag_north = 1;
-	tag_north_con = 0.8;
-	tag_south = 1;
-	tag_south_con = 0.2
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion)
+/obj/structure/lattice/catwalk/indoor,
+/turf/space/dynamic,
+/area/horizon/exterior)
 "wpT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/stool/chair/padded/black{
@@ -29023,25 +29206,34 @@
 	},
 /area/rnd/xenoarch_atrium)
 "wub" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10
 	},
 /turf/space/dynamic,
 /area/horizon/exterior)
 "wup" = (
-/obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/horizon/exterior)
 "wuD" = (
 /turf/simulated/wall,
 /area/hangar/intrepid)
 "wuW" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/manifold/visible/purple,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8;
+	layer = 2.8
+	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "wvx" = (
 /turf/simulated/floor/reinforced,
@@ -29134,10 +29326,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
-"wAg" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black,
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion/starboard)
 "wAk" = (
 /obj/machinery/door/window/westright{
 	name = "Xenoarchaeology Platform Access";
@@ -29257,8 +29445,11 @@
 /turf/simulated/floor/bluegrid,
 /area/rnd/xenoarch_atrium)
 "wIO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
@@ -29395,9 +29586,15 @@
 	},
 /area/medical/morgue/lower)
 "wOZ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/machinery/atmospherics/omni/mixer{
+	active_power_usage = 7500;
+	tag_east = 2;
+	tag_north = 1;
+	tag_north_con = 0.8;
+	tag_south = 1;
+	tag_south_con = 0.2
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "wPo" = (
@@ -29486,11 +29683,11 @@
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/engineering/atmos)
 "wSC" = (
-/obj/machinery/atmospherics/binary/passive_gate{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion/starboard)
+/turf/space,
+/area/horizon/exterior)
 "wSS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/plasticflaps/airtight,
@@ -29516,10 +29713,10 @@
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/xenoarch_atrium)
 "wUo" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 6
+	dir = 9
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/horizon/exterior)
 "wUz" = (
@@ -29599,13 +29796,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
 "wWe" = (
-/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/bed/stool/chair/office/dark{
 	dir = 1
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
@@ -30191,13 +30388,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "xnS" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/table/steel,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "xof" = (
@@ -30214,22 +30412,34 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "xoH" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 10
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner_wide/black/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "xoI" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/black,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8;
+	layer = 2.8
+	},
+/obj/effect/floor_decal/corner_wide/black/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "xoY" = (
@@ -30247,11 +30457,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "xpS" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "xpT" = (
@@ -30411,9 +30621,6 @@
 /turf/simulated/wall/r_wall,
 /area/rnd/xenoarch_atrium)
 "xtY" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 10
-	},
 /obj/machinery/button/remote/blast_door{
 	id = "portpropulsionexterior";
 	name = "Exterior Blast Door";
@@ -30426,9 +30633,6 @@
 	pixel_x = 25;
 	pixel_y = 8
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
 /obj/machinery/button/remote/airlock{
 	id = "port_combustion";
 	name = "Door Bolt Control";
@@ -30436,6 +30640,15 @@
 	pixel_y = 8;
 	req_access = list(10);
 	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -30598,12 +30811,15 @@
 /turf/simulated/wall/shuttle/scc/cardinal,
 /area/shuttle/escape_pod/pod3)
 "xEb" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/machinery/atmospherics/omni/mixer{
+	active_power_usage = 7500;
+	tag_north = 1;
+	tag_north_con = 0.8;
+	tag_south = 1;
+	tag_south_con = 0.2;
+	tag_west = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
-	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "xEd" = (
@@ -30715,20 +30931,15 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "xHW" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	frequency = 1441;
-	id = "h_in";
-	name = "hydrogen injector";
-	use_power = 1
+/obj/structure/lattice,
+/obj/machinery/atmospherics/valve{
+	dir = 4
 	},
-/turf/simulated/floor/reinforced/hydrogen,
-/area/engineering/atmos)
+/turf/space/dynamic,
+/area/horizon/exterior)
 "xHX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -30850,9 +31061,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "xMk" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 10
-	},
 /turf/space,
 /area/horizon/exterior)
 "xMm" = (
@@ -30868,10 +31076,13 @@
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "xMr" = (
-/obj/machinery/atmospherics/binary/passive_gate{
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor,
+/obj/structure/window/shuttle/scc_space_ship,
+/obj/structure/grille,
+/turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "xMv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -31122,9 +31333,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "xVk" = (
@@ -31288,9 +31496,6 @@
 /turf/simulated/floor/tiled,
 /area/operations/loading)
 "ybl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
 "ybm" = (
@@ -45342,9 +45547,9 @@ xWM
 dGu
 hqH
 awJ
-awJ
-eSV
-awJ
+vyG
+vyG
+vyG
 awJ
 awJ
 tuP
@@ -45545,9 +45750,9 @@ awJ
 awJ
 jiL
 awJ
-awJ
-vyG
-awJ
+uZU
+iCX
+dCC
 awJ
 awJ
 tuP
@@ -45749,7 +45954,7 @@ jQh
 xGQ
 awJ
 uZU
-iCX
+gal
 dCC
 awJ
 awJ
@@ -45948,8 +46153,8 @@ rrD
 szM
 bxJ
 fBs
-mqI
-eBf
+iQR
+mxq
 awJ
 uZU
 eDE
@@ -46151,8 +46356,8 @@ mNU
 szM
 szM
 xQU
-dgC
-ekt
+lYV
+sfF
 awJ
 uZU
 gal
@@ -46354,8 +46559,8 @@ mNU
 tsn
 tsn
 awJ
+beu
 awJ
-lEw
 awJ
 awJ
 uob
@@ -46558,12 +46763,12 @@ fQE
 awJ
 awJ
 dBG
-ekt
 awJ
+kCG
 bwJ
 cWX
 gAK
-sfF
+wfg
 awJ
 jZo
 uwB
@@ -46761,12 +46966,12 @@ szM
 xQU
 nFs
 iTW
-apQ
 awJ
-wSC
+gVu
 wsO
-ekt
 sfF
+ekt
+dNa
 awJ
 ldW
 nAT
@@ -46963,13 +47168,13 @@ szM
 bxJ
 fBs
 tJq
-wAg
 hXq
 mDx
-qhz
+uCr
 ntJ
-kzC
-mxq
+sfF
+ekt
+pzY
 awJ
 jLn
 crh
@@ -47167,12 +47372,12 @@ szM
 xQU
 vUo
 lsd
-apQ
 awJ
-mYb
-srw
-xoI
+akw
 sfF
+sfF
+ekt
+dNa
 awJ
 jLn
 crh
@@ -47370,11 +47575,11 @@ tsn
 awJ
 awJ
 jsq
-ekt
 awJ
+lrd
 vPo
-vPf
-scL
+sfF
+ekt
 psr
 awJ
 hcD
@@ -47572,12 +47777,12 @@ mNU
 fQE
 fQE
 awJ
+beu
 awJ
-lEw
 awJ
 koH
-rzT
 sfF
+kzC
 pzY
 awJ
 pBJ
@@ -47776,7 +47981,7 @@ szM
 szM
 xQU
 lYV
-ekt
+sfF
 awJ
 iQM
 lOi
@@ -47979,7 +48184,7 @@ szM
 bxJ
 fBs
 mqI
-lrd
+mxq
 awJ
 dwr
 wuW
@@ -48186,8 +48391,8 @@ sfF
 awJ
 jaP
 uIN
-mUj
-fTm
+xoI
+fRj
 awJ
 wYp
 dei
@@ -48588,7 +48793,7 @@ eSV
 awJ
 awJ
 eyU
-qrh
+eyU
 awJ
 iei
 cwa
@@ -48794,9 +48999,9 @@ awJ
 awJ
 nEm
 nEm
-nEm
+qrh
+aix
 sXg
-nEm
 nEm
 aJB
 jsV
@@ -49409,7 +49614,7 @@ ezt
 mmh
 aJB
 fTJ
-fRj
+crh
 bfX
 gWv
 gWv
@@ -49807,7 +50012,7 @@ eSV
 nYA
 pQv
 ybl
-pTF
+ybl
 tGU
 gVx
 trc
@@ -50216,9 +50421,9 @@ gJK
 oma
 oma
 nEm
+qrh
 nEm
-nEm
-nEm
+sXg
 nEm
 bQj
 hcC
@@ -50413,15 +50618,15 @@ eSV
 eSV
 oam
 cpF
-uzj
+wSC
 etT
 onU
 qEq
 oap
 oap
 uVD
-beu
-qgu
+xfS
+aZd
 fxC
 jue
 cvZ
@@ -50616,7 +50821,7 @@ eSV
 eSV
 sPo
 pYB
-oNp
+kSb
 oDB
 bID
 fOC
@@ -50819,21 +51024,21 @@ eSV
 eSV
 sPo
 wEY
-aZd
+mYb
 jvE
 lPP
-xHW
+dBA
 vBr
 dDM
-kBt
-cnx
-kCG
+pYB
+lQF
+oNp
 hWb
 jCK
 jCK
 jCK
 sNH
-mRc
+fkH
 hpU
 dMa
 qew
@@ -51022,15 +51227,15 @@ eSV
 eSV
 iSu
 wEY
-aZd
+gnP
 twq
 dBA
 pMX
 dBA
 ipg
 wEY
-wup
-ckd
+lQF
+aZd
 hWb
 flw
 cpt
@@ -51225,13 +51430,13 @@ eSV
 eSV
 sPo
 wEY
-aZd
+mYb
 foN
 htn
 nnh
 siF
 kSH
-kCG
+etT
 wup
 nto
 dzi
@@ -51427,16 +51632,16 @@ eSV
 eSV
 eSV
 sPo
-cHK
-iQR
+pYB
+kSb
 oDB
 nAX
 vWL
 mnL
 oDB
-ckd
-wup
-wEY
+clT
+lQF
+aZd
 gaC
 lqh
 rNy
@@ -51444,7 +51649,7 @@ dVG
 hqV
 fkH
 xol
-aix
+mzL
 ehH
 oDB
 wXF
@@ -51630,23 +51835,23 @@ eSV
 eSV
 eSV
 sPo
-aZd
+wEY
 kka
-eRb
-qgu
-qgu
-qgu
-eRb
+pYB
+wEY
+wub
+vnK
+etT
 vRX
 cnx
-kid
+nto
 dzi
 sta
 xlr
 xmJ
 tTl
 hfR
-lRH
+lEw
 lJi
 vTT
 fPF
@@ -51833,8 +52038,8 @@ eSV
 eSV
 eSV
 sPo
-oNp
-lSx
+pYB
+kSb
 oDB
 kna
 uAi
@@ -51842,7 +52047,7 @@ wVU
 oDB
 xMk
 lQF
-wEY
+aZd
 hWb
 aph
 sXy
@@ -52036,8 +52241,8 @@ eSV
 eSV
 eSV
 sPo
-aZd
-qZc
+wEY
+ckd
 xJv
 ebN
 sEE
@@ -52045,7 +52250,7 @@ wSr
 rmC
 eFn
 seU
-eFn
+cHK
 iog
 qjF
 nrq
@@ -52239,16 +52444,16 @@ eSV
 eSV
 eSV
 qNr
-aZd
-qZc
+xMk
+lSx
 tBT
 dKY
 nRZ
 dKY
 fFm
 wEY
-clT
-wEY
+lQF
+aZd
 gaC
 keQ
 mzL
@@ -52442,8 +52647,8 @@ eSV
 eSV
 eSV
 sPo
-aZd
-qZc
+wEY
+ckd
 wnz
 bGf
 enn
@@ -52451,7 +52656,7 @@ eKU
 ulJ
 kid
 seU
-eFn
+cHK
 iog
 qjF
 eKb
@@ -52645,16 +52850,16 @@ eSV
 eSV
 eSV
 sPo
-oNp
-lSx
+pYB
+kSb
 oDB
 eMK
 lzc
 iMg
 oDB
 tFM
-clT
-wEY
+lQF
+aZd
 hWb
 aph
 sXy
@@ -52848,16 +53053,16 @@ eSV
 eSV
 eSV
 sPo
-aZd
-xMk
-kid
-ozF
 wEY
-wEY
+kka
 pYB
-wUo
-akw
+ozF
+bbY
+qgu
 eRb
+eRb
+qsn
+dpF
 pFK
 jID
 ivW
@@ -53051,16 +53256,16 @@ eSV
 eSV
 eSV
 sPo
-uCr
+pYB
 kSb
 oDB
 vbv
 dEU
 bFw
-oDB
+dgC
 qZc
-clT
-wEY
+wUo
+aZd
 gaC
 bBR
 uPe
@@ -53255,16 +53460,16 @@ eSV
 eSV
 sPo
 wEY
-aZd
+ckd
 uKu
 vuB
 jpI
 tYp
 vVL
-dpF
+xHW
 clT
-wUo
-pFK
+oNp
+gya
 jID
 uYW
 msn
@@ -53458,16 +53663,16 @@ eSV
 eSV
 xbB
 wEY
-aZd
+lSx
 lJK
 ckB
 pTj
 aoR
 xki
-qgu
-xfS
-qZc
-hWb
+srw
+pTF
+aZd
+pvO
 jzL
 err
 sll
@@ -53661,7 +53866,7 @@ eSV
 eSV
 sPo
 wEY
-aZd
+ckd
 fQZ
 wdX
 ckB
@@ -53670,7 +53875,7 @@ gJa
 kid
 qsn
 dpF
-gCN
+mil
 riL
 aEs
 ppu
@@ -53864,15 +54069,15 @@ eSV
 eSV
 sPo
 pYB
-oNp
+kSb
 oDB
 ukl
 eeb
 iES
-oDB
+dgC
 uzj
 jyY
-vnK
+aZd
 gCN
 aYt
 pAp
@@ -54072,10 +54277,10 @@ etT
 boC
 boC
 boC
-boC
+wup
 fvy
-lQF
-wub
+wpM
+rzT
 akS
 kzi
 heH
@@ -54277,7 +54482,7 @@ uoG
 uVL
 aLK
 nSi
-uVL
+xMr
 uVL
 gCN
 ieu
@@ -54891,7 +55096,7 @@ fnL
 bxw
 bxo
 bvb
-hAU
+lIE
 coo
 lIE
 lIE
@@ -55083,8 +55288,8 @@ aAV
 fWs
 iFH
 jFb
-gwg
-lJB
+dZQ
+cuY
 uVL
 nrY
 bLu
@@ -55286,8 +55491,8 @@ wjY
 fWs
 fWs
 qxV
-mil
-fCd
+fvq
+hRF
 uVL
 jSF
 eKg
@@ -55489,12 +55694,12 @@ wjY
 dip
 dip
 uVL
+hAU
 uVL
-bbY
 uVL
 oWe
-fKe
 hRF
+wVE
 uzC
 uVL
 lUr
@@ -55692,12 +55897,12 @@ aqY
 aqY
 uVL
 uVL
-pvO
-fCd
+fvq
 uVL
+xoH
 fnB
-gnP
-wpM
+hRF
+fCd
 pyd
 uVL
 lUr
@@ -55895,12 +56100,12 @@ fWs
 fWs
 qxV
 rsP
-hRF
-trT
+apQ
 uVL
-xMr
-xoH
-dNa
+eET
+hRF
+hRF
+fCd
 uni
 uVL
 lUr
@@ -56098,13 +56303,13 @@ fWs
 iFH
 jFb
 wkj
-eET
 xMb
+cIU
 rDE
-gya
 mHe
-wVE
-cuY
+hRF
+fCd
+uzC
 uVL
 lUr
 riL
@@ -56301,13 +56506,13 @@ fWs
 fWs
 qxV
 fQk
-hRF
-trT
+qhz
 uVL
-gVu
+fKe
 uKh
+hRF
 fCd
-wfg
+uni
 uVL
 lUr
 lUr
@@ -56505,8 +56710,8 @@ dip
 uVL
 uVL
 gGE
-dZQ
 uVL
+lJB
 xtY
 tkS
 mKb
@@ -56707,8 +56912,8 @@ wjY
 aqY
 aqY
 uVL
+hAU
 uVL
-bbY
 uVL
 uVL
 aoh
@@ -56911,7 +57116,7 @@ fWs
 fWs
 qxV
 fvq
-fCd
+hRF
 uVL
 eBj
 wsF
@@ -57114,7 +57319,7 @@ fWs
 iFH
 jFb
 gwg
-cIU
+cuY
 uVL
 eBj
 lBi
@@ -57320,7 +57525,7 @@ bQb
 hRF
 uVL
 eBj
-moj
+wsF
 cne
 uVL
 uVL
@@ -57520,11 +57725,11 @@ dip
 dip
 uVL
 uVL
+hRF
 uVL
-uVL
-uVL
-dLn
-uVL
+eBj
+moj
+cne
 uVL
 uVL
 vil
@@ -57725,9 +57930,9 @@ uVL
 uVL
 uVL
 uVL
-uVL
-eSV
-uVL
+dLn
+dLn
+dLn
 uVL
 uVL
 oTX

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -29598,7 +29598,9 @@
 	tag_north = 1;
 	tag_north_con = 0.8;
 	tag_south = 1;
-	tag_south_con = 0.2
+	tag_south_con = 0.2;
+	tag_west = 1;
+	tag_west_con = 0.0
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
@@ -30402,6 +30404,7 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
 "xof" = (
@@ -30823,7 +30826,9 @@
 	tag_north_con = 0.8;
 	tag_south = 1;
 	tag_south_con = 0.2;
-	tag_west = 2
+	tag_west = 2;
+	tag_east = 1;
+	tag_east_con = 0.0
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -312,13 +312,15 @@
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
+/obj/machinery/computer/general_air_control/large_tank_control{
+	name = "Carbon Dioxide - Fuel Bay";
+	output_tag = "CO2_out_fuelbay";
+	sensors = list("co2_sensor"="Tank");
+	max_pressure_setting = 5000
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
 "apQ" = (
 /obj/machinery/light,
@@ -540,6 +542,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion/starboard)
+"aAe" = (
+/turf/simulated/wall/r_wall,
+/area/hangar/intrepid)
 "aAk" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/junk,
@@ -1201,6 +1206,12 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "aWx" = (
@@ -1788,6 +1799,24 @@
 	},
 /turf/simulated/floor/reinforced/airmix,
 /area/engineering/atmos/air)
+"buf" = (
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Fuel Access";
+	req_access = null;
+	req_one_access = list(26,29,31,48,67,24,47)
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/reinforced,
+/area/hangar/intrepid)
 "bup" = (
 /obj/machinery/door/firedoor/multi_tile,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -2074,14 +2103,9 @@
 	output_tag = "ph_out";
 	sensors = list("ph_sensor"="Tank")
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
 "bCi" = (
 /turf/simulated/wall,
@@ -2223,6 +2247,8 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/operations)
 "bFw" = (
@@ -2407,15 +2433,15 @@
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/horizon/stairwell/bridge)
 "bLu" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 4;
-	layer = 2.8
-	},
 /obj/effect/floor_decal/corner_wide/black{
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
+	},
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4;
+	layer = 2.8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -2997,6 +3023,12 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/simple/visible/aux{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
 /turf/space/dynamic,
 /area/horizon/exterior)
 "cnE" = (
@@ -3056,9 +3088,6 @@
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/crew_compartment)
 "cpt" = (
-/obj/machinery/requests_console{
-	pixel_x = -29
-	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 1
 	},
@@ -3220,6 +3249,12 @@
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
@@ -3728,6 +3763,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"cSo" = (
+/obj/machinery/atmospherics/binary/pump/fuel{
+	name = "Phoron Pump";
+	req_one_access = list(26,29,31,48,67,24,47);
+	max_pressure_setting = 5000
+	},
+/obj/effect/floor_decal/corner/black/full,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/light/spot/weak{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hangar/intrepid)
 "cSq" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3924,6 +3974,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "cZw" = (
@@ -3948,6 +4000,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
+"dau" = (
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 10
+	},
+/turf/space/dynamic,
+/area/horizon/exterior)
 "dbS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3977,6 +4035,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "ddL" = (
@@ -4458,6 +4518,12 @@
 	},
 /obj/effect/floor_decal/corner/yellow/diagonal,
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "dvT" = (
@@ -6358,6 +6424,7 @@
 "eRb" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/space/dynamic,
 /area/horizon/exterior)
 "eRF" = (
@@ -6540,6 +6607,12 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/full,
@@ -7223,6 +7296,10 @@
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/hallway/engineering)
 "fyb" = (
@@ -7456,6 +7533,7 @@
 /obj/structure/tank_wall/carbon_dioxide{
 	icon_state = "co2-15"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
 "fHn" = (
@@ -7837,6 +7915,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/random/junk,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/operations)
 "fUf" = (
@@ -7957,6 +8037,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/storage/eva)
+"fWf" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/simple/visible/aux{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/turf/space/dynamic,
+/area/horizon/exterior)
 "fWp" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -9510,6 +9604,12 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/full,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "hcD" = (
@@ -9643,6 +9743,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "hgA" = (
@@ -9700,6 +9806,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
+"hic" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/aux,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/turf/space/dynamic,
+/area/horizon/exterior)
 "hjt" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -10163,6 +10277,17 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/airless,
 /area/hangar/auxiliary)
+"hBd" = (
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 9
+	},
+/turf/space/dynamic,
+/area/horizon/exterior)
 "hBn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -10401,6 +10526,12 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/operations)
 "hNC" = (
@@ -10561,7 +10692,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/service{
 	name = "Disposals and Recycling";
-	req_one_access = list(26,67)
+	req_one_access = list(26,67,31,29)
 	},
 /turf/simulated/floor/tiled/full,
 /area/horizon/custodial/disposals)
@@ -10931,9 +11062,22 @@
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod/pod4)
 "ifX" = (
-/obj/structure/foamedmetal,
-/turf/simulated/floor/plating,
-/area/horizon/stairwell/central)
+/obj/machinery/atmospherics/portables_connector/aux{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/door/window/brigdoor/northright{
+	req_access = null;
+	req_one_access = list(26,29,31,48,67,24,47);
+	name = "Fuel Access"
+	},
+/obj/machinery/camera/network/first_deck{
+	c_tag = "First Deck - Hangar Fuel Bay";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/reinforced,
+/area/hangar/intrepid)
 "igj" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -11338,6 +11482,11 @@
 /obj/random/loot,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"iDB" = (
+/obj/structure/dispenser/phoron,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark/full,
+/area/storage/eva)
 "iDM" = (
 /obj/structure/plasticflaps/airtight,
 /obj/machinery/door/airlock/medical{
@@ -11413,6 +11562,20 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/engineering/atmos)
+"iGH" = (
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/simple/visible/aux{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/turf/space/dynamic,
+/area/horizon/exterior)
 "iGO" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -12287,21 +12450,27 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/deck1)
 "jtI" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 4;
-	layer = 2.8
-	},
 /obj/effect/floor_decal/corner_wide/black/full{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4;
+	layer = 2.8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "jue" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
@@ -13290,14 +13459,10 @@
 	output_tag = "co2_out";
 	sensors = list("co2_sensor"="Tank")
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
 "kfb" = (
 /obj/machinery/gravity_generator/main/station,
@@ -13886,6 +14051,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/ramp,
 /area/maintenance/engineering)
 "kCG" = (
@@ -14072,17 +14239,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
 "kGf" = (
-/obj/effect/decal/fake_object{
-	density = 1;
-	desc = "That looks like it doesn't open easily.";
-	icon = 'icons/obj/doors/rapid_pdoor.dmi';
-	icon_state = "shutter1";
-	name = "Residential Deck Stairwell Shutter";
-	opacity = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/horizon/stairwell/central)
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/turf/simulated/floor/tiled/dark/full,
+/area/hangar/intrepid)
 "kHg" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -14441,6 +14600,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "kVu" = (
@@ -14539,6 +14704,14 @@
 	dir = 4
 	},
 /area/hangar/auxiliary)
+"kZi" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/turf/space/dynamic,
+/area/horizon/exterior)
 "laL" = (
 /obj/effect/floor_decal/corner/blue/full,
 /obj/machinery/computer/shuttle_control/explore/intrepid{
@@ -14878,14 +15051,10 @@
 	output_tag = "h_out";
 	sensors = list("h_sensor"="Tank")
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
 "lqr" = (
 /obj/structure/table/reinforced,
@@ -14931,6 +15100,20 @@
 /obj/item/melee/baton/loaded,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
+"lrF" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hangar/intrepid)
 "lsd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
@@ -15237,6 +15420,14 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
+"lJl" = (
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	dir = 1;
+	frequency = 1441;
+	id_tag = "Ph_out_FuelBay"
+	},
+/turf/simulated/floor/reinforced/phoron,
+/area/engineering/atmos)
 "lJy" = (
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
@@ -15265,6 +15456,7 @@
 /obj/structure/tank_wall/phoron{
 	icon_state = "ph2"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
 "lKs" = (
@@ -15474,6 +15666,12 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/simple/visible/aux{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
 /turf/space/dynamic,
 /area/horizon/exterior)
 "lQI" = (
@@ -15637,6 +15835,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/storage/eva)
+"lUH" = (
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/turf/space/dynamic,
+/area/horizon/exterior)
 "lUT" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
 /turf/simulated/floor/tiled/dark,
@@ -16006,6 +16211,12 @@
 	name = "Engineering Maintenance";
 	req_access = list(10)
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/full,
 /area/hallway/engineering)
 "mlL" = (
@@ -16309,6 +16520,27 @@
 	},
 /turf/simulated/floor/reinforced/nitrogen,
 /area/engineering/atmos/air)
+"mxW" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Fuel Bay Maintenance";
+	req_one_access = list(26,29,31,48,67,24,47)
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hangar/intrepid)
 "mxX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17267,6 +17499,16 @@
 /obj/effect/shuttle_landmark/horizon/deckone/fore,
 /turf/template_noop,
 /area/template_noop)
+"nie" = (
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/turf/space/dynamic,
+/area/horizon/exterior)
 "nig" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -17429,6 +17671,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/deck1)
+"noH" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/turf/space,
+/area/horizon/exterior)
 "noZ" = (
 /obj/item/modular_computer/console/preset/civilian{
 	dir = 8;
@@ -17459,6 +17708,8 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/operations)
 "nqq" = (
@@ -18197,6 +18448,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "nTP" = (
@@ -18594,6 +18847,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/operations)
 "olu" = (
@@ -18894,8 +19149,9 @@
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/rnd/test_range)
 "ozF" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/space,
-/area/space)
+/area/horizon/exterior)
 "oAi" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/plating,
@@ -19597,6 +19853,8 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/operations)
 "piS" = (
@@ -19869,6 +20127,30 @@
 /obj/effect/floor_decal/corner/mauve/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/storage/eva)
+"ptI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hangar/intrepid)
 "pvn" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/floor_decal/industrial/warning,
@@ -20230,6 +20512,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "pIm" = (
@@ -20242,6 +20526,8 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/operations)
 "pIy" = (
@@ -20408,6 +20694,13 @@
 /obj/turbolift_map_holder/scc_ship/research,
 /turf/simulated/floor/plating,
 /area/turbolift/research/deck_1)
+"pOp" = (
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	frequency = 1441;
+	id_tag = "CO2_out_fuelbay"
+	},
+/turf/simulated/floor/reinforced/carbon_dioxide,
+/area/engineering/atmos)
 "pOO" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -20535,6 +20828,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/cargo_bay)
+"pTw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
+	},
+/obj/machinery/firealarm/north,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/hangar/intrepid)
 "pTF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 5
@@ -20932,6 +21241,7 @@
 /area/shuttle/escape_pod/pod3)
 "qgu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/space/dynamic,
 /area/horizon/exterior)
 "qhz" = (
@@ -21249,6 +21559,11 @@
 /obj/effect/decal/fake_object/light_source/invisible,
 /turf/simulated/floor/reinforced/nitrogen,
 /area/engineering/atmos/air)
+"qsg" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/turf/space/dynamic,
+/area/horizon/exterior)
 "qsn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
@@ -21314,6 +21629,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/ramp{
 	dir = 1
 	},
@@ -21329,6 +21646,12 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/operations)
 "qvT" = (
@@ -22612,6 +22935,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "rso" = (
@@ -22670,6 +22999,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "ruN" = (
@@ -22875,6 +23206,12 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/simple/visible/aux{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
 /turf/space/dynamic,
 /area/horizon/exterior)
 "rEl" = (
@@ -22951,6 +23288,24 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
+/area/maintenance/operations)
+"rJw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/full,
 /area/maintenance/operations)
 "rJZ" = (
 /obj/machinery/conveyor{
@@ -23489,6 +23844,9 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
 /turf/space/dynamic,
 /area/horizon/exterior)
 "sfh" = (
@@ -23763,6 +24121,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 4
 	},
+/obj/structure/lattice,
 /turf/space/dynamic,
 /area/horizon/exterior)
 "srC" = (
@@ -24076,6 +24435,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/deck1)
+"sCe" = (
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
+/turf/space/dynamic,
+/area/horizon/exterior)
 "sCB" = (
 /obj/effect/floor_decal/corner_wide/purple{
 	dir = 9
@@ -24191,6 +24556,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/hangar)
+"sIN" = (
+/obj/machinery/atmospherics/binary/pump/aux{
+	name = "Carbon Dioxide Pump";
+	req_one_access = list(26,29,31,48,67,24,47)
+	},
+/obj/effect/floor_decal/corner/black/full{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hangar/intrepid)
 "sIQ" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/hazmat/anomaly,
@@ -24395,6 +24773,12 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
@@ -25056,6 +25440,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "tqs" = (
@@ -25858,6 +26244,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "tUv" = (
@@ -27294,6 +27682,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage/tech)
+"uYi" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/nosmoking_1{
+	pixel_y = 32
+	},
+/obj/machinery/computer/general_air_control/large_tank_control{
+	input_tag = null;
+	name = "Phoron Supply - Fuel Bay";
+	output_tag = "Ph_out_FuelBay";
+	sensors = list("ph_sensor"="Tank");
+	max_pressure_setting = 1000
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/turf/simulated/floor/tiled/dark/full,
+/area/engineering/atmos)
 "uYW" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 4
@@ -27362,6 +27768,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/operations)
 "vbv" = (
@@ -27618,6 +28026,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/full,
@@ -28308,6 +28722,12 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "vPo" = (
@@ -28661,7 +29081,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck - Hangar 9";
+	c_tag = "First Deck - Hangar Fuel Bay";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/green{
@@ -29229,15 +29649,15 @@
 /turf/simulated/wall,
 /area/hangar/intrepid)
 "wuW" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 8;
-	layer = 2.8
-	},
 /obj/effect/floor_decal/corner_wide/black{
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8;
+	layer = 2.8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
@@ -29330,6 +29750,8 @@
 	req_one_access = list(12,26)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "wAk" = (
@@ -29384,6 +29806,24 @@
 "wEY" = (
 /turf/space/dynamic,
 /area/horizon/exterior)
+"wFw" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/full,
+/area/maintenance/engineering)
 "wGa" = (
 /obj/machinery/iff_beacon/horizon,
 /obj/structure/railing/mapped,
@@ -29553,14 +29993,18 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light/spot/weak{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/green{
 	dir = 9
+	},
+/obj/machinery/camera/network/first_deck{
+	c_tag = "First Deck - Hangar 7";
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
@@ -29767,12 +30211,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/firealarm/west,
-/obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck - Hangar 7";
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/green{
 	dir = 9
+	},
+/obj/machinery/light/spot/weak{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
@@ -30013,6 +30456,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hangar/auxiliary)
+"xdT" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hangar/intrepid)
 "xdV" = (
 /obj/effect/shuttle_landmark/escape_pod/start/pod3,
 /turf/simulated/floor/shuttle/dark_blue,
@@ -30059,6 +30516,12 @@
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/aux{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 6
 	},
 /turf/space/dynamic,
 /area/horizon/exterior)
@@ -30109,6 +30572,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
 "xhL" = (
@@ -30347,8 +30812,14 @@
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/xenoarch_atrium)
 "xmc" = (
-/turf/simulated/wall/r_wall,
-/area/horizon/stairwell/central)
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_mining{
+	name = "Fuel Bay";
+	req_one_access = list(26,29,31,48,67,24,47)
+	},
+/turf/simulated/floor/tiled,
+/area/hangar/intrepid)
 "xmg" = (
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos)
@@ -30439,15 +30910,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "xoI" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 8;
-	layer = 2.8
-	},
 /obj/effect/floor_decal/corner_wide/black/full{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
+	},
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8;
+	layer = 2.8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
@@ -30755,6 +31226,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/operations)
 "xAr" = (
@@ -30941,6 +31418,12 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/full,
 /area/maintenance/engineering)
@@ -31344,6 +31827,12 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
 "xVk" = (
@@ -31618,6 +32107,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/port)
+"yfH" = (
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/simple/visible/aux{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/turf/space/dynamic,
+/area/horizon/exterior)
 "yfK" = (
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 8
@@ -48846,7 +49348,7 @@ qUu
 oOk
 hMr
 nqp
-hII
+rJw
 aBw
 hII
 iNV
@@ -49048,11 +49550,11 @@ oOk
 oOk
 oOk
 qvl
-xmc
-xmc
-xmc
-xmc
-xmc
+aAe
+mxW
+aAe
+aAe
+aAe
 fKD
 tYN
 qju
@@ -49251,10 +49753,10 @@ fUb
 bFv
 okA
 xAf
-xmc
-ifX
-ifX
-ifX
+aAe
+ptI
+cSo
+buf
 kGf
 lOn
 okw
@@ -49454,9 +49956,9 @@ txk
 ney
 rIS
 uNH
-xmc
-ifX
-ifX
+aAe
+pTw
+sIN
 ifX
 kGf
 rau
@@ -49625,7 +50127,7 @@ ezt
 mmh
 aJB
 fTJ
-crh
+wFw
 bfX
 gWv
 gWv
@@ -49657,11 +50159,11 @@ wuD
 nyV
 wuD
 wuD
+aAe
+kGf
 xmc
-xmc
-xmc
-xmc
-xmc
+kGf
+aAe
 wKW
 mBx
 qju
@@ -49861,8 +50363,8 @@ ref
 xMm
 feW
 fga
-xFo
-xFo
+lrF
+xdT
 wMB
 wVd
 ikF
@@ -50637,7 +51139,7 @@ oap
 oap
 uVD
 xfS
-aZd
+hic
 fxC
 jue
 cvZ
@@ -51042,7 +51544,7 @@ dBA
 vBr
 dDM
 pYB
-lQF
+yfH
 oNp
 hWb
 jCK
@@ -51244,8 +51746,8 @@ dBA
 pMX
 dBA
 ipg
-wEY
-lQF
+pYB
+yfH
 aZd
 hWb
 flw
@@ -51448,7 +51950,7 @@ nnh
 siF
 kSH
 etT
-wup
+iGH
 nto
 dzi
 sta
@@ -51651,7 +52153,7 @@ vWL
 mnL
 oDB
 clT
-lQF
+yfH
 aZd
 gaC
 lqh
@@ -52057,7 +52559,7 @@ uAi
 wVU
 oDB
 xMk
-lQF
+yfH
 aZd
 hWb
 aph
@@ -52260,7 +52762,7 @@ sEE
 wSr
 rmC
 eFn
-seU
+fWf
 cHK
 iog
 qjF
@@ -52460,9 +52962,9 @@ lSx
 tBT
 dKY
 nRZ
-dKY
+pOp
 fFm
-wEY
+qEq
 lQF
 aZd
 gaC
@@ -52869,10 +53371,10 @@ lzc
 iMg
 oDB
 tFM
-lQF
+nie
 aZd
 hWb
-aph
+uYi
 sXy
 mzL
 pZd
@@ -53064,15 +53566,15 @@ eSV
 eSV
 eSV
 sPo
-wEY
-kka
-pYB
-ozF
 bbY
+noH
+qsg
+ozF
+lUH
 qgu
 eRb
 eRb
-qsn
+hBd
 dpF
 pFK
 jID
@@ -53267,7 +53769,7 @@ eSV
 eSV
 eSV
 sPo
-pYB
+xHW
 kSb
 oDB
 vbv
@@ -53470,7 +53972,7 @@ eSV
 eSV
 eSV
 sPo
-wEY
+sCe
 ckd
 uKu
 vuB
@@ -53673,10 +54175,10 @@ eSV
 eSV
 eSV
 xbB
-wEY
-lSx
+dau
+kZi
 lJK
-ckB
+lJl
 pTj
 aoR
 xki
@@ -55124,7 +55626,7 @@ geN
 ttK
 geN
 geN
-oYC
+iDB
 cZw
 cZw
 fDU

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -2513,6 +2513,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/storage/eva)
+"bOr" = (
+/obj/effect/floor_decal/corner/yellow,
+/obj/effect/floor_decal/corner/blue{
+	dir = 8
+	},
+/obj/structure/dispenser,
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos)
 "bOs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -52571,7 +52579,7 @@ pZd
 wIO
 lRH
 eNU
-vTT
+bOr
 oDB
 sWB
 slH

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -8552,6 +8552,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering)
+"gsr" = (
+/turf/template_noop,
+/area/engineering/atmos/propulsion/starboard)
 "gsG" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating/cooled,
@@ -11613,6 +11616,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
+"iPb" = (
+/turf/template_noop,
+/area/engineering/atmos/propulsion)
 "iPz" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -45547,9 +45553,9 @@ xWM
 dGu
 hqH
 awJ
-vyG
-vyG
-vyG
+gsr
+gsr
+gsr
 awJ
 awJ
 tuP
@@ -45750,9 +45756,9 @@ awJ
 awJ
 jiL
 awJ
-uZU
-iCX
-dCC
+vyG
+vyG
+vyG
 awJ
 awJ
 tuP
@@ -45954,7 +45960,7 @@ jQh
 xGQ
 awJ
 uZU
-gal
+iCX
 dCC
 awJ
 awJ
@@ -57525,7 +57531,7 @@ bQb
 hRF
 uVL
 eBj
-wsF
+moj
 cne
 uVL
 uVL
@@ -57727,9 +57733,9 @@ uVL
 uVL
 hRF
 uVL
-eBj
-moj
-cne
+dLn
+dLn
+dLn
 uVL
 uVL
 vil
@@ -57930,9 +57936,9 @@ uVL
 uVL
 uVL
 uVL
-dLn
-dLn
-dLn
+iPb
+iPb
+iPb
 uVL
 uVL
 oTX

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -16539,6 +16539,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "mxX" = (
@@ -30818,6 +30819,7 @@
 	name = "Fuel Bay";
 	req_one_access = list(26,29,31,48,67,24,47)
 	},
+/obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "xmg" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -40,18 +40,21 @@
 /turf/simulated/floor/carpet/red,
 /area/horizon/bar)
 "aau" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
+/obj/machinery/door/airlock/glass_atmos{
+	name = "Atmospherics Locker Room";
+	req_access = list(24)
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/effect/floor_decal/corner_wide/blue{
+	dir = 2
 	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 8
 	},
-/obj/machinery/suit_cycler/engineering,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
 /area/engineering/atmos/storage)
 "aax" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -132,14 +135,17 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
 "abR" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/corner_wide/blue{
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner_wide/yellow/full{
-	dir = 1
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4;
+	name = "Portable Scrubbers to Scrubbers Loop";
+	target_pressure = 15000
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -212,16 +218,9 @@
 /turf/simulated/floor/lino/grey,
 /area/horizon/bar)
 "aem" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/structure/closet/wardrobe/atmospherics_yellow,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/structure/closet/secure_closet/atmos_personal,
+/turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "aeC" = (
 /obj/machinery/door/airlock/glass_service{
@@ -432,8 +431,8 @@
 /area/hallway/primary/central_two)
 "amk" = (
 /obj/machinery/light,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/closet/firecloset,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/lobby)
 "amt" = (
@@ -448,11 +447,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_waste)
 "amE" = (
-/obj/effect/floor_decal/corner/yellow/diagonal,
-/obj/effect/floor_decal/industrial/outline/firefighting_closet,
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled,
-/area/hallway/engineering)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_atmos{
+	name = "Atmospherics Locker Room";
+	req_access = list(24)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/full,
+/area/engineering/atmos/storage)
 "amF" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -506,19 +513,6 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/maintenance/wing/starboard)
-"aor" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/machinery/disposal/small/south,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos/storage)
 "aov" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -562,25 +556,6 @@
 "aoD" = (
 /turf/simulated/wall,
 /area/rnd/xenobiology)
-"aoQ" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/engineering/atmos/storage)
 "apd" = (
 /obj/structure/cable{
 	icon_state = "11-2"
@@ -1201,27 +1176,18 @@
 /turf/simulated/floor/carpet,
 /area/horizon/bar/backroom)
 "ayY" = (
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/machinery/pipedispenser/disposal,
 /obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
 /obj/structure/cable/green{
-	icon_state = "0-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/machinery/pipedispenser,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Atmospherics Storage"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "azx" = (
 /obj/structure/railing/mapped,
@@ -1436,9 +1402,9 @@
 /turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_one)
 "aFm" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "aFy" = (
@@ -2660,14 +2626,10 @@
 /turf/simulated/floor/tiled,
 /area/engineering/lobby)
 "biI" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
 "biZ" = (
@@ -4449,34 +4411,25 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/ors)
 "bYT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/effect/floor_decal/corner_wide/blue{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
 "bYW" = (
-/obj/machinery/firealarm/west,
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
-	},
-/obj/machinery/pipedispenser/disposal,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/engineering/atmos/storage)
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/vending/zora,
+/turf/simulated/floor/tiled/dark/full,
+/area/engineering/lobby)
 "bYY" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -4518,7 +4471,6 @@
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -4534,6 +4486,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/void/atmos,
 /obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "bZz" = (
@@ -4644,20 +4597,12 @@
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "cdq" = (
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/structure/closet/wardrobe/atmospherics_yellow,
+/obj/structure/fireaxecabinet{
 	pixel_x = 32
 	},
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "cdv" = (
 /obj/effect/floor_decal/corner/mauve{
@@ -5413,13 +5358,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
-"cCy" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(24)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/full,
-/area/engineering/atmos/storage)
 "cDx" = (
 /obj/machinery/appliance/cooker/stove,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7271,17 +7209,6 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/turret_protected/ai_upload)
-"dAw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/full,
-/area/hallway/engineering/tesla)
 "dAy" = (
 /obj/effect/shuttle_landmark/horizon/decktwo/starboard_fore,
 /turf/template_noop,
@@ -7756,7 +7683,6 @@
 	dir = 4;
 	name = "\improper Secure Ammunition Storage Turret Control Console";
 	pixel_x = -26;
-	dir = 4;
 	req_access = null;
 	req_one_access = list(11,19,20,24,31,41)
 	},
@@ -8069,21 +7995,14 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/smes/tesla)
 "dVY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/yellow{
+/obj/effect/floor_decal/corner_wide/blue{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/spline/plain/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
 "dWk" = (
@@ -8445,8 +8364,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room)
 "ego" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/lobby)
 "egq" = (
@@ -10189,8 +10108,14 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "fbT" = (
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner_wide/blue{
+	dir = 2
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -11405,6 +11330,12 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
 "fGJ" = (
@@ -11975,25 +11906,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/reinforced/airless,
 /area/turret_protected/ai_upload)
-"fTZ" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner_wide/yellow,
-/obj/effect/floor_decal/corner_wide/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/hallway/engineering/tesla)
 "fUc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -13529,11 +13441,13 @@
 /area/rnd/xenobiology)
 "gzX" = (
 /obj/effect/floor_decal/corner_wide/yellow{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
-/area/hallway/engineering/tesla)
+/area/engineering/atmos/storage)
 "gAs" = (
 /obj/machinery/camera/network/reactor{
 	c_tag = "Engineering - Particle Generator Room";
@@ -13546,7 +13460,6 @@
 /turf/simulated/floor/carpet/rubber,
 /area/engineering/engine_monitoring/tesla)
 "gAt" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -13562,6 +13475,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/void/atmos,
 /obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "gAN" = (
@@ -16794,17 +16708,10 @@
 /turf/simulated/floor/lino/grey,
 /area/chapel/main)
 "idU" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/structure/dispenser,
+/obj/machinery/firealarm/south,
+/turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "idX" = (
 /obj/structure/grille,
@@ -17258,15 +17165,11 @@
 /turf/simulated/floor/carpet,
 /area/horizon/security/head_of_security)
 "inc" = (
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_wide/blue,
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 8
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -17583,12 +17486,12 @@
 /turf/simulated/wall/r_wall,
 /area/rnd/xenobiology)
 "iwr" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "iwu" = (
@@ -18007,18 +17910,6 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
-"iHQ" = (
-/obj/structure/closet/secure_closet/atmos_personal,
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/engineering/atmos/storage)
 "iIf" = (
 /obj/structure/sign/greencross,
 /obj/machinery/door/blast/shutters{
@@ -18146,8 +18037,6 @@
 	c_tag = "Engineering - Hallway 6";
 	dir = 8
 	},
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/engineering/tesla)
 "iKg" = (
@@ -18713,15 +18602,10 @@
 /turf/simulated/floor/tiled/full,
 /area/maintenance/wing/port)
 "iYn" = (
-/obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -19157,11 +19041,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/icu)
 "jkb" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "jkc" = (
@@ -19371,45 +19255,43 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
 "jnQ" = (
-/obj/effect/floor_decal/corner/yellow{
+/obj/effect/floor_decal/corner_wide/blue{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 8
 	},
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_y = 32
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Atmospherics Locker Room";
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/structure/table/standard,
-/obj/item/device/hand_labeler,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
 "jnV" = (
-/obj/machinery/door/airlock/glass_atmos{
-	name = "Atmospherics Locker Room";
-	req_access = list(24)
+/obj/effect/floor_decal/corner_wide/blue{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 6
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
 "joM" = (
 /obj/effect/landmark{
@@ -20124,16 +20006,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "Atmospherics";
-	sortType = "Atmospherics"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/full,
 /area/hallway/engineering/tesla)
@@ -21738,14 +21618,15 @@
 /turf/simulated/open,
 /area/horizon/stairwell/central)
 "kyV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+/obj/structure/table/standard,
+/obj/item/device/hand_labeler,
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC";
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "kyX" = (
 /obj/structure/railing/mapped,
@@ -22504,14 +22385,14 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "kUU" = (
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/obj/effect/floor_decal/corner_wide/yellow/diagonal{
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -23788,7 +23669,6 @@
 	c_tag = "Engineering - Hallway 5";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
 "lFE" = (
@@ -24701,8 +24581,6 @@
 /obj/effect/floor_decal/corner_wide/yellow/full{
 	dir = 8
 	},
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
 "lZQ" = (
@@ -25309,7 +25187,19 @@
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "mpX" = (
+/obj/effect/floor_decal/corner_wide/blue{
+	dir = 2
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
 "mqg" = (
@@ -25333,15 +25223,14 @@
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "mqn" = (
-/obj/machinery/light{
+/obj/effect/floor_decal/corner_wide/blue{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain/corner{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/blue{
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
-	},
-/obj/structure/fireaxecabinet{
-	pixel_x = 32
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -25997,9 +25886,6 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
 "mGc" = (
@@ -26328,17 +26214,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/wing/port/far)
 "mMn" = (
-/obj/effect/floor_decal/corner_wide/yellow{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/spline/plain/corner,
 /turf/simulated/floor/tiled,
-/area/hallway/engineering/tesla)
+/area/engineering/atmos/storage)
 "mMz" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/full,
@@ -27553,9 +27436,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
 "nmD" = (
@@ -27885,7 +27765,6 @@
 /turf/simulated/floor/wood,
 /area/maintenance/wing/port)
 "nvW" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/firealarm/south,
 /obj/structure/railing/mapped{
 	dir = 8
@@ -27894,6 +27773,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "nxk" = (
@@ -30016,8 +29896,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "oAN" = (
+/obj/structure/lattice,
 /obj/structure/ladder{
-	pixel_y = 8
+	pixel_y = 10
 	},
 /turf/simulated/open,
 /area/engineering/atmos/storage)
@@ -30227,9 +30108,6 @@
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
 "oGy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner_wide/yellow,
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
@@ -31266,8 +31144,8 @@
 /turf/simulated/floor/tiled,
 /area/engineering/locker_room)
 "piC" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/space_heater,
+/obj/structure/closet/firecloset,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark/full,
 /area/hallway/engineering)
 "piE" = (
@@ -31546,11 +31424,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/operations/qm)
-"ppm" = (
-/obj/machinery/vending/zora,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
-/area/engineering/lobby)
 "ppn" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -31727,9 +31600,6 @@
 /turf/simulated/floor/wood,
 /area/hallway/primary/central_two)
 "pwB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 4
 	},
@@ -32024,8 +31894,19 @@
 /turf/simulated/floor/wood,
 /area/horizon/crew_quarters/lounge/bar)
 "pFx" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/corner_wide/blue{
 	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/atmospherics/binary/pump/high_power{
+	name = "Air Mix Tank to Portable Air Pumps";
+	target_pressure = 15000;
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -32562,10 +32443,10 @@
 /turf/simulated/open,
 /area/maintenance/wing/starboard)
 "pSl" = (
-/obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	dir = 1
-	},
 /obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 8
+	},
 /turf/simulated/open,
 /area/engineering/atmos/storage)
 "pSI" = (
@@ -34064,11 +33945,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 1;
-	name = "Portable Scrubbers to Scrubbers Loop";
-	target_pressure = 15000
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
 "qEe" = (
@@ -34546,11 +34422,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/wing_starboard)
 "qRh" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -34586,20 +34462,17 @@
 /turf/simulated/floor/wood,
 /area/horizon/bar)
 "qSm" = (
-/obj/structure/closet/secure_closet/atmos_personal,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/small/south,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
 "qSn" = (
@@ -35275,9 +35148,9 @@
 /turf/simulated/floor/carpet/rubber,
 /area/medical/pharmacy)
 "rjk" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
-/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/lobby)
 "rju" = (
@@ -35434,10 +35307,6 @@
 "rof" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 6
-	},
-/obj/machinery/atmospherics/binary/pump/high_power{
-	name = "Air Mix Tank to Portable Air Pumps";
-	target_pressure = 15000
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
@@ -35692,14 +35561,16 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "Atmospherics";
+	sortType = "Atmospherics"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/full,
 /area/hallway/engineering/tesla)
@@ -35757,21 +35628,6 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_one)
-"rvC" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_atmos{
-	name = "Atmospherics Storage";
-	req_access = list(24)
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/full,
-/area/engineering/atmos/storage)
 "rvJ" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 10
@@ -36102,18 +35958,6 @@
 /obj/structure/bed/stool/bar/padded/red,
 /turf/simulated/floor/wood,
 /area/horizon/bar)
-"rEk" = (
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/engineering/tesla)
 "rEn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
@@ -37971,11 +37815,13 @@
 /turf/simulated/open,
 /area/maintenance/wing/starboard)
 "sDz" = (
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/machinery/suit_cycler/engineering,
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Atmos Locker Room";
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "sDQ" = (
 /obj/effect/floor_decal/spline/plain{
@@ -38546,9 +38392,6 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
@@ -39523,12 +39366,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
-"tts" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/atmos/storage)
 "tun" = (
 /obj/machinery/suit_cycler/hos,
 /obj/machinery/firealarm/north,
@@ -39619,7 +39456,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
 "twC" = (
@@ -39699,12 +39535,12 @@
 /turf/simulated/floor/plating,
 /area/engineering/aft_airlock)
 "tzf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_atmos{
-	name = "Atmospherics Storage";
-	req_access = list(24)
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/machinery/pipedispenser,
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "tzl" = (
 /obj/structure/cable/green{
@@ -39798,17 +39634,26 @@
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "tBf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner_wide/blue{
+	dir = 2
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/full,
-/area/hallway/engineering/tesla)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/atmos/storage)
 "tBS" = (
 /obj/structure/bed/stool/chair/office/dark,
 /obj/effect/floor_decal/corner/brown{
@@ -40207,6 +40052,9 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Locker Room Maintenance";
 	req_access = list(24)
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/full,
 /area/engineering/atmos/storage)
@@ -41315,9 +41163,6 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 10
 	},
@@ -42275,16 +42120,13 @@
 /turf/simulated/floor/wood,
 /area/rnd/conference)
 "uHh" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
 	},
-/obj/machinery/firealarm/south,
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "uHq" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -42358,7 +42200,13 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/exam)
 "uIx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/corner_wide/blue{
+	dir = 2
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -44014,15 +43862,9 @@
 /turf/simulated/floor/tiled/full,
 /area/horizon/security/hallway)
 "vCQ" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue{
-	dir = 8
-	},
-/obj/structure/dispenser,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "vDc" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -46007,12 +45849,15 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/kitchen)
 "wrO" = (
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/obj/effect/floor_decal/corner_wide/yellow/diagonal{
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/yellow,
-/obj/effect/floor_decal/corner/blue{
-	dir = 4
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -47404,9 +47249,6 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
 	},
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 10
@@ -49335,7 +49177,23 @@
 /turf/simulated/floor/carpet,
 /area/horizon/security/head_of_security)
 "xWL" = (
-/turf/simulated/floor/tiled,
+/obj/machinery/door/airlock/glass_atmos{
+	name = "Atmospherics Locker Room";
+	req_access = list(24)
+	},
+/obj/effect/floor_decal/corner_wide/blue{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/full,
 /area/engineering/atmos/storage)
 "xWV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -67370,7 +67228,7 @@ mKJ
 mqq
 mzS
 piC
-amE
+nkT
 nkT
 rAw
 nTS
@@ -69397,7 +69255,7 @@ eMT
 fKi
 nbJ
 isH
-ego
+akn
 oUt
 auj
 axS
@@ -69786,7 +69644,7 @@ lZP
 dFC
 qtY
 nlT
-rEk
+sUv
 qEd
 two
 sUv
@@ -69800,8 +69658,8 @@ vBE
 vBE
 oWB
 nbJ
-dpG
-ppm
+uMn
+guQ
 oUt
 oUt
 uMM
@@ -69987,11 +69845,11 @@ inD
 qMd
 whx
 vxY
-dAw
 ftj
 ftj
 ftj
-tBf
+ftj
+ftj
 dto
 usj
 kvG
@@ -70002,9 +69860,9 @@ elz
 elz
 elz
 qFf
-uMn
-guQ
-akn
+gbT
+dpG
+bYW
 ayF
 wTb
 pyc
@@ -70190,7 +70048,7 @@ hwH
 gci
 mFX
 lFn
-gzX
+rof
 rof
 pwB
 oGy
@@ -70390,12 +70248,12 @@ ydI
 cWj
 lnv
 gci
-mMn
+xPv
 fnn
 npL
 iwr
-bwU
-bPf
+inc
+gzX
 nvW
 nlG
 aql
@@ -70596,8 +70454,8 @@ ulg
 fnn
 tUR
 aFm
-abR
-inc
+bwU
+bPf
 jkb
 nlG
 fqL
@@ -70797,11 +70655,11 @@ lmf
 wZK
 fnn
 fnn
+aFm
+bwU
+bPf
+jkb
 puO
-puO
-tzf
-fnn
-nlG
 aWi
 iVp
 iVp
@@ -70997,13 +70855,13 @@ lMD
 hbG
 prh
 ulg
-fnn
-aau
 vCQ
+fnn
+aFm
 biI
 qRh
-bYW
-nlG
+jkb
+puO
 rNE
 iVp
 iVp
@@ -71198,14 +71056,14 @@ uph
 inD
 lgh
 xhQ
-mMn
-puO
-aor
-tts
+xPv
+vCQ
+fnn
+fnn
 xWL
-xWL
-sDz
-cCy
+aau
+nlG
+nlG
 rNE
 iVp
 iVp
@@ -71400,14 +71258,14 @@ xsX
 lMD
 mtf
 jFu
-fTZ
-rvC
-aoQ
+ulg
+fnn
+fnn
 kyV
 pFx
-xWL
+abR
 gAt
-nlG
+puO
 svh
 iVp
 iVp
@@ -71609,7 +71467,7 @@ bYT
 mqn
 fbT
 bZu
-nlG
+puO
 rNE
 iVp
 iVp
@@ -71806,11 +71664,11 @@ pzc
 gci
 fxe
 fnn
-fnn
+tzf
 jnV
-fnn
-puO
-fnn
+mMn
+tBf
+sDz
 nlG
 rls
 kpC
@@ -72007,7 +71865,7 @@ pHp
 xMu
 rtP
 fGD
-fnn
+amE
 jnQ
 dVY
 iYn
@@ -72412,7 +72270,7 @@ wfD
 esX
 wfD
 nlG
-iHQ
+aem
 cdq
 aem
 wrO

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -54,6 +54,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/full,
 /area/engineering/atmos/storage)
 "aax" = (
@@ -29902,6 +29903,7 @@
 /obj/structure/ladder{
 	pixel_y = 10
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/engineering/atmos/storage)
 "oAR" = (
@@ -32449,6 +32451,7 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/engineering/atmos/storage)
 "pSI" = (
@@ -49195,6 +49198,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/full,
 /area/engineering/atmos/storage)
 "xWV" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -17145,6 +17145,11 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},
+/obj/machinery/ringer{
+	pixel_y = -30;
+	name = "Engineering Ringer Terminal";
+	id = "Engineering_Ringer"
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/lobby)
 "imA" = (
@@ -19211,6 +19216,12 @@
 	dir = 4;
 	id = "shutters_deck2_eng_frontdesk";
 	name = "Engineering Front Desk Shutter"
+	},
+/obj/machinery/ringer_button{
+	id = "Engineering_Ringer";
+	name = "Engineering Ringer";
+	pixel_y = 10;
+	pixel_x = 6
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/lobby)
@@ -24035,18 +24046,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
-"lMN" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/engineering/lobby)
 "lMO" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, armoury"
@@ -68649,7 +68648,7 @@ mfq
 fQz
 ilT
 nge
-lMN
+fKi
 nbJ
 oyK
 sYl

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -17146,11 +17146,6 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},
-/obj/machinery/ringer{
-	pixel_y = -30;
-	name = "Engineering Ringer Terminal";
-	id = "Engineering_Ringer"
-	},
 /turf/simulated/floor/tiled,
 /area/engineering/lobby)
 "imA" = (
@@ -19217,12 +19212,6 @@
 	dir = 4;
 	id = "shutters_deck2_eng_frontdesk";
 	name = "Engineering Front Desk Shutter"
-	},
-/obj/machinery/ringer_button{
-	id = "Engineering_Ringer";
-	name = "Engineering Ringer";
-	pixel_y = 10;
-	pixel_x = 6
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/lobby)

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -142,9 +142,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/spline/plain,
-/obj/machinery/atmospherics/binary/pump/high_power{
+/obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 4;
-	name = "Portable Scrubbers to Scrubbers Loop";
+	name = "Scrubber to Waste";
 	target_pressure = 15000
 	},
 /turf/simulated/floor/tiled,
@@ -220,6 +220,7 @@
 "aem" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/closet/secure_closet/atmos_personal,
+/obj/item/clothing/gloves/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "aeC" = (
@@ -2970,7 +2971,8 @@
 	id = "engineering_storage";
 	name = "Engineering Hard Storage";
 	pixel_x = -25;
-	pixel_y = 25
+	pixel_y = 25;
+	req_one_access = list(11,24)
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -3048,7 +3050,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Hard Storage Maintenance";
-	req_access = list(11)
+	req_one_access = list(11,24)
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/full,
@@ -5915,7 +5917,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Hard Storage";
-	req_access = list(11)
+	req_one_access = list(11,24)
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
@@ -25164,7 +25166,8 @@
 	id = "engineering_storage";
 	name = "Engineering Hard Storage";
 	pixel_x = 25;
-	pixel_y = 25
+	pixel_y = 25;
+	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/storage_hard)
@@ -31903,10 +31906,10 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/machinery/atmospherics/binary/pump/high_power{
-	name = "Air Mix Tank to Portable Air Pumps";
-	target_pressure = 15000;
-	dir = 8
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 8;
+	name = "Air Supply to Pumps";
+	target_pressure = 15000
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -35662,7 +35665,7 @@
 	},
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Supermatter Reactor External Access";
-	req_access = list(11)
+	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/tiled/full,
 /area/engineering/engine_room)

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -1007,11 +1007,10 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/turbolift/scc_ship/robotics_lift)
 "axa" = (
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/structure/closet/wardrobe/atmospherics_yellow,
+/turf/simulated/floor/tiled/dark/full,
+/area/engineering/atmos/storage)
 "axB" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4470,13 +4469,6 @@
 /turf/simulated/floor/lino/grey,
 /area/chapel/main)
 "bZu" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/door/window/northright{
 	name = "Atmospherics Voidsuit Access";
 	req_access = list(24)
@@ -4601,10 +4593,11 @@
 /area/rnd/hallway)
 "cdq" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
-/obj/structure/closet/wardrobe/atmospherics_yellow,
 /obj/structure/fireaxecabinet{
 	pixel_x = 32
 	},
+/obj/structure/closet/secure_closet/atmos_personal,
+/obj/item/clothing/gloves/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "cdv" = (
@@ -18040,7 +18033,7 @@
 	c_tag = "Engineering - Hallway 6";
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/hallway/engineering/tesla)
 "iKg" = (
 /obj/structure/cable/green{
@@ -22388,17 +22381,9 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "kUU" = (
-/obj/effect/floor_decal/corner_wide/blue/diagonal,
-/obj/effect/floor_decal/corner_wide/yellow/diagonal{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "kVk" = (
 /obj/effect/floor_decal/corner/mauve{
@@ -37807,11 +37792,25 @@
 /turf/simulated/open,
 /area/maintenance/wing/starboard)
 "sDz" = (
-/obj/effect/floor_decal/industrial/outline/engineering,
-/obj/machinery/suit_cycler/engineering,
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering - Atmos Locker Room";
 	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/structure/table/rack,
+/obj/item/storage/bag/inflatable,
+/obj/item/device/suit_cooling_unit,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/void/atmos,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/head/helmet/space/void/atmos,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/northright{
+	name = "Atmospherics Voidsuit Access";
+	req_access = list(24)
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
@@ -40041,14 +40040,15 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "tJB" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Atmospherics Locker Room Maintenance";
-	req_access = list(24)
-	},
-/obj/effect/floor_decal/spline/plain/corner{
+/obj/effect/floor_decal/corner_wide/yellow/diagonal{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/full,
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
 "tJP" = (
 /obj/structure/cable/green{
@@ -41804,9 +41804,19 @@
 /turf/simulated/floor/wood,
 /area/horizon/bar)
 "uxE" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/door/airlock/maintenance{
+	name = "Atmospherics Locker Room Maintenance";
+	req_access = list(24)
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/full,
+/area/engineering/atmos/storage)
 "uyb" = (
 /obj/machinery/disposal/small/east{
 	pixel_x = -16
@@ -42112,12 +42122,12 @@
 /turf/simulated/floor/wood,
 /area/rnd/conference)
 "uHh" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -28
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/machinery/suit_cycler/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "uHq" = (
@@ -45848,8 +45858,8 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 9
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/storage)
@@ -46358,9 +46368,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
-"wFh" = (
-/turf/simulated/wall,
-/area/maintenance/aft)
 "wFj" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/security/checkpoint2)
@@ -72469,7 +72476,7 @@ nlG
 nlG
 nlG
 tJB
-nlG
+axa
 nlG
 nAz
 vmv
@@ -72669,10 +72676,10 @@ dVN
 xHd
 jWI
 bkv
-axa
+nlG
 uxE
-aUB
-wFh
+nlG
+nlG
 xpv
 nHq
 bQx

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -29903,7 +29903,6 @@
 /obj/structure/ladder{
 	pixel_y = 10
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/engineering/atmos/storage)
 "oAR" = (
@@ -32451,7 +32450,6 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/engineering/atmos/storage)
 "pSI" = (

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -144,6 +144,19 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/horizon/security/washroom)
+"adz" = (
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Engineer"
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/break_room)
 "adQ" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -187,10 +200,16 @@
 /turf/simulated/floor/lino/grey,
 /area/horizon/cafeteria)
 "aeP" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/landmark/start{
+	name = "Atmospheric Technician"
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "aeV" = (
 /obj/machinery/camera/network/third_deck{
@@ -324,11 +343,12 @@
 /area/lawoffice/representative)
 "aiV" = (
 /obj/structure/bed/stool/chair/office/dark{
-	dir = 8
+	dir = 1
 	},
 /obj/effect/landmark/start{
 	name = "Atmospheric Technician"
 	},
+/obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "ajj" = (
@@ -727,9 +747,10 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/port/docks)
 "aCZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/structure/table/steel,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/folder/blue,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "aDg" = (
@@ -946,7 +967,7 @@
 /area/medical/equipment)
 "aMn" = (
 /obj/structure/railing/mapped,
-/obj/effect/floor_decal/corner/yellow{
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
@@ -1445,16 +1466,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_armoury)
 "bdI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/bed/stool/chair/office/dark{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/landmark/start{
+	name = "Engineer"
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "bej" = (
 /obj/structure/disposalpipe/trunk{
@@ -1639,13 +1660,8 @@
 /turf/simulated/floor/tiled/full,
 /area/horizon/security/evidence_storage)
 "bpd" = (
-/obj/structure/bed/stool/chair/padded/black,
-/obj/effect/landmark/start{
-	name = "Chief Engineer"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/structure/table/steel,
+/obj/item/material/ashtray/bronze,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "bpD" = (
@@ -1908,13 +1924,14 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/interrogation/monitoring)
 "bHB" = (
-/obj/effect/floor_decal/corner/yellow/full{
-	dir = 4
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "bIm" = (
 /obj/machinery/door/firedoor,
@@ -1985,17 +2002,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/crew_armoury)
 "bKy" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 8
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 10
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "bLO" = (
@@ -2847,10 +2861,10 @@
 /turf/simulated/floor/reinforced/airless,
 /area/horizon/exterior)
 "cJm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "cJn" = (
 /obj/structure/bed/stool/chair{
@@ -3204,11 +3218,9 @@
 /turf/simulated/floor,
 /area/bridge/selfdestruct)
 "ddt" = (
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Engineer"
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
@@ -3773,21 +3785,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/controlroom)
 "dGO" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/corner/yellow{
-	dir = 10
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/structure/table/steel,
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering - Meeting Room";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/noticeboard{
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "dGU" = (
 /obj/structure/window/reinforced,
@@ -3921,7 +3931,13 @@
 /turf/simulated/floor,
 /area/maintenance/bridge)
 "dNV" = (
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "dOh" = (
 /obj/effect/floor_decal/spline/fancy,
@@ -4314,19 +4330,16 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "efE" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner/yellow{
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 6
 	},
-/obj/item/storage/box/fancy/donut{
-	pixel_y = 5
-	},
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "egX" = (
@@ -4381,14 +4394,20 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/security/autopsy_laboratory)
 "ehK" = (
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 6
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 28
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "eih" = (
@@ -4736,14 +4755,19 @@
 /turf/simulated/floor/tiled,
 /area/horizon/cafeteria)
 "evZ" = (
-/obj/structure/table/steel,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/effect/floor_decal/corner/yellow{
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
@@ -4940,11 +4964,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/hallway/deck_three/primary/port)
 "eFf" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 5
+/obj/structure/bed/stool/chair/padded/black,
+/obj/effect/landmark/start{
+	name = "Chief Engineer"
 	},
-/obj/effect/floor_decal/spline/plain,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "eFn" = (
 /obj/machinery/door/airlock/security{
@@ -5382,13 +5409,16 @@
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "eZt" = (
-/obj/structure/bed/stool/chair/office/dark{
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/landmark/start{
-	name = "Engineer"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "faY" = (
 /obj/item/device/flashlight/lamp,
@@ -5866,15 +5896,15 @@
 /turf/simulated/floor/tiled,
 /area/bridge)
 "fpy" = (
-/obj/structure/bookcase/manuals/engineering{
-	opacity = 0
-	},
-/obj/item/book/manual/atmospipes,
-/obj/item/book/manual/wiki/engineering_guide,
-/obj/item/book/manual/supermatter_engine,
-/obj/effect/floor_decal/corner/yellow/full{
+/obj/effect/floor_decal/corner_wide/yellow/full{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/machinery/firealarm/west,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "fqz" = (
@@ -7245,9 +7275,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/hallway/deck_three/primary/central)
 "guz" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/railing/mapped,
 /turf/simulated/open,
 /area/engineering/break_room)
 "guL" = (
@@ -7545,9 +7573,14 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical/upper)
 "gHu" = (
-/obj/item/material/ashtray/bronze,
-/obj/structure/table/steel,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "gHD" = (
 /obj/effect/floor_decal/corner/blue{
@@ -8090,13 +8123,17 @@
 /area/journalistoffice)
 "heq" = (
 /obj/effect/floor_decal/spline/plain{
-	dir = 4
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "heB" = (
@@ -8235,17 +8272,7 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical/upper)
 "hho" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/yellow/diagonal,
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -8255,7 +8282,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction/yjunction,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "hhr" = (
 /obj/structure/railing/mapped,
@@ -8526,18 +8557,13 @@
 	},
 /area/horizon/hallway/deck_three/primary/central)
 "hoo" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "hou" = (
 /obj/machinery/alarm{
@@ -8659,6 +8685,23 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/maintenance/security_starboard)
+"hvb" = (
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/structure/table/steel,
+/obj/machinery/recharger{
+	pixel_y = 3
+	},
+/obj/machinery/requests_console{
+	department = "Engineering";
+	departmentType = 1;
+	name = "Engineering RC";
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/break_room)
 "hvK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -9162,9 +9205,13 @@
 /turf/simulated/floor/wood,
 /area/lawoffice/consular)
 "hUj" = (
-/obj/structure/table/steel,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Engineer"
+	},
+/obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "hUw" = (
@@ -9175,13 +9222,11 @@
 /turf/simulated/floor/tiled,
 /area/bridge/bridge_crew)
 "hUQ" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 5
+/obj/structure/bed/stool/chair/office/dark,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "hVM" = (
 /obj/structure/cable/green{
@@ -9358,6 +9403,15 @@
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice)
 "iib" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -9912,12 +9966,17 @@
 /turf/simulated/floor/wood,
 /area/lawoffice/representative)
 "iFI" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/obj/effect/landmark/start{
+	name = "Engineer"
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "iGb" = (
 /obj/effect/floor_decal/spline/plain{
@@ -11134,10 +11193,10 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "jIj" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 5
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "jIF" = (
 /obj/structure/cable/green{
@@ -11257,13 +11316,10 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/bridge/aibunker)
 "jKF" = (
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 8
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 10
 	},
-/obj/effect/landmark/start{
-	name = "Engineer"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "jKZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -12274,16 +12330,16 @@
 /turf/simulated/open,
 /area/horizon/hallway/deck_three/primary/central)
 "kwx" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 10
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/structure/table/steel,
+/obj/item/storage/box/fancy/crayons/chalkbox{
+	pixel_y = 5
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/item/storage/box/fancy/crayons/chalkbox,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "kxn" = (
 /obj/machinery/telecomms/bus/preset_one,
@@ -13233,16 +13289,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/longbow)
 "lnA" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner/yellow/full{
+/obj/effect/floor_decal/corner_wide/yellow/full{
 	dir = 1
 	},
-/obj/machinery/recharger{
-	pixel_y = 3
+/obj/effect/floor_decal/corner_wide/yellow/diagonal{
+	dir = 4
 	},
-/obj/structure/noticeboard{
-	pixel_x = 32
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "lnI" = (
@@ -13466,7 +13522,10 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "lwZ" = (
-/turf/simulated/open,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "lxj" = (
 /obj/effect/floor_decal/spline/plain{
@@ -13982,14 +14041,11 @@
 /turf/simulated/floor,
 /area/maintenance/bridge)
 "lWa" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/obj/machinery/bluespace_beacon,
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "lWE" = (
 /obj/structure/sign/securearea{
@@ -14345,17 +14401,13 @@
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
 "miX" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 10
-	},
-/obj/effect/floor_decal/spline/plain/corner{
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/machinery/recharge_station,
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/disposal/small/north,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "mjb" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -14716,6 +14768,10 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "mCX" = (
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "mDS" = (
@@ -15189,28 +15245,30 @@
 /turf/simulated/floor/carpet/rubber,
 /area/bridge/controlroom)
 "mZd" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 5
+/obj/structure/bed/stool/chair/office/dark,
+/obj/effect/landmark/start{
+	name = "Engineer"
 	},
-/obj/effect/floor_decal/spline/plain/corner,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
-/area/engineering/break_room)
-"mZm" = (
-/obj/structure/railing/mapped{
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/yellow/diagonal,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/turf/simulated/floor/tiled/dark,
+/area/engineering/break_room)
+"mZm" = (
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "mZB" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -17434,18 +17492,16 @@
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "oOA" = (
-/obj/structure/table/steel,
-/obj/machinery/newscaster{
-	pixel_x = 29
-	},
-/obj/effect/floor_decal/corner/yellow{
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 6
 	},
-/obj/item/storage/box/snack{
-	desc = "A box full of snack foods. A label is attached that reads, 'Sorry about the microwaves.'";
-	name = "corporate care package"
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
-/obj/item/storage/box/cups,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "oOE" = (
@@ -18670,10 +18726,20 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/lounge/secondary)
 "qez" = (
-/obj/machinery/firealarm/west,
 /obj/structure/railing/mapped,
-/obj/effect/floor_decal/corner/yellow/full,
-/obj/machinery/recharge_station,
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Engineering Apprentice"
+	},
+/obj/effect/floor_decal/corner_wide/yellow/full,
+/obj/effect/floor_decal/corner_wide/yellow/diagonal{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "qgA" = (
@@ -19135,7 +19201,10 @@
 /area/horizon/hallway/deck_three/primary/central)
 "qyo" = (
 /obj/effect/floor_decal/spline/plain{
-	dir = 8
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
@@ -19625,22 +19694,15 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/bridge/aibunker)
 "qWi" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/structure/table/steel,
+/obj/item/storage/box/fancy/donut{
+	pixel_y = 5
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 6
+/obj/machinery/newscaster{
+	pixel_x = 29
 	},
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Engineering Apprentice"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "qWk" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -20005,18 +20067,16 @@
 	},
 /area/bridge/controlroom)
 "rrl" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 10
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/bluespace_beacon,
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "rrp" = (
@@ -20782,18 +20842,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/controlroom)
 "rVD" = (
-/obj/effect/floor_decal/corner/yellow/full,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "rWG" = (
 /obj/effect/floor_decal/corner/green{
@@ -21215,18 +21278,31 @@
 /turf/simulated/floor/wood,
 /area/horizon/hallway/deck_three/primary/port)
 "sio" = (
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Engineering Apprentice"
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 9
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
+	},
 /obj/machinery/power/apc/low{
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/table/steel,
-/obj/item/storage/box/fancy/crayons/chalkbox,
-/obj/item/storage/box/fancy/crayons/chalkbox,
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled,
@@ -24855,17 +24931,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/longbow)
 "vhp" = (
-/obj/effect/floor_decal/corner/yellow{
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
@@ -25032,20 +25111,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/ward/isolation)
 "vmr" = (
-/obj/machinery/requests_console{
-	department = "Engineering";
-	departmentType = 1;
-	name = "Engineering RC";
-	pixel_x = 32
+/obj/effect/floor_decal/corner_wide/yellow/full{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 6
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/structure/table/steel,
+/obj/machinery/chemical_dispenser/bar_soft{
+	pixel_y = 8
 	},
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 8
+/obj/item/storage/box/cups{
+	pixel_y = -8
 	},
-/obj/effect/landmark/start{
-	name = "Engineering Apprentice"
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
@@ -25602,13 +25680,15 @@
 /turf/simulated/floor/tiled,
 /area/bridge)
 "vNY" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 10
-	},
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/small/north,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "vOl" = (
 /obj/structure/closet/secure_closet/guncabinet{
@@ -27602,16 +27682,16 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "xrY" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 5
+	},
 /obj/machinery/button/remote/blast_door{
 	id = "shutters_deck3_engibreakwindows";
 	name = "Viewing Shutters";
 	pixel_x = 25;
 	pixel_y = 25
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "xsn" = (
 /obj/item/modular_computer/console/preset/command{
@@ -48905,7 +48985,7 @@ bdI
 dNV
 iib
 aMn
-lwZ
+guz
 mZm
 fpr
 czo
@@ -49103,7 +49183,7 @@ feY
 hBq
 bfL
 mZd
-rrl
+cEY
 iFI
 heq
 bKy
@@ -49304,13 +49384,13 @@ feY
 feY
 hBq
 jjy
-eFf
+lwZ
 aCZ
+adz
 eZt
-eZt
-eZt
+rrl
 mCX
-kwx
+hvb
 xJx
 fHK
 itk
@@ -49510,7 +49590,7 @@ eFf
 bpd
 hUj
 gHu
-cEY
+jKF
 ddt
 dGO
 xJx
@@ -49708,12 +49788,12 @@ feY
 feY
 hBq
 bfL
-eFf
+lwZ
 aCZ
 aiV
-aiV
+qyo
 jKF
-mCX
+ddt
 kwx
 xJx
 vxf
@@ -49911,11 +49991,11 @@ mjb
 aTd
 jjy
 hUQ
-lWa
+cEY
+aiV
 qyo
-qyo
-qyo
-qyo
+jKF
+ddt
 miX
 xJx
 dHx
@@ -50115,9 +50195,9 @@ jjy
 xrY
 aeP
 cJm
-cJm
-cJm
-cJm
+qyo
+jKF
+lWa
 vNY
 xJx
 qmu

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -20073,9 +20073,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/bluespace_beacon,
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)


### PR DESCRIPTION
Per: https://forums.aurorastation.org/topic/18154-engineering-the-mappening/#comment-163998

Updates include:

- Added a hydrogen line to each propulsion side, for unique burns/engineering mischief
- Expanded the propulsion combustion chambers
- Modified the atmospheric locker room
- Added additional scrubber/portable pump connectors, and removed the same from random engineering hallways.
- Added a manual valve that can be flipped to connect the Phoron fuel lines