### PR TITLE
Simple mobs no longer one-shot structures

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -653,14 +653,13 @@
 			var/obj/O = A
 			O.hear_talk(M, text, verb, speaking)
 
-/obj/structure/closet/attack_generic(var/mob/user, var/damage, var/attack_message = "destroys", var/wallbreaker)
+/obj/structure/closet/attack_generic(var/mob/user, var/damage, var/attack_message = "attacks", var/wallbreaker)
 	if(!damage || !wallbreaker)
 		return
 	user.do_attack_animation(src)
-	visible_message(SPAN_DANGER("[user] [attack_message] the [src]!"))
-	dump_contents()
-	QDEL_IN(src, 1)
-	return 1
+	visible_message(SPAN_DANGER("[user] [attack_message] \the [src]!"))
+	damage(damage)
+	return TRUE
 
 /obj/structure/closet/proc/req_breakout()
 	if(!opened) //Door's open... wait, why are you in it's contents then?

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -44,6 +44,8 @@
 	pass_flags = PASSTABLE
 	density = 0
 	mob_size = 3
+	destroy_surroundings = FALSE
+
 
 /mob/living/simple_animal/hostile/retaliate/shantak
 	name = "shantak"
@@ -65,6 +67,7 @@
 	speak = list("Shuhn","Shrunnph?","Shunpf")
 	emote_see = list("scratches the ground","shakes out it's mane","tinkles gently")
 	mob_size = 5
+	break_stuff_probability = 1
 
 /mob/living/simple_animal/yithian
 	name = "yithian"

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -38,6 +38,7 @@
 	minbodytemp = 0
 
 	environment_smash = 1
+	destroy_surroundings = FALSE
 
 	faction = "scarybat"
 	flying = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/cavern.dm
@@ -28,7 +28,7 @@
 	speed = 4
 	projectiletype = /obj/item/projectile/beam/cavern
 	projectilesound = 'sound/magic/lightningbolt.ogg'
-	destroy_surroundings = 1
+	break_stuff_probability = 2
 
 	emote_see = list("stares","hovers ominously","blinks")
 
@@ -98,7 +98,7 @@
 	emote_hear = list("chirps cheerfully","buzzes","whirrs","hums placidly","chirps","hums")
 	projectiletype = /obj/item/projectile/beam/plasmacutter
 	projectilesound = 'sound/weapons/plasma_cutter.ogg'
-	destroy_surroundings = 1
+	destroy_surroundings = FALSE
 	min_oxy = 0
 	max_oxy = 0
 	min_tox = 0

--- a/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
@@ -255,6 +255,7 @@
 	health = 5
 	mob_size = 2
 	density = FALSE
+	destroy_surroundings = FALSE
 
 	blood_overlay_icon = 'icons/mob/npc/blood_overlay_carp.dmi'
 	harm_intent_damage = 5

--- a/code/modules/mob/living/simple_animal/hostile/toy/mech.dm
+++ b/code/modules/mob/living/simple_animal/hostile/toy/mech.dm
@@ -19,6 +19,7 @@
 	speed = 2
 	mob_size = MOB_MINISCULE
 	tameable = FALSE
+	destroy_surroundings = FALSE
 
 	blood_overlay_icon = null
 

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -52,6 +52,13 @@
 			visible_message(SPAN_WARNING("\The [src] breaks down!"), intent_message = THUNK_SOUND)
 		return break_to_parts() // if we break and form shards, return them to the caller to do !FUN! things with
 
+/obj/structure/table/attack_generic(var/mob/user, var/damage, var/attack_message = "attacks", var/wallbreaker)
+	if(!damage || !wallbreaker)
+		return
+	user.do_attack_animation(src)
+	visible_message(SPAN_DANGER("[user] [attack_message] \the [src]!"))
+	take_damage(damage)
+	return TRUE
 
 /obj/structure/table/ex_act(severity)
 	switch(severity)

--- a/html/changelogs/doxxmedearly-mob_breaking_fixes.yml
+++ b/html/changelogs/doxxmedearly-mob_breaking_fixes.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Simple mobs should no longer destroy closets and tables in one hit. They'll damage them as usual."
+  - tweak: "Some animals, like diyaabs and toy mechs, no longer randomly destroy their surroundings."
+  - tweak: "Some animals, like cavern dwellers and shantaks, are less likely to randomly damage their surroundings."


### PR DESCRIPTION
Fixes #16694

Closets/crates and tables handled taking generic attack damage by breaking as soon as they took any.
Made it so attack_generic() actually does damage to the structure's health like anything else.

Also adjusted some simple mobs breaking shit randomly. Some shouldn't (bats, toy mechs, diyaab, mining rovers), some should do it less (cavern dwellers, shantaks). For the latter, note that they'll still break stuff as usual when pursuing a target; this just affects them when they're wandering idle.