### PR TITLE
Medical belts can no longer carry rescue axes, first responder belts can

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -208,9 +208,39 @@
 
 /obj/item/storage/belt/medical/first_responder
 	name = "first responder utility belt"
-	desc = "A sturdy black webbing belt with attached pouches."
+	desc = "A sturdy black webbing belt with attached pouches. There's a small hook for holding a rescue axe on the back."
 	icon_state = "emsbelt"
 	item_state = "emsbelt"
+	can_hold = list(
+		/obj/item/device/breath_analyzer,
+		/obj/item/device/healthanalyzer,
+		/obj/item/dnainjector,
+		/obj/item/reagent_containers/dropper,
+		/obj/item/reagent_containers/glass/beaker,
+		/obj/item/reagent_containers/glass/bottle,
+		/obj/item/reagent_containers/pill,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/reagent_containers/inhaler,
+		/obj/item/reagent_containers/personal_inhaler_cartridge,
+		/obj/item/personal_inhaler,
+		/obj/item/flame/lighter/zippo,
+		/obj/item/storage/box/fancy/cigarettes,
+		/obj/item/storage/pill_bottle,
+		/obj/item/stack/medical,
+		/obj/item/device/flashlight/pen,
+		/obj/item/clothing/mask/surgical,
+		/obj/item/clothing/head/surgery,
+		/obj/item/clothing/gloves/latex,
+		/obj/item/reagent_containers/hypospray,
+		/obj/item/clothing/glasses/hud/health,
+		/obj/item/crowbar,
+		/obj/item/device/flashlight,
+		/obj/item/extinguisher/mini,
+		/obj/item/device/radio,
+		/obj/item/taperoll/medical,
+		/obj/item/storage/box/fancy/med_pouch,
+		/obj/item/crowbar/rescue_axe
+		)
 
 /obj/item/storage/belt/medical/first_responder/combat
 	name = "tactical medical belt"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -198,7 +198,6 @@
 		/obj/item/clothing/gloves/latex,
 		/obj/item/reagent_containers/hypospray,
 		/obj/item/clothing/glasses/hud/health,
-		/obj/item/crowbar,
 		/obj/item/device/flashlight,
 		/obj/item/extinguisher/mini,
 		/obj/item/device/radio,
@@ -238,8 +237,7 @@
 		/obj/item/extinguisher/mini,
 		/obj/item/device/radio,
 		/obj/item/taperoll/medical,
-		/obj/item/storage/box/fancy/med_pouch,
-		/obj/item/crowbar/rescue_axe
+		/obj/item/storage/box/fancy/med_pouch
 		)
 
 /obj/item/storage/belt/medical/first_responder/combat

--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: OolongCow
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds the ability to carry a rescue axe on the first responder belt. The description has been updated to reflect this."

--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Adds the ability to carry a rescue axe on the first responder belt. The description has been updated to reflect this."
+  - balance: "Removes the ability of medical belts to carry rescue axes. First responder belts retain this ability and have had their descriptions updated to reflect this fact."

--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - balance: "Removes the ability of medical belts to carry rescue axes. First responder belts retain this ability and have had their descriptions updated to reflect this fact."
+  - maptweak: "Removes the extraneous first responder belts in deck three medical storage."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -963,12 +963,6 @@
 /obj/effect/floor_decal/corner/green/diagonal{
 	dir = 8
 	},
-/obj/item/storage/belt/medical/first_responder{
-	pixel_y = 4
-	},
-/obj/item/storage/belt/medical/first_responder{
-	pixel_y = 4
-	},
 /obj/item/storage/belt/medical{
 	pixel_y = -4
 	},
@@ -4978,7 +4972,6 @@
 	pixel_y = 28
 	},
 /obj/machinery/button/remote/airlock{
-	dir = 2;
 	id = "deck2_medicaltoilet";
 	name = "Door Bolt Control";
 	pixel_x = -14;
@@ -6854,7 +6847,6 @@
 "fHn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
-	req_access = null;
 	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -7189,15 +7181,13 @@
 	name = "representative door bolts";
 	pixel_x = -7;
 	pixel_y = 28;
-	req_access = null;
 	specialfunctions = 4
 	},
 /obj/machinery/button/remote/airlock{
 	id = "rep_office";
 	name = "representative door control";
 	pixel_x = -7;
-	pixel_y = 37;
-	req_access = null
+	pixel_y = 37
 	},
 /obj/machinery/light_switch{
 	pixel_x = 2;
@@ -14691,7 +14681,6 @@
 	dir = 6
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_x = 32;
 	pixel_y = 36
 	},
@@ -16723,16 +16712,14 @@
 	pixel_y = -1
 	},
 /obj/item/pen{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 30
 	},
 /obj/machinery/light/small{
 	dir = 1;
-	pixel_x = -11;
-	pixel_y = 0
+	pixel_x = -11
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
@@ -18050,7 +18037,6 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 28;
-	pixel_y = 0;
 	req_one_access = list(24,11,55)
 	},
 /turf/simulated/floor/tiled/white,
@@ -20099,8 +20085,7 @@
 	id = "consular_office";
 	name = "consular door control";
 	pixel_x = -35;
-	pixel_y = 7;
-	req_access = null
+	pixel_y = 7
 	},
 /obj/machinery/button/remote/airlock{
 	dir = 4;
@@ -20108,7 +20093,6 @@
 	name = "consular door bolts";
 	pixel_x = -35;
 	pixel_y = -7;
-	req_access = null;
 	specialfunctions = 4
 	},
 /obj/item/paper_scanner,
@@ -21104,7 +21088,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
-	req_access = null;
 	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/tiled,
@@ -24421,7 +24404,6 @@
 	id = "main_unit_2";
 	name = "Door Bolt Control";
 	pixel_y = 32;
-	req_access = null;
 	specialfunctions = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -26014,7 +25996,6 @@
 /area/medical/smoking)
 "uQt" = (
 /obj/machinery/door/airlock/command{
-	id_tag = null;
 	name = "Direct Fire Artillery System";
 	req_one_access = list(75)
 	},
@@ -26156,7 +26137,6 @@
 	id = "main_unit_1";
 	name = "Door Bolt Control";
 	pixel_y = 32;
-	req_access = null;
 	specialfunctions = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -27976,7 +27956,6 @@
 /area/horizon/hallway/deck_three/primary/central)
 "wqS" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access = null;
 	req_one_access = list(11,24)
 	},
 /obj/machinery/door/firedoor,
@@ -28031,7 +28010,6 @@
 "wtM" = (
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
-	req_access = null;
 	req_one_access = list(2,3,4)
 	},
 /obj/machinery/door/firedoor,
@@ -28285,7 +28263,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access = null;
 	req_one_access = list(11,24)
 	},
 /turf/simulated/floor,
@@ -28870,9 +28847,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced/steel,
-/obj/machinery/atmospherics/unary/vent_pump/aux{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_pump/aux,
 /turf/simulated/floor/tiled/dark/full,
 /area/bridge/aibunker)
 "wYq" = (


### PR DESCRIPTION
Medical belts can no longer hold crowbars / rescue axes. First responder belts can. The description of the first responder belt has been updated to reflect this better. Also deletes extra first responder belts in deck three medical storage after concerns about other medical staff stealing them was raised. The first responder room still has two spares. Companion PR to #16761 which adds them to the first responder lockers. This PR should prevent code and mapping-based concerns of other medical staff feeling justified in carrying rescue axes by making it clear to well-intentioned medical players that these tools are not intended for anyone but first responders.