### PR TITLE
 Smartfridges : Unwrenchable By Regular Wrench

### DIFF
--- a/code/modules/cooking/machinery/smartfridge.dm
+++ b/code/modules/cooking/machinery/smartfridge.dm
@@ -262,11 +262,15 @@
 		return
 
 	if(O.iswrench())
-		anchored = !anchored
-		user.visible_message("\The [user] [anchored ? "secures" : "unsecures"] the bolts holding \the [src] to the floor.", "You [anchored ? "secure" : "unsecure"] the bolts holding \the [src] to the floor.")
-		playsound(get_turf(src), O.usesound, 50, 1)
-		power_change()
-		return
+		if(O.toolspeed >= 2)
+			anchored = !anchored
+			user.visible_message("\The [user] [anchored ? "secures" : "unsecures"] the bolts holding \the [src] to the floor.", "You [anchored ? "secure" : "unsecure"] the bolts holding \the [src] to the floor.")
+			playsound(get_turf(src), O.usesound, 50, 1)
+			power_change()
+			return
+		else
+			to_chat(user, SPAN_NOTICE("\The [O] isn't strong enough to unwrench this!"))
+			return
 
 	if(O.ismultitool()||O.iswirecutter())
 		if(panel_open)

--- a/html/changelogs/wezzy_unwrenchable.yml
+++ b/html/changelogs/wezzy_unwrenchable.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Wowzewow(Wezzy)
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Smartfridges are no longer able to be unanchored using regular wrenches now."


### PR DESCRIPTION
title

You now need to use impact wrench or better.

Stops powergaming medical players from breaking into chemistry constantly.

If you want to do this ask engineering. Either that or break into the kitchen.
