### PR TITLE
Replaces turf gas vars and fixes exoplanet atmosphere generation.

### DIFF
--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -251,26 +251,16 @@
 	//Create gas mixture to hold data for passing
 	var/datum/gas_mixture/GM = new
 
-	GM.adjust_multi(GAS_OXYGEN, oxygen, GAS_CO2, carbon_dioxide, GAS_NITROGEN, nitrogen, GAS_PHORON, phoron, GAS_HYDROGEN, hydrogen)
-	GM.temperature = temperature
-
-	return GM
-
-/turf/remove_air(amount as num)
-	var/datum/gas_mixture/GM = new
-
-	var/sum = oxygen + carbon_dioxide + nitrogen + phoron
-	if(sum>0)
-		GM.gas[GAS_OXYGEN] = (oxygen/sum)*amount
-		GM.gas[GAS_CO2] = (carbon_dioxide/sum)*amount
-		GM.gas[GAS_NITROGEN] = (nitrogen/sum)*amount
-		GM.gas[GAS_PHORON] = (phoron/sum)*amount
-		GM.gas[GAS_HYDROGEN] = (hydrogen/sum)*amount
-
+	if(initial_gas)
+		GM.gas = initial_gas.Copy()
 	GM.temperature = temperature
 	GM.update_values()
 
 	return GM
+
+/turf/remove_air(amount as num)
+	var/datum/gas_mixture/GM = return_air()
+	return GM.remove(amount)
 
 /turf/simulated/assume_air(datum/gas_mixture/giver)
 	var/datum/gas_mixture/my_air = return_air()
@@ -285,10 +275,6 @@
 		my_air.adjust_gas_temp(gasid, moles, temp)
 
 	return 1
-
-/turf/simulated/remove_air(amount as num)
-	var/datum/gas_mixture/my_air = return_air()
-	return my_air.remove(amount)
 
 /turf/simulated/return_air()
 	if(zone)
@@ -308,9 +294,9 @@
 /turf/proc/make_air()
 	air = new/datum/gas_mixture
 	air.temperature = temperature
-	air.adjust_multi(GAS_OXYGEN, oxygen, GAS_CO2, carbon_dioxide, GAS_NITROGEN, nitrogen, GAS_PHORON, phoron, GAS_HYDROGEN, hydrogen)
-	air.group_multiplier = 1
-	air.volume = CELL_VOLUME
+	if(initial_gas)
+		air.gas = initial_gas.Copy()
+	air.update_values()
 
 /turf/simulated/proc/c_copy_air()
 	if(!air)

--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -426,14 +426,15 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 		return edge
 
 /datum/controller/subsystem/air/proc/has_same_air(turf/A, turf/B)
-	if(A.oxygen != B.oxygen)
+	if(A.initial_gas && !B.initial_gas)
 		return 0
-	if(A.nitrogen != B.nitrogen)
+	if(B.initial_gas && !A.initial_gas)
 		return 0
-	if(A.phoron != B.phoron)
-		return 0
-	if(A.carbon_dioxide != B.carbon_dioxide)
-		return 0
+	for(var/g in A.initial_gas)
+		if(!(g in B.initial_gas))
+			return 0
+		if(A.initial_gas[g] != B.initial_gas[g])
+			return 0
 	if(A.temperature != B.temperature)
 		return 0
 	return 1

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -86,7 +86,7 @@
 			if(locate(src.type) in T)
 				door_directions |= direction
 
-			if(T.oxygen <= 0)
+			if(T.initial_gas == null)
 				noair_directions |= direction
 
 			if(get_area(src.loc) != get_area(T))

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -12,8 +12,7 @@
 	initial_flooring = /singleton/flooring/carpet/blue
 
 /turf/simulated/floor/carpet/blue/airless
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 
 /turf/simulated/floor/carpet/rubber
 	name = "rubber carpet"
@@ -86,8 +85,7 @@
 	footstep_sound = /singleton/sound_category/wood_footstep
 
 /turf/simulated/floor/wood/airless
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 
 /turf/simulated/floor/wood/coloured
 	icon_state = "woodcolour"
@@ -145,8 +143,7 @@
 
 /turf/simulated/floor/tiled/full/airless
 	name = "airless full steel tile"
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 
 /turf/simulated/floor/reinforced
 	name = "reinforced floor"
@@ -160,56 +157,38 @@
 	temperature = 278
 
 /turf/simulated/floor/reinforced/airless
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 
 	roof_type = null
 
 /turf/simulated/floor/reinforced/airmix
-	oxygen = MOLES_O2ATMOS
-	nitrogen = MOLES_N2ATMOS
+	initial_gas = list("oxygen" = MOLES_O2ATMOS, "nitrogen" = MOLES_N2ATMOS)
 
 /turf/simulated/floor/reinforced/nitrogen
-	oxygen = 0
-	nitrogen = ATMOSTANK_NITROGEN
+	initial_gas = list("nitrogen" = ATMOSTANK_NITROGEN)
 
 // Reinforced Reactor Flooring
 /turf/simulated/floor/reinforced/reactor
 	name = "reinforced reactor floor"
-	oxygen = 0
-	nitrogen = MOLES_CELLSTANDARD // One atmosphere of nitrogen.
+	initial_gas = list("nitrogen" = MOLES_CELLSTANDARD) // One atmosphere of nitrogen.
 
 /turf/simulated/floor/reinforced/oxygen
-	oxygen = ATMOSTANK_OXYGEN
-	nitrogen = 0
+	initial_gas = list("oxygen" = ATMOSTANK_OXYGEN)
 
 /turf/simulated/floor/reinforced/phoron
-	oxygen = 0
-	nitrogen = 0
-	phoron = ATMOSTANK_PHORON
+	initial_gas = list("phoron" = ATMOSTANK_PHORON)
 
 /turf/simulated/floor/reinforced/phoron/scarce
-	phoron = ATMOSTANK_PHORON_SCARCE
+	initial_gas = list("phoron" = ATMOSTANK_PHORON_SCARCE)
 
 /turf/simulated/floor/reinforced/carbon_dioxide
-	oxygen = 0
-	nitrogen = 0
-	carbon_dioxide = ATMOSTANK_CO2
+	initial_gas = list("carbon_dioxide" = ATMOSTANK_CO2)
 
 /turf/simulated/floor/reinforced/n20
-	oxygen = 0
-	nitrogen = 0
-
-/turf/simulated/floor/reinforced/n20/Initialize()
-	. = ..()
-	if(!air)
-		make_air()
-	air.adjust_gas(GAS_N2O, ATMOSTANK_NITROUSOXIDE)
+	initial_gas = list("sleeping_agent" = ATMOSTANK_NITROUSOXIDE)
 
 /turf/simulated/floor/reinforced/hydrogen
-	oxygen = 0
-	nitrogen = 0
-	hydrogen = ATMOSTANK_HYDROGEN
+	initial_gas = list("hydrogen" = ATMOSTANK_HYDROGEN)
 
 /turf/simulated/floor/cult
 	name = "engraved floor"
@@ -231,8 +210,7 @@
 	temperature = 278
 
 /turf/simulated/floor/tiled/dark/airless
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 
 /turf/simulated/floor/tiled/dark/full
 	name = "full plasteel tile"
@@ -241,8 +219,7 @@
 
 /turf/simulated/floor/tiled/dark/full/airless
 	name = "airless full plasteel tile"
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 
 /turf/simulated/floor/tiled/red
 	name = "red floor"
@@ -257,8 +234,7 @@
 	initial_flooring = /singleton/flooring/tiling/steel
 
 /turf/simulated/floor/tiled/steel/airless
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	roof_type = null
 
 /turf/simulated/floor/tiled/old
@@ -285,8 +261,7 @@
 	initial_flooring = /singleton/flooring/tiling/asteroid
 
 /turf/simulated/floor/tiled/asteroid/airless
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	roof_type = null
 
 /turf/simulated/floor/plating/cooled
@@ -338,15 +313,13 @@
 //ATMOS PREMADES
 /turf/simulated/floor/reinforced/airless
 	name = "vacuum floor"
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	temperature = TCMB
 	roof_type = null
 
 /turf/simulated/floor/airless
 	name = "airless plating"
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	temperature = TCMB
 	footstep_sound = /singleton/sound_category/plating_footstep
 
@@ -354,29 +327,25 @@
 
 /turf/simulated/floor/tiled/airless
 	name = "airless floor"
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	temperature = TCMB
 
 /turf/simulated/floor/bluegrid/airless
 	name = "airless floor"
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	temperature = TCMB
 
 /turf/simulated/floor/greengrid/airless
 	name = "airless floor"
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	temperature = TCMB
 
 /turf/simulated/floor/greengrid/nitrogen
-	oxygen = 0
+	initial_gas = list("nitrogen" = MOLES_N2STANDARD)
 
 /turf/simulated/floor/tiled/white/airless
 	name = "airless floor"
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	temperature = TCMB
 
 // Placeholders

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -70,6 +70,11 @@
 	name = "cooled mainframe floor"
 	temperature = 278
 
+/turf/simulated/floor/bluegrid/server
+	name = "cooled mainframe floor"
+	temperature = 80
+	initial_gas = list("nitrogen" = MOLES_CELLSTANDARD) //one atmosphere of nitrogen
+
 /turf/simulated/floor/greengrid
 	name = "mainframe floor"
 	icon = 'icons/turf/flooring/circuit.dmi'

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -5,8 +5,7 @@
 	var/image/wet_overlay = null
 
 	var/thermite = 0
-	oxygen = MOLES_O2STANDARD
-	nitrogen = MOLES_N2STANDARD
+	initial_gas = list("oxygen" = MOLES_O2STANDARD, "nitrogen" = MOLES_N2STANDARD)
 	var/to_be_destroyed = 0 //Used for fire, if a melting temperature was reached, it will be destroyed
 	var/max_fire_temperature_sustained = 0 //The max temperature of the fire which it was subjected to
 	var/dirt = 0

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -9,6 +9,5 @@
 	flags = TURF_REMOVE_SHOVEL|TURF_REMOVE_WELDER
 
 /turf/simulated/floor/diona/airless
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	temperature = TCMB

--- a/code/game/turfs/simulated/shuttle_turfs.dm
+++ b/code/game/turfs/simulated/shuttle_turfs.dm
@@ -458,8 +458,7 @@
 	initial_flooring = /singleton/flooring/shuttle/dark_blue
 
 /turf/simulated/floor/shuttle/dark_blue/airless
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 
 /turf/simulated/floor/shuttle/advanced
 	icon_state = "advanced_plating"
@@ -475,16 +474,14 @@
 	footstep_sound = /singleton/sound_category/sand_footstep
 
 /turf/simulated/floor/shuttle/skrell/airless
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 
 /turf/simulated/floor/shuttle/skrell/blue
 	icon_state = "skrell_blue"
 	initial_flooring = /singleton/flooring/shuttle/skrell/blue
 
 /turf/simulated/floor/shuttle/skrell/blue/airless
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 
 /turf/simulated/floor/shuttle/skrell/ramp
 	name = "footramp"
@@ -503,8 +500,7 @@
 	icon_state = "roof_white"
 	smooth = SMOOTH_DIAGONAL|SMOOTH_TRUE
 	smooth_underlays = TRUE
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	roof_type = null
 	permit_ao = 0
 	canSmoothWith = list(

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -6,11 +6,7 @@
 	var/holy = 0
 
 	// Initial air contents (in moles)
-	var/oxygen = 0
-	var/carbon_dioxide = 0
-	var/nitrogen = 0
-	var/phoron = 0
-	var/hydrogen = 0
+	var/list/initial_gas
 
 	//Properties for airtight tiles (/wall)
 	var/thermal_conductivity = 0.05

--- a/code/game/turfs/unsimulated.dm
+++ b/code/game/turfs/unsimulated.dm
@@ -1,4 +1,3 @@
 /turf/unsimulated
 	name = "command"
-	oxygen = MOLES_O2STANDARD
-	nitrogen = MOLES_N2STANDARD
+	initial_gas = list("oxygen" = MOLES_O2STANDARD, "nitrogen" = MOLES_N2STANDARD)

--- a/code/game/turfs/unsimulated/floor.dm
+++ b/code/game/turfs/unsimulated/floor.dm
@@ -29,8 +29,7 @@
 	name = "chasm mask"
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "alienvault"
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	temperature = TCMB
 
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -28,8 +28,7 @@ var/list/mineral_can_smooth_with = list(
 	smooth = SMOOTH_MORE | SMOOTH_BORDER | SMOOTH_NO_CLEAR_ICON
 	smoothing_hints = SMOOTHHINT_CUT_F | SMOOTHHINT_ONLY_MATCH_TURF | SMOOTHHINT_TARGETS_NOT_UNIQUE
 
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	opacity = TRUE
 	density = TRUE
 	blocks_air = TRUE
@@ -611,8 +610,7 @@ var/list/mineral_can_smooth_with = list(
 	base_icon = 'icons/turf/map_placeholders.dmi'
 	base_icon_state = "ash"
 
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	temperature = TCMB
 	var/dug = 0 //Increments by 1 everytime it's dug. 11 is the last integer that should ever be here.
 	var/digging

--- a/code/modules/multiz/turfs/open_space.dm
+++ b/code/modules/multiz/turfs/open_space.dm
@@ -139,8 +139,7 @@
 		LAZYREMOVE(climbers, climber)
 
 /turf/simulated/open/airless
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	temperature = TCMB
 	icon_state = "opendebug_airless"
 
@@ -153,8 +152,7 @@
 	name = "hole"
 
 /turf/simulated/open/chasm/airless
-	oxygen = 0
-	nitrogen = 0
+	initial_gas = null
 	temperature = TCMB
 	icon_state = "debug_airless"
 

--- a/code/modules/overmap/exoplanets/decor/_turfs.dm
+++ b/code/modules/overmap/exoplanets/decor/_turfs.dm
@@ -18,8 +18,10 @@
 		var/obj/effect/overmap/visitable/sector/exoplanet/E = map_sectors["[z]"]
 		if(istype(E))
 			if(E.atmosphere)
+				initial_gas = E.atmosphere.gas.Copy()
 				temperature = E.atmosphere.temperature
 			else
+				initial_gas = list()
 				temperature = T0C
 			//Must be done here, as light data is not fully carried over by ChangeTurf (but overlays are).
 			set_light(MINIMUM_USEFUL_LIGHT_RANGE, E.lightlevel, COLOR_WHITE)

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -217,8 +217,7 @@
 			var/zone/A = U.A
 			var/offending_turfs = "Problem turfs: \n"
 			for(var/turf/simulated/S in A.contents)
-				if(S.initial_gas)
-					offending_turfs += "[S] ([S.x], [S.y], [S.z])\t"
+				offending_turfs += "[S] ([S.x], [S.y], [S.z])\t"
 
 			fail_message += "[offending_turfs]"
 
@@ -243,8 +242,7 @@
 
 			var/offending_turfs = "Problem turfs: "
 			for(var/turf/simulated/S in problem.contents)
-				if(S.initial_gas)
-					offending_turfs += "[S] ([S.x], [S.y], [S.z])\t"
+				offending_turfs += "[S] ([S.x], [S.y], [S.z])\t"
 
 			fail_message += "[offending_turfs]"
 

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -217,7 +217,8 @@
 			var/zone/A = U.A
 			var/offending_turfs = "Problem turfs: \n"
 			for(var/turf/simulated/S in A.contents)
-				offending_turfs += "[S] ([S.x], [S.y], [S.z])\t"
+				if("oxygen" in S.initial_gas || "nitrogen" in S.initial_gas)
+					offending_turfs += "[S] ([S.x], [S.y], [S.z])\t"
 
 			fail_message += "[offending_turfs]"
 
@@ -242,7 +243,8 @@
 
 			var/offending_turfs = "Problem turfs: "
 			for(var/turf/simulated/S in problem.contents)
-				offending_turfs += "[S] ([S.x], [S.y], [S.z])\t"
+				if("oxygen" in S.initial_gas || "nitrogen" in S.initial_gas)
+					offending_turfs += "[S] ([S.x], [S.y], [S.z])\t"
 
 			fail_message += "[offending_turfs]"
 

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -217,7 +217,7 @@
 			var/zone/A = U.A
 			var/offending_turfs = "Problem turfs: \n"
 			for(var/turf/simulated/S in A.contents)
-				if("oxygen" in S.initial_gas || "nitrogen" in S.initial_gas)
+				if(("oxygen" in S.initial_gas) || ("nitrogen" in S.initial_gas))
 					offending_turfs += "[S] ([S.x], [S.y], [S.z])\t"
 
 			fail_message += "[offending_turfs]"
@@ -243,7 +243,7 @@
 
 			var/offending_turfs = "Problem turfs: "
 			for(var/turf/simulated/S in problem.contents)
-				if("oxygen" in S.initial_gas || "nitrogen" in S.initial_gas)
+				if(("oxygen" in S.initial_gas) || ("nitrogen" in S.initial_gas))
 					offending_turfs += "[S] ([S.x], [S.y], [S.z])\t"
 
 			fail_message += "[offending_turfs]"

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -217,7 +217,7 @@
 			var/zone/A = U.A
 			var/offending_turfs = "Problem turfs: \n"
 			for(var/turf/simulated/S in A.contents)
-				if(S.oxygen || S.nitrogen)
+				if(S.initial_gas)
 					offending_turfs += "[S] ([S.x], [S.y], [S.z])\t"
 
 			fail_message += "[offending_turfs]"
@@ -243,7 +243,7 @@
 
 			var/offending_turfs = "Problem turfs: "
 			for(var/turf/simulated/S in problem.contents)
-				if(S.oxygen || S.nitrogen)
+				if(S.initial_gas)
 					offending_turfs += "[S] ([S.x], [S.y], [S.z])\t"
 
 			fail_message += "[offending_turfs]"

--- a/html/changelogs/RustingWithYou - fear.yml
+++ b/html/changelogs/RustingWithYou - fear.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Turfs now have an initial_gas list instead of vars for individual gases."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -8969,11 +8969,7 @@
 	pixel_x = 5;
 	pixel_y = 16
 	},
-/turf/unsimulated/floor/asteroid/ash/rocky{
-	nitrogen = 82.1472;
-	oxygen = 21.8366;
-	temperature = 293.15
-	},
+/turf/simulated/floor/exoplanet/barren,
 /area/centcom/shared_dream)
 "ccF" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
@@ -10807,11 +10803,7 @@
 /obj/structure/ore_box{
 	icon_state = "orebox1"
 	},
-/turf/unsimulated/floor/asteroid/ash/rocky{
-	nitrogen = 82.1472;
-	oxygen = 21.8366;
-	temperature = 293.15
-	},
+/turf/simulated/floor/exoplanet/barren,
 /area/centcom/shared_dream)
 "dio" = (
 /obj/structure/bed/stool/chair/office/dark{
@@ -10953,11 +10945,7 @@
 /obj/effect/landmark{
 	name = "skrell_entry"
 	},
-/turf/unsimulated/floor/asteroid/ash/rocky{
-	nitrogen = 82.1472;
-	oxygen = 21.8366;
-	temperature = 293.15
-	},
+/turf/simulated/floor/exoplanet/barren,
 /area/centcom/shared_dream)
 "dob" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -14090,11 +14078,7 @@
 	can_buckle = 0;
 	name = "dusty chair"
 	},
-/turf/unsimulated/floor/asteroid/ash/rocky{
-	nitrogen = 82.1472;
-	oxygen = 21.8366;
-	temperature = 293.15
-	},
+/turf/simulated/floor/exoplanet/barren,
 /area/centcom/shared_dream)
 "fri" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -26264,11 +26248,7 @@
 	},
 /area/centcom/bar)
 "mZh" = (
-/turf/unsimulated/floor/asteroid/ash/rocky{
-	nitrogen = 82.1472;
-	oxygen = 21.8366;
-	temperature = 293.15
-	},
+/turf/simulated/floor/exoplanet/barren,
 /area/centcom/shared_dream)
 "mZj" = (
 /turf/unsimulated/mineral/asteroid,
@@ -28002,11 +27982,7 @@
 	icon_state = "boulder1";
 	name = "rubble"
 	},
-/turf/unsimulated/floor/asteroid/ash/rocky{
-	nitrogen = 82.1472;
-	oxygen = 21.8366;
-	temperature = 293.15
-	},
+/turf/simulated/floor/exoplanet/barren,
 /area/centcom/shared_dream)
 "nYo" = (
 /obj/structure/bed/stool/chair/office/bridge{
@@ -29968,11 +29944,7 @@
 /area/centcom/bar)
 "pux" = (
 /obj/item/pickaxe,
-/turf/unsimulated/floor/asteroid/ash/rocky{
-	nitrogen = 82.1472;
-	oxygen = 21.8366;
-	temperature = 293.15
-	},
+/turf/simulated/floor/exoplanet/barren,
 /area/centcom/shared_dream)
 "puD" = (
 /turf/simulated/wall/shuttle/unique/merchant{
@@ -30824,11 +30796,7 @@
 	pixel_x = 11;
 	pixel_y = -6
 	},
-/turf/unsimulated/floor/asteroid/ash/rocky{
-	nitrogen = 82.1472;
-	oxygen = 21.8366;
-	temperature = 293.15
-	},
+/turf/simulated/floor/exoplanet/barren,
 /area/centcom/shared_dream)
 "pUh" = (
 /obj/structure/shuttle_part/merchant{
@@ -31753,11 +31721,7 @@
 	name = "beacon";
 	pixel_y = -2
 	},
-/turf/unsimulated/floor/asteroid/ash/rocky{
-	nitrogen = 82.1472;
-	oxygen = 21.8366;
-	temperature = 293.15
-	},
+/turf/simulated/floor/exoplanet/barren,
 /area/centcom/shared_dream)
 "qGr" = (
 /obj/structure/window/shuttle/unique/merchant{
@@ -38613,11 +38577,7 @@
 "vze" = (
 /obj/structure/table/steel,
 /obj/item/deck/cards,
-/turf/unsimulated/floor/asteroid/ash/rocky{
-	nitrogen = 82.1472;
-	oxygen = 21.8366;
-	temperature = 293.15
-	},
+/turf/simulated/floor/exoplanet/barren,
 /area/centcom/shared_dream)
 "vzG" = (
 /obj/machinery/vending/snack{

--- a/maps/aurora/aurora-3_sublevel.dmm
+++ b/maps/aurora/aurora-3_sublevel.dmm
@@ -1342,11 +1342,7 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/turf/simulated/floor/reinforced{
-	name = "vacuum floor";
-	nitrogen = 0.01;
-	oxygen = 0.01
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos)
 "adr" = (
 /obj/structure/grille,
@@ -1757,11 +1753,7 @@
 	},
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/reinforced{
-	name = "vacuum floor";
-	nitrogen = 0.01;
-	oxygen = 0.01
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos)
 "aeg" = (
 /obj/machinery/door/firedoor,
@@ -2019,11 +2011,7 @@
 	pixel_y = 1;
 	use_power = 1
 	},
-/turf/simulated/floor/reinforced{
-	name = "vacuum floor";
-	nitrogen = 0.01;
-	oxygen = 0.01
-	},
+/turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos)
 "aeQ" = (
 /obj/machinery/door/firedoor,

--- a/maps/aurora/aurora-4_mainlevel.dmm
+++ b/maps/aurora/aurora-4_mainlevel.dmm
@@ -1525,12 +1525,7 @@
 	icon_state = "map_vent_out";
 	use_power = 1
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/server)
 "adh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2178,20 +2173,10 @@
 	dir = 8
 	},
 /obj/machinery/r_n_d/server/advanced/core,
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/server)
 "aes" = (
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/server)
 "aet" = (
 /obj/item/material/shard{
@@ -2906,12 +2891,7 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/server)
 "afH" = (
 /obj/structure/cable/green{
@@ -18696,12 +18676,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/server)
 "aGI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -18901,12 +18876,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/server)
 "aHa" = (
 /obj/structure/grille,

--- a/maps/aurora/aurora-6_surface.dmm
+++ b/maps/aurora/aurora-6_surface.dmm
@@ -2908,12 +2908,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "cmT" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -3350,12 +3345,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "cHp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3917,12 +3907,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "dkX" = (
 /obj/machinery/door/firedoor,
@@ -5341,12 +5326,7 @@
 	pressure_checks_default = 0;
 	use_power = 1
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "eHq" = (
 /obj/effect/floor_decal/corner/red{
@@ -5572,12 +5552,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "eRk" = (
 /obj/machinery/telecomms/server/presets/common,
@@ -6077,12 +6052,7 @@
 	name = "SERVER ROOM";
 	pixel_y = 32
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "foh" = (
 /obj/structure/grille,
@@ -8342,12 +8312,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "hlx" = (
 /obj/structure/window/reinforced,
@@ -12816,12 +12781,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "ljj" = (
 /turf/simulated/open/airless,
@@ -12905,12 +12865,7 @@
 	name = "SERVER ROOM";
 	pixel_y = 32
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "loo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14980,12 +14935,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "nbA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18242,12 +18192,7 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "pKM" = (
 /obj/structure/grille,
@@ -19364,12 +19309,7 @@
 /area/tcommsat/entrance)
 "qJW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "qJZ" = (
 /obj/effect/floor_decal/corner/white/diagonal{
@@ -19532,12 +19472,7 @@
 	pixel_x = 8;
 	pixel_y = 25
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "qTD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -22022,12 +21957,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "sTR" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -23178,12 +23108,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "tMF" = (
 /turf/simulated/wall/shuttle/unique/research{
@@ -23698,12 +23623,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "ujs" = (
 /obj/structure/cable{
@@ -25940,12 +25860,7 @@
 /area/hydroponics/garden)
 "wiv" = (
 /obj/machinery/firealarm/north,
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "wkD" = (
 /obj/structure/grille,
@@ -27379,12 +27294,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "xvJ" = (
 /obj/structure/cable/green{
@@ -27524,12 +27434,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/central)
 "xBr" = (
-/turf/simulated/floor/bluegrid{
-	name = "Mainframe Base";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/tcommsat/chamber)
 "xBt" = (
 /obj/structure/cable/green{

--- a/maps/away/away_site/sol_bunker/bunker.dmm
+++ b/maps/away/away_site/sol_bunker/bunker.dmm
@@ -2,10 +2,7 @@
 "aj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "aC" = (
 /obj/structure/table/reinforced,
@@ -22,10 +19,7 @@
 /obj/item/bedsheet/blue,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "bK" = (
 /obj/structure/grille,
@@ -41,10 +35,7 @@
 "cn" = (
 /obj/effect/decal/cleanable/spiderling_remains,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "cv" = (
 /obj/structure/grille,
@@ -139,10 +130,7 @@
 /area/derelict)
 "hE" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "hS" = (
 /obj/machinery/door/airlock/centcom{
@@ -160,16 +148,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "iU" = (
 /obj/effect/decal/cleanable/spiderling_remains,
-/turf/simulated/floor/tiled/airless,
-/area/derelict)
-"jr" = (
 /turf/simulated/floor/tiled/airless,
 /area/derelict)
 "jC" = (
@@ -260,10 +242,7 @@
 /obj/structure/bed/padded,
 /obj/item/bedsheet/blue,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "lu" = (
 /obj/structure/curtain/open/shower,
@@ -313,10 +292,7 @@
 "mM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/door_assembly,
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "mP" = (
 /obj/structure/table/wood,
@@ -327,10 +303,7 @@
 /obj/effect/decal/cleanable/ash,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "nx" = (
 /obj/structure/table/wood,
@@ -361,10 +334,7 @@
 /obj/structure/door_assembly{
 	anchored = 1
 	},
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "oZ" = (
 /turf/simulated/floor/tiled,
@@ -442,10 +412,7 @@
 /obj/structure/sign/poster{
 	pixel_x = 32
 	},
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "sI" = (
 /obj/structure/grille,
@@ -472,10 +439,7 @@
 /obj/machinery/light{
 	brightness_color = "#FA8282"
 	},
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "tz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -521,10 +485,7 @@
 "un" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "us" = (
 /obj/structure/grille,
@@ -559,10 +520,7 @@
 	name = "dilapitated cryogenic freezer";
 	pixel_x = 1
 	},
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "uQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -635,10 +593,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "Bl" = (
 /obj/structure/toilet,
@@ -675,10 +630,7 @@
 "CD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/sol/marine,
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "DF" = (
 /obj/random/junk,
@@ -691,10 +643,7 @@
 	dir = 1
 	},
 /obj/structure/bed/stool/padded/red,
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "Em" = (
 /obj/structure/toilet,
@@ -774,10 +723,7 @@
 	dir = 1;
 	status = 2
 	},
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "GX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -849,10 +795,7 @@
 /obj/machinery/light{
 	brightness_color = "#FA8282"
 	},
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "KL" = (
 /obj/structure/boulder,
@@ -919,10 +862,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/derelict)
 "Oh" = (
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "Oi" = (
 /obj/effect/decal/cleanable/mucus,
@@ -971,10 +911,7 @@
 /obj/structure/bed/padded,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "QX" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -1032,10 +969,7 @@
 /obj/effect/decal/cleanable/dirt{
 	layer = 3.1
 	},
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "SI" = (
 /obj/machinery/door/airlock/vault/bolted,
@@ -1099,10 +1033,7 @@
 /obj/structure/sign/flag/sol{
 	pixel_x = 32
 	},
-/turf/simulated/floor/wood{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/simulated/floor/wood/airless,
 /area/derelict)
 "WE" = (
 /obj/structure/grille,
@@ -1184,9 +1115,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor,
 /area/derelict)
-"ZG" = (
-/turf/unsimulated/floor/asteroid/ash/rocky,
-/area/space)
 
 (1,1,1) = {"
 YV
@@ -29331,13 +29259,13 @@ YV
 YV
 YV
 YV
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 YV
 YV
 YV
@@ -29587,16 +29515,16 @@ YV
 YV
 YV
 YV
-ZG
-ZG
+Yp
+Yp
 zM
 zM
 zM
-ZG
-ZG
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
+Yp
+Yp
 YV
 YV
 YV
@@ -29844,19 +29772,19 @@ zM
 YV
 YV
 YV
-ZG
+Yp
 zM
 zM
 zM
 zM
 zM
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 YV
 YV
 YV
@@ -30108,11 +30036,11 @@ zM
 zM
 zM
 zM
-ZG
-ZG
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
+Yp
+Yp
 zM
 zM
 YV
@@ -30340,7 +30268,7 @@ YV
 YV
 YV
 YV
-ZG
+Yp
 YV
 zM
 zM
@@ -30367,8 +30295,8 @@ zM
 zM
 zM
 zM
-ZG
-ZG
+Yp
+Yp
 zM
 zM
 zM
@@ -30596,8 +30524,8 @@ YV
 YV
 YV
 YV
-ZG
-ZG
+Yp
+Yp
 zM
 zM
 zM
@@ -30625,7 +30553,7 @@ zM
 zM
 zM
 zM
-ZG
+Yp
 zM
 zM
 zM
@@ -30852,8 +30780,8 @@ YV
 YV
 YV
 YV
-ZG
-ZG
+Yp
+Yp
 zM
 zM
 zM
@@ -30882,8 +30810,8 @@ zM
 zM
 zM
 zM
-ZG
-ZG
+Yp
+Yp
 zM
 zM
 zM
@@ -31106,9 +31034,9 @@ YV
 YV
 YV
 YV
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
 zM
 zM
 zM
@@ -31119,8 +31047,8 @@ zM
 zM
 zM
 zM
-ZG
-ZG
+Yp
+Yp
 zM
 zM
 zM
@@ -31139,9 +31067,9 @@ zM
 zM
 zM
 zM
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
 zM
 zM
 zM
@@ -31362,8 +31290,8 @@ YV
 YV
 YV
 YV
-ZG
-ZG
+Yp
+Yp
 zM
 zM
 zM
@@ -31375,7 +31303,7 @@ zM
 zM
 zM
 zM
-ZG
+Yp
 Gy
 Va
 Uq
@@ -31396,9 +31324,9 @@ zM
 zM
 zM
 zM
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
 zM
 zM
 zM
@@ -31618,12 +31546,12 @@ YV
 YV
 YV
 YV
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 zM
 zM
 zM
@@ -31631,10 +31559,10 @@ zM
 zM
 zM
 zM
-ZG
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
+Yp
 Lu
 xW
 nR
@@ -31653,9 +31581,9 @@ zM
 zM
 zM
 zM
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
 zM
 zM
 zM
@@ -31873,25 +31801,25 @@ YV
 YV
 YV
 YV
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 Lu
 xU
 xU
@@ -31910,9 +31838,9 @@ zM
 zM
 zM
 zM
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
 zM
 zM
 zM
@@ -32131,23 +32059,23 @@ YV
 YV
 YV
 YV
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 Gy
-ZG
+Yp
 Vs
 Uq
 Uq
@@ -32167,9 +32095,9 @@ zM
 zM
 zM
 zM
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
 zM
 zM
 zM
@@ -32390,21 +32318,21 @@ YV
 YV
 YV
 YV
-ZG
+Yp
 YV
-ZG
+Yp
 zM
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 Yp
 Uq
 Uq
@@ -32424,9 +32352,9 @@ zM
 zM
 zM
 zM
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
 zM
 zM
 zM
@@ -32652,16 +32580,16 @@ YV
 YV
 zM
 zM
-ZG
+Yp
 zM
 zM
 zM
 zM
 zM
 zM
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
 Uq
 Uq
 gd
@@ -32681,9 +32609,9 @@ zM
 zM
 zM
 zM
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
 zM
 zM
 zM
@@ -32916,8 +32844,8 @@ zM
 zM
 zM
 zM
-ZG
-ZG
+Yp
+Yp
 Uq
 Uq
 gd
@@ -34975,7 +34903,7 @@ pV
 vN
 Jc
 Ce
-jr
+gd
 Mf
 gd
 WG
@@ -36021,8 +35949,8 @@ zM
 zM
 zM
 zM
-ZG
-ZG
+Yp
+Yp
 zM
 zM
 zM
@@ -36278,8 +36206,8 @@ zM
 zM
 zM
 zM
-ZG
-ZG
+Yp
+Yp
 zM
 zM
 zM
@@ -36535,8 +36463,8 @@ zM
 zM
 zM
 KL
-ZG
-ZG
+Yp
+Yp
 zM
 zM
 zM
@@ -36788,12 +36716,12 @@ KG
 Uq
 zM
 zM
-ZG
-ZG
+Yp
+Yp
 KL
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
 zM
 zM
 zM
@@ -37043,13 +36971,13 @@ hE
 Oh
 hE
 Uq
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 zM
 zM
 zM
@@ -37301,12 +37229,12 @@ lp
 lp
 Uq
 zM
-ZG
-ZG
-ZG
-ZG
-ZG
-ZG
+Yp
+Yp
+Yp
+Yp
+Yp
+Yp
 zM
 zM
 zM
@@ -37559,8 +37487,8 @@ sN
 Uq
 zM
 zM
-ZG
-ZG
+Yp
+Yp
 zM
 zM
 zM

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -1155,9 +1155,8 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/ramp{
-	dir = 4;
-	nitrogen = 0;
-	oxygen = 0
+	dir = 8;
+	initial_gas = list()
 	},
 /area/ship/orion_express_ship)
 "iCX" = (
@@ -2353,9 +2352,8 @@
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/ramp{
-	dir = 8;
-	nitrogen = 0;
-	oxygen = 0
+	dir = 4;
+	initial_gas = list()
 	},
 /area/ship/orion_express_ship)
 "rvq" = (

--- a/maps/random_ruins/exoplanets/asteroid/coc_ship/coc_ship_unique.dmm
+++ b/maps/random_ruins/exoplanets/asteroid/coc_ship/coc_ship_unique.dmm
@@ -551,10 +551,7 @@
 	icon_state = "11,16";
 	name = "skipjack cockpit"
 	},
-/turf/simulated/floor/plating{
-	nitrogen = 0;
-	oxygen = 0
-	},
+/turf/space,
 /area/template_noop)
 "lP" = (
 /obj/structure/shuttle_part/raider{

--- a/maps/random_ruins/exoplanets/asteroid/coc_ship/coc_ship_unique.dmm
+++ b/maps/random_ruins/exoplanets/asteroid/coc_ship/coc_ship_unique.dmm
@@ -1039,10 +1039,7 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /mob/living/simple_animal/carp/baby,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/asteroid{
-	oxygen = 0;
-	nitrogen = 0
-	},
+/turf/unsimulated/floor/asteroid/ash,
 /area/template_noop)
 "vQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
@@ -1125,10 +1122,7 @@
 "xj" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/asteroid{
-	oxygen = 0;
-	nitrogen = 0
-	},
+/turf/unsimulated/floor/asteroid/ash,
 /area/template_noop)
 "xL" = (
 /obj/structure/shuttle_part/raider{
@@ -1862,10 +1856,7 @@
 "XI" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/asteroid{
-	oxygen = 0;
-	nitrogen = 0
-	},
+/turf/simulated/floor/airless/ceiling,
 /area/template_noop)
 "XY" = (
 /obj/item/material/shard/shrapnel,

--- a/maps/random_ruins/exoplanets/asteroid/listening_post/listening_post_unique.dmm
+++ b/maps/random_ruins/exoplanets/asteroid/listening_post/listening_post_unique.dmm
@@ -285,23 +285,20 @@
 "aQ" = (
 /obj/effect/decal/remains/rat,
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "aR" = (
 /obj/random/powercell,
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "aT" = (
 /obj/item/bluespace_crystal,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "aU" = (
@@ -338,15 +335,13 @@
 /obj/machinery/constructable_frame/temp_deco,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "ba" = (
 /obj/item/bluespace_crystal,
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "bb" = (
@@ -387,8 +382,7 @@
 	},
 /obj/item/trash/syndi_cakes,
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "bh" = (
@@ -396,15 +390,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "bi" = (
 /obj/item/stock_parts/scanning_module/adv,
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "bj" = (
@@ -431,23 +423,20 @@
 "bm" = (
 /obj/machinery/constructable_frame/temp_deco,
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "bn" = (
 /obj/effect/decal/remains/robot,
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "bo" = (
 /obj/item/stock_parts/capacitor/adv,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "bp" = (
@@ -461,24 +450,21 @@
 "br" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "bs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "bt" = (
 /obj/item/circuitboard/telecomms/broadcaster,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "bu" = (
@@ -514,8 +500,7 @@
 /area/template_noop)
 "bA" = (
 /turf/simulated/floor/shuttle/dark_red{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = list()
 	},
 /area/template_noop)
 "bB" = (

--- a/maps/random_ruins/exoplanets/asteroid/skrell_ship/skrell_crash_unique.dmm
+++ b/maps/random_ruins/exoplanets/asteroid/skrell_ship/skrell_crash_unique.dmm
@@ -57,7 +57,7 @@
 	name = "Command Copula"
 	},
 /turf/simulated/floor/shuttle/skrell/ramp{
-	initial_gas = null
+	initial_gas = list()
 	},
 /area/template_noop)
 "an" = (
@@ -796,12 +796,6 @@
 /obj/machinery/light/skrell,
 /turf/simulated/floor/shuttle/skrell/blue/airless,
 /area/template_noop)
-"IN" = (
-/turf/simulated/floor/shuttle/skrell/blue{
-	nitrogen = 0;
-	oxygen = 0
-	},
-/area/template_noop)
 "OB" = (
 /obj/structure/closet/skrell,
 /obj/random/weapon_and_ammo,
@@ -1233,7 +1227,7 @@ Vf
 ba
 au
 az
-IN
+Ug
 aI
 Ug
 ap

--- a/maps/random_ruins/exoplanets/asteroid/skrell_ship/skrell_crash_unique.dmm
+++ b/maps/random_ruins/exoplanets/asteroid/skrell_ship/skrell_crash_unique.dmm
@@ -45,10 +45,7 @@
 /area/template_noop)
 "aj" = (
 /obj/structure/computerframe,
-/turf/simulated/floor/shuttle/skrell{
-	oxygen = 0;
-	nitrogen = 0
-	},
+/turf/simulated/floor/shuttle/skrell/airless,
 /area/template_noop)
 "al" = (
 /turf/simulated/floor/shuttle/skrell/blue,
@@ -60,8 +57,7 @@
 	name = "Command Copula"
 	},
 /turf/simulated/floor/shuttle/skrell/ramp{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = null
 	},
 /area/template_noop)
 "an" = (
@@ -79,10 +75,7 @@
 /obj/structure/table/skrell,
 /obj/item/paper_scanner,
 /obj/item/pen/black,
-/turf/simulated/floor/shuttle/skrell{
-	oxygen = 0;
-	nitrogen = 0
-	},
+/turf/simulated/floor/shuttle/skrell/airless,
 /area/template_noop)
 "ap" = (
 /turf/simulated/wall/shuttle/skrell,
@@ -109,20 +102,14 @@
 	},
 /obj/structure/table/skrell,
 /obj/item/skrell_projector,
-/turf/simulated/floor/shuttle/skrell{
-	oxygen = 0;
-	nitrogen = 0
-	},
+/turf/simulated/floor/shuttle/skrell/airless,
 /area/template_noop)
 "av" = (
 /obj/structure/bed/stool/chair/office/hover/command{
 	icon_state = "hover_command";
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/skrell{
-	oxygen = 0;
-	nitrogen = 0
-	},
+/turf/simulated/floor/shuttle/skrell/airless,
 /area/template_noop)
 "aw" = (
 /obj/structure/closet/crate/freezer,
@@ -134,10 +121,7 @@
 	},
 /obj/structure/table/skrell,
 /obj/item/stack/rods,
-/turf/simulated/floor/shuttle/skrell{
-	oxygen = 0;
-	nitrogen = 0
-	},
+/turf/simulated/floor/shuttle/skrell/airless,
 /area/template_noop)
 "ay" = (
 /obj/effect/decal/cleanable/blood/tracks/footprints{
@@ -150,10 +134,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/shuttle/skrell{
-	oxygen = 0;
-	nitrogen = 0
-	},
+/turf/simulated/floor/shuttle/skrell/airless,
 /area/template_noop)
 "aA" = (
 /obj/machinery/bodyscanner,
@@ -303,10 +284,7 @@
 	},
 /obj/structure/table/skrell,
 /obj/item/material/shard/phoron,
-/turf/simulated/floor/shuttle/skrell{
-	oxygen = 0;
-	nitrogen = 0
-	},
+/turf/simulated/floor/shuttle/skrell/airless,
 /area/template_noop)
 "bb" = (
 /obj/machinery/door/airlock/skrell/grey,
@@ -477,10 +455,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/item/material/shard/phoron,
-/turf/simulated/floor/shuttle/skrell{
-	oxygen = 0;
-	nitrogen = 0
-	},
+/turf/simulated/floor/shuttle/skrell/airless,
 /area/template_noop)
 "bG" = (
 /obj/item/device/t_scanner,
@@ -658,9 +633,6 @@
 	},
 /turf/simulated/floor/shuttle/skrell,
 /area/template_noop)
-"cl" = (
-/turf/simulated/floor/shuttle/skrell,
-/area/template_noop)
 "cm" = (
 /obj/structure/cryofeed{
 	icon_state = "cryo_rear";
@@ -836,10 +808,7 @@
 /turf/simulated/floor/shuttle/skrell/blue,
 /area/template_noop)
 "Th" = (
-/turf/simulated/floor/shuttle/skrell{
-	oxygen = 0;
-	nitrogen = 0
-	},
+/turf/simulated/floor/shuttle/skrell/airless,
 /area/template_noop)
 "Ug" = (
 /turf/simulated/floor/shuttle/skrell/blue/airless,
@@ -1031,7 +1000,7 @@ aq
 aq
 aq
 ap
-cl
+aH
 cC
 aL
 ck
@@ -1473,7 +1442,7 @@ aq
 aq
 aq
 ap
-cl
+aH
 bX
 aH
 aH

--- a/maps/random_ruins/exoplanets/asteroid/sol_ship/sol_ship_unique.dmm
+++ b/maps/random_ruins/exoplanets/asteroid/sol_ship/sol_ship_unique.dmm
@@ -278,13 +278,11 @@
 /turf/simulated/floor/shuttle/dark_blue/airless,
 /area/template_noop)
 "zm" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/ramp{
-	oxygen = 0;
-	nitrogen = 0
+	initial_gas = null
 	},
 /area/template_noop)
 "Ah" = (
@@ -345,13 +343,11 @@
 /turf/simulated/floor/shuttle/dark_blue/airless,
 /area/template_noop)
 "JP" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/ramp{
-	nitrogen = 0;
-	oxygen = 0
+	initial_gas = null
 	},
 /area/template_noop)
 "Lc" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -3911,12 +3911,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/server)
 "bOA" = (
 /obj/structure/cable/green{
@@ -4532,12 +4527,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/server)
 "caB" = (
 /obj/structure/table/standard,
@@ -12771,12 +12761,7 @@
 /obj/machinery/alarm/server{
 	pixel_y = 28
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/server)
 "gma" = (
 /obj/machinery/camera/network/research{
@@ -23117,12 +23102,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/server)
 "lmz" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -25480,12 +25460,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/server)
 "mvc" = (
 /obj/structure/cable{
@@ -32281,12 +32256,7 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/bluegrid/server,
 /area/server)
 "pMT" = (
 /obj/effect/floor_decal/corner/lime{


### PR DESCRIPTION
Taking a page from Baystation's book, replaces the vars for individual initial gases with an initial_gas list. The consequences of this are many and far-reaching, but the most important gameplay-facing one is that exoplanet atmosphere generation should work now, as all floor/exoplanet turfs get their initial_gas data from the generated planet atmosphere. This also should mean that for outside turfs for planet ruins, variables such as temperature will not need to be mapped in.

Disclaimer, there is a lot of stuff touched here and I don't fully understand it, so this will definitely need to be reviewed by someone who actually understands how atmospherics code works.