### PR TITLE
Revert "Flavour-only height system no longer gives shells away, also grammar tweaks"

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -501,7 +501,7 @@
 		if(-10 to -6)
 			descriptor = "slightly shorter than"
 		if(-5 to 5)
-			descriptor = "around about the same height"
+			descriptor = "around the same height as"
 		if(6 to 10)
 			descriptor = "slightly taller than"
 		if(11 to 20)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -501,7 +501,7 @@
 		if(-10 to -6)
 			descriptor = "slightly shorter than"
 		if(-5 to 5)
-			descriptor = "around the same height as"
+			descriptor = "about the same height as"
 		if(6 to 10)
 			descriptor = "slightly taller than"
 		if(11 to 20)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -501,7 +501,7 @@
 		if(-10 to -6)
 			descriptor = "slightly shorter than"
 		if(-5 to 5)
-			descriptor = "about the same height as"
+			descriptor = "around the same height as"
 		if(6 to 10)
 			descriptor = "slightly taller than"
 		if(11 to 20)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -461,7 +461,7 @@
 	return output_text
 
 /mob/living/carbon/human/assembleHeightString(mob/examiner)
-	var/list/heightString = list()
+	var/heightString = null
 	var/descriptor
 	if(height == HEIGHT_NOT_USED)
 		return heightString
@@ -483,9 +483,7 @@
 				descriptor = "huge"
 			else
 				descriptor = "gargantuan"
-		heightString += "[get_pronoun("He")] look[get_pronoun("end")] [descriptor]"
-		if(!species.hide_name)
-			heightString += " for a [species.name]"
+		heightString = "[get_pronoun("He")] look[get_pronoun("end")] [descriptor] for \a [species.name]"
 
 
 	if(examiner.height == HEIGHT_NOT_USED)
@@ -503,7 +501,7 @@
 		if(-10 to -6)
 			descriptor = "slightly shorter than"
 		if(-5 to 5)
-			descriptor = "around the same height as"
+			descriptor = "around about the same height"
 		if(6 to 10)
 			descriptor = "slightly taller than"
 		if(11 to 20)
@@ -515,5 +513,6 @@
 		else
 			descriptor = "to tower over"
 	if(heightString)
-		return heightString += ", and [get_pronoun("he")] seem[get_pronoun("end")] [descriptor] you."
+		return heightString + ", and [get_pronoun("he")] seem[get_pronoun("end")] [descriptor] you."
 	return "[get_pronoun("He")] seem[get_pronoun("end")] [descriptor] you."
+

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1542,7 +1542,7 @@
 		if(-49 to -11)
 			descriptor = "shorter than"
 		if(-10 to 10)
-			descriptor = "about the same height as"
+			descriptor = "around about the same height"
 		if(11 to 50)
 			descriptor = "taller than"
 		if(51 to 100)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1542,7 +1542,7 @@
 		if(-49 to -11)
 			descriptor = "shorter than"
 		if(-10 to 10)
-			descriptor = "around about the same height"
+			descriptor = "about the same height as"
 		if(11 to 50)
 			descriptor = "taller than"
 		if(51 to 100)

--- a/html/changelogs/sniblet-revert-same-height-you.yml
+++ b/html/changelogs/sniblet-revert-same-height-you.yml
@@ -1,4 +1,4 @@
-author: ChangeMe
+author: Sniblet
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -9,4 +9,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscdel: "Reverts the last height string fix because it broke."
+  - rscdel: "Reverts the last height string fix because it broke. Shells remain exposed by their heightstrings."

--- a/html/changelogs/sniblet-revert-same-height-you.yml
+++ b/html/changelogs/sniblet-revert-same-height-you.yml
@@ -1,0 +1,12 @@
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Reverts the last height string fix because it broke."


### PR DESCRIPTION
Reverts Aurorastation/Aurora.3#16309 except for the grammar part because it broke height.
![image](https://github.com/Aurorastation/Aurora.3/assets/36427443/4e407332-f8fd-4310-a266-cd0d3d1c527b)

This is fixed by #16369. I'd close this? But I don't know what you want.