### PR TITLE
Restores KA damage against mineral turfs in atmosphere

### DIFF
--- a/code/modules/custom_ka/projectiles.dm
+++ b/code/modules/custom_ka/projectiles.dm
@@ -40,6 +40,6 @@
 /obj/item/projectile/kinetic/proc/strike_thing(var/turf/target_turf)
 	for(var/new_target in RANGE_TURFS(aoe, target_turf))
 		var/turf/aoe_turf = new_target
-		do_damage(aoe_turf, max(base_damage - base_damage * get_dist(aoe_turf, target_turf) * 0.25, 0), base_damage)
+		do_damage(aoe_turf, max(base_damage - base_damage * get_dist(aoe_turf, target_turf) * 0.25, 0), damage)
 	if(!QDELETED(src))
 		qdel(src)

--- a/html/changelogs/nalarac-kamineralturf.yml
+++ b/html/changelogs/nalarac-kamineralturf.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Nalarac
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Restores kinetic accelerator damage against mineral turfs in atmosphere."


### PR DESCRIPTION
Fixes #17268

Makes damage against mineral turfs return the damage of the kinetic accelerator since currently it uses a flat value of 5 in atmosphere.


