### PR TITLE
Overmap events now respect their opacity settings, rather than all hazards being opaque

### DIFF
--- a/code/modules/overmap/contacts/_contacts.dm
+++ b/code/modules/overmap/contacts/_contacts.dm
@@ -74,7 +74,6 @@
 	if(pinged)
 		return
 	pinged = TRUE
-	effect.opacity = 1
 	show()
 	animate(marker, alpha=255, 0.5 SECOND, 1, LINEAR_EASING)
 	addtimer(CALLBACK(src, PROC_REF(unping)), 1 SECOND)

--- a/code/modules/overmap/contacts/_contacts.dm
+++ b/code/modules/overmap/contacts/_contacts.dm
@@ -74,6 +74,7 @@
 	if(pinged)
 		return
 	pinged = TRUE
+	effect.opacity = initial(effect.opacity)
 	show()
 	animate(marker, alpha=255, 0.5 SECOND, 1, LINEAR_EASING)
 	addtimer(CALLBACK(src, PROC_REF(unping)), 1 SECOND)
@@ -103,6 +104,7 @@
 		owner = null
 
 	// Remove the effect opacity and null the effect
+	effect.opacity = 0
 	effect = null
 
 	QDEL_NULL_LIST(images)

--- a/code/modules/overmap/contacts/_contacts.dm
+++ b/code/modules/overmap/contacts/_contacts.dm
@@ -103,7 +103,6 @@
 		owner = null
 
 	// Remove the effect opacity and null the effect
-	effect.opacity = 0
 	effect = null
 
 	QDEL_NULL_LIST(images)

--- a/code/modules/overmap/events/event.dm
+++ b/code/modules/overmap/events/event.dm
@@ -260,13 +260,13 @@
 /obj/effect/overmap/event/meteor
 	name = "asteroid field"
 	events = list(/datum/event/meteor_wave/overmap)
+	opacity = 1
 	event_icon_states = list("meteor1", "meteor2", "meteor3", "meteor4")
 	difficulty = EVENT_LEVEL_MAJOR
 
 /obj/effect/overmap/event/electric
 	name = "electrical storm"
 	events = list(/datum/event/electrical_storm)
-	opacity = 0
 	event_icon_states = list("electrical1", "electrical2")
 	difficulty = EVENT_LEVEL_MAJOR
 	can_be_destroyed = FALSE
@@ -274,13 +274,13 @@
 /obj/effect/overmap/event/dust
 	name = "dust cloud"
 	events = list(/datum/event/meteor_wave/dust/overmap)
+	opacity = 1
 	event_icon_states = list("dust1", "dust2", "dust3", "dust4")
 	can_be_destroyed = FALSE
 
 /obj/effect/overmap/event/ion
 	name = "ion cloud"
 	events = list(/datum/event/ionstorm)
-	opacity = 0
 	event_icon_states = list("ion1", "ion2", "ion3", "ion4")
 	difficulty = EVENT_LEVEL_MAJOR
 	can_be_destroyed = FALSE
@@ -288,19 +288,18 @@
 /obj/effect/overmap/event/carp
 	name = "carp shoal"
 	events = list(/datum/event/carp_migration/overmap)
-	opacity = 0
 	difficulty = EVENT_LEVEL_MODERATE
 	event_icon_states = list("carp")
 	movable_event_chance = 5
 
 /obj/effect/overmap/event/carp/major
 	name = "carp school"
+	opacity = 1
 	difficulty = EVENT_LEVEL_MAJOR
 
 /obj/effect/overmap/event/gravity
 	name = "dark matter influx"
 	events = list(/datum/event/gravity)
-	opacity = 0
 	can_be_destroyed = FALSE
 
 //These now are basically only used to spawn hazards. Will be useful when we need to spawn group of moving hazards
@@ -309,13 +308,14 @@
 	var/radius = 2
 	var/count = 6
 	var/hazards
-	var/opacity = 1
+	var/opacity = 0
 	var/continuous = TRUE //if it should form continous blob, or can have gaps
 
 /datum/overmap_event/meteor
 	name = "asteroid field"
 	count = 15
 	radius = 4
+	opacity = 1
 	continuous = FALSE
 	hazards = /obj/effect/overmap/event/meteor
 
@@ -323,27 +323,25 @@
 	name = "electrical storm"
 	count = 11
 	radius = 3
-	opacity = 0
 	hazards = /obj/effect/overmap/event/electric
 
 /datum/overmap_event/dust
 	name = "dust cloud"
 	count = 16
 	radius = 4
+	opacity = 1
 	hazards = /obj/effect/overmap/event/dust
 
 /datum/overmap_event/ion
 	name = "ion cloud"
 	count = 8
 	radius = 3
-	opacity = 0
 	hazards = /obj/effect/overmap/event/ion
 
 /datum/overmap_event/carp
 	name = "carp shoal"
 	count = 8
 	radius = 3
-	opacity = 0
 	continuous = FALSE
 	hazards = /obj/effect/overmap/event/carp
 
@@ -351,11 +349,11 @@
 	name = "carp school"
 	count = 5
 	radius = 4
+	opacity = 1
 	hazards = /obj/effect/overmap/event/carp/major
 
 /datum/overmap_event/gravity
 	name = "dark matter influx"
 	count = 12
 	radius = 4
-	opacity = 0
 	hazards = /obj/effect/overmap/event/gravity

--- a/html/changelogs/llywelwyn-sensors fix.yml
+++ b/html/changelogs/llywelwyn-sensors fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Llywelwyn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Overmap events now respect their opacity settings, rather than all hazards being opaque. Now only asteroids and dust clouds block vision, as intended."

--- a/html/changelogs/llywelwyn-sensors fix.yml
+++ b/html/changelogs/llywelwyn-sensors fix.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "Overmap events now respect their opacity settings, rather than all hazards being opaque. Now only asteroids and dust clouds block vision, as intended."
+  - bugfix: "Overmap events now respect their opacity settings, rather than all hazards being opaque. Now only asteroids, dust clouds, and large carp schools block vision, as intended."


### PR DESCRIPTION
fixes #16427

bugfix: "Overmap events now respect their opacity settings, rather than all hazards being opaque. Now only asteroids and dust clouds block vision, as intended."

this might need following up with tweaks that change which events are opaque and which aren't, because although this was the original intent its also kinda a balance change because vision was bugged for like 4 months by this point.

**bugged overmap**
![image](https://github.com/Aurorastation/Aurora.3/assets/82828093/1e310c27-3a54-4a60-b21d-7ee11a91a7df)


**fixed overmap**
![image](https://github.com/Aurorastation/Aurora.3/assets/82828093/a3b3ca13-7c05-4edc-93a5-579f295171ff)
