### PR TITLE
Kill unnecessary startup exceptions

### DIFF
--- a/code/controllers/subsystems/cargo.dm
+++ b/code/controllers/subsystems/cargo.dm
@@ -170,6 +170,11 @@ var/datum/controller/subsystem/cargo/SScargo
 //Loads the cargo data from JSON
 /datum/controller/subsystem/cargo/proc/load_from_json()
 	var/list/cargoconfig = list()
+
+	if(!isfile("config/cargo.json"))
+		log_config("The file config/cargo.json was not found, cargo items will not be loaded")
+		return
+
 	try
 		cargoconfig = json_decode(return_file_text("config/cargo.json"))
 	catch(var/exception/ej)

--- a/code/controllers/subsystems/cargo.dm
+++ b/code/controllers/subsystems/cargo.dm
@@ -172,7 +172,7 @@ var/datum/controller/subsystem/cargo/SScargo
 	var/list/cargoconfig = list()
 
 	if(!isfile("config/cargo.json"))
-		log_config("The file config/cargo.json was not found, cargo items will not be loaded")
+		log_config("The file config/cargo.json was not found, cargo items will not be loaded.")
 		return
 
 	try

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -129,6 +129,11 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 /datum/controller/subsystem/chemistry/proc/load_secret_chemicals()
 	. = 0
 	var/list/chemconfig = list()
+
+	if(!isfile("config/secretchem.json"))
+		log_config("The file config/secretchem.json was not found, secret chemicals will not be loaded.")
+		return
+
 	try
 		chemconfig = json_decode(return_file_text("config/secretchem.json"))
 	catch(var/exception/e)

--- a/code/datums/helper_datums/synthsprites.dm
+++ b/code/datums/helper_datums/synthsprites.dm
@@ -25,6 +25,11 @@ paiicon is the pai icon sprite name
 
 /proc/loadsynths_from_json()
 	var/list/customsynthsprites = list()
+
+	if(!isfile("config/customsynths.json"))
+		log_config("The file config/customsynths.json was not found, custom synth config will not be loaded.")
+		return
+
 	try
 		customsynthsprites = json_decode(return_file_text("config/customsynths.json"))
 	catch(var/exception/ej)

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -58,7 +58,7 @@ var/list/forum_groupids_to_ranks = list()
 	forum_groupids_to_ranks.Cut()
 
 	if(!isfile(rank_file))
-		log_config("The file [rank_file] does not exist, unable to load the admin ranks")
+		log_config("The file [rank_file] does not exist, unable to load the admin ranks.")
 		return
 
 	var/list/data = json_decode(file2text(rank_file))

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -57,6 +57,10 @@ var/list/forum_groupids_to_ranks = list()
 	admin_ranks.Cut()
 	forum_groupids_to_ranks.Cut()
 
+	if(!isfile(rank_file))
+		log_config("The file [rank_file] does not exist, unable to load the admin ranks")
+		return
+
 	var/list/data = json_decode(file2text(rank_file))
 
 	for (var/list/group in data)

--- a/html/changelogs/FluffyGhost-kill_unnecessary_startup_exceptions.yml
+++ b/html/changelogs/FluffyGhost-kill_unnecessary_startup_exceptions.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Admin ranks, cargo, chemistry and synthsprites do not throw an exception in VSC anymore if the config files are missing, writing a log instead."


### PR DESCRIPTION
Admin ranks, cargo, chemistry and synthsprites do not throw an exception in VSC anymore if the config files are missing, writing a log instead.