### PR TITLE
Place Grauwolf Sensor Probe on Map

### DIFF
--- a/html/changelogs/fluffyghost-givegrauwolfprobes.yml
+++ b/html/changelogs/fluffyghost-givegrauwolfprobes.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Fluffyghost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Added a rack with the Grauwolf probes in the Grauwolf room. There are ten probes on it."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -44,9 +44,7 @@
 	name = "Atmospherics Locker Room";
 	req_access = list(24)
 	},
-/obj/effect/floor_decal/corner_wide/blue{
-	dir = 2
-	},
+/obj/effect/floor_decal/corner_wide/blue,
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 8
 	},
@@ -74,8 +72,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction/flipped{
 	name = "CE Office";
-	sortType = "CE Office";
-	tag = null
+	sortType = "CE Office"
 	},
 /turf/simulated/floor/tiled/full,
 /area/hallway/engineering)
@@ -136,9 +133,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
 "abR" = (
-/obj/effect/floor_decal/corner_wide/blue{
-	dir = 2
-	},
+/obj/effect/floor_decal/corner_wide/blue,
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 8
 	},
@@ -3151,8 +3146,7 @@
 "bvV" = (
 /obj/structure/plasticflaps/airtight,
 /obj/machinery/door/window/westleft{
-	name = "Server Room";
-	req_access = null
+	name = "Server Room"
 	},
 /obj/machinery/door/window/eastleft{
 	name = "Server Room"
@@ -4897,8 +4891,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 1;
-	name = "Medical Reception";
-	req_access = null
+	name = "Medical Reception"
 	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -6282,7 +6275,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/glass_mining{
 	name = "Break Room";
-	req_access = null;
 	req_one_access = list(26,29,31,48,67)
 	},
 /obj/machinery/door/firedoor,
@@ -6600,7 +6592,6 @@
 	name = "Primary Armament Interior Bolts";
 	pixel_x = 22;
 	pixel_y = -20;
-	req_access = null;
 	req_one_access = list(19,43);
 	specialfunctions = 4
 	},
@@ -6635,7 +6626,6 @@
 "dlQ" = (
 /obj/machinery/door/airlock/glass_mining{
 	name = "Operations Bay";
-	req_access = null;
 	req_one_access = list(26,29,31,48,67)
 	},
 /obj/machinery/door/firedoor,
@@ -10102,9 +10092,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "fbT" = (
-/obj/effect/floor_decal/corner_wide/blue{
-	dir = 2
-	},
+/obj/effect/floor_decal/corner_wide/blue,
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 8
 	},
@@ -12913,7 +12901,6 @@
 	name = "Viewing Blast Doors";
 	pixel_x = 7;
 	pixel_y = -23;
-	req_access = null;
 	req_one_access = list(19,11)
 	},
 /obj/structure/table/standard,
@@ -13752,7 +13739,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_mining{
 	name = "Operations Bay";
-	req_access = null;
 	req_one_access = list(26,29,31,48,67)
 	},
 /obj/effect/map_effect/door_helper/unres{
@@ -14396,8 +14382,7 @@
 "gUA" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
-	name = "Research Hallway";
-	req_one_access = null
+	name = "Research Hallway"
 	},
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 2
@@ -17328,7 +17313,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_mining{
 	name = "Operations Bay";
-	req_access = null;
 	req_one_access = list(26,29,31,48,67)
 	},
 /obj/effect/map_effect/door_helper/unres{
@@ -21418,8 +21402,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
 	name = "Research and Development Maintenance";
-	req_access = list(7);
-	req_one_access = null
+	req_access = list(7)
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -23180,7 +23163,6 @@
 	name = "External Blast Doors";
 	pixel_x = 7;
 	pixel_y = -23;
-	req_access = null;
 	req_one_access = list(19,11)
 	},
 /obj/machinery/light/small,
@@ -23575,8 +23557,7 @@
 	name = "Xenobiology Emergency Lockdown Control";
 	pixel_x = -6;
 	pixel_y = -30;
-	req_access = list(47);
-	req_one_access = null
+	req_access = list(47)
 	},
 /obj/machinery/button/remote/airlock{
 	dir = 1;
@@ -23789,7 +23770,6 @@
 	id_tag = "bolts_cannon_entrance";
 	locked = 1;
 	name = "Primary Armament";
-	req_access = null;
 	req_one_access = list(19,43)
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -25159,9 +25139,7 @@
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "mpX" = (
-/obj/effect/floor_decal/corner_wide/blue{
-	dir = 2
-	},
+/obj/effect/floor_decal/corner_wide/blue,
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 4
 	},
@@ -27064,7 +27042,6 @@
 	name = "Entrance Airlock Bolts";
 	pixel_x = 22;
 	pixel_y = 12;
-	req_access = null;
 	req_one_access = list(19,43);
 	specialfunctions = 4
 	},
@@ -27074,7 +27051,6 @@
 	name = "Primary Armament Exterior Bolts";
 	pixel_x = 22;
 	pixel_y = -13;
-	req_access = null;
 	req_one_access = list(19,43);
 	specialfunctions = 4
 	},
@@ -27495,8 +27471,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Deck 1, 2, and 3 Medical Substation";
-	req_access = list(66);
-	req_one_access = null
+	req_access = list(66)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -31299,8 +31274,7 @@
 	id = "xenobio";
 	name = "Xenobiology Emergency Lockdown Control";
 	pixel_x = 25;
-	req_access = list(47);
-	req_one_access = null
+	req_access = list(47)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
@@ -33431,7 +33405,6 @@
 	id_tag = "bolts_cannon_internal";
 	locked = 1;
 	name = "Primary Armament Interior";
-	req_access = null;
 	req_one_access = list(19,43);
 	secured_wires = 1
 	},
@@ -35592,8 +35565,7 @@
 "rvf" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
-	name = "Research Hallway";
-	req_one_access = null
+	name = "Research Hallway"
 	},
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 2
@@ -36749,6 +36721,23 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/operations/mail_room)
+"rYL" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/structure/table/rack,
+/obj/item/ship_ammunition/grauwolf_probe,
+/obj/item/ship_ammunition/grauwolf_probe,
+/obj/item/ship_ammunition/grauwolf_probe,
+/obj/item/ship_ammunition/grauwolf_probe,
+/obj/item/ship_ammunition/grauwolf_probe,
+/obj/item/ship_ammunition/grauwolf_probe,
+/obj/item/ship_ammunition/grauwolf_probe,
+/obj/item/ship_ammunition/grauwolf_probe,
+/obj/item/ship_ammunition/grauwolf_probe,
+/obj/item/ship_ammunition/grauwolf_probe,
+/turf/simulated/floor/tiled/dark,
+/area/horizon/grauwolf)
 "rYM" = (
 /obj/effect/floor_decal/corner/purple/full,
 /obj/structure/closet/hazmat/custodial,
@@ -38809,7 +38798,6 @@
 	name = "Primary Armament Interior Bolts";
 	pixel_x = 22;
 	pixel_y = 22;
-	req_access = null;
 	req_one_access = list(19,43);
 	specialfunctions = 4
 	},
@@ -39620,9 +39608,7 @@
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "tBf" = (
-/obj/effect/floor_decal/corner_wide/blue{
-	dir = 2
-	},
+/obj/effect/floor_decal/corner_wide/blue,
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 8
 	},
@@ -40359,7 +40345,6 @@
 /obj/machinery/door/airlock/hatch{
 	id_tag = "bolts_cannon_external";
 	name = "Primary Armament Exterior";
-	req_access = null;
 	req_one_access = list(19,43);
 	secured_wires = 1
 	},
@@ -42197,9 +42182,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/exam)
 "uIx" = (
-/obj/effect/floor_decal/corner_wide/blue{
-	dir = 2
-	},
+/obj/effect/floor_decal/corner_wide/blue,
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 4
 	},
@@ -45204,8 +45187,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/multi_tile,
 /obj/machinery/door/airlock/multi_tile/glass{
-	name = "Medical Reception";
-	req_access = null
+	name = "Medical Reception"
 	},
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -48385,7 +48367,6 @@
 	name = "Entrance Airlock Bolts";
 	pixel_x = 22;
 	pixel_y = -22;
-	req_access = null;
 	req_one_access = list(19,43);
 	specialfunctions = 4
 	},
@@ -49844,7 +49825,6 @@
 	name = "Primary Armament Exterior Bolts";
 	pixel_x = -6;
 	pixel_y = -38;
-	req_access = null;
 	req_one_access = list(19,43);
 	specialfunctions = 4
 	},
@@ -49854,7 +49834,6 @@
 	name = "Entrance Airlock Bolts";
 	pixel_x = 6;
 	pixel_y = -38;
-	req_access = null;
 	req_one_access = list(19,43);
 	specialfunctions = 4
 	},
@@ -49864,7 +49843,6 @@
 	name = "Primary Armament Interior Bolts";
 	pixel_x = -6;
 	pixel_y = -28;
-	req_access = null;
 	req_one_access = list(19,43);
 	specialfunctions = 4
 	},
@@ -57761,7 +57739,7 @@ wRu
 wRu
 wRu
 wCS
-jJU
+rYL
 uKV
 aFy
 hFU


### PR DESCRIPTION
Added a rack with the Grauwolf probes in the Grauwolf room. There are ten probes on it.

The speed will likely need to be tweaked, depending on how fast/slow their processing is on live, this needs to be done after some playtest and feedback, and probably in another PR.