### PR TITLE
SSMob correctly reevaluate processing list on resumed fire

### DIFF
--- a/code/controllers/subsystems/mob.dm
+++ b/code/controllers/subsystems/mob.dm
@@ -71,7 +71,11 @@
 		src.currentrun = mob_list.Copy()
 		src.currentrun += processing.Copy()
 
-	var/list/currentrun = src.currentrun
+	//Mobs might have been removed between the previous and a resumed fire, yet we want to mantain the priority to process
+	//the mobs that we didn't in the previous run, hence we have to pay the price of a list subtraction
+	//with &= we say to remove any item in the first list that is not in the second one
+	//of course, if we haven't resumed, this comparison would be useless, hence we skip it
+	var/list/currentrun = resumed ? (src.currentrun &= mob_list) : src.currentrun
 
 	while (currentrun.len)
 		var/datum/thing = currentrun[currentrun.len]

--- a/code/controllers/subsystems/mob.dm
+++ b/code/controllers/subsystems/mob.dm
@@ -71,7 +71,7 @@
 		src.currentrun = mob_list.Copy()
 		src.currentrun += processing.Copy()
 
-	//Mobs might have been removed between the previous and a resumed fire, yet we want to mantain the priority to process
+	//Mobs might have been removed between the previous and a resumed fire, yet we want to maintain the priority to process
 	//the mobs that we didn't in the previous run, hence we have to pay the price of a list subtraction
 	//with &= we say to remove any item in the first list that is not in the second one
 	//of course, if we haven't resumed, this comparison would be useless, hence we skip it

--- a/html/changelogs/FluffyGhost-mob_correctly_reevaluate_on_resume_fire.yml
+++ b/html/changelogs/FluffyGhost-mob_correctly_reevaluate_on_resume_fire.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed the mob subsystem, that could try to run on removed mobs on a resumed fire."


### PR DESCRIPTION
Fixed the mob subsystem, that could try to run on removed mobs on a resumed fire.

Atomized from #17023 