### PR TITLE
Horizon Prisoner Admin Ghost Role

### DIFF
--- a/code/datums/outfits/outfit_admin.dm
+++ b/code/datums/outfits/outfit_admin.dm
@@ -102,3 +102,13 @@
 	head = /obj/item/clothing/head/chameleon
 	mask = /obj/item/clothing/mask/chameleon
 	glasses = /obj/item/clothing/glasses/chameleon
+
+/datum/outfit/admin/horizonprisoner
+	name = "Prisoner"
+	uniform = /obj/item/clothing/under/color/orange
+	back = /obj/item/storage/backpack/satchel/leather
+	shoes = /obj/item/clothing/shoes/orange
+	l_ear = /obj/item/device/radio/headset
+
+	id = /obj/item/card/id
+	pda = /obj/item/modular_computer/handheld/pda/civilian

--- a/code/modules/ghostroles/spawner/human/admin/ccia.dm
+++ b/code/modules/ghostroles/spawner/human/admin/ccia.dm
@@ -124,6 +124,25 @@
 	mob_name_prefix = "Agt. "
 	mob_name_pick_message = "Pick a name."
 
+// Horizon Prisoner
+/datum/ghostspawner/human/admin/corporate/horizonprisoner
+	short_name = "prisoner"
+	name = "SCCV Horizon Prisoner"
+	desc = "You are a prisoner being held within the brig aboard the SCCV Horizon. This role requires special staff authorization to be used. You are not an antagonist, self antagonist rules still apply to you."
+
+	landmark_name = "HorizonPrisoner"
+	possible_species = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_IPC, SPECIES_UNATHI)
+
+	outfit = /datum/outfit/admin/horizonprisoner
+
+	enabled = FALSE
+
+	tags = list("CCIA")
+	req_perms = null
+	req_perms_edit = R_CCIAA
+	max_count = 1
+
+	mob_name_pick_message = "Pick a name."
 /*
 	ERT and Similar Commanders
 */

--- a/html/changelogs/EyeveriChangelog.yml
+++ b/html/changelogs/EyeveriChangelog.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ReadThisNamePlz
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds a Staff-enabled ghost role for CCIA Prisoners."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -13196,6 +13196,15 @@
 /obj/structure/window/shuttle/scc_space_ship,
 /turf/simulated/floor/reinforced,
 /area/horizon/crew_quarters/lounge/bar)
+"gtj" = (
+/obj/structure/bed/stool/chair/plastic{
+	dir = 8
+	},
+/obj/effect/landmark{
+	name = "HorizonPrisoner"
+	},
+/turf/simulated/floor/tiled,
+/area/horizon/security/brig)
 "gtk" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Communal Observation";
@@ -79883,7 +79892,7 @@ fSy
 huP
 huP
 huP
-lBc
+gtj
 lBc
 xzV
 fXA


### PR DESCRIPTION
Adds a ghost role for CCIA to enable, based upon request from the CCIA staff team. 
