### PR TITLE
Changes Profiler Log Directory

### DIFF
--- a/code/controllers/subsystems/profiler.dm
+++ b/code/controllers/subsystems/profiler.dm
@@ -56,8 +56,8 @@ var/datum/controller/subsystem/profiler/SSprofiler
 	admin_notice(SPAN_DANGER("Profiler: dump profile after CPU spike."), R_SERVER|R_DEV)
 
 	var/name = "[game_id]_[time2text(world.timeofday, "hh-mm-ss")]"
-	text2file(world.Profile(PROFILE_REFRESH, "json"), "data/logs/profiler/[game_id]/[name].json")
-	text2file(world.Profile(PROFILE_REFRESH, type = "sendmaps", format = "json"), "data/logs/profiler/[game_id]/[name]_sendmaps.json")
+	text2file(world.Profile(PROFILE_REFRESH, "json"), "data/logs/[game_id]/profiler/[name].json")
+	text2file(world.Profile(PROFILE_REFRESH, type = "sendmaps", format = "json"), "data/logs/[game_id]/profiler/[name]_sendmaps.json")
 
 /datum/controller/subsystem/profiler/proc/RestartProfiler()
 	world.Profile(PROFILE_CLEAR)

--- a/html/changelogs/change-profilder-log-location.yml
+++ b/html/changelogs/change-profilder-log-location.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "The profiler logs are now stored in the logs/[game_id]/profiler directory (together with all the other logs)"


### PR DESCRIPTION
The profiler logs are now stored together with all the other logs in the logs/[game_id]/profiler directory.

That ensures that they are archived/processed together with them.
