### PR TITLE
Ut create destroy tempfix

### DIFF
--- a/code/unit_tests/create_and_destroy.dm
+++ b/code/unit_tests/create_and_destroy.dm
@@ -8,7 +8,7 @@
 	//We'll spawn everything here
 	var/turf/spawn_at = locate()
 
-	/**
+	/*
 	 * EXCLUSIONS FROM THE TEST
 	 *
 	 * This is to be used when there's no other possible way to make this test work, to exclude a specific path from being scrutinized
@@ -97,6 +97,9 @@
 		/obj/screen/click_catcher,
 		/obj/screen/new_player/selection/polls,
 
+		//Temporary exclusion while matt fixes it
+		/obj/item/projectile/beam/psi_lightning/wide,
+
 	)
 
 	// Paths and all the subpaths excluded
@@ -159,7 +162,7 @@
 	// do_spread sleeps and tries to addtimer after the src is qdeleted
 	ignore += typesof(/obj/effect/plant)
 
-	/**
+	/*
 	 * END EXCLUSIONS OF THE TEST
 	 */
 
@@ -223,9 +226,11 @@
 			garbage_queue_processed = TRUE
 			break
 
+		#if !defined(REFERENCE_TRACKING)
 		if(world.time > start_time + time_needed + 30 MINUTES) //If this gets us gitbanned I'm going to laugh so hard
 			result = TEST_FAIL("Something has gone horribly wrong, the garbage queue has been processing for well over 30 minutes. What the hell did you do")
 			break
+		#endif
 
 		//Immediately fire the gc right after
 		SSgarbage.next_fire = 1

--- a/html/changelogs/FluffyGhost-ut_create_destroy_tempfix.yml
+++ b/html/changelogs/FluffyGhost-ut_create_destroy_tempfix.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - backend: "Added a temporary exclusion for the psi_lightning/wide psionic projectile that is failing the UT, while matt fix it."
+  - backend: "Added a define check, if we're running with REFERENCE_TRACKING on the CI, do not abort the test after 30 minutes."

--- a/html/changelogs/FluffyGhost-ut_create_destroy_tempfix.yml
+++ b/html/changelogs/FluffyGhost-ut_create_destroy_tempfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Added a temporary exclusion for the psi_lightning/wide psionic projectile that is failing the UT, while matt fix it."


### PR DESCRIPTION
Added a temporary exclusion for the psi_lightning/wide psionic projectile that is failing the UT, while matt fix it.
Added a define check, if we're running with REFERENCE_TRACKING on the CI, do not abort the test after 30 minutes.

Basically what happens is, it causes an infinite loop, which prevents the unit test from running fully, this is not even catched so it appears as if everything is running fine, unless you run the CI in VSC with the exceptions on, then you see the error.

Atomized from #17023 