### PR TITLE
Miners now have access to the flight room

### DIFF
--- a/html/changelogs/RustingWithYou - digthefuckinghole.yml
+++ b/html/changelogs/RustingWithYou - digthefuckinghole.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Miners now have access to the flight room on Deck 1."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -9083,7 +9083,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_command{
 	name = "Pilot Room";
-	req_one_access = list(73, 48)
+	req_one_access = list(73,48)
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -9248,12 +9248,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "gua" = (
-/obj/machinery/button/remote/blast_door{
-	id = "canary_hangar";
-	name = "Canary Hangar Control";
-	pixel_x = 21;
-	pixel_y = 22
-	},
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/mechanical{
 	pixel_y = 3
@@ -13000,12 +12994,11 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
-/obj/machinery/door/blast/shutters/open{
-	dir = 4;
-	id = "canary_hangar";
-	name = "Canary Hangar"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_command{
+	name = "Canary Hangar";
+	req_one_access = list(73)
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hangar/control)
 "jio" = (
@@ -58579,7 +58572,7 @@ aWP
 aWP
 aWP
 jhH
-jhH
+aWP
 aWP
 aWP
 wNS

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -9083,7 +9083,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_command{
 	name = "Pilot Room";
-	req_one_access = list(73)
+	req_one_access = list(73, 48)
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"


### PR DESCRIPTION
Like it says in the title, miners now get access to the flight room. 

Why? They fly a shuttle, and it's the only place they can get the sensor readings in rounds without command or bridge crew.