### PR TITLE
Changes VSCodes debug build tasks to use /tg/'s cbt instead of DM

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,18 +4,20 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
 	"configurations": [
-		{
+		{ // Builds with CBT and launches DreamSeeker.
 			"type": "byond",
 			"request": "launch",
-			"name": "Launch with build",
-			"preLaunchTask": "dm: build - aurorastation.dme",
+			"name": "Launch DreamSeeker",
+			"preLaunchTask": "Build All",
 			"dmb": "${workspaceFolder}/${command:CurrentDMB}"
 		},
-		{
+		{ // Builds with CBT and starts the server with DreamDaemon.
 			"type": "byond",
 			"request": "launch",
-			"name": "Launch WITHOUT BUILD",
+			"name": "Launch DreamDaemon",
+			"preLaunchTask": "Build All",
 			"dmb": "${workspaceFolder}/${command:CurrentDMB}",
+			"dreamDaemon": true
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,16 +4,6 @@
     "version": "2.0.0",
     "tasks": [
       {
-        "type": "shell",
-        "command": "tools/dreamchecker/dreamchecker",
-        "windows": {
-          "command": ".\\tools\\dreamchecker\\dreamchecker.bat \".\\tools\\dreamchecker\\dreamchecker.exe\"",
-          "echo": "false"
-        },
-        "group": "build",
-        "label": "dreamchecker"
-      },
-      {
         "type": "process",
         "command": "tools/build/build",
         "windows": {
@@ -33,8 +23,18 @@
             "kind": "build",
             "isDefault": true
         },
-        "dependsOn": "dm: reparse",
+        "dependsOn": ["dm: reparse", "dreamchecker"],
         "label": "Build All"
+      },
+      {
+        "type": "shell",
+        "command": "tools/dreamchecker/dreamchecker",
+        "windows": {
+          "command": ".\\tools\\dreamchecker\\dreamchecker.bat \".\\tools\\dreamchecker\\dreamchecker.exe\"",
+          "echo": "false"
+        },
+        "group": "build",
+        "label": "dreamchecker"
       },
       {
         "type": "dreammaker",

--- a/html/changelogs/cbt-build-io-util.yml
+++ b/html/changelogs/cbt-build-io-util.yml
@@ -1,0 +1,6 @@
+author: io-util
+
+delete-after: True
+
+changes:
+  - backend: "Switches the vscode build task to /tg/'s cbt."


### PR DESCRIPTION
Title says it all. When you build using Visual Studio Code it no longer just uses DreamMaker, it now uses /tg/'s famous CBT (Continuous Build Tool). 

DreamChecker (which fluffy added) still runs beforehand.