### PR TITLE
Allows portraits/icons to be stored in wallets.

### DIFF
--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -34,7 +34,8 @@
 		/obj/item/fluff,
 		/obj/item/storage/business_card_holder,
 		/obj/item/sample,
-		/obj/item/key
+		/obj/item/key,
+		/obj/item/sign/painting_frame
 	)
 	slot_flags = SLOT_ID
 	build_from_parts = TRUE

--- a/html/changelogs/paintings_in_wallets.yml
+++ b/html/changelogs/paintings_in_wallets.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - tweak: "Allows wallets to hold the Tajaran portraits and Dominian icons."


### PR DESCRIPTION
This allows you to put the Tajaran leader picture, or the Dominian Goddess/matyr icons, into wallets.

I know complaints have been made in the past about how many things can be stored in wallets, but as these have no mechanical benefit, I think this will just make life easier for folk without offices to put them in.
