### PR TITLE
Fixes firing delays.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -367,6 +367,8 @@
 
 	update_held_icon()
 
+	user.setClickCooldown(get_appropriate_delay())
+
 // Similar to the above proc, but does not require a user, which is ideal for things like turrets.
 /obj/item/gun/proc/Fire_userless(atom/target)
 	if(!target)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -285,6 +285,12 @@
 	else
 		return ..() //Pistolwhippin'
 
+/obj/item/gun/proc/get_appropriate_delay()
+	var/fire_time = burst > 1 ? ((burst -1) * burst_delay) : fire_delay
+	var/appropriate_delay = burst > 1 ? burst_delay : fire_delay
+	var/shoot_time = max(fire_time, appropriate_delay)
+	return shoot_time
+
 /obj/item/gun/proc/fire_checks(atom/target, mob/living/user, clickparams, pointblank=0, reflex=0)
 	if(!user || !target)
 		return FALSE
@@ -311,7 +317,7 @@
 			to_chat(user, SPAN_WARNING("\The [src] is not ready to fire again!"))
 		return FALSE
 
-	var/shoot_time = max((burst - 1) * burst_delay, burst_delay)
+	var/shoot_time = get_appropriate_delay()
 	user.setClickCooldown(shoot_time)
 	next_fire_time = world.time + shoot_time
 
@@ -361,8 +367,6 @@
 
 	update_held_icon()
 
-	user.setClickCooldown(max(burst_delay+1, fire_delay))
-
 // Similar to the above proc, but does not require a user, which is ideal for things like turrets.
 /obj/item/gun/proc/Fire_userless(atom/target)
 	if(!target)
@@ -371,7 +375,7 @@
 	if(world.time < next_fire_time)
 		return FALSE
 
-	var/shoot_time = (burst - 1)* burst_delay
+	var/shoot_time = get_appropriate_delay()
 	next_fire_time = world.time + shoot_time
 
 	var/turf/targloc = get_turf(target) //cache this in case target gets deleted during shooting, e.g. if it was a securitron that got destroyed.

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -21,7 +21,7 @@
 		list(mode_name="semiauto",       can_autofire=0, burst=1, fire_delay=ROF_SMG),
 		list(mode_name="3-round bursts", can_autofire=0, burst=3, burst_accuracy=list(1,0,0), dispersion=list(0, 10, 15)),
 		list(mode_name="short bursts",   can_autofire=0, burst=5, burst_accuracy=list(1,0,,-1,-1), dispersion=list(5, 10, 15, 20)),
-		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=1, one_hand_fa_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(5, 10, 15, 20, 25))
+		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=2, one_hand_fa_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(5, 10, 15, 20, 25))
 		)
 
 //Submachine guns and personal defence weapons, go.
@@ -138,7 +138,7 @@
 		list(mode_name="semiauto",       burst=1, fire_delay=ROF_RIFLE),
 		list(mode_name="3-round bursts", burst=3, burst_accuracy=list(1,0,0),       dispersion=list(0, 5, 10)),
 		list(mode_name="short bursts",   burst=5, burst_accuracy=list(1,0,0,-1,-1), dispersion=list(5, 5, 15)),
-		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=1, one_hand_fa_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(5, 10, 15, 20, 25)),
+		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=2, one_hand_fa_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(5, 10, 15, 20, 25)),
 		)
 
 	//slower to regain aim, more inaccurate if not wielding
@@ -183,7 +183,7 @@
 	knife_y_offset = 13
 	firemodes = list(
 		list(mode_name="semiauto",       burst=1, fire_delay=ROF_HEAVY),
-		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=1, one_hand_fa_penalty=22, burst_accuracy = list(0,-1,-1,-1,-2,-2,-2,-3), dispersion = list(5, 5, 10, 15, 20)),
+		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=2, one_hand_fa_penalty=22, burst_accuracy = list(0,-1,-1,-1,-2,-2,-2,-3), dispersion = list(5, 5, 10, 15, 20)),
 		)
 
 	accuracy = 2
@@ -395,7 +395,7 @@
 	firemodes = list(
 		list(mode_name="short bursts",	burst=5, burst_accuracy = list(1,0,0,-1,-1), dispersion = list(3, 6, 9)),
 		list(mode_name="long bursts",	burst=8, burst_accuracy = list(1,0,0,-1,-1,-1,-2,-2), dispersion = list(8)),
-		list(mode_name="full auto", can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=1, one_hand_fa_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(5, 10, 15, 20, 25))
+		list(mode_name="full auto", can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=2, one_hand_fa_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(5, 10, 15, 20, 25))
 		)
 
 	var/cover_open = 0

--- a/code/modules/projectiles/guns/projectile/minigun.dm
+++ b/code/modules/projectiles/guns/projectile/minigun.dm
@@ -129,7 +129,7 @@
 	firemodes = list(
 		list(mode_name="short bursts",	can_autofire=0, burst=6, move_delay=8, burst_accuracy = list(0,-1,-1,-2,-2), dispersion = list(3, 6, 9)),
 		list(mode_name="long bursts",	can_autofire=0, burst=12, move_delay=9, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(8)),
-		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=1, one_hand_fa_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(5, 10, 15, 20, 25))
+		list(mode_name="full auto",		can_autofire=1, burst=1, fire_delay=5, fire_delay_wielded=3, one_hand_fa_penalty=12, burst_accuracy = list(0,-1,-1,-2,-2,-2,-3,-3), dispersion = list(5, 10, 15, 20, 25))
 		)
 
 
@@ -138,11 +138,11 @@
 /obj/item/gun/projectile/automatic/rifle/minigun/special_check(var/mob/user)
 	if(!wielded)
 		to_chat(user, "<span class='danger'>You cannot fire this weapon with just one hand!</span>")
-		return 0
+		return FALSE
 
 	if (user.back!= source)
 		to_chat(user, "<span class='warning'>\The [source] must be worn to fire \the [src]!</span>")
-		return 0
+		return FALSE
 
 	return ..()
 

--- a/html/changelogs/mattatlas-dontjusttakeabow.yml
+++ b/html/changelogs/mattatlas-dontjusttakeabow.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Guns with single-fire firing delays are now properly used when appropriate, instead of only the burst delay being used."

--- a/html/changelogs/mattatlas-dontjusttakeabow.yml
+++ b/html/changelogs/mattatlas-dontjusttakeabow.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Guns with single-fire firing delays are now properly used when appropriate, instead of only the burst delay being used."
+  - bugfix: "New firing delays are now appropriately assigned when switching firemode."


### PR DESCRIPTION
Previous behaviour was the following:
```
    var/shoot_time = max((burst - 1) * burst_delay, burst_delay)
    user.setClickCooldown(shoot_time)
```
The single-fire firing delay was never used for any gun, instead defaulting to the burst delay in all cases.