### PR TITLE
Changed the uplink spacesuit into a standard spacesuit with extra armor

### DIFF
--- a/code/datums/uplink/devices_and_tools.dm
+++ b/code/datums/uplink/devices_and_tools.dm
@@ -96,7 +96,7 @@
 	name = "Space Suit"
 	telecrystal_cost = 2
 	bluecrystal_cost = 2
-	path = /obj/item/storage/box/syndie_kit/space
+	path = /obj/item/storage/box/syndie_kit/space/covert
 
 /datum/uplink_item/item/tools/thermal
 	name = "Thermal Imaging Glasses"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -42,6 +42,16 @@
 		/obj/item/tank/emergency_oxygen/double = 1
 	)
 
+/obj/item/storage/box/syndie_kit/space/covert
+	name = "boxed space suit and helmet"
+	worn_overlay = "syndiesuit"
+	starts_with = list(
+		/obj/item/clothing/suit/space/syndicate/covert = 1,
+		/obj/item/clothing/head/helmet/space/syndicate/covert = 1,
+		/obj/item/clothing/mask/breath = 1,
+		/obj/item/tank/emergency_oxygen/double = 1
+	)
+
 
 /obj/item/storage/box/syndie_kit/chameleon
 	name = "chameleon kit"

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -39,6 +39,33 @@
 	siemens_coefficient = 0.5
 	contained_sprite = FALSE
 
+/obj/item/clothing/head/helmet/space/syndicate/covert
+	name = "softsuit helmet"
+	desc = "A special helmet designed for work in a hazardous, low-pressure environment."
+	desc_antag = "This helmet is specially armored for additional protection, compared to a standard softsuit helmet."
+	icon = 'icons/obj/item/clothing/softsuits/softsuit.dmi'
+	icon_state = "softsuit_helmet"
+	item_state = "softsuit_helmet"
+	contained_sprite = TRUE
+
+/obj/item/clothing/head/helmet/space/syndicate/covert/examine(mob/user, distance)
+	..()
+	if(distance <= 1)
+		to_chat(user, SPAN_NOTICE("This helmet has extra armor compared to a normal softsuit helmet."))
+
+/obj/item/clothing/suit/space/syndicate/covert
+	name = "softsuit"
+	desc = "A suit that protects against low pressure environments."
+	desc_antag = "This suit is specially armored for additional protection, compared to a standard softsuit."
+	icon = 'icons/obj/item/clothing/softsuits/softsuit.dmi'
+	icon_state = "softsuit"
+	item_state = "softsuit"
+	contained_sprite = TRUE
+
+/obj/item/clothing/suit/space/syndicate/covert/examine(mob/user, distance)
+	..()
+	if(distance <= 1)
+		to_chat(user, SPAN_NOTICE("This suit has extra armor compared to a normal softsuit."))
 
 //Green syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/green

--- a/html/changelogs/GeneralCamo - Covert Spacesuit.yml
+++ b/html/changelogs/GeneralCamo - Covert Spacesuit.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "The standard uplink spacesuit is now a modified standard softsuit, that only looks different up-close. It has the same armor values as the red softsuit."


### PR DESCRIPTION
The red spacesuit is not only old, but it's extremely suspicious looking. It's hard not to be suspicious as security when looking at it, just from a meta perspective. This PR changes that by making the standard spacesuit that antagonists can get from "Devices & Tools" into a covert variant, that only looks different up-close (1 tile away or less). This allows them a bit more leeway to get around without security hounding them for meta reasons.