### PR TITLE
Mech healthscanner qdel

### DIFF
--- a/code/modules/heavy_vehicle/equipment/medical.dm
+++ b/code/modules/heavy_vehicle/equipment/medical.dm
@@ -267,11 +267,15 @@
 /obj/item/device/healthanalyzer/mech //Used to set up the full body scan feature
 	var/obj/machinery/body_scanconsole/internal_bodyscanner = null
 	var/fullScan = FALSE //Toggle whether to do full or basic scan
-	
+
 /obj/item/device/healthanalyzer/mech/Initialize()
 	. = ..()
 	internal_bodyscanner = new /obj/machinery/body_scanconsole(src)
 	internal_bodyscanner.use_power = FALSE
+
+/obj/item/device/healthanalyzer/mech/Destroy()
+	QDEL_NULL(internal_bodyscanner)
+	. = ..()
 
 /obj/item/mecha_equipment/mounted_system/medanalyzer/CtrlClick(mob/user)
 	var/obj/item/device/healthanalyzer/mech/HA = holding

--- a/html/changelogs/FluffyGhost-mech_healthscanner_qdel.yml
+++ b/html/changelogs/FluffyGhost-mech_healthscanner_qdel.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The mech health analyzer component now queues the internally used bodyscanner for deletion upon destroy."


### PR DESCRIPTION
The mech health analyzer component now queues the internally used bodyscanner for deletion upon destroy.