### PR TITLE
Fixes basic device power cell charging

### DIFF
--- a/code/game/objects/items/weapons/power_cells.dm
+++ b/code/game/objects/items/weapons/power_cells.dm
@@ -26,7 +26,7 @@
 	force = 0
 	throw_speed = 5
 	throw_range = 7
-	maxcharge = 100
+	maxcharge = 120
 	matter = list(MATERIAL_STEEL = 70, MATERIAL_GLASS = 5)
 
 /obj/item/cell/device/high

--- a/html/changelogs/doxxmedearly-device_cell_fix.yml
+++ b/html/changelogs/doxxmedearly-device_cell_fix.yml
@@ -1,0 +1,5 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Basic device power cells now have 120J charge maximums. This allows them to be recharged, for some reason."
+  - bugfix: "Flashlights can be recharged again."


### PR DESCRIPTION
Fixes #16304
Fixes #16450

For some reason the recharge math is angry when things have 100J charge ratings. This small bump fixes the recharge issue and is so inconsequential that it's not really a buff. 