### PR TITLE
Fixed admin rank loading and the other file config checks

### DIFF
--- a/code/controllers/subsystems/cargo.dm
+++ b/code/controllers/subsystems/cargo.dm
@@ -171,7 +171,7 @@ var/datum/controller/subsystem/cargo/SScargo
 /datum/controller/subsystem/cargo/proc/load_from_json()
 	var/list/cargoconfig = list()
 
-	if(!isfile("config/cargo.json"))
+	if(!(rustg_file_exists("config/cargo.json") == "true"))
 		log_config("The file config/cargo.json was not found, cargo items will not be loaded.")
 		return
 

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -130,7 +130,7 @@ var/datum/controller/subsystem/chemistry/SSchemistry
 	. = 0
 	var/list/chemconfig = list()
 
-	if(!isfile("config/secretchem.json"))
+	if(!(rustg_file_exists("config/secretchem.json") == "true"))
 		log_config("The file config/secretchem.json was not found, secret chemicals will not be loaded.")
 		return
 

--- a/code/datums/helper_datums/synthsprites.dm
+++ b/code/datums/helper_datums/synthsprites.dm
@@ -26,7 +26,7 @@ paiicon is the pai icon sprite name
 /proc/loadsynths_from_json()
 	var/list/customsynthsprites = list()
 
-	if(!isfile("config/customsynths.json"))
+	if(!(rustg_file_exists("config/customsynths.json") == "true"))
 		log_config("The file config/customsynths.json was not found, custom synth config will not be loaded.")
 		return
 

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -57,7 +57,7 @@ var/list/forum_groupids_to_ranks = list()
 	admin_ranks.Cut()
 	forum_groupids_to_ranks.Cut()
 
-	if(!isfile(rank_file))
+	if(!(rustg_file_exists(rank_file) == "true"))
 		log_config("The file [rank_file] does not exist, unable to load the admin ranks.")
 		return
 

--- a/html/changelogs/fluffyghost-fixadminranksloading.yml
+++ b/html/changelogs/fluffyghost-fixadminranksloading.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed admin rank loading and the other file config checks, using rustg to detect the file instead of the native and ill-documented DM proc."


### PR DESCRIPTION
Fixed admin rank loading and the other file config checks, using rustg to detect the file instead of the native and ill-documented DM proc.