### PR TITLE
Fixes Cyborgs becoming invisible once created by Machinists

### DIFF
--- a/code/modules/mob/living/silicon/robot/items/robot_parts.dm
+++ b/code/modules/mob/living/silicon/robot/items/robot_parts.dm
@@ -222,8 +222,8 @@
 			O.job = "AI Shell"
 			O.cell = chest.cell
 			O.cell.forceMove(O)
-			W.forceMove(O) 
-			
+			W.forceMove(O)
+
 			if(O.cell)
 				var/datum/robot_component/cell_component = O.components["power cell"]
 				cell_component.wrapped = O.cell
@@ -284,7 +284,7 @@
 
 				user.drop_from_inventory(M, O)
 				O.mmi = W
-				O.set_invisibility(101)
+				O.set_invisibility(0)
 				O.custom_name = created_name
 				O.updatename("Default")
 

--- a/html/changelogs/io-util-cyborgfix.yml
+++ b/html/changelogs/io-util-cyborgfix.yml
@@ -1,0 +1,6 @@
+author: io-util
+
+delete-after: True
+
+changes:
+  - bugfix: "Cyborgs are no longer invisible when they get created by Players."


### PR DESCRIPTION
Tiny fix that will make machinists happy again.

Cyborgs had an invisibility value of `101` applied to them when they were created, not cool, now it is `0` like it was before that change. Also removes some whitespace in the file ;(

resolves #16273