### PR TITLE
Fixes cable coil wound suturing

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -550,9 +550,8 @@ By design, d1 is the smallest direction and d2 is the highest
 							W.bandage("cable-stitched")
 							use(10)
 							affecting.add_pain(25)
-							if(prob(min(20 + (germ_level/5), 65))) //Less chance of infection if you clean the coil. Coil's germ level is set to GERM_LEVEL_AMBIENT
+							if(prob(min(30 + (germ_level/5), 65))) //Less chance of infection if you clean the coil. Coil's germ level is set to GERM_LEVEL_AMBIENT
 								var/obj/item/organ/external/O = H.get_organ(user.zone_sel.selecting)
-								to_chat(H, SPAN_DANGER("Something burns in your [O.name]!"))
 								O.germ_level += rand(150, 250) + germ_level //Again, if you did your prep, the infection will not be as bad
 						else
 							to_chat(user, SPAN_NOTICE("This wound isn't large enough for a stitch!"))

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -516,10 +516,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	update_wclass()
 
 /obj/item/stack/cable_coil/attack(mob/living/carbon/M, mob/user)
-	if(..())
-		return TRUE
-
-	if(ishuman(M))
+	if(ishuman(M) && user.a_intent == I_HELP)
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
@@ -531,9 +528,9 @@ By design, d1 is the smallest direction and d2 is the highest
 			if(!BP_IS_ROBOTIC(affecting))
 				if(affecting.is_bandaged())
 					to_chat(user, SPAN_WARNING("The wounds on [M]'s [affecting.name] have already been closed."))
-					return ..()
+					return
 				else
-					if(amount <= 10)
+					if(!can_use(10, user))
 						to_chat(user, SPAN_NOTICE("You don't have enough coils for this!"))
 						return
 					user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
@@ -553,15 +550,15 @@ By design, d1 is the smallest direction and d2 is the highest
 							W.bandage("cable-stitched")
 							use(10)
 							affecting.add_pain(25)
-							if(prob(50))
+							if(prob(min(20 + (germ_level/5), 65))) //Less chance of infection if you clean the coil. Coil's germ level is set to GERM_LEVEL_AMBIENT
 								var/obj/item/organ/external/O = H.get_organ(user.zone_sel.selecting)
 								to_chat(H, SPAN_DANGER("Something burns in your [O.name]!"))
-								O.germ_level += rand(400, 600)
+								O.germ_level += rand(150, 250) + germ_level //Again, if you did your prep, the infection will not be as bad
 						else
 							to_chat(user, SPAN_NOTICE("This wound isn't large enough for a stitch!"))
 					affecting.update_damages()
-			else
-				return ..()
+	else
+		return ..()
 
 /obj/item/stack/cable_coil/afterattack(var/mob/living/M, var/mob/user)
 	if(ishuman(M))

--- a/html/changelogs/doxxmedearly-cablestitching_bugfix.yml
+++ b/html/changelogs/doxxmedearly-cablestitching_bugfix.yml
@@ -1,0 +1,5 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Stitching wounds closed with cable coil works again."
+  - tweak: "Infection severity from cable coil stitching has been greatly reduced. Both the chance and severity of infection are lower if you sterilize the cable coil first."


### PR DESCRIPTION
Fixes #12337

Stupid ..() returns made it so you couldn't stitch other people. That's fixed.

It may be ghetto med, but giving an immediate acute infection for doing it was kinda wild. It's already slow and painful, and therefore a last resort, so making the infection severity a lesser- but still very real- risk seems sensible.

Infection chance is still basically where it was if a dirty coil is used, and the severity is still enough that it requires fairly quick treatment by medical. However, preparation is rewarded; if the coil was sterilized, chances/severity are lower (But never zero) Germ_level_ambient is 110.