### PR TITLE
Meteor Overmap Fun

### DIFF
--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -52,7 +52,7 @@
 	if(current_map.use_overmap)
 		var/area/map = global.map_overmap
 		for(var/turf/T in map)
-			T.overlays += image('icons/obj/overmap/overmap_effects.dmi', "meteor[rand(1,4)]")
+			new/obj/effect/overmap/event/meteor(T)
 	next_wave = round_duration_in_ticks + meteor_wave_delay
 
 /datum/game_mode/meteor/process()

--- a/html/changelogs/alberyk-overmaphell.yml
+++ b/html/changelogs/alberyk-overmaphell.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - rscadd: "The meteor gamemode now spawns meteor hazards on the overmap when it starts the meteor waves."


### PR DESCRIPTION
When the waves start, the meteor gamemode now spawns real meteor hazards on the overmap. You can't easily escape anymore.
