### PR TITLE
Simplifies the variable assignment for asset_transport

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -996,7 +996,7 @@ var/list/gamemode_cache = list()
 				if("cache_assets")
 					cache_assets = text2num(value)
 				if("asset_transport")
-					asset_transport = (value in list("simple", "webroot") ? value : "simple")
+					asset_transport = value
 				if("asset_simple_preload")
 					asset_simple_preload = TRUE
 				if("asset_cdn_webroot")


### PR DESCRIPTION
Simplifies the way the variable asset_transport is set.
-> the asset system already checks if its "webroot" before enabling the variable no need to do that again
-> currently when setting the variable to "webroot" it becomes 0