### PR TITLE
Civstation Custodian ID fix

### DIFF
--- a/html/changelogs/llywelwyn-civstation.yml
+++ b/html/changelogs/llywelwyn-civstation.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Llywelwyn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The Civilian Station janitor now spawns with the proper role on their ID."

--- a/maps/away/away_site/civ_station/civilian_station_ghostroles.dm
+++ b/maps/away/away_site/civ_station/civilian_station_ghostroles.dm
@@ -129,6 +129,9 @@
 	possible_species = list(SPECIES_HUMAN, SPECIES_HUMAN_OFFWORLD, SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION)
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 
+	assigned_role = "Station Custodian"
+	special_role = "Station Custodian"
+
 /datum/outfit/admin/shopkeeper/custodian
 	name = "Station Custodian"
 


### PR DESCRIPTION
changes:
  - bugfix: "The Civilian Station janitor now spawns with the proper role on their ID."