### PR TITLE
Put rock nomads where they belong

### DIFF
--- a/html/changelogs/johnwildkins-fixruin.yml
+++ b/html/changelogs/johnwildkins-fixruin.yml
@@ -1,0 +1,6 @@
+author: JohnWildkins
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed rock nomads spawning outside Adhomai, causing (among other things) unit test failures."

--- a/maps/random_ruins/exoplanets/adhomai/adhomai_sole_rock_nomad.dm
+++ b/maps/random_ruins/exoplanets/adhomai/adhomai_sole_rock_nomad.dm
@@ -6,6 +6,7 @@
 	spawn_weight = 1
 	spawn_cost = 2
 	sectors = list(SECTOR_SRANDMARR)
+	template_flags = TEMPLATE_FLAG_NO_RUINS|TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED
 	suffixes = list("adhomai/adhomai_sole_rock_nomad.dmm")
 
 //ghost roles


### PR DESCRIPTION
rock nomads weren't STARTS_DISALLOWED like other adhomai ruins, so they were only limited by the sector

this broke a few things, mostly exoplanet testing (which ignores sectors for reasons of testing all ruins and planet types)