### PR TITLE
Holodecks with random programs

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -280,6 +280,8 @@ var/global/list/additional_antag_types = list()
 	var/welcome_delay = rand(waittime_l, waittime_h)
 	addtimer(CALLBACK(current_map, TYPE_PROC_REF(/datum/map, send_welcome)), welcome_delay)
 
+	addtimer(CALLBACK(current_map, TYPE_PROC_REF(/datum/map, load_holodeck_programs)), 5 MINUTES)
+
 	//Assign all antag types for this game mode. Any players spawned as antags earlier should have been removed from the pending list, so no need to worry about those.
 	for(var/datum/antagonist/antag in antag_templates)
 		if(!(antag.flags & ANTAG_OVERRIDE_JOB))

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -1,3 +1,6 @@
+
+var/global/list/obj/machinery/computer/HolodeckControl/holodeck_controls = list()
+
 /obj/machinery/computer/HolodeckControl
 	name = "holodeck control console"
 	desc = "A computer used to control a nearby holodeck."
@@ -29,6 +32,7 @@
 /obj/machinery/computer/HolodeckControl/Initialize()
 	. = ..()
 	linkedholodeck = locate(linkedholodeck_area)
+	holodeck_controls += src
 
 /obj/machinery/computer/HolodeckControl/attack_ai(var/mob/user as mob)
 	if(!ai_can_interact(user))
@@ -372,6 +376,10 @@
 		to_chat(user, "<span class='warning'>Access denied.</span>")
 		return TRUE
 
+/obj/machinery/computer/HolodeckControl/proc/load_random_program()
+	var/prog_to_load = pick(current_map.holodeck_programs)
+	loadProgram(current_map.holodeck_programs[prog_to_load])
+
 /obj/machinery/computer/HolodeckControl/Aurora
 	density = 0
 	linkedholodeck_area = /area/holodeck/alphadeck
@@ -379,11 +387,6 @@
 /obj/machinery/computer/HolodeckControl/Horizon
 	density = 0
 	linkedholodeck_area = /area/horizon/holodeck/alphadeck
-
-/obj/machinery/computer/HolodeckControl/Horizon/Initialize()
-	. = ..()
-	var/prog_to_load = pick(current_map.holodeck_programs)
-	loadProgram(current_map.holodeck_programs[prog_to_load])
 
 /obj/machinery/computer/HolodeckControl/Horizon/beta
 	linkedholodeck_area = /area/horizon/holodeck/betadeck

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -377,7 +377,7 @@ var/global/list/obj/machinery/computer/HolodeckControl/holodeck_controls = list(
 		return TRUE
 
 /obj/machinery/computer/HolodeckControl/proc/load_random_program()
-	var/prog_to_load = pick(current_map.holodeck_programs)
+	var/datum/holodeck_program/prog_to_load = pick(current_map.holodeck_programs)
 	loadProgram(current_map.holodeck_programs[prog_to_load])
 
 /obj/machinery/computer/HolodeckControl/Aurora

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -380,5 +380,10 @@
 	density = 0
 	linkedholodeck_area = /area/horizon/holodeck/alphadeck
 
+/obj/machinery/computer/HolodeckControl/Horizon/Initialize()
+	. = ..()
+	var/prog_to_load = pick(current_map.holodeck_programs)
+	loadProgram(current_map.holodeck_programs[prog_to_load])
+
 /obj/machinery/computer/HolodeckControl/Horizon/beta
 	linkedholodeck_area = /area/horizon/holodeck/betadeck

--- a/html/changelogs/DreamySkrell-holodeck-load-program-at-round-start.yml
+++ b/html/changelogs/DreamySkrell-holodeck-load-program-at-round-start.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Horizon's holodecks each now start the round with a random program loaded."

--- a/html/changelogs/DreamySkrell-holodeck-load-program-at-round-start.yml
+++ b/html/changelogs/DreamySkrell-holodeck-load-program-at-round-start.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-    tweak: "If at least two engineers are present, Horizon's holodecks load random programs 5 minutes into the round."
+  - tweak: "If at least two engineers are present, Horizon's holodecks load random programs 5 minutes into the round."

--- a/html/changelogs/DreamySkrell-holodeck-load-program-at-round-start.yml
+++ b/html/changelogs/DreamySkrell-holodeck-load-program-at-round-start.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Horizon's holodecks each now start the round with a random program loaded."
+    tweak: "If at least two engineers are present, Horizon's holodecks load random programs 5 minutes into the round."

--- a/maps/_common/mapsystem/map.dm
+++ b/maps/_common/mapsystem/map.dm
@@ -219,6 +219,9 @@
 /datum/map/proc/send_welcome()
 	return
 
+/datum/map/proc/load_holodeck_programs()
+	return
+
 /datum/map/proc/build_away_sites()
 #ifdef UNIT_TEST
 	log_admin("Unit testing, so not loading away sites")

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -197,7 +197,9 @@
 /datum/map/sccv_horizon/load_holodeck_programs()
 	// loads only if at least two engineers are present
 	// so as to not drain power on deadpop
+	// also only loads if no program is loaded already
 	var/list/roles = number_active_with_role()
 	if(roles && roles["Engineer"] && roles["Engineer"] >= 2)
 		for(var/obj/machinery/computer/HolodeckControl/holo in holodeck_controls)
-			holo.load_random_program()
+			if(!holo.active)
+				holo.load_random_program()

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -193,3 +193,11 @@
 
 	post_comm_message("SCCV Horizon Sensor Readings", welcome_text)
 	priority_announcement.Announce(message = "Long-range sensor readings have been printed out at all communication consoles.")
+
+/datum/map/sccv_horizon/load_holodeck_programs()
+	// loads only if at least two engineers are present
+	// so as to not drain power on deadpop
+	var/list/roles = number_active_with_role()
+	if(roles && roles["Engineer"] && roles["Engineer"] >= 2)
+		for(var/obj/machinery/computer/HolodeckControl/holo in holodeck_controls)
+			holo.load_random_program()


### PR DESCRIPTION
changes:
  - tweak: "If at least two engineers are present, Horizon's holodecks load random programs 5 minutes into the round."


Why? Currently they start just kinda sad and empty. We have lots of pretty holodeck programs, and I'm sure there are people who aren't even aware they exit, and don't care to check. I like to think this change would maybe occasionally pique the interest of passerby's or whatever to check out the programs.

Also it just looks nice as decoration, even if no one's using the holodecks.

They load only if at least two engineers are present, so they don't drain power on deadpop, where engines may not be set up yet (or ever).