### PR TITLE
ISS Module Tech Reduction

### DIFF
--- a/code/modules/research/designs/mechfab/hardsuit/modules.dm
+++ b/code/modules/research/designs/mechfab/hardsuit/modules.dm
@@ -13,7 +13,7 @@
 /datum/design/hardsuitmodules/iss_module
 	name = "IIS Module"
 	desc = "An integrated intelligence system module suitable for most hardsuits."
-	req_tech = list(TECH_DATA = 4, TECH_MATERIAL = 3)
+	req_tech = list(TECH_DATA = 3, TECH_MATERIAL = 3)
 	materials = list(DEFAULT_WALL_MATERIAL = 5000, MATERIAL_GLASS = 7500)
 	build_path = /obj/item/rig_module/ai_container
 

--- a/html/changelogs/ramke - pai research buff.yml
+++ b/html/changelogs/ramke - pai research buff.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ramke
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Reduced tech level requirement for the ISS hardsuit module."


### PR DESCRIPTION
This PR adjusts the R&D tech level requirement for the ISS module by reducing it by 1, allowing it to be made by machinists at round start.

This module is basically never used because you need scientists, machinists and a pAI player. This PR makes it generally a bit more available.