### PR TITLE
Switched out the Operations EFTPOS device with an NT-Quikpay

### DIFF
--- a/html/changelogs/FlamingLily-Quikpay.yml
+++ b/html/changelogs/FlamingLily-Quikpay.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FlamingLily
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Replaced the generic EFTPOS device in Operations with an Operations-set Quikpay, allowing transactions without an OM present."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -7756,7 +7756,6 @@
 	dir = 4;
 	name = "\improper Secure Ammunition Storage Turret Control Console";
 	pixel_x = -26;
-	dir = 4;
 	req_access = null;
 	req_one_access = list(11,19,20,24,31,41)
 	},
@@ -18307,11 +18306,11 @@
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 4
 	},
-/obj/item/device/eftpos{
-	eftpos_name = "Operations Bay EFTPOS scanner"
-	},
 /obj/item/device/destTagger,
 /obj/item/paper_scanner,
+/obj/item/device/nanoquikpay{
+	destinationact = "Operations"
+	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "iNY" = (


### PR DESCRIPTION
As the title says. makes it a little easier to charge people for things (like warehouse stuff or printing from an autolathe) without it either going to your personal account or requiring an OM to be active.