### PR TITLE
Electrical storm event refdrop

### DIFF
--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -8,8 +8,8 @@
 	var/global/lightning_color
 
 /datum/event/electrical_storm/Destroy(force)
-	. = ..()
 	valid_apcs = null
+	. = ..()
 
 /datum/event/electrical_storm/get_skybox_image()
 	if(!lightning_color)

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -7,6 +7,10 @@
 	var/list/valid_apcs
 	var/global/lightning_color
 
+/datum/event/electrical_storm/Destroy(force)
+	. = ..()
+	valid_apcs = null
+
 /datum/event/electrical_storm/get_skybox_image()
 	if(!lightning_color)
 		lightning_color = pick("#ffd98c", "#ebc7ff", "#bdfcff", "#bdd2ff", "#b0ffca", "#ff8178", "#ad74cc")
@@ -67,6 +71,7 @@
 
 /datum/event/electrical_storm/end()
 	..()
+	valid_apcs = null
 	for (var/zlevel in affecting_z)
 		if(zlevel in current_map.station_levels)
 			command_announcement.Announce("The [location_name()] has cleared the electrical storm. Please repair any electrical overloads.", "Electrical Storm Alert", zlevels = affecting_z)

--- a/html/changelogs/FluffyGhost-electrical_storm_event_refdrop.yml
+++ b/html/changelogs/FluffyGhost-electrical_storm_event_refdrop.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The electrical storm event now drops the reference to APCs on deletion and end."


### PR DESCRIPTION
The electrical storm event now drops the reference to APCs on deletion and end