### PR TITLE
Potassium Chloride/Chlorophoride Adjustments

### DIFF
--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -67,7 +67,7 @@
 		var/should_stop = prob(80) && owner.get_blood_circulation() < BLOOD_VOLUME_SURVIVE //cardiovascular shock, not enough liquid to pump
 		should_stop = should_stop || prob(max(0, owner.getBrainLoss() - owner.maxHealth * 0.75)) //brain failing to work heart properly
 		should_stop = should_stop || (prob(5) && pulse == PULSE_THREADY) //erratic heart patterns, usually caused by oxyloss
-		should_stop = owner.chem_effects[CE_NOPULSE]
+		should_stop = should_stop || owner.chem_effects[CE_NOPULSE]
 		if(should_stop) // The heart has stopped due to going into traumatic or cardiovascular shock.
 			to_chat(owner, "<span class='danger'>Your heart has stopped!</span>")
 			pulse = PULSE_NONE

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -56,7 +56,7 @@
 	if(oxy < BLOOD_VOLUME_BAD) //MOAR
 		pulse_mod++
 
-	if(owner.status_flags & FAKEDEATH || owner.chem_effects[CE_NOPULSE])
+	if(owner.status_flags & FAKEDEATH)
 		pulse = Clamp(PULSE_NONE + pulse_mod, PULSE_NONE, PULSE_2FAST) //pretend that we're dead. unlike actual death, can be inflienced by meds
 		return
 
@@ -67,6 +67,7 @@
 		var/should_stop = prob(80) && owner.get_blood_circulation() < BLOOD_VOLUME_SURVIVE //cardiovascular shock, not enough liquid to pump
 		should_stop = should_stop || prob(max(0, owner.getBrainLoss() - owner.maxHealth * 0.75)) //brain failing to work heart properly
 		should_stop = should_stop || (prob(5) && pulse == PULSE_THREADY) //erratic heart patterns, usually caused by oxyloss
+		should_stop = owner.chem_effects[CE_NOPULSE]
 		if(should_stop) // The heart has stopped due to going into traumatic or cardiovascular shock.
 			to_chat(owner, "<span class='danger'>Your heart has stopped!</span>")
 			pulse = PULSE_NONE

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -229,12 +229,12 @@
 	reagent_state = SOLID
 	color = "#FFFFFF"
 	strength = 0
-	overdose = 5
-	od_minimum_dose = 20
+	metabolism = REM * 0.5
+	overdose = 15
+	od_minimum_dose = 5
 	taste_description = "salt"
 
-/singleton/reagent/toxin/potassium_chloride/overdose(var/mob/living/carbon/M, var/alien, var/datum/reagents/holder)
-	..()
+/singleton/reagent/toxin/potassium_chloride/overdose(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
 	var/mob/living/carbon/human/H = M
 	if(!istype(H) || (H.species.flags & NO_BLOOD))
 		return
@@ -250,13 +250,12 @@
 	description = "Potassium Chlorophoride is an expensive, vastly improved variant of Potassium Chloride. Potassium Chlorophoride, unlike the original drug, acts immediately to block neuromuscular junctions, causing general paralysis."
 	reagent_state = SOLID
 	color = "#FFFFFF"
-	strength = 10
+	strength = 0
 	overdose = 5
 	od_minimum_dose = 20
 	taste_description = "salt"
 
 /singleton/reagent/toxin/potassium_chlorophoride/affect_blood(var/mob/living/carbon/M, var/alien, var/removed, var/datum/reagents/holder)
-	..()
 	var/mob/living/carbon/human/H = M
 	if(!istype(H) || (H.species.flags & NO_BLOOD))
 		return

--- a/html/changelogs/doxxmedearly-Pchloride_changes.yml
+++ b/html/changelogs/doxxmedearly-Pchloride_changes.yml
@@ -1,0 +1,6 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Potassium Chloride/Chlorophoride now properly stop the heart as intended."
+  - tweak: "Potassium Chloride takes time to kick in, and metabolizes a little faster. It still requires 20u minimum to stop the heart."
+  - tweak: "Potassium Chloride/Chlorophoride no longer cause toxins damage. Stopping the heart is enough."


### PR DESCRIPTION
Fixes #16910

CE_NOPULSE was not stopping the heart, it was lumped in with FAKEDEATH. Probably because Zombie Powder had CE_NOPULSE and was intended to fake death. Buuut since it gives the FAKEDEATH flag as it is... I just made sure that CE_NOPULSE stops the heart properly and removed it from zombie powder. It now actually stops the heart.

Someone mixed up the OD threshold vars for Sodium Chloride, so it would take 25u minimum and only affect after 20u was metabolized... at .02 a tick. Adjusted the values and made it metabolize faster, which means it takes a minute or two to affect the target and also will leave the body faster.

Also both of the toxins were causing damage. Given how serious stopping the heart is, this feels no longer necessary.