### PR TITLE
Fixes invisible crafted locks

### DIFF
--- a/code/modules/lock/lock_construct.dm
+++ b/code/modules/lock/lock_construct.dm
@@ -1,7 +1,7 @@
 /obj/item/material/lock_construct
 	name = "lock"
 	desc = "A crude but useful lock and bolt."
-	icon = 'icons/obj/storage.dmi'
+	icon = 'icons/obj/crate.dmi'
 	icon_state = "largebinemag"
 	w_class = ITEMSIZE_TINY
 	var/lock_data

--- a/html/changelogs/doxxmedearly-lock_invis_fix.yml
+++ b/html/changelogs/doxxmedearly-lock_invis_fix.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Crafted locks have their sprite again."


### PR DESCRIPTION
Fixes #15701
Fixes #15331

Caused by #13339 (Path was not adjusted when .dmi was reorganized).