### PR TITLE
Fixes Farmbot Pathing

### DIFF
--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -163,13 +163,15 @@
 				break
 		else
 			for(var/obj/machinery/portable_atmospherics/hydroponics/tray in view(7, src))
-				if(process_tray(tray))
+				if(!tray.seed) //No seed? We don't care.
+					continue
+				if(!process_tray(tray)) //If there's nothing for us to do with the plant, ignore this tray.
+					continue
+				if(pathfind(tray)) //If we can get there, we can accept it as a target. 
 					target = tray
 					frustration = 0
 					break
-			if(target) //We found a tray we can do something to. Set path to there.
-				pathfind(target)
-				return
+
 			if(check_tank())
 				for(var/obj/structure/sink/source in view(7, src))
 					if(pathfind(source)) //If we can find a valid path to this sink, it's our target
@@ -179,8 +181,18 @@
 
 
 /mob/living/bot/farmbot/proc/pathfind(var/atom/A)
-	var/t = get_dir(A, src) // Turf with the tray is impassable, so a* can't navigate directly to it
-	path = AStar(loc, get_step(A, t), /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30, id = botcard)
+	var/turf/targetloc = get_turf(A)
+	if(!targetloc)
+		return FALSE
+
+	//Check if there is a free space around the tray. A* cannot navigate directly to the tray since it is impassable
+	var/list/freespaces = targetloc.CardinalTurfsWithAccess(botcard)
+	if(!length(freespaces))
+		return FALSE
+
+	//If we got here, we know there's a space around it that we can use to access the tray/target. Let's try to find a path to it.	
+	var/turf/location_goal = pick(freespaces)
+	path = AStar(loc, location_goal, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 30, id = botcard)
 	if(!path)
 		path = list()
 		return FALSE

--- a/html/changelogs/doxxmedearly-farmbot_path_fix.yml
+++ b/html/changelogs/doxxmedearly-farmbot_path_fix.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Farmbots properly tend to their duties again."


### PR DESCRIPTION
Fixes #15482
Partially handles  #16748

Farmbots usually "stop working" due to them getting hung up on an impossible-to-reach target. They will constantly re-target it even after the target is dropped due to an invalid path. It used to happen with sinks. Now, with the new map, it happens with trays.

First problem was that it would want to tend to trays or soil it could not reach; usually, this was soil, as the path to the public garden is blocked off. This was fixed by making sure we only accept trays we can path to as a valid target.

Next issue was with how GETTING the path worked. It used `get_dir()` and `get_step()` to find the open space nearest the tray. This was fine on previous maps, as the trays were usually on the edge of hydro and/or in a single row. However, now that the trays are arranged in rows two trays thick, sometimes `get_step()` would pick another tray that's between the bot and the target, making the path invalid while telling the bot that it was valid.

Now pathfinding tries to find any accessible adjacent space, and then we pick a path to that. This stops the bot from getting hung up on the northmost trays if it's near the south of hydro. 

tl;dr bots stopped bc target path issue. Issue fixed.