### PR TITLE
Adds bullet holes/scorch marks 

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -869,6 +869,7 @@
 #include "code\game\objects\effects\chem\chemsmoke.dm"
 #include "code\game\objects\effects\chem\foam.dm"
 #include "code\game\objects\effects\chem\water.dm"
+#include "code\game\objects\effects\decals\bullet_holes.dm"
 #include "code\game\objects\effects\decals\cleanable.dm"
 #include "code\game\objects\effects\decals\contraband.dm"
 #include "code\game\objects\effects\decals\crayon.dm"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -675,3 +675,29 @@
 
 /atom/proc/handle_pointed_at(var/mob/pointer)
 	return
+
+/atom/proc/create_bullethole(obj/item/projectile/Proj)
+	var/p_x = Proj.p_x + rand(-6, 6)
+	var/p_y = Proj.p_y + rand(-6, 6)
+	var/obj/effect/overlay/bmark/bullet_mark = new(src)
+
+	bullet_mark.pixel_x = p_x
+	bullet_mark.pixel_y = p_y
+
+	//Offset correction
+	bullet_mark.pixel_x--
+	bullet_mark.pixel_y--
+
+	if(Proj.damage_flags & DAMAGE_FLAG_BULLET)
+		bullet_mark.icon_state = "dent"
+	else if(Proj.damage_flags & DAMAGE_FLAG_LASER)
+		bullet_mark.name = "scorch mark"
+		if(Proj.damage >= 20)
+			bullet_mark.icon_state = "scorch"
+			bullet_mark.set_dir(pick(NORTH,SOUTH,EAST,WEST)) // Pick random scorch design
+		else
+			bullet_mark.icon_state = "light_scorch"
+	
+/atom/proc/clear_bulletholes()
+	for(var/obj/effect/overlay/bmark/bullet_mark in src)
+		qdel(bullet_mark)

--- a/code/game/objects/effects/decals/bullet_holes.dm
+++ b/code/game/objects/effects/decals/bullet_holes.dm
@@ -1,0 +1,6 @@
+/obj/effect/overlay/bmark
+    name = "bullet hole"
+    desc = "Somebody's been shooting."
+    icon = 'icons/effects/effects.dmi'
+    layer = ABOVE_OBJ_LAYER
+    icon_state = "dent"

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -179,6 +179,7 @@
 			if(WT.use_tool(src, user, max(5, damage / 5), volume = 50) && WT && WT.isOn())
 				to_chat(user, SPAN_NOTICE("You finish repairing the damage to [src]."))
 				take_damage(-damage)
+				clear_bulletholes()
 		else
 			to_chat(user, SPAN_NOTICE("You need more welding fuel to complete this task."))
 			return

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -86,6 +86,7 @@
 		burn(500)
 	
 	bullet_ping(Proj)
+	create_bullethole(Proj)
 
 	var/proj_damage = Proj.get_structure_damage()
 	var/damage = proj_damage
@@ -123,6 +124,7 @@
 
 /turf/simulated/wall/ChangeTurf(var/newtype)
 	clear_plants()
+	clear_bulletholes()
 	..(newtype)
 
 //Appearance
@@ -205,6 +207,7 @@
 			O.forceMove(src)
 
 	clear_plants()
+	clear_bulletholes()
 	material = SSmaterials.get_material_by_name("placeholder")
 	reinf_material = null
 

--- a/html/changelogs/llywelwyn-bulletholes.yml
+++ b/html/changelogs/llywelwyn-bulletholes.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Llywelwyn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds bullet holes to walls."
+  - backend: "Adds an atom/proc/ to create and clear bullet holes, so they can be added to other turfs, etc more easily going forwards."


### PR DESCRIPTION
partial port from [bay](https://github.com/Baystation12/Baystation12/pull/33580) but using our damage flags and stuff

pr creates atom/proc/ for creating and deleting bullet holes, and then makes turf/simulated/walls use it

![2023-05-30_14-57-01](https://github.com/Aurorastation/Aurora.3/assets/82828093/293c186e-270e-4069-bb2b-071214f484b6)

plenty of room to expand this in a cool way by someone who can sprite (more variety in bulletholes, stuff for other damage types, etc.), but right now just works with the stuff we already have in effects.dmi