### PR TITLE
Removes PEAC HE ammo from the armory, adds it to the uplink.

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -67,7 +67,18 @@
 /datum/uplink_item/item/ammo/peac
 	name = "Anti-materiel Cannon Cartridge"
 	path = /obj/item/ammo_casing/peac
-	desc = "Contains one anti-materiel cannon cartridge."
+	desc = "Contains one AP anti-materiel cannon cartridge."
+
+/datum/uplink_item/item/ammo/peac/he
+	name = "HE Anti-materiel Cannon Cartridge"
+	telecrystal_cost = 2
+	path = /obj/item/ammo_casing/peac/he
+	desc = "Contains one HE anti-materiel cannon cartridge."
+
+/datum/uplink_item/item/ammo/peac/shrapnel
+	name = "Fragmentation Anti-materiel Cannon Cartridge"
+	path = /obj/item/ammo_casing/peac/shrapnel
+	desc = "Contains one fragmentation anti-materiel cannon cartridge."
 
 /datum/uplink_item/item/ammo/super_heavy
 	name = "K2557 Magazine"

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -52,8 +52,7 @@
 
 /obj/structure/closet/secure_closet/guncabinet/peac/fill()
 	new /obj/item/gun/projectile/peac(src)
-	for(var/i = 1 to 2)
-		new /obj/item/ammo_casing/peac(src)
-	new /obj/item/ammo_casing/peac/he(src)
 	for(var/i = 1 to 3)
+		new /obj/item/ammo_casing/peac(src)
+	for(var/i = 1 to 2)
 		new /obj/item/ammo_casing/peac/shrapnel(src)

--- a/html/changelogs/dansemacabre-peacHEbegone.yml
+++ b/html/changelogs/dansemacabre-peacHEbegone.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheDanseMacabre
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added the new PEAC ammo to the uplink."
+  - balance: "The PEAC HE ammo has been removed from the armory."


### PR DESCRIPTION
I think it's cool too, I promise. But the fact of the matter is that it's busted. It's a free instant kill that can deal extra damage to people around the guy getting instantly killed. It's not at all a fair thing for security to get, especially considering how strong the security armory is at present. To be frank I'm surprised this was even allowed in the first place, but I wanted to see how it'd turn out. It turned out too strong.