### PR TITLE
Signs for port propulsion access tweak

### DIFF
--- a/html/changelogs/doxxmedearly-more_propsign.yml
+++ b/html/changelogs/doxxmedearly-more_propsign.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - maptweak: "Adds two more signs that will direct lazy engineers to a shorter route to port propulsion. Check maintenance behind the elevator."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -597,6 +597,10 @@
 /obj/effect/floor_decal/corner/green/full{
 	dir = 1
 	},
+/obj/structure/sign/directions/prop{
+	dir = 4;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/lobby)
 "aqo" = (
@@ -48233,6 +48237,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/sign/directions/prop{
+	dir = 1;
+	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)


### PR DESCRIPTION
Saw a shorter path to access the new port propulsion route. This just adds signs that directs engineers that way, too, in case their wimpy little legs can't go up and around by the tesla.