### PR TITLE
Removes changeling from secret rotation

### DIFF
--- a/code/game/antagonist/station/changeling/changeling.dm
+++ b/code/game/antagonist/station/changeling/changeling.dm
@@ -20,7 +20,7 @@
 
 	welcome_text = "Use say \"#g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you perform a Full DNA Extraction them."
 	antag_sound = 'sound/effects/antag_notice/ling_alert.ogg'
-	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
+	flags = ANTAG_SUSPICIOUS
 	antaghud_indicator = "hudchangeling"
 
 	faction = "Changeling"

--- a/html/changelogs/example - Copy.yml
+++ b/html/changelogs/example - Copy.yml
@@ -1,0 +1,6 @@
+author: kyres1
+
+delete-after: True
+
+changes:
+  - rscdel: "Removed the Changeling gamemode from secret rotation."


### PR DESCRIPTION
Feedback thread: https://forums.aurorastation.org/topic/18892-feedback-removes-changeling-from-secret-rotation
\-
What the title says. 

Continuation of https://github.com/Aurorastation/Aurora.3/pull/7688 that, instead of removing the file from defines, tries to remove the flag that lets it spawn in secret to begin with. If I'm reading the code comments correctly, removing these two flags will just prevent it from rolling in secret to begin with, while remaining a votable gamemode, if by some unholy and extremely unlikely chance some masochistic individuals want to endure this in the year 2023.
\-
_edited by SleepyGemmy @ 2023-08-14: added the feedback thread link._
