### PR TITLE
Aut'akh Augment Tweaks

### DIFF
--- a/code/modules/organs/subtypes/autakh.dm
+++ b/code/modules/organs/subtypes/autakh.dm
@@ -117,6 +117,7 @@
 	action_button_name = "Activate Protein Breakdown Valve"
 	cooldown = 300
 	activable = TRUE
+	var/expended = FALSE
 
 /obj/item/organ/internal/augment/protein_valve/attack_self(var/mob/user)
 	. = ..()
@@ -124,20 +125,14 @@
 	if(!.)
 		return FALSE
 
+	if(expended)
+		to_chat(owner, SPAN_WARNING("\The [src] has already been used up!"))
+		return
+
 	if(owner.reagents)
-		var/obj/item/organ/F = owner.internal_organs_by_name[BP_STOMACH]
-
-		if(isnull(F))
-			return FALSE
-
-		if(F.is_broken())
-			return FALSE
-
-		F.take_damage(10)
-
-		to_chat(owner, "<span class='notice'>\The [src] activates, releasing a stream of chemicals into your veins!</span>")
-
+		to_chat(owner, SPAN_NOTICE("\The [src] activates, releasing a stream of chemicals into your veins!"))
 		owner.reagents.add_reagent(/singleton/reagent/adrenaline, 15)
+		expended = TRUE
 
 /obj/item/organ/internal/augment/venomous_rest
 	name = "venomous rest implant"
@@ -148,6 +143,7 @@
 	action_button_icon = "stabilizer"
 	cooldown = 300
 	activable = TRUE
+	var/expended = FALSE
 
 /obj/item/organ/internal/augment/venomous_rest/attack_self(var/mob/user)
 	. = ..()
@@ -155,12 +151,16 @@
 	if(!.)
 		return FALSE
 
+	if(expended)
+		to_chat(owner, SPAN_WARNING("\The [src] has already been used up!"))
+		return
+
 	if(owner.reagents)
 		owner.reagents.add_reagent(/singleton/reagent/inaprovaline, 10)
 		owner.reagents.add_reagent(/singleton/reagent/tricordrazine, 10)
 		owner.reagents.add_reagent(/singleton/reagent/soporific, 15)
-		take_damage(15)
-		to_chat(owner, "<span class='notice'>\The [src] activates, releasing a stream of chemicals into your veins!</span>")
+		to_chat(owner, SPAN_NOTICE("\The [src] activates, releasing a stream of chemicals into your veins!"))
+		expended = TRUE
 
 /obj/item/organ/internal/augment/farseer_eye
 	name = "farseer eye"
@@ -178,8 +178,14 @@
 	if(!.)
 		return FALSE
 
-	owner.visible_message("<b>[user]'s</b> eyes whirrs loudly as they focus ahead.")
-	take_damage(1)
+	if(zoom)
+		owner.visible_message("<b>[user]'s</b> eyes whirrs loudly as the zoom lenses retract.", range = 3)
+	else
+		owner.visible_message("<b>[user]'s</b> eyes whirrs loudly as the zoom lenses begin sliding into place...", range = 3)
+		if(!do_after(user, 1.5 SECONDS))
+			return
+		owner.visible_message("<b>[user]'s</b> eyes clicks loudly as they focus ahead.", range = 3)
+
 	zoom(owner, 7, 7, FALSE, FALSE)
 
 /obj/item/organ/internal/augment/eye_flashlight

--- a/html/changelogs/geeves-autakh_augment_tweaks.yml
+++ b/html/changelogs/geeves-autakh_augment_tweaks.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Aut'akh farseer eyes no longer take damage on zooming, but need a second and a half to zoom in."
+  - tweak: "Aut'akh protein breakdown valves and venomous rest implants no longer cause internal damage, but are expended after one use."


### PR DESCRIPTION
* Aut'akh farseer eyes no longer take damage on zooming, but need a second and a half to zoom in.
* Aut'akh protein breakdown valves and venomous rest implants no longer cause internal damage, but are expended after one use.

Keeps Aut'akh augments somewhat shitty, while making them not a total pain to use.