### PR TITLE
Some martial art tweaks

### DIFF
--- a/code/modules/martial_arts/sol_combat.dm
+++ b/code/modules/martial_arts/sol_combat.dm
@@ -22,14 +22,32 @@
 	return 0
 
 /datum/martial_art/sol_combat/proc/leg_sweep(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	A.do_attack_animation(D)
-	if(D.stat || D.weakened)
-		return 0
-	A.visible_message("<span class='warning'>[A] leg sweeps [D]!</span>")
-	playsound(get_turf(A), /singleton/sound_category/swing_hit_sound, 50, 1, -1)
-	D.apply_damage(5, DAMAGE_BRUTE)
-	D.Weaken(2)
-	return 1
+	var/list/sweepedatoms = list()
+	var/atom/sweeptarget
+	var/distfromcaster
+
+	for(var/turf/T in range(1,A))
+		for(var/atom/movable/AM in T)
+			sweepedatoms += AM
+
+	for(var/am in sweepedatoms)
+		var/atom/movable/AM = am
+		if(AM == A || AM.anchored)
+			continue
+
+		sweeptarget = get_edge_target_turf(A, get_dir(A, get_step_away(AM, A)))
+		distfromcaster = get_dist(A, AM)
+		if(istype(AM, /mob/living))
+			var/mob/living/M = AM
+			if(M.stat || M.incapacitated() || distfromcaster == 0)
+				D.apply_damage(25, DAMAGE_BRUTE)
+				A.visible_message("<span class='danger'>[A] hits [M] with a powerful kick!</span>")
+			else
+				if(istype(AM, /mob/living))
+					A.spin(10,1)
+					M.Weaken(3)
+					A.visible_message(M, "<span class='danger'>[A] swiftly leg sweeps [M]!</span>")
+					AM.throw_at(sweeptarget, ((Clamp((1 - (Clamp(distfromcaster - 2, 0, distfromcaster))), 1, 1))), 1)
 
 /datum/martial_art/sol_combat/proc/quick_choke(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)//is actually lung punch
 	A.do_attack_animation(D)
@@ -45,7 +63,7 @@
 	A.visible_message("<span class='warning'>[A] karate chops [D]'s neck!</span>")
 	playsound(get_turf(A), /singleton/sound_category/punch_sound, 50, 1, -1)
 	D.apply_damage(5, DAMAGE_BRUTE)
-	D.silent += 10
+	D.silent += 30
 	return 1
 
 datum/martial_art/sol_combat/grab_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
@@ -106,7 +124,7 @@ datum/martial_art/sol_combat/grab_act(var/mob/living/carbon/human/A, var/mob/liv
 
 	to_chat(usr, "<b><i>You clench your fists and have a flashback of knowledge...</i></b>")
 	to_chat(usr, "<span class='notice'>Neck Chop</span>: Harm Harm Disarm. Injures the neck, stopping the victim from speaking for a while.")
-	to_chat(usr, "<span class='notice'>Leg Sweep</span>: Disarm Harm Disarm. Trips the victim, rendering them prone and unable to move for a short time.")
+	to_chat(usr, "<span class='notice'>Leg Sweep</span>: Disarm Harm Disarm. Trips the victim and everyone else around you, rendering them prone and unable to move for a short time.")
 	to_chat(usr, "<span class='notice'>Lung Punch</span>: Harm Disarm Harm. Delivers a strong punch just above the victim's abdomen, constraining the lungs. The victim will be unable to breathe for a short time.")
 
 #undef NECK_CHOP

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -306,6 +306,8 @@
 				if(M.is_drowsy())
 					disarm_cost *= 1.25
 				usesStamina = TRUE
+			if(attacker_style && attacker_style.disarm_act(H, src))
+				usesStamina = FALSE
 			else if(M.max_stamina <= 0)
 				if(M.isSynthetic())
 					disarm_cost = potato.maxcharge / 24

--- a/html/changelogs/4000daniel1-PR-04.yml
+++ b/html/changelogs/4000daniel1-PR-04.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: 4000daniel1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "It is now possible to disarm while exhausted if you know a martial art."
+  - balance: "Buffed the solarian combat martial art's leg sweep ability, it now lasts a little longer and is AoE."
+  - balance: "Its neck chop ability also silences the victim for twenty seconds longer now."


### PR DESCRIPTION
This PR buffs the rarely seen solarian combat martial art by making its leg sweep ability AoE, along with making its neck chop ability last twenty seconds longer. It also makes it possible to use disarms while exhausted, if you know a martial art.

Some notes: The idea here is that wrestling is better suited for locking down a single target and dealing a lot of damage to them, while sol com is better suited for fending off a group. Along with the leg sweep being AoE it pushes people away one tile, and lasts sliiightly longer. People seem to sometimes INSTANTLY get back up if you only have weakened(2) so I changed it to 3, half of what a suplex inflicts. Additionally, if someone is already on the ground it'll kick them and do 25 brute instead. Since, y'know, hard to leg sweep someone laying down.

I assumed that it being impossible to use disarms while exhausted when you know a martial art was an oversight since there was already code that makes martial art disarms not consume any stamina.

As for the neck chop, it might last long enough to take someone's headset off now, I guess?