### PR TITLE
Body scanner bugfixes and alt clicking

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -366,7 +366,7 @@
 	toggle_pump()
 
 /obj/machinery/sleeper/AltClick()
-	if(usr.Adjacent(src))
+	if(usr.use_check_and_message(src))
 		go_out()
 
 /obj/machinery/sleeper/proc/remove_beaker()

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -365,6 +365,10 @@
 	toggle_filter()
 	toggle_pump()
 
+/obj/machinery/sleeper/AltClick()
+	if(usr.Adjacent(src))
+		go_out()
+
 /obj/machinery/sleeper/proc/remove_beaker()
 	if(beaker)
 		beaker.forceMove(get_turf(src))

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -366,7 +366,7 @@
 	toggle_pump()
 
 /obj/machinery/sleeper/AltClick()
-	if(usr.use_check_and_message(src))
+	if(use_check_and_message(usr))
 		go_out()
 
 /obj/machinery/sleeper/proc/remove_beaker()

--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -525,7 +525,7 @@
 				else
 					unk += 1
 			if (unk)
-				wounds += "has an abnormal mass present"
+				wounds += "has unknown object(s) present"
 			var/friends = length(organic)
 			if(friends)
 				wounds += friends > 1 ? "multiple abnormal organic bodies present" : "abnormal organic body present"
@@ -675,7 +675,7 @@
 	dat += text("[]\tRadiation Level %: []</font><br>", ("<font color='[occ["rads"] < 10  ? "blue" : "red"]'>"), occ["rads"])
 	dat += text("Genetic Tissue Damage: []<br>", occ["cloneloss"])
 	dat += text("Paralysis Summary %: [] ([] seconds left!)<br>", occ["paralysis"], round(occ["paralysis"] / 4))
-	dat += text("Body Temperature: [occ["bodytemp"]]&deg;C ([occ["bodytemp"] + T0C ]K)<br><HR>")
+	dat += text("Body Temperature: [occ["bodytemp"]]&deg;C<br><HR>")
 
 	if(occ["borer_present"])
 		dat += "Large growth detected in frontal lobe, possibly cancerous. Surgical removal is recommended.<br>"
@@ -701,9 +701,9 @@
 		dat += "<tr>"
 
 		if(e.status & ORGAN_ARTERY_CUT)
-			wounds += "arterial bleeding"
+			wounds += "severed [e.artery_name]"
 		if(e.tendon_status() & TENDON_CUT)
-			wounds += "severed tendon"
+			wounds += "severed [e.tendon.name]"
 		if(istype(e, /obj/item/organ/external/chest) && occ["lung_ruptured"])
 			wounds += "lung ruptured"
 		if(e.status & ORGAN_SPLINTED)
@@ -727,22 +727,20 @@
 			wounds += infection
 
 		if (e.implants.len)
-			var/unknown_body = 0
+			var/unk = 0
 			var/list/organic = list()
-			var/imp
-			for(var/I in e.implants)
-				if(is_type_in_list(I,known_implants))
-					imp += "[I] implanted:"
+			for (var/atom/movable/I in e.implants)
+				if(is_type_in_list(I, known_implants))
+					wounds += "\a [I.name] implanted:"
 				else if(istype(I, /obj/effect/spider))
 					organic += I
 				else
-					unknown_body++
-			if(unknown_body)
-				imp += "Unknown body present:"
+					unk += 1
+			if (unk)
+				wounds += "has unknown object(s) present:"
 			var/friends = length(organic)
 			if(friends)
-				imp += friends > 1 ? "multiple abnormal organic bodies present" : "abnormal organic body present"
-				wounds += imp
+				wounds += friends > 1 ? "multiple abnormal organic bodies present" : "abnormal organic body present"
 		if(!length(wounds))
 			wounds += "none"
 		if(!e.is_stump())
@@ -761,7 +759,7 @@
 
 		var/infection = get_infection_level(i.germ_level)
 		if(infection == "")
-			infection = "No Infection."
+			infection = "No infection."
 		else
 			infection = "[infection] infection."
 		if(i.rejecting)

--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -89,7 +89,7 @@
 	return
 
 /obj/machinery/bodyscanner/AltClick()
-	if(usr.Adjacent(src))
+	if(usr.use_check_and_message(src))
 		eject()
 
 /obj/machinery/bodyscanner/verb/move_inside()

--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -89,7 +89,7 @@
 	return
 
 /obj/machinery/bodyscanner/AltClick()
-	if(usr.use_check_and_message(src))
+	if(use_check_and_message(usr))
 		eject()
 
 /obj/machinery/bodyscanner/verb/move_inside()

--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -529,7 +529,7 @@
 				else
 					unk += 1
 			if (unk)
-				wounds += "has unknown object(s) present"
+				wounds += "has unknown objects present"
 			var/friends = length(organic)
 			if(friends)
 				wounds += friends > 1 ? "multiple abnormal organic bodies present" : "abnormal organic body present"
@@ -733,15 +733,15 @@
 		if (e.implants.len)
 			var/unk = 0
 			var/list/organic = list()
-			for (var/atom/movable/I in e.implants)
+			for(var/atom/movable/I in e.implants)
 				if(is_type_in_list(I, known_implants))
 					wounds += "\a [I.name] implanted:"
 				else if(istype(I, /obj/effect/spider))
 					organic += I
 				else
 					unk += 1
-			if (unk)
-				wounds += "has unknown object(s) present:"
+			if(unk)
+				wounds += "has unknown objects present:"
 			var/friends = length(organic)
 			if(friends)
 				wounds += friends > 1 ? "multiple abnormal organic bodies present" : "abnormal organic body present"

--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -675,7 +675,7 @@
 	dat += text("[]\tRadiation Level %: []</font><br>", ("<font color='[occ["rads"] < 10  ? "blue" : "red"]'>"), occ["rads"])
 	dat += text("Genetic Tissue Damage: []<br>", occ["cloneloss"])
 	dat += text("Paralysis Summary %: [] ([] seconds left!)<br>", occ["paralysis"], round(occ["paralysis"] / 4))
-	dat += text("Body Temperature: [occ["bodytemp"] - T0C]&deg;C ([occ["bodytemp"]]&deg;K)<br><HR>")
+	dat += text("Body Temperature: [occ["bodytemp"]]&deg;C ([occ["bodytemp"] + T0C ]K)<br><HR>")
 
 	if(occ["borer_present"])
 		dat += "Large growth detected in frontal lobe, possibly cancerous. Surgical removal is recommended.<br>"

--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -88,6 +88,10 @@
 	add_fingerprint(usr)
 	return
 
+/obj/machinery/bodyscanner/AltClick()
+	if(usr.Adjacent(src))
+		eject()
+
 /obj/machinery/bodyscanner/verb/move_inside()
 	set src in oview(1)
 	set category = "Object"

--- a/html/changelogs/nauticall-bodyscannertemp.yml
+++ b/html/changelogs/nauticall-bodyscannertemp.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: nauticall
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed incorrect temperature readout, and shrapnel not being present, when printing scans from body scanner consoles."
+  - tweak: "Tweaked some wording in the body scanner printouts to be more consistent with the GUI version."

--- a/html/changelogs/nauticall-bodyscannertemp.yml
+++ b/html/changelogs/nauticall-bodyscannertemp.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "Fixed incorrect temperature readout, and shrapnel not being present, when printing scans from body scanner consoles."
+  - bugfix: "Fixed incorrect temperature readout, and implants/shrapnel not being displayed, when printing scans from body scanner consoles."
   - tweak: "Tweaked some wording in the body scanner printouts to be more consistent with the GUI version."

--- a/html/changelogs/nauticall-bodyscannertemp.yml
+++ b/html/changelogs/nauticall-bodyscannertemp.yml
@@ -40,3 +40,4 @@ delete-after: True
 changes:
   - bugfix: "Fixed incorrect temperature readout, and implants/shrapnel not being displayed, when printing scans from body scanner consoles."
   - tweak: "Tweaked some wording in the body scanner printouts to be more consistent with the GUI version."
+  - tweak: "Added alt-click eject functionality to the body scanner and to the sleeper."


### PR DESCRIPTION
Fixes two bugs with body scanner print outs:
1. Body scanners displaying body temperature wrong (and showing something like -240 degrees C). Doesn't show Kelvin anymore because the Kelvin readout is useless and can confuse people.
2. Body scanners not showing shrapnel (or _any_ implant for that matter) on the printouts. Turns out the code saves all the implants/shrapnel to a list and then just... never printed out that list. Weird.

In addition, also tweaks some wording so that the paper printouts from the body scanners will mimic the GUI scans more accurately.

Also added alt-click eject functionality to the body scanner and sleeper, because we're on this path so we might as well double down.