### PR TITLE
Unathi Origin Traits & Accent Stuff

### DIFF
--- a/code/modules/background/origins/origins/unathi/autakh.dm
+++ b/code/modules/background/origins/origins/unathi/autakh.dm
@@ -12,7 +12,7 @@
 /singleton/origin_item/origin/autakh
 	name = "Aut'akh Valley"
 	desc = "A large commune on Ouerea surrounded by mountains, the Aut'akh Valley is birthplace of the Aut'akh religion - a place for specifically augmented unathi to find sanctuary from the violence often found against their kind in cities and towns. It is largely disconnected from any government and is heavily guarded by the Aut'akh defending the clans there with their lives. Life here is simple, and more than half of the population is elderly or disabled with augments. The area is foggy and filled with natural lakes, and the area gets cold enough to snow in the cold season."
-	possible_accents = list(ACCENT_HEARTLAND_NOBLE, ACCENT_HEARTLAND_PEASANT, ACCENT_TRAD_NOBLE, ACCENT_TRAD_PEASANT, ACCENT_WASTELAND, ACCENT_AUTAKH, ACCENT_TZA_PEASANT, ACCENT_TZA_NOBLE, ACCENT_SOUTHLANDS_PEASANT, ACCENT_SOUTHLANDS_NOBLE, ACCENT_TORN, ACCENT_ZAZ_LOW, ACCENT_ZAZ_HIGH, ACCENT_BROKEN_PEASANT, ACCENT_BROKEN_NOBLE, ACCENT_UNATHI_SPACER)
+	possible_accents = list(ACCENT_HEARTLAND_NOBLE, ACCENT_HEARTLAND_PEASANT, ACCENT_TRAD_NOBLE, ACCENT_TRAD_PEASANT, ACCENT_WASTELAND, ACCENT_AUTAKH, ACCENT_TZA_PEASANT, ACCENT_TZA_NOBLE, ACCENT_SOUTHLANDS_PEASANT, ACCENT_SOUTHLANDS_NOBLE, ACCENT_TORN, ACCENT_ZAZ_LOW, ACCENT_ZAZ_HIGH, ACCENT_BROKEN_PEASANT, ACCENT_BROKEN_NOBLE, ACCENT_UNATHI_SPACER, ACCENT_OUEREA)
 	possible_citizenships = list(CITIZENSHIP_IZWESKI)
 	possible_religions = list(RELIGION_AUTAKH)
 
@@ -24,11 +24,20 @@
 	name = "Eridani Underworld Commune"
 	desc = "In the depths of Eridani I under the city, a small commune of Unathi have made some order out of the chaos. The first Aut'akh to come here didn't have the credits or the legal standing to make it on top in the corporate over-world; however, they did have enough muscle to clear out a mining drone factory of drug-addicted dregs. A few years is all it took for a community of Aut'akh to grow, walling off the Factory and setting up a safe spot for them to fit. Over time, the surrounding local dreg community came to accept the Aut'akh in. Even still, some have treated the augmented Unathi as just another gang they have to deal with."
 	possible_citizenships = list(CITIZENSHIP_ERIDANI)
+	origin_traits = list(TRAIT_ORIGIN_TOX_RESISTANCE, TRAIT_ORIGIN_DRUG_RESISTANCE) //dreg moment
+	origin_traits_descriptions = list("have a higher resistance to toxins", "have a higher tolerance to recreative drugs")
 
 /singleton/origin_item/origin/autakh/razortail
 	name = "Razortail Enclave"
 	desc = "Considered a bunch of ruffians by their sister communes, the Razortail Enclave is a commune located in District 7 of Mendell City: Sin City. In order to survive in Biesel, Aut’akh participate in organized crime as hired muscle, allured to the practice by the prospect of stealing from the megacorps and Biesel’s own government to help the slums of the district. Similar to the Factory commune on Eridani I, the Razortail Enclave is stuck in the poorer regions of the city, trapped there by a lack of wealth and a conviction to not stray too far from their ideals; however, unlike their sister commune, these sinta do not ignore the gang conflicts of the streets, and often themselves get involved to prevent their rank from kidnappings and having their prosthetics stripped from them — a barbaric practice in the eyes of these fanatics."
 	possible_citizenships = list(CITIZENSHIP_BIESEL)
+
+/singleton/origin_item/origin/autakh/luthien
+	name = "Luthien Pact"
+	desc = "The Aut'akh of the Luthien Pact, in Tau Ceti, have formed a tenuous relationship with the megacorporate presence on the planet - sacrificing some measure of their anti-capitalist politics in order to survive. They work closely with NanoTrasen and Zavodskoi Interstellar, and have formed a unique spiritual perspective on the sentience and spiritual nature of the IPCs they work with - something which has become concerning to their corporate employers. The Aut'akh of the Luthien Pact will often use modified corporate augmentations rather than those crafted by their fellow Aut'akh as a matter of practicality, and can often be found working in hazardous fields where their cybernetics allow them to survive easier than the unaugmented."
+	possible_citizenships = list(CITIZENSHIP_BIESEL)
+	origin_traits = list(TRAIT_ORIGIN_TOX_RESISTANCE) //good at adapting to hostile environments
+	origin_traits_descriptions = list("have a higher resistance to toxins")
 
 /singleton/origin_item/origin/autakh/hidden
 	name = "Unknown Aut'akh Commune"

--- a/code/modules/background/origins/origins/unathi/queendom.dm
+++ b/code/modules/background/origins/origins/unathi/queendom.dm
@@ -14,4 +14,4 @@
 	origin_traits_descriptions = list("have a small resistance to radiation") //they live in the wasteland
 
 /singleton/origin_item/origin/wastelander/on_apply(var/mob/living/carbon/human/H)
-  H.AddComponent(/datum/component/armor, list(rad = ARMOR_RAD_MINOR))
+	H.AddComponent(/datum/component/armor, list(rad = ARMOR_RAD_MINOR))

--- a/code/modules/background/origins/origins/unathi/queendom.dm
+++ b/code/modules/background/origins/origins/unathi/queendom.dm
@@ -11,3 +11,7 @@
 	possible_accents = list(ACCENT_QUEENDOM)
 	possible_citizenships = list(CITIZENSHIP_IZWESKI)
 	possible_religions = list(RELIGION_THAKH, RELIGION_SKAKH, RELIGION_SIAKH, RELIGION_OTHER, RELIGION_NONE)
+	origin_traits_descriptions = list("have a small resistance to radiation") //they live in the wasteland
+
+/singleton/origin_item/origin/wastelander/on_apply(var/mob/living/carbon/human/H)
+  H.AddComponent(/datum/component/armor, list(rad = ARMOR_RAD_MINOR))

--- a/code/modules/background/origins/origins/unathi/spaceborn.dm
+++ b/code/modules/background/origins/origins/unathi/spaceborn.dm
@@ -12,7 +12,7 @@
 	name = "Pirates of the Spur"
 	desc = "Pirates have no common group holding them all together to work as one. They tend towards ambition and passion, acting impulsively towards what they desire. With Not'zar Izweski's call to pirates to forsake their lifestyles and join his space navy, any pirate that has served four or more years under the Hegemony has their crimes pardoned by him (but not necessarily other states). With this, a good handful of pirates that knew no normalcy are now finding it abroad. Unathi pirates don't have citizenship in their respective countries, typically having a work or visitation visa instead."
 	important_information = "Outside of the Hegemony, records should say they have some kind of visa instead of citizenship."
-	possible_accents = list(ACCENT_TRAD_PEASANT, ACCENT_HEARTLAND_PEASANT, ACCENT_TRAD_NOBLE, ACCENT_TZA_PEASANT, ACCENT_TZA_NOBLE, ACCENT_SOUTHLANDS_NOBLE, ACCENT_SOUTHLANDS_PEASANT, ACCENT_TORN, ACCENT_ZAZ_LOW, ACCENT_ZAZ_HIGH, ACCENT_BROKEN_PEASANT, ACCENT_BROKEN_NOBLE, ACCENT_WASTELAND, ACCENT_UNATHI_SPACER, ACCENT_HAZANA)
+	possible_accents = list(ACCENT_TRAD_PEASANT, ACCENT_HEARTLAND_PEASANT, ACCENT_TRAD_NOBLE, ACCENT_TZA_PEASANT, ACCENT_TZA_NOBLE, ACCENT_SOUTHLANDS_NOBLE, ACCENT_SOUTHLANDS_PEASANT, ACCENT_TORN, ACCENT_ZAZ_LOW, ACCENT_ZAZ_HIGH, ACCENT_BROKEN_PEASANT, ACCENT_BROKEN_NOBLE, ACCENT_WASTELAND, ACCENT_UNATHI_SPACER, ACCENT_HAZANA, ACCENT_OUEREA)
 	possible_citizenships = list(CITIZENSHIP_IZWESKI, CITIZENSHIP_BIESEL, CITIZENSHIP_COALITION)
 	possible_religions = list(RELIGION_THAKH, RELIGION_SKAKH, RELIGION_AUTAKH, RELIGION_OTHER, RELIGION_NONE)
 
@@ -45,6 +45,8 @@
 	possible_accents = list(ACCENT_DOMINIA_VULGAR, ACCENT_DOMINIA_HIGH)
 	possible_citizenships = list(CITIZENSHIP_DOMINIA, CITIZENSHIP_BIESEL)
 	possible_religions = list(RELIGION_MOROZ, RELIGION_THAKH)
+	origin_traits = list(TRAIT_ORIGIN_COLD_RESISTANCE)
+	origin_traits_descriptions = list("are more acclimatised to the cold.")
 
 /singleton/origin_item/origin/mictlan_unathi
 	name = "Mictlan Unathi"
@@ -52,5 +54,7 @@
 	Unathi refugees on the planet of Mictlan, where they began to rebuild - and eventually established the Free City of Vezdukh. The Unathi of Mictlan have restructured their society, creating one which is far more meritocratic than the feudal states of Moghes, \
 	and have integrated into the population smoothly. Following the Republic of Biesel's annexation of Mictlan, the Unathi of the planet have largely refused to involve themselves in the ongoing struggle between the Samaritan movement and Biesel, simply wishing not to see another home consumed in war."
 	possible_accents = list(ACCENT_MICTLAN)
-	possible_citizenships = list(CITIZENSHIP_SOL, CITIZENSHIP_BIESEL)
+	possible_citizenships = list(CITIZENSHIP_BIESEL)
 	possible_religions = list(RELIGION_THAKH, RELIGION_SKAKH, RELIGION_NONE)
+	origin_traits = list(TRAIT_ORIGIN_IGNORE_CAPSAICIN)
+	origin_traits_descriptions = list("are not affected by spicy foods")

--- a/code/modules/background/origins/origins/unathi/traditionalist.dm
+++ b/code/modules/background/origins/origins/unathi/traditionalist.dm
@@ -63,4 +63,4 @@
 	origin_traits_descriptions = list("have a small resistance to radiation")
 
 /singleton/origin_item/origin/wastelander/on_apply(var/mob/living/carbon/human/H)
-  H.AddComponent(/datum/component/armor, list(rad = ARMOR_RAD_MINOR))
+	H.AddComponent(/datum/component/armor, list(rad = ARMOR_RAD_MINOR))

--- a/code/modules/background/origins/origins/unathi/traditionalist.dm
+++ b/code/modules/background/origins/origins/unathi/traditionalist.dm
@@ -60,3 +60,7 @@
 	possible_accents = list(ACCENT_WASTELAND)
 	possible_citizenships = list(CITIZENSHIP_IZWESKI, CITIZENSHIP_BIESEL, CITIZENSHIP_COALITION)
 	possible_religions = list(RELIGION_THAKH, RELIGION_SIAKH, RELIGION_OTHER, RELIGION_NONE)
+	origin_traits_descriptions = list("have a small resistance to radiation")
+
+/singleton/origin_item/origin/wastelander/on_apply(var/mob/living/carbon/human/H)
+  H.AddComponent(/datum/component/armor, list(rad = ARMOR_RAD_MINOR))

--- a/html/changelogs/RustingWithYou - lizardorigins.yml
+++ b/html/changelogs/RustingWithYou - lizardorigins.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "The Ouerean accent is now available to the Aut'akh and Pirate origins."
+  - tweak: "Adds some origin traits to Unathi origins."


### PR DESCRIPTION
Like the name says, adds origin traits to some Unathi origins. The Wasteland and Queendom origins now have radiation resistance for living in a radioactive hellscape, Mictlan Unathi like spicy food, Dominian Unathi will suffer a little less in the cold and Eridani Aut'akh are better at doing drugs.

Also adds an origin for the Luthien Pact as the only unrepresented Aut'akh commune. They have minor toxin resistance to represent the fact that they're specialised in lore for working in hostile environments.

The Ouerea accent has been added to the Aut'akh and Pirate origins, as those filthy democracy-lovers are basically criminals anyway.