### PR TITLE
Runtime map: Fixes two non-airless variant tiles that should be airless

### DIFF
--- a/html/changelogs/DreamySkrell-cursed-runtime.yml
+++ b/html/changelogs/DreamySkrell-cursed-runtime.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes two non-airless variant tiles that should be airless."

--- a/html/changelogs/DreamySkrell-cursed-runtime.yml
+++ b/html/changelogs/DreamySkrell-cursed-runtime.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "Fixes two non-airless variant tiles that should be airless."
+  - bugfix: "Runtime map. Fixes two non-airless variant tiles that should be airless."

--- a/maps/runtime/runtime-3.dmm
+++ b/maps/runtime/runtime-3.dmm
@@ -1,10 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aa" = (
-/obj/machinery/door/airlock/generic/maintenance{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/construction/qmaint)
 "ab" = (
 /obj/machinery/door/airlock/external/blue{
 	dir = 1
@@ -44,12 +38,6 @@
 	},
 /turf/simulated/floor/wood/mahogany,
 /area/construction/solars)
-"ah" = (
-/obj/machinery/door/airlock/external/merc{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/antag/mercenary)
 "aj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -137,12 +125,6 @@
 	},
 /turf/simulated/floor,
 /area/construction/hallway)
-"bY" = (
-/obj/machinery/door/airlock/external/red{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/antag/mercenary)
 "cC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -175,12 +157,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction/hallway)
-"dT" = (
-/obj/machinery/door/airlock/external/khaki{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/antag/mercenary)
 "dX" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -925,9 +901,6 @@
 "tZ" = (
 /turf/simulated/wall,
 /area/construction/hallway)
-"uj" = (
-/turf/simulated/floor,
-/area/template_noop)
 "um" = (
 /turf/simulated/floor/wood/birch,
 /area/construction/solars)
@@ -956,12 +929,6 @@
 	},
 /turf/simulated/floor/wood/birch,
 /area/construction/storage)
-"wo" = (
-/obj/machinery/door/airlock/external/blue{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/antag/mercenary)
 "wq" = (
 /obj/machinery/light{
 	dir = 1
@@ -1266,12 +1233,6 @@
 "Ci" = (
 /turf/simulated/wall,
 /area/construction/supplyshuttle)
-"Cj" = (
-/obj/machinery/door/airlock/external/purple{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/antag/mercenary)
 "Cr" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/wood/birch,
@@ -8905,7 +8866,7 @@ Pz
 Pz
 Pz
 Bc
-uj
+Bc
 nA
 pM
 nA
@@ -9162,7 +9123,7 @@ Bc
 Bc
 Bc
 Bc
-uj
+Bc
 nA
 pM
 nA
@@ -24813,7 +24774,7 @@ WY
 nW
 KW
 ye
-aa
+pI
 pz
 pz
 pz
@@ -31232,7 +31193,7 @@ pz
 pz
 pz
 pz
-wo
+ab
 Vu
 lB
 za
@@ -32774,7 +32735,7 @@ pz
 pz
 pz
 pz
-Cj
+ac
 Vu
 lB
 bb
@@ -34316,7 +34277,7 @@ pz
 pz
 pz
 pz
-dT
+ae
 Vu
 lB
 Dt
@@ -35858,7 +35819,7 @@ Uv
 pz
 pz
 pz
-bY
+af
 Vu
 lB
 ol
@@ -37407,7 +37368,7 @@ DE
 ek
 Bd
 Bd
-ah
+KZ
 Bd
 Bd
 Bd


### PR DESCRIPTION
  - bugfix: "Runtime map. Fixes two non-airless variant tiles that should be airless."
