### PR TITLE
removes rnd server from away site

### DIFF
--- a/html/changelogs/RustingWithYou - serverfix.yml
+++ b/html/changelogs/RustingWithYou - serverfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Removes an RND server from an exoplanet ruin."

--- a/maps/random_ruins/exoplanets/grove/hut/hut.dmm
+++ b/maps/random_ruins/exoplanets/grove/hut/hut.dmm
@@ -11,7 +11,7 @@
 /turf/simulated/floor/wood,
 /area/template_noop)
 "f" = (
-/obj/machinery/r_n_d/server,
+/obj/machinery/artifact_analyser,
 /turf/simulated/floor/wood,
 /area/template_noop)
 "g" = (


### PR DESCRIPTION
RND servers on away sites break the Horizon's servers. This removes it from the random exoplanet ruin that had one, so that all three science mains can sleep at night.