### PR TITLE
Add DMM codecheck guard

### DIFF
--- a/html/changelogs/fluffyghost-dmmcodecheckguard.yml
+++ b/html/changelogs/fluffyghost-dmmcodecheckguard.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Fluffyghost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Added a DMM (map) inclusion guard in the code_check for the CI."

--- a/scripts/code_check.sh
+++ b/scripts/code_check.sh
@@ -111,6 +111,15 @@ else
     echo "PASS: Did not find outdated proc references."
 fi
 
+echo "Checking for erroneous map inclusion in the compiler" >> code_error.log
+grep -rE '^#include "(.)*\.dmm"' >> code_error.log
+if [ $? -eq 0 ]; then
+    ERROR_COUNT=$(($ERROR_COUNT+1))
+    echo -e "FAIL: You are trying to include a map in the compilation! Remove it."
+else
+    echo "PASS: Did not find any DMM being included to be compiled."
+fi
+
 echo "Found $ERROR_COUNT errors while performing code check"
 
 if [ $ERROR_COUNT -ne 0 ]; then


### PR DESCRIPTION
This PR includes a DMM inclusion guard, to prevent (make easier to know) when a map (.DMM) is being included for the compiler, which is not supposed to happen.