### PR TITLE
Nerfs KAs in Atmosphere

### DIFF
--- a/code/modules/custom_ka/barrels.dm
+++ b/code/modules/custom_ka/barrels.dm
@@ -69,7 +69,7 @@
 	desc = "A very experimental kinetic accelerator energy converter. Not much is known about this thing, other than it kicks like a mule and stings like an e-sword."
 	icon_state = "barrel05"
 	damage_increase = 30
-	firedelay_increase = 1 SECONDS
+	firedelay_increase = 2 SECONDS
 	range_increase = 7
 	recoil_increase = 10
 	cost_increase = 10

--- a/code/modules/custom_ka/cells.dm
+++ b/code/modules/custom_ka/cells.dm
@@ -234,7 +234,7 @@
 	icon_state = "cell_uraniumloader"
 	cell_increase = 300
 	capacity_increase = -5
-
+	firedelay_increase = 0.5 SECONDS
 	pump_restore = 0
 	pump_delay = 0
 

--- a/code/modules/custom_ka/core.dm
+++ b/code/modules/custom_ka/core.dm
@@ -234,19 +234,43 @@
 		installed_upgrade_chip.on_fire(src)
 	if(installed_barrel)
 		installed_barrel.on_fire(src)
+		
+	//Get turf and see if in atmos or not
+	var/turf/T = get_turf(src)
+	
+	if(T)
+		var/datum/gas_mixture/environment = T.return_air()
+		var/pressure = (environment)? environment.return_pressure() : 0
+		//If pressure is greater than about 40 kPA
+		if(pressure > ONE_ATMOSPHERE*0.4)
+			if(ispath(installed_barrel.projectile_type, /obj/item/projectile/kinetic))
+				var/obj/item/projectile/kinetic/shot_projectile = new installed_barrel.projectile_type(get_turf(src))
+				shot_projectile.damage = damage_increase
+				shot_projectile.range = range_increase
+				shot_projectile.aoe = max(1, aoe_increase)
+				shot_projectile.base_damage = 5
+				return shot_projectile
+				
+			if(ispath(installed_barrel.projectile_type, /obj/item/projectile/beam))
+				var/obj/item/projectile/beam/shot_projectile = new installed_barrel.projectile_type(get_turf(src))
+				shot_projectile.damage = damage_increase
+				shot_projectile.range = range_increase
+				return shot_projectile
 
-	if(ispath(installed_barrel.projectile_type, /obj/item/projectile/kinetic))
-		var/obj/item/projectile/kinetic/shot_projectile = new installed_barrel.projectile_type(get_turf(src))
-		shot_projectile.damage = damage_increase
-		shot_projectile.range = range_increase
-		shot_projectile.aoe = max(1, aoe_increase)
-		shot_projectile.base_damage = damage_increase
-		return shot_projectile
-	if(ispath(installed_barrel.projectile_type, /obj/item/projectile/beam))
-		var/obj/item/projectile/beam/shot_projectile = new installed_barrel.projectile_type(get_turf(src))
-		shot_projectile.damage = damage_increase
-		shot_projectile.range = range_increase
-		return shot_projectile
+		if(pressure < ONE_ATMOSPHERE*0.4)
+			if(ispath(installed_barrel.projectile_type, /obj/item/projectile/kinetic))
+				var/obj/item/projectile/kinetic/shot_projectile = new installed_barrel.projectile_type(get_turf(src))
+				shot_projectile.damage = damage_increase
+				shot_projectile.range = range_increase
+				shot_projectile.aoe = max(1, aoe_increase)
+				shot_projectile.base_damage = damage_increase
+				return shot_projectile
+				
+			if(ispath(installed_barrel.projectile_type, /obj/item/projectile/beam))
+				var/obj/item/projectile/beam/shot_projectile = new installed_barrel.projectile_type(get_turf(src))
+				shot_projectile.damage = damage_increase
+				shot_projectile.range = range_increase
+				return shot_projectile
 
 /obj/item/gun/custom_ka/Initialize()
 	. = ..()

--- a/html/changelogs/CampinKiller24-KA-nerf.yml
+++ b/html/changelogs/CampinKiller24-KA-nerf.yml
@@ -1,0 +1,6 @@
+author: CampinKiller24
+
+delete-after: True
+
+changes:
+  - rscadd: "Nerfed KA damaged in atmosphere, and increased fire delay of some components."


### PR DESCRIPTION
KAs have long been considered a strong weapon in low/no atmosphere only, despite this not being the case, especially with the right upgrades. A "properly" upgraded KA can instantly crit someone in heavy armor in a single shot in atmosphere currently. This nerfs KAs in atmosphere (>~40 kPA), but keeps them strong in low atmosphere/void conditions, as was intended. Also nerfs a couple components that allow straight shredding of people in armor.

EDIT: For reference, a "fully upgraded" KA would now do the following damages:
Unarmored target in atmosphere: ~25 brute damage
Target in heavy armor in atmosphere: ~16 brute damage
Target in security voidsuit in void: ~65 brute damage