### PR TITLE
Fix for nested lists in ruin definition 'sectors' variable

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -831,3 +831,12 @@
 	. = list()
 	for (var/string in L)
 		. += capitalize(string)
+
+// Transforms a list of lists (of lists) into a single flat list.
+/proc/flatten_list(var/list/L)
+	. = list()
+	for(var/M in L)
+		if(!islist(M))
+			. += M
+		else
+			. += flatten_list(M)

--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -25,5 +25,5 @@
 		mappaths = list()
 		for (var/suffix in suffixes)
 			mappaths += (prefix + suffix)
-
+	sectors = flatten_list(sectors)
 	..()

--- a/html/changelogs/DreamySkrell-flatten-list-sectors.yml
+++ b/html/changelogs/DreamySkrell-flatten-list-sectors.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Nested lists in ruin definition 'sectors' variable can now be used."


### PR DESCRIPTION
The flattening:
![image](https://github.com/Aurorastation/Aurora.3/assets/107256943/d676a20c-0f17-4a7a-b6c1-7a65b1e55afb)

Testing if everything works as I think it should:
![image](https://github.com/Aurorastation/Aurora.3/assets/107256943/f8f908d1-939d-441c-aa60-5498365721e9)

The problem: Nested lists there are convenient, but currently do not work, cause `x in list(a, b, list(x))` will not return TRUE.
Simple but bad solution: Manually flatten the sectors lists. This is bad and annoying cause we have a lot of sectors.
Better solution: Programatically flatten the lists.

This should fix stuff like the COC ranger ship not spawning in coalition sectors.
Currently it has `sectors = list(SECTOR_BADLANDS, ALL_COALITION_SECTORS)` which is a nested list.