### PR TITLE
Overmap Drifting

### DIFF
--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -125,8 +125,9 @@
 		data["autopilot"] = autopilot
 		data["manual_control"] = viewing_overmap(user)
 		data["canburn"] = connected.can_burn()
+		data["canturn"] = connected.can_turn()
 		data["cancombatroll"] = connected.can_combat_roll()
-		data["cancombatturn"] = connected.can_turn()
+		data["cancombatturn"] = connected.can_combat_turn()
 		data["accellimit"] = accellimit*1000
 
 		var/speed = round(connected.get_speed()*1000, 0.01)
@@ -267,6 +268,14 @@
 			if(connected.can_turn())
 				connected.turn_ship(ndir)
 				addtimer(CALLBACK(src, PROC_REF(updateUsrDialog)), min(connected.vessel_mass / 10, 1) SECONDS + 1)
+
+		if (href_list["combat_turn"])
+			var/ndir = text2num(href_list["combat_turn"])
+			if(ishuman(usr))
+				var/mob/living/carbon/human/H = usr
+				if(do_after(H, 1 SECOND) && connected.can_combat_turn())
+					visible_message(SPAN_DANGER("[H] twists the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
+					connected.combat_turn(ndir)
 
 		if (href_list["brake"])
 			connected.decelerate()

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -126,7 +126,7 @@
 		data["manual_control"] = viewing_overmap(user)
 		data["canburn"] = connected.can_burn()
 		data["cancombatroll"] = connected.can_combat_roll()
-		data["cancombatturn"] = connected.can_combat_turn()
+		data["cancombatturn"] = connected.can_turn()
 		data["accellimit"] = accellimit*1000
 
 		var/speed = round(connected.get_speed()*1000, 0.01)
@@ -241,14 +241,6 @@
 				visible_message(SPAN_DANGER("[H] tilts the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
 				connected.combat_roll(ndir)
 
-	if (href_list["turn"])
-		var/ndir = text2num(href_list["turn"])
-		if(ishuman(usr))
-			var/mob/living/carbon/human/H = usr
-			if(do_after(H, 1 SECOND) && connected.can_combat_turn())
-				visible_message(SPAN_DANGER("[H] twists the yoke all the way to the [ndir == WEST ? "left" : "right"]!"))
-				connected.combat_turn(ndir)
-
 	if (href_list["manual"])
 		viewing_overmap(usr) ? unlook(usr) : look(usr)
 
@@ -264,11 +256,17 @@
 
 	if(!issilicon(usr)) // AI and robots aren't allowed to pilot
 		if (href_list["move"])
-			var/ndir = text2num(href_list["move"])
 			if(prob(usr.confused * 5))
-				ndir = turn(ndir, pick(45, -45))
-			connected.relaymove(usr, ndir, accellimit)
-			addtimer(CALLBACK(src, PROC_REF(updateUsrDialog)), connected.burn_delay + 1) // remove when turning into vueui
+				href_list["turn"] = pick("45", "-45")
+			else
+				connected.relaymove(usr, connected.dir, accellimit)
+				addtimer(CALLBACK(src, PROC_REF(updateUsrDialog)), connected.burn_delay + 1) // remove when turning into vueui
+
+		if (href_list["turn"])
+			var/ndir = text2num(href_list["turn"])
+			if(connected.can_turn())
+				connected.turn_ship(ndir)
+				addtimer(CALLBACK(src, PROC_REF(updateUsrDialog)), min(connected.vessel_mass / 10, 1) SECONDS + 1)
 
 		if (href_list["brake"])
 			connected.decelerate()

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -42,7 +42,7 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 	var/burn_delay = 1 SECOND           // how often ship can do burns
 	var/fore_dir = NORTH                // what dir ship flies towards for purpose of moving stars effect procs
 	var/last_combat_roll = 0
-	var/last_combat_turn = 0
+	var/last_turn = 0
 
 	var/list/engines = list()
 	var/engines_state = 0 //global on/off toggle for all engines
@@ -209,7 +209,6 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 	pixel_y = position[2] * (world.icon_size/2)
 	if(!is_still())
 		icon_state = moving_state
-		dir = get_heading()
 	else
 		icon_state = initial(icon_state)
 	for(var/obj/machinery/computer/ship/machine in consoles)
@@ -281,11 +280,11 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 		return TRUE
 	return FALSE
 
-/obj/effect/overmap/visitable/ship/proc/can_combat_turn()
+/obj/effect/overmap/visitable/ship/proc/can_turn()
 	if(!can_burn())
 		return FALSE
-	var/cooldown = min(vessel_mass / 200, 20) SECONDS //max 20s for horizon
-	if(world.time >= (last_combat_turn + cooldown))
+	var/cooldown = min(vessel_mass / 10, 1) SECONDS //max 1s for horizon
+	if(world.time >= (last_turn + cooldown))
 		return TRUE
 	return FALSE
 
@@ -306,39 +305,12 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 			sound_to(L, sound('sound/effects/combatroll.ogg'))
 	last_combat_roll = world.time
 
-/obj/effect/overmap/visitable/ship/proc/combat_turn(var/new_dir)
+/obj/effect/overmap/visitable/ship/proc/turn_ship(var/new_dir)
 	burn()
-	var/angle = -45
-	if(new_dir == WEST)
-		angle = 45
-	var/direction = turn(dir, angle)
-	accelerate(direction, 1000)
-	if(direction & EAST)
-		speed[1] = abs(speed[1])
-	else if(direction & WEST)
-		if(speed[1] > 0)
-			speed[1] = -speed[1]
-	else
-		speed[1] = 0
-	if(direction & NORTH)
-		speed[2] = abs(speed[2])
-	else if(direction & SOUTH)
-		if(speed[2] > 0)
-			speed[2] = -speed[2]
-	else
-		speed[2] = 0
+	var/angle = new_dir == WEST ? 45 : -45
+	dir = turn(dir, angle)
 	update_icon()
-	for(var/mob/living/L in living_mob_list)
-		if(L.z in map_z)
-			if(!gravity_generator?.on && !L.anchored)
-				to_chat(L, SPAN_DANGER("The ship rapidly turns beneath you!"))
-				if(!L.buckled_to)
-					L.Weaken(3)
-			else
-				to_chat(L, SPAN_WARNING("The ship turns beneath you, but the artificial gravity keeps you on your feet."))
-			shake_camera(L, 1 SECOND, 2)
-			L.playsound_simple(soundin = 'sound/machines/thruster.ogg', volume = 50)
-	last_combat_turn = world.time
+	last_turn = world.time
 
 /obj/effect/overmap/visitable/ship/signal_hit(var/list/hit_data)
 	for(var/obj/machinery/computer/ship/targeting/TR in consoles)

--- a/html/changelogs/geeves-eurobeat.yml
+++ b/html/changelogs/geeves-eurobeat.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Ships and shuttles can now only move forward and turn left and right. Additionally, the direction the ship faces is no longer locked to the direction it's going."

--- a/nano/templates/helm.tmpl
+++ b/nano/templates/helm.tmpl
@@ -3,7 +3,7 @@
 
 <div style="float:left;width:45%;">
 	<fieldset style="min-height:180px;background-color: #202020;">
-		<legend style="text-align:center">Flight data</legend> 
+		<legend style="text-align:center">Flight data</legend>
 		<div class='item'>
 			<div class="itemLabelWider">
 				ETA to next grid:
@@ -35,7 +35,7 @@
 			<div style="float:right">
 				{{:data.heading}}&deg;
 			</div>
-		</div> 
+		</div>
 		<div class='item'>
 			<div class="itemLabelWider">
 				Acceleration limiter:
@@ -43,37 +43,28 @@
 			<div style="float:right">
 				{{:helper.link(data.accellimit, null, { 'accellimit' : 1}, null, null)}} Gm/h
 			</div>
-		</div> 
+		</div>
 	</fieldset>
 </div>
-	
+
 <div style="float:left;width:25%">
 <fieldset style="min-height:180px;background-color: #202020;">
 	<legend style="text-align:center">Manual control</legend>
 	<div class='item'>
 		<div class='item'>
-			{{:helper.link('', 'triangle-1-nw', { 'move' : 9 }, data.canburn ? null : 'disabled', null)}}
+			{{:helper.link('', '', { 'move' : 1 }, 'disabled', null)}}
 			{{:helper.link('', 'triangle-1-n', { 'move' : 1 }, data.canburn ? null : 'disabled', null)}}
-			{{:helper.link('', 'triangle-1-ne', { 'move' : 5 }, data.canburn ? null : 'disabled', null)}}
+			{{:helper.link('', '', { 'move' : 1 }, 'disabled', null)}}
 		</div>
 		<div class='item'>
-			{{:helper.link('', 'triangle-1-w', { 'move' : 8 }, data.canburn ? null : 'disabled', null)}}
+			{{:helper.link('', 'arrowstop-1-w', {'turn' : 8}, data.cancombatturn ? null : 'disabled', null)}}
 			{{:helper.link('', 'circle-close', { 'brake' : 1 }, data.canburn ? null : 'disabled', null)}}
-			{{:helper.link('', 'triangle-1-e', { 'move' : 4 }, data.canburn ? null : 'disabled', null)}}
-		</div>
-		<div class='item'>
-			{{:helper.link('', 'triangle-1-sw', { 'move' : 10 }, data.canburn ? null : 'disabled', null)}}
-			{{:helper.link('', 'triangle-1-s', { 'move' : 2 }, data.canburn ? null : 'disabled', null)}}
-			{{:helper.link('', 'triangle-1-se', { 'move' : 6 }, data.canburn ? null : 'disabled', null)}}
+			{{:helper.link('', 'arrowstop-1-e', {'turn' : 4}, data.cancombatturn ? null : 'disabled', null)}}
 		</div>
 		<div class='item'>
 			<div class="itemLabel">
 				Maneuvers
 			</div><br>
-			<div class="itemContent">
-				{{:helper.link('', 'arrowstop-1-w', {'turn' : 8}, data.cancombatturn ? null : 'disabled', null)}}
-				{{:helper.link('', 'arrowstop-1-e', {'turn' : 4}, data.cancombatturn ? null : 'disabled', null)}}
-			</div>
 			<div class="itemContent">
 				{{:helper.link('', 'arrowreturnthick-1-w', {'roll' : 8}, data.cancombatroll ? null : 'disabled', null)}}
 				{{:helper.link('', 'arrowreturnthick-1-e', {'roll' : 4}, data.cancombatroll ? null : 'disabled', null)}}
@@ -88,7 +79,7 @@
 	</div>
 </fieldset>
 </div>
-	
+
 <div style="float:left;width:30%">
 <fieldset style="min-height:180px;background-color: #202020;">
 	<legend style="text-align:center">Autopilot</legend>
@@ -103,7 +94,7 @@
 				{{:helper.link('None', null, { 'sety' : 1, 'setx' : 1 }, null, null)}}
 			{{/if}}
 		</div>
-	</div> 
+	</div>
 	<div class='item'>
 		<div class="itemLabelWide">
 			Speed limit:
@@ -111,13 +102,13 @@
 		<div class="itemContent">
 			{{:helper.link(data.speedlimit, null, { 'speedlimit' : 1 }, null, null)}} Gm/h
 		</div>
-	</div> 
+	</div>
 	<div class="item">
 		{{:helper.link(data.autopilot ? 'Engaged' : 'Disengaged', 'gear', { 'apilot' : 1 }, data.dest ? null : 'disabled', data.autopilot ? 'selected' : null)}}
 	</div>
 </fieldset>
 </div>
-	
+
 	<div class='block' style='clear: both;'>
 		<h3>Navigation data</h3>
 		<div class='item'>
@@ -168,5 +159,4 @@
 		</table>
 	</div>
 	</div>
-	
-	
+

--- a/nano/templates/helm.tmpl
+++ b/nano/templates/helm.tmpl
@@ -57,14 +57,18 @@
 			{{:helper.link('', '', { 'move' : 1 }, 'disabled', null)}}
 		</div>
 		<div class='item'>
-			{{:helper.link('', 'arrowstop-1-w', {'turn' : 8}, data.cancombatturn ? null : 'disabled', null)}}
+			{{:helper.link('', 'arrowstop-1-w', {'turn' : 8}, data.canturn ? null : 'disabled', null)}}
 			{{:helper.link('', 'circle-close', { 'brake' : 1 }, data.canburn ? null : 'disabled', null)}}
-			{{:helper.link('', 'arrowstop-1-e', {'turn' : 4}, data.cancombatturn ? null : 'disabled', null)}}
+			{{:helper.link('', 'arrowstop-1-e', {'turn' : 4}, data.canturn ? null : 'disabled', null)}}
 		</div>
 		<div class='item'>
 			<div class="itemLabel">
 				Maneuvers
 			</div><br>
+			<div class="itemContent">
+				{{:helper.link('', 'arrowstop-1-w', {'combat_turn' : 8}, data.cancombatturn ? null : 'disabled', null)}}
+				{{:helper.link('', 'arrowstop-1-e', {'combat_turn' : 4}, data.cancombatturn ? null : 'disabled', null)}}
+			</div>
 			<div class="itemContent">
 				{{:helper.link('', 'arrowreturnthick-1-w', {'roll' : 8}, data.cancombatroll ? null : 'disabled', null)}}
 				{{:helper.link('', 'arrowreturnthick-1-e', {'roll' : 4}, data.cancombatroll ? null : 'disabled', null)}}


### PR DESCRIPTION
* Ships and shuttles can now only move forward and turn left and right. Additionally, the direction the ship faces is no longer locked to the direction it's going.


Video file too big, it's here though:
https://cdn.discordapp.com/attachments/951240371885735946/1119714888256864267/2023-06-17_21-43-22.mp4
https://discord.com/channels/268916453099569164/951240371885735946/1119714889066369186