### PR TITLE
Borg grippers no longer pick up anchored items

### DIFF
--- a/code/modules/mob/living/silicon/robot/items/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/items/gripper.dm
@@ -57,6 +57,9 @@
 	//This function returns 1 if we successfully took the item, or 0 if it was invalid. This information is useful to the caller
 	if(!wrapped)
 		if((can_hold && is_type_in_list(I, can_hold)) || (cant_hold && !is_type_in_list(I, cant_hold)))
+			if(I.anchored)
+				to_chat(user, SPAN_WARNING("\The [I] is anchored down!"))
+				return FALSE
 			if(feedback)
 				to_chat(user, SPAN_NOTICE("You collect \the [I]."))
 			if(isturf(I.loc) && I.Adjacent(user))

--- a/html/changelogs/doxxmedearly-drone_anchored.yml
+++ b/html/changelogs/doxxmedearly-drone_anchored.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Drone and robot grippers can no longer pick up anchored objects, such as intercoms."


### PR DESCRIPTION
Fixes #16632

This was allowing them to just yoink intercoms off the wall. Check should have been added a while ago probably.