### PR TITLE
Ship Ammunition Weight Loss

### DIFF
--- a/code/modules/overmap/ship_weaponry/_ship_ammunition.dm
+++ b/code/modules/overmap/ship_weaponry/_ship_ammunition.dm
@@ -25,7 +25,7 @@
 	var/obj/item/projectile/original_projectile
 	var/heading = SOUTH
 	var/range = OVERMAP_PROJECTILE_RANGE_MEDIUM
-	var/mob_carry_size = MOB_LARGE //How large a mob has to be to carry the shell
+	var/mob_carry_size = 12 //How large a mob has to be to carry the shell
 	//Cookoff variables.
 	var/cookoff_devastation = 0
 	var/cookoff_heavy = 2

--- a/html/changelogs/geeves-xion_fox.yml
+++ b/html/changelogs/geeves-xion_fox.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Lowered the weight of ship ammunition so that Xion frames, vaurca workers, and non-Coeus Diona can lift them without mechanical assistance."


### PR DESCRIPTION
* Lowered the weight of ship ammunition so that Xion frames, vaurca workers, and non-Coeus Diona can lift them without mechanical assistance.