### PR TITLE
Makes IV tank valves automatically open when strapping masks

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -355,13 +355,14 @@
 					to_chat(usr, SPAN_WARNING("You must remove \the [breather]'s [breather.wear_mask] first!"))
 					breather = null
 					return
+				if(tank)
+					tank_on()
 				visible_message("<b>[usr]</b> secures the mask over \the <b>[breather]'s</b> face.")
 				playsound(breather, 'sound/effects/buckle.ogg', 50)
 				breath_mask.forceMove(breather.loc)
 				breather.equip_to_slot(breath_mask, slot_wear_mask)
 				breather.update_inv_wear_mask()
 				update_icon()
-				tank_on()
 				return
 
 /obj/machinery/iv_drip/AltClick(mob/user)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -606,7 +606,6 @@
 	return
 
 /obj/machinery/iv_drip/proc/tank_off()
-	playsound(src, 'sound/effects/internals.ogg', 100)
 	tank.forceMove(src)
 	if(breather.internals)
 		breather.internals.icon_state = "internal0"

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -216,7 +216,7 @@
 
 			if(!tank_active) // Activates and sets the kPa to a safe pressure. This keeps from it constantly resetting itself
 				tank.distribute_pressure = safe_pressure_min
-				src.visible_message(SPAN_NOTICE("\The [src] chimes and adjusts \the [tank]'s release pressure"))
+				src.visible_message(SPAN_NOTICE("\The [src] chimes and adjusts \the [tank]'s release pressure."))
 				playsound(src, 'sound/machines/chime.ogg', 50)
 				tank_active = TRUE
 			if(L.checking_rupture == FALSE) // Safely retracts in case the lungs are about to rupture
@@ -361,6 +361,7 @@
 				breather.equip_to_slot(breath_mask, slot_wear_mask)
 				breather.update_inv_wear_mask()
 				update_icon()
+				tank_on()
 				return
 
 /obj/machinery/iv_drip/AltClick(mob/user)
@@ -593,7 +594,18 @@
 	breather = null
 	update_icon()
 
+/obj/machinery/iv_drip/proc/tank_on()
+	playsound(src, 'sound/effects/internals.ogg', 100)
+	tank.forceMove(breather)
+	breather.internal = tank
+	if(breather.internals)
+		breather.internals.icon_state = "internal1"
+	valve_open = TRUE
+	update_icon()
+	return
+
 /obj/machinery/iv_drip/proc/tank_off()
+	playsound(src, 'sound/effects/internals.ogg', 100)
 	tank.forceMove(src)
 	if(breather.internals)
 		breather.internals.icon_state = "internal0"
@@ -642,22 +654,17 @@
 
 	if(!valve_open)
 		usr.visible_message("<b>[usr]</b> opens \the [tank]'s valve.", SPAN_NOTICE("You open \the [tank]'s valve."))
-		playsound(src, 'sound/effects/internals.ogg', 100)
-		tank.forceMove(breather)
-		breather.internal = tank
-		if(breather.internals)
-			breather.internals.icon_state = "internal1"
-		valve_open = TRUE
-		update_icon()
+		tank_on()
 		return
-	if(epp_active)
-		var/response = alert(usr, "Are you sure you want to close \the [tank]'s valve? The Emergency Positive Pressure system is currently active!", "Toggle Valve", "Yes", "No")
-		if(response == "No")
-			return
-		epp_active = FALSE
-	usr.visible_message("<b>[usr]</b> closes \the [tank]'s valve.", SPAN_NOTICE("You close \the [tank]'s valve."))
-	playsound(src, 'sound/effects/internals.ogg', 100)
-	tank_off()
+	if(valve_open)
+		if(epp_active)
+			var/response = alert(usr, "Are you sure you want to close \the [tank]'s valve? The Emergency Positive Pressure system is currently active!", "Toggle Valve", "Yes", "No")
+			if(response == "No")
+				return
+			epp_active = FALSE
+		usr.visible_message("<b>[usr]</b> closes \the [tank]'s valve.", SPAN_NOTICE("You close \the [tank]'s valve."))
+		tank_off()
+		return
 
 /obj/machinery/iv_drip/verb/toggle_epp()
 	set category = "Object"

--- a/html/changelogs/nauticall-autovalveopen.yml
+++ b/html/changelogs/nauticall-autovalveopen.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: nauticall
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "When putting a breath mask on someone via the IV drip with an oxygen mask attached, the valve now opens automatically."


### PR DESCRIPTION
Currently, when putting an IV on a person in medical, you strap the mask onto them and _then_ turn on the valve as a second step. The problem is, in high-stress situations people might not immediately turn on the valve (or don't realize it's not on), _or_ inexperienced medical players don't realize they have to turn on said valve in order for it to function properly.

This PR makes it so putting a breath mask on a person (assuming it's connected to an IV drip) _automatically_ opens the associated tank. Sure, there can be some edge cases where you wouldn't want this to happen, but generally speaking this should save time, double-checks, and even lives.