### PR TITLE
Materials stacktrace on deletion

### DIFF
--- a/code/modules/item_worth/materials.dm
+++ b/code/modules/item_worth/materials.dm
@@ -1,6 +1,11 @@
 /material
 	var/value = 1
 
+/material/Destroy(force)
+	stack_trace("Some genius is trying to delete a /material ...")
+	. = ..()
+	return QDEL_HINT_LETMELIVE //Materials cannot be deleted, as you cannot poof the concept out of existence
+
 /material/uranium
 	value = 100
 

--- a/html/changelogs/FluffyGhost-materials_stacktrace_on_deletion.yml
+++ b/html/changelogs/FluffyGhost-materials_stacktrace_on_deletion.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed material Delete(), now dumps a stack trace and returns the hint to not be harddel'd."

--- a/html/changelogs/FluffyGhost-materials_stacktrace_on_deletion.yml
+++ b/html/changelogs/FluffyGhost-materials_stacktrace_on_deletion.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "Fixed material Delete(), now dumps a stack trace and returns the hint to not be harddel'd."
+  - bugfix: "Fixed material Destroy(), now dumps a stack trace and returns the hint to not be harddel'd."


### PR DESCRIPTION
Fixed material Destroy(), now dumps a stack trace and returns the hint to not be harddel'd.

Atomized from #17023 