### PR TITLE
Remove requirement for round completion from bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yaml
@@ -16,8 +16,6 @@ body:
     options:
       - label: I have searched the bug with a few keywords, and I confirm this bug was not yet reported.
         required: true
-      - label: The round I am reporting the bug from, or I am going to talk about, has already ended.
-        required: true
 
 - type: dropdown
   id: location


### PR DESCRIPTION
No in-game user facing changes.

The chance of someone metagaming on GitHub is extremely low. But the need for quality and timely bug reports is high, especially with the high amount of high-risk and extensive changes lately. This removes the requirement for bug reports to have had the round finished, in favor of getting more timely bug reports done. 