### PR TITLE
Fixes some harddels + reference tracking

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -114,15 +114,15 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 		A = locate(refID)
 		if (A && A.gcDestroyed == GCd_at_time) // So if something else coincidently gets the same ref, it's not deleted by mistake
 			#ifdef REFERENCE_TRACKING
-			if(reference_find_on_fail[text_ref(D)])
-				INVOKE_ASYNC(D, TYPE_PROC_REF(/datum, find_references))
+			if(reference_find_on_fail[text_ref(A)])
+				INVOKE_ASYNC(A, TYPE_PROC_REF(/datum, find_references))
 				ref_searching = TRUE
 			#ifdef GC_FAILURE_HARD_LOOKUP
 			else
-				INVOKE_ASYNC(D, TYPE_PROC_REF(/datum, find_references))
+				INVOKE_ASYNC(A, TYPE_PROC_REF(/datum, find_references))
 				ref_searching = TRUE
 			#endif
-			reference_find_on_fail -= text_ref(D)
+			reference_find_on_fail -= text_ref(A)
 			#endif
 
 			// Something's still referring to the qdel'd object.  Kill it.
@@ -138,7 +138,7 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 			++gcedlasttick
 			++totalgcs
 			#ifdef REFERENCE_TRACKING
-			reference_find_on_fail -= text_ref(D)
+			reference_find_on_fail -= text_ref(A)
 			#endif
 
 	if (idex > 1)

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -96,6 +96,14 @@
 	if(SSticker.mode)
 		SSticker.mode.check_win()
 
+	//This might seems like an useless computation to the programmer of the future, why would we do this?
+	//Easy! That's because otherwise, the hostile AI will keep us referenced, leading to an harddel
+	for(var/mob/living/simple_animal/hostile/hostile_in_sight in get_targets_in_LOS(world.view))
+		hostile_in_sight.targets.Remove(src)
+
+		if(hostile_in_sight.target_mob == src)
+			hostile_in_sight.target_mob = null
+
 	return 1
 
 /mob/proc/set_respawn_time()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -69,7 +69,7 @@
 	var/atom/T = null
 	var/target_range = INFINITY
 	for (var/atom/A in targets)
-		if(A == src)
+		if(A == src || QDELING(A)) //Avoid targeting ourself, and targets that are being GC'd
 			continue
 		if(ismob(A)) //Don't target mobs with keys that have logged out.
 			var/mob/M = A

--- a/code/modules/overmap/contacts/_contacts.dm
+++ b/code/modules/overmap/contacts/_contacts.dm
@@ -103,9 +103,11 @@
 			owner.contact_datums -= effect
 		owner = null
 
-	// Remove the effect opacity and null the effect
+	// Remove the effect opacity, effect, marker and radar
 	effect.opacity = 0
 	effect = null
+	marker = null
+	radar = null
 
 	QDEL_NULL_LIST(images)
 	. = ..()

--- a/html/changelogs/fluffyghost-fixsomeharddels.yml
+++ b/html/changelogs/fluffyghost-fixsomeharddels.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed some references not being dropped from the hostile mob AI, which leads to some harddels."
+  - bugfix: "Fixed some references not being dropped from the sensor contacts, which leads to some harddels."
+  - bugfix: "Fixed reference tracking, now works."


### PR DESCRIPTION
Fixed some references not being dropped from the hostile mob AI, which leads to some harddels.
Fixed some references not being dropped from the sensor contacts, which leads to some harddels.
Fixed reference tracking, now works.