### PR TITLE
Reduces the cost of the Frontier Cowboys gear loadout crate

### DIFF
--- a/code/datums/uplink/gear loadout.dm
+++ b/code/datums/uplink/gear loadout.dm
@@ -58,13 +58,13 @@
 
 /datum/uplink_item/item/gear_loadout/cowboys
 	name = "Frontier Cowboys (Group)"
-	path = /obj/structure/closet/crate/secure/gear_loadout/ram_ranch
-	telecrystal_cost = 35
+	path = /obj/structure/closet/crate/secure/gear_loadout/frontier_cowboys
+	telecrystal_cost = 15
 
 /datum/uplink_item/item/gear_loadout/cowboy_single
 	name = "Frontier Cowboy (Single)"
-	path = /obj/structure/closet/crate/secure/gear_loadout/ram_ranch/single
-	telecrystal_cost = 10
+	path = /obj/structure/closet/crate/secure/gear_loadout/frontier_cowboys/single
+	telecrystal_cost = 5
 
 /datum/uplink_item/item/gear_loadout/kosmostrelki
 	name = "Kosmostrelki Assets (Group)"

--- a/code/game/objects/structures/crates_lockers/crates/gear_loadout.dm
+++ b/code/game/objects/structures/crates_lockers/crates/gear_loadout.dm
@@ -228,10 +228,10 @@
 		new /obj/item/clothing/suit/space/syndicate/black/orange(src)
 		new /obj/item/tank/emergency_oxygen/double(src)
 
-/obj/structure/closet/crate/secure/gear_loadout/ram_ranch
+/obj/structure/closet/crate/secure/gear_loadout/frontier_cowboys
 	req_access = list()
 
-/obj/structure/closet/crate/secure/gear_loadout/ram_ranch/fill()
+/obj/structure/closet/crate/secure/gear_loadout/frontier_cowboys/fill()
 	for(var/i in 1 to 6)
 		var/obj/item/clothing/under/shorts/khaki/pants = new(src)
 		var/obj/item/clothing/accessory/dressshirt/rolled/shirt = new(src)
@@ -253,7 +253,7 @@
 		new /obj/item/melee/whip(src)
 		new /obj/item/gun/projectile/revolver/detective(src)
 
-/obj/structure/closet/crate/secure/gear_loadout/ram_ranch/single/fill()
+/obj/structure/closet/crate/secure/gear_loadout/frontier_cowboys/single/fill()
 	var/obj/item/clothing/under/shorts/khaki/pants = new(src)
 	var/obj/item/clothing/accessory/dressshirt/rolled/shirt = new(src)
 	var/obj/item/clothing/accessory/chaps/chaps = new(src)

--- a/html/changelogs/GeneralCamo - Cowboy Buff.yml
+++ b/html/changelogs/GeneralCamo - Cowboy Buff.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Reduced the cost of the Frontier Cowboys gear crate from 10 to 5 (Group from 35 to 15)"


### PR DESCRIPTION
[From the original PR](https://github.com/Aurorastation/Aurora.3/pull/7971): 

> [The crate is] cheaper because it isn't EVA capable, nor has any armour.

However, this was removed when the crate cost was rebalanced. There is no reason for this however as it still lacks any form of armor, and it isn't EVA capable. This brings back the intended points cost of the crate.