### PR TITLE
Simplemob AI Tweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -75,9 +75,9 @@
 			var/mob/M = A
 			if(M.key && !M.client)
 				continue
-		if(ishuman(A))
-			var/mob/living/carbon/human/H = A
-			if(H.paralysis)
+		if(isliving(A))
+			var/mob/living/M = A
+			if(M.paralysis)
 				continue
 		if(!isturf(A.loc))
 			A = A.loc
@@ -218,11 +218,10 @@
 			resist_grab()
 			return
 	var/atom/target
-	if(ishuman(target_mob))
-		if(target_mob.paralysis)
-			return
 	if(isliving(target_mob))
 		var/mob/living/L = target_mob
+		if(L.paralysis)
+			return
 		on_attack_mob(L, L.attack_generic(src, rand(melee_damage_lower, melee_damage_upper), attacktext, armor_penetration, attack_flags, damage_type))
 		target = L
 	else if(istype(target_mob, /obj/machinery/bot))

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -75,6 +75,10 @@
 			var/mob/M = A
 			if(M.key && !M.client)
 				continue
+		if(ishuman(A))
+			var/mob/living/carbon/human/H = A
+			if(H.paralysis)
+				continue
 		if(!isturf(A.loc))
 			A = A.loc
 		var/datum/callback/cb = null
@@ -214,6 +218,9 @@
 			resist_grab()
 			return
 	var/atom/target
+	if(ishuman(target_mob))
+		if(target_mob.paralysis)
+			return
 	if(isliving(target_mob))
 		var/mob/living/L = target_mob
 		on_attack_mob(L, L.attack_generic(src, rand(melee_damage_lower, melee_damage_upper), attacktext, armor_penetration, attack_flags, damage_type))
@@ -236,7 +243,7 @@
 	if(target)
 		face_atom(target)
 		if(!ranged && smart_melee)
-			addtimer(CALLBACK(src, PROC_REF(PostAttack), target), 0.6 SECONDS)
+			addtimer(CALLBACK(src, PROC_REF(PostAttack), target), 1.2 SECONDS)
 		return target
 
 /mob/living/simple_animal/hostile/proc/PostAttack(var/atom/target)

--- a/html/changelogs/hostiles-fairness.yml
+++ b/html/changelogs/hostiles-fairness.yml
@@ -1,0 +1,8 @@
+
+author: atteria
+
+delete-after: True
+
+changes:
+  - tweak: "Doubled the delay on simplemob dodging."
+  - bugfix: "Hostile simplemobs no longer beat you to death when you're down."


### PR DESCRIPTION
Doubled the callback time on the simplemob dodging. It feels a lot less frustrating.
Made hostile simplemobs targeting discard targets that are paralyzed. This mostly solves the problem, and also prevents mobs from shooting at and really aggressively camping downed targets. (Fixes #12008.)
Interrupts attacks against paralyzed targets, since targeting takes a bit to recalculate.

Doesn't prevent attacks on stunned/weakened opponents.

Tested a bunch by losing to hivebot swarms, works great, feels more fun.