### PR TITLE
Clarify assets/sounds are licensed under CC-BY-SA 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ If you wish to develop and host this codebase in a closed source manner you may 
 
 See [here](https://www.gnu.org/licenses/why-affero-gpl.html) for more information.
 
+All assets including icons and sound are under a [Creative Commons 3.0 BY-SA license](https://creativecommons.org/licenses/by-sa/3.0/) unless otherwise indicated.
+
 ### GETTING THE CODE
 The simplest way to obtain the code is using the github .zip feature.
 


### PR DESCRIPTION
Per line 8 of the changelog header, https://github.com/Aurorastation/Aurora.3/blob/db311a4a1951debee57b76b88bb18f712f6138ed/html/templates/header.html#L8 Our assets are licensed under CC-BY-SA 3.0. This clarifies this in the main readme as well.