### PR TITLE
Cult Tweak + Gamemode Start Failure Message Tweak

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -1191,10 +1191,12 @@ var/list/gamemode_cache = list()
 			log_config("GAMEMODE: ERROR: [M] does not exist!")
 			continue
 
-		var/can_start = M.can_start()
-		if(can_start != GAME_FAILURE_NONE)
+		var/list/can_start = M.can_start()
+		var/game_failure = can_start[1]
+
+		if(game_failure != GAME_FAILURE_NONE)
 			#if !defined(UNIT_TEST) // Do not print this useless log during unit tests
-			log_game("GAMEMODE: [M.name] cannot start! Reason: [can_start]")
+			log_game("GAMEMODE: [M.name] cannot start! Reason: [game_failure]")
 			#endif
 
 			continue

--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -30,7 +30,7 @@ var/datum/antagonist/cultist/cult
 	flags = ANTAG_SUSPICIOUS | ANTAG_VOTABLE
 	hard_cap = 5
 	hard_cap_round = 6
-	initial_spawn_req = 4
+	initial_spawn_req = 2
 	initial_spawn_target = 6
 	antaghud_indicator = "hudcultist"
 	required_age = 10

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -2,7 +2,7 @@
 	name = "Cult"
 	config_tag = "cult"
 	required_players = 9
-	required_enemies = 4
+	required_enemies = 2
 	antag_tags = list(MODE_CULTIST)
 
 /datum/game_mode/cult/pre_setup()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -147,26 +147,28 @@ var/global/list/additional_antag_types = list()
 
 ///can_start()
 ///Checks to see if the game can be setup and ran with the current number of players or whatnot.
+/// returns a list of results, 1: the GAME_FAILURE state, 2: the amount of players ready, 3: the amount of eligible antags
 /datum/game_mode/proc/can_start()
 
 	log_game_mode("Checking gamemode possibility selection for: [name]...")
 
-	var/returning = GAME_FAILURE_NONE
+	var/list/returning = list(GAME_FAILURE_NONE, 0, 0)
 
 	var/playerC = 0
 	for(var/mob/abstract/new_player/player in player_list)
 		if(player.client && player.ready)
 			playerC++
+	returning[2] += playerC
 
 	log_traitor("[playerC] players checked and readied.")
 
 	if(required_players && playerC < required_players)
 		log_game_mode("There aren't enough players ([playerC]/[required_players]) to start [name]!")
-		returning |= GAME_FAILURE_NO_PLAYERS
+		returning[1] |= GAME_FAILURE_NO_PLAYERS
 
 	if(max_players && playerC > max_players)
 		log_game_mode("There are too many players ([playerC]/[max_players]) to start [name]!")
-		returning |= GAME_FAILURE_TOO_MANY_PLAYERS
+		returning[1] |= GAME_FAILURE_TOO_MANY_PLAYERS
 
 	if(antag_templates && antag_templates.len)
 		log_game_mode("Checking antag templates...")
@@ -206,15 +208,16 @@ var/global/list/additional_antag_types = list()
 					total_enemies |= potential //Only count candidates once for our total enemy pool
 					if(antag.initial_spawn_req && require_all_templates && potential.len < antag.initial_spawn_req)
 						log_game_mode("There are not enough antagonists ([potential.len]/[antag.initial_spawn_req]) for the role [antag.role_text]!")
-						returning |= GAME_FAILURE_NO_ANTAGS
+						returning[1] |= GAME_FAILURE_NO_ANTAGS
+					returning[3] += length(potential)
 
 			log_traitor("GAMEMODE: Found [total_enemies.len] total enemies for [name].")
 
 			if(required_enemies && total_enemies.len < required_enemies)
 				log_traitor("GAMEMODE: There are not enough total antagonists ([total_enemies.len]/[required_enemies]) to start [name]!")
-				returning |= GAME_FAILURE_NO_ANTAGS
+				returning[1] |= GAME_FAILURE_NO_ANTAGS
 
-	log_game_mode("Finished gamemode checking. [name] returned [returning].")
+	log_game_mode("Finished gamemode checking. [name] returned [returning[1]].")
 
 	return returning
 

--- a/html/changelogs/geeves-cult_tweak.yml
+++ b/html/changelogs/geeves-cult_tweak.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Reduced the players needed to start a game of Cult to 2, down from 4."
+  - tweak: "Tweaked gamemode start failure messages to include the name of the gamemode that failed to start, as well as additional info on the number of people eligible to join."


### PR DESCRIPTION
* Reduced the players needed to start a game of Cult to 2, down from 4.
* Tweaked gamemode start failure messages to include the name of the gamemode that failed to start, as well as additional info on the number of people eligible to join.