### PR TITLE
Higher SMES input/output defaults for a less tedious RCON setup

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -37,13 +37,13 @@
 
 	var/input_attempt = 0 			// 1 = attempting to charge, 0 = not attempting to charge
 	var/inputting = 0 				// 1 = actually inputting, 0 = not inputting
-	var/input_level = 150000 		// amount of power the SMES attempts to charge by
+	var/input_level = 50000 		// amount of power the SMES attempts to charge by
 	var/input_level_max = 200000 	// cap on input_level
 	var/input_taken = 0 			// amount that we received from powernet last tick
 
 	var/output_attempt = 0 			// 1 = attempting to output, 0 = not attempting to output
 	var/outputting = 0 				// 1 = actually outputting, 0 = not outputting
-	var/output_level = 140000		// amount of power the SMES attempts to output
+	var/output_level = 50000		// amount of power the SMES attempts to output
 	var/output_level_max = 200000	// cap on output_level
 	var/output_used = 0				// amount of power actually outputted. may be less than output_level if the powernet returns excess power
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -43,7 +43,7 @@
 
 	var/output_attempt = 0 			// 1 = attempting to output, 0 = not attempting to output
 	var/outputting = 0 				// 1 = actually outputting, 0 = not outputting
-	var/output_level = 150000		// amount of power the SMES attempts to output
+	var/output_level = 140000		// amount of power the SMES attempts to output
 	var/output_level_max = 200000	// cap on output_level
 	var/output_used = 0				// amount of power actually outputted. may be less than output_level if the powernet returns excess power
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -37,13 +37,13 @@
 
 	var/input_attempt = 0 			// 1 = attempting to charge, 0 = not attempting to charge
 	var/inputting = 0 				// 1 = actually inputting, 0 = not inputting
-	var/input_level = 50000 		// amount of power the SMES attempts to charge by
+	var/input_level = 150000 		// amount of power the SMES attempts to charge by
 	var/input_level_max = 200000 	// cap on input_level
 	var/input_taken = 0 			// amount that we received from powernet last tick
 
 	var/output_attempt = 0 			// 1 = attempting to output, 0 = not attempting to output
 	var/outputting = 0 				// 1 = actually outputting, 0 = not outputting
-	var/output_level = 50000		// amount of power the SMES attempts to output
+	var/output_level = 150000		// amount of power the SMES attempts to output
 	var/output_level_max = 200000	// cap on output_level
 	var/output_used = 0				// amount of power actually outputted. may be less than output_level if the powernet returns excess power
 

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -73,6 +73,11 @@
 	output_level = 500000
 	charge =1.5e+7
 
+// For the substation SMES around the Horizon.
+/obj/machinery/power/smes/buildable/substation
+	input_level = 150000
+	output_level = 140000
+
 // The Horizon's shuttles want something with decent capacity to sustain themselves and enough transmission to meet their energy needs.
 /obj/machinery/power/smes/buildable/horizon_shuttle/Initialize()
 	. = ..()

--- a/html/changelogs/llywelwyn-higher_smes_defaults.yml
+++ b/html/changelogs/llywelwyn-higher_smes_defaults.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: Llywelwyn
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/llywelwyn-higher_smes_defaults.yml
+++ b/html/changelogs/llywelwyn-higher_smes_defaults.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Changes SMES input/output defaults to 150kW, up from 50kW. Should make RCON less tedious, whilst still leaving room for optimisation round-by-round."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -367,7 +367,7 @@
 	},
 /area/engineering/atmos/propulsion)
 "arn" = (
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Service"
 	},
 /obj/structure/cable,
@@ -3418,7 +3418,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/mining)
 "cyS" = (
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Hangar"
 	},
 /obj/structure/cable,
@@ -5635,7 +5635,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
 "ejL" = (
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Engineering Lower Deck"
 	},
 /obj/structure/cable/green,
@@ -11028,7 +11028,7 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/intrepid/crew_compartment)
 "hXX" = (
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Xenoarchaeology"
 	},
 /obj/structure/cable{
@@ -11878,7 +11878,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/security/checkpoint)
 "iJR" = (
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Operations"
 	},
 /obj/structure/cable/green{
@@ -20576,7 +20576,7 @@
 /turf/simulated/floor/tiled,
 /area/hangar/canary)
 "pkG" = (
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Security"
 	},
 /obj/structure/cable,

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -7030,7 +7030,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_waste)
 "dwb" = (
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Starboard Wing"
 	},
 /obj/structure/cable/green{
@@ -9935,7 +9935,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port)
 "eYp" = (
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Port Wing"
 	},
 /obj/structure/cable/green{
@@ -11641,7 +11641,7 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "fLU" = (
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Research"
 	},
 /obj/structure/cable{
@@ -26703,7 +26703,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "mVR" = (
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Medical"
 	},
 /obj/structure/cable{
@@ -37019,7 +37019,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/kitchen)
 "sbO" = (
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Engineering Main"
 	},
 /obj/structure/cable,

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -7300,7 +7300,7 @@
 	dir = 9
 	},
 /obj/machinery/light,
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Deck 3 Telecommunications";
 	charge = 5e+006;
 	input_attempt = 1;
@@ -11076,7 +11076,7 @@
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/entrance)
 "jbg" = (
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Deck 3 Civilian"
 	},
 /obj/structure/cable{
@@ -17121,7 +17121,7 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "nJT" = (
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Shield Substation";
 	charge = 1e+007;
 	cur_coils = 6;
@@ -19223,7 +19223,7 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/crew_quarters/fitness/changing)
 "pxf" = (
-/obj/machinery/power/smes/buildable{
+/obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Deck 3 Command"
 	},
 /obj/structure/cable,


### PR DESCRIPTION
Increases default input/output on SMES from 50kW/50kW to 150kW/140kW

![image](https://github.com/Aurorastation/Aurora.3/assets/82828093/df0d61b2-4d33-491a-a47d-3d5309080075)

150kW/140kW should be enough to run every department on an average round, without being high enough to cause brownouts.

still leaves room for engineers to optimise by increasing/reducing output as and when to keep shock damage at a minimum. 

proposed solution for [this suggestion](https://forums.aurorastation.org/topic/18300-streamline-rcon/). having to make a subtype (or map in the I/O) for every single substation seems like a bad decision, because it'd be invalidated with mapping changes and different playercounts (causing differing power consumption) across rounds, meaning it'd be a whole lot more effort for something that wouldn't even end up being optimal anyway, even if we got every engineer to agree on "perfect" numbers right now.

this doesn't effect any SMES which already has numbers specified, like containment/shields/intrepid/etc, just those that are currently running off the default.
