### PR TITLE
Paxazide stops harm intent

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -41,6 +41,12 @@
 #undef HUMAN_EATING_NO_MOUTH
 #undef HUMAN_EATING_BLOCKED_MOUTH
 
+/mob/living/carbon/human/set_intent(var/set_intent)
+	if(is_pacified() && set_intent == I_HURT && !is_berserk())
+		to_chat(src, SPAN_WARNING("You don't want to harm other beings!"))
+		return
+	..()
+
 /mob/living/carbon/human/proc/update_equipment_vision()
 	flash_protection = 0
 	equipment_tint_total = 0

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -107,7 +107,7 @@
 	//Ears
 	handle_hearing()
 
-	if((is_pacified()) && a_intent == I_HURT)
+	if((is_pacified()) && a_intent == I_HURT && !is_berserk())
 		to_chat(src, "<span class='notice'>You don't feel like harming anybody.</span>")
 		a_intent_change(I_HELP)
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -108,7 +108,7 @@
 	handle_hearing()
 
 	if((is_pacified()) && a_intent == I_HURT && !is_berserk())
-		to_chat(src, "<span class='notice'>You don't feel like harming anybody.</span>")
+		to_chat(src, SPAN_NOTICE("You don't feel like harming anybody."))
 		a_intent_change(I_HELP)
 
 //this handles hud updates. Calls update_vision() and handle_hud_icons()

--- a/html/changelogs/doxxmedearly-pacify_fixes.yml
+++ b/html/changelogs/doxxmedearly-pacify_fixes.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Being pacified, such as via Paxazide, now properly prevents switching to harm intent unless the user is also berserk."


### PR DESCRIPTION
Fixes #16922

Being pacified stops you from moving to harm intent altogether, unless you're also berserk.

Could not replicate other part of issue where they were being harmed as if it were mindbreaker toxin. Tried injecting, ingesting, and inhaling.