### PR TITLE
Fixes scrubbing the color out of floors

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -391,7 +391,7 @@ var/const/enterloopsanity = 100
 		if(istype(src, /turf/simulated))
 			var/turf/simulated/T = src
 			T.dirt = 0
-			T.color = null
+			T.color = initial(color)
 		for(var/obj/effect/O in src)
 			if(istype(O,/obj/effect/decal/cleanable) || istype(O,/obj/effect/overlay))
 				qdel(O)

--- a/html/changelogs/doxxmedearly-floor_color__soap_fix.yml
+++ b/html/changelogs/doxxmedearly-floor_color__soap_fix.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "You can no longer scrub the color out of wood floors with soap, no matter how hard you try."


### PR DESCRIPTION
Fixes #14730

Caused by old code intended to allow cleaning paint off floors.