### PR TITLE
Flashlight changes and fixes

### DIFF
--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -17,7 +17,7 @@
 
 /obj/machinery/floodlight/Initialize()
 	. = ..()
-	cell = new /obj/item/cell/device(src) // 41minutes @ 200W
+	cell = new /obj/item/cell(src)
 
 /obj/machinery/floodlight/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -65,7 +65,7 @@
 				charging = null
 				update_icon()
 			else
-				to_chat(user, SPAN_DANGER("Your gripper cannot hold \the [charging].")
+				to_chat(user, SPAN_DANGER("Your gripper cannot hold \the [charging]."))
 		return TRUE
 
 	if(!G.dropsafety())

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -179,7 +179,8 @@
 	active_power_usage = 75 KILOWATTS
 	allowed_devices = list(
 		/obj/item/gun/energy,
-		/obj/item/melee/baton
+		/obj/item/melee/baton,
+		/obj/item/device/flashlight
 	)
 	icon_state_charged = "wrecharger100"
 	icon_state_charging = "wrecharger"

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -65,7 +65,7 @@
 				charging = null
 				update_icon()
 			else
-				to_chat(user, SPAN_DANGER("Your gripper cannot hold \the [charging].</span>"))
+				to_chat(user, SPAN_DANGER("Your gripper cannot hold \the [charging].")
 		return TRUE
 
 	if(!G.dropsafety())
@@ -77,11 +77,11 @@
 				to_chat(user, SPAN_WARNING("\The [G][G.charge_failure_message]"))
 			return TRUE
 		if(charging)
-			to_chat(user, SPAN_WARNING("\A [charging] is already charging here.</span>"))
+			to_chat(user, SPAN_WARNING("\A [charging] is already charging here."))
 			return TRUE
 		// Checks to make sure he's not in space doing it, and that the area got proper power.
 		if(!powered())
-			to_chat(user, SPAN_WARNING("\The [name] blinks red as you try to insert the item!</span>"))
+			to_chat(user, SPAN_WARNING("\The [name] blinks red as you try to insert the item!"))
 			return TRUE
 
 		user.drop_from_inventory(G,src)

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -65,7 +65,7 @@
 				charging = null
 				update_icon()
 			else
-				to_chat(user, "<span class='danger'>Your gripper cannot hold \the [charging].</span>")
+				to_chat(user, SPAN_DANGER("Your gripper cannot hold \the [charging].</span>"))
 		return TRUE
 
 	if(!G.dropsafety())
@@ -74,14 +74,14 @@
 	if(is_type_in_list(G, allowed_devices))
 		if (G.get_cell() == DEVICE_NO_CELL)
 			if (G.charge_failure_message)
-				to_chat(user, "<span class='warning'>\The [G][G.charge_failure_message]</span>")
+				to_chat(user, SPAN_WARNING("\The [G][G.charge_failure_message]"))
 			return TRUE
 		if(charging)
-			to_chat(user, "<span class='warning'>\A [charging] is already charging here.</span>")
+			to_chat(user, SPAN_WARNING("\A [charging] is already charging here.</span>"))
 			return TRUE
 		// Checks to make sure he's not in space doing it, and that the area got proper power.
 		if(!powered())
-			to_chat(user, "<span class='warning'>\The [name] blinks red as you try to insert the item!</span>")
+			to_chat(user, SPAN_WARNING("\The [name] blinks red as you try to insert the item!</span>"))
 			return TRUE
 
 		user.drop_from_inventory(G,src)

--- a/code/game/objects/items/devices/lighting/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/flashlight.dm
@@ -32,7 +32,7 @@
 	var/obj/item/cell/cell
 	var/cell_type = /obj/item/cell/device
 	var/list/brightness_levels
-	var/brightness_level = "medium"
+	var/brightness_level = "high"
 	var/power_usage
 	/// Does the light use power?
 	var/power_use = TRUE
@@ -52,7 +52,7 @@
 	if(power_use && cell_type)
 		if(starts_with_cell)
 			cell = new cell_type(src)
-		brightness_levels = list("low" = 0.25, "medium" = 0.5, "high" = 1)
+		brightness_levels = list("low" = 0.0625, "medium" = 0.125, "high" = 0.25)
 		power_usage = (brightness_levels[brightness_level] / efficiency_modifier)
 	else
 		verbs -= /obj/item/device/flashlight/verb/toggle_brightness
@@ -393,7 +393,7 @@
 		)
 	force = 10
 	attack_verb = list("bludgeoned, bashed, whacked")
-	w_class = ITEMSIZE_NORMAL
+	w_class = ITEMSIZE_SMALL
 	matter = list(MATERIAL_STEEL = 200,MATERIAL_GLASS = 100)
 	flashlight_power = 1
 	brightness_on = 4

--- a/code/game/objects/items/devices/lighting/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/flashlight.dm
@@ -129,7 +129,7 @@
 	if(power_use && brightness_level)
 		to_chat(user, SPAN_NOTICE("\The [src] is set to [brightness_level]."))
 		if(cell)
-			to_chat(user, SPAN_NOTICE("\The [src] has a \the [cell] attached."))
+			to_chat(user, SPAN_NOTICE("\The [src] has \a [cell] attached. It has [round(cell.percent())]% charge remaining."))
 
 /obj/item/device/flashlight/attack_self(mob/user)
 	if(always_on)
@@ -393,7 +393,6 @@
 		)
 	force = 10
 	attack_verb = list("bludgeoned, bashed, whacked")
-	w_class = ITEMSIZE_SMALL
 	matter = list(MATERIAL_STEEL = 200,MATERIAL_GLASS = 100)
 	flashlight_power = 1
 	brightness_on = 4

--- a/code/game/objects/items/devices/lighting/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/flashlight.dm
@@ -52,7 +52,7 @@
 	if(power_use && cell_type)
 		if(starts_with_cell)
 			cell = new cell_type(src)
-		brightness_levels = list("low" = 0.0625, "medium" = 0.125, "high" = 0.25)
+		brightness_levels = list("low" = 1/32, "medium" = 1/16, "high" = 1/8) // ~26 minutes at high power with a device cell.
 		power_usage = (brightness_levels[brightness_level] / efficiency_modifier)
 	else
 		verbs -= /obj/item/device/flashlight/verb/toggle_brightness
@@ -143,7 +143,7 @@
 			return 0
 
 	if(!isturf(user.loc))
-		to_chat(user, SPAN_NOTICE("You cannot turn the light on while in this [user.loc].")) //To prevent some lighting anomalities.
+		to_chat(user, SPAN_NOTICE("You cannot turn the light on while in this [user.loc].")) //To prevent some lighting anomalies.
 		return 0
 
 	playsound(src.loc, toggle_sound, 60, 1)
@@ -258,6 +258,9 @@
 	else
 		return ..()
 
+/obj/item/device/flashlight/AltClick()
+	toggle_brightness()
+
 /obj/item/device/flashlight/proc/inspect_vision(obj/item/organ/vision, mob/living/user)
 	var/mob/living/carbon/human/H = vision.owner
 
@@ -317,6 +320,7 @@
 	item_state = ""
 	flags = CONDUCT
 	brightness_on = 2
+	efficiency_modifier = 2
 	w_class = ITEMSIZE_TINY
 
 /obj/item/device/flashlight/heavy
@@ -337,6 +341,7 @@
 	item_state = "maglight"
 	force = 10
 	brightness_on = 5
+	efficiency_modifier = 0.8
 	w_class = ITEMSIZE_NORMAL
 	uv_intensity = 70
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
@@ -391,7 +396,6 @@
 		slot_l_hand_str = 'icons/mob/items/lefthand_mining.dmi',
 		slot_r_hand_str = 'icons/mob/items/righthand_mining.dmi',
 		)
-	force = 10
 	attack_verb = list("bludgeoned, bashed, whacked")
 	matter = list(MATERIAL_STEEL = 200,MATERIAL_GLASS = 100)
 	flashlight_power = 1

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -164,11 +164,11 @@
 	if(istype(W, /obj/item/cell))
 		if(cover_open)
 			if(cell)
-				to_chat(user, SPAN_WARNING("There is a [cell] already installed here."))
+				to_chat(user, SPAN_WARNING("There is \a [cell] already installed here."))
 			else
 				user.drop_from_inventory(W,src)
 				cell = W
-				to_chat(user, SPAN_NOTICE("You insert the [cell]."))
+				to_chat(user, SPAN_NOTICE("You insert \the [cell]."))
 		update_icon()
 		return
 
@@ -228,7 +228,7 @@
 
 	if(cover_open)
 		if(cell)
-			to_chat(user, SPAN_NOTICE("The panel is open, exposing the [cell]."))
+			to_chat(user, SPAN_NOTICE("The panel is open, exposing \the [cell]."))
 		else
 			to_chat(user, SPAN_NOTICE("The panel is open."))
 

--- a/code/modules/clothing/gloves/stungloves.dm
+++ b/code/modules/clothing/gloves/stungloves.dm
@@ -33,12 +33,12 @@
 	//add cell
 	else if(wired && istype(W, /obj/item/cell))
 		if(cell)
-			to_chat(user, "<span class='notice'>A [cell] is already attached to the [src].</span>")
+			to_chat(user, "<span class='notice'>\A [cell] is already attached to the [src].</span>")
 			return
 		user.drop_from_inventory(W,src)
 		cell = W
 		w_class = ITEMSIZE_NORMAL
-		to_chat(user, "<span class='notice'>You attach the [cell] to the [src].</span>")
+		to_chat(user, "<span class='notice'>You attach \the [cell] to the [src].</span>")
 		update_icon()
 		return
 
@@ -47,7 +47,7 @@
 		//stunglove stuff
 		if(cell)
 			cell.update_icon()
-			to_chat(user, "<span class='notice'>You cut the [cell] away from the [src].</span>")
+			to_chat(user, "<span class='notice'>You cut \the [cell] away from the [src].</span>")
 			cell.forceMove(get_turf(src.loc))
 			cell = null
 			w_class = ITEMSIZE_SMALL

--- a/html/changelogs/llywelwyn-flashlights.yml
+++ b/html/changelogs/llywelwyn-flashlights.yml
@@ -1,0 +1,46 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Llywelwyn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Flashlights now use much less power across the board. Most flashlights last ~26 minutes, with lanterns the exception at ~133 minutes, as they contain a larger cell."
+  - tweak: "Flashlights now default to high brightness - try turning them down if you need to conserve power."
+  - tweak: "Flashlight brightness can now be selected with alt-click."
+  - tweak: "Flashlights can now be placed into wall rechargers."
+  - tweak: "Lanterns are now back to being small items, but have had their force reduced to compensate."
+  - spellcheck: "Fixed various cell-related typos."

--- a/html/changelogs/llywelwyn-flashlights.yml
+++ b/html/changelogs/llywelwyn-flashlights.yml
@@ -39,8 +39,8 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Flashlights now use much less power across the board. Most flashlights last ~26 minutes, with lanterns the exception at ~133 minutes, as they contain a larger cell."
-  - tweak: "Flashlights now default to high brightness - try turning them down if you need to conserve power."
-  - tweak: "Flashlight brightness can now be selected with alt-click."
+  - tweak: "Flashlights now default to high brightness, and their charge is displayed on examine."
+  - tweak: "Flashlight brightness can now be selected with alt-click - try turning it down if you need to conserve power!"
   - tweak: "Flashlights can now be placed into wall rechargers."
   - tweak: "Lanterns are now back to being small items, but have had their force reduced to compensate."
   - spellcheck: "Fixed various cell-related typos."


### PR DESCRIPTION
changes:
  - bugfix: "Flashlights now use much less power across the board. Most flashlights last ~26 minutes, with lanterns the exception at ~133 minutes, as they contain a larger cell."
  - tweak: "Flashlights now default to high brightness, and their charge is displayed on examine."
  - tweak: "Flashlight brightness can now be selected with alt-click - try turning it down if you need to conserve power!"
  - tweak: "Flashlights can now be placed into wall rechargers."
  - tweak: "Lanterns are now back to being small items, but have had their force reduced to compensate."
  - spellcheck: "Fixed various cell-related typos."

continuation of #16264 with permission from camo

tl;dr: flashlight power consumption was reduced to an eight what it was, but now they default to high brightness which uses twice as much power. everything will last ~4x longer, or twice/quadruple that if ppl reduce the brightness to med/low.

2 efficiency - penlights ~52min
1 efficiency - flashlights/heavy-duty ~26min 
0.8 efficiency - maglights ~20min
0.5 efficiency - lanterns start w/ a regular cell so they last ~133min