### PR TITLE
Prevent reprocessing zas invalid zones on turf deletion

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -152,7 +152,7 @@
 		new /obj/effect/decal/cleanable/blood/oil(src)
 
 /turf/simulated/Destroy()
-	if (zone)
+	if (zone && !zone.invalid)
 		// Try to remove it gracefully first.
 		if (can_safely_remove_from_zone())
 			c_copy_air()

--- a/html/changelogs/FluffyGhost-prevent_reprocessing_zas_invalid_zones.yml
+++ b/html/changelogs/FluffyGhost-prevent_reprocessing_zas_invalid_zones.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "ZAS invalid zones would not be reprocessed during turf deletions."


### PR DESCRIPTION
ZAS invalid zones would not be reprocessed during turf deletions