### PR TITLE
Fixes Crushing People Out of Viewing Range

### DIFF
--- a/code/modules/psionics/abilities/grip.dm
+++ b/code/modules/psionics/abilities/grip.dm
@@ -29,19 +29,21 @@
 		return
 	if(world.time < next_squeeze_time)
 		return
-	if(!length(get_line(user, victim)))
+	var/rangecheck = length(get_line(user, victim))
+	if(!length(get_line(user, victim)) || rangecheck > 8)
 		to_chat(user, SPAN_WARNING("You need to have direct line of sight to your target!"))
 		return
 	. = ..()
 	if(!.)
 		return
-	user.visible_message(SPAN_WARNING("[user] squeezes [user.get_pronoun("his")] hand!"), SPAN_WARNING("You squeeze your hand to tighten the psionic force around [victim]."))
-	log_and_message_admins("[key_name(owner)] has psionically crushed [victim]", owner, get_turf(owner))
-	to_chat(victim, SPAN_DANGER(FONT_HUGE("You are crushed by an invisible force!")))
-	victim.apply_damage(20, DAMAGE_BRUTE, armor_pen = 15, def_zone = BP_HEAD)
-	victim.SetStunned(2)
-	apply_cooldown(user)
-	next_squeeze_time = world.time + 2 SECONDS
+	if (rangecheck < 9)
+		user.visible_message(SPAN_WARNING("[user] squeezes [user.get_pronoun("his")] hand!"), SPAN_WARNING("You squeeze your hand to tighten the psionic force around [victim]."))
+		log_and_message_admins("[key_name(owner)] has psionically crushed [victim]", owner, get_turf(owner))
+		to_chat(victim, SPAN_DANGER(FONT_HUGE("You are crushed by an invisible force!")))
+		victim.apply_damage(20, DAMAGE_BRUTE, armor_pen = 15, def_zone = BP_HEAD)
+		victim.SetStunned(2)
+		apply_cooldown(user)
+		next_squeeze_time = world.time + 2 SECONDS
 
 /obj/item/spell/grip/on_ranged_cast(atom/hit_atom, mob/user, bypass_psi_check)
 	if(!isliving(hit_atom))

--- a/code/modules/psionics/abilities/grip.dm
+++ b/code/modules/psionics/abilities/grip.dm
@@ -36,14 +36,13 @@
 	. = ..()
 	if(!.)
 		return
-	if (rangecheck < 9)
-		user.visible_message(SPAN_WARNING("[user] squeezes [user.get_pronoun("his")] hand!"), SPAN_WARNING("You squeeze your hand to tighten the psionic force around [victim]."))
-		log_and_message_admins("[key_name(owner)] has psionically crushed [victim]", owner, get_turf(owner))
-		to_chat(victim, SPAN_DANGER(FONT_HUGE("You are crushed by an invisible force!")))
-		victim.apply_damage(20, DAMAGE_BRUTE, armor_pen = 15, def_zone = BP_HEAD)
-		victim.SetStunned(2)
-		apply_cooldown(user)
-		next_squeeze_time = world.time + 2 SECONDS
+	user.visible_message(SPAN_WARNING("[user] squeezes [user.get_pronoun("his")] hand!"), SPAN_WARNING("You squeeze your hand to tighten the psionic force around [victim]."))
+	log_and_message_admins("[key_name(owner)] has psionically crushed [victim]", owner, get_turf(owner))
+	to_chat(victim, SPAN_DANGER(FONT_HUGE("You are crushed by an invisible force!")))
+	victim.apply_damage(20, DAMAGE_BRUTE, armor_pen = 15, def_zone = BP_HEAD)
+	victim.SetStunned(2)
+	apply_cooldown(user)
+	next_squeeze_time = world.time + 2 SECONDS
 
 /obj/item/spell/grip/on_ranged_cast(atom/hit_atom, mob/user, bypass_psi_check)
 	if(!isliving(hit_atom))

--- a/html/changelogs/CampinKiller24-psi-and-bugs.yml
+++ b/html/changelogs/CampinKiller24-psi-and-bugs.yml
@@ -1,0 +1,6 @@
+author: CampinKiller24
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed being able to crush people when they're not in viewing range."


### PR DESCRIPTION
Fixes #16993 

Range is now checked to make sure you're within range to actually see the person, so you can't just crush people from the other side of the ship anymore. You can still crush people through the wall/being above or below them, as long as you're within normal viewing range.