### PR TITLE
Raises minimu age for engineering interns to 24

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -228,9 +228,9 @@
 	blacklisted_species = list(SPECIES_VAURCA_BREEDER)
 
 	minimum_character_age = list(
-		SPECIES_HUMAN = 18,
-		SPECIES_SKRELL = 50,
-		SPECIES_SKRELL_AXIORI = 50
+		SPECIES_HUMAN = 24,
+		SPECIES_SKRELL = 59,
+		SPECIES_SKRELL_AXIORI = 59
 	)
 
 /datum/outfit/job/intern_eng

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -229,8 +229,8 @@
 
 	minimum_character_age = list(
 		SPECIES_HUMAN = 24,
-		SPECIES_SKRELL = 59,
-		SPECIES_SKRELL_AXIORI = 59
+		SPECIES_SKRELL = 58,
+		SPECIES_SKRELL_AXIORI = 58
 	)
 
 /datum/outfit/job/intern_eng

--- a/html/changelogs/engineeringinternnerf.yml
+++ b/html/changelogs/engineeringinternnerf.yml
@@ -1,0 +1,6 @@
+author: Pirouette
+
+delete-after: True
+
+changes:
+  - tweak: "Engineering and atmospherics interns now have a minimum age of 24."


### PR DESCRIPTION
Investigator is a minimum age of 25 and has an identical restriction on its intern role. I would have frankly preferred it being 25, but 24 seems more lenient to allow you to start a year below and age up for the job hop - as of now, I've seen a good few characters in the 18-22 range using this slot just to be a permanently young engineer, which seems unfair to new players that may need to actually actively learn the role.