### PR TITLE
Fixes a few TGUI bugs.

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -109,7 +109,7 @@
 		var/remembered_info = ""
 		remembered_info += "<b>Your account number is:</b> #[M.account_number]<br>"
 		remembered_info += "<b>Your account pin is:</b> [M.remote_access_pin]<br>"
-		remembered_info += "<b>Your account funds are:</b> $[M.money]<br>"
+		remembered_info += "<b>Your account funds are:</b> [M.money]电<br>"
 
 		if(M.transactions.len)
 			var/datum/transaction/T = M.transactions[1]

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1487,6 +1487,8 @@
 
 	if(species.psi_deaf || HAS_FLAG(species.flags, IS_MECHANICAL) || HAS_FLAG(species.flags, NO_SCAN))
 		ADD_TRAIT(src, TRAIT_PSIONICALLY_DEAF, INNATE_TRAIT)
+	else if(HAS_TRAIT(src, TRAIT_PSIONICALLY_DEAF))
+		REMOVE_TRAIT(src, TRAIT_PSIONICALLY_DEAF)
 
 	if(client)
 		client.init_verbs()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1488,7 +1488,7 @@
 	if(species.psi_deaf || HAS_FLAG(species.flags, IS_MECHANICAL) || HAS_FLAG(species.flags, NO_SCAN))
 		ADD_TRAIT(src, TRAIT_PSIONICALLY_DEAF, INNATE_TRAIT)
 	else if(HAS_TRAIT(src, TRAIT_PSIONICALLY_DEAF))
-		REMOVE_TRAIT(src, TRAIT_PSIONICALLY_DEAF)
+		REMOVE_TRAIT(src, TRAIT_PSIONICALLY_DEAF, INNATE_TRAIT)
 
 	if(client)
 		client.init_verbs()

--- a/code/modules/modular_computers/file_system/programs/engineering/rcon.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/rcon.dm
@@ -55,42 +55,36 @@
 			var/obj/machinery/power/smes/buildable/SMES = GetSMESByTag(params["smes_in_toggle"])
 			if(SMES)
 				SMES.toggle_input()
-				computer.update_static_data_for_all_viewers()
 				. = TRUE
 
 		if("smes_out_toggle")
 			var/obj/machinery/power/smes/buildable/SMES = GetSMESByTag(params["smes_out_toggle"])
 			if(SMES)
 				SMES.toggle_output()
-				computer.update_static_data_for_all_viewers()
 				. = TRUE
 
 		if("smes_in_set")
 			var/obj/machinery/power/smes/buildable/SMES = GetSMESByTag(params["smes_in_set"])
 			if(SMES)
 				SMES.set_input(params["value"])
-				computer.update_static_data_for_all_viewers()
 				. = TRUE
 
 		if("smes_out_set")
 			var/obj/machinery/power/smes/buildable/SMES = GetSMESByTag(params["smes_out_set"])
 			if(SMES)
 				SMES.set_output(params["value"])
-				computer.update_static_data_for_all_viewers()
 				. = TRUE
 
 		if("smes_in_max")
 			var/obj/machinery/power/smes/buildable/SMES = GetSMESByTag(params["smes_in_max"])
 			if(SMES)
 				SMES.set_input(SMES.input_level_max)
-				computer.update_static_data_for_all_viewers()
 				. = TRUE
 
 		if("smes_out_max")
 			var/obj/machinery/power/smes/buildable/SMES = GetSMESByTag(params["smes_out_max"])
 			if(SMES)
 				SMES.set_output(SMES.output_level_max)
-				computer.update_static_data_for_all_viewers()
 				. = TRUE
 
 		if("toggle_breaker")
@@ -100,7 +94,6 @@
 					to_chat(usr, SPAN_WARNING("The breaker box was recently toggled. Please wait before toggling it again."))
 				else
 					toggle.auto_toggle()
-					computer.update_static_data_for_all_viewers()
 					. = TRUE
 
 /datum/computer_file/program/rcon_console/proc/GetSMESByTag(var/tag)

--- a/code/modules/vehicles/droppod.dm
+++ b/code/modules/vehicles/droppod.dm
@@ -146,6 +146,8 @@
 
 /obj/vehicle/droppod/attack_hand(mob/user as mob)
 	..()
+	if(isobserver(user))
+		return
 	if(user == humanload || user == passenger)
 		if(status != USED)
 			launchinterface()

--- a/html/changelogs/mattatlas-tguifixes.yml
+++ b/html/changelogs/mattatlas-tguifixes.yml
@@ -44,3 +44,5 @@ changes:
   - bugfix: "Shield generator now has colours for when its features are online/offline."
   - bugfix: "The IC notes' money display now uses the credit sign instead of a dollar sign."
   - bugfix: "Vending machines now properly grey out items if they're being vended or have run out."
+  - bugfix: "Drop pods can no longer be used by ghosts."
+  - bugfix: "Psionic deafness should now reset when species is changed."

--- a/html/changelogs/mattatlas-tguifixes.yml
+++ b/html/changelogs/mattatlas-tguifixes.yml
@@ -42,3 +42,5 @@ changes:
   - bugfix: "Removed the in-code sensor tag from the atmos control."
   - bugfix: "Fixed the atmos control datapoint display to be neater."
   - bugfix: "Shield generator now has colours for when its features are online/offline."
+  - bugfix: "The IC notes' money display now uses the credit sign instead of a dollar sign."
+  - bugfix: "Vending machines now properly grey out items if they're being vended or have run out."

--- a/html/changelogs/mattatlas-tguifixes.yml
+++ b/html/changelogs/mattatlas-tguifixes.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "RCON management should no longer fully refresh when clicking buttons."
+  - bugfix: "Removed the in-code sensor tag from the atmos control."
+  - bugfix: "Fixed the atmos control datapoint display to be neater."
+  - bugfix: "Shield generator now has colours for when its features are online/offline."

--- a/tgui/packages/tgui/interfaces/AtmosControl.tsx
+++ b/tgui/packages/tgui/interfaces/AtmosControl.tsx
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Section, Box, LabeledList } from '../components';
+import { Section, LabeledList, NoticeBox } from '../components';
 import { capitalize } from '../../common/string';
 
 export type AtmosData = {
@@ -22,35 +22,30 @@ type Datapoint = {
 
 export const AtmosControl = (props, context) => {
   const { act, data } = useBackend<AtmosData>(context);
-  return (
-    <Section title="Sensor Data">
-      {data.sensors.length ? <SensorData /> : 'No sensors connected.'}
-    </Section>
+  return data.sensors.length ? (
+    <SensorData />
+  ) : (
+    <NoticeBox>No sensors connected.</NoticeBox>
   );
 };
 
 export const SensorData = (props, context) => {
   const { act, data } = useBackend<AtmosData>(context);
-  return (
-    <Section>
-      {data.sensors.map((sensor) => (
-        <Box bold key={sensor.id_tag}>
-          {sensor.name}
-          <LabeledList>
-            {sensor.datapoints.map((datapoint) =>
-              datapoint.data !== null ? (
-                <LabeledList.Item
-                  key={datapoint.datapoint}
-                  label={capitalize(datapoint.datapoint)}>
-                  {datapoint.data} {datapoint.unit}
-                </LabeledList.Item>
-              ) : (
-                ''
-              )
-            )}
-          </LabeledList>
-        </Box>
-      ))}
+  return data.sensors.map((sensor) => (
+    <Section title={sensor.name} key={sensor.id_tag}>
+      <LabeledList>
+        {sensor.datapoints.map((datapoint) =>
+          datapoint.data !== null ? (
+            <LabeledList.Item
+              key={datapoint.datapoint}
+              label={capitalize(datapoint.datapoint)}>
+              {datapoint.data} {datapoint.unit}
+            </LabeledList.Item>
+          ) : (
+            ''
+          )
+        )}
+      </LabeledList>
     </Section>
-  );
+  ));
 };

--- a/tgui/packages/tgui/interfaces/AtmosControl.tsx
+++ b/tgui/packages/tgui/interfaces/AtmosControl.tsx
@@ -35,18 +35,20 @@ export const SensorData = (props, context) => {
     <Section>
       {data.sensors.map((sensor) => (
         <Box bold key={sensor.id_tag}>
-          {sensor.name} ({sensor.id_tag})
-          {sensor.datapoints.map((datapoint) => (
-            <LabeledList key={datapoint.datapoint}>
-              {datapoint.data !== null ? (
-                <LabeledList.Item label={capitalize(datapoint.datapoint)}>
+          {sensor.name}
+          <LabeledList>
+            {sensor.datapoints.map((datapoint) =>
+              datapoint.data !== null ? (
+                <LabeledList.Item
+                  key={datapoint.datapoint}
+                  label={capitalize(datapoint.datapoint)}>
                   {datapoint.data} {datapoint.unit}
                 </LabeledList.Item>
               ) : (
                 ''
-              )}
-            </LabeledList>
-          ))}
+              )
+            )}
+          </LabeledList>
         </Box>
       ))}
     </Section>

--- a/tgui/packages/tgui/interfaces/AtmosControl.tsx
+++ b/tgui/packages/tgui/interfaces/AtmosControl.tsx
@@ -31,21 +31,25 @@ export const AtmosControl = (props, context) => {
 
 export const SensorData = (props, context) => {
   const { act, data } = useBackend<AtmosData>(context);
-  return data.sensors.map((sensor) => (
-    <Section title={sensor.name} key={sensor.id_tag}>
-      <LabeledList>
-        {sensor.datapoints.map((datapoint) =>
-          datapoint.data !== null ? (
-            <LabeledList.Item
-              key={datapoint.datapoint}
-              label={capitalize(datapoint.datapoint)}>
-              {datapoint.data} {datapoint.unit}
-            </LabeledList.Item>
-          ) : (
-            ''
-          )
-        )}
-      </LabeledList>
-    </Section>
-  ));
+  return (
+    <>
+      {data.sensors.map((sensor) => (
+        <Section title={sensor.name} key={sensor.id_tag}>
+          <LabeledList>
+            {sensor.datapoints.map((datapoint) =>
+              datapoint.data !== null ? (
+                <LabeledList.Item
+                  key={datapoint.datapoint}
+                  label={capitalize(datapoint.datapoint)}>
+                  {datapoint.data} {datapoint.unit}
+                </LabeledList.Item>
+              ) : (
+                ''
+              )
+            )}
+          </LabeledList>
+        </Section>
+      ))}
+    </>
+  );
 };

--- a/tgui/packages/tgui/interfaces/Doors.tsx
+++ b/tgui/packages/tgui/interfaces/Doors.tsx
@@ -27,7 +27,7 @@ export type DoorsData = {
 
 export const Doors = (props, context) => {
   const { act, data } = useBackend<DoorsData>(context);
-  const door_title = data.doorArea + ' - ' + data.doorName;
+  const door_title = data.doorArea + '(' + data.doorName + ')';
   return (
     <Window resizable>
       <Window.Content scrollable>

--- a/tgui/packages/tgui/interfaces/SMES.tsx
+++ b/tgui/packages/tgui/interfaces/SMES.tsx
@@ -87,6 +87,7 @@ export const SMESWindow = (props, context) => {
           <LabeledList.Item label="Charge Mode">
             <Button
               content={data.charge_attempt ? 'Auto' : 'Off'}
+              color={data.charge_attempt ? 'good' : 'bad'}
               icon={data.charge_attempt ? 'sync' : 'times'}
               onClick={() => act('cmode')}
             />
@@ -125,6 +126,7 @@ export const SMESWindow = (props, context) => {
           <LabeledList.Item label="Output Status">
             <Button
               content={data.output_attempt ? 'Online' : 'Offline'}
+              color={data.output_attempt ? 'good' : 'bad'}
               icon={data.output_attempt ? 'power-off' : 'times'}
               onClick={() => act('online')}
             />

--- a/tgui/packages/tgui/interfaces/ShieldGenerator.tsx
+++ b/tgui/packages/tgui/interfaces/ShieldGenerator.tsx
@@ -32,6 +32,7 @@ export const ShieldGenerator = (props, context) => {
           buttons={
             <Button
               content={data.active ? 'Online' : 'Offline'}
+              color={data.active ? "good" : "bad"}
               icon={data.active ? 'power-off' : 'times'}
               onClick={() => act('toggle')}
             />
@@ -47,6 +48,7 @@ export const ShieldGenerator = (props, context) => {
             <LabeledList.Item label="Multi-Level Shield">
               <Button
                 content={data.multiz ? 'Online' : 'Offline'}
+                color={data.multiz ? "good" : "bad"}
                 icon={data.multiz ? 'power-off' : 'times'}
                 onClick={() => act('multiz')}
               />

--- a/tgui/packages/tgui/interfaces/ShieldGenerator.tsx
+++ b/tgui/packages/tgui/interfaces/ShieldGenerator.tsx
@@ -32,7 +32,7 @@ export const ShieldGenerator = (props, context) => {
           buttons={
             <Button
               content={data.active ? 'Online' : 'Offline'}
-              color={data.active ? "good" : "bad"}
+              color={data.active ? 'good' : 'bad'}
               icon={data.active ? 'power-off' : 'times'}
               onClick={() => act('toggle')}
             />
@@ -48,7 +48,7 @@ export const ShieldGenerator = (props, context) => {
             <LabeledList.Item label="Multi-Level Shield">
               <Button
                 content={data.multiz ? 'Online' : 'Offline'}
-                color={data.multiz ? "good" : "bad"}
+                color={data.multiz ? 'good' : 'bad'}
                 icon={data.multiz ? 'power-off' : 'times'}
                 onClick={() => act('multiz')}
               />

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -97,6 +97,7 @@ export const ShowAllItems = (props, context) => {
             <Button
               tooltip={product.name}
               key={product.name}
+              disabled={data.vending_item || product.amount <= 0}
               onClick={() => act('vendItem', { vendItem: product.key })}
               style={{
                 height: '70px',
@@ -105,7 +106,6 @@ export const ShowAllItems = (props, context) => {
               <Box
                 as="img"
                 className={product.icon_tag}
-                disabled={product.amount <= 0}
                 style={{
                   '-ms-interpolation-mode': 'nearest-neighbor',
                   transform: 'scale(1.5) translate(30%, 30%)',


### PR DESCRIPTION
  - bugfix: "RCON management should no longer fully refresh when clicking buttons."
  - bugfix: "Removed the in-code sensor tag from the atmos control."
  - bugfix: "Fixed the atmos control datapoint display to be neater."
  - bugfix: "Shield generator now has colours for when its features are online/offline."
  - bugfix: "The IC notes' money display now uses the credit sign instead of a dollar sign."
  - bugfix: "Vending machines now properly grey out items if they're being vended or have run out."
  - bugfix: "Drop pods can no longer be used by ghosts."
  - bugfix: "Psionic deafness should now reset when species is changed."
