### PR TITLE
Kataphract shield replacement

### DIFF
--- a/html/changelogs/RustingWithYou - katashield.yml
+++ b/html/changelogs/RustingWithYou - katashield.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Replaces the Hegemony energy shields on the Kataphract ship with the Kataphract energy shields."

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -2831,9 +2831,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/dorms)
-"ge" = (
-/turf/simulated/floor/wood,
-/area/kataphract_chapter/dorms)
 "gf" = (
 /obj/machinery/light_switch{
 	pixel_y = 25
@@ -6338,17 +6335,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/sparring_chamber)
-"nl" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	icon_state = "door_locked";
-	id_tag = "kataphract_shuttle_in";
-	locked = 1;
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
-/area/shuttle/kataphract_shuttle/main_compartment)
 "nm" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -8773,12 +8759,12 @@
 /obj/structure/table/rack,
 /obj/item/material/twohanded/pike/flag/hegemony,
 /obj/item/material/twohanded/pike/flag/hegemony,
-/obj/item/shield/energy/hegemony,
-/obj/item/shield/energy/hegemony,
-/obj/item/shield/energy/hegemony,
-/obj/item/shield/energy/hegemony,
-/obj/item/shield/energy/hegemony,
-/obj/item/shield/energy/hegemony,
+/obj/item/shield/energy/hegemony/kataphract,
+/obj/item/shield/energy/hegemony/kataphract,
+/obj/item/shield/energy/hegemony/kataphract,
+/obj/item/shield/energy/hegemony/kataphract,
+/obj/item/shield/energy/hegemony/kataphract,
+/obj/item/shield/energy/hegemony/kataphract,
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/commissary)
 "Jr" = (
@@ -20448,7 +20434,7 @@ fZ
 mR
 fZ
 mR
-ge
+hG
 fK
 tu
 yM
@@ -20605,11 +20591,11 @@ eQ
 cf
 fK
 ga
-ge
-ge
-ge
-ge
-ge
+hG
+hG
+hG
+hG
+hG
 hF
 fK
 tu
@@ -20767,11 +20753,11 @@ eR
 ft
 fK
 gb
-ge
+hG
 pH
 pH
-ge
-ge
+hG
+hG
 Gk
 fK
 tu
@@ -20933,7 +20919,7 @@ gD
 hd
 hg
 pH
-ge
+hG
 hH
 fK
 tu
@@ -21095,7 +21081,7 @@ gE
 he
 hl
 pH
-ge
+hG
 fZ
 fK
 ou
@@ -21252,12 +21238,12 @@ cf
 eU
 cf
 hI
-ge
+hG
 gF
 NJ
 YT
 pH
-ge
+hG
 kE
 fK
 ou
@@ -21419,7 +21405,7 @@ gG
 hg
 Ew
 pH
-ge
+hG
 hH
 fK
 ou
@@ -21577,11 +21563,11 @@ eU
 cf
 fK
 gg
-ge
+hG
 pH
 pH
-ge
-ge
+hG
+hG
 hF
 fK
 lb
@@ -21738,12 +21724,12 @@ cg
 eU
 fv
 fK
-ge
-ge
-ge
-ge
-ge
-ge
+hG
+hG
+hG
+hG
+hG
+hG
 hG
 fK
 lb
@@ -21924,7 +21910,7 @@ GO
 aq
 bn
 lq
-nl
+af
 Re
 hK
 TP


### PR DESCRIPTION
Replaces the Hegemony energy shields on the Kataphract ship with the Kataphract ones.