### PR TITLE
Scans can no longer be reused in the surgery bed

### DIFF
--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -64,6 +64,12 @@
 			to_chat(usr, SPAN_NOTICE("You try to insert \the [O], but \the [src] buzzes. There is already a [O] inside!"))
 			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 1)
 			return TRUE
+
+		if(O.name != "Scan ([victim])")
+			to_chat(usr, SPAN_NOTICE("This scan is of a different patient! Please insert the scan of the correct patient."))
+			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 1)
+			return TRUE
+
 		user.drop_from_inventory(O, src)
 		input_scan = O
 		input_scan.color = "#272727"

--- a/html/changelogs/fluffyghost-fixscanreuse.yml
+++ b/html/changelogs/fluffyghost-fixscanreuse.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Scans can no longer be reused in the surgery bed, you need a scan of the correct patient to load it."


### PR DESCRIPTION
Scans can no longer be reused in the surgery bed, you need a scan of the correct patient to load it.

Fixes #16661 