### PR TITLE
Allows Vaurcae (excluding Breeders) to take they/them pronouns

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -10,7 +10,7 @@
 	age_min = 1
 	age_max = 20
 	default_genders = list(NEUTER)
-	selectable_pronouns = null
+	selectable_pronouns = list(NEUTER, PLURAL)
 	economic_modifier = 2
 	language = LANGUAGE_VAURCA
 	primitive_form = SPECIES_MONKEY_VAURCA

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca_subspecies.dm
@@ -80,6 +80,7 @@
 
 	age_max = 1000
 	default_genders = list(FEMALE)
+	selectable_pronouns = null
 	economic_modifier = 3
 
 	speech_sounds = list('sound/voice/hiss1.ogg','sound/voice/hiss2.ogg','sound/voice/hiss3.ogg','sound/voice/hiss4.ogg')

--- a/html/changelogs/SimpleMaroon-theythembugzzz.yml
+++ b/html/changelogs/SimpleMaroon-theythembugzzz.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: SimpleMaroon
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Vaurcae, exclusing Breeders, can select they/them pronouns."


### PR DESCRIPTION
Title.

For some reasoning on this, I don't think Vaurcae have ever been barred from using whatever pronouns they desire, much in a similar vein to positronics, at least non-mechanically. Enabling plural pronouns for all of the non-Breeder subspecies would make perfect sense for Akaix, while Viax can continue to use it/its.

**Will almost definitely require lore maintainer approval before moving forward.**