### PR TITLE
fixes atmosphere generation for lore planets

### DIFF
--- a/code/modules/maps/planet_types/lore/srandmarr.dm
+++ b/code/modules/maps/planet_types/lore/srandmarr.dm
@@ -15,6 +15,7 @@
 /obj/effect/overmap/visitable/sector/exoplanet/barren/aethemir/generate_atmosphere()
 	..()
 	if(atmosphere)
+		atmosphere.remove_ratio(1)
 		atmosphere.adjust_gas(GAS_NITROGEN, MOLES_O2STANDARD)
 		atmosphere.update_values()
 
@@ -50,6 +51,7 @@
 /obj/effect/overmap/visitable/sector/exoplanet/barren/azmar/generate_atmosphere()
 	..()
 	if(atmosphere)
+		atmosphere.remove_ratio(1)
 		atmosphere.adjust_gas(GAS_CHLORINE, MOLES_O2STANDARD)
 		atmosphere.temperature = T0C + 500
 		atmosphere.update_values()
@@ -186,6 +188,9 @@
 /obj/effect/overmap/visitable/sector/exoplanet/adhomai/generate_atmosphere()
 	..()
 	if(atmosphere)
+		atmosphere.remove_ratio(1)
+		atmosphere.adjust_gas(GAS_OXYGEN, MOLES_O2STANDARD, 1)
+		atmosphere.adjust_gas(GAS_NITROGEN, MOLES_N2STANDARD, 1)
 		if(landing_faction == "North Pole")
 			atmosphere.temperature = T0C - 40
 		else

--- a/html/changelogs/RustingWithYou - suffering.yml
+++ b/html/changelogs/RustingWithYou - suffering.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes atmosphere generation on lore planets."


### PR DESCRIPTION
This should prevent our existing lore planets from generating with atmospheres they shouldn't have. I will try and replace this with a proper fix for habitability at some point, if I can figure it out.