### PR TITLE
Fixes doubling up on bodybags

### DIFF
--- a/code/game/objects/items/airbubble.dm
+++ b/code/game/objects/items/airbubble.dm
@@ -485,8 +485,8 @@
 	else
 		return attack_hand(user)
 
-/obj/structure/closet/airbubble/store_mobs(var/stored_units)
-	contains_body = ..()
+/obj/structure/closet/airbubble/store_mobs(var/stored_units, var/mob_limit)
+	contains_body = ..(stored_units, mob_limit = TRUE)
 	return contains_body
 
 /obj/structure/closet/airbubble/update_icon()

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -54,14 +54,22 @@
 	open_sound = 'sound/items/zip.ogg'
 	close_sound = 'sound/items/zip.ogg'
 	density = FALSE
-	storage_capacity = 15
-	store_misc = FALSE
-	store_items = FALSE
+	storage_capacity = 30
 	var/item_path = /obj/item/bodybag
 	var/contains_body = FALSE
 	can_be_buckled = TRUE
 
 /obj/structure/closet/body_bag/content_info(mob/user, content_size)
+	if(!content_size && !contains_body)
+		to_chat(user, "\The [src] is empty.")
+	else if(storage_capacity > content_size*4)
+		to_chat(user, "\The [src] is barely filled.")
+	else if(storage_capacity > content_size*2)
+		to_chat(user, "\The [src] is less than half full.")
+	else if(storage_capacity > content_size)
+		to_chat(user, "\The [src] still has some free space.")
+	else
+		to_chat(user, "\The [src] is full.")
 	to_chat(user, "It [contains_body ? "contains" : "does not contain"] a body.")
 
 /obj/structure/closet/body_bag/attackby(var/obj/item/W, mob/user as mob)
@@ -87,8 +95,8 @@
 		LAZYREMOVE(overlays, image(icon, "bodybag_label"))
 		return TRUE
 
-/obj/structure/closet/body_bag/store_mobs(var/stored_units)
-	contains_body = ..()
+/obj/structure/closet/body_bag/store_mobs(var/stored_units, var/mob_limit)
+	contains_body = ..(stored_units, mob_limit = TRUE)
 	slowdown = 0
 	if(contains_body)
 		for(var/mob/living/M in contents)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -53,23 +53,15 @@
 	icon_state = "bodybag"
 	open_sound = 'sound/items/zip.ogg'
 	close_sound = 'sound/items/zip.ogg'
-	density = 0
-	storage_capacity = 30
+	density = FALSE
+	storage_capacity = 15
+	store_misc = FALSE
+	store_items = FALSE
 	var/item_path = /obj/item/bodybag
 	var/contains_body = FALSE
 	can_be_buckled = TRUE
 
 /obj/structure/closet/body_bag/content_info(mob/user, content_size)
-	if(!content_size && !contains_body)
-		to_chat(user, "\The [src] is empty.")
-	else if(storage_capacity > content_size*4)
-		to_chat(user, "\The [src] is barely filled.")
-	else if(storage_capacity > content_size*2)
-		to_chat(user, "\The [src] is less than half full.")
-	else if(storage_capacity > content_size)
-		to_chat(user, "\The [src] still has some free space.")
-	else
-		to_chat(user, "\The [src] is full.")
 	to_chat(user, "It [contains_body ? "contains" : "does not contain"] a body.")
 
 /obj/structure/closet/body_bag/attackby(var/obj/item/W, mob/user as mob)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -228,7 +228,7 @@
 			added_units += item_size
 	return added_units
 
-/obj/structure/closet/proc/store_mobs(var/stored_units)
+/obj/structure/closet/proc/store_mobs(var/stored_units, var/mob_limit)
 	var/added_units = 0
 	for(var/mob/living/M in loc)
 		if(M.buckled_to || M.pinned.len)
@@ -242,6 +242,8 @@
 			M.client.eye = src
 		M.forceMove(src)
 		added_units += M.mob_size
+		if(mob_limit) //We only want to store one valid mob
+			break
 	return added_units
 
 /obj/structure/closet/proc/store_structure(var/stored_units)

--- a/html/changelogs/doxxmedearly-bodybag_fix.yml
+++ b/html/changelogs/doxxmedearly-bodybag_fix.yml
@@ -1,4 +1,4 @@
 author: Doxxmedearly
 delete-after: True
 changes:
-  - bugfix: "Bodybags and Stasis bags can now only fit one person in them. They can also ONLY store bodies in them."
+  - bugfix: "Bodybags, stasis bags, and air bubbles can no longer hold multiple mobs."

--- a/html/changelogs/doxxmedearly-bodybag_fix.yml
+++ b/html/changelogs/doxxmedearly-bodybag_fix.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Bodybags and Stasis bags can now only fit one person in them. They can also ONLY store bodies in them."


### PR DESCRIPTION
Bodybags, cryostasis bags, and air bubbles can now only fit one body in them, as it should be.