### PR TITLE
Visible Overmap Projectiles

### DIFF
--- a/code/modules/overmap/ship_weaponry/projectiles/_overmap_projectiles.dm
+++ b/code/modules/overmap/ship_weaponry/projectiles/_overmap_projectiles.dm
@@ -4,6 +4,7 @@
 	icon_state = "cannon"
 	scannable = TRUE
 	layer = ABOVE_OBJ_LAYER
+	requires_contact = FALSE
 
 	var/obj/item/ship_ammunition/ammunition
 	var/atom/target //The target is the actual overmap object we're hitting.

--- a/html/changelogs/geeves-rapid_ship_munitions.yml
+++ b/html/changelogs/geeves-rapid_ship_munitions.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Overmap projectiles no longer need to be scanned to be visible."


### PR DESCRIPTION
* Overmap projectiles no longer need to be scanned to be visible.


https://github.com/Aurorastation/Aurora.3/assets/22774890/8da4dd95-783a-4950-a9e4-78b80786b81f