### PR TITLE
Fixes drones unable to use closet toggle open

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -536,7 +536,7 @@
 	if(!usr.canmove || usr.stat || usr.restrained())
 		return
 
-	if(ishuman(usr))
+	if(ishuman(usr) || (issilicon(usr) && Adjacent(usr)))
 		add_fingerprint(usr)
 		toggle(usr)
 	else

--- a/html/changelogs/doxxmedearly-dronelocker_verbfix.yml
+++ b/html/changelogs/doxxmedearly-dronelocker_verbfix.yml
@@ -1,0 +1,4 @@
+author: Doxxmedearly
+delete-after: True
+changes:
+  - bugfix: "Drones and borgs can now properly use the Toggle Open verb for closets and crates."


### PR DESCRIPTION
Fixes #16955

Funny enough, the toggle lock verb already enabled silicons to open it. This one must have been overlooked.