### PR TITLE
Sprite Accent Fix

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -127,9 +127,11 @@
 
 /obj/item/update_icon()
 	. = ..()
+	if(build_from_parts || has_accents)
+		cut_overlays()
 	if(build_from_parts)
 		add_overlay(overlay_image(icon,"[icon_state]_[worn_overlay]", flags=RESET_COLOR)) //add the overlay w/o coloration of the original sprite
-	if(accent_color && has_accents)
+	if(has_accents)
 		add_overlay(overlay_image(icon,"[icon_state]_acc",accent_color, RESET_COLOR))
 
 /obj/item/device

--- a/html/changelogs/accent_fix.yml
+++ b/html/changelogs/accent_fix.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed overlays sticking for accent items when toggled."


### PR DESCRIPTION
Fixes an issue where toggleable sprites end up with both versions of their accents overlayed.
