### PR TITLE
Refactor and dmdoc ss material

### DIFF
--- a/code/controllers/subsystems/materials.dm
+++ b/code/controllers/subsystems/materials.dm
@@ -18,6 +18,9 @@ var/datum/controller/subsystem/materials/SSmaterials
 	create_material_lists()
 	. = ..()
 
+/**
+ * Initialize the lists of materials, if they are not initialized already
+ */
 /datum/controller/subsystem/materials/proc/create_material_lists()
 	if(LAZYLEN(materials))
 		return
@@ -31,14 +34,24 @@ var/datum/controller/subsystem/materials/SSmaterials
 			materials += material
 			materials_by_name[lowertext(material.name)] = material
 
-/datum/controller/subsystem/materials/proc/get_material_by_name(var/M)
+/**
+ * Returns a `/material` based on its name, or null if the material does not exists
+ *
+ * * material_name - A string, lowercase, representing the name of the material
+ */
+/datum/controller/subsystem/materials/proc/get_material_by_name(var/material_name)
 	if(!materials_by_name)
 		create_material_lists()
-	. = materials_by_name[M]
+	. = materials_by_name[material_name]
 	if(!.)
-		LOG_DEBUG("Material not found: [M].")
+		stack_trace("SSmaterials received a request for a material that was not found: [material_name].")
 
-/datum/controller/subsystem/materials/proc/material_display_name(var/M)
-	var/material/material = get_material_by_name(M)
+/**
+ * Returns a `/material` based on its display name
+ *
+ * * material_name - A string, lowercase, representing the display name of the material
+ */
+/datum/controller/subsystem/materials/proc/material_display_name(var/material_name)
+	var/material/material = get_material_by_name(material_name)
 	if(material)
 		return material.display_name

--- a/html/changelogs/FluffyGhost-refactor_and_dmdoc_SSMaterial.yml
+++ b/html/changelogs/FluffyGhost-refactor_and_dmdoc_SSMaterial.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - refactor: "SSMaterials now stack_trace on receiving a request for a material that was not found."
+  - refactor: "Added some dmdocs and some variables names expansion to SSMaterials."


### PR DESCRIPTION
SSMaterials now stack_trace on receiving a request for a material that was not found.
Added some dmdocs and some variables names expansion to SSMaterials.

Atomized from #17023 
Depends on #17045