### PR TITLE
Radiation Storm Rework

### DIFF
--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -1,30 +1,6 @@
 var/eventchance = 10 // Percent chance per 5 minutes.
 var/hadevent    = 0
 
-/proc/high_radiation_event()
-
-	for(var/mob/living/carbon/human/H in living_mob_list)
-		var/turf/T = get_turf(H)
-		if(!T)
-			continue
-		if(isNotStationLevel(T.z))
-			continue
-
-		H.apply_damage((rand(15,75)), DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED)
-		if (prob(5))
-			H.apply_damage((rand(90,150)), DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED)
-		if (prob(25))
-			if (prob(75))
-				randmutb(H)
-				domutcheck(H,null,MUTCHK_FORCED)
-			else
-				randmutg(H)
-				domutcheck(H,null,MUTCHK_FORCED)
-	sleep(100)
-	command_announcement.Announce("High levels of radiation detected near the station. Please report to the Med-bay if you feel strange.", "Anomaly Alert")
-
-
-
 //Changing this to affect the main station. Blame Urist. --Pete
 /proc/prison_break() // -- Callagan
 

--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -1060,7 +1060,8 @@
 		/obj/item/airalarm_electronics = 10,
 		/obj/item/firealarm_electronics = 10,
 		/obj/item/cell/high = 10,
-		/obj/item/grenade/chem_grenade/antifuel = 5
+		/obj/item/grenade/chem_grenade/antifuel = 5,
+		/obj/item/device/geiger = 5
 	)
 	contraband = list(
 		/obj/item/cell/potato = 3

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -45,10 +45,6 @@
 	var/radiation_level = rand(20, 40)
 	for(var/z in affecting_z)
 		SSradiation.z_radiate(locate(1, 1, z), radiation_level, TRUE)
-		
-	//for(var/mob/living/C in living_mob_list)
-		//if(istype(C,/mob/living/carbon/human))
-			//C.handle_mutations_and_radiation()
 
 /datum/event/radiation_storm/end(var/faked)
 	..()

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -42,36 +42,13 @@
 		lights()
 
 /datum/event/radiation_storm/proc/radiate()
-	var/radiation_level = rand(15, 30)
+	var/radiation_level = rand(20, 40)
 	for(var/z in affecting_z)
-		SSradiation.z_radiate(locate(1, 1, z), radiation_level, 1)
+		SSradiation.z_radiate(locate(1, 1, z), radiation_level, TRUE)
 		
-	for(var/mob/living/C in living_mob_list)
-		var/area/A = get_area(C)
-		if(!A)
-			continue
-		if(isNotStationLevel(A.z))
-			continue
-		if(A.flags & RAD_SHIELDED)
-			continue
-		if(istype(C,/mob/living/carbon/human))
-			var/mob/living/carbon/human/H = C
-			
-			if(H.is_diona())
-				var/damage = rand(15, 30)
-				H.adjustToxLoss(-damage)
-				if(prob(5))
-					damage = rand(20, 60)
-					H.adjustToxLoss(-damage)
-				to_chat(H, SPAN_NOTICE("You can feel flow of energy which makes you regenerate."))
-			
-			if(prob(5 * (1 - H.get_blocked_ratio(null, DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED, armor_pen = radiation_level))))
-				if (prob(75))
-					randmutb(H) // Applies bad mutation
-					domutcheck(H,null,MUTCHK_FORCED)
-				else
-					randmutg(H) // Applies good mutation
-					domutcheck(H,null,MUTCHK_FORCED)
+	//for(var/mob/living/C in living_mob_list)
+		//if(istype(C,/mob/living/carbon/human))
+			//C.handle_mutations_and_radiation()
 
 /datum/event/radiation_storm/end(var/faked)
 	..()

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -42,8 +42,36 @@
 		lights()
 
 /datum/event/radiation_storm/proc/radiate()
+	var/radiation_level = rand(15, 30)
+	for(var/z in affecting_z)
+		SSradiation.z_radiate(locate(1, 1, z), radiation_level, 1)
+		
 	for(var/mob/living/C in living_mob_list)
-		C.apply_radiation_effects()
+		var/area/A = get_area(C)
+		if(!A)
+			continue
+		if(isNotStationLevel(A.z))
+			continue
+		if(A.flags & RAD_SHIELDED)
+			continue
+		if(istype(C,/mob/living/carbon/human))
+			var/mob/living/carbon/human/H = C
+			
+			if(H.is_diona())
+				var/damage = rand(15, 30)
+				H.adjustToxLoss(-damage)
+				if(prob(5))
+					damage = rand(20, 60)
+					H.adjustToxLoss(-damage)
+				to_chat(H, SPAN_NOTICE("You can feel flow of energy which makes you regenerate."))
+			
+			if(prob(5 * (1 - H.get_blocked_ratio(null, DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED, armor_pen = radiation_level))))
+				if (prob(75))
+					randmutb(H) // Applies bad mutation
+					domutcheck(H,null,MUTCHK_FORCED)
+				else
+					randmutg(H) // Applies good mutation
+					domutcheck(H,null,MUTCHK_FORCED)
 
 /datum/event/radiation_storm/end(var/faked)
 	..()

--- a/code/modules/mob/living/announcer.dm
+++ b/code/modules/mob/living/announcer.dm
@@ -91,9 +91,6 @@
 /mob/living/announcer/InStasis()
 	return FALSE
 
-/mob/living/announcer/apply_radiation_effects()
-	return FALSE
-
 /mob/living/announcer/flash_act(intensity = FLASH_PROTECTION_MODERATE, override_blindness_check = FALSE, affect_silicon = FALSE, ignore_inherent = FALSE, type = /obj/screen/fullscreen/flash, length = 2.5 SECONDS)
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2028,30 +2028,6 @@
 				var/matrix/M = new()
 				B.transform = M.Scale(scale)
 
-/mob/living/carbon/human/apply_radiation_effects()
-	. = ..()
-	if(. == TRUE)
-		if(src.is_diona())
-			var/damage = rand(15, 30)
-			src.adjustToxLoss(-damage)
-			if(prob(5))
-				damage = rand(20, 60)
-				src.adjustToxLoss(-damage)
-			to_chat(src, SPAN_NOTICE("You can feel flow of energy which makes you regenerate."))
-
-		if(species.radiation_mod <= 0)
-			return
-
-		apply_damage((rand(15,30)), DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED)
-		if(prob(4))
-			apply_damage((rand(20,60)), DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED)
-			if (prob(75))
-				randmutb(src) // Applies bad mutation
-				domutcheck(src,null,MUTCHK_FORCED)
-			else
-				randmutg(src) // Applies good mutation
-				domutcheck(src,null,MUTCHK_FORCED)
-
 /mob/living/carbon/human/get_accent_icon(var/datum/language/speaking, var/mob/hearer, var/force_accent)
 	var/used_accent = accent //starts with the mob's default accent
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -227,10 +227,10 @@
 			var/damage = 0
 			total_radiation -= 1 * RADIATION_SPEED_COEFFICIENT
 			if(prob(25))
-				damage = 1
+				damage = 2
 
 			if (total_radiation > 50)
-				damage = 1
+				damage = 3
 				total_radiation -= 1 * RADIATION_SPEED_COEFFICIENT
 				if(prob(5) && prob(100 * RADIATION_SPEED_COEFFICIENT))
 					src.apply_radiation(-5 * RADIATION_SPEED_COEFFICIENT)
@@ -247,9 +247,10 @@
 
 			if (total_radiation > 75)
 				src.apply_radiation(-1 * RADIATION_SPEED_COEFFICIENT)
-				damage = 3
+				damage = 7
 				if(prob(5))
-					take_overall_damage(0, 5 * RADIATION_SPEED_COEFFICIENT, used_weapon = "Radiation Burns")
+					take_overall_damage(0, 10 * RADIATION_SPEED_COEFFICIENT, used_weapon = "Radiation Burns")
+					to_chat(src, "<span class='warning'>You feel a burning sensation!</span>")
 				if(prob(1))
 					to_chat(src, "<span class='warning'>You feel strange!</span>")
 					adjustCloneLoss(5 * RADIATION_SPEED_COEFFICIENT)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -989,16 +989,6 @@ default behaviour is:
 	update_icon()
 	return TRUE
 
-/mob/living/proc/apply_radiation_effects()
-	var/area/A = get_area(src)
-	if(!A)
-		return FALSE
-	if(isNotStationLevel(A.z))
-		return FALSE
-	if(A.flags & RAD_SHIELDED)
-		return FALSE
-	. = TRUE
-
 /mob/living/proc/needs_wheelchair()
 	return FALSE
 

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -156,11 +156,6 @@
 	. = ..()
 	handle_radiation_light()
 
-/mob/living/simple_animal/cat/apply_radiation_effects()
-	. = ..()
-	if(.)
-		apply_damage((rand(30,60)), DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED)
-
 /mob/living/simple_animal/cat/proc/handle_flee_target()
 	//see if we should stop fleeing
 	if (flee_target && !(flee_target.loc in view(src)))

--- a/html/changelogs/CampinKiller24-Radstorm-Rework.yml
+++ b/html/changelogs/CampinKiller24-Radstorm-Rework.yml
@@ -6,3 +6,4 @@ delete-after: True
 changes:
   - rscadd: "Ports how radiation storms work from Bay. Geiger counters can now detect radiation during storms, and radiation-resistant clothing (such as radsuits) now block radiation during storms."
   - rscadd: "Adds geiger counters to Engi-Vend."
+  - rscadd: "Exposure to extreme radiation is now much more harmful than before."

--- a/html/changelogs/CampinKiller24-Radstorm-Rework.yml
+++ b/html/changelogs/CampinKiller24-Radstorm-Rework.yml
@@ -5,3 +5,4 @@ delete-after: True
 
 changes:
   - rscadd: "Ports how radiation storms work from Bay. Geiger counters can now detect radiation during storms, and radiation-resistant clothing (such as radsuits) now block radiation during storms."
+  - rscadd: "Adds geiger counters to Engi-Vend."

--- a/html/changelogs/CampinKiller24-Radstorm-Rework.yml
+++ b/html/changelogs/CampinKiller24-Radstorm-Rework.yml
@@ -1,0 +1,7 @@
+author: CampinKiller24
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes:
+  - rscadd: "Ports how radiation storms work from Bay. Geiger counters can now detect radiation during storms, and radiation-resistant clothing (such as radsuits) now block radiation during storms."

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -84,9 +84,9 @@
 	dust_contact_message = "The ship is now passing through a belt of space dust."
 	dust_end_message = "The ship has now passed through the belt of space dust."
 
-	radiation_detected_message = "High levels of radiation detected near the ship. Please evacuate into one of the shielded maintenance tunnels." 
+	radiation_detected_message = "High levels of radiation detected near the ship. Please evacuate into one of the shielded maintenance tunnels."
 	radiation_contact_message = "The ship has entered the radiation belt. Please remain in a sheltered area until we have passed the radiation belt."
-	radiation_end_message = "The ship has passed the radiation belt. Please allow for up to one minute while radiation levels dissipate, and report to medbay if you experience any unusual symptoms. Maintenance will lose all-access again shortly."
+	radiation_end_message = "The ship has passed the radiation belt. Please report to medbay if you experience any unusual symptoms. Maintenance will lose all-access again shortly."
 
 	rogue_drone_detected_messages = list("Combat drone swarm from a nearby facility have engaged the ship. If any are sighted in the area, approach with caution.",
 													"Malfunctioning combat drones have been detected close to the ship. If any are sighted in the area, approach with caution.")

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -84,7 +84,7 @@
 	dust_contact_message = "The ship is now passing through a belt of space dust."
 	dust_end_message = "The ship has now passed through the belt of space dust."
 
-	radiation_detected_message = "High levels of radiation detected near the ship. Please evacuate into one of the shielded maintenance tunnels."
+	radiation_detected_message = "High levels of radiation detected near the ship. Please evacuate into one of the shielded maintenance tunnels." 
 	radiation_contact_message = "The ship has entered the radiation belt. Please remain in a sheltered area until we have passed the radiation belt."
 	radiation_end_message = "The ship has passed the radiation belt. Please allow for up to one minute while radiation levels dissipate, and report to medbay if you experience any unusual symptoms. Maintenance will lose all-access again shortly."
 

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -86,7 +86,7 @@
 
 	radiation_detected_message = "High levels of radiation detected near the ship. Please evacuate into one of the shielded maintenance tunnels."
 	radiation_contact_message = "The ship has entered the radiation belt. Please remain in a sheltered area until we have passed the radiation belt."
-	radiation_end_message = "The ship has passed the radiation belt. Please report to medbay if you experience any unusual symptoms. Maintenance will lose all-access again shortly."
+	radiation_end_message = "The ship has passed the radiation belt. Please allow for up to one minute while radiation levels dissipate, and report to medbay if you experience any unusual symptoms. Maintenance will lose all-access again shortly."
 
 	rogue_drone_detected_messages = list("Combat drone swarm from a nearby facility have engaged the ship. If any are sighted in the area, approach with caution.",
 													"Malfunctioning combat drones have been detected close to the ship. If any are sighted in the area, approach with caution.")


### PR DESCRIPTION
Ports the way radiation storms work from Bay. Unshielded areas are now hit with radiation, instead of mobs receiving the damage directly. Geiger counters detect radiation during radstorms now, and radiation-resistant clothing protects the wearer. Radiation does take some time to dissipate after the storm ends (approx 15-30 seconds, depending on the level), so the announcement has been updated to reflect that. Also adds geiger counters to the Engi-Vend.

Radiation exposure is now more harmful, especially extreme exposure, though it's still easily treated with proper medical care.
