### PR TITLE
Fixes PKA examine typo: offical -> official

### DIFF
--- a/code/modules/custom_ka/core.dm
+++ b/code/modules/custom_ka/core.dm
@@ -92,7 +92,7 @@
 		if(custom_name)
 			to_chat(user,"[custom_name] is written crudely in pen across the side, covering up the offical designation.")
 		else
-			to_chat(user,"The offical designation \"[official_name]\" is etched neatly on the side.")
+			to_chat(user,"The official designation \"[official_name]\" is etched neatly on the side.")
 
 	if(installed_cell)
 		to_chat(user, "It has <b>[get_ammo()]</b> shots remaining.")

--- a/html/changelogs/epicgamer545-pkaspellerror.yml
+++ b/html/changelogs/epicgamer545-pkaspellerror.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Epicgamer545
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - spellcheck: "Fixed PKA examine text: offical -> official"


### PR DESCRIPTION
Fixes the type when you examine a KA (or, PKA, as they say). 
* "offical" is now "official"
* This really bugged me since I started playing as a miner. Hopefully this releases Aurora from the typo curse.
