### PR TITLE
Baloon alert runtime and vsc missing reparse fix

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -27,6 +27,11 @@
         "label": "Build All"
       },
       {
+        "command": "${command:dreammaker.reparse}",
+        "group": "build",
+        "label": "dm: reparse"
+      },
+      {
         "type": "shell",
         "command": "tools/dreamchecker/dreamchecker",
         "windows": {

--- a/code/modules/balloon_alert/balloon_alert.dm
+++ b/code/modules/balloon_alert/balloon_alert.dm
@@ -24,14 +24,16 @@
 		if(hearer.is_blind())
 			continue
 		balloon_alert(hearer, message)
-	balloon_alert(src, self_message)
+
+	if(self_message)
+		balloon_alert(src, self_message)
 
 // Do not use.
 // MeasureText blocks. I have no idea for how long.
 // I would've made the maptext_height update on its own, but I don't know
 // if this would look bad on laggy clients.
 /atom/proc/balloon_alert_perform(mob/viewer, text)
-	var/client/viewer_client = viewer.client
+	var/client/viewer_client = viewer?.client
 	if (isnull(viewer_client))
 		return
 

--- a/html/changelogs/FluffyGhost-tasks_and_baloon_alert.yml
+++ b/html/changelogs/FluffyGhost-tasks_and_baloon_alert.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Resolved a runtime with baloon alerts."
+  - bugfix: "The VSC compilation now reparses as expected, the task was missing from the port."


### PR DESCRIPTION
Resolved a runtime with baloon alerts.
The VSC compilation now reparses as expected, the task was missing from the port.