### PR TITLE
Fixes multisurgery, reduces surgical times

### DIFF
--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -12,8 +12,8 @@
 	can_infect = TRUE
 	blood_level = 1
 
-	min_duration = 50
-	max_duration = 60
+	min_duration = 30
+	max_duration = 40
 
 /singleton/surgery_step/glue_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -48,8 +48,8 @@
 	WRENCH = 75		\
 	)
 
-	min_duration = 60
-	max_duration = 70
+	min_duration = 30
+	max_duration = 50
 
 /singleton/surgery_step/set_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -88,8 +88,8 @@
 	WRENCH = 75		\
 	)
 
-	min_duration = 60
-	max_duration = 70
+	min_duration = 40
+	max_duration = 50
 
 /singleton/surgery_step/mend_skull/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -125,8 +125,8 @@
 	can_infect = TRUE
 	blood_level = 1
 
-	min_duration = 50
-	max_duration = 60
+	min_duration = 30
+	max_duration = 40
 
 /singleton/surgery_step/finish_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -24,8 +24,8 @@
 	/obj/item/material/hatchet = 75
 	)
 
-	min_duration = 50
-	max_duration = 70
+	min_duration = 30
+	max_duration = 50
 
 /singleton/surgery_step/open_encased/saw/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -71,8 +71,8 @@
 	/obj/item/crowbar = 75
 	)
 
-	min_duration = 30
-	max_duration = 40
+	min_duration = 20
+	max_duration = 30
 
 /singleton/surgery_step/open_encased/retract/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -123,7 +123,7 @@
 	)
 
 	min_duration = 20
-	max_duration = 40
+	max_duration = 30
 
 /singleton/surgery_step/open_encased/close/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -181,7 +181,7 @@
 	)
 
 	min_duration = 20
-	max_duration = 40
+	max_duration = 30
 
 /singleton/surgery_step/open_encased/mend/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -23,8 +23,8 @@
 	/obj/item/material/shard = 50
 	)
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 70
+	max_duration = 90
 
 /singleton/surgery_step/generic/cut_face/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target_zone == BP_MOUTH && target.op_stage.face == FACE_NORMAL
@@ -62,8 +62,8 @@
 	/obj/item/material/shard = 50
 	)
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 70
+	max_duration = 90
 
 /singleton/surgery_step/robotics/face/synthskin/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target.op_stage.face == FACE_NORMAL && target.get_species() == SPECIES_IPC_SHELL

--- a/code/modules/surgery/facial_surgery.dm
+++ b/code/modules/surgery/facial_surgery.dm
@@ -23,8 +23,8 @@
 	/obj/item/material/knife/tacknife = 75
 	)
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 70
+	max_duration = 90
 
 /singleton/surgery_step/generic/prepare_face/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target_zone == BP_MOUTH && target.op_stage.face == FACE_CUT_OPEN
@@ -55,8 +55,8 @@
 	/obj/item/device/assembly/mousetrap = 10	//I don't know. Don't ask me. But I'm leaving it because hilarity.
 	)
 
-	min_duration = 40
-	max_duration = 90
+	min_duration = 30
+	max_duration = 70
 
 /singleton/surgery_step/generic/alter_face/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target_zone == BP_MOUTH && target.op_stage.face == FACE_RETRACTED
@@ -102,8 +102,8 @@
 	/obj/item/weldingtool = 25
 	)
 
-	min_duration = 70
-	max_duration = 100
+	min_duration = 50
+	max_duration = 80
 
 /singleton/surgery_step/face/cauterize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target.op_stage.face > FACE_NORMAL
@@ -145,8 +145,8 @@
 	/obj/item/material/shard = 50
 	)
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 70
+	max_duration = 90
 
 /singleton/surgery_step/robotics/face/synthskinopen/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target.op_stage.face == FACE_NORMAL && target.get_species() == SPECIES_IPC_SHELL
@@ -173,8 +173,8 @@
 	/obj/item/material/knife/tacknife = 75
 	)
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 70
+	max_duration = 90
 
 /singleton/surgery_step/robotics/face/prepare_face/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target_zone == BP_MOUTH && target.op_stage.face == FACE_CUT_OPEN
@@ -202,8 +202,8 @@
 	/obj/item/device/assembly/mousetrap = 10	//I don't know. Don't ask me. But I'm leaving it because hilarity.
 	)
 
-	min_duration = 40
-	max_duration = 90
+	min_duration = 30
+	max_duration = 70
 
 /singleton/surgery_step/robotics/face/alter_synthface/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target_zone == BP_MOUTH && target.op_stage.face == FACE_RETRACTED
@@ -247,8 +247,8 @@
 	/obj/item/weldingtool = 25
 	)
 
-	min_duration = 70
-	max_duration = 100
+	min_duration = 50
+	max_duration = 80
 
 /singleton/surgery_step/robotics/face/seal_face/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target.op_stage.face > FACE_NORMAL

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -30,8 +30,8 @@
 	/obj/item/surgery/scalpel/laser1 = 75
 	)
 	priority = 2
-	min_duration = 90
-	max_duration = 110
+	min_duration = 50
+	max_duration = 70
 
 /singleton/surgery_step/generic/cut_with_laser/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -73,8 +73,8 @@
 	/obj/item/surgery/scalpel/manager = 100
 	)
 	priority = 2
-	min_duration = 80
-	max_duration = 120
+	min_duration = 60
+	max_duration = 80
 
 /singleton/surgery_step/generic/incision_manager/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -117,8 +117,8 @@
 	/obj/item/material/shard = 50
 	)
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 60
+	max_duration = 80
 
 /singleton/surgery_step/generic/cut_open/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -161,8 +161,8 @@
 	/obj/item/pickaxe/ = 15
 	)
 
-	min_duration = 110
-	max_duration = 130
+	min_duration = 80
+	max_duration = 100
 
 /singleton/surgery_step/generic/cut_open_vaurca/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -205,8 +205,8 @@
 	/obj/item/device/assembly/mousetrap = 20
 	)
 
-	min_duration = 40
-	max_duration = 60
+	min_duration = 20
+	max_duration = 30
 
 /singleton/surgery_step/generic/clamp_bleeders/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -244,8 +244,8 @@
 	/obj/item/material/kitchen/utensil/fork = 50
 	)
 
-	min_duration = 30
-	max_duration = 40
+	min_duration = 20
+	max_duration = 30
 
 /singleton/surgery_step/generic/retract_skin/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -303,8 +303,8 @@
 	/obj/item/weldingtool = 75
 	)
 
-	min_duration = 70
-	max_duration = 100
+	min_duration = 40
+	max_duration = 70
 
 /singleton/surgery_step/generic/cauterize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -47,8 +47,8 @@
 	/obj/item/stack/rods = 50
 	)
 
-	min_duration = 60
-	max_duration = 80
+	min_duration = 50
+	max_duration = 70
 
 /singleton/surgery_step/cavity/make_space/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -80,8 +80,8 @@
 	/obj/item/weldingtool = 25
 	)
 
-	min_duration = 60
-	max_duration = 80
+	min_duration = 50
+	max_duration = 70
 
 /singleton/surgery_step/cavity/close_space/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -107,8 +107,8 @@
 	priority = 0
 	allowed_tools = list(/obj/item = 100)
 
-	min_duration = 80
-	max_duration = 100
+	min_duration = 60
+	max_duration = 80
 
 /singleton/surgery_step/cavity/place_item/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -162,8 +162,8 @@
 	/obj/item/material/kitchen/utensil/fork = 20
 	)
 
-	min_duration = 80
-	max_duration = 100
+	min_duration = 60
+	max_duration = 80
 
 /singleton/surgery_step/cavity/implant_removal/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -25,8 +25,8 @@
 	name = "Replace Limb"
 	allowed_tools = list(/obj/item/organ/external = 100)
 
-	min_duration = 50
-	max_duration = 70
+	min_duration = 40
+	max_duration = 60
 
 /singleton/surgery_step/limb/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = tool
@@ -58,8 +58,8 @@
 	)
 	can_infect = TRUE
 
-	min_duration = 100
-	max_duration = 120
+	min_duration = 80
+	max_duration = 100
 
 /singleton/surgery_step/limb/connect/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -95,8 +95,8 @@
 	name = "Attach Prosthetic Limb"
 	allowed_tools = list(/obj/item/robot_parts = 100)
 
-	min_duration = 80
-	max_duration = 100
+	min_duration = 60
+	max_duration = 80
 
 /singleton/surgery_step/limb/mechanize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -26,8 +26,8 @@
 	/obj/item/stack/medical/bruise_pack = 20
 	)
 
-	min_duration = 70
-	max_duration = 90
+	min_duration = 50
+	max_duration = 70
 
 /singleton/surgery_step/internal/fix_organ/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -113,8 +113,8 @@
 	SCREWDRIVER = 70
 	)
 
-	min_duration = 70
-	max_duration = 90
+	min_duration = 50
+	max_duration = 70
 
 /singleton/surgery_step/internal/fix_organ_robotic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -183,8 +183,8 @@
 	/obj/item/material/shard = 50
 	)
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 70
+	max_duration = 90
 
 /singleton/surgery_step/internal/detach_organ/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -246,8 +246,8 @@
 	/obj/item/material/kitchen/utensil/fork = 20
 	)
 
-	min_duration = 60
-	max_duration = 80
+	min_duration = 40
+	max_duration = 60
 
 /singleton/surgery_step/internal/remove_organ/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -305,8 +305,8 @@
 	/obj/item/organ = 100
 	)
 
-	min_duration = 60
-	max_duration = 80
+	min_duration = 40
+	max_duration = 60
 
 /singleton/surgery_step/internal/replace_organ/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -410,8 +410,8 @@
 	/obj/item/stack/cable_coil = 75
 	)
 
-	min_duration = 100
-	max_duration = 120
+	min_duration = 80
+	max_duration = 100
 
 /singleton/surgery_step/internal/attach_organ/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -464,8 +464,8 @@
 	/obj/item/pickaxe/ = 5
 	)
 
-	min_duration = 100
-	max_duration = 120
+	min_duration = 80
+	max_duration = 100
 
 /singleton/surgery_step/internal/prepare/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -14,8 +14,8 @@
 	can_infect = TRUE
 	blood_level = 1
 
-	min_duration = 70
-	max_duration = 90
+	min_duration = 40
+	max_duration = 60
 
 /singleton/surgery_step/fix_vein/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -62,8 +62,8 @@
 	can_infect = TRUE
 	blood_level = 1
 
-	min_duration = 110
-	max_duration = 160
+	min_duration = 80
+	max_duration = 130
 
 /singleton/surgery_step/internal/fix_dead_tissue/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -127,8 +127,8 @@
 	can_infect = FALSE
 	blood_level = 0
 
-	min_duration = 100
-	max_duration = 110
+	min_duration = 80
+	max_duration = 90
 
 /singleton/surgery_step/treat_necrosis/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -193,8 +193,8 @@
 	can_infect = TRUE
 	blood_level = 1
 
-	min_duration = 70
-	max_duration = 90
+	min_duration = 50
+	max_duration = 70
 
 /singleton/surgery_step/fix_tendon/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -234,8 +234,8 @@
 	can_infect = FALSE
 	blood_level = 0
 
-	min_duration = 120
-	max_duration = 180
+	min_duration = 100
+	max_duration = 160
 
 /singleton/surgery_step/hardsuit/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -271,8 +271,8 @@
 	/obj/item/material/hatchet = 55
 	)
 
-	min_duration = 110
-	max_duration = 160
+	min_duration = 90
+	max_duration = 140
 
 /singleton/surgery_step/amputate/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -30,8 +30,8 @@
 		/obj/item/material/kitchen/utensil/knife = 50
 	)
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 70
+	max_duration = 90
 
 	requires_surgery_compatibility = FALSE
 
@@ -72,8 +72,8 @@
 		/obj/item/material/kitchen/utensil/knife = 50
 	)
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 70
+	max_duration = 90
 
 	requires_surgery_compatibility = FALSE
 
@@ -114,8 +114,8 @@
 		/obj/item/material/kitchen/utensil = 50
 	)
 
-	min_duration = 30
-	max_duration = 40
+	min_duration = 20
+	max_duration = 30
 
 /singleton/surgery_step/robotics/open_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -151,8 +151,8 @@
 		/obj/item/material/kitchen/utensil = 50
 	)
 
-	min_duration = 70
-	max_duration = 100
+	min_duration = 50
+	max_duration = 80
 
 /singleton/surgery_step/robotics/close_hatch/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -191,8 +191,8 @@
 		/obj/item/gun/energy/plasmacutter = 50
 	)
 
-	min_duration = 50
-	max_duration = 60
+	min_duration = 30
+	max_duration = 40
 
 /singleton/surgery_step/robotics/repair_brute/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -236,8 +236,8 @@
 		/obj/item/stack/cable_coil/cyborg = 100
 	)
 
-	min_duration = 50
-	max_duration = 60
+	min_duration = 30
+	max_duration = 40
 
 /singleton/surgery_step/robotics/repair_burn/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -279,8 +279,8 @@
 	/obj/item/device/multitool = 100
 	)
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 70
+	max_duration = 90
 
 /singleton/surgery_step/robotics/detach_organ_robotic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())
@@ -329,8 +329,8 @@
 		SCREWDRIVER = 100
 	)
 
-	min_duration = 100
-	max_duration = 120
+	min_duration = 80
+	max_duration = 100
 
 	requires_surgery_compatibility = FALSE
 
@@ -380,8 +380,8 @@
 	/obj/item/device/mmi = 100
 	)
 
-	min_duration = 60
-	max_duration = 80
+	min_duration = 40
+	max_duration = 60
 
 /singleton/surgery_step/robotics/install_mmi/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!..())

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -122,6 +122,13 @@
 		to_chat(user, SPAN_WARNING("You can't operate on this area while surgery is already in progress."))
 		return TRUE
 
+	//Check that one surgeon is not doing multiple surgeries at once
+	for(var/surg in M.op_stage.in_progress)
+		var/current_surgeon = M.op_stage.in_progress[surg]
+		if(user == current_surgeon)
+			to_chat(user, SPAN_WARNING("You can only focus on one surgery at a time!"))
+			return TRUE
+
 	// What surgeries does our tool/target enable?
 	var/list/possible_surgeries
 	var/list/all_surgeries = GET_SINGLETON_SUBTYPE_MAP(/singleton/surgery_step)
@@ -151,17 +158,17 @@
 		if(zone in M.op_stage.in_progress)
 			to_chat(user, SPAN_WARNING("You can't operate on this area while surgery is already in progress."))
 		else if(S.is_valid_target(M))
-			M.op_stage.in_progress += zone
+			M.op_stage.in_progress += list(zone = user)
 			S.begin_step(user, M, zone, tool)
 			var/duration = rand(S.min_duration, S.max_duration)
-			if(prob(S.tool_quality(tool)) && do_mob(user, M, duration))
+			if(prob(S.tool_quality(tool)) && do_mob(user, M, duration) && !autofail)
 				S.end_step(user, M, zone, tool)
 			else if ((tool in user.contents) && user.Adjacent(M))
 				S.fail_step(user, M, zone, tool)
 			else
 				to_chat(user, SPAN_WARNING("You must remain close to your patient to conduct surgery."))
 			if(!QDELETED(M))
-				M.op_stage.in_progress -= zone
+				M.op_stage.in_progress -= list(zone = user)
 				if(ishuman(M))
 					var/mob/living/carbon/human/H = M
 					H.update_surgery()

--- a/html/changelogs/doxxmedearly-remove_multisurgery.yml
+++ b/html/changelogs/doxxmedearly-remove_multisurgery.yml
@@ -4,3 +4,4 @@ changes:
   - bugfix: "You can no longer queue up multiple surgeries on a patient simultaneously. You must finish a surgical step before moving on to another. This does NOT affect multiple surgeons working on the same patient."
   - bugfix: "Doing surgery on surfaces other than an operating table now properly reduce the surgery success chance."
   - tweak: "Reduced surgery times across the board."
+  - tweak: "Laser scalpels are now slightly faster at making incisions than regular scalpels."

--- a/html/changelogs/doxxmedearly-remove_multisurgery.yml
+++ b/html/changelogs/doxxmedearly-remove_multisurgery.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "You can no longer queue up multiple surgeries on a patient simultaneously. You must finish a surgical step before moving on to another. This does NOT affect multiple surgeons working on the same patient."
+  - bugfix: "Doing surgery on surfaces other than an operating table now properly reduce the surgery success chance."
+  - tweak: "Reduced surgery times across the board."


### PR DESCRIPTION
One surgeon can no longer queue up a ton of surgery steps on a patient, aka multisurgery. This does not affect multiple surgeons doing simultaneous surgery. It just checks to make sure you're currently not in the middle of a surgery step if you go to start another. 

Since apparently this was a major way surgeons sped up surgery time, despite being an exploit, surgery times have been reduced across the board by 2-3 seconds per step. 

Also it was intended that doing surgery outside of an operating table would give a failure chance. All the steps were calculated properly, but `var/autofail` was never checked. It is, now. 

Laser scalpels make incisions a second faster. More timesaving. Yeehaw.