### PR TITLE
Reagents, Cryotubes, etc no longer fix prosthetics

### DIFF
--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -618,7 +618,7 @@
 		var/list/damaged_organs = get_damaged_organs(TRUE, TRUE, FALSE)
 		if(length(damaged_organs))
 			// Heal an absurd amount, basically regenerate one organ.
-			heal_organ_damage(50, 50, FALSE)
+			heal_organ_damage(50, 50)
 			blood_used += 3
 
 		var/missing_blood = species.blood_volume - REAGENT_VOLUME(vessel, /singleton/reagent/blood)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -279,7 +279,7 @@
 //Heals ONE external organ, organ gets randomly selected from damaged ones.
 //It automatically updates damage overlays if necesary
 //It automatically updates health status
-/mob/living/carbon/human/heal_organ_damage(var/brute, var/burn, var/prosthetic = TRUE)
+/mob/living/carbon/human/heal_organ_damage(var/brute, var/burn, var/prosthetic = FALSE)
 	var/list/obj/item/organ/external/parts = get_damaged_organs(brute, burn, prosthetic)
 	if(!length(parts))
 		return

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -218,6 +218,8 @@
 		var/obj/item/organ/internal/I = internal
 		if(amount <= 0)
 			break
+		if(BP_IS_ROBOTIC(I))
+			continue //Chems won't help, you need surgery to fix robot organs
 		if(heal)
 			if(I.damage < amount)
 				amount -= I.damage

--- a/html/changelogs/doxxmedearly-medicine_cant_fix_steel_limbs.yml
+++ b/html/changelogs/doxxmedearly-medicine_cant_fix_steel_limbs.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+
+delete-after: True
+
+changes:
+  - bugfix: "Cryotubes, medicine, and other reagents should no longer heal prosthetic limbs."

--- a/html/changelogs/doxxmedearly-medicine_cant_fix_steel_limbs.yml
+++ b/html/changelogs/doxxmedearly-medicine_cant_fix_steel_limbs.yml
@@ -4,3 +4,4 @@ delete-after: True
 
 changes:
   - bugfix: "Cryotubes, medicine, and other reagents should no longer heal prosthetic limbs."
+  - bugfix: "Prosthetic internal organs can no longer be fixed with reagents such as clonexadone. They must be fixed via surgery."


### PR DESCRIPTION
Fixes #16435

**External Prosthetics:**
Reagents (And technically even bandages/kits) were healing prosthetics because the default for `heal_organ_damage()` was set that way. Every instance of this proc being called is done by a reagent or medical pack, which both have no reason to heal prosthetics. Other methods of fixing prosthetics and healing (spells, admin stuff, surgery, etc) is done elsewhere. 

Verified that you can still heal prosthetics with nanopaste and welding and such, and that normal organs still heal properly. 

**Internal Prosthetics:**
Healing prosthetic internal organs are done by the toxLoss proc like normal internal organs, which makes sense as they get damaged with toxLoss the same way, but robotic organs should not be repaired by negative toxLoss (aka healing) values. So when healing internal organs with reagents (Like Clonexadone), prosthetic ones now get skipped. They can only be fixed by surgery.