### PR TITLE
Throw changes: relative mobsizes determines throw range, and itemsize matters for EVA movement

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -422,8 +422,9 @@ var/list/slot_equipment_priority = list( \
 		if(!src.lastarea)
 			src.lastarea = get_area(src.loc)
 		if((istype(src.loc, /turf/space)) || (src.lastarea.has_gravity() == 0))
-			src.inertia_dir = get_dir(target, src)
-			step(src, inertia_dir)
+			if(prob((itemsize * itemsize * 10) * MOB_MEDIUM/src.mob_size)) // 10% chance with a tiny item, 90% with normal, guaranteed above
+				src.inertia_dir = get_dir(target, src)
+				step(src, inertia_dir)
 		if(istype(item,/obj/item))
 			var/obj/item/W = item
 			W.randpixel_xy()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -431,7 +431,7 @@ var/list/slot_equipment_priority = list( \
 		if(!src.lastarea)
 			src.lastarea = get_area(src.loc)
 		if((istype(src.loc, /turf/space)) || (src.lastarea.has_gravity() == 0))
-			if(prob((itemsize * itemsize * 10) * MOB_MEDIUM/src.mob_size)) // 10% chance with a tiny item, 90% with normal, guaranteed above
+			if(prob((itemsize * itemsize * 20) * MOB_MEDIUM/src.mob_size)) // 20% chance with a tiny item, 40% with small, guaranteed above
 				src.inertia_dir = get_dir(target, src)
 				step(src, inertia_dir)
 		if(istype(item,/obj/item))

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -342,14 +342,19 @@ var/list/slot_equipment_priority = list( \
 	if(!item)
 		return FALSE
 
+	var/throw_range = item.throw_range
+	var/itemsize
+
 	if(istype(item, /obj/item/grab))
 		var/obj/item/grab/G = item
 		item = G.throw_held() //throw the person instead of the grab
 		if(ismob(item) && G.state >= GRAB_NECK)
+			var/mob/M = item
+			throw_range = round(throw_range * (src.mob_size/M.mob_size))
+			itemsize = round(M.mob_size/4)
 			var/turf/start_T = get_turf(loc) //Get the start and target tile for the descriptors
 			var/turf/end_T = get_turf(target)
 			if(start_T && end_T)
-				var/mob/M = item
 				if(is_pacified())
 					to_chat(src, "<span class='notice'>You gently let go of [M].</span>")
 					src.remove_from_mob(item)
@@ -365,6 +370,10 @@ var/list/slot_equipment_priority = list( \
 			qdel(G)
 		else
 			return FALSE
+	
+	else if(istype(item, /obj/item))
+		var/obj/item/I = item
+		itemsize = I.w_class
 
 	if(!item)
 		return FALSE //Grab processing has a chance of returning null
@@ -434,7 +443,7 @@ var/list/slot_equipment_priority = list( \
 		// Animate the mob throwing.
 		animate_throw()
 
-		item.throw_at(target, item.throw_range, item.throw_speed, src)
+		item.throw_at(target, throw_range, item.throw_speed, src)
 
 		return TRUE
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -49,6 +49,7 @@
 	abstract = 1
 	item_state = "nothing"
 	w_class = ITEMSIZE_HUGE
+	throw_range = 5
 
 	drop_sound = null
 	pickup_sound = null

--- a/html/changelogs/llywelwyn-tossing-stuff.yml
+++ b/html/changelogs/llywelwyn-tossing-stuff.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Llywelwyn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "When throwing items to manoeuvre in EVA, itemsize compared to the mob's size now determines if it'll move you or not."

--- a/html/changelogs/llywelwyn-tossing-stuff.yml
+++ b/html/changelogs/llywelwyn-tossing-stuff.yml
@@ -38,4 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
+  - rscadd: "Relative mob sizes are now taken into account when determining how far you can throw someone, defaulting to 5 tiles for same-sized mobs."
   - tweak: "When throwing items to manoeuvre in EVA, itemsize compared to the mob's size now determines if it'll move you or not."


### PR DESCRIPTION
1. instead of every mob being able to be thrown 7 tiles, every grabbable mob can now be thrown 5 tiles _multiplied by relative mob sizes_, i.e. a human throwing a small mob like a monkey will go 7 tiles, same-sized mobs will go 5, large mobs like vaurca/some ipcs go 3, and massive stuff like bulwarks will just go 1 tile (see img)

![image](https://github.com/Aurorastation/Aurora.3/assets/82828093/6c7f85e2-30c8-4b72-a3ff-56d38e783317)

2. instead of throwing anything having a 100% chance to change your direction in eva, even if you're a bulwark and you're tossing a cigarette butt, direction change is determined instead by comparing the itemsize against the size of the mob throwing the item (ported from https://github.com/Baystation12/Baystation12/pull/21739)

atm a tiny item has a 20% chance of moving a normal sized mob, a small item has a 40% chance, and above is guaranteed

if one but not both of these are wanted lmk and ill atomise
