### PR TITLE
consular directives for vaurca

### DIFF
--- a/code/modules/background/citizenship/human.dm
+++ b/code/modules/background/citizenship/human.dm
@@ -19,15 +19,30 @@
 
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
-			rep_objectives = pick("Compile and report and audit [rand(1,3)] suspicious indivduals who might be spies or otherwise act hostile against the Republic.",
-							"Have [rand(2,6)] crewmembers sign a pledge of loyalty to the Republic.")
+			if(isvaurca(H))
+				rep_objectives = pick("Compile and report and audit [rand(1,3)] suspicious indivduals who might be spies or otherwise act hostile against the Republic.",
+								"Collect evidence of the [current_map.boss_name] being unfair or bigoted to Vaurca employees, to be used as leverage in future hive labor negotiations.",
+								"Convince the command of the [current_map.station_name] of the utility of Bound labor over similar alternatives such as cyborgs or owned synthetics.")
+			else
+				rep_objectives = pick("Compile and report and audit [rand(1,3)] suspicious indivduals who might be spies or otherwise act hostile against the Republic.",
+								"Have [rand(2,6)] crewmembers sign a pledge of loyalty to the Republic.")
 
 		if(REPRESENTATIVE_MISSION_MEDIUM)
-			rep_objectives = pick("Convince [rand(2,4)] Tau Ceti crewmembers who are not a part of Command or Security to join the Tau Ceti Foreign Legion.",
-							"Convince [rand(3,6)] crewmembers of Tau Ceti superiority over the Sol Alliance.")
+			if(isvaurca(H))
+				rep_objectives = pick("Promote the superiority of the Republic of Biesel over the Sol Alliance.",
+								"Encourage non-citizens to seek citizenship in the Republic via enlistment in the Tau Ceti Foreign Legion.",
+								"Promote Zo'rane products such as Zo'ra Soda to the crew.")
+			else
+				rep_objectives = pick("Convince [rand(2,4)] Tau Ceti crewmembers who are not a part of Command or Security to join the Tau Ceti Foreign Legion.",
+								"Convince [rand(3,6)] crewmembers of Tau Ceti superiority over the Sol Alliance.")
 		else
-			rep_objectives = pick("Run a questionnaire on Tau Ceti citizens' views on synthetic citizenship.",
-							"Run a questionnaire on Tau Ceti citizens' views on vaurca citizenship.")
+			if(isvaurca(H))
+				rep_objectives = pick("Run a questionanaire on Tau Ceti citizens' views on Vaurca citizenship.",
+								"Question non-Vaurca employees about their Vaurca coworkers, looking for areas of improvement.",
+								"Protect and promote the public image of the Zo'ra Hive to all [current_map.boss_name] employees.")
+			else
+				rep_objectives = pick("Run a questionnaire on Tau Ceti citizens' views on synthetic citizenship.",
+								"Run a questionnaire on Tau Ceti citizens' views on vaurca citizenship.")
 
 
 	return rep_objectives
@@ -55,8 +70,8 @@
 			H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec(H), slot_back)
 			H.equip_to_slot_or_del(new /obj/item/gun/energy/vaurca/blaster(H), slot_belt)
 		else
-			addtimer(CALLBACK(src, .proc/send_representative_mission, H), 5 MINUTES)
 			H.equip_to_slot_or_del(new /obj/item/gun/energy/blaster/revolver(H), slot_belt)
+		addtimer(CALLBACK(src, .proc/send_representative_mission, H), 5 MINUTES)
 	return TRUE
 
 /datum/citizenship/sol_alliance

--- a/code/modules/background/citizenship/skrell.dm
+++ b/code/modules/background/citizenship/skrell.dm
@@ -36,17 +36,34 @@
 
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
-			rep_objectives = pick("Some Skrell are not part of the Federation; attempt to convince them to become a citizen",
-							"Acquire information on dissidents towards the Federation, forwarding it to the embassy",
-							"Curtail the spreading of written literature or verbal notions that contain negative connotations towards the Federation")
+			if(isvaurca(H))
+				rep_objectives = pick("Collect evidence of the [current_map.boss_name] being unfair or bigoted to Federation employees, to be used as leverage in future hive labor negotiations",
+								"Acquire information on dissidents towards the Federation, forwarding it to the embassy",
+								"Convince the command of the [current_map.boss_name] of the advantages that Bound Vaurcae hold over synthetics.")
+			else
+				rep_objectives = pick("Some Skrell are not part of the Federation; attempt to convince them to become a citizen",
+								"Acquire information on dissidents towards the Federation, forwarding it to the embassy",
+								"Curtail the spreading of written literature or verbal notions that contain negative connotations towards the Federation")
 
 		if(REPRESENTATIVE_MISSION_MEDIUM)
-			rep_objectives = pick("Ensure the interests of Federation citizens are upheld by the vessel. This includes C'thur and Diona of Federation origin",
-							"Legally curtail the advancements and liberal thinking towards synthetics",
-							"The [current_map.station_name] hosts some of the brightest minds in the galaxy; winning them over towards the Federation is a major victory")
+			if(isvaurca(H))
+				rep_objectives = pick("Legally curtail the advancements and liberal thinking towards synthetics.",
+								"Remind C'thur Vaurcae aboard the [current_map.station_name] that they are representative of their hive-cell, and encourage them to increase their social credit",
+								"Ensure the interests of Federation citizens are upheld by the vessel - whether Skrell, C'thur or Diona.")
+			else
+				rep_objectives = pick("Ensure the interests of Federation citizens are upheld by the vessel. This includes C'thur and Diona of Federation origin",
+								"Legally curtail the advancements and liberal thinking towards synthetics.",
+								"The [current_map.station_name] hosts some of the brightest minds in the galaxy; winning them over towards the Federation is a major victory",
+								"Encourage Federation citizens with low social credit to work to increase their score.")
 		else
-			rep_objectives = pick("Consider assisting crew within the capacity of your role, an altruistic image is good PR towards the federation",
-							"Some Skrell are not part of the Federation; attempt to convince them to become a citizen")
+			if(isvaurca(H))
+				rep_objectives = pick("Consider assisting crew within the capacity of your role, an altruistic image is good PR towards both the Federation and the C'thur Hive.",
+								"Question Non-Vaurca employees about Vaurca employees, looking for areas of improvement.",
+								"Some Skrell are not part of the Federation; attempt to convince them to become a citizen.")
+			else
+				rep_objectives = pick("Consider assisting crew within the capacity of your role, an altruistic image is good PR towards the Federation",
+								"Some Skrell are not part of the Federation; attempt to convince them to become a citizen.",
+								"Promote Nralakk tourism among the non-citizen employees of the [current_map.boss_name] in order to build positive opinion.")
 
 	return rep_objectives
 
@@ -64,6 +81,5 @@
 			H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/vaurca/breeder/nralakk(H), slot_wear_suit)
 			H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec/cthur(H), slot_back)
-		else
-			addtimer(CALLBACK(src, PROC_REF(send_representative_mission), H), 5 MINUTES)
+		addtimer(CALLBACK(src, PROC_REF(send_representative_mission), H), 5 MINUTES)
 	return TRUE

--- a/code/modules/background/citizenship/unathi.dm
+++ b/code/modules/background/citizenship/unathi.dm
@@ -37,25 +37,30 @@
 	switch(mission_level)
 		if(REPRESENTATIVE_MISSION_HIGH)
 			if(isvaurca(H))
-				rep_objectives = pick("Obtain [rand(2,3)] sheets of solid phoron below market value, buying directly from the source")
+				rep_objectives = pick("Obtain [rand(2,3)] sheets of solid phoron below market value, buying directly from the source.",
+								"Compile and report information on Hegemony citizens who could potentially harbor anti-Izweski sentiment.",
+								"Promote the advantages of K'lax engineering to the [current_map.boss_name] in order to invite future investment in the Hegemony.")
 			else
 				rep_objectives = pick("Encourage [rand(1,2)] Unathi to become Zo'saa by signing up with the local Order",
-								"Gather [rand(2,3)] evidences of any marginalization of Unathi beliefs")
+								"Gather [rand(2,3)] evidences of any marginalization of Unathi beliefs",
+								"Compile and report information on Hegemony citizens who could potentially harbor anti-Izweski sentiment.")
 
 		if(REPRESENTATIVE_MISSION_MEDIUM)
 			if(isvaurca(H))
 				rep_objectives = pick("Collect evidence of the [current_map.boss_name] being unfair or bigoted to Vaurca or Unathi Employees, to be used as leverage in future labor negotiations",
-								"Upsell K'laxan Vaurca to different command staff. Have one complete a Bound Vaurca requisition form")
+								"Upsell K'laxan Vaurca to different command staff. Have one complete a Bound Vaurca requisition form.",
+								"Promote K'lax and Unathi culture to the crew of the [current_map.station_name]. Encourage tourism to Izweski space.")
 			else
 				rep_objectives = pick("Speak out against any violation of the Honor Code to or by Unathi on the [current_map.station_short]",
-								"Proselytize the Sk'akh or Tha'kh religions to the crew",
-								"Encourage [rand(2,4)] Unathi to visit the Akhandi Order temples in Tau Ceti")
+								"Proselytize the Sk'akh or Tha'kh religions to the crew.",
+								"Discourage the Unathi crew of the [current_map.station_name] from the Aut'akh or Si'akh heresies.")
 		else
 			if(isvaurca(H))
-				rep_objectives = pick("Promote Cultural Exchange between Vaurca, Unathi and other species")
+				rep_objectives = pick("Promote Cultural Exchange between Vaurca, Unathi and other species.",
+								"Question employees about their K'laxan and Unathi coworkers to discern areas of potential improvement.")
 			else
 				rep_objectives = pick("Ensure all Unathi on the  are being respected in their beliefs and customs and traditions",
-								"Discourage people from associating with Guwans, but convince [rand(2,3)] Guwan to redeem themselves by becoming Zo'saa or Ahkandi")
+								"Discourage people from associating with Guwans, but convince Guwan to seek atonement and redemption for their crimes.")
 
 	return rep_objectives
 
@@ -76,6 +81,6 @@
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/vaurca/breeder/klax(H), slot_wear_suit)
 			H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec/klax(H), slot_back)
 		else
-			addtimer(CALLBACK(src, .proc/send_representative_mission, H), 5 MINUTES)
 			H.equip_to_slot_or_del(new /obj/item/clothing/accessory/poncho/unathimantle(H), slot_wear_suit)
+		addtimer(CALLBACK(src, .proc/send_representative_mission, H), 5 MINUTES)
 	return TRUE

--- a/html/changelogs/RustingWithYou - sovlinstallation.yml
+++ b/html/changelogs/RustingWithYou - sovlinstallation.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds consular directives for Vaurca consulars representing Biesel, the Hegemony and the Federation."


### PR DESCRIPTION
Adds new consular directives for Biesel, Hegemony and Nralakk Vaurca representatives, as well as a few miscellaneous ones just because.

I know that people consider directives a bit of an outdated mechanic, but I personally like them and I wanted to expand on them for the funny bugs.