### PR TITLE
Vault Safe Tweaks

### DIFF
--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -833,6 +833,19 @@
 		/obj/item/clothing/accessory/storage/bayonet
 	)
 
+/obj/random/melee/highvalue
+	name = "random high value melee weapon"
+	desc = "This is a random high value melee weapon."
+	icon = 'icons/obj/weapons.dmi'
+	icon_state = "baton"
+	spawnlist = list(
+		/obj/item/melee/energy/sword,
+		/obj/item/melee/energy/glaive,
+		/obj/item/melee/chainsword,
+		/obj/item/melee/hammer,
+		/obj/item/melee/hammer/powered
+	)
+
 /obj/random/coin
 	name = "random coin"
 	desc = "This is a random coin."
@@ -1315,6 +1328,24 @@
 	problist = list(
 	/obj/item/storage/secure/briefcase/money = 1,
 	/obj/item/stack/material/phoron/full = 0.1
+	)
+
+/obj/random/highvalue/safe
+	name = "random corporate safe high valuable item"
+	desc = "This is a random corporate safe high valuable item."
+	icon = 'icons/obj/coins.dmi'
+	icon_state = "coin_diamond_heads"
+	problist = list(
+		/obj/item/device/personal_shield = 0.4,
+		/obj/random/safe_rig = 0.4,
+		/obj/item/clothing/glasses/thermal = 0.3,
+		/obj/item/storage/toolbox/infiltration = 0.3,
+		/obj/random/melee/highvalue = 0.3,
+		/obj/item/gun/energy/disruptorpistol/magnum = 0.3,
+		/obj/item/gun/projectile/shotgun/pump/combat = 0.2,
+		/obj/item/gun/energy/lawgiver = 0.1,
+		/obj/item/gun/projectile/automatic/terminator = 0.1,
+		/obj/item/gun/projectile/automatic/rifle/shotgun = 0.1
 	)
 
 /obj/random/junk

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -27,8 +27,8 @@ FLOOR SAFES
 	var/time_to_drill = 300 SECONDS		// Drill duration of the current thermal drill.
 	var/last_drill_time = 0				// Last world.time the drill time was checked. Used to reduce time_to_drill accurately
 	var/image/drill_overlay				// The drill overlay image to display during the drilling process.
-	var/drill_x_offset = -13			// The X pixel offset for the drill
-	var/drill_y_offset = -3				// The Y pixel offset for the drill
+	var/drill_x_offset = -4				// The X pixel offset for the drill
+	var/drill_y_offset = -8				// The Y pixel offset for the drill
 
 /obj/structure/safe/Initialize()
 	. = ..()
@@ -251,6 +251,7 @@ FLOOR SAFES
 
 /obj/structure/safe/proc/drill_open()
 	broken = TRUE
+	drill.soundloop.stop()
 	STOP_PROCESSING(SSprocessing, src)
 	update_icon()
 
@@ -286,11 +287,11 @@ FLOOR SAFES
 
 /obj/structure/safe/station/Initialize()
 	. = ..()
-	new /obj/random/highvalue(src)
-	new /obj/random/highvalue(src)
-	new /obj/random/highvalue(src)
-	new /obj/random/highvalue(src)
-	new /obj/random/highvalue(src)
+	new /obj/item/stack/telecrystal/twentyfive(src)
+	new /obj/random/highvalue/safe(src)
+	new /obj/random/highvalue/safe(src)
+	new /obj/random/highvalue/safe(src)
+	new /obj/random/highvalue/safe(src)
 
 /obj/structure/safe/cash
 	name = "credit safe"

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -292,6 +292,7 @@ FLOOR SAFES
 	new /obj/random/highvalue/safe(src)
 	new /obj/random/highvalue/safe(src)
 	new /obj/random/highvalue/safe(src)
+	new /obj/random/highvalue/safe(src)
 
 /obj/structure/safe/cash
 	name = "credit safe"

--- a/html/changelogs/geeves-vault_undersuit.yml
+++ b/html/changelogs/geeves-vault_undersuit.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Added a guaranteed 25 telecrystals in the vault safe. Reduced the chance for thermal goggles to spawn, and made only high power melee weapons spawn in it."
+  - rscadd: "Added a chance for the spaceproof infiltrator suit to spawn in the vaults safe."
+  - bugfix: "Fixed thermal drill offsets on the safe, as well as the soundloop not stopping correctly."


### PR DESCRIPTION
* Added a guaranteed 25 telecrystals in the vault safe. Reduced the chance for thermal goggles to spawn, and made only high power melee weapons spawn in it.
* Added a chance for the spaceproof infiltrator suit to spawn in the vaults safe.
* Fixed thermal drill offsets on the safe, as well as the soundloop not stopping correctly.