### PR TITLE
Adds alt-click removal to chemistry machines

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -54,7 +54,7 @@
 		if(Adjacent(usr))
 			usr.put_in_hands(beaker, TRUE)
 		else
-			beaker:loc = get_turf(src)
+			beaker.loc = get_turf(src)
 		beaker = null
 		reagents.clear_reagents()
 		icon_state = "mixer0"

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -51,7 +51,7 @@
 
 /obj/machinery/chem_master/proc/eject()
 	if(beaker && usr)
-		if(Adjacent(usr))
+		if(use_check_and_message(usr))
 			usr.put_in_hands(beaker, TRUE)
 		else
 			beaker.loc = get_turf(src)
@@ -61,7 +61,7 @@
 		return TRUE
 
 /obj/machinery/chem_master/AltClick()
-	if(usr.Adjacent(src))
+	if(use_check_and_message(usr))
 		eject()
 
 /obj/machinery/chem_master/attackby(var/obj/item/B, mob/user)

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -49,6 +49,19 @@
 				qdel(src)
 				return
 
+/obj/machinery/chem_master/proc/eject()
+	if(beaker && usr)
+		if(Adjacent(usr))
+			usr.put_in_hands(beaker)
+		else
+			beaker:loc = get_turf(src)
+		beaker = null
+		reagents.clear_reagents()
+		icon_state = "mixer0"
+		return TRUE
+
+/obj/machinery/chem_master/AltClick()
+	eject()
 
 /obj/machinery/chem_master/attackby(var/obj/item/B, mob/user)
 
@@ -215,16 +228,8 @@
 			return TRUE
 
 		else if (action == "eject")
-			if(beaker)
-				if(Adjacent(usr))
-					usr.put_in_hands(beaker)
-				else
-					beaker:loc = get_turf(src)
-				beaker = null
-				reagents.clear_reagents()
-				icon_state = "mixer0"
-			CHEMMASTER_BOTTLE_SOUND
-			return TRUE
+			if(eject())
+				return TRUE
 
 	if (action == "toggle")
 		mode = !mode

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -52,7 +52,7 @@
 /obj/machinery/chem_master/proc/eject()
 	if(beaker && usr)
 		if(Adjacent(usr))
-			usr.put_in_hands(beaker)
+			usr.put_in_hands(beaker, TRUE)
 		else
 			beaker:loc = get_turf(src)
 		beaker = null
@@ -61,7 +61,8 @@
 		return TRUE
 
 /obj/machinery/chem_master/AltClick()
-	eject()
+	if(usr.Adjacent(src))
+		eject()
 
 /obj/machinery/chem_master/attackby(var/obj/item/B, mob/user)
 

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -82,7 +82,10 @@
 /obj/machinery/chemical_dispenser/proc/eject()
 	if(container && usr)
 		var/obj/item/reagent_containers/B = container
-		usr.put_in_hands(B, TRUE)
+		if(use_check_and_message(usr))
+			usr.put_in_hands(B, TRUE)
+		else
+			B.loc = get_turf(src)
 		container = null
 		if(icon_state_active)
 			icon_state = initial(icon_state)

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -79,6 +79,18 @@
 	cartridges -= label
 	SStgui.update_uis(src)
 
+/obj/machinery/chemical_dispenser/proc/try_eject()
+	if(container && usr)
+		var/obj/item/reagent_containers/B = container
+		usr.put_in_hands(B)
+		container = null
+		if(icon_state_active)
+			icon_state = initial(icon_state)
+		return TRUE
+
+/obj/machinery/chemical_dispenser/AltClick(mob/user)
+	try_eject()
+
 /obj/machinery/chemical_dispenser/attackby(obj/item/W, mob/user)
 	if(W.iswrench())
 		to_chat(user, SPAN_NOTICE("You begin to [anchored ? "un" : ""]fasten [src]."))
@@ -180,12 +192,7 @@
 				. = TRUE
 
 		if("ejectBeaker")
-			if(container)
-				var/obj/item/reagent_containers/B = container
-				usr.put_in_hands(B)
-				container = null
-				if(icon_state_active)
-					icon_state = initial(icon_state)
+			if(try_eject())
 				. = TRUE
 
 	add_fingerprint(usr)

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -79,17 +79,18 @@
 	cartridges -= label
 	SStgui.update_uis(src)
 
-/obj/machinery/chemical_dispenser/proc/try_eject()
+/obj/machinery/chemical_dispenser/proc/eject()
 	if(container && usr)
 		var/obj/item/reagent_containers/B = container
-		usr.put_in_hands(B)
+		usr.put_in_hands(B, TRUE)
 		container = null
 		if(icon_state_active)
 			icon_state = initial(icon_state)
 		return TRUE
 
 /obj/machinery/chemical_dispenser/AltClick(mob/user)
-	try_eject()
+	if(usr.Adjacent(src))
+		eject()
 
 /obj/machinery/chemical_dispenser/attackby(obj/item/W, mob/user)
 	if(W.iswrench())
@@ -192,7 +193,7 @@
 				. = TRUE
 
 		if("ejectBeaker")
-			if(try_eject())
+			if(eject())
 				. = TRUE
 
 	add_fingerprint(usr)

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -89,7 +89,7 @@
 		return TRUE
 
 /obj/machinery/chemical_dispenser/AltClick(mob/user)
-	if(usr.Adjacent(src))
+	if(use_check_and_message(usr))
 		eject()
 
 /obj/machinery/chemical_dispenser/attackby(obj/item/W, mob/user)

--- a/html/changelogs/nauticall-altclickdispenser.yml
+++ b/html/changelogs/nauticall-altclickdispenser.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: nauticall
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Containers can now be ejected from chem dispensers, chem masters, drink fountains, etc. using alt-click."


### PR DESCRIPTION
What it says on the tin. Machines that handle or dispense reagents, like chemicals or drinks, such as ChemMasters, chem dispensers, soda/booze/coffee machines, etc, can now have their containers ejected from the machines using a simple **alt+click**. No more button-hunting on the GUI if you wanna be nice and :sparkles:efficient:sparkles:.
