### PR TITLE
Changelings no longer are required to absorb people to gain powers

### DIFF
--- a/code/game/gamemodes/changeling/helpers/_framework.dm
+++ b/code/game/gamemodes/changeling/helpers/_framework.dm
@@ -14,11 +14,12 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	var/changelingID = "Changeling"
 	var/geneticdamage = 0
 	var/isabsorbing = 0
-	var/geneticpoints = 5
+	var/geneticpoints = 10
 	var/list/purchasedpowers = list()
 	var/mimicing = ""
 	var/mimiced_accent = "Biesellite"
 	var/justate
+	var/can_respec = FALSE
 
 /datum/changeling/New(var/gender=FEMALE)
 	..()
@@ -99,17 +100,46 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 
 	return TRUE
 
-//removes our changeling verbs
-/mob/proc/remove_changeling_powers()
+/**
+ * Resets a changeling to the point where they were when they first became a changeling.
+ */
+/mob/proc/changeling_respec()
+	var/datum/changeling/changeling = null
+	if(mind)
+		changeling = mind.antag_datums[MODE_CHANGELING]
+	if(!changeling)
+		return
+	remove_changeling_powers(TRUE)
+	changeling.prepared_sting = null
+	changeling.absorbedcount = initial(changeling.absorbedcount)
+	changeling.chem_charges = initial(changeling.chem_charges)
+	changeling.sting_range = initial(changeling.sting_range)
+	changeling.chem_recharge_rate = initial(changeling.chem_recharge_rate)
+	changeling.chem_storage = initial(changeling.chem_storage)
+	changeling.chem_charges = min(changeling.chem_charges, changeling.chem_storage)
+	changeling.geneticpoints = initial(changeling.geneticpoints)
+	changeling.mimicing = null
+	changeling.mimiced_accent = initial(changeling.mimiced_accent)
+
+/**
+ * Removes a changeling's abilities
+ */
+/mob/proc/remove_changeling_powers(reset_powers = FALSE)
 	var/datum/changeling/changeling
 	if(mind)
 		changeling = mind.antag_datums[MODE_CHANGELING]
 	if(!changeling)
 		return
 	for(var/datum/power/changeling/P in changeling.purchasedpowers)
-		if(P.isVerb)
+		if(P.isVerb && !reset_powers)
 			remove_verb(src, P.verbpath)
-	remove_language(LANGUAGE_CHANGELING)
+		else if(reset_powers && (P.genomecost != 0))
+			if(P.isVerb)
+				remove_verb(src, P.verbpath)
+			changeling.purchasedpowers -= P
+			qdel(P)
+	if(!reset_powers)
+		remove_language(LANGUAGE_CHANGELING)
 
 
 //Helper proc. Does all the checks and stuff for us to avoid copypasta
@@ -147,6 +177,24 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	add_language(LANGUAGE_CHANGELING)
 	return
 
+/mob/proc/changeling_try_respec()
+	set category = "Changeling"
+	set name = "Re-evolve"
+
+	var/datum/changeling/changeling
+	if(mind)
+		changeling = mind.antag_datums[MODE_CHANGELING]
+	if(!changeling)
+		return FALSE
+	if(changeling.can_respec)
+		to_chat(src, SPAN_NOTICE("We have removed our evolutions in this form, and are now ready to re-adapt."))
+		changeling_respec()
+		changeling.can_respec = FALSE
+		return TRUE
+	else
+		to_chat(src, SPAN_WARNING("You lack the power to re-adapt your evolutions!"))
+		return FALSE
+
 //DNA related datums
 
 /datum/absorbed_dna
@@ -169,11 +217,15 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 /mob/proc/sting_can_reach(mob/M as mob, sting_range = 1)
 	if(M.loc == src.loc)
 		return TRUE //target and source are in the same thing
+	var/target_distance = get_dist(src, M)
+	if(target_distance < sting_range)
+		to_chat(src, SPAN_WARNING("\The [M] is too far for our sting!"))
+		return FALSE //Too far, don't bother pathfinding
 	if(!isturf(src.loc) || !isturf(M.loc))
-		to_chat(src, "<span class='warning'>We cannot reach \the [M] with a sting!</span>")
+		to_chat(src, SPAN_WARNING("We cannot reach \the [M] with a sting!"))
 		return FALSE //One is inside, the other is outside something.
 	// Maximum queued turfs set to 25; I don't *think* anything raises sting_range above 2, but if it does the 25 may need raising
 	if(!AStar(src.loc, M.loc, /turf/proc/AdjacentTurfs, /turf/proc/Distance, max_nodes=25, max_node_depth=sting_range)) //If we can't find a path, fail
-		to_chat(src, "<span class='warning'>We cannot find a path to sting \the [M] by!</span>")
+		to_chat(src, SPAN_WARNING("We cannot find a path to sting \the [M] by!"))
 		return FALSE
 	return TRUE

--- a/code/game/gamemodes/changeling/helpers/_store.dm
+++ b/code/game/gamemodes/changeling/helpers/_store.dm
@@ -12,11 +12,18 @@ var/list/datum/power/changeling/powerinstances = list()
 	var/allowduringlesserform = FALSE
 	var/genomecost = 69420 // Cost for the changeling to evolve this power.
 
+/datum/power/changeling/respec
+	name = "Re-adapt"
+	desc = "Permits us to re-adapt ourselves to fit a new situation. Requires that we absorb a victim first."
+	allowduringlesserform = TRUE
+	genomecost = 0
+	verbpath = /mob/proc/changeling_try_respec
+
 //DNA absorption
 
 /datum/power/changeling/absorb_dna
 	name = "Absorb DNA"
-	desc = "Permits us to forcibly absorb a massive quantity DNA from another sentient creature. They will perish during the process, and we become stronger, especially if they were another changeling. Have caution, this takes some time."
+	desc = "Permits us to forcibly absorb DNA from another sentient creature. They will perish during the process, but we will be able to mimic their form or re-evolve ourselves. Have caution, this takes some time."
 	genomecost = 0
 	verbpath = /mob/proc/changeling_absorb_dna
 
@@ -134,7 +141,7 @@ var/list/datum/power/changeling/powerinstances = list()
 /datum/power/changeling/paralysis_sting
 	name = "Paralysis Sting"
 	desc = "We sting a human, paralyzing them for a short time."
-	genomecost = 8
+	genomecost = 6
 	verbpath = /mob/proc/changeling_paralysis_sting
 
 /datum/power/changeling/hallucinate_sting
@@ -147,7 +154,7 @@ var/list/datum/power/changeling/powerinstances = list()
 /datum/power/changeling/death_sting
 	name = "Death Sting"
 	desc = "We sting a human, transferring five units of cyanide. Their death is likely, unless immediate intervention occurs."
-	genomecost = 10
+	genomecost = 8
 	verbpath = /mob/proc/changeling_death_sting
 
 //Chems and stuff
@@ -273,7 +280,7 @@ var/list/datum/power/changeling/powerinstances = list()
 // After an HTML course, I finally conquered this. Convert into TGUI eventually. - Geeves
 /datum/changeling/proc/EvolutionMenu()//The new one
 	set category = "Changeling"
-	set desc = "Buy new abilities with the genomes we obtained."
+	set desc = "Buy new abilities.."
 
 	var/datum/changeling/changeling = usr.mind.antag_datums[MODE_CHANGELING]
 	if(!usr || !usr.mind || !changeling)
@@ -458,7 +465,6 @@ var/list/datum/power/changeling/powerinstances = list()
 					<font size='5'><b>Changeling Evolution Menu</b></font><br>
 					Hover over a power to see more information<br>
 					Current evolution points left to evolve with: [geneticpoints]<br>
-					Absorb genomes to acquire more evolution points
 					<p>
 				</td>
 			</tr>
@@ -548,13 +554,13 @@ var/list/datum/power/changeling/powerinstances = list()
 			break
 
 	if(power == null)
-		to_chat(M.current, "This is awkward. Changeling power purchase failed, please report this bug to a coder!")
+		to_chat(M.current, SPAN_WARNING("This is awkward. Changeling power purchase failed, please report this bug to a coder!"))
 		return
 	if(power in purchasedpowers)
-		to_chat(M.current, "We have already evolved this ability!")
+		to_chat(M.current, SPAN_WARNING("We have already evolved this ability!"))
 		return
 	if(geneticpoints < power.genomecost)
-		to_chat(M.current, "We cannot evolve this. We must acquire more DNA.")
+		to_chat(M.current, SPAN_WARNING("We lack the genome to evolve this. Re-evolve yourself to reset your genome points."))
 		return
 
 	geneticpoints -= power.genomecost

--- a/code/game/gamemodes/changeling/implements/powers/suck.dm
+++ b/code/game/gamemodes/changeling/implements/powers/suck.dm
@@ -68,7 +68,7 @@
 	playsound(get_turf(src), 'sound/effects/lingabsorbs.ogg', 50, 1)
 
 	changeling.chem_charges += 50
-	changeling.geneticpoints += 3
+	changeling.can_respec = TRUE
 
 	//Steal all of their languages!
 	for(var/language in T.languages)

--- a/html/changelogs/GeneralCamo - Changeling Redo.yml
+++ b/html/changelogs/GeneralCamo - Changeling Redo.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - experiment: "Changelings can no longer absorb mobs to gain genomes. They start with a pool of 10 genome points, and can re-evolve to reset their abilities and points if they absorb someone."
+  - balance: "Reduced the cost of the death sting from 10 points to 8 points."
+  - balance: "Reduced the cost of the paralysis sting from 8 points to 6 points."


### PR DESCRIPTION
Based on Paradise's changeling. 

Instead of being forced to kill people to get powers, you can instead just reset your purchased abilities if you absorb someone. This should reduce a lot of headaches as you aren't encouraged to mass kill as a ling, and it should allow for much more flexible gameplay as the goals of a ling will be more open-ended.

Reduced two high-cost powers to reflect the new maximum points a changeling has.

This should be test-merged.