### PR TITLE
Removes fragmentation ammo from the sec armory

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -52,7 +52,5 @@
 
 /obj/structure/closet/secure_closet/guncabinet/peac/fill()
 	new /obj/item/gun/projectile/peac(src)
-	for(var/i = 1 to 3)
+	for(var/i = 3)
 		new /obj/item/ammo_casing/peac(src)
-	for(var/i = 1 to 2)
-		new /obj/item/ammo_casing/peac/shrapnel(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -52,5 +52,5 @@
 
 /obj/structure/closet/secure_closet/guncabinet/peac/fill()
 	new /obj/item/gun/projectile/peac(src)
-	for(var/i = 3)
+	for(var/i = 1 to 3)
 		new /obj/item/ammo_casing/peac(src)

--- a/html/changelogs/dansemacabre-peacfrag.yml
+++ b/html/changelogs/dansemacabre-peacfrag.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: TheDanseMacabre
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Security no longer has any PEAC fragmentation ammo."


### PR DESCRIPTION
Like the now-removed PEAC HE ammo, it's a one-hit kill weapon. Sec doesn't need this.