### PR TITLE
Voting panel sorted

### DIFF
--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -253,7 +253,7 @@ var/datum/controller/subsystem/vote/SSvote
 					var/datum/game_mode/M = gamemode_cache[F]
 					if(!M)
 						continue
-					AddChoice(F, capitalize(M.name), "[M.required_players]")
+					AddChoice(F, capitalize(M.name), "", M.required_players)
 				AddChoice(ROUNDTYPE_STR_SECRET, "Secret")
 				if(ROUNDTYPE_STR_MIXED_SECRET in choices)
 					AddChoice(ROUNDTYPE_STR_MIXED_SECRET, "Mixed Secret")
@@ -315,10 +315,15 @@ var/datum/controller/subsystem/vote/SSvote
 		return 1
 	return 0
 
-/datum/controller/subsystem/vote/proc/AddChoice(name, display_name, extra_text)
+/datum/controller/subsystem/vote/proc/AddChoice(name, display_name, extra_text = "", required_players = 0)
 	if(!display_name)
 		display_name = name
-	choices[name] = list("name" = display_name, "extra" = extra_text, "votes" = 0)
+	choices[name] = list(
+		"name" = display_name,
+		"extra" = extra_text,
+		"required_players" = required_players,
+		"votes" = 0
+	)
 
 /datum/controller/subsystem/vote/ui_state(mob/user)
     return always_state
@@ -416,7 +421,8 @@ var/datum/controller/subsystem/vote/SSvote
 		data["choices"] += list(list(
 			"choice" = choice,
 			"votes" = choices[choice]["votes"],
-			"extra" = choices[choice]["extra"]
+			"extra" = choices[choice]["extra"],
+			"required_players" = choices[choice]["required_players"],
 		))
 
 	data["mode"] = mode
@@ -433,6 +439,7 @@ var/datum/controller/subsystem/vote/SSvote
 	data["is_staff"] = user.client.holder && (user.client.holder.rights & (R_ADMIN|R_MOD))
 	var/slevel = get_security_level()
 	data["is_code_red"] = (slevel == "red" || slevel == "delta")
+	data["clients_connected"] = clients.len
 	return data
 
 /mob/verb/vote()

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -439,7 +439,8 @@ var/datum/controller/subsystem/vote/SSvote
 	data["is_staff"] = user.client.holder && (user.client.holder.rights & (R_ADMIN|R_MOD))
 	var/slevel = get_security_level()
 	data["is_code_red"] = (slevel == "red" || slevel == "delta")
-	data["clients_connected"] = clients.len
+	data["total_players"] = SSticker.total_players
+	data["total_players_ready"] = SSticker.total_players_ready
 	return data
 
 /mob/verb/vote()

--- a/html/changelogs/DreamySkrell-voting-panel-a.yml
+++ b/html/changelogs/DreamySkrell-voting-panel-a.yml
@@ -39,4 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - tweak: "Gamemodes in the mode vote panel are sorted by required players to start."
-  - tweak: "Gamemodes in the mode vote panel have grayed out required player numbers, if there's less players connected than required."
+  - tweak: "Gamemodes in the mode vote panel have grayed out required player numbers, if there are less players readied up than required."

--- a/html/changelogs/DreamySkrell-voting-panel-a.yml
+++ b/html/changelogs/DreamySkrell-voting-panel-a.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Gamemodes in the mode vote panel are sorted by required players to start."
+  - tweak: "Gamemodes in the mode vote panel have grayed out required player numbers, if there's less players connected than required."

--- a/tgui/packages/tgui/interfaces/Voting.tsx
+++ b/tgui/packages/tgui/interfaces/Voting.tsx
@@ -7,6 +7,7 @@ type VoteChoice = {
   choice: string;
   votes: number;
   extra: string;
+  required_players: number;
 };
 
 export type VotingData = {
@@ -18,6 +19,7 @@ export type VotingData = {
   allow_vote_restart: boolean;
   allow_vote_mode: boolean;
   allow_extra_antags: boolean;
+  clients_connected: number;
 };
 
 export const Voting = (props, context) => {
@@ -34,6 +36,25 @@ export const Voting = (props, context) => {
 
 export const VoteWindow = (props, context) => {
   const { act, data } = useBackend<VotingData>(context);
+
+  const extra_column =
+    data.choices.filter((choice) => {
+      return choice.extra && choice.extra != '';
+    }).length > 0;
+
+  const required_players_column =
+    data.choices.filter((choice) => {
+      return choice.required_players && choice.required_players > 0;
+    }).length > 0;
+
+  if (required_players_column) {
+    data.choices.sort((a, b) => {
+      if (a.required_players < b.required_players) return -1;
+      else if (a.required_players > b.required_players) return +1;
+      else return 0;
+    });
+  }
+
   return (
     <Section
       collapsing
@@ -53,7 +74,8 @@ export const VoteWindow = (props, context) => {
           <Table.Cell textAlign="right">
             <Box bold>Votes</Box>
           </Table.Cell>
-          {data.mode === 'gamemode' && (
+          {extra_column && <Table.Cell textAlign="center"></Table.Cell>}
+          {required_players_column && (
             <Table.Cell textAlign="center">Minimum Players</Table.Cell>
           )}
         </Table.Row>
@@ -67,8 +89,19 @@ export const VoteWindow = (props, context) => {
               />
             </Table.Cell>
             <Table.Cell textAlign="center">{choice.votes}</Table.Cell>
-            {data.mode === 'gamemode' && (
+            {extra_column && (
               <Table.Cell textAlign="center">{choice.extra}</Table.Cell>
+            )}
+            {required_players_column && (
+              <Table.Cell
+                textAlign="center"
+                color={
+                  choice.required_players > data.clients_connected
+                    ? 'gray'
+                    : false
+                }>
+                {choice.required_players ? choice.required_players : ''}
+              </Table.Cell>
             )}
           </Table.Row>
         ))}

--- a/tgui/packages/tgui/interfaces/Voting.tsx
+++ b/tgui/packages/tgui/interfaces/Voting.tsx
@@ -39,7 +39,7 @@ export const VoteWindow = (props, context) => {
 
   const extra_column =
     data.choices.filter((choice) => {
-      return choice.extra && choice.extra != '';
+      return choice.extra && choice.extra !== '';
     }).length > 0;
 
   const required_players_column =
@@ -74,7 +74,7 @@ export const VoteWindow = (props, context) => {
           <Table.Cell textAlign="right">
             <Box bold>Votes</Box>
           </Table.Cell>
-          {extra_column && <Table.Cell textAlign="center"></Table.Cell>}
+          {extra_column && <Table.Cell textAlign="center" />}
           {required_players_column && (
             <Table.Cell textAlign="center">Minimum Players</Table.Cell>
           )}

--- a/tgui/packages/tgui/interfaces/Voting.tsx
+++ b/tgui/packages/tgui/interfaces/Voting.tsx
@@ -97,11 +97,13 @@ export const VoteWindow = (props, context) => {
               <Table.Cell
                 textAlign="center"
                 color={(() => {
-                  if (choice.required_players < data.total_players_ready)
+                  if (choice.required_players < data.total_players_ready) {
                     return 'white';
-                  else if (choice.required_players < data.total_players)
+                  } else if (choice.required_players < data.total_players) {
                     return 'lightgray';
-                  else return 'gray';
+                  } else {
+                    return 'gray';
+                  }
                 })()}>
                 {choice.required_players ? choice.required_players : ''}
               </Table.Cell>

--- a/tgui/packages/tgui/interfaces/Voting.tsx
+++ b/tgui/packages/tgui/interfaces/Voting.tsx
@@ -19,7 +19,8 @@ export type VotingData = {
   allow_vote_restart: boolean;
   allow_vote_mode: boolean;
   allow_extra_antags: boolean;
-  clients_connected: number;
+  total_players: number;
+  total_players_ready: number;
 };
 
 export const Voting = (props, context) => {
@@ -95,11 +96,13 @@ export const VoteWindow = (props, context) => {
             {required_players_column && (
               <Table.Cell
                 textAlign="center"
-                color={
-                  choice.required_players > data.clients_connected
-                    ? 'gray'
-                    : false
-                }>
+                color={(() => {
+                  if (choice.required_players < data.total_players_ready)
+                    return 'white';
+                  else if (choice.required_players < data.total_players)
+                    return 'lightgray';
+                  else return 'gray';
+                })()}>
                 {choice.required_players ? choice.required_players : ''}
               </Table.Cell>
             )}


### PR DESCRIPTION
![image](https://github.com/Aurorastation/Aurora.3/assets/107256943/aec19a00-bd59-4000-832d-b17acbe36289)
above image is current panel on the left side, and from my PR on the right (with 24 total players and 17 readied up)

changes:
  - tweak: "Gamemodes in the mode vote panel are sorted by required players to start."
  - tweak: "Gamemodes in the mode vote panel have grayed out required player numbers, if there are less players readied up than required."

Why?
- It is very annoying to me how secret is the most voted mode, but currently it is at the bottom of the voting panel, so you need to scroll down to actually click it, every single time.
- Only at highpop the server also actually has the pop to start modes like crossfire or towerdefense, so with my changes, they will be at the bottom, putting modes that actually have a chance to start at the top.
