### PR TITLE
Speeds up init by ignoring contrib guidelines

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -27,7 +27,6 @@ var/global/list/the_station_areas = list()
 
 var/global/list/implants = list()
 
-var/global/list/turfs = list()						//list of all turfs
 var/global/list/station_turfs = list()
 var/global/list/areas_by_type = list()
 var/global/list/all_areas = list()

--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -138,7 +138,10 @@ Class Procs:
 	admin_notice(SPAN_DANGER("Processing Geometry..."), R_DEBUG)
 
 	var/simulated_turf_count = 0
-	for(var/turf/simulated/S in turfs)
+	for(var/turf/T in world)
+		var/turf/simulated/S = T
+		if(!istype(S))
+			continue
 		simulated_turf_count++
 		S.update_air_properties()
 

--- a/code/controllers/subsystems/initialization/xenoarch.dm
+++ b/code/controllers/subsystems/initialization/xenoarch.dm
@@ -21,10 +21,11 @@ var/datum/controller/subsystem/xenoarch/SSxenoarch
 	set background=1
 
 	//create digsites
-	for(var/turf/simulated/mineral/M in turfs)
+	for(var/turf/TIW in world)
 		CHECK_TICK
+		var/turf/simulated/mineral/M = TIW
 
-		if(!prob(XENOARCH_SPAWN_CHANCE))
+		if(!istype(M) || !prob(XENOARCH_SPAWN_CHANCE))
 			continue
 
 		digsite_spawning_turfs.Add(M)

--- a/code/game/gamemodes/cult/hell_universe.dm
+++ b/code/game/gamemodes/cult/hell_universe.dm
@@ -60,8 +60,7 @@ In short:
 
 /datum/universal_state/hell/OverlayAndAmbientSet()
 	set waitfor = FALSE
-	for(var/thing in turfs)	// Expensive, but CHECK_TICK should prevent lag.
-		var/turf/T = thing
+	for(var/turf/T in world)	// Expensive, but CHECK_TICK should prevent lag.
 		if(istype(T, /turf/space))
 			T.add_overlay("hell01")
 		else

--- a/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/universe.dm
@@ -100,7 +100,7 @@ The access requirements on the Asteroid Shuttles' consoles have now been revoked
 
 /datum/universal_state/supermatter_cascade/OverlayAndAmbientSet()
 	set waitfor = FALSE
-	for(var/turf/T in turfs)
+	for(var/turf/T in world)
 		if(istype(T, /turf/space))
 			T.add_overlay("end01")
 		else

--- a/code/game/gamemodes/events/holidays/easter.dm
+++ b/code/game/gamemodes/events/holidays/easter.dm
@@ -5,8 +5,9 @@
 /proc/Random_Egg()
     to_world("<h3>There is a golden egg hidden somewhere on the station...</h3>")
     var/list/Floorlist = list()
-    for(var/turf/simulated/floor/T in turfs)
-        if(T.contents)
+    for(var/turf/T in world)
+        var/turf/simulated/floor/F = T
+        if(istype(F) && F.contents)
             Floorlist += T
     var/turf/simulated/floor/F = Floorlist[rand(1,Floorlist.len)]
     Floorlist = null

--- a/code/game/gamemodes/events/wormholes.dm
+++ b/code/game/gamemodes/events/wormholes.dm
@@ -1,9 +1,10 @@
 /proc/wormhole_event()
 	spawn()
 		var/list/pick_turfs = list()
-		for(var/turf/simulated/floor/T in turfs)
-			if(isStationLevel(T.z))
-				pick_turfs += T
+		for(var/turf/T in world)
+			var/turf/simulated/floor/F = T
+			if(istype(F) && isStationLevel(F.z))
+				pick_turfs += F
 
 		if(pick_turfs.len)
 			//All ready. Announce that bad juju is afoot.

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/tree_manipulation.dm
@@ -129,7 +129,7 @@
 		to_chat(user, "Please pick a suitable camera.")
 
 
-/datum/game_mode/malfunction/verb/emergency_forcefield(var/turf/T as turf in turfs)
+/datum/game_mode/malfunction/verb/emergency_forcefield(var/turf/T in world)
 	set name = "Emergency Forcefield"
 	set desc = "275 CPU - Uses station's emergency shielding system to create temporary barrier which lasts for few minutes, but won't resist gunfire."
 	set category = "Software"

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -241,7 +241,7 @@
 		to_chat(src, SPAN_WARNING("You broke your gaze."))
 
 // Targeted teleportation, must be to a low-light tile.
-/mob/living/carbon/human/proc/vampire_veilstep(var/turf/T in turfs)
+/mob/living/carbon/human/proc/vampire_veilstep(var/turf/T in world)
 	set category = "Vampire"
 	set name = "Veil Step (20)"
 	set desc = "For a moment, move through the Veil and emerge at a shadow of your choice."

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -38,8 +38,6 @@
 	for(var/atom/movable/AM as mob|obj in src)
 		src.Entered(AM, AM.loc)
 
-	turfs += src
-
 	if (isStationLevel(z))
 		station_turfs += src
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -66,8 +66,6 @@
 	for(var/atom/movable/AM as mob|obj in src)
 		Entered(AM, src)
 
-	turfs += src
-
 	if (isStationLevel(z))
 		station_turfs += src
 
@@ -112,7 +110,6 @@
 		crash_with("Improper turf qdeletion.")
 
 	changing_turf = FALSE
-	turfs -= src
 
 	if (isStationLevel(z))
 		station_turfs -= src

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -25,7 +25,7 @@
 	else
 		alert("Admin jumping disabled")
 
-/client/proc/jumptoturf(var/turf/T in turfs)
+/client/proc/jumptoturf(var/turf/T in world)
 	set name = "Jump to Turf"
 	set category = "Admin"
 

--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -28,7 +28,7 @@
 
 	to_chat(usr, "Checking for overlapping pipes...")
 	next_turf:
-		for(var/turf/T in turfs)
+		for(var/turf/T in world)
 			for(var/dir in cardinal)
 				var/list/connect_types = list(1 = 0, 2 = 0, 3 = 0)
 				for(var/obj/machinery/atmospherics/pipe in T)

--- a/code/modules/lighting/lighting_verbs.dm
+++ b/code/modules/lighting/lighting_verbs.dm
@@ -42,7 +42,7 @@ var/list/admin_verbs_lighting = list(
 	SSlighting.corner_queue = list()
 	SSlighting.overlay_queue = list()
 
-/client/proc/lighting_reconsider_target(turf/T in turfs)
+/client/proc/lighting_reconsider_target(turf/T in world)
 	set category = "Lighting"
 	set name = "Reconsider Visibility"
 	set desc = "Triggers a visibility update for a turf."
@@ -57,7 +57,7 @@ var/list/admin_verbs_lighting = list(
 
 	T.reconsider_lights()
 
-/client/proc/lighting_build_overlay(turf/T in turfs)
+/client/proc/lighting_build_overlay(turf/T in world)
 	set category = "Lighting"
 	set name = "Build Overlay"
 	set desc = "Builds a lighting overlay for a turf if it does not have one."
@@ -72,7 +72,7 @@ var/list/admin_verbs_lighting = list(
 
 	T.lighting_build_overlay()
 
-/client/proc/lighting_clear_overlay(turf/T in turfs)
+/client/proc/lighting_clear_overlay(turf/T in world)
 	set category = "Lighting"
 	set name = "Clear Overlay"
 	set desc = "Clears a lighting overlay for a turf if it has one."

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -69,8 +69,6 @@ var/list/mineral_can_smooth_with = list(
 
 	initialized = TRUE
 
-	turfs += src
-
 	if(isStationLevel(z))
 		station_turfs += src
 
@@ -197,8 +195,6 @@ var/list/mineral_can_smooth_with = list(
 		icon = actual_icon
 
 	initialized = TRUE
-
-	turfs += src
 
 	if(isStationLevel(z))
 		station_turfs += src
@@ -657,8 +653,6 @@ var/list/asteroid_floor_smooth = list(
 
 	base_desc = desc
 	base_name = name
-
-	turfs += src
 
 	if(isStationLevel(z))
 		station_turfs += src

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -672,7 +672,7 @@ mob/living/carbon/human/proc/change_monitor()
 		to_chat(src, "<span class='notice'>You return your vision to normal.</span>")
 		src.stop_sight_update = 0
 
-/mob/living/carbon/human/proc/shadow_step(var/turf/T in turfs)
+/mob/living/carbon/human/proc/shadow_step(var/turf/T in world)
 	set category = "Abilities"
 	set name = "Shadow Step"
 	set desc = "Travel from place to place using the shadows."

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -683,8 +683,9 @@
 	P.icon_state = "anom"
 	P.name = "wormhole"
 	var/list/pick_turfs = list()
-	for(var/turf/simulated/floor/exit in turfs)
-		if(isStationLevel(exit.z))
+	for(var/turf/TIW in world)
+		var/turf/simulated/floor/exit = TIW
+		if(istype(exit) && isStationLevel(exit.z))
 			pick_turfs += exit
 	P.target = pick(pick_turfs)
 	QDEL_IN(P, rand(150,300))

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -261,7 +261,7 @@
 			TEST_FAIL("Unconnected [pipe.name] located at [pipe.x],[pipe.y],[pipe.z] ([get_area(pipe.loc)])")
 
 	next_turf:
-		for(var/turf/T in turfs)
+		for(var/turf/T in world)
 			for(var/dir in cardinal)
 				var/list/connect_types = list(1 = 0, 2 = 0, 3 = 0)
 				for(var/obj/machinery/atmospherics/pipe in T)

--- a/html/changelogs/johnwildkins-inworld.yml
+++ b/html/changelogs/johnwildkins-inworld.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - refactor: "Increase init speed by removing the global turfs list and reverting to turf in world loops."


### PR DESCRIPTION
We have a global turf list that is updated every time a turf is created or destroyed, to avoid doing `turf in world` checks for certain global functions.

The problem is, `turf in world` is more performant than a global turf list. Significantly. And it doesn't slow down turf creation and destruction like searching a 1.2m entry list does. As long as you do an `in world` search with an ATOM base type, it's reasonably performant, and it means we don't have to search a massive list every time we create an atom.

![image](https://cdn.discordapp.com/attachments/131489773268238336/1095834922259849356/image.png)

This change shaves five seconds off /turf/Destroy alone in an average horizon init. 