### PR TITLE
Vaurca Ghostrole Language Augments

### DIFF
--- a/html/changelogs/RustingWithYou - vaurcaghostroles.yml
+++ b/html/changelogs/RustingWithYou - vaurcaghostroles.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Vaurca ghostroles that could have any hive now recieve a language modulator based on their surname."

--- a/maps/away/away_site/space_bar/space_bar_ghostroles.dm
+++ b/maps/away/away_site/space_bar/space_bar_ghostroles.dm
@@ -147,6 +147,17 @@
 	var/obj/item/organ/internal/vaurca/preserve/preserve = H.internal_organs_by_name[BP_PHORON_RESERVE]
 	H.internal = preserve
 	H.internals.icon_state = "internal1"
+	var/surname = splittext(H.name, " ")
+	switch(surname)
+		if("K'lax")
+			var/obj/item/organ/A = new /obj/item/organ/internal/augment/language/klax(H)
+			var/obj/item/organ/external/affected = H.get_organ(A.parent_organ)
+			A.replaced(H, affected)
+		if("C'thur")
+			var/obj/item/organ/A = new /obj/item/organ/internal/augment/language/cthur(H)
+			var/obj/item/organ/external/affected = H.get_organ(A.parent_organ)
+			A.replaced(H, affected)
+	H.update_body()
 
 /datum/outfit/admin/random/space_bar_patron/offworlder
 	r_pocket = /obj/item/storage/pill_bottle/rmt

--- a/maps/away/ships/freebooter/freebooter_ship_ghostroles.dm
+++ b/maps/away/ships/freebooter/freebooter_ship_ghostroles.dm
@@ -45,6 +45,17 @@
 		H.internal = preserve
 		H.internals.icon_state = "internal1"
 		H.equip_or_collect(new /obj/item/reagent_containers/food/snacks/koisbar, slot_in_backpack)
+		var/surname = splittext(H.name, " ")
+		switch(surname)
+			if("K'lax")
+				var/obj/item/organ/A = new /obj/item/organ/internal/augment/language/klax(H)
+				var/obj/item/organ/external/affected = H.get_organ(A.parent_organ)
+				A.replaced(H, affected)
+			if("C'thur")
+				var/obj/item/organ/A = new /obj/item/organ/internal/augment/language/cthur(H)
+				var/obj/item/organ/external/affected = H.get_organ(A.parent_organ)
+				A.replaced(H, affected)
+		H.update_body()
 	if(isoffworlder(H))
 		H.equip_or_collect(new /obj/item/storage/pill_bottle/rmt, slot_in_backpack)
 

--- a/maps/away/ships/iac/iac_rescue_ship_ghostroles.dm
+++ b/maps/away/ships/iac/iac_rescue_ship_ghostroles.dm
@@ -48,6 +48,17 @@
 		H.internal = preserve
 		H.internals.icon_state = "internal1"
 		H.equip_or_collect(new /obj/item/reagent_containers/food/snacks/koisbar, slot_in_backpack)
+		var/surname = splittext(H.name, " ")
+		switch(surname)
+			if("K'lax")
+				var/obj/item/organ/A = new /obj/item/organ/internal/augment/language/klax(H)
+				var/obj/item/organ/external/affected = H.get_organ(A.parent_organ)
+				A.replaced(H, affected)
+			if("C'thur")
+				var/obj/item/organ/A = new /obj/item/organ/internal/augment/language/cthur(H)
+				var/obj/item/organ/external/affected = H.get_organ(A.parent_organ)
+				A.replaced(H, affected)
+		H.update_body()
 	if(isoffworlder(H))
 		H.equip_or_collect(new /obj/item/storage/pill_bottle/rmt, slot_in_backpack)
 

--- a/maps/away/ships/orion/orion_express_ship_ghostroles.dm
+++ b/maps/away/ships/orion/orion_express_ship_ghostroles.dm
@@ -47,6 +47,17 @@
 		H.internal = preserve
 		H.internals.icon_state = "internal1"
 		H.equip_or_collect(new /obj/item/reagent_containers/food/snacks/koisbar, slot_in_backpack)
+		var/surname = splittext(H.name, " ")
+		switch(surname)
+			if("K'lax")
+				var/obj/item/organ/A = new /obj/item/organ/internal/augment/language/klax(H)
+				var/obj/item/organ/external/affected = H.get_organ(A.parent_organ)
+				A.replaced(H, affected)
+			if("C'thur")
+				var/obj/item/organ/A = new /obj/item/organ/internal/augment/language/cthur(H)
+				var/obj/item/organ/external/affected = H.get_organ(A.parent_organ)
+				A.replaced(H, affected)
+		H.update_body()
 	if(isoffworlder(H))
 		H.equip_or_collect(new /obj/item/storage/pill_bottle/rmt, slot_in_backpack)
 

--- a/maps/away/ships/tramp_freighter/tramp_freighter_ghostroles.dm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter_ghostroles.dm
@@ -45,6 +45,17 @@
 		H.internal = preserve
 		H.internals.icon_state = "internal1"
 		H.equip_or_collect(new /obj/item/reagent_containers/food/snacks/koisbar, slot_in_backpack)
+		var/surname = splittext(H.name, " ")
+		switch(surname)
+			if("K'lax")
+				var/obj/item/organ/A = new /obj/item/organ/internal/augment/language/klax(H)
+				var/obj/item/organ/external/affected = H.get_organ(A.parent_organ)
+				A.replaced(H, affected)
+			if("C'thur")
+				var/obj/item/organ/A = new /obj/item/organ/internal/augment/language/cthur(H)
+				var/obj/item/organ/external/affected = H.get_organ(A.parent_organ)
+				A.replaced(H, affected)
+		H.update_body()
 	if(isoffworlder(H))
 		H.equip_or_collect(new /obj/item/storage/pill_bottle/rmt, slot_in_backpack)
 


### PR DESCRIPTION
Adds C'thur or K'lax language augments to Vaurca in ghostroles that are suitably generic to have any hive. Currently this is Freebooter, Tramp Freighter, IAC, Orion Express, civilian station and space bar.

Augments are added based off surname.