### PR TITLE
Bar added to ops maint

### DIFF
--- a/html/changelogs/DreamySkrell-bar-ops-325243646.yml
+++ b/html/changelogs/DreamySkrell-bar-ops-325243646.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Adds secret bar to maint tunnels near ops."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -1505,6 +1505,10 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/engineering/storage_eva)
+"aIh" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/wood,
+/area/maintenance/wing/starboard)
 "aIj" = (
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck - Hallway 2"
@@ -2414,14 +2418,8 @@
 /turf/simulated/floor/tiled,
 /area/operations/mail_room)
 "bci" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/open,
+/obj/structure/bed/stool/bar/padded/red,
+/turf/simulated/floor/wood,
 /area/maintenance/wing/starboard)
 "bcL" = (
 /obj/effect/floor_decal/corner_wide/orange{
@@ -4048,6 +4046,13 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_waste)
+"bPQ" = (
+/obj/structure/table/wood/gamblingtable,
+/obj/item/deck/cards{
+	pixel_y = -6
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/wing/starboard)
 "bQd" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
@@ -5035,6 +5040,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/horizon/library)
+"coX" = (
+/obj/structure/bed/stool/bar/padded/red,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
+/area/maintenance/wing/starboard)
 "cpi" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	dir = 1
@@ -5614,11 +5624,9 @@
 /turf/simulated/floor/plating,
 /area/horizon/maintenance/deck_two/fore/port)
 "cKP" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/plating,
+/obj/structure/reagent_dispensers/keg/mead,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
 /area/maintenance/wing/starboard)
 "cLt" = (
 /obj/structure/table/standard,
@@ -7390,6 +7398,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/wing_port)
+"dFQ" = (
+/obj/structure/shuttle_part/scc_space_ship{
+	icon_state = "d3-4-f"
+	},
+/turf/simulated/wall/shuttle/scc_space_ship/cardinal,
+/area/maintenance/wing/starboard)
 "dGd" = (
 /obj/effect/landmark/entry_point/aft{
 	name = "aft, AI airlock"
@@ -8151,8 +8165,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/zta)
 "dZL" = (
-/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/structure/window/reinforced,
+/obj/structure/lattice,
 /turf/simulated/open,
 /area/maintenance/wing/starboard)
 "dZU" = (
@@ -13507,6 +13524,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hydroponics)
+"gAX" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/decal/cleanable/cobweb2{
+	icon_state = "cobweb1"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/starboard)
 "gBa" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -16667,11 +16692,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_two)
 "idh" = (
-/obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
+/obj/structure/lattice,
 /turf/simulated/open,
 /area/maintenance/wing/starboard)
 "ids" = (
@@ -16946,10 +16971,12 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room/tesla)
 "ijb" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/cans/root_beer{
+	pixel_x = 6;
+	pixel_y = 4
 	},
-/obj/effect/floor_decal/industrial/warning,
+/obj/item/reagent_containers/food/drinks/cans/root_beer,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "ijc" = (
@@ -18264,14 +18291,8 @@
 /turf/simulated/floor/wood,
 /area/horizon/crew_quarters/lounge/bar)
 "iPP" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/open,
+/obj/random/junk,
+/turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "iQK" = (
 /obj/structure/table/rack,
@@ -21603,10 +21624,8 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/storage_eva)
 "kyA" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood,
 /area/maintenance/wing/starboard)
 "kyO" = (
 /obj/structure/railing/mapped{
@@ -22135,14 +22154,13 @@
 /turf/simulated/floor/wood,
 /area/chapel/office)
 "kPj" = (
-/obj/structure/foamedmetal,
 /obj/structure/shuttle_part/scc_space_ship{
 	icon_state = "d3-5-f"
 	},
 /obj/effect/landmark/entry_point/aft{
 	name = "aft, starboard maintenance"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/maintenance/wing/starboard)
 "kPn" = (
 /obj/structure/railing/mapped{
@@ -26888,6 +26906,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
+"nbh" = (
+/obj/structure/bed/stool/bar/padded/red,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/starboard)
 "nbJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31416,6 +31439,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/ors)
+"pqB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/wing/starboard)
 "pqE" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/power/apc{
@@ -32379,6 +32409,10 @@
 /obj/structure/flora/ausbushes/palebush,
 /turf/simulated/floor/grass/alt,
 /area/hallway/primary/central_one)
+"pQq" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/starboard)
 "pRd" = (
 /obj/structure/foamedmetal,
 /turf/simulated/floor/plating,
@@ -35229,7 +35263,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "rlv" = (
-/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/open,
 /area/maintenance/wing/starboard)
 "rlX" = (
@@ -37442,6 +37481,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
 /area/horizon/crew_quarters/lounge/bar)
+"sry" = (
+/obj/structure/table/wood/gamblingtable,
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor/wood,
+/area/maintenance/wing/starboard)
 "srY" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -37745,6 +37789,15 @@
 	},
 /turf/simulated/floor/grass/alt,
 /area/horizon/hydroponics/garden)
+"sBz" = (
+/obj/structure/bed/stool/chair/office{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/wing/starboard)
 "sBE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/lino/grey,
@@ -37806,10 +37859,8 @@
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "sDy" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/open,
+/obj/structure/reagent_dispensers/keg/beerkeg,
+/turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "sDz" = (
 /obj/machinery/camera/network/engineering{
@@ -39131,6 +39182,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_two/fore)
+"tkh" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/starboard)
 "tki" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -39488,6 +39547,9 @@
 "twT" = (
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/open,
 /area/maintenance/wing/starboard)
@@ -40064,6 +40126,14 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
+"tJt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/obj/structure/bed/stool/chair,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/starboard)
 "tJB" = (
 /obj/effect/floor_decal/corner_wide/yellow/diagonal{
 	dir = 4
@@ -42001,11 +42071,7 @@
 /turf/simulated/floor/tiled,
 /area/turret_protected/ai_upload_foyer)
 "uEl" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood,
 /area/maintenance/wing/starboard)
 "uEq" = (
 /turf/simulated/wall/r_wall,
@@ -45490,6 +45556,10 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
+"wiH" = (
+/obj/structure/bed/stool/bar/padded/red,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/starboard)
 "wjU" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -46857,11 +46927,10 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "wPJ" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/open,
+/obj/random/junk,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "wPX" = (
 /obj/structure/cable/green{
@@ -46983,10 +47052,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_one)
 "wTd" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "wTh" = (
@@ -47927,12 +47993,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/hydroponics/garden)
 "xoW" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/open,
+/obj/structure/table/steel,
+/turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "xpv" = (
 /obj/structure/railing/mapped,
@@ -59177,7 +59239,7 @@ ojK
 qMJ
 oIL
 oIL
-oIL
+gAX
 oIL
 svA
 cKn
@@ -59377,11 +59439,11 @@ qgN
 qgN
 aOj
 nNE
-ycb
-qrz
-qrz
-qrz
-ijb
+xoW
+wTd
+xGl
+oIL
+uLC
 fsf
 iYH
 uWx
@@ -59579,11 +59641,11 @@ qgN
 qgN
 dzL
 oiL
-uLC
-iPP
-sDy
 xoW
-uEl
+ycb
+qrz
+oIL
+oIL
 prk
 oAX
 vZB
@@ -59779,13 +59841,13 @@ qgN
 qgN
 qgN
 ojK
-iAB
+qMJ
 oIL
-pGp
+pqB
 wPJ
 rlv
 dZL
-uEl
+oIL
 ceU
 xas
 xpJ
@@ -59981,13 +60043,13 @@ qgN
 qgN
 qgN
 aOj
-ugZ
-oIL
-wTd
-bci
+nNE
+aIh
+xGl
+uLC
 twT
 idh
-uEl
+oIL
 ceU
 nyI
 pRA
@@ -60183,13 +60245,13 @@ qgN
 qgN
 qgN
 dzL
-ftS
-oIL
+oiL
+sBz
 kyA
-aLc
-aLc
-aLc
-cKP
+coX
+wiH
+oIL
+oIL
 ceU
 vqi
 aob
@@ -60384,12 +60446,12 @@ qgN
 qgN
 qgN
 ojK
-iAB
-pEQ
-oIL
-oIL
-oIL
-oIL
+oxb
+tkh
+xGl
+uEl
+bPQ
+sry
 oIL
 pGp
 jIg
@@ -60587,11 +60649,11 @@ qgN
 qgN
 aOj
 kPj
-pEQ
-pEQ
-pEQ
-pEQ
-pEQ
+tJt
+pQq
+iPP
+bci
+nbh
 oIL
 cKn
 fsf
@@ -60788,12 +60850,12 @@ qgN
 qgN
 qgN
 dzL
-oiL
-oIL
-oIL
-oIL
-oIL
-oIL
+dFQ
+sDy
+ijb
+xGl
+wTd
+cKP
 oIL
 rbO
 rbO
@@ -60993,10 +61055,10 @@ oxb
 gGB
 gGB
 cww
-fsf
-fsf
-maq
-fsf
+oIL
+oIL
+oIL
+oIL
 fsf
 fsf
 rqA

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -1507,6 +1507,10 @@
 /area/engineering/storage_eva)
 "aIh" = (
 /obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/teapot{
+	pixel_y = 7;
+	pixel_x = 2
+	},
 /turf/simulated/floor/wood,
 /area/maintenance/wing/starboard)
 "aIj" = (
@@ -8963,6 +8967,11 @@
 /obj/item/toy/desk/officetoy,
 /turf/simulated/floor/carpet/red,
 /area/horizon/library)
+"eww" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/maintenance/wing/starboard)
 "ewx" = (
 /obj/item/modular_computer/console/preset/command,
 /turf/simulated/floor/reinforced,
@@ -16977,6 +16986,7 @@
 	pixel_y = 4
 	},
 /obj/item/reagent_containers/food/drinks/cans/root_beer,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "ijc" = (
@@ -17929,6 +17939,17 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
+/area/maintenance/wing/starboard)
+"iIe" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner/purple{
+	dir = 5
+	},
+/obj/item/stack/material/steel/full{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/turf/simulated/floor/tiled,
 /area/maintenance/wing/starboard)
 "iIf" = (
 /obj/structure/sign/greencross,
@@ -20359,6 +20380,11 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/storage/secure)
+"jNO" = (
+/obj/effect/floor_decal/corner/purple/full,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
+/area/maintenance/wing/starboard)
 "jNY" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 4
@@ -32411,6 +32437,10 @@
 /area/hallway/primary/central_one)
 "pQq" = (
 /obj/structure/table/wood,
+/obj/item/flame/candle{
+	pixel_y = 3;
+	pixel_x = -5
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "pRd" = (
@@ -33398,6 +33428,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard)
 "qrK" = (
@@ -47052,8 +47083,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/hallway/primary/central_one)
 "wTd" = (
+/obj/effect/floor_decal/corner/purple{
+	dir = 9
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
 /area/maintenance/wing/starboard)
 "wTh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -47994,7 +48029,10 @@
 /area/horizon/hydroponics/garden)
 "xoW" = (
 /obj/structure/table/steel,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/purple/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
 /area/maintenance/wing/starboard)
 "xpv" = (
 /obj/structure/railing/mapped,
@@ -59441,7 +59479,7 @@ aOj
 nNE
 xoW
 wTd
-xGl
+jNO
 oIL
 uLC
 fsf
@@ -59641,7 +59679,7 @@ qgN
 qgN
 dzL
 oiL
-xoW
+iIe
 ycb
 qrz
 oIL
@@ -60854,7 +60892,7 @@ dFQ
 sDy
 ijb
 xGl
-wTd
+eww
 cKP
 oIL
 rbO


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/107256943/233489370-6ae23d9d-0587-4531-8028-fe078e231fa8.png)

Bar removed from sec maint in https://github.com/Aurorastation/Aurora.3/pull/16243, and reasoning for such is there too.

Why two different PRs? PRs should be atomic. At least in theory it is good practice. Also makes reviewing easier.