### PR TITLE
Ion Storm event fixes and adjustments

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -45,7 +45,7 @@
 /datum/event/ionstorm/tick()
 	if(botEmagChance)
 		for(var/obj/machinery/bot/bot in SSmachinery.machinery)
-			if(prob(botEmagChance) && bot.z in affecting_z)
+			if(prob(botEmagChance) && (bot.z in affecting_z))
 				bot.emag_act(1)
 
 /datum/event/ionstorm/end(var/faked)

--- a/html/changelogs/doxxmedearly-ionlaw_fixes.yml
+++ b/html/changelogs/doxxmedearly-ionlaw_fixes.yml
@@ -1,0 +1,7 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Non-Horizon ships passing through ion clouds should no longer trigger ion storm events on the Horizon."
+  - bugfix: "When finding a target player for an ion law, only players currently on station should be chosen."
+  - tweak: "The list of words that get added to the telecomms spam filter from an ion storm has been changed to words that might actually be said. Bet you didn't know ion storms did that."
+  - tweak: "Adjusts the phrases of some ion laws that didn't quite fit with the setting."


### PR DESCRIPTION
Fixes #16800
Fixes #16658

Most events properly only hit the ship that triggered them. Ion storms were an exception though because, well, there's only one AI, and one set of telecomms message servers.

It now checks that the triggering ship is the Horizon before doing either of these things. Bots also have an emag chance for an ion storm; it only affects bots on the triggering ship, now.

Other tweaks:
Fixes the unusual monarch of England ion law.
Replaces the LRP words in the spam filter adjustment with words that fit our setting.
Made the ion storm event last longer so there's less multi-triggers. Unless you like, sit in the damn storm like an idiot, I guess.

Someone should probably add other effects for an ion storm, because right now ghost role ships that pass through them do nothing unless they for some reason have medbots/farmbots/cleanbots on their ship.