### PR TITLE
Chat bad connection notification moved up

### DIFF
--- a/html/changelogs/DreamySkrell-bad-connection-123542356626.yml
+++ b/html/changelogs/DreamySkrell-bad-connection-123542356626.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Chat bad connection notification/popup moved up so it does not block new messages in the chat."

--- a/tgui/packages/tgui-panel/styles/components/Notifications.scss
+++ b/tgui/packages/tgui-panel/styles/components/Notifications.scss
@@ -5,7 +5,7 @@
 
 .Notifications {
   position: absolute;
-  bottom: 10em;
+  top: 1em;
   left: 1em;
   right: 2em;
 }

--- a/tgui/packages/tgui-panel/styles/components/Notifications.scss
+++ b/tgui/packages/tgui-panel/styles/components/Notifications.scss
@@ -5,7 +5,7 @@
 
 .Notifications {
   position: absolute;
-  bottom: 1em;
+  bottom: 10em;
   left: 1em;
   right: 2em;
 }


### PR DESCRIPTION
![image](https://github.com/Aurorastation/Aurora.3/assets/107256943/3f30c85c-7e32-42df-bdb6-6cd13b4748fb)


  - tweak: "Chat bad connection notification/popup moved up so it does not block new messages in the chat."