### PR TITLE
Circuit-less consoles can now be repaired.

### DIFF
--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -121,18 +121,18 @@
 		if(circuit)
 			if(W.use_tool(src, user, 20, volume = 50))
 				var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )
-				var/obj/item/circuitboard/M = new circuit( A )
+				var/obj/item/circuitboard/M = new circuit(A)
 				A.circuit = M
 				A.anchored = TRUE
-				for (var/obj/C in src)
+				for(var/obj/C in src)
 					C.forceMove(src.loc)
-				if (src.stat & BROKEN)
-					to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
+				if(src.stat & BROKEN)
+					to_chat(user, SPAN_NOTICE("The broken glass falls out."))
 					new /obj/item/material/shard( src.loc )
 					A.state = 3
 					A.icon_state = "3"
 				else
-					to_chat(user, "<span class='notice'>You disconnect the glass keyboard panel.</span>")
+					to_chat(user, SPAN_NOTICE("You disconnect the glass keyboard panel."))
 					A.state = 4
 					A.icon_state = "4"
 				M.deconstruct(src)

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -117,25 +117,32 @@
 	return text
 
 /obj/machinery/computer/attackby(var/obj/item/W as obj, user as mob)
-	if(W.isscrewdriver() && circuit)
-		if(W.use_tool(src, user, 20, volume = 50))
-			var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )
-			var/obj/item/circuitboard/M = new circuit( A )
-			A.circuit = M
-			A.anchored = 1
-			for (var/obj/C in src)
-				C.forceMove(src.loc)
-			if (src.stat & BROKEN)
-				to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
-				new /obj/item/material/shard( src.loc )
-				A.state = 3
-				A.icon_state = "3"
-			else
-				to_chat(user, "<span class='notice'>You disconnect the glass keyboard panel.</span>")
-				A.state = 4
-				A.icon_state = "4"
-			M.deconstruct(src)
-			qdel(src)
+	if(W.isscrewdriver())
+		if(circuit)
+			if(W.use_tool(src, user, 20, volume = 50))
+				var/obj/structure/computerframe/A = new /obj/structure/computerframe( src.loc )
+				var/obj/item/circuitboard/M = new circuit( A )
+				A.circuit = M
+				A.anchored = TRUE
+				for (var/obj/C in src)
+					C.forceMove(src.loc)
+				if (src.stat & BROKEN)
+					to_chat(user, "<span class='notice'>The broken glass falls out.</span>")
+					new /obj/item/material/shard( src.loc )
+					A.state = 3
+					A.icon_state = "3"
+				else
+					to_chat(user, "<span class='notice'>You disconnect the glass keyboard panel.</span>")
+					A.state = 4
+					A.icon_state = "4"
+				M.deconstruct(src)
+				qdel(src)
+		else if(stat & BROKEN)
+			to_chat(user, SPAN_NOTICE("You start fixing \the [src]..."))
+			if(W.use_tool(src, user, 5 SECONDS, volume = 50))
+				to_chat(user, SPAN_NOTICE("You fix the console's screen and tie up a few loose cables."))
+				stat &= ~BROKEN
+				update_icon()
 		return TRUE
 	else
 		return ..()

--- a/html/changelogs/mattatlas-consolefixes.yml
+++ b/html/changelogs/mattatlas-consolefixes.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Consoles without a circuit (such as cockpit consoles) can now actually be repaired with a screwdriver."


### PR DESCRIPTION
Consoles without a circuit (such as cockpit consoles) can now actually be repaired with a screwdriver.