### PR TITLE
QoL First Responder buffs

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -89,6 +89,7 @@
 	new /obj/item/clothing/glasses/hud/health(src)
 	new /obj/item/storage/backpack/medic(src)
 	new /obj/item/clothing/suit/storage/medical_chest_rig(src)
+	new /obj/item/clothing/accessory/storage/white_vest(src)
 	new /obj/item/clothing/under/rank/medical/first_responder(src)
 	new /obj/item/clothing/under/rank/medical/first_responder/zeng(src)
 	new /obj/item/clothing/under/rank/medical/first_responder/pmc(src)
@@ -96,8 +97,8 @@
 	new /obj/item/device/flashlight/pen(src)
 	new /obj/item/clothing/accessory/stethoscope(src)
 	new /obj/item/storage/belt/medical/first_responder(src)
-	new /obj/item/storage/toolbox/mechanical
-	new /obj/item/storage/bag/inflatable
+	new /obj/item/storage/toolbox/mechanical(src)
+	new /obj/item/storage/bag/inflatable(src)
 	new /obj/item/device/gps/medical(src)
 	new /obj/item/reagent_containers/hypospray(src)
 	new /obj/item/taperoll/medical(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -96,12 +96,14 @@
 	new /obj/item/device/flashlight/pen(src)
 	new /obj/item/clothing/accessory/stethoscope(src)
 	new /obj/item/storage/belt/medical/first_responder(src)
+	new /obj/item/storage/toolbox/mechanical
+	new /obj/item/storage/bag/inflatable
 	new /obj/item/device/gps/medical(src)
 	new /obj/item/reagent_containers/hypospray(src)
 	new /obj/item/taperoll/medical(src)
 	new /obj/item/device/radio/med(src)
 	new /obj/item/roller(src)
-	new /obj/item/crowbar/red(src)
+	new /obj/item/crowbar/rescue_axe(src)
 	new /obj/item/clothing/mask/gas/alt(src)
 	new /obj/item/clothing/mask/gas/half(src)
 	new /obj/item/auto_cpr(src)

--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: OolongCow
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "First responder lockers now contain their own mechanical toolbox and box of inflatables."
+  - maptweak: "Removed the mapped mechanical toolbox from the first responder room."
+  - maptweak: "Moves the spare hyposprays in the first responder room to other parts of the department, one in the pharmacy and one in storage."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -926,19 +926,14 @@
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/table/standard,
 /obj/item/reagent_containers/hypospray{
-	pixel_x = -2;
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/hypospray{
 	layer = 2.99;
-	pixel_x = 4;
-	pixel_y = 5
+	pixel_y = -13
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = -11
 	},
 /turf/simulated/floor/tiled,
 /area/medical/first_responder)


### PR DESCRIPTION
Adds white webbing to the first responders' lockers. Gives first responders a full mechanical toolbox (they only had one between them) in each locker. Gives them a proper box of inflatables in each locker. Replaces the crowbar in their lockers with a rescue axe (a generally pretty bad weapon whose main notable feature is quickly breaking windows) because it's kind of silly for the "rescue" tool to not be given to the people whose entire job it is to rescue people in time-critical situations when the tool is basically designed for them. Moves their spare hyposprays to other parts of the department: one in the pharmacy and one in medical storage.

![frfr](https://github.com/Aurorastation/Aurora.3/assets/61329630/3c3f0cd1-46c9-4368-a4eb-233c17a44ca1)

If maintainers decide the rescue axe as-is is too threatening for first responders to have, I'd like to argue that's an issue with its values and not the idea of giving first responders a tool like this. I'm more than happy to adjust the numbers within the scope of this PR if it's decided to be necessary.
