### PR TITLE
Adds cryptobiolin and impedrezene to the anomaly toxins trigger.

### DIFF
--- a/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_unknown.dm
@@ -207,7 +207,7 @@
 				my_effect.ToggleActivate()
 			if(secondary_effect?.trigger == TRIGGER_VOLATILE)
 				secondary_effect.ToggleActivate()
-		else if(W.reagents.has_reagent(/singleton/reagent/toxin, 1) || W.reagents.has_reagent(/singleton/reagent/toxin/cyanide, 1) || W.reagents.has_reagent(/singleton/reagent/toxin/amatoxin, 1) || W.reagents.has_reagent(/singleton/reagent/alcohol/neurotoxin, 1))
+		else if(W.reagents.has_reagent(/singleton/reagent/toxin, 1) || W.reagents.has_reagent(/singleton/reagent/toxin/cyanide, 1) || W.reagents.has_reagent(/singleton/reagent/cryptobiolin, 1) || W.reagents.has_reagent(/singleton/reagent/impedrezene, 1) || W.reagents.has_reagent(/singleton/reagent/toxin/amatoxin, 1) || W.reagents.has_reagent(/singleton/reagent/alcohol/neurotoxin, 1))
 			if(my_effect.trigger == TRIGGER_TOXIN)
 				my_effect.ToggleActivate()
 			if(secondary_effect?.trigger == TRIGGER_TOXIN)

--- a/html/changelogs/Leudoberct1-anomalytoxin.yml
+++ b/html/changelogs/Leudoberct1-anomalytoxin.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Leudoberct1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Added cryptobiolin and impedrezene to the list of anomaly toxin triggers."


### PR DESCRIPTION
As of current, the only toxins that can trigger an anomaly with the toxin trigger is the simple toxin reagent, cyanide, amatoxin, and the drink neurotoxin. Some of these are unobtainable, some are hard to get, compared to the complete ease with which all of the other chemical-based triggers can be acquired. This adds cryptobiolin and impedrezene to it, to make it a little easier.
