### PR TITLE
Adds a requests console to Xenoarchaeology.

### DIFF
--- a/html/changelogs/Leudoberct1-xenoarchconsole.yml
+++ b/html/changelogs/Leudoberct1-xenoarchconsole.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Leudoberct1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Added a requests console to Xenoarchaeology."
+

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -3021,9 +3021,9 @@
 	name = "fore, d1 garden"
 	},
 /obj/machinery/door/blast/shutters{
+	dir = 2;
 	id = "shutters_deck2_hydroponicswindowssafety";
-	name = "Viewing Shutter";
-	dir = 2
+	name = "Viewing Shutter"
 	},
 /turf/simulated/floor/plating,
 /area/horizon/hydroponics/lower)
@@ -3509,6 +3509,12 @@
 /obj/machinery/camera/network/research{
 	c_tag = "Research - Xenoarchaeology 3";
 	dir = 4
+	},
+/obj/machinery/requests_console{
+	department = "Xenoarchaeology";
+	departmentType = 2;
+	name = "Xenoarchaeology Requests Console";
+	pixel_x = -30
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenoarch_atrium)
@@ -4705,9 +4711,9 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/shutters{
+	dir = 4;
 	id = "shutters_deck2_hydroponicswindowssafety";
-	name = "Viewing Shutter";
-	dir = 4
+	name = "Viewing Shutter"
 	},
 /turf/simulated/floor/plating,
 /area/horizon/hydroponics/lower)
@@ -20679,8 +20685,8 @@
 /area/horizon/custodial/disposals)
 "ozA" = (
 /obj/machinery/atmospherics/valve/digital/open{
-	name = "airlock shutoff valve";
-	dir = 4
+	dir = 4;
+	name = "airlock shutoff valve"
 	},
 /obj/machinery/atmospherics/binary/pump/fuel{
 	dir = 1;
@@ -26286,8 +26292,8 @@
 /area/operations/storage)
 "sDN" = (
 /obj/machinery/shipsensors/weak/scc_shuttle{
-	pixel_y = -15;
-	density = 1
+	density = 1;
+	pixel_y = -15
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -26833,9 +26839,9 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/shutters{
+	dir = 2;
 	id = "shutters_deck2_hydroponicswindowssafety";
-	name = "Viewing Shutter";
-	dir = 2
+	name = "Viewing Shutter"
 	},
 /turf/simulated/floor/plating,
 /area/horizon/hydroponics/lower)
@@ -28497,10 +28503,10 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/alarm{
-	req_one_access = list(24,11,48);
-	pixel_y = 11;
+	dir = 4;
 	pixel_x = -25;
-	dir = 4
+	pixel_y = 11;
+	req_one_access = list(24,11,48)
 	},
 /obj/structure/table/rack,
 /obj/item/clothing/head/helmet/pilot{
@@ -33608,8 +33614,8 @@
 /area/rnd/xenoarch_atrium)
 "xwo" = (
 /obj/machinery/iff_beacon/horizon/shuttle{
-	pixel_y = -15;
-	density = 1
+	density = 1;
+	pixel_y = -15
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10


### PR DESCRIPTION
This PR adds a requests console to Xenoarchaeology- the reason for this being that Xenoarchaeology has some fleshed out paperwork for cataloguing and document finds, and having to entirely leave your lab to be able to print said paperwork is a little silly.

Image of change (requests console right in the middle of the photo): https://gyazo.com/c7735b53f33c5b6e2e619a4565a6b149