### PR TITLE
Fix premature harddel during hunt

### DIFF
--- a/code/controllers/master/failsafe.dm
+++ b/code/controllers/master/failsafe.dm
@@ -65,7 +65,16 @@ var/datum/controller/failsafe/Failsafe
 							FAILSAFE_MSG("Warning: DEFCON [defcon_pretty()]. The Master Controller has still not fired within the last [(5-defcon) * processing_interval] ticks. Killing and restarting...")
 							log_failsafe("MC has not fired within last [(5-defcon) * processing_interval] ticks, killing and restarting.")
 							--defcon
+
+							//Do not restart the MC if we are doing a REFERENCE_TRACKING hard lookup
+							#if !defined(GC_FAILURE_HARD_LOOKUP)
 							var/rtn = Recreate_MC()
+							#else
+							log_failsafe("MC was not actually recreated, because we're compiled with GC_FAILURE_HARD_LOOKUP")
+							FAILSAFE_MSG("MC was not actually recreated, because we're compiled with GC_FAILURE_HARD_LOOKUP")
+							var/rtn = TRUE
+							#endif
+
 							if(rtn > 0)
 								defcon = 4
 								master_iteration = 0
@@ -77,7 +86,16 @@ var/datum/controller/failsafe/Failsafe
 							//if the return number was 0, it just means the mc was restarted too recently, and it just needs some time before we try again
 							//no need to handle that specially when defcon 0 can handle it
 						if(0) //DEFCON 0! (mc failed to restart)
+
+							//Do not restart the MC if we are doing a REFERENCE_TRACKING hard lookup
+							#if !defined(GC_FAILURE_HARD_LOOKUP)
 							var/rtn = Recreate_MC()
+							#else
+							var/rtn = TRUE
+							log_failsafe("MC was not actually recreated, because we're compiled with GC_FAILURE_HARD_LOOKUP")
+							FAILSAFE_MSG("MC was not actually recreated, because we're compiled with GC_FAILURE_HARD_LOOKUP")
+							#endif
+
 							if(rtn > 0)
 								defcon = 4
 								master_iteration = 0

--- a/code/controllers/master/master.dm
+++ b/code/controllers/master/master.dm
@@ -126,9 +126,15 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 			if(2)
 				msg = "The [BadBoy.name] subsystem was the last to fire for 2 controller restarts. It will be recovered now and disabled if it happens again."
 				FireHim = TRUE
+
+			//If we are running a REFERENCE_TRACKING with hard lookups, this is expected and we do not want the master controller
+			//to stop the garbage collector from working
+			#if !defined(GC_FAILURE_HARD_LOOKUP)
 			if(3)
 				msg = "The [BadBoy.name] subsystem seems to be destabilizing the MC and will be offlined."
 				BadBoy.flags |= SS_NO_FIRE
+			#endif
+
 		if(msg)
 			admin_notice("<span class='danger'>[msg]</span>", R_DEBUG | R_DEV)
 			log_subsystem_mastercontroller(msg)

--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -130,6 +130,11 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 			log_subsystem_garbage_harddel("-- \ref[A] | [type] was unable to be GC'd and was deleted --", type)
 			didntgc["[type]"]++
 
+			#ifdef REFERENCE_TRACKING
+			if(ref_searching)
+				continue //ref searching intentionally cancels all further fires while running so things that hold references don't end up getting deleted, so we want to return here instead of continue
+			#endif
+
 			HardDelete(A)
 
 			++delslasttick
@@ -267,6 +272,6 @@ var/datum/controller/subsystem/garbage_collector/SSgarbage
 	..()
 	return QDEL_HINT_HARDDEL_NOW
 
-/image/Destroy()
-	..()
-	return QDEL_HINT_HARDDEL
+// /image/Destroy()
+// 	..()
+// 	return QDEL_HINT_HARDDEL

--- a/html/changelogs/FluffyGhost-fix_premature_harddel_during_hunt.yml
+++ b/html/changelogs/FluffyGhost-fix_premature_harddel_during_hunt.yml
@@ -41,3 +41,4 @@ changes:
   - bugfix: "The garbage collection should not happen if we're running a reference tracking search."
   - bugfix: "If we're compiled with GC_FAILURE_HARD_LOOKUP, prevent the failsafe controller from gutting the master controller (DEFCON 1)."
   - bugfix: "If we're compiled with GC_FAILURE_HARD_LOOKUP, prevent the master controller from gutting SSgarbage controller."
+  - backend: "Now gives images a chance to be garbage collected, instead of immediately gutting them with an harddel."

--- a/html/changelogs/FluffyGhost-fix_premature_harddel_during_hunt.yml
+++ b/html/changelogs/FluffyGhost-fix_premature_harddel_during_hunt.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The garbage collection should not happen if we're running a reference tracking search."
+  - bugfix: "If we're compiled with GC_FAILURE_HARD_LOOKUP, prevent the failsafe controller from gutting the master controller (DEFCON 1)."
+  - bugfix: "If we're compiled with GC_FAILURE_HARD_LOOKUP, prevent the master controller from gutting SSgarbage controller."


### PR DESCRIPTION
The garbage collection should not happen if we're running a reference tracking search.
If we're compiled with GC_FAILURE_HARD_LOOKUP, prevent the failsafe controller from gutting the master controller (DEFCON 1).
If we're compiled with GC_FAILURE_HARD_LOOKUP, prevent the master controller from gutting SSgarbage controller.
Now gives images a chance to be garbage collected, instead of immediately gutting them with an harddel.