### PR TITLE
Assisted organ fix

### DIFF
--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -360,12 +360,16 @@
 		name = robotic_name
 
 /obj/item/organ/proc/mechassist() //Used to add things like pacemakers, etc
-	robotize()
 	status = ORGAN_ASSISTED
 	robotic = 1
-	if(!robotize_type)
-		name = initial(name)
-		icon_state = initial(icon_state)
+	switch(organ_tag)
+				if(BP_HEART)
+					name = "pacemaker-assisted [initial(name)]"
+				if(BP_EYES)
+					name = "retinal overlayed [initial(name)]"
+				else
+					name = "mechanically assisted [initial(name)]"
+	icon_state = initial(icon_state)
 
 /obj/item/organ/emp_act(var/severity)
 	if(!(status & ORGAN_ASSISTED))

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -361,7 +361,7 @@
 
 /obj/item/organ/proc/mechassist() //Used to add things like pacemakers, etc
 	status = ORGAN_ASSISTED
-	robotic = 1
+	robotic = ROBOTIC_ASSISTED
 	switch(organ_tag)
 				if(BP_HEART)
 					name = "pacemaker-assisted [initial(name)]"

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -363,12 +363,12 @@
 	status = ORGAN_ASSISTED
 	robotic = ROBOTIC_ASSISTED
 	switch(organ_tag)
-				if(BP_HEART)
-					name = "pacemaker-assisted [initial(name)]"
-				if(BP_EYES)
-					name = "retinal overlayed [initial(name)]"
-				else
-					name = "mechanically assisted [initial(name)]"
+		if(BP_HEART)
+			name = "pacemaker-assisted [initial(name)]"
+		if(BP_EYES)
+			name = "retinal overlayed [initial(name)]"
+		else
+			name = "mechanically assisted [initial(name)]"
 	icon_state = initial(icon_state)
 
 /obj/item/organ/emp_act(var/severity)

--- a/html/changelogs/assistedorganfix.yml
+++ b/html/changelogs/assistedorganfix.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes assisted organs being turned into mechanical variants."


### PR DESCRIPTION
Fixes assisted organs being turned into mechanical variants. i.e. Currently choosing an assisted heart gives you an assisted circulatory pump, not a pacemaker.