### PR TITLE
Fixes sleeper eject button sometimes disappearing

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -171,9 +171,10 @@
 	else
 		data["occupant"] = FALSE
 	if(beaker)
-		data["beaker"] = REAGENTS_FREE_SPACE(beaker.reagents)
+		data["beaker"] = TRUE
+		data["beakerreagents"] = REAGENTS_FREE_SPACE(beaker.reagents)
 	else
-		data["beaker"] = -1
+		data["beaker"] = FALSE
 	data["filtering"] = filtering
 	data["pump"] = pump
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -172,7 +172,7 @@
 		data["occupant"] = FALSE
 	if(beaker)
 		data["beaker"] = TRUE
-		data["beakerreagents"] = REAGENTS_FREE_SPACE(beaker.reagents)
+		data["beakerfreespace"] = REAGENTS_FREE_SPACE(beaker.reagents)
 	else
 		data["beaker"] = FALSE
 	data["filtering"] = filtering

--- a/html/changelogs/doxxmedearly-sleeper_beaker_eject.yml
+++ b/html/changelogs/doxxmedearly-sleeper_beaker_eject.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "The sleeper interface should no longer sometimes remove the eject button if the beaker is full."

--- a/tgui/packages/tgui/interfaces/Sleeper.tsx
+++ b/tgui/packages/tgui/interfaces/Sleeper.tsx
@@ -19,7 +19,7 @@ export type SleeperData = {
   reagents: SleeperReagent[];
   stasissettings: number[];
   beaker: BooleanLike;
-  beakerreagents: number;
+  beakerfreespace: number;
   filtering: BooleanLike;
   pump: BooleanLike;
 };
@@ -193,20 +193,20 @@ export const OccupantStatus = (props, context) => {
               <Button
                 content="Blood Dialysis"
                 color={data.filtering ? 'good' : ''}
-                disabled={data.beaker ? data.beakerreagents <= 0 : 1}
+                disabled={!data.beaker || data.beakerfreespace <= 0}
                 icon="heart"
                 onClick={() => act('filter')}
               />
               <Button
                 content="Stomach Pump"
                 color={data.pump ? 'good' : ''}
-                disabled={data.beaker ? data.beakerreagents <= 0 : 1}
+                disabled={!data.beaker || data.beakerfreespace <= 0}
                 icon="splotch"
                 onClick={() => act('pump')}
               />
               {data.beaker ? (
                 <BlockQuote>
-                  {Math.round(data.beakerreagents)}u of free space remaining.
+                  {Math.round(data.beakerfreespace)}u of free space remaining.
                 </BlockQuote>
               ) : (
                 <BlockQuote color="bad">No beaker inserted.</BlockQuote>

--- a/tgui/packages/tgui/interfaces/Sleeper.tsx
+++ b/tgui/packages/tgui/interfaces/Sleeper.tsx
@@ -18,7 +18,8 @@ export type SleeperData = {
   pulse: string;
   reagents: SleeperReagent[];
   stasissettings: number[];
-  beaker: number;
+  beaker: BooleanLike;
+  beakerreagents: number;
   filtering: BooleanLike;
   pump: BooleanLike;
 };
@@ -45,10 +46,10 @@ export const Sleeper = (props, context) => {
           <Table>
             <BlockQuote>No occupant detected.</BlockQuote>
             <Button
-              content={data.beaker < 0 ? 'No Beaker' : 'Eject Beaker'}
+              content={data.beaker ? 'Eject Beaker' : 'No Beaker'}
               icon="medkit"
               color="red"
-              disabled={data.beaker < 0}
+              disabled={!data.beaker}
               onClick={() => act('beaker')}
             />
           </Table>
@@ -182,30 +183,30 @@ export const OccupantStatus = (props, context) => {
               title="Dialysis"
               buttons={
                 <Button
-                  content={data.beaker < 0 ? 'No Beaker' : 'Eject Beaker'}
+                  content={data.beaker ? 'Eject Beaker' : 'No Beaker'}
                   icon="medkit"
                   color="red"
-                  disabled={data.beaker < 0}
+                  disabled={!data.beaker}
                   onClick={() => act('beaker')}
                 />
               }>
               <Button
                 content="Blood Dialysis"
                 color={data.filtering ? 'good' : ''}
-                disabled={data.beaker < 0}
+                disabled={data.beaker ? data.beakerreagents <= 0 : 1}
                 icon="heart"
                 onClick={() => act('filter')}
               />
               <Button
                 content="Stomach Pump"
                 color={data.pump ? 'good' : ''}
-                disabled={data.beaker < 0}
+                disabled={data.beaker ? data.beakerreagents <= 0 : 1}
                 icon="splotch"
                 onClick={() => act('pump')}
               />
-              {data.beaker > -1 ? (
+              {data.beaker ? (
                 <BlockQuote>
-                  {Math.round(data.beaker)}u of free space remaining.
+                  {Math.round(data.beakerreagents)}u of free space remaining.
                 </BlockQuote>
               ) : (
                 <BlockQuote color="bad">No beaker inserted.</BlockQuote>


### PR DESCRIPTION
Fixes  #16820

I assume this might sometimes be caused by a rounding error? I dunno, it shouldn't do this but weird things happen. 

This separates the presence of a beaker from the reagent amount of the beaker, though, to prevent it from happening in those fringe instances.