### PR TITLE
Vaurca filters now work as described

### DIFF
--- a/code/datums/outfits/ert/kataphract.dm
+++ b/code/datums/outfits/ert/kataphract.dm
@@ -43,7 +43,7 @@
 
 	uniform = /obj/item/clothing/under/vaurca
 	head = /obj/item/clothing/head/helmet/unathi/klax
-	mask = /obj/item/clothing/mask/breath/vaurca/filter
+	mask = /obj/item/clothing/mask/gas/vaurca/filter
 	suit = /obj/item/clothing/suit/armor/unathi/klax
 	suit_store = /obj/item/gun/launcher/grenade
 	shoes = /obj/item/clothing/shoes/vaurca

--- a/code/datums/outfits/ert/tcfl.dm
+++ b/code/datums/outfits/ert/tcfl.dm
@@ -17,7 +17,7 @@
 /datum/outfit/admin/ert/legion/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(isvaurca(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"

--- a/code/datums/trading/misc.dm
+++ b/code/datums/trading/misc.dm
@@ -205,7 +205,7 @@
 	name_language = LANGUAGE_VAURCA
 
 	possible_trading_items = list(
-		/obj/item/clothing/mask/breath/vaurca            = TRADER_THIS_TYPE,
+		/obj/item/clothing/mask/gas/vaurca            = TRADER_THIS_TYPE,
 		/obj/item/melee/energy/vaurca             = TRADER_THIS_TYPE,
 		/obj/item/vaurca/box                             = TRADER_THIS_TYPE,
 		/obj/item/melee/vaurca/rock               = TRADER_THIS_TYPE,

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -38,7 +38,7 @@
 	var/epp_active = FALSE
 
 	var/list/mask_blacklist = list(
-		/obj/item/clothing/mask/breath/vaurca,
+		/obj/item/clothing/mask/gas/vaurca,
 		/obj/item/clothing/mask/breath/skrell,
 		/obj/item/clothing/mask/breath/lyodsuit,
 		/obj/item/clothing/mask/breath/infiltrator)

--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -1,7 +1,7 @@
 #define EPP "Emergency Positive Pressure system"
 
 /obj/item/auto_cpr
-	name = "stabilizer harness" 
+	name = "stabilizer harness"
 	desc = "A specialized medical harness that gives regular compressions to the patient's ribcage for cases of urgent heart issues, and functions as an emergency \
 	artificial respirator for cases of urgent lung issues."
 	desc_info = "The Stabilizer Harness' CPR mode is capable of restarting the heart much like manual CPR with a chance for rib cracking ONLY IF the patient is flat lining,\
@@ -34,7 +34,7 @@
 	var/epp_active = FALSE
 
 	var/list/mask_blacklist = list(
-		/obj/item/clothing/mask/breath/vaurca,
+		/obj/item/clothing/mask/gas/vaurca,
 		/obj/item/clothing/mask/breath/skrell,
 		/obj/item/clothing/mask/breath/lyodsuit,
 		/obj/item/clothing/mask/breath/infiltrator)

--- a/code/game/objects/items/weapons/vaurca_items.dm
+++ b/code/game/objects/items/weapons/vaurca_items.dm
@@ -1,19 +1,20 @@
 //Weapons and items used exclusively by the Vaurcae, typically only for event shenanigans, and possibly random finds in the future. All items here should have
 //"Vaurca" in the item path at some point, so they can be easily spawned in-game.
 
-/obj/item/clothing/mask/breath/vaurca
+/obj/item/clothing/mask/gas/vaurca
 	desc = "A Vaurcae mandible garment with an attached gas filter and air-tube."
 	name = "mandible garment"
 	icon = 'icons/obj/vaurca_items.dmi'
 	icon_state = "m_garment"
 	item_state = "m_garment"
+	filtered_gases = list(GAS_NITROGEN, GAS_N2O, GAS_CHLORINE, GAS_ALIEN)
 	contained_sprite = 1
 
-/obj/item/clothing/mask/breath/vaurca/adjust_mask(mob/user)
+/obj/item/clothing/mask/gas/vaurca/adjust_mask(mob/user)
 	to_chat(user, "This mask is too tight to adjust.")
 	return
 
-/obj/item/clothing/mask/breath/vaurca/filter
+/obj/item/clothing/mask/gas/vaurca/filter
 	desc = "A basic screw on filter attached beneath the mouthparts of the common Vaurca."
 	name = "filter port"
 	icon_state = "filterport"

--- a/code/modules/background/citizenship/human.dm
+++ b/code/modules/background/citizenship/human.dm
@@ -50,7 +50,7 @@
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/gearharness(H), slot_w_uniform)
 			H.equip_to_slot_or_del(new /obj/item/clothing/head/vaurca_breeder/biesel(H), slot_head)
 			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/vaurca/breeder(H), slot_shoes)
-			H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+			H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/vaurca/breeder(H), slot_wear_suit)
 			H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec(H), slot_back)
 			H.equip_to_slot_or_del(new /obj/item/gun/energy/vaurca/blaster(H), slot_belt)

--- a/code/modules/background/citizenship/skrell.dm
+++ b/code/modules/background/citizenship/skrell.dm
@@ -61,7 +61,7 @@
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/gearharness(H), slot_w_uniform)
 			H.equip_to_slot_or_del(new /obj/item/clothing/head/vaurca_breeder/nralakk(H), slot_head)
 			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/vaurca/breeder/nralakk(H), slot_shoes)
-			H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+			H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/vaurca/breeder/nralakk(H), slot_wear_suit)
 			H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec/cthur(H), slot_back)
 		else

--- a/code/modules/background/citizenship/unathi.dm
+++ b/code/modules/background/citizenship/unathi.dm
@@ -72,7 +72,7 @@
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/gearharness(H), slot_w_uniform)
 			H.equip_to_slot_or_del(new /obj/item/clothing/head/vaurca_breeder/hegemony(H), slot_head)
 			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/vaurca/breeder/klax(H), slot_shoes)
-			H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+			H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/vaurca/breeder/klax(H), slot_wear_suit)
 			H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec/klax(H), slot_back)
 		else

--- a/code/modules/background/citizenship/vaurca.dm
+++ b/code/modules/background/citizenship/vaurca.dm
@@ -59,7 +59,7 @@
 	glasses = null
 	head = /obj/item/clothing/head/vaurca_breeder
 	shoes = /obj/item/clothing/shoes/vaurca/breeder
-	mask = /obj/item/clothing/mask/breath/vaurca/filter
+	mask = /obj/item/clothing/mask/gas/vaurca/filter
 	suit = /obj/item/clothing/suit/vaurca/breeder
 
 /datum/outfit/job/representative/consular/zora/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -131,7 +131,7 @@
 	glasses = null
 	head = /obj/item/clothing/head/vaurca_breeder/klax
 	shoes = /obj/item/clothing/shoes/vaurca/breeder/klax
-	mask = /obj/item/clothing/mask/breath/vaurca/filter
+	mask = /obj/item/clothing/mask/gas/vaurca/filter
 	suit = /obj/item/clothing/suit/vaurca/breeder/klax
 
 /datum/outfit/job/representative/consular/klax/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -202,7 +202,7 @@
 	glasses = null
 	head = /obj/item/clothing/head/vaurca_breeder/cthur
 	shoes = /obj/item/clothing/shoes/vaurca/breeder/cthur
-	mask = /obj/item/clothing/mask/breath/vaurca/filter
+	mask = /obj/item/clothing/mask/gas/vaurca/filter
 	suit = /obj/item/clothing/suit/vaurca/breeder/cthur
 
 /datum/outfit/job/representative/consular/cthur/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/modules/client/preference_setup/loadout/loadout_xeno/vaurca.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno/vaurca.dm
@@ -8,7 +8,7 @@
 
 /datum/gear/mask/vaurca
 	display_name = "mandible garment"
-	path = /obj/item/clothing/mask/breath/vaurca
+	path = /obj/item/clothing/mask/gas/vaurca
 	cost = 1
 	whitelisted = list(SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_BULWARK)
 	sort_category = "Xenowear - Vaurca"
@@ -16,7 +16,7 @@
 
 /datum/gear/mask/filterport
 	display_name = "filter port"
-	path = /obj/item/clothing/mask/breath/vaurca/filter
+	path = /obj/item/clothing/mask/gas/vaurca/filter
 	cost = 1
 	whitelisted = list(SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_BREEDER, SPECIES_VAURCA_BULWARK)
 	sort_category = "Xenowear - Vaurca"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -11,7 +11,7 @@
 	permeability_coefficient = 0.01
 	siemens_coefficient = 0.9
 	var/gas_filter_strength = 1			//For gas mask filters
-	var/list/filtered_gases = list(GAS_PHORON, GAS_N2O)
+	var/list/filtered_gases = list(GAS_PHORON, GAS_N2O, GAS_CHLORINE, GAS_ALIEN)
 	armor = list(
 		bio = ARMOR_BIO_STRONG
 	)

--- a/code/modules/clothing/masks/voice.dm
+++ b/code/modules/clothing/masks/voice.dm
@@ -39,19 +39,19 @@
 	. = ..()
 	changer = new(src)
 
-/obj/item/clothing/mask/breath/vaurca/filter/voice
+/obj/item/clothing/mask/gas/vaurca/filter/voice
 	var/obj/item/voice_changer/changer
 	origin_tech = list(TECH_ILLEGAL = 4)
 	desc_antag = "A Lii'draic filter port that allows to change voices."
 
-/obj/item/clothing/mask/breath/vaurca/filter/voice/verb/Toggle_Voice_Changer()
+/obj/item/clothing/mask/gas/vaurca/filter/voice/verb/Toggle_Voice_Changer()
 	set category = "Object"
 	set src in usr
 
 	changer.active = !changer.active
 	to_chat(usr, SPAN_NOTICE("You [changer.active ? "enable" : "disable"] the voice-changing module in \the [src]."))
 
-/obj/item/clothing/mask/breath/vaurca/filter/voice/verb/Set_Voice(name as text)
+/obj/item/clothing/mask/gas/vaurca/filter/voice/verb/Set_Voice(name as text)
 	set category = "Object"
 	set src in usr
 
@@ -60,7 +60,7 @@
 	changer.voice = voice
 	to_chat(usr, SPAN_NOTICE("You are now mimicking <B>[changer.voice]</B>."))
 
-/obj/item/clothing/mask/breath/vaurca/filter/voice/verb/Toggle_Accent()
+/obj/item/clothing/mask/gas/vaurca/filter/voice/verb/Toggle_Accent()
 	set category = "Object"
 	set src in usr
 
@@ -69,6 +69,6 @@
 		to_chat(usr, SPAN_NOTICE("You are now mimicking the [choice] accent."))
 		changer.current_accent = choice
 
-/obj/item/clothing/mask/breath/vaurca/filter/voice/Initialize()
+/obj/item/clothing/mask/gas/vaurca/filter/voice/Initialize()
 	. = ..()
 	changer = new(src)

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -66,7 +66,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 /mob/living/carbon/human/type_a/cargo/Initialize(mapload)
 	. = ..()
 	// Equip mask to allow the drone to breathe
-	equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(src), slot_wear_mask)
+	equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(src), slot_wear_mask)
 	// Set internals
 	var/obj/item/organ/internal/vaurca/preserve/P = internal_organs_by_name[BP_PHORON_RESERVE]
 	internal = P

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -145,7 +145,7 @@
 /datum/species/bug/before_equip(var/mob/living/carbon/human/H)
 	. = ..()
 	H.gender = NEUTER
-	var/obj/item/clothing/mask/breath/vaurca/filter/M = new /obj/item/clothing/mask/breath/vaurca/filter(H)
+	var/obj/item/clothing/mask/gas/vaurca/filter/M = new /obj/item/clothing/mask/gas/vaurca/filter(H)
 	H.equip_to_slot_or_del(M, slot_wear_mask)
 
 /datum/species/bug/after_equip(var/mob/living/carbon/human/H)

--- a/html/changelogs/RustingWithYou - gasmask.yml
+++ b/html/changelogs/RustingWithYou - gasmask.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Vaurca masks now act as described in lore, filtering toxic gases in addition to working as a breath mask."
+  - tweak: "Expands the list of harmful gases that can be filtered by gas masks to include chlorine and random gases."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -123,7 +123,7 @@
 	pixel_x = -3;
 	pixel_y = 2
 	},
-/obj/item/clothing/mask/breath/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
 /turf/unsimulated/floor{
 	icon_state = "new_white"
 	},
@@ -9239,7 +9239,7 @@
 /obj/item/clothing/under/legion,
 /obj/item/clothing/under/legion,
 /obj/item/clothing/under/legion,
-/obj/item/clothing/mask/breath/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
 /turf/unsimulated/floor{
 	icon_state = "cafeteria"
 	},
@@ -12452,7 +12452,7 @@
 /obj/item/storage/box/practiceshells,
 /obj/item/storage/box/trackingslugs,
 /obj/effect/decal/warning_stripes,
-/obj/item/clothing/mask/breath/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
 /turf/unsimulated/floor,
 /area/antag/loner)
 "enU" = (
@@ -13720,10 +13720,10 @@
 "fdr" = (
 /obj/structure/table/wood,
 /obj/random/coin,
-/obj/item/clothing/mask/breath/vaurca/filter,
-/obj/item/clothing/mask/breath/vaurca/filter,
-/obj/item/clothing/mask/breath/vaurca/filter,
-/obj/item/clothing/mask/breath/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
 /turf/unsimulated/floor{
 	icon_state = "wood"
 	},
@@ -21925,8 +21925,8 @@
 /obj/structure/table/wood{
 	table_reinf = "wood"
 	},
-/obj/item/clothing/mask/breath/vaurca/filter,
-/obj/item/clothing/mask/breath/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
 /turf/unsimulated/floor{
 	icon_state = "wood"
 	},
@@ -33285,10 +33285,10 @@
 "rPi" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/handheld/pda/syndicate,
-/obj/item/clothing/mask/breath/vaurca/filter,
-/obj/item/clothing/mask/breath/vaurca/filter,
-/obj/item/clothing/mask/breath/vaurca/filter,
-/obj/item/clothing/mask/breath/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
 /turf/unsimulated/floor{
 	icon_state = "wood_light"
 	},
@@ -36678,7 +36678,7 @@
 /area/centcom/specops)
 "ujT" = (
 /obj/structure/table/standard,
-/obj/item/clothing/mask/breath/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
 /turf/unsimulated/floor{
 	icon_state = "new_reinforced"
 	},
@@ -36724,12 +36724,12 @@
 	pixel_y = 6
 	},
 /obj/effect/floor_decal/industrial/warning,
-/obj/item/clothing/mask/breath/vaurca/filter,
-/obj/item/clothing/mask/breath/vaurca/filter,
-/obj/item/clothing/mask/breath/vaurca/filter,
-/obj/item/clothing/mask/breath/vaurca/filter,
-/obj/item/clothing/mask/breath/vaurca/filter,
-/obj/item/clothing/mask/breath/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
 /turf/unsimulated/floor{
 	icon_state = "engine"
 	},

--- a/maps/away/away_site/space_bar/space_bar_ghostroles.dm
+++ b/maps/away/away_site/space_bar/space_bar_ghostroles.dm
@@ -42,7 +42,7 @@
 /datum/outfit/admin/space_bar_bartender/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(isvaurca(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"
@@ -97,7 +97,7 @@
 /datum/outfit/admin/space_bar_chef/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(isvaurca(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"
@@ -139,7 +139,7 @@
 		H.equip_to_slot_or_del(new S, slot_shoes)
 
 /datum/outfit/admin/random/space_bar_patron/vaurca
-	mask = /obj/item/clothing/mask/breath/vaurca/filter
+	mask = /obj/item/clothing/mask/gas/vaurca/filter
 	r_pocket = /obj/item/reagent_containers/inhaler/phoron_special
 
 /datum/outfit/admin/random/space_bar_patron/vaurca/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/maps/away/ships/elyra/elyra_strike_craft_ghostroles.dm
+++ b/maps/away/ships/elyra/elyra_strike_craft_ghostroles.dm
@@ -35,7 +35,7 @@
 /datum/outfit/admin/elyran_naval_infantry/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(isvaurca(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"

--- a/maps/away/ships/freebooter/freebooter_ship_ghostroles.dm
+++ b/maps/away/ships/freebooter/freebooter_ship_ghostroles.dm
@@ -40,7 +40,7 @@
 /datum/outfit/admin/freebooter_crew/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(isvaurca(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
@@ -6497,7 +6497,7 @@
 /obj/item/clothing/suit/vaurca/silver,
 /obj/item/vaurca/box,
 /obj/item/skrell_projector/vaurca_projector,
-/obj/item/clothing/mask/breath/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
 /obj/item/melee/energy/vaurca,
 /obj/item/clothing/under/vaurca/gearharness/black,
 /obj/item/clothing/under/vaurca/gearharness,

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_ghostroles.dm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_ghostroles.dm
@@ -93,7 +93,7 @@
 /datum/outfit/admin/izweski/klax
 
 	uniform = /obj/item/clothing/under/vaurca
-	mask = /obj/item/clothing/mask/breath/vaurca/filter
+	mask = /obj/item/clothing/mask/gas/vaurca/filter
 	belt = /obj/item/melee/energy/sword/hegemony
 	shoes = /obj/item/clothing/shoes/vaurca
 	id = /obj/item/card/id/distress/kataphract

--- a/maps/away/ships/iac/iac_rescue_ship_ghostroles.dm
+++ b/maps/away/ships/iac/iac_rescue_ship_ghostroles.dm
@@ -43,7 +43,7 @@
 /datum/outfit/admin/iac_volunteer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(isvaurca(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"

--- a/maps/away/ships/kataphracts/kataphract_ship_ghostroles.dm
+++ b/maps/away/ships/kataphracts/kataphract_ship_ghostroles.dm
@@ -94,7 +94,7 @@
 /datum/outfit/admin/kataphract/klax
 
 	uniform = /obj/item/clothing/under/vaurca
-	mask = /obj/item/clothing/mask/breath/vaurca/filter
+	mask = /obj/item/clothing/mask/gas/vaurca/filter
 	belt = /obj/item/melee/energy/sword/hegemony
 	shoes = /obj/item/clothing/shoes/vaurca
 	id = /obj/item/card/id/distress/kataphract

--- a/maps/away/ships/orion/orion_express_ship_ghostroles.dm
+++ b/maps/away/ships/orion/orion_express_ship_ghostroles.dm
@@ -42,7 +42,7 @@
 /datum/outfit/admin/orion_express_courier/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(isvaurca(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"

--- a/maps/away/ships/tcfl_patrol/tcfl_peacekeeper_ship_ghostroles.dm
+++ b/maps/away/ships/tcfl_patrol/tcfl_peacekeeper_ship_ghostroles.dm
@@ -45,7 +45,7 @@
 /datum/outfit/admin/tcfl_peacekeeper/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(isvaurca(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"

--- a/maps/away/ships/tramp_freighter/tramp_freighter_ghostroles.dm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter_ghostroles.dm
@@ -40,7 +40,7 @@
 /datum/outfit/admin/freighter_crew/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(isvaurca(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"

--- a/maps/random_ruins/exoplanets/grove/crashsurvivors/crashsurvivors.dm
+++ b/maps/random_ruins/exoplanets/grove/crashsurvivors/crashsurvivors.dm
@@ -42,7 +42,7 @@
 /datum/outfit/admin/survivor/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(isvaurca(H))
-		H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath/vaurca/filter(H), slot_wear_mask)
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 		var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 		H.internal = preserve
 		H.internals.icon_state = "internal1"


### PR DESCRIPTION
Vaurca filters and other Vaurca mask items are now gas masks rather than breath masks, filtering out nitrogen and other toxic gases. This means that in the event of a Vaurca running out of phoron, they will now only suffocate, rather than suffocating and being poisoned.

The list of gases filtered out by normal gas masks has also been expanded to include chlorine and randomly generated gases. 