### PR TITLE
Off-Duty Vaurca Breeders

### DIFF
--- a/code/game/jobs/job/ship_crew.dm
+++ b/code/game/jobs/job/ship_crew.dm
@@ -42,7 +42,6 @@
 	access = list()
 	minimal_access = list()
 	outfit = /datum/outfit/job/visitor
-	blacklisted_species = list(SPECIES_VAURCA_BREEDER)
 
 /datum/outfit/job/visitor
 	name = "Off-Duty Crew Member"
@@ -51,6 +50,44 @@
 	uniform = /obj/item/clothing/under/color/black
 	shoes = /obj/item/clothing/shoes/black
 
+/datum/outfit/job/visitor/post_equip(mob/living/carbon/human/H, visualsOnly)
+	if(!H)
+		return
+	if(isvaurca(H, TRUE))
+		var/citizenship = H.citizenship
+		H.equip_to_slot_or_del(new /obj/item/clothing/under/gearharness(H), slot_w_uniform)
+		H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
+		switch(citizenship)
+			if(CITIZENSHIP_ZORA)
+				H.equip_to_slot_or_del(new /obj/item/clothing/head/vaurca_breeder(H), slot_head)
+				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/vaurca/breeder(H), slot_shoes)
+				H.equip_to_slot_or_del(new /obj/item/clothing/suit/vaurca/breeder(H), slot_wear_suit)
+				H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec(H), slot_back)
+			if(CITIZENSHIP_KLAX)
+				H.equip_to_slot_or_del(new /obj/item/clothing/head/vaurca_breeder/klax(H), slot_head)
+				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/vaurca/breeder/klax(H), slot_shoes)
+				H.equip_to_slot_or_del(new /obj/item/clothing/suit/vaurca/breeder/klax(H), slot_wear_suit)
+				H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec/klax(H), slot_back)
+			if(CITIZENSHIP_CTHUR)
+				H.equip_to_slot_or_del(new /obj/item/clothing/head/vaurca_breeder/cthur(H), slot_head)
+				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/vaurca/breeder/cthur(H), slot_shoes)
+				H.equip_to_slot_or_del(new /obj/item/clothing/suit/vaurca/breeder/cthur(H), slot_wear_suit)
+				H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec/cthur(H), slot_back)
+			if(CITIZENSHIP_BIESEL)
+				H.equip_to_slot_or_del(new /obj/item/clothing/head/vaurca_breeder/biesel(H), slot_head)
+				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/vaurca/breeder(H), slot_shoes)
+				H.equip_to_slot_or_del(new /obj/item/clothing/suit/vaurca/breeder(H), slot_wear_suit)
+				H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec(H), slot_back)
+			if(CITIZENSHIP_IZWESKI)
+				H.equip_to_slot_or_del(new /obj/item/clothing/head/vaurca_breeder/hegemony(H), slot_head)
+				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/vaurca/breeder/klax(H), slot_shoes)
+				H.equip_to_slot_or_del(new /obj/item/clothing/suit/vaurca/breeder/klax(H), slot_wear_suit)
+				H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec/klax(H), slot_back)
+			if(CITIZENSHIP_NRALAKK)
+				H.equip_to_slot_or_del(new /obj/item/clothing/head/vaurca_breeder/nralakk(H), slot_head)
+				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/vaurca/breeder/nralakk(H), slot_shoes)
+				H.equip_to_slot_or_del(new /obj/item/clothing/suit/vaurca/breeder/nralakk(H), slot_wear_suit)
+				H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec/cthur(H), slot_back)
 /datum/outfit/job/visitor/passenger
 	name = "Passenger"
 	jobtype = /datum/job/passenger

--- a/html/changelogs/RustingWithYou - letthebugschill.yml
+++ b/html/changelogs/RustingWithYou - letthebugschill.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: RustingWithYou
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/RustingWithYou - letthebugschill.yml
+++ b/html/changelogs/RustingWithYou - letthebugschill.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Vaurca Breeders can now join as off-duty crew members."


### PR DESCRIPTION
As the title describes, Vaurca Breeders can now join as off-duty crew members.

This will require Vaurca lore approval, as well as potentially restricting the species by command whitelist if deemed necessary.