### PR TITLE
Adds an Expeditionary Channel and Intercoms & Gives the Interrogation Channel a Name

### DIFF
--- a/code/__defines/radio.dm
+++ b/code/__defines/radio.dm
@@ -5,7 +5,9 @@
 // Reminder: frequencies should only be odd numbers
 
 // Public frequencies (no encryption key required), see range above
+#define EXP_FREQ	1445
 #define BOT_FREQ	1447
+#define INT_FREQ	1449
 #define PEN_FREQ	1451
 #define PUB_FREQ	1459
 #define ENT_FREQ	1461
@@ -56,7 +58,9 @@ var/list/radiochannels = list(
 	"AI Private"	= AI_FREQ,
 	"Entertainment" = ENT_FREQ,
 	"Medical (I)"	= MED_I_FREQ,
-	"Security (I)"	= SEC_I_FREQ
+	"Security (I)"	= SEC_I_FREQ,
+	"Interrogation" = INT_FREQ,
+	"Expeditionary" = EXP_FREQ
 )
 
 var/list/reverseradiochannels = list(

--- a/code/controllers/subsystems/radio.dm
+++ b/code/controllers/subsystems/radio.dm
@@ -181,13 +181,13 @@ var/datum/controller/subsystem/radio/SSradio
 			return "comradio"
 		if (AI_FREQ)	// AI Private
 			return "airadio"
-		if (SEC_FREQ,SEC_I_FREQ)
+		if (SEC_FREQ,SEC_I_FREQ,INT_FREQ)
 			return "secradio"
 		if (PEN_FREQ)
 			return "penradio"
 		if (ENG_FREQ)
 			return "engradio"
-		if (SCI_FREQ)
+		if (SCI_FREQ, EXP_FREQ)
 			return "sciradio"
 		if (MED_FREQ,MED_I_FREQ)
 			return"medradio"

--- a/code/controllers/subsystems/radio.dm
+++ b/code/controllers/subsystems/radio.dm
@@ -187,7 +187,7 @@ var/datum/controller/subsystem/radio/SSradio
 			return "penradio"
 		if (ENG_FREQ)
 			return "engradio"
-		if (SCI_FREQ, EXP_FREQ)
+		if (SCI_FREQ)
 			return "sciradio"
 		if (MED_FREQ,MED_I_FREQ)
 			return"medradio"
@@ -201,6 +201,8 @@ var/datum/controller/subsystem/radio/SSradio
 			return "bluespaceradio"
 		if (HAIL_FREQ)
 			return "hailradio"
+		if(EXP_FREQ)
+			return "expradio"
 
 	if(DEPT_FREQS_ASSOC[fstr])
 		return "deptradio"

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -155,7 +155,26 @@ pixel_x = 8;
 
 /obj/item/device/radio/intercom/interrogation/Initialize()
 	. = ..()
-	set_frequency(1449)
+	set_frequency(INT_FREQ)
+
+/obj/item/device/radio/intercom/expedition
+	name = "intercom (expeditionary)"
+
+/obj/item/device/radio/intercom/expedition/north
+	PRESET_NORTH
+
+/obj/item/device/radio/intercom/expeditionn/south
+	PRESET_SOUTH
+
+/obj/item/device/radio/intercom/expedition/west
+	PRESET_WEST
+
+/obj/item/device/radio/intercom/expedition/east
+	PRESET_EAST
+
+/obj/item/device/radio/intercom/expedition/Initialize()
+	. = ..()
+	set_frequency(EXP_FREQ)
 
 /obj/item/device/radio/intercom/interrogation/broadcasting/north
 	PRESET_NORTH

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -156,6 +156,24 @@ pixel_x = 8;
 /obj/item/device/radio/intercom/interrogation/Initialize()
 	. = ..()
 	set_frequency(INT_FREQ)
+	internal_channels = default_interrogation_channels
+
+/obj/item/device/radio/intercom/interrogation/broadcasting/north
+	PRESET_NORTH
+
+/obj/item/device/radio/intercom/interrogation/broadcasting/south
+	PRESET_SOUTH
+
+/obj/item/device/radio/intercom/interrogation/broadcasting/west
+	PRESET_WEST
+
+/obj/item/device/radio/intercom/interrogation/broadcasting/east
+	PRESET_EAST
+
+/obj/item/device/radio/intercom/interrogation/broadcasting/Initialize() // The detainee's side.
+	. = ..()
+	set_broadcasting(TRUE)
+	set_listening(FALSE)
 
 /obj/item/device/radio/intercom/expedition
 	name = "intercom (expeditionary)"
@@ -175,23 +193,24 @@ pixel_x = 8;
 /obj/item/device/radio/intercom/expedition/Initialize()
 	. = ..()
 	set_frequency(EXP_FREQ)
+	internal_channels = default_expedition_channels
 
-/obj/item/device/radio/intercom/interrogation/broadcasting/north
+/obj/item/device/radio/intercom/expedition/hailing/north
 	PRESET_NORTH
 
-/obj/item/device/radio/intercom/interrogation/broadcasting/south
+/obj/item/device/radio/intercom/expedition/hailing/south
 	PRESET_SOUTH
 
-/obj/item/device/radio/intercom/interrogation/broadcasting/west
+/obj/item/device/radio/intercom/expedition/hailing/west
 	PRESET_WEST
 
-/obj/item/device/radio/intercom/interrogation/broadcasting/east
+/obj/item/device/radio/intercom/expedition/hailing/east
 	PRESET_EAST
 
-/obj/item/device/radio/intercom/interrogation/broadcasting/Initialize() // The detainee's side.
+/obj/item/device/radio/intercom/expedition/hailing/Initialize()
 	. = ..()
-	set_broadcasting(TRUE)
-	set_listening(FALSE)
+	set_frequency(HAIL_FREQ)
+	internal_channels = default_expedition_channels
 
 /obj/item/device/radio/intercom/private
 	name = "intercom (private)"

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -163,7 +163,7 @@ pixel_x = 8;
 /obj/item/device/radio/intercom/expedition/north
 	PRESET_NORTH
 
-/obj/item/device/radio/intercom/expeditionn/south
+/obj/item/device/radio/intercom/expedition/south
 	PRESET_SOUTH
 
 /obj/item/device/radio/intercom/expedition/west

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -23,6 +23,16 @@ var/global/list/default_medbay_channels = list(
 	num2text(MED_I_FREQ) = list(access_medical_equip)
 )
 
+var/global/list/default_expedition_channels = list(
+	num2text(PUB_FREQ) = list(),
+	num2text(EXP_FREQ) = list(),
+	num2text(HAIL_FREQ) = list()
+)
+
+var/global/list/default_interrogation_channels = list(
+	num2text(INT_FREQ) = list()
+)
+
 //
 // Radios
 //

--- a/html/changelogs/expeditionfrequency.yml
+++ b/html/changelogs/expeditionfrequency.yml
@@ -1,0 +1,7 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - maptweak: "Added expeditionary intercomms to both the Intrepid and Spark, which can be tuned into manually on shortwaves."
+  - tweak: "Interrogation and Expeditionary comm channels are now labelled in chat, and use security and research colours respectively."

--- a/html/changelogs/expeditionfrequency.yml
+++ b/html/changelogs/expeditionfrequency.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - maptweak: "Added expeditionary intercomms to both the Intrepid and Spark, which can be tuned into manually on shortwaves."
-  - tweak: "Interrogation and Expeditionary comm channels are now labelled in chat, and use security and research colours respectively."
+  - tweak: "Interrogation and Expeditionary comm channels are now labelled in chat, and are coloured based on channel too."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -2400,6 +2400,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/dark_blue/diagonal,
+/obj/item/device/radio/intercom/expedition/hailing/east,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/intrepid/crew_compartment)
 "bID" = (
@@ -7287,6 +7288,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/item/device/radio/intercom/expedition/hailing/north{
+	pixel_x = -8;
+	pixel_y = 18
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
 "fdA" = (

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -751,7 +751,7 @@
 /area/hangar/operations)
 "aFx" = (
 /obj/structure/bed/stool/chair/sofa/left/red,
-/obj/item/device/radio/intercom/north,
+/obj/item/device/radio/intercom/expedition/north,
 /turf/simulated/floor/lino,
 /area/shuttle/intrepid/crew_compartment)
 "aFA" = (
@@ -862,7 +862,7 @@
 	pixel_x = -7;
 	pixel_y = 3
 	},
-/obj/item/device/radio/intercom/north,
+/obj/item/device/radio/intercom/expedition/north,
 /turf/simulated/floor/lino,
 /area/shuttle/intrepid/quarters)
 "aJA" = (
@@ -3193,7 +3193,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/item/device/radio/intercom/south,
+/obj/item/device/radio/intercom/expedition,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/intrepid/crew_compartment)
 "cpt" = (
@@ -3551,7 +3551,7 @@
 	pixel_x = -23;
 	req_access = null
 	},
-/obj/item/device/radio/intercom/west{
+/obj/item/device/radio/intercom/expedition/west{
 	pixel_y = -21
 	},
 /turf/simulated/floor/tiled/dark,
@@ -10169,7 +10169,7 @@
 /area/hangar/auxiliary)
 "hcq" = (
 /obj/structure/bed/stool/chair/office/bridge,
-/obj/item/device/radio/intercom/west{
+/obj/item/device/radio/intercom/expedition/west{
 	pixel_y = 2
 	},
 /obj/machinery/button/remote/blast_door{
@@ -14791,7 +14791,7 @@
 	id = "intrepid_bay_outer";
 	name = "Intrepid Shutter"
 	},
-/obj/item/device/radio/intercom/east,
+/obj/item/device/radio/intercom/expedition/east,
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/cargo_bay)
 "kyq" = (
@@ -16177,7 +16177,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/item/device/radio/intercom/east{
+/obj/item/device/radio/intercom/expedition/east{
 	pixel_y = 21
 	},
 /obj/structure/cable/green{
@@ -17366,7 +17366,7 @@
 	},
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/bed/roller,
-/obj/item/device/radio/intercom/south,
+/obj/item/device/radio/intercom/expedition,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/intrepid/crew_compartment)
 "mmh" = (
@@ -33418,7 +33418,7 @@
 	layer = 2.8
 	},
 /obj/structure/lattice/catwalk/indoor,
-/obj/item/device/radio/intercom/east,
+/obj/item/device/radio/intercom/expedition/east,
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/cargo_bay)
 "xqv" = (

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -3193,7 +3193,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/item/device/radio/intercom/expedition,
+/obj/item/device/radio/intercom/expedition/south,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/intrepid/crew_compartment)
 "cpt" = (
@@ -17366,7 +17366,7 @@
 	},
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/bed/roller,
-/obj/item/device/radio/intercom/expedition,
+/obj/item/device/radio/intercom/expedition/south,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/intrepid/crew_compartment)
 "mmh" = (

--- a/nano/templates/radio_basic.tmpl
+++ b/nano/templates/radio_basic.tmpl
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 Title: Basic Radio UI
 Used In File(s): /code/game/objects/item/devices/radio/radio.dm
 -->
@@ -19,6 +19,7 @@ Used In File(s): /code/game/objects/item/devices/radio/radio.dm
 		.sciradio				{color: #c03bc0;}
 		.supradio				{color: #c09141;}
 		.srvradio				{color: #7fc732;}
+    .expradio       {color: #5a3975;}
 
 		.channelList			{overflow: clip;}
 	</style>
@@ -71,7 +72,7 @@ Used In File(s): /code/game/objects/item/devices/radio/radio.dm
 		</div>
 	</div>
 {{/if}}
-		
+
 {{if data.has_loudspeaker}}
 	<div class="item">
 		<div class="itemLabelWide">

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -455,6 +455,10 @@ em {
   color: #7fc732;
 }
 
+.expradio {
+  color: #5a3975;
+}
+
 /* Miscellaneous */
 .name {
   font-weight: bold;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -454,7 +454,6 @@ em {
 .srvradio {
   color: #7fc732;
 }
-
 .expradio {
   color: #5a3975;
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -460,7 +460,6 @@ em {
 .srvradio {
   color: #6eaa2c;
 }
-
 .expradio {
   color: #5a3975;
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -461,6 +461,10 @@ em {
   color: #6eaa2c;
 }
 
+.expradio {
+  color: #5a3975;
+}
+
 /* Miscellaneous */
 .name {
   font-weight: bold;


### PR DESCRIPTION
Adds Expeditionary intercomms to both the Spark and Intrepid, able to be tuned into on shortwaves. Both Interrogation and Expeditionary comm channels are now labelled in chat, with security and research colours respectively. 

(Yes I know the numbering is wrong)