### PR TITLE
Smartfridge atmos blocking fix

### DIFF
--- a/code/modules/cooking/machinery/smartfridge.dm
+++ b/code/modules/cooking/machinery/smartfridge.dm
@@ -38,7 +38,7 @@
 	)
 
 	var/datum/wires/smartfridge/wires = null
-	atmos_canpass = CANPASS_NEVER
+	atmos_canpass = CANPASS_DENSITY
 
 /obj/machinery/smartfridge/secure
 	is_secure = 1

--- a/html/changelogs/doxxmedearly-chem_smartfridge_fix.yml
+++ b/html/changelogs/doxxmedearly-chem_smartfridge_fix.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Smartfridges that do not block movement, such as the one in the pharmacy, no longer block airflow."


### PR DESCRIPTION
Fixes #16837

Smartfridges now block atmos based on density instead of always, so any fridges like the pharmacy one that don't have density also don't block atmos. Should also prevent any weirdness if any "half-tile" or wall-mounted fridge subtypes are made in the future.