### PR TITLE
Added apprentice alt-titles for Security and Engineering

### DIFF
--- a/code/game/jobs/faction/hephaestus.dm
+++ b/code/game/jobs/faction/hephaestus.dm
@@ -44,6 +44,7 @@
 		"Engineer" = /datum/outfit/job/engineer/hephaestus,
 		"Atmospheric Technician" = /datum/outfit/job/atmos/hephaestus,
 		"Engineering Apprentice" = /datum/outfit/job/intern_eng/hephaestus,
+		"Atmospherics Apprentice" = /datum/outfit/job/intern_atmos/hephaestus,
 		"Corporate Liaison" = /datum/outfit/job/representative/hephaestus
 	)
 
@@ -106,6 +107,18 @@
 
 /datum/outfit/job/intern_eng/hephaestus
 	name = "Engineering Apprentice - Hephaestus"
+
+	uniform = /obj/item/clothing/under/rank/engineer/apprentice/heph
+	head = /obj/item/clothing/head/beret/corporate/heph
+	id = /obj/item/card/id/hephaestus
+
+	backpack_faction = /obj/item/storage/backpack/heph
+	satchel_faction = /obj/item/storage/backpack/satchel/heph
+	dufflebag_faction = /obj/item/storage/backpack/duffel/heph
+	messengerbag_faction = /obj/item/storage/backpack/messenger/heph
+
+/datum/outfit/job/intern_atmos/hephaestus
+	name = "Atmospherics Apprentice - Hephaestus"
 
 	uniform = /obj/item/clothing/under/rank/engineer/apprentice/heph
 	head = /obj/item/clothing/head/beret/corporate/heph

--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -48,6 +48,7 @@
 		"Security Officer" = /datum/outfit/job/officer/idris,
 		"Warden" = /datum/outfit/job/warden/idris,
 		"Security Cadet" = /datum/outfit/job/intern_sec/idris,
+		"Investigator Intern" = /datum/outfit/job/intern_forensics/idris
 		"Investigator" =/datum/outfit/job/forensics/idris,
 		"Bartender" = /datum/outfit/job/bartender/idris,
 		"Chef" = /datum/outfit/job/chef/idris,
@@ -99,6 +100,17 @@
 
 /datum/outfit/job/intern_sec/idris
 	name = "Security Cadet - Idris"
+
+	uniform = /obj/item/clothing/under/rank/cadet/idris
+	id = /obj/item/card/id/idris/sec
+
+	backpack_faction = /obj/item/storage/backpack/idris
+	satchel_faction = /obj/item/storage/backpack/satchel/idris
+	dufflebag_faction = /obj/item/storage/backpack/duffel/idris
+	messengerbag_faction = /obj/item/storage/backpack/messenger/idris
+
+/datum/outfit/job/intern_forensics/idris
+	name = "Investigator Intern - Idris"
 
 	uniform = /obj/item/clothing/under/rank/cadet/idris
 	id = /obj/item/card/id/idris/sec

--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -48,7 +48,7 @@
 		"Security Officer" = /datum/outfit/job/officer/idris,
 		"Warden" = /datum/outfit/job/warden/idris,
 		"Security Cadet" = /datum/outfit/job/intern_sec/idris,
-		"Investigator Intern" = /datum/outfit/job/intern_forensics/idris
+		"Investigator Intern" = /datum/outfit/job/intern_forensics/idris,
 		"Investigator" =/datum/outfit/job/forensics/idris,
 		"Bartender" = /datum/outfit/job/bartender/idris,
 		"Chef" = /datum/outfit/job/chef/idris,

--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -48,7 +48,7 @@
 		"Security Officer" = /datum/outfit/job/officer/idris,
 		"Warden" = /datum/outfit/job/warden/idris,
 		"Security Cadet" = /datum/outfit/job/intern_sec/idris,
-		"Investigator Intern" = /datum/outfit/job/intern_forensics/idris,
+		"Investigator Intern" = /datum/outfit/job/intern_sec/forensics/idris,
 		"Investigator" =/datum/outfit/job/forensics/idris,
 		"Bartender" = /datum/outfit/job/bartender/idris,
 		"Chef" = /datum/outfit/job/chef/idris,
@@ -109,7 +109,7 @@
 	dufflebag_faction = /obj/item/storage/backpack/duffel/idris
 	messengerbag_faction = /obj/item/storage/backpack/messenger/idris
 
-/datum/outfit/job/intern_forensics/idris
+/datum/outfit/job/intern_sec/forensics/idris
 	name = "Investigator Intern - Idris"
 
 	uniform = /obj/item/clothing/under/rank/cadet/idris

--- a/code/game/jobs/faction/pmc.dm
+++ b/code/game/jobs/faction/pmc.dm
@@ -41,7 +41,7 @@
 		"Security Officer" = /datum/outfit/job/officer/pmc,
 		"Warden" = /datum/outfit/job/warden/pmc,
 		"Security Cadet" = /datum/outfit/job/intern_sec/pmc,
-		"Investigator Intern" = /datum/outfit/job/intern_forensics/pmc,
+		"Investigator Intern" = /datum/outfit/job/intern_sec/forensics/pmc,
 		"Investigator" =/datum/outfit/job/forensics/pmc,
 		"Physician" = /datum/outfit/job/doctor/pmc,
 		"Surgeon" = /datum/outfit/job/doctor/surgeon/pmc,
@@ -89,7 +89,7 @@
 	dufflebag_faction = /obj/item/storage/backpack/duffel/pmcg
 	messengerbag_faction = /obj/item/storage/backpack/messenger/pmcg
 
-/datum/outfit/job/intern_forensics/pmc
+/datum/outfit/job/intern_sec/forensics/pmc
 	name = "Investigator Intern - PMC"
 
 	uniform = /obj/item/clothing/under/rank/cadet/pmc

--- a/code/game/jobs/faction/pmc.dm
+++ b/code/game/jobs/faction/pmc.dm
@@ -41,7 +41,7 @@
 		"Security Officer" = /datum/outfit/job/officer/pmc,
 		"Warden" = /datum/outfit/job/warden/pmc,
 		"Security Cadet" = /datum/outfit/job/intern_sec/pmc,
-		"Investigator Intern" = /datum/outfit/job/intern_forensics/pmc
+		"Investigator Intern" = /datum/outfit/job/intern_forensics/pmc,
 		"Investigator" =/datum/outfit/job/forensics/pmc,
 		"Physician" = /datum/outfit/job/doctor/pmc,
 		"Surgeon" = /datum/outfit/job/doctor/surgeon/pmc,

--- a/code/game/jobs/faction/pmc.dm
+++ b/code/game/jobs/faction/pmc.dm
@@ -41,6 +41,7 @@
 		"Security Officer" = /datum/outfit/job/officer/pmc,
 		"Warden" = /datum/outfit/job/warden/pmc,
 		"Security Cadet" = /datum/outfit/job/intern_sec/pmc,
+		"Investigator Intern" = /datum/outfit/job/intern_forensics/pmc
 		"Investigator" =/datum/outfit/job/forensics/pmc,
 		"Physician" = /datum/outfit/job/doctor/pmc,
 		"Surgeon" = /datum/outfit/job/doctor/surgeon/pmc,
@@ -79,6 +80,17 @@
 
 /datum/outfit/job/intern_sec/pmc
 	name = "Security Cadet - PMC"
+
+	uniform = /obj/item/clothing/under/rank/cadet/pmc
+	id = /obj/item/card/id/pmc
+
+	backpack_faction = /obj/item/storage/backpack/pmcg
+	satchel_faction = /obj/item/storage/backpack/satchel/pmcg
+	dufflebag_faction = /obj/item/storage/backpack/duffel/pmcg
+	messengerbag_faction = /obj/item/storage/backpack/messenger/pmcg
+
+/datum/outfit/job/intern_forensics/pmc
+	name = "Investigator Intern - PMC"
 
 	uniform = /obj/item/clothing/under/rank/cadet/pmc
 	id = /obj/item/card/id/pmc

--- a/code/game/jobs/faction/zavodskoi.dm
+++ b/code/game/jobs/faction/zavodskoi.dm
@@ -50,7 +50,7 @@
 		"Security Officer" = /datum/outfit/job/officer/zavodskoi,
 		"Warden" = /datum/outfit/job/warden/zavodskoi,
 		"Security Cadet" = /datum/outfit/job/intern_sec/zavodskoi,
-		"Investigator Intern" = /datum/outfit/job/intern_forensics/zavodskoi,
+		"Investigator Intern" = /datum/outfit/job/intern_sec/forensics/zavodskoi,
 		"Investigator" =/datum/outfit/job/forensics/zavodskoi,
 		"Scientist" = /datum/outfit/job/scientist/zavodskoi,
 		"Xenobiologist" = /datum/outfit/job/scientist/xenobiologist/zavodskoi,
@@ -100,7 +100,7 @@
 	dufflebag_faction = /obj/item/storage/backpack/duffel/zavod
 	messengerbag_faction = /obj/item/storage/backpack/messenger/zavod
 
-/datum/outfit/job/intern_forensics/zavodskoi
+/datum/outfit/job/intern_sec/forensics/zavodskoi
 	name = "Investigator Intern - Zavodskoi Interstellar"
 
 	uniform = /obj/item/clothing/under/rank/cadet/zavod

--- a/code/game/jobs/faction/zavodskoi.dm
+++ b/code/game/jobs/faction/zavodskoi.dm
@@ -50,6 +50,7 @@
 		"Security Officer" = /datum/outfit/job/officer/zavodskoi,
 		"Warden" = /datum/outfit/job/warden/zavodskoi,
 		"Security Cadet" = /datum/outfit/job/intern_sec/zavodskoi,
+		"Investigator Intern" = /datum/outfit/job/intern_forensics/zavodskoi,
 		"Investigator" =/datum/outfit/job/forensics/zavodskoi,
 		"Scientist" = /datum/outfit/job/scientist/zavodskoi,
 		"Xenobiologist" = /datum/outfit/job/scientist/xenobiologist/zavodskoi,
@@ -59,6 +60,7 @@
 		"Engineer" = /datum/outfit/job/engineer/zavodskoi,
 		"Atmospheric Technician" = /datum/outfit/job/atmos/zavodskoi,
 		"Engineering Apprentice" = /datum/outfit/job/intern_eng/zavodskoi,
+		"Atmospherics Apprentice" = /datum/outfit/job/intern_atmos/zavodskoi,
 		"Corporate Liaison" = /datum/outfit/job/representative/zavodskoi
 	)
 
@@ -89,6 +91,17 @@
 
 /datum/outfit/job/intern_sec/zavodskoi
 	name = "Security Cadet - Zavodskoi Interstellar"
+
+	uniform = /obj/item/clothing/under/rank/cadet/zavod
+	id = /obj/item/card/id/zavodskoi/sec
+
+	backpack_faction = /obj/item/storage/backpack/zavod
+	satchel_faction = /obj/item/storage/backpack/satchel/zavod
+	dufflebag_faction = /obj/item/storage/backpack/duffel/zavod
+	messengerbag_faction = /obj/item/storage/backpack/messenger/zavod
+
+/datum/outfit/job/intern_forensics/zavodskoi
+	name = "Investigator Intern - Zavodskoi Interstellar"
 
 	uniform = /obj/item/clothing/under/rank/cadet/zavod
 	id = /obj/item/card/id/zavodskoi/sec
@@ -190,6 +203,18 @@
 
 /datum/outfit/job/intern_eng/zavodskoi
 	name = "Engineering Apprentice - Zavodskoi Interstellar"
+
+	uniform = /obj/item/clothing/under/rank/engineer/apprentice/zavod
+	head = /obj/item/clothing/head/beret/corporate/zavod
+	id = /obj/item/card/id/zavodskoi
+
+	backpack_faction = /obj/item/storage/backpack/zavod
+	satchel_faction = /obj/item/storage/backpack/satchel/zavod
+	dufflebag_faction = /obj/item/storage/backpack/duffel/zavod
+	messengerbag_faction = /obj/item/storage/backpack/messenger/zavod
+
+/datum/outfit/job/intern_atmos/zavodskoi
+	name = "Atmospherics Apprentice - Zavodskoi Interstellar"
 
 	uniform = /obj/item/clothing/under/rank/engineer/apprentice/zavod
 	head = /obj/item/clothing/head/beret/corporate/zavod

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -215,6 +215,8 @@
 	departments = SIMPLEDEPT(DEPARTMENT_ENGINEERING)
 	department_flag = ENGSEC
 	faction = "Station"
+	alt_titles = list("Atmospherics Apprentice")
+	alt_outfits = list("Atmospherics Apprentice" = /datum/outfit/job/intern_atmos)
 	total_positions = 3
 	spawn_positions = 3
 	intro_prefix = "an"
@@ -262,3 +264,37 @@
 	tab_pda = /obj/item/modular_computer/handheld/pda/engineering
 	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/engineering
 	tablet = /obj/item/modular_computer/handheld/preset/engineering
+
+/datum/outfit/job/intern_atmos
+	name = "Atmospherics Apprentice"
+	jobtype = /datum/job/intern_eng
+	box = /obj/item/storage/box/survival/engineer
+
+	uniform = /obj/item/clothing/under/rank/engineer/apprentice
+	shoes = /obj/item/clothing/shoes/orange
+	head = /obj/item/clothing/head/beret/engineering
+	belt = /obj/item/storage/belt/utility
+
+	belt_contents = list(
+		/obj/item/weldingtool = 1,
+		/obj/item/crowbar = 1,
+		/obj/item/wirecutters = 1,
+		/obj/item/device/t_scanner = 1,
+		/obj/item/device/analyzer = 1,
+		/obj/item/pipewrench = 1,
+		/obj/item/powerdrill = 1
+	)
+
+	headset = /obj/item/device/radio/headset/headset_eng
+	bowman = /obj/item/device/radio/headset/headset_eng/alt
+	double_headset = /obj/item/device/radio/headset/alt/double/eng
+	wrist_radio = /obj/item/device/radio/headset/wrist/eng
+
+	backpack = /obj/item/storage/backpack/industrial
+	satchel = /obj/item/storage/backpack/satchel/eng
+	dufflebag = /obj/item/storage/backpack/duffel/eng
+	messengerbag = /obj/item/storage/backpack/messenger/engi
+
+	tab_pda = /obj/item/modular_computer/handheld/pda/engineering/atmos
+	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/engineering/atmos
+	tablet = /obj/item/modular_computer/handheld/preset/engineering/atmos

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -319,7 +319,23 @@
 	departments = SIMPLEDEPT(DEPARTMENT_MEDICAL)
 	department_flag = MEDSCI
 	faction = "Station"
-	alt_titles = list("First Responder Intern", "Surgeon Intern")
+	alt_titles = list("First Responder Trainee", "Pharmacy Intern", "Resident Surgeon", "Resident Psychiatrist")
+	alt_outfits = list("First Responder Trainee" = /datum/outfit/job/intern_med/medtech, "Pharmacy Intern" = /datum/outfit/job/intern_med/pharmacist, "Resident Surgeon" = /datum/outfit/job/intern_med/surgeon, "Resident Psychiatrist" = /datum/outfit/job/intern_med/psychiatrist)
+	alt_ages = list("Pharmacy Intern" = list(
+		SPECIES_HUMAN = 25,
+		SPECIES_SKRELL = 58,
+		SPECIES_SKRELL_AXIORI = 58
+	),
+	"Resident Surgeon" = list(
+		SPECIES_HUMAN = 28,
+		SPECIES_SKRELL = 58,
+		SPECIES_SKRELL_AXIORI = 58
+	),
+	"Resident Psychiatrist" = list(
+		SPECIES_HUMAN = 28,
+		SPECIES_SKRELL = 58,
+		SPECIES_SKRELL_AXIORI = 58
+	))
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the Chief Medical Officer"
@@ -357,3 +373,51 @@
 	tab_pda = /obj/item/modular_computer/handheld/pda/medical
 	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/medical
 	tablet = /obj/item/modular_computer/handheld/preset/medical
+
+/datum/outfit/job/intern_med/medtech
+	name = "First Responder Trainee"
+
+	head = /obj/item/clothing/head/softcap/nt
+	shoes = /obj/item/clothing/shoes/jackboots
+
+	backpack = /obj/item/storage/backpack/emt
+	satchel = /obj/item/storage/backpack/satchel/emt
+	dufflebag = /obj/item/storage/backpack/duffel/emt
+	messengerbag = /obj/item/storage/backpack/messenger/emt
+
+	backpack_contents = list(
+		/obj/item/storage/firstaid = 1
+	)
+
+/datum/outfit/job/intern_med/pharmacist
+	name = "Pharmacy Intern"
+
+	shoes = /obj/item/clothing/shoes/chemist
+
+	backpack = /obj/item/storage/backpack/pharmacy
+	satchel = /obj/item/storage/backpack/satchel/pharm
+	dufflebag = /obj/item/storage/backpack/duffel/pharm
+	messengerbag = /obj/item/storage/backpack/messenger/pharm
+
+/datum/outfit/job/intern_med/surgeon
+	name = "Resident Surgeon"
+
+	shoes = /obj/item/clothing/shoes/surgeon
+
+/datum/outfit/job/intern_med/surgeon/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(!isskrell(H))
+		H.equip_to_slot_or_del(new /obj/item/clothing/head/surgery(H), slot_head)
+
+/datum/outfit/job/intern_med/psychiatrist
+	name = "Resident Psychiatrist"
+
+	shoes = /obj/item/clothing/shoes/psych
+
+	backpack = /obj/item/storage/backpack/psychiatrist
+	satchel = /obj/item/storage/backpack/satchel/psych
+	dufflebag = /obj/item/storage/backpack/duffel/psych
+	messengerbag = /obj/item/storage/backpack/messenger/psych
+
+	tab_pda = /obj/item/modular_computer/handheld/pda/medical/psych
+	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/medical/psych
+	tablet = /obj/item/modular_computer/handheld/preset/medical/psych

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -250,7 +250,17 @@
 	department_flag = ENGSEC
 	faction = "Station"
 	alt_titles = list("Investigator Intern", "Warden Cadet")
-	alt_outfits = list("Investigator Intern" = /datum/outfit/job/intern_forensics)
+	alt_outfits = list("Investigator Intern" = /datum/outfit/job/intern_sec/forensics)
+	alt_ages = list("Investigator Intern" = list(
+		SPECIES_HUMAN = 24,
+		SPECIES_SKRELL = 58,
+		SPECIES_SKRELL_AXIORI = 58
+	),
+	"Warden Cadet" = list(
+		SPECIES_HUMAN = 24,
+		SPECIES_SKRELL = 58,
+		SPECIES_SKRELL_AXIORI = 58
+	))
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the Head of Security"
@@ -301,27 +311,12 @@
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(H), slot_shoes)
 		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black_leather(H), slot_gloves)
 
-/datum/outfit/job/intern_forensics
+/datum/outfit/job/intern_sec/forensics
 	name = "Investigator Intern"
 	jobtype = /datum/job/intern_sec
 
-	uniform = /obj/item/clothing/under/rank/cadet
 	shoes = /obj/item/clothing/shoes/laceup/all_species
 
-	headset = /obj/item/device/radio/headset/headset_sec
-	bowman = /obj/item/device/radio/headset/headset_sec/alt
-	double_headset = /obj/item/device/radio/headset/alt/double/sec
-	wrist_radio = /obj/item/device/radio/headset/wrist/sec
-
-	backpack = /obj/item/storage/backpack/security
-	satchel = /obj/item/storage/backpack/satchel/sec
-	dufflebag = /obj/item/storage/backpack/duffel/sec
-	messengerbag = /obj/item/storage/backpack/messenger/sec
-
-	tab_pda = /obj/item/modular_computer/handheld/pda/security
-	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/security
-	tablet = /obj/item/modular_computer/handheld/preset/security
-
-/datum/outfit/job/intern_forensics/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/intern_sec/forensics/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	H.equip_or_collect(new /obj/item/clothing/gloves/black/forensic(H), slot_gloves)

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -249,6 +249,8 @@
 	departments = SIMPLEDEPT(DEPARTMENT_SECURITY)
 	department_flag = ENGSEC
 	faction = "Station"
+	alt_titles = list("Investigator Intern", "Warden Cadet")
+	alt_outfits = list("Investigator Intern" = /datum/outfit/job/intern_forensics)
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the Head of Security"
@@ -298,3 +300,28 @@
 	else
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(H), slot_shoes)
 		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/black_leather(H), slot_gloves)
+
+/datum/outfit/job/intern_forensics
+	name = "Investigator Intern"
+	jobtype = /datum/job/intern_sec
+
+	uniform = /obj/item/clothing/under/rank/cadet
+	shoes = /obj/item/clothing/shoes/laceup/all_species
+
+	headset = /obj/item/device/radio/headset/headset_sec
+	bowman = /obj/item/device/radio/headset/headset_sec/alt
+	double_headset = /obj/item/device/radio/headset/alt/double/sec
+	wrist_radio = /obj/item/device/radio/headset/wrist/sec
+
+	backpack = /obj/item/storage/backpack/security
+	satchel = /obj/item/storage/backpack/satchel/sec
+	dufflebag = /obj/item/storage/backpack/duffel/sec
+	messengerbag = /obj/item/storage/backpack/messenger/sec
+
+	tab_pda = /obj/item/modular_computer/handheld/pda/security
+	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/security
+	tablet = /obj/item/modular_computer/handheld/preset/security
+
+/datum/outfit/job/intern_forensics/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	H.equip_or_collect(new /obj/item/clothing/gloves/black/forensic(H), slot_gloves)

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -482,7 +482,7 @@
 	if((global.all_species[src.species].spawn_flags & NO_AGE_MINIMUM))
 		return choices
 	for(var/t in choices)
-		if (src.age >= (job.get_alt_character_age(t) || job.get_minimum_character_age(species)))
+		if (src.age >= (job.get_alt_character_age(species, t) || job.get_minimum_character_age(species)))
 			continue
 		choices -= t
 	return choices

--- a/html/changelogs/GeneralCamo - Cadet Alt Titles.yml
+++ b/html/changelogs/GeneralCamo - Cadet Alt Titles.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: GeneralCamo
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/GeneralCamo - Cadet Alt Titles.yml
+++ b/html/changelogs/GeneralCamo - Cadet Alt Titles.yml
@@ -40,3 +40,6 @@ delete-after: True
 changes:
   - rscadd: "Added Investigator Interns and Warden Cadets for Security."
   - rscadd: "Added Atmospherics Apprentices for Engineering."
+  - rscadd: "Added Pharmacy Interns and Resident Psychiatrists for Medical."
+  - balance: "The Surgeon Intern has been renamed to the Resident Surgeon, and now has a minimum age restriction of 28 for humans."
+  - tweak: "All medical intern alt-titles have changes to their outfits, similar to their intended roles in medical."

--- a/html/changelogs/GeneralCamo - Cadet Alt Titles.yml
+++ b/html/changelogs/GeneralCamo - Cadet Alt Titles.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added Investigator Interns and Warden Cadets for Security."
+  - rscadd: "Added Atmospherics Apprentices for Engineering."


### PR DESCRIPTION
From a suggestion by greenjoe.

Adds apprentice alt-titles for Security and Engineering. The Investigator Intern has a slightly different outfit removing the hazard vest and giving them normal shoes and forensic gloves like other Investigators. The Atmospherics Intern gets their special PDA and tools in the toolbelt. No other changes are given to them, and they have the same access as the standard cadet.

EDIT: This now also makes changes to medical alt-titles. Roles for Pharmacy Interns and Resident Psychiatrists have been added, and the Surgeon Intern has been renamed to the "Resident Surgeon" and given an age restriction similar to what investigator interns get. All medical alt-titles get similar outfit changes to their intended target roles.