### PR TITLE
Changes Radstorm Announcement/Maintenance Access

### DIFF
--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -2,7 +2,7 @@
 	var/const/enterBelt		= 45
 	var/const/radIntervall 	= 5	// 20 ticks
 	var/const/leaveBelt		= 145
-	var/const/revokeAccess	= 200
+	var/const/revokeAccess	= 220
 	has_skybox_image = TRUE
 	startWhen				= 2
 	announceWhen			= 1

--- a/html/changelogs/CampinKiller24-Radstorm-Part2.yml
+++ b/html/changelogs/CampinKiller24-Radstorm-Part2.yml
@@ -1,0 +1,7 @@
+author: CampinKiller24
+
+delete-after: True
+
+changes:
+  - rscadd: "Updated the radiation storm announcements to account for the lingering radiation."
+  - rscadd: "Extended the time before maintenance access is lost after radiation storms."

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -89,8 +89,8 @@
 	dust_end_message = "The ship has now passed through the belt of space dust."
 
 	radiation_detected_message = "High levels of radiation detected near the ship. Please evacuate into one of the shielded maintenance tunnels."
-	radiation_contact_message = "The ship has entered the radiation belt. Please remain in a sheltered area until the ship has cleared it."
-	radiation_end_message = "The ship has passed the radiation belt. Please report to the medbay if you experience any unusual symptoms. Maintenance will lose all-access again shortly."
+	radiation_contact_message = "The ship has entered the radiation belt. Please remain in a sheltered area until the ship has cleared it and engineering has given the all-clear."
+	radiation_end_message = "The ship has passed the radiation belt. Please await the all-clear from engineering staff before exiting maintenance. Report to the medbay if you experience any unusual symptoms. Maintenance will lose all-access again shortly."
 
 	rogue_drone_detected_messages = list("Combat drone swarms from a nearby facility have engaged the ship. If any are sighted in the area, approach with caution.",
 													"Malfunctioning combat drones have been detected close to the ship. If any are sighted in the area, approach with caution.")


### PR DESCRIPTION
Radiation storm announcements have been changed to account for lingering radiation:

The ship has entered the radiation belt. Please remain in a sheltered area until the ship has cleared it and engineering has given the all-clear.
The ship has passed the radiation belt. Please await the all-clear from engineering staff before exiting maintenance. Report to the medbay if you experience any unusual symptoms. Maintenance will lose all-access again shortly.

Additionally, maintenance access loss time has been extended.