### PR TITLE
Tarwa Conglomerate Diona Limbs

### DIFF
--- a/html/changelogs/RustingWithYou - tarwalimbs.yml
+++ b/html/changelogs/RustingWithYou - tarwalimbs.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Tarwa Conglomerate pirates now have a chance to spawn with diona nymph limbs."

--- a/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa.dm
+++ b/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa.dm
@@ -2,8 +2,7 @@
 	name = "Tarwa Conglomerate Ship"
 	description = "Ship with pirate lizards, pirate plants"
 	suffixes = list("away_site/unathi_pirate/tarwa/unathi_pirate_tarwa.dmm")
-	sectors = list(SECTOR_BADLANDS, SECTOR_GAKAL, SECTOR_LIGHTS_EDGE, SECTOR_WEEPING_STARS, ALL_POSSIBLE_SECTORS)
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
+	sectors = list(SECTOR_BADLANDS, SECTOR_GAKAL, SECTOR_LIGHTS_EDGE, SECTOR_WEEPING_STARS)
 	spawn_weight = 1
 	ship_cost = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/tarwa_shuttle)

--- a/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa.dm
+++ b/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa.dm
@@ -2,7 +2,8 @@
 	name = "Tarwa Conglomerate Ship"
 	description = "Ship with pirate lizards, pirate plants"
 	suffixes = list("away_site/unathi_pirate/tarwa/unathi_pirate_tarwa.dmm")
-	sectors = list(SECTOR_BADLANDS, SECTOR_GAKAL, SECTOR_LIGHTS_EDGE, SECTOR_WEEPING_STARS)
+	sectors = list(SECTOR_BADLANDS, SECTOR_GAKAL, SECTOR_LIGHTS_EDGE, SECTOR_WEEPING_STARS, ALL_POSSIBLE_SECTORS)
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 	spawn_weight = 1
 	ship_cost = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/tarwa_shuttle)

--- a/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa_ghostroles.dm
+++ b/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa_ghostroles.dm
@@ -17,7 +17,7 @@
 	respawn_flag = null
 	extra_languages = list(LANGUAGE_AZAZIBA)
 	away_site = TRUE
-	welcome_message = "The Tarwa Conglomerate is a pirate group, largely operating towards the southeastern edge of the Spur. Little is known of them to others, and your ship likely thrives on this mystique. The wiki page for Unathi Piracy contains more information on this group, and how they operate."
+	welcome_message = "The Tarwa Conglomerate is a pirate group, largely operating towards the southeastern edge of the Spur. Little is known of them to others, and your ship likely thrives on this mystique. The wiki page for Unathi Piracy contains more information on this group, and how they operate. NOTE - If you spawned with a Diona limb and are missing a hand or foot, use the 'Detach Nymph' verb and then reattach the nymph to fix this."
 
 /datum/ghostspawner/human/tarwa/diona
 	short_name = "tarwa_diona"
@@ -34,7 +34,7 @@
 /datum/ghostspawner/human/tarwa/captain
 	short_name = "tarwa_captain"
 	name = "Tarwa Conglomerate Captain"
-	desc = "You are the captain of a pirate crew of the Tarwa Conglomerate - also called the living-dead fleet. Lead your crew to profit and glory, for the sake of your fleet. NOT AN ANTAGONIST! Do not act as such."
+	desc = "You are the captain of a pirate crew of the Tarwa Conglomerate - also called the living-dead fleet. Lead your crew to profit and glory, for the sake of your fleet. NOT AN ANTAGONIST! Do not act as such. NOTE - If you spawned with a Diona limb and are missing a hand or foot, use the 'Detach Nymph' verb and then reattach the nymph to fix this."
 	max_count = 1
 	uses_species_whitelist = TRUE
 	assigned_role = "Tarwa Conglomerate Captain"
@@ -59,7 +59,10 @@
 /datum/outfit/admin/tarwa/post_equip(mob/living/carbon/human/H, visualsOnly)
 	if(!istype(H))
 		return
-	for(var/obj/item/organ/external/O in H.organs)
+	for(var/name in H.organs_by_name)
+		var/obj/item/organ/external/O = H.organs_by_name[name]
+		if(!O || name == BP_HEAD || name == BP_CHEST || name == BP_GROIN)
+			continue
 		if(prob(25))
 			O.AddComponent(/datum/component/nymph_limb)
 			var/datum/component/nymph_limb/D = O.GetComponent(/datum/component/nymph_limb)
@@ -73,6 +76,7 @@
 	name = "Tarwa Conglomerate Diona"
 	suit = /obj/item/clothing/accessory/poncho/green
 	head = /obj/item/clothing/head/bandana/pirate
+	backpack_contents = list(/obj/item/device/uv_light = 1)
 
 /datum/outfit/admin/tarwa/diona/post_equip(mob/living/carbon/human/H, visualsOnly) //don't give a diona a diona nymph limb. idiot.
 

--- a/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa_ghostroles.dm
+++ b/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa_ghostroles.dm
@@ -59,9 +59,9 @@
 /datum/outfit/admin/tarwa/post_equip(mob/living/carbon/human/H, visualsOnly)
 	if(!istype(H))
 		return
-	for(var/name in H.organs_by_name)
-		var/obj/item/organ/external/O = H.organs_by_name[name]
-		if(!O || name == BP_HEAD || name == BP_CHEST || name == BP_GROIN)
+	for(var/organ in H.organs_by_name)
+		var/obj/item/organ/external/O = H.organs_by_name[organ]
+		if(!O || organ == BP_HEAD || organ == BP_CHEST || organ == BP_GROIN)
 			continue
 		if(prob(25))
 			O.AddComponent(/datum/component/nymph_limb)

--- a/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa_ghostroles.dm
+++ b/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa_ghostroles.dm
@@ -56,6 +56,16 @@
 		/obj/item/storage/box/survival = 1
 	)
 
+/datum/outfit/admin/tarwa/post_equip(mob/living/carbon/human/H, visualsOnly)
+	if(!istype(H))
+		return
+	for(var/obj/item/organ/external/O in H.organs)
+		if(prob(25))
+			O.AddComponent(/datum/component/nymph_limb)
+			var/datum/component/nymph_limb/D = O.GetComponent(/datum/component/nymph_limb)
+			if(D)
+				D.nymphize(H, O.limb_name, TRUE)
+
 /datum/outfit/admin/tarwa/get_id_access()
 	return list(access_unathi_pirate, access_external_airlocks)
 
@@ -63,6 +73,8 @@
 	name = "Tarwa Conglomerate Diona"
 	suit = /obj/item/clothing/accessory/poncho/green
 	head = /obj/item/clothing/head/bandana/pirate
+
+/datum/outfit/admin/tarwa/diona/post_equip(mob/living/carbon/human/H, visualsOnly) //don't give a diona a diona nymph limb. idiot.
 
 /datum/outfit/admin/tarwa/captain
 	name = "Tarwa Conglomerate Captain"

--- a/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa_ghostroles.dm
+++ b/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa_ghostroles.dm
@@ -79,6 +79,7 @@
 	backpack_contents = list(/obj/item/device/uv_light = 1)
 
 /datum/outfit/admin/tarwa/diona/post_equip(mob/living/carbon/human/H, visualsOnly) //don't give a diona a diona nymph limb. idiot.
+	return
 
 /datum/outfit/admin/tarwa/captain
 	name = "Tarwa Conglomerate Captain"


### PR DESCRIPTION
Tarwa Conglomerate pirates now have a chance to spawn with nymph limbs.

Sometimes when an arm or leg nymphizes, the child limb doesn't nymphize correctly and just disappears. I couldn't find a way to prevent this from happening, but the player can detach and reattach the limb to fix it, which has been mentioned in the welcome message.