### PR TITLE
Ghost roles listing in lobby tweak.

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -447,7 +447,7 @@ var/datum/controller/subsystem/ticker/SSticker
 		if(G.enabled \
 			&& !("Antagonist" in G.tags) \
 			&& !(G.loc_type == GS_LOC_ATOM && !length(G.spawn_atoms)) \
-			&& (("Simple Mobs" in G.tags) || ("External" in G.tags)) \
+			&& (G.req_perms == null) \
 		)
 			available_ghostroles |= G.name
 

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -444,7 +444,11 @@ var/datum/controller/subsystem/ticker/SSticker
 
 	for(var/s in SSghostroles.spawners)
 		var/datum/ghostspawner/G = SSghostroles.spawners[s]
-		if(G.enabled && !("Antagonist" in G.tags) && !(G.loc_type == GS_LOC_ATOM && !length(G.spawn_atoms)))
+		if(G.enabled \
+			&& !("Antagonist" in G.tags) \
+			&& !(G.loc_type == GS_LOC_ATOM && !length(G.spawn_atoms)) \
+			&& (("Simple Mobs" in G.tags) || ("External" in G.tags)) \
+		)
 			available_ghostroles |= G.name
 
 	// Special case, to list the Merchant in case it is available at roundstart
@@ -452,8 +456,12 @@ var/datum/controller/subsystem/ticker/SSticker
 		available_ghostroles |= SSjobs.type_occupations[/datum/job/merchant].title
 
 	if(length(available_ghostroles))
-		to_world("<br /><br />" + SPAN_BOLD(SPAN_NOTICE("Ghost roles available for this round:")) + "[english_list(available_ghostroles)].<br />" + \
-		SPAN_INFO("Please note that the actual availability depends on additional things, including your user (eg. job bans)"))
+		to_world("<br>" \
+			+ SPAN_BOLD(SPAN_NOTICE("Ghost roles available for this round: ")) \
+			+ "[english_list(available_ghostroles)]. " \
+			+ SPAN_INFO("Actual availability may vary.") \
+			+ "<br>" \
+		)
 
 	callHook("pregame_start")
 

--- a/html/changelogs/DreamySkrell-roles-start-ahhhhh.yml
+++ b/html/changelogs/DreamySkrell-roles-start-ahhhhh.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Ghost roles listing in lobby tweak."


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/107256943/232321498-359a3ae7-fcd5-4a5d-aa54-7e3b408a9c2a.png)

No more CCIAA or whatever roles listed there.