### PR TITLE
Observable move not unregistering correctly  fix

### DIFF
--- a/code/datums/observation/moved.dm
+++ b/code/datums/observation/moved.dm
@@ -14,6 +14,16 @@ var/singleton/observ/moved/moved_event = new()
 			child = parent
 			parent = child.loc
 
+/singleton/observ/moved/unregister(event_source, datum/listener, proc_call)
+	. = ..()
+	var/atom/movable/child = event_source
+	if(.)
+		var/atom/movable/parent = child.loc
+		while(istype(parent) && moved_event.is_listening(parent, child))
+			moved_event.unregister(parent, child, TYPE_PROC_REF(/atom/movable, recursive_move))
+			child = parent
+			parent = child.loc
+
 /singleton/observ/moved/proc/register_all_movement(var/event_source, var/listener)
 	moved_event.register(event_source, listener, /atom/movable/proc/recursive_move)
 	dir_set_event.register(event_source, listener, /atom/proc/recursive_dir_set)

--- a/html/changelogs/FluffyGhost-observable_move_not_unregistering_correctly_went_unobserved_fix.yml
+++ b/html/changelogs/FluffyGhost-observable_move_not_unregistering_correctly_went_unobserved_fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes the observable moved_event that was not unregistering some child atoms."


### PR DESCRIPTION
Fixes the observable moved_event that was not unregistering some child atoms.