### PR TITLE
Fixes turtlenecks in the loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -296,7 +296,7 @@
 	flags = GEAR_HAS_DESC_SELECTION
 	culture_restriction = list(/singleton/origin_item/culture/dominia, /singleton/origin_item/culture/dominian_unathi)
 
-/datum/gear/uniform/turtleneck
+/datum/gear/uniform/vysoka
 	display_name = "vysokan temperwear"
 	description = "A loose outfit of thinned and shredded ohdker fur."
 	path = /obj/item/clothing/under/vysoka

--- a/html/changelogs/kyres1-turtleneck_fix.yml
+++ b/html/changelogs/kyres1-turtleneck_fix.yml
@@ -1,0 +1,6 @@
+author: kyres1
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed tactical turtlenecks not being an option anymore in the loadout."


### PR DESCRIPTION
Unintentionally made turtlenecks not selectable due to #16312 

Fixes https://github.com/Aurorastation/Aurora.3/issues/16378
