### PR TITLE
 Crew manifest follow button for ghosts (tgui edition)

### DIFF
--- a/code/controllers/subsystems/records.dm
+++ b/code/controllers/subsystems/records.dm
@@ -186,12 +186,16 @@
 /datum/controller/subsystem/records/ui_status(mob/user, datum/ui_state/state)
 	return (isnewplayer(user) || isobserver(user) || issilicon(user)) ? UI_INTERACTIVE : UI_CLOSE
 
-/datum/controller/subsystem/records/Topic(href, href_list)
-	if(href_list["action"] == "follow") // from manifest.vue
+/datum/controller/subsystem/records/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
+
+	if(action == "follow")
 		var/mob/abstract/observer/O = usr
 		if(istype(O))
-			for(var/mob/living/M in player_list)
-				if(istype(M) && M.real_name == href_list["name"])
+			for(var/mob/living/M in human_mob_list)
+				if(istype(M) && M.real_name == params["name"])
 					O.ManualFollow(M)
 					break
 	. = ..()
@@ -199,6 +203,7 @@
 /datum/controller/subsystem/records/ui_static_data(mob/user)
 	var/list/data = list()
 	data["manifest"] = SSrecords.get_manifest_list()
+	data["allow_follow"] = isobserver(usr)
 	return data
 
 /datum/controller/subsystem/records/proc/open_manifest_tgui(mob/user, datum/tgui/ui)

--- a/code/modules/modular_computers/file_system/programs/generic/manifest.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/manifest.dm
@@ -14,6 +14,7 @@
 /datum/computer_file/program/manifest/ui_static_data(mob/user)
 	var/list/data = list()
 	data["manifest"] = SSrecords.get_manifest_list()
+	data["allow_follow"] = isobserver(usr)
 	return data
 
 // /datum/computer_file/program/manifest/Topic(href, href_list)

--- a/html/changelogs/DreamySkrell-manifest-follow-tgui.yml
+++ b/html/changelogs/DreamySkrell-manifest-follow-tgui.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Ghosts can again follow crew on the crew manifest."

--- a/tgui/packages/tgui/interfaces/common/Manifest.tsx
+++ b/tgui/packages/tgui/interfaces/common/Manifest.tsx
@@ -1,10 +1,11 @@
 import { BooleanLike } from '../../../common/react';
 import { useBackend } from '../../backend';
-import { Icon, Section, Table, Tooltip } from '../../components';
+import { Button, Icon, Section, Table, Tooltip } from '../../components';
 import { TableCell, TableRow } from '../../components/Table';
 
 type ManifestData = {
   manifest: { department: Crew[] };
+  allow_follow: BooleanLike;
 };
 
 type Crew = {
@@ -17,6 +18,7 @@ type Crew = {
 export const Manifest = (props, context) => {
   const { act, data } = useBackend<ManifestData>(context);
   const manifest = data.manifest || {};
+  const allow_follow = data.allow_follow;
   return (
     <Section>
       {Object.keys(manifest).length === 0 && 'There are no crew active.'}
@@ -49,6 +51,20 @@ export const Manifest = (props, context) => {
                         />
                       </Tooltip>
                     </TableCell>
+                    {allow_follow ? (
+                      <TableCell textAlign="right">
+                        <Tooltip content="Follow mob">
+                          <Button
+                            content="F"
+                            onClick={() =>
+                              act('follow', { name: crewmate.name })
+                            }
+                          />
+                        </Tooltip>
+                      </TableCell>
+                    ) : (
+                      ''
+                    )}
                   </TableRow>
                 );
               })}


### PR DESCRIPTION
![image](https://github.com/Aurorastation/Aurora.3/assets/107256943/1eb4865c-e204-4b4a-a0f9-62f2f82a437d)

Brings back https://github.com/Aurorastation/Aurora.3/pull/15089 as it was not added/ported/rewritten with tgui

- rscadd: "Ghosts can again follow crew on the crew manifest."