### PR TITLE
Cycle target zone verb

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1378,6 +1378,11 @@
  	set hidden = 1
  	toggle_zone_sel(list(BP_L_LEG,BP_L_FOOT))
 
+/client/verb/cycle_target_zone()
+	set name = "cycle-zone"
+	set hidden = 1
+	toggle_zone_sel(BP_ALL_LIMBS)
+
 /client/proc/toggle_zone_sel(list/zones)
 	if(!check_has_body_select())
 		return

--- a/html/changelogs/cycletargetzone.yml
+++ b/html/changelogs/cycletargetzone.yml
@@ -1,0 +1,5 @@
+author: Sparky_hotdog
+
+delete-after: True
+changes:
+  - rscadd: "Added a client verb to cycle through target zones, which can be macro'd to whichever key you like."


### PR DESCRIPTION
Title.

cycle-zone can be macro'd to any key to switch between the major target zones (all excluding eyes and mouth).

While not added by this, for those wondering:
body-toggle-head switches between the head, eyes and mouth
body-r-arm/body-r-leg/body-l-arm/body-l-leg switches between the right/left arm/leg and right/left hand/foot respectively
body-chest switches to the chest
body-groun switches to the groin
