### PR TITLE
Fixes Mictlan accent for Unathi and removes Sol citizenship

### DIFF
--- a/code/modules/background/origins/origins/unathi/spaceborn.dm
+++ b/code/modules/background/origins/origins/unathi/spaceborn.dm
@@ -3,7 +3,8 @@
 	desc = "Whether colonists in the far reaches of space, pirates that have forsaken their lives to find a new culture, or those that are merely living on ships and roaming or serving the Hegemon, the Spaceborn Unathi are a vast collective of emerging or niche cultures found across the Orion Spur."
 	possible_origins = list(
 		/singleton/origin_item/origin/unathi_pirate,
-		/singleton/origin_item/origin/colonist
+		/singleton/origin_item/origin/colonist,
+		/singleton/origin_item/origin/mictlan_unathi
 	)
 
 /singleton/origin_item/origin/unathi_pirate
@@ -11,7 +12,7 @@
 	desc = "Pirates have no common group holding them all together to work as one. They tend towards ambition and passion, acting impulsively towards what they desire. With Not'zar Izweski's call to pirates to forsake their lifestyles and join his space navy, any pirate that has served four or more years under the Hegemony has their crimes pardoned by him (but not necessarily other states). With this, a good handful of pirates that knew no normalcy are now finding it abroad. Unathi pirates don't have citizenship in their respective countries, typically having a work or visitation visa instead."
 	important_information = "Outside of the Hegemony, records should say they have some kind of visa instead of citizenship."
 	possible_accents = list(ACCENT_TRAD_PEASANT, ACCENT_HEGEMON_PEASANT, ACCENT_TRAD_NOBLE, ACCENT_WASTELAND, ACCENT_UNATHI_SPACER, ACCENT_HAZANA)
-	possible_citizenships = list(CITIZENSHIP_IZWESKI, CITIZENSHIP_BIESEL, CITIZENSHIP_SOL, CITIZENSHIP_COALITION)
+	possible_citizenships = list(CITIZENSHIP_IZWESKI, CITIZENSHIP_BIESEL, CITIZENSHIP_COALITION)
 	possible_religions = list(RELIGION_THAKH, RELIGION_SKAKH, RELIGION_AUTAKH, RELIGION_OTHER, RELIGION_NONE)
 
 /singleton/origin_item/origin/colonist

--- a/html/changelogs/RustingWithYou - accents2.yml
+++ b/html/changelogs/RustingWithYou - accents2.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Allows Unathi to correctly select the Mictlan accent, and removes Sol citizenship as an option from the species."


### PR DESCRIPTION
The Mictlan Unathi origin was not correctly selectable. Now it is. This also removes Sol Alliance citizenship from the remaining origins that had it as an option which shouldn't. 