### PR TITLE
Disruptor and Blaster changes

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -169,7 +169,7 @@
 
 /obj/item/projectile/energy/blaster
 	name = "blaster bolt"
-	icon_state = "heavybolt"
+	icon_state = "laser"
 	damage = 30
 	check_armor = "laser"
 	damage_type = DAMAGE_BURN
@@ -189,7 +189,7 @@
 
 /obj/item/projectile/energy/disruptorstun
 	name = "disruptor bolt"
-	icon_state = "blue_laser"
+	icon_state = "bluelaser"
 	damage = 1
 	agony = 40
 	speed = 0.4

--- a/html/changelogs/ClemTheDuck Blaster and disruptor bolt change.yml
+++ b/html/changelogs/ClemTheDuck Blaster and disruptor bolt change.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ClemTheDuck
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Changed the sprites of the projectile fired from TCFL blaster guns and sec disruptors, they should now look like bolts over orbs"
+ 

--- a/html/changelogs/ClemTheDuck Blaster and disruptor bolt change.yml
+++ b/html/changelogs/ClemTheDuck Blaster and disruptor bolt change.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Changed the sprites of the projectile fired from TCFL blaster guns and sec disruptors, they should now look like bolts over orbs"
+  - tweak: "Changed the sprites of the projectile fired from TCFL blaster guns and sec disruptors, they should now look like bolts over orbs."
  


### PR DESCRIPTION
Changes the projectile sprite used by the security Disrptors and TCFL Blasters. They should be more inline with the bolts used by science guns (more visually noticeable and interesting)