### PR TITLE
Overmap Range Tweak

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -466,7 +466,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	icon_state = "holopad0_lr"
 	icon_state_suffix = "_lr"
 	long_range = TRUE
-	max_overmap_call_range = 4
+	max_overmap_call_range = 6
 
 /obj/machinery/hologram/holopad/long_range/get_holopad_id()
 	holopad_id = ""

--- a/code/game/machinery/telecomms/machines/allinone.dm
+++ b/code/game/machinery/telecomms/machines/allinone.dm
@@ -11,7 +11,7 @@
 	idle_power_usage = 0
 	active_power_usage = 0
 	produces_heat = FALSE
-	overmap_range = 2
+	overmap_range = 3
 
 	var/away_aio = FALSE
 	var/list/recent_broadcasts

--- a/code/game/machinery/telecomms/machines/broadcaster.dm
+++ b/code/game/machinery/telecomms/machines/broadcaster.dm
@@ -15,7 +15,7 @@
 	produces_heat = FALSE
 	delay = 7
 	circuitboard = "/obj/item/circuitboard/telecomms/broadcaster"
-	overmap_range = 2
+	overmap_range = 3
 	var/list/recent_broadcasts
 
 /obj/machinery/telecomms/broadcaster/Initialize(mapload)

--- a/code/game/machinery/telecomms/machines/receiver.dm
+++ b/code/game/machinery/telecomms/machines/receiver.dm
@@ -10,7 +10,7 @@
 	desc = "This machine has a dish-like shape and green lights. It is designed to detect and process subspace radio activity."
 	telecomms_type = /obj/machinery/telecomms/receiver
 	produces_heat = FALSE
-	overmap_range = 2
+	overmap_range = 3
 	circuitboard = "/obj/item/circuitboard/telecomms/receiver"
 
 /obj/machinery/telecomms/receiver/Initialize(mapload)

--- a/html/changelogs/geeves-range_buff.yml
+++ b/html/changelogs/geeves-range_buff.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Increased the overmap range for holopads to six tiles (up from four), for radios to three tiles (up from two)."


### PR DESCRIPTION
* Increased the overmap range for holopads to six tiles (up from four), for radios to three tiles (up from two).