### PR TITLE
Fixes some plants not having growth stages

### DIFF
--- a/code/modules/hydroponics/seed_datums/nralakk.dm
+++ b/code/modules/hydroponics/seed_datums/nralakk.dm
@@ -36,7 +36,7 @@
 	set_trait(TRAIT_POTENCY, 5)
 	set_trait(TRAIT_PRODUCT_ICON,"wumpafruit")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#61E2EC")
-	set_trait(TRAIT_PLANT_ICON,"wumpafruit")
+	set_trait(TRAIT_PLANT_ICON,"wumpavines")
 	set_trait(TRAIT_WATER_CONSUMPTION, 10)
 
 /obj/item/seeds/wulumunushaseed
@@ -155,7 +155,7 @@
 	set_trait(TRAIT_PRODUCT_ICON,"fjylozyn")
 	set_trait(TRAIT_PRODUCT_COLOUR,"#990000")
 	set_trait(TRAIT_PLANT_COLOUR,"#993333")
-	set_trait(TRAIT_PLANT_ICON,"fjylozyn")
+	set_trait(TRAIT_PLANT_ICON,"vine2")
 	set_trait(TRAIT_YIELD, 6)
 	set_trait(TRAIT_BIOLUM,1)
 	set_trait(TRAIT_BIOLUM_COLOUR,"#990033")

--- a/html/changelogs/doxxmedearly-growthstage_fix.yml
+++ b/html/changelogs/doxxmedearly-growthstage_fix.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Fjylozyn and Wulumunusha plants now have growth icons, and will not cause serverwide error messages when planted."


### PR DESCRIPTION
Fixes #16774

Fjylozyn and Wulumunusha had their plant icon states set to states that didn't exist in the .dmi, causing the error. The latter already had sprites; if unique plant growth sprites are desired for Fjylozyn, get a spriter.