### PR TITLE
Blueriver fixes

### DIFF
--- a/html/changelogs/wickedcybs_blueriverfix.yml
+++ b/html/changelogs/wickedcybs_blueriverfix.yml
@@ -1,0 +1,7 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - bugfix: "The blue river away site doesn't have an actual R&D server anymore."
+  - maptweak: "The blue river away site shuttle can refill atmosphere now if for some reason you power it."

--- a/maps/away/away_site/blueriver/blueriver-2.dmm
+++ b/maps/away/away_site/blueriver/blueriver-2.dmm
@@ -156,7 +156,8 @@
 	icon = 'icons/obj/machinery/research.dmi';
 	icon_state = "server";
 	name = "broken down R&D server";
-	desc = "A server which used to house a back-up of all ship research. It can be used to restore lost data, or to act as another point of retrieval. Looks like it's too far gone for that though."
+	desc = "A server which used to house a back-up of all ship research. It can be used to restore lost data, or to act as another point of retrieval. Looks like it's too far gone for that though.";
+	density = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/bluespaceriver/ship)

--- a/maps/away/away_site/blueriver/blueriver-2.dmm
+++ b/maps/away/away_site/blueriver/blueriver-2.dmm
@@ -149,9 +149,14 @@
 /turf/simulated/floor/tiled/white,
 /area/bluespaceriver/ship)
 "aE" = (
-/obj/machinery/r_n_d/server,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/decal/fake_object{
+	icon = 'icons/obj/machinery/research.dmi';
+	icon_state = "server";
+	name = "broken down R&D server";
+	desc = "A server which used to house a back-up of all ship research. It can be used to restore lost data, or to act as another point of retrieval. Looks like it's too far gone for that though."
 	},
 /turf/simulated/floor/tiled/white,
 /area/bluespaceriver/ship)
@@ -372,6 +377,11 @@
 	dir = 8;
 	level = 2
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -25;
+	rcon_setting = 3
+	},
 /turf/simulated/floor/tiled/white,
 /area/bluespaceriver/ship)
 "bo" = (
@@ -521,7 +531,6 @@
 /turf/simulated/floor/tiled/white,
 /area/bluespaceriver/ship)
 "bN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -531,10 +540,16 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/bluespaceriver/ship)
 "bP" = (
 /obj/structure/fuel_port,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
 /turf/simulated/wall/titanium,
 /area/bluespaceriver/ship)
 "bQ" = (
@@ -562,30 +577,27 @@
 /turf/simulated/floor/tiled/white,
 /area/bluespaceriver/ship)
 "bT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/power/smes/buildable,
 /turf/simulated/floor/tiled/white,
 /area/bluespaceriver/ship)
 "bU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 1
 	},
-/turf/simulated/wall/titanium,
+/turf/simulated/floor/tiled/white,
 /area/bluespaceriver/ship)
 "bV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
+/obj/structure/shuttle/engine/propulsion{
+	icon_state = "propulsion_l"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/wall/titanium,
 /area/bluespaceriver/ship)
 "bW" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 8;
+	dir = 1;
 	use_power = 1
 	},
 /turf/simulated/floor,
@@ -779,8 +791,21 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/high{
-	name = "south bump";
-	pixel_y = -24
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/white,
+/area/bluespaceriver/ship)
+"ge" = (
+/obj/structure/curtain/open/bed,
+/obj/machinery/alarm{
+	pixel_y = 28;
+	req_one_access = list(24,11,55)
 	},
 /turf/simulated/floor/tiled/white,
 /area/bluespaceriver/ship)
@@ -815,10 +840,21 @@
 	temperature = 250
 	},
 /area/bluespaceriver/ground)
+"uq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/wall/titanium,
+/area/bluespaceriver/ship)
 "vc" = (
 /obj/structure/bookcase/libraryspawn/reference,
 /obj/machinery/light/small{
 	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/bluespaceriver/ship)
+"AW" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/white,
 /area/bluespaceriver/ship)
@@ -828,12 +864,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bluespaceriver/ship)
+"Ed" = (
+/obj/machinery/alarm{
+	pixel_y = 28;
+	req_one_access = list(24,11,55)
+	},
+/turf/simulated/floor/tiled/white,
+/area/bluespaceriver/ship)
 "HI" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/exoplanet/snow{
 	temperature = 250
 	},
 /area/bluespaceriver/ground)
+"Iz" = (
+/obj/machinery/alarm{
+	pixel_y = 28;
+	req_one_access = list(24,11,55)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/bluespaceriver/ship)
 "JT" = (
 /obj/structure/bed/stool/chair/office/bridge/generic{
 	dir = 1
@@ -2542,7 +2592,7 @@ bD
 bG
 ay
 ay
-bC
+ay
 ac
 ac
 ac
@@ -2941,7 +2991,7 @@ an
 an
 at
 ay
-aF
+Ed
 aF
 aV
 bf
@@ -3041,7 +3091,7 @@ ac
 ac
 an
 ao
-aF
+AW
 ay
 aG
 aO
@@ -3049,7 +3099,7 @@ ay
 bf
 bt
 ay
-bJ
+ge
 ay
 bJ
 ay
@@ -3359,7 +3409,7 @@ bJ
 ay
 bJ
 ay
-ch
+Iz
 ay
 ay
 ay
@@ -3864,11 +3914,11 @@ ay
 ay
 bm
 hN
-ay
+uq
 dT
 bU
 ay
-bC
+ay
 ac
 ac
 ac
@@ -3968,7 +4018,7 @@ bn
 bq
 ay
 bP
-bV
+ay
 bC
 ac
 ac
@@ -4069,7 +4119,7 @@ an
 an
 bA
 ay
-bC
+bV
 bW
 ac
 ac


### PR DESCRIPTION
Makes the blueriver rnd server a prop.

Adds an air pressure tank if anyone powers the ship through a particular means and puts it into an APC. Not that it's really needed but verisimilitude and all that.