### PR TITLE
Ghosts can now hear whispers

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -48,8 +48,6 @@
 
 	var/track = null
 	if(isobserver(src))
-		if(italics && client.prefs.toggles & CHAT_GHOSTRADIO)
-			return
 		if(speaker_name != speaker.real_name && speaker.real_name)
 			speaker_name = "[speaker.real_name] ([speaker_name])"
 		track = "[ghost_follow_link(speaker, src)] "

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -285,7 +285,7 @@ var/list/channel_to_radio_key = new
 
 	//speaking into radios
 	if(length(used_radios))
-		italics = 1
+		italics = TRUE
 		message_range = 1
 		if(speaking)
 			message_range = speaking.get_talkinto_msg_range(message)
@@ -312,7 +312,7 @@ var/list/channel_to_radio_key = new
 				message_range = 1
 
 			if (pressure < ONE_ATMOSPHERE*0.4) //sound distortion pressure, to help clue people in that the air is thin, even if it isn't a vacuum yet
-				italics = 1
+				italics = TRUE
 				sound_vol *= 0.5 //muffle the sound a bit, so it's like we're actually talking through contact
 
 		listening = get_hearers_in_view(message_range, src)
@@ -320,6 +320,8 @@ var/list/channel_to_radio_key = new
 	if(client)
 		for (var/mob/player_mob in player_list)
 			if(!player_mob || player_mob.stat != DEAD || (player_mob in listening))
+				continue
+			if(player_mob.client?.prefs.toggles & CHAT_GHOSTRADIO && length(used_radios)) //If they are talking into a radio and we hear all radio messages, don't duplicate for observers
 				continue
 			if(player_mob.client?.prefs.toggles & CHAT_GHOSTEARS)
 				listening |= player_mob

--- a/code/modules/mob/living/whisper.dm
+++ b/code/modules/mob/living/whisper.dm
@@ -56,29 +56,30 @@
 			whisper_text = "[speak_text] [adverb]"
 			not_heard = "[speak_text] something [adverb]"
 
-	var/list/listening = list(src)
-
-	//ghosts
-	for(var/mob/M in dead_mob_list)
-		if(M.stat == DEAD && M.client && (M.client.prefs.toggles & CHAT_GHOSTEARS))
-			listening |= M
-
-	//Pass whispers on to anything inside the immediate listeners.
-	for(var/mob/L in listening)
-		for(var/mob/living/C in L.contents)
-			listening += C
-
+	//Check to see who hears the full whisper message, and who just gets the not_heard message
 	var/list/eavesdropping = list()
 	var/list/watching = list()
-
+	var/list/observers = list()
 	var/list/all_in_range = hearers(watching_range, src)
 	for(var/mob/M as anything in all_in_range)
-		if(get_dist(src, M) <= message_range)
-			listening |= M
+		if(M.stat == DEAD && M.client && (M.client.prefs.toggles & CHAT_GHOSTEARS)) //Preventing duplicate messages to ghostear'd observers
+			continue
+		if(get_dist(src, M) <= message_range) //In range to hear
+			continue
 		else if(get_dist(src, M) <= eavesdropping_range)
-			eavesdropping += M
+			if(M.stat == DEAD && M.client)
+				observers += M
+			else
+				eavesdropping += M
 		else if(get_dist(src, M) <= watching_range)
-			watching += M
+			if(M.stat == DEAD && M.client)
+				observers += M
+			else	
+				watching += M
+
+	if(length(observers)) //For ghosts who do NOT have ghost ears. They will see the whole message if nearby, no *s or not_heard messages.
+		for(var/mob/M in observers)
+			M.hear_say(message, "whispers", speaking, "", TRUE, src)
 
 	if(length(eavesdropping))
 		var/new_message = stars(message)

--- a/html/changelogs/doxxmedearly-ghostwhisper_fix.yml
+++ b/html/changelogs/doxxmedearly-ghostwhisper_fix.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Observers can now hear mobs whisper, per their ghostears preference. They should always hear the full whisper message."


### PR DESCRIPTION
Fixes #4128

The cause of this was a bit in hear_say code that made it so ghosts with the Ghost Radio preference on would not hear italicized messages. This was a fix meant to make sure that when someone speaks into the radio across the map, they don't hear the local text of the mob speaking into the radio.

Now it just checks to see if a radio was used if a mob has Ghost Radio on, and if so, doesn't show it if the mob also has Ghost Ears on. This fixes the issue the italicized thing was trying to fix.

Did some stuff in whisper() to make sure that ghosts don't get duplicate messages from being nearby mobs whispering. Also made it so that if ghostears is set to nearby only, ghosts can hear the whisper message in full if they're nearby (So they don't ever get the "Whispers something softly" or *'d up messages.