### PR TITLE
EVA’s Main Area Actually Has Oxy Tanks Instead of Phoron - Research Gets Phoron Tanks

### DIFF
--- a/html/changelogs/wickedcybs_tankfix.yml
+++ b/html/changelogs/wickedcybs_tankfix.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - bugfix: "The tank dispenser in EVA had its phoron tanks swapped to oxy tanks and the tank dispenser in Research's tank storage area does have phoron tanks along with oxy tanks."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -12086,8 +12086,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "iDB" = (
-/obj/structure/dispenser/phoron,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/dark/full,
 /area/storage/eva)
 "iDM" = (
@@ -27513,8 +27513,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/operations)
 "txT" = (
-/obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/dispenser,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
 "tyw" = (


### PR DESCRIPTION
Title. For a while now, the tank dispenser in the main part of EVA itself had... phoron tanks only for some reason.

![image](https://github.com/Aurorastation/Aurora.3/assets/52309324/3761d0fe-e9b4-4287-8318-a3164950da63)

I changed it to only dispense oxy tanks. Phoron tanks can still be found in the research suit storage room, as they're the ones who would be using those.