### PR TITLE
Circus clown now requires a Taj WL

### DIFF
--- a/html/changelogs/dansemacabre-roleplayersonly.yml
+++ b/html/changelogs/dansemacabre-roleplayersonly.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheDanseMacabre
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "The Adhomian circus clown role now requires a Tajara whitelist."

--- a/maps/away/ships/tajara/circus/adhomian_circus_roles.dm
+++ b/maps/away/ships/tajara/circus/adhomian_circus_roles.dm
@@ -146,7 +146,7 @@
 
 	assigned_role = "Adhomian Circus Clown"
 	special_role = "Adhomian Circus Clown"
-
+	uses_species_whitelist = TRUE
 
 /datum/outfit/admin/adhomian_circus/clown
 	name = "Adhomian Circus Clown"


### PR DESCRIPTION
What it says up there. This is done to make sure anyone trying to play as the clown has at least a clear baseline level of roleplaying ability, which is necessitated by its unique situation with regards to immersion and overall roleplay quality.