### PR TITLE
Action and action button refdrop

### DIFF
--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -32,6 +32,7 @@
 /datum/action/Destroy()
 	if(owner)
 		Remove(owner)
+	target = null
 	return ..()
 
 /datum/action/proc/SetTarget(var/atom/Target)
@@ -51,8 +52,7 @@
 	if(button)
 		if(T.client)
 			T.client.screen -= button
-		qdel(button)
-		button = null
+		QDEL_NULL(button)
 	T.actions.Remove(src)
 	T.update_action_buttons()
 	owner = null
@@ -121,6 +121,10 @@
 /obj/screen/movable/action_button
 	var/datum/action/owner
 	screen_loc = "WEST,NORTH"
+
+/obj/screen/movable/action_button/Destroy(force)
+	owner = null
+	. = ..()
 
 /obj/screen/movable/action_button/Click(location,control,params)
 	var/list/modifiers = params2list(params)
@@ -266,4 +270,4 @@
 #undef AB_CHECK_STUNNED
 #undef AB_CHECK_LYING
 #undef AB_CHECK_ALIVE
-#undef AB_CHECK_INSIDE 
+#undef AB_CHECK_INSIDE

--- a/html/changelogs/FluffyGhost-action_and_action_button_refdrop.yml
+++ b/html/changelogs/FluffyGhost-action_and_action_button_refdrop.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "/datum/action and /obj/screen/movable/action_button now drops their references on GC."

--- a/html/changelogs/FluffyGhost-action_and_action_button_refdrop.yml
+++ b/html/changelogs/FluffyGhost-action_and_action_button_refdrop.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "/datum/action and /obj/screen/movable/action_button now drops their references on GC."
+  - bugfix: "/datum/action and /obj/screen/movable/action_button now drops their references on QDEL."


### PR DESCRIPTION
/datum/action and /obj/screen/movable/action_button now drops their references on QDEL