### PR TITLE
Clickable Storage Backgrounds

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -135,6 +135,26 @@
 			usr.ClickOn(master)
 	return TRUE
 
+/obj/screen/storage/background
+	name = "background storage"
+	layer = SCREEN_LAYER+0.01
+
+/obj/screen/storage/background/Initialize(mapload, var/obj/set_master, var/set_icon_state)
+	. = ..()
+	master = set_master
+	if(master)
+		name = master.name
+	icon_state = set_icon_state
+
+/obj/screen/storage/background/Click()
+	if(!usr.canClick())
+		return TRUE
+	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
+		return TRUE
+	if(master)
+		usr.ClickOn(master)
+	return TRUE
+
 /obj/screen/zone_sel
 	name = "damage zone"
 	icon_state = "zone_sel"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -147,9 +147,7 @@
 	icon_state = set_icon_state
 
 /obj/screen/storage/background/Click()
-	if(!usr.canClick())
-		return TRUE
-	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
+	if(usr.incapacitated())
 		return TRUE
 	if(master)
 		usr.ClickOn(master)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -28,9 +28,7 @@
 	var/obj/screen/storage/storage_start //storage UI
 	var/obj/screen/storage/storage_continue
 	var/obj/screen/storage/storage_end
-	var/obj/screen/storage/stored_start
-	var/obj/screen/storage/stored_continue
-	var/obj/screen/storage/stored_end
+	var/list/storage_screens = list()
 	var/obj/screen/close/closer
 	var/care_about_storage_depth = TRUE
 	var/use_to_pickup	//Set this to make it possible to use this item in an inverse way, so you can have the item in your hand and click items on the floor to pick them up.
@@ -51,9 +49,7 @@
 	QDEL_NULL(storage_start)
 	QDEL_NULL(storage_continue)
 	QDEL_NULL(storage_end)
-	QDEL_NULL(stored_start)
-	QDEL_NULL(stored_continue)
-	QDEL_NULL(stored_end)
+	QDEL_NULL_LIST(storage_screens)
 	QDEL_NULL(closer)
 	return ..()
 
@@ -167,7 +163,10 @@
 /obj/item/storage/proc/close(mob/user as mob)
 	hide_from(user)
 	user.s_active = null
-	return
+	if(!length(can_see_contents()))
+		storage_start.vis_contents = list()
+		QDEL_NULL_LIST(storage_screens)
+		storage_screens = list()
 
 /obj/item/storage/proc/close_all()
 	for(var/mob/M in can_see_contents())
@@ -266,9 +265,17 @@
 	var/startpoint = 0
 	var/endpoint = 1
 
+	storage_start.vis_contents = list()
+	QDEL_NULL_LIST(storage_screens)
+	storage_screens = list()
+
 	for(var/obj/item/O in contents)
 		startpoint = endpoint + 1
 		endpoint += storage_width * O.get_storage_cost()/max_storage_space
+
+		var/obj/screen/storage/background/stored_start = new /obj/screen/storage/background(null, O, "stored_start")
+		var/obj/screen/storage/background/stored_continue = new /obj/screen/storage/background(null, O, "stored_continue")
+		var/obj/screen/storage/background/stored_end = new /obj/screen/storage/background(null, O, "stored_end")
 
 		var/matrix/M_start = matrix()
 		var/matrix/M_continue = matrix()
@@ -280,11 +287,13 @@
 		stored_start.transform = M_start
 		stored_continue.transform = M_continue
 		stored_end.transform = M_end
-		storage_start.add_overlay(list(stored_start, stored_continue, stored_end))
+
+		storage_screens += list(stored_start, stored_continue, stored_end)
+		storage_start.vis_contents += list(stored_start, stored_continue, stored_end)
 
 		O.screen_loc = "4:[round((startpoint+endpoint)/2)+2],2:16"
 		O.maptext = ""
-		O.layer = SCREEN_LAYER+0.01
+		O.layer = SCREEN_LAYER+0.02
 
 	if (!defer_overlays)
 		storage_start.compile_overlays()
@@ -670,12 +679,6 @@
 
 	storage_end = new /obj/screen/storage{icon_state = "storage_end"}
 	storage_end.master = src
-
-	stored_start = new /obj/storage_bullshit{icon_state = "stored_start"} //we just need these to hold the icon
-
-	stored_continue = new /obj/storage_bullshit{icon_state = "stored_continue"}
-
-	stored_end = new /obj/storage_bullshit{icon_state = "stored_end"}
 
 	closer = new /obj/screen/close{
 		icon_state = "x";

--- a/html/changelogs/geeves-clickable_storage_backgrounds.yml
+++ b/html/changelogs/geeves-clickable_storage_backgrounds.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "You can now click on the background of an item inside a box/backpack to pick it up. This only affects storages that don't use the square slots for now."


### PR DESCRIPTION
* You can now click on the background of an item inside a box/backpack to pick it up. This only affects storages that don't use the square slots for now.


https://user-images.githubusercontent.com/22774890/233785108-65314af5-5fb4-4268-b1ab-d000c4a8a262.mp4