### PR TITLE
Magboot refdrop

### DIFF
--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -16,13 +16,18 @@
 	drop_sound = 'sound/items/drop/toolbox.ogg'
 	pickup_sound = 'sound/items/pickup/toolbox.ogg'
 
+/obj/item/clothing/shoes/magboots/Destroy()
+	. = ..()
+	src.shoes = null
+	src.wearer = null
+
 /obj/item/clothing/shoes/magboots/proc/set_slowdown()
 	slowdown = shoes? max(0, shoes.slowdown): 0	//So you can't put on magboots to make you walk faster.
 	if (magpulse)
 		slowdown += 3
 
 /obj/item/clothing/shoes/magboots/proc/update_wearer()
-	if(!wearer)
+	if(QDELETED(wearer))
 		return
 
 	var/mob/living/carbon/human/H = wearer

--- a/html/changelogs/FluffyGhost-magbood_refdrop_del.yml
+++ b/html/changelogs/FluffyGhost-magbood_refdrop_del.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Magboots now drop the references correctly and avoid trying to process a wearer that is being qdel'd, which can raise an exception."


### PR DESCRIPTION
Magboots now drop the references correctly and avoid trying to process a wearer that is being qdel'd, which can raise an exception.