### PR TITLE
Big Mob Preview Fixes

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -282,6 +282,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 	out += "</td><td><b>Preview</b>"
 	out += "<br><a href='?src=\ref[src];cycle_bg=1'>Cycle background</a>"
+	out += "<br><a href='?src=\ref[src];set_preview_scale=1'>Set Preview Scale - [pref.scale_x] - [pref.scale_y]</a>"
 	out += "<br><a href='?src=\ref[src];toggle_preview_value=[EQUIP_PREVIEW_LOADOUT]'>[pref.equip_preview_mob & EQUIP_PREVIEW_LOADOUT ? "Hide loadout" : "Show loadout"]</a>"
 	out += "<br><a href='?src=\ref[src];toggle_preview_value=[EQUIP_PREVIEW_JOB]'>[pref.equip_preview_mob & EQUIP_PREVIEW_JOB ? "Hide job gear" : "Show job gear"]</a>"
 	out += "</td></tr></table>"
@@ -418,6 +419,24 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 			else
 				//this shouldn't happen
 				pref.f_style = facial_hair_styles_list["Shaved"]
+
+			var/list/valid_hair_gradients = list()
+			for(var/hair_gradient in hair_gradient_styles_list)
+				var/datum/sprite_accessory/S = hair_gradient_styles_list[hair_gradient]
+				if(pref.gender == MALE && S.gender == FEMALE)
+					continue
+				if(pref.gender == FEMALE && S.gender == MALE)
+					continue
+				if(!(mob_species.type in S.species_allowed))
+					continue
+
+				valid_hair_gradients[hair_gradient] = valid_hair_gradients[hair_gradient]
+
+			if(length(valid_hair_gradients))
+				pref.g_style = pick(valid_hair_gradients)
+			else
+				//this shouldn't happen
+				pref.g_style = valid_hair_gradients["None"]
 
 			//reset hair colour and skin colour
 			pref.r_hair = 0//hex2num(copytext(new_hair, 2, 4))
@@ -807,6 +826,13 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 	else if(href_list["cycle_bg"])
 		pref.bgstate = next_in_list(pref.bgstate, pref.bgstate_options)
+		return TOPIC_REFRESH_UPDATE_PREVIEW
+
+	else if(href_list["set_preview_scale"])
+		var/new_x = input(user, "Set X Scale for Preview", "Preview Preference") as null|num
+		pref.scale_x = new_x ? clamp(new_x, 0.1, 2) : 1
+		var/new_y = input(user, "Set Y Scale for Preview", "Preview Preference") as null|num
+		pref.scale_y = new_y ? clamp(new_y, 0.1, 2) : 1
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 
 	else if(href_list["toggle_preview_value"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -103,11 +103,10 @@ var/list/preferences_datums = list()
 
 	var/list/char_render_holders		//Should only be a key-value list of north/south/east/west = obj/screen.
 	var/static/list/preview_screen_locs = list(
-		"1" = "character_preview_map:1,5:-12",
-		"2" = "character_preview_map:1,3:15",
-		"4"  = "character_preview_map:1:0,2:10",
-		"8"  = "character_preview_map:1:0,1:5",
-		"BG" = "character_preview_map:1,1 to 1,5"
+		"1" = list(1, 0, 5, -12),
+		"2" = list(1, 0, 3, 15),
+		"4" = list(1, 0, 2, 10),
+		"8" = list(1, 0, 1, 5)
 	)
 
 		//Jobs, uses bitflags
@@ -191,6 +190,9 @@ var/list/preferences_datums = list()
 
 	var/fov_cone_alpha = 255
 
+	var/scale_x = 1
+	var/scale_y = 1
+
 /datum/preferences/New(client/C)
 	new_setup()
 
@@ -260,7 +262,7 @@ var/list/preferences_datums = list()
 	popup.open(FALSE) // Skip registering onclose on the browser pane
 	onclose(user, "preferences_window", src) // We want to register on the window itself
 
-/datum/preferences/proc/update_character_previews(mutable_appearance/MA)
+/datum/preferences/proc/update_character_previews(mutable_appearance/MA, var/big_mob = FALSE)
 	if(!client)
 		return
 
@@ -277,8 +279,9 @@ var/list/preferences_datums = list()
 		LAZYSET(char_render_holders, "BG", BG)
 		client.screen |= BG
 	BG.icon_state = bgstate
-	BG.screen_loc = preview_screen_locs["BG"]
+	BG.screen_loc = "character_preview_map:1,1 to 1,5"
 
+	var/index = 0
 	for(var/D in global.cardinal)
 		var/obj/screen/O = LAZYACCESS(char_render_holders, "[D]")
 		if(!O)
@@ -287,7 +290,17 @@ var/list/preferences_datums = list()
 			client.screen |= O
 		O.appearance = MA
 		O.dir = D
-		O.screen_loc = preview_screen_locs["[D]"]
+		var/list/screen_locs = preview_screen_locs["[D]"]
+		var/screen_x = screen_locs[1]
+		var/screen_x_minor = screen_locs[2]
+		screen_x_minor -= MA.pixel_x
+		var/screen_y = screen_locs[3]
+		var/screen_y_minor = screen_locs[4]
+		if(big_mob)
+			screen_y_minor += round(30 - (index * 15))
+		screen_y_minor -= MA.pixel_y
+		O.screen_loc = "character_preview_map:[screen_x]:[screen_x_minor],[screen_y]:[screen_y_minor]"
+		index++
 
 /datum/preferences/proc/show_character_previews()
 	if(!client || !char_render_holders)

--- a/code/modules/mob/abstract/new_player/preferences_setup.dm
+++ b/code/modules/mob/abstract/new_player/preferences_setup.dm
@@ -261,5 +261,14 @@
 	return mannequin
 
 /datum/preferences/proc/update_preview_icon()
-	var/mannequin = update_mannequin()
-	update_character_previews(new /mutable_appearance(mannequin))
+	var/mob/living/carbon/human/dummy/mannequin/mannequin = update_mannequin()
+	var/mutable_appearance/MA = new /mutable_appearance(mannequin)
+	MA.appearance_flags = PIXEL_SCALE
+	if(mannequin.species?.icon_x_offset)
+		MA.pixel_x = mannequin.species.icon_x_offset
+	if(mannequin.species?.icon_y_offset)
+		MA.pixel_y = mannequin.species.icon_y_offset
+	var/matrix/M = matrix()
+	M.Scale(scale_x, scale_y)
+	MA.transform = M
+	update_character_previews(MA, (MA.pixel_x != 0 || MA.pixel_y != 0))

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -435,6 +435,7 @@ There are several things that need to be remembered:
 	var/icon/face_standing = SSicon_cache.human_hair_cache[cache_key]
 	if (!face_standing)	// Not cached, generate it from scratch.
 		face_standing = new /icon(species.canvas_icon, "blank")
+
 		// Beard.
 		if(f_style)
 			var/datum/sprite_accessory/facial_hair_style = facial_hair_styles_list[f_style]
@@ -454,9 +455,10 @@ There are several things that need to be remembered:
 				if(hair_style.do_colouration)
 					if(g_style)
 						var/datum/sprite_accessory/gradient_style = hair_gradient_styles_list[g_style]
-						grad_s = new/icon("icon" = gradient_style.icon, "icon_state" = gradient_style.icon_state)
-						grad_s.Blend(hair_s, ICON_AND)
-						grad_s.Blend(rgb(r_grad, g_grad, b_grad), ICON_MULTIPLY)
+						if(gradient_style && gradient_style.species_allowed && (species.type in gradient_style.species_allowed))
+							grad_s = new/icon("icon" = gradient_style.icon, "icon_state" = gradient_style.icon_state)
+							grad_s.Blend(hair_s, ICON_AND)
+							grad_s.Blend(rgb(r_grad, g_grad, b_grad), ICON_MULTIPLY)
 					hair_s.Blend(rgb(r_hair, g_hair, b_hair), hair_style.icon_blend_mode)
 					if(!isnull(grad_s))
 						var/icon/grad_s_final = new/icon("icon" = hair_style.icon, "icon_state" = hair_style.icon_state)

--- a/html/changelogs/geeves-big_mob_preview_fixes.yml
+++ b/html/changelogs/geeves-big_mob_preview_fixes.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed big mobs not appearing correctly in the loadout preview."
+  - bugfix: "Fixed the wrong gradient being selected when species are swapped."

--- a/html/changelogs/geeves-big_mob_preview_fixes.yml
+++ b/html/changelogs/geeves-big_mob_preview_fixes.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes:
   - bugfix: "Fixed big mobs not appearing correctly in the loadout preview."
   - bugfix: "Fixed the wrong gradient being selected when species are swapped."
+  - rscadd: "Added a scale adjuster in the loadout, so you can size your mob up and down to get a closer look, if you ever want to do that."


### PR DESCRIPTION
* Fixed big mobs not appearing correctly in the loadout preview.
* Fixed the wrong gradient being selected when species are swapped.
* Added a scale adjuster in the loadout, so you can size your mob up and down to get a closer look, if you ever want to do that.

![image](https://github.com/Aurorastation/Aurora.3/assets/22774890/806f2a35-af57-4382-8abb-7fd08b86ae09)
