### PR TITLE
Trinary Fixes

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/religion.dm
+++ b/code/modules/client/preference_setup/loadout/items/religion.dm
@@ -10,11 +10,16 @@
 	path = /obj/item/clothing/accessory/badge/trinary
 	slot = slot_tie
 
+/datum/gear/religion/trinary/coif
+	display_name = "trinary perfection coif"
+	path = /obj/item/clothing/head/trinary
+	slot = slot_head
+
 /datum/gear/religion/trinary/robe
 	display_name = "trinary perfection robes selection"
 	description = "A selection of robes worn by adherents of the Trinary Perfection."
 	path = /obj/item/clothing/suit/trinary_robes
-	slot = slot_w_uniform
+	slot = slot_wear_suit
 
 /datum/gear/religion/trinary/robe/New()
 	..()

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -106,10 +106,10 @@
 	flags_inv = HIDEJUMPSUIT
 
 /obj/item/clothing/suit/trinary_robes
-    name = "trinary perfection robe"
-    desc = "Robes worn by those who serve The Trinary Perfection."
-    icon_state = "trinary_robes"
-    item_state = "trinary_robes"
+	name = "trinary perfection robe"
+	desc = "Robes worn by those who serve The Trinary Perfection."
+	icon_state = "trinary_robes"
+	item_state = "trinary_robes"
 
 /*
  * Misc

--- a/html/changelogs/geeves-trinary_fix.yml
+++ b/html/changelogs/geeves-trinary_fix.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed Trinary robes not appearing correctly in the loadout."
+  - bugfix: "Fixed Trinary coif not being in the loadout."


### PR DESCRIPTION
* Fixed Trinary robes not appearing correctly in the loadout.
* Fixed Trinary coif not being in the loadout.

I'm not sure if adding the coif to the loadout counts as a fix, but as far as I'm aware it was supposed to be in the loadout but isn't. If it's an issue feel free to remove the bugfix tag on this PR.