### PR TITLE
Font size macros now produce correctly sized text

### DIFF
--- a/code/__defines/_macros.dm
+++ b/code/__defines/_macros.dm
@@ -24,17 +24,19 @@
 
 #define SPAN_HIGHDANGER(X) (FONT_LARGE(SPAN_DANGER(X)))
 
-#define FONT_SIZE_SMALL 1
-#define FONT_SIZE_NORMAL 2
-#define FONT_SIZE_LARGE 3
-#define FONT_SIZE_HUGE 4
-#define FONT_SIZE_GIANT 5
+#define SPAN_SIZE(size, text) ("<span style="font-size: [size]">" + text + "</span>")
 
-#define FONT_SMALL(X) ("<font size=1>" + X + "</font>")
-#define FONT_NORMAL(X) ("<font size=2>" + X + "</font>")
-#define FONT_LARGE(X) ("<font size=3>" + X + "</font>")
-#define FONT_HUGE(X) ("<font size=4>" + X + "</font>")
-#define FONT_GIANT(X) ("<font size=5>" + X + "</font>")
+#define FONT_SIZE_SMALL 10px
+#define FONT_SIZE_NORMAL 13px
+#define FONT_SIZE_LARGE 16px
+#define FONT_SIZE_HUGE 18px
+#define FONT_SIZE_GIANT 24px
+
+#define FONT_SMALL(X) SPAN_SIZE(FONT_SIZE_SMALL, X)
+#define FONT_NORMAL(X) SPAN_SIZE(FONT_SIZE_NORMAL, X)
+#define FONT_LARGE(X) SPAN_SIZE(FONT_SIZE_LARGE, X)	
+#define FONT_HUGE(X) SPAN_SIZE(FONT_SIZE_HUGE, X)
+#define FONT_GIANT(X) SPAN_SIZE(FONT_SIZE_GIANT, X)
 
 #define MATRIX_DANGER(X) (FONT_LARGE(SPAN_DANGER(X)))
 #define MATRIX_NOTICE(X) (FONT_LARGE(SPAN_NOTICE(X)))

--- a/code/__defines/_macros.dm
+++ b/code/__defines/_macros.dm
@@ -22,19 +22,19 @@
 #define SPAN_SOGHUN(X) ("<span class='soghun'>" + X + "</span>")
 #define SPAN_VOTE(X) ("<span class='vote'>" + X + "</span>")
 
+#define SPAN_SIZE(size, text) ("<span style=\"font-size: [size]\">" + text + "</span>")
+
 #define SPAN_HIGHDANGER(X) (FONT_LARGE(SPAN_DANGER(X)))
 
-#define SPAN_SIZE(size, text) ("<span style="font-size: [size]">" + text + "</span>")
-
-#define FONT_SIZE_SMALL 10px
-#define FONT_SIZE_NORMAL 13px
-#define FONT_SIZE_LARGE 16px
-#define FONT_SIZE_HUGE 18px
-#define FONT_SIZE_GIANT 24px
+#define FONT_SIZE_SMALL "10px"
+#define FONT_SIZE_NORMAL "13px"
+#define FONT_SIZE_LARGE "16px"
+#define FONT_SIZE_HUGE "18px"
+#define FONT_SIZE_GIANT "24px"
 
 #define FONT_SMALL(X) SPAN_SIZE(FONT_SIZE_SMALL, X)
 #define FONT_NORMAL(X) SPAN_SIZE(FONT_SIZE_NORMAL, X)
-#define FONT_LARGE(X) SPAN_SIZE(FONT_SIZE_LARGE, X)	
+#define FONT_LARGE(X) SPAN_SIZE(FONT_SIZE_LARGE, X)
 #define FONT_HUGE(X) SPAN_SIZE(FONT_SIZE_HUGE, X)
 #define FONT_GIANT(X) SPAN_SIZE(FONT_SIZE_GIANT, X)
 

--- a/html/changelogs/GeneralCamo - Font Fixes.yml
+++ b/html/changelogs/GeneralCamo - Font Fixes.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Font size macros accurately describe what the result will be."


### PR DESCRIPTION
This was most noticable with examine text, where the extra fluff descriptions were supposedly `FONT_SMALL` but were much larger than the rest of the text. 

In addition, I have removed the usage of the now-deprecated `<font>` tags used by these macros, in favor of the `<span style>` tags that are now recommended for usage with HTML 5