### PR TITLE
Rings no longer fall off when unequipping gloves

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -506,9 +506,8 @@
 
 	var/mob/living/carbon/human/H = wearer
 	if(ring && istype(H))
-		if(!H.equip_to_slot_if_possible(ring, slot_gloves))
-			ring.forceMove(get_turf(src))
-		src.ring = null
+		H.equip_to_slot(ring, slot_gloves)
+		ring = null
 	wearer = null
 
 /obj/item/clothing/gloves/dropped()

--- a/html/changelogs/doxxmedearly-gloves_ring_fix.yml
+++ b/html/changelogs/doxxmedearly-gloves_ring_fix.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Rings no longer fall to the floor when removing gloves that were worn over them."


### PR DESCRIPTION
Fixes #15432 
Fixes #14640

When taking off gloves that were worn over a ring, the rings always fail the `equip_to_slot_if_possible()` check because it still thinks the gloves are equipped when `update_wearer()` is called. I don't love that this fix requires `equip_to_slot()` but it shouldn't cause issues. Tested fine. Open to any other ways to make this work, though. 