### PR TITLE
Adds Belt/Sunglasses to Investigator Locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -293,9 +293,12 @@
 	new /obj/item/device/camera/detective(src)
 	new /obj/item/device/camera_film(src)
 	new /obj/item/stamp/investigations(src)
+	new /obj/item/clothing/glasses/sunglasses/sechud/aviator(src)
+	new /obj/item/clothing/glasses/sunglasses/sechud(src)
 	//Belts
 	new /obj/item/clothing/accessory/holster/waist(src)
 	new /obj/item/clothing/accessory/storage/pouches/black(src)
+	new /obj/item/storage/belt/security(src)
 
 /obj/structure/closet/secure_closet/injection
 	name = "lethal injections locker"

--- a/html/changelogs/CampinKiller24-investigator-stuff.yml
+++ b/html/changelogs/CampinKiller24-investigator-stuff.yml
@@ -1,0 +1,6 @@
+author: CampinKiller24
+
+delete-after: True
+
+changes:
+  - rscadd: "Added sec sunglasses and belts to investigator lockers."


### PR DESCRIPTION
Adds belts and sunglasses to the investigator lockers. Seems odd that investigators are given flashes and not sunglasses (which they can get via loadout anyway). Also adds belts for convenient storage of some of the other items they can carry as well.
