### PR TITLE
Laser rifle nerfs and laser armour buffs.

### DIFF
--- a/code/__defines/armor.dm
+++ b/code/__defines/armor.dm
@@ -18,9 +18,9 @@
 #define  ARMOR_LASER_SMALL			25
 #define  ARMOR_LASER_KEVLAR			30
 #define  ARMOR_LASER_PISTOL			35
-#define  ARMOR_LASER_MEDIUM			40
-#define  ARMOR_LASER_RIFLE			45 //Used by security ablatives. Drops midlasers down to 13.5 damage.
-#define  ARMOR_LASER_MAJOR			55
+#define  ARMOR_LASER_MEDIUM			40 // Drops midlasers down to 22.5 damage.
+#define  ARMOR_LASER_RIFLE			45 // Drops midlasers down to 18 damage.
+#define  ARMOR_LASER_MAJOR			55 // Drops midlasers down to 9 damage.
 #define  ARMOR_LASER_AP				70
 #define  ARMOR_LASER_HEAVY			100
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -178,7 +178,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_SMALL,
 		bullet = ARMOR_BALLISTIC_MINOR,
-		laser = ARMOR_LASER_RIFLE,
+		laser = ARMOR_LASER_MAJOR,
 		energy = ARMOR_ENERGY_RESISTANT
 	)
 	siemens_coefficient = 0

--- a/code/modules/clothing/suits/modular_armor.dm
+++ b/code/modules/clothing/suits/modular_armor.dm
@@ -166,7 +166,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_MINOR,
 		bullet = ARMOR_BALLISTIC_MINOR,
-		laser = ARMOR_LASER_RIFLE,
+		laser = ARMOR_LASER_MAJOR,
 		energy = ARMOR_ENERGY_RESISTANT
 	)
 	slowdown = 1
@@ -180,7 +180,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
 		bullet = ARMOR_BALLISTIC_MAJOR,
-		laser = ARMOR_LASER_MEDIUM,
+		laser = ARMOR_LASER_RIFLE,
 		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_PADDED,
 	)
@@ -194,7 +194,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
 		bullet = ARMOR_BALLISTIC_MAJOR,
-		laser = ARMOR_LASER_MEDIUM,
+		laser = ARMOR_LASER_RIFLE,
 		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_PADDED,
 	)

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -39,7 +39,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_MINOR,
 		bullet = ARMOR_BALLISTIC_MINOR,
-		laser = ARMOR_LASER_RIFLE,
+		laser = ARMOR_LASER_MAJOR,
 		energy = ARMOR_ENERGY_RESISTANT
 	)
 	siemens_coefficient = 0
@@ -153,7 +153,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_MINOR,
 		bullet = ARMOR_BALLISTIC_MINOR,
-		laser = ARMOR_LASER_RIFLE,
+		laser = ARMOR_LASER_MAJOR,
 		energy = ARMOR_ENERGY_RESISTANT
 	)
 	siemens_coefficient = 0

--- a/code/modules/projectiles/guns/energy/rifle.dm
+++ b/code/modules/projectiles/guns/energy/rifle.dm
@@ -21,7 +21,7 @@
 	turret_is_lethal = 0
 	has_item_ratio = FALSE
 
-	fire_delay_wielded = 4
+	fire_delay_wielded = 5
 	accuracy_wielded = 2
 	sel_mode = 1
 
@@ -47,8 +47,7 @@
 	has_item_ratio = FALSE // the back and suit slots have ratio sprites but the in-hands dont
 	fire_sound = 'sound/weapons/laser1.ogg'
 	max_shots = 15
-	fire_delay = 5
-	burst_delay = 5
+	fire_delay = 6
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 2)
 	projectile_type = /obj/item/projectile/beam/midlaser
 	secondary_projectile_type = null

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -45,7 +45,7 @@
 
 /obj/item/projectile/beam/midlaser
 	damage = 30
-	armor_penetration = 25
+	armor_penetration = 20
 
 /obj/item/projectile/beam/midlaser/skrell
 	armor_penetration = 0

--- a/html/changelogs/mattatlas-garuda.yml
+++ b/html/changelogs/mattatlas-garuda.yml
@@ -41,3 +41,4 @@ changes:
   - balance: "Midlasers (the lasers shot by the laser rifle) now have 5 less armor piercing."
   - balance: "Buffed most laser-resistant armour. Midlasers will now do 18 damage to heavy armour instead of the full 30."
   - balance: "Nerfed the laser rifle firing speed a bit."
+  - balance: "Buffed ablatives' laser protection."

--- a/html/changelogs/mattatlas-garuda.yml
+++ b/html/changelogs/mattatlas-garuda.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Midlasers (the lasers shot by the laser rifle) now have 5 less armor piercing."
+  - balance: "Buffed most laser-resistant armour. Midlasers will now do 18 damage to heavy armour instead of the full 30."
+  - balance: "Nerfed the laser rifle firing speed a bit."


### PR DESCRIPTION
  - balance: "Midlasers (the lasers shot by the laser rifle) now have 5 less armor piercing."
  - balance: "Buffed most laser-resistant armour. Midlasers will now do 18 damage to heavy armour instead of the full 30."
  - balance: "Nerfed the laser rifle firing speed a bit."
  - balance: "Buffed ablatives' laser protection."
