### PR TITLE
Unathi and skrell are now cold-blooded, as intended.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
+++ b/code/modules/mob/living/carbon/human/species/station/skrell/skrell.dm
@@ -88,7 +88,7 @@
 	fast_pulse = 70 // Default 90
 	v_fast_pulse = 90 // Default 120
 	max_pulse = 130 // Default 160
-	body_temperature = T0C + 27
+	body_temperature = null // Cold-blooded
 
 	default_h_style = "Headtails"
 

--- a/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/unathi/unathi.dm
@@ -54,7 +54,7 @@
 	fast_pulse = 60 // Default 90
 	v_fast_pulse = 80// Default 120
 	max_pulse = 100// Default 160
-	body_temperature = T0C + 24
+	body_temperature = null // Cold-blooded
 
 	rarity_value = 3
 	break_cuffs = TRUE

--- a/html/changelogs/GeneralCamo - Unathi Fix.yml
+++ b/html/changelogs/GeneralCamo - Unathi Fix.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: GeneralCamo
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/GeneralCamo - Unathi Fix.yml
+++ b/html/changelogs/GeneralCamo - Unathi Fix.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Unathi are now cold-blooded, as intended."
+  - bugfix: "Skrell are now cold-blooded, as intended."

--- a/html/changelogs/GeneralCamo - Unathi Fix.yml
+++ b/html/changelogs/GeneralCamo - Unathi Fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Unathi are now cold-blooded, as intended."


### PR DESCRIPTION
Per the [lore](https://wiki.aurorastation.org/index.php?title=Unathi#Biology), unathi are intended to be cold-blooded. Despite this, they had a body temperature set in the code, which allowed them to regulate body temperature as a warm-blooded species does. This PR fixes this by setting the body temperature to `null`, which correctly allows unathi to emulate the temperature of their surroundings.

EDIT: Skrell are also now included, as per their [lore](https://wiki.aurorastation.org/index.php?title=Skrell#Biology) they are also cold-blooded.