### PR TITLE
Tajara religious loadout fixes

### DIFF
--- a/code/game/objects/items/weapons/chaplain_items.dm
+++ b/code/game/objects/items/weapons/chaplain_items.dm
@@ -75,7 +75,7 @@
 	return "around [user.get_pronoun("his")] neck"
 
 /obj/item/nullrod/matake
-	name = "\improper Mata'ke sword"
+	name = "\improper Mata'ke spear"
 	desc = "A ceremonial spear crafted after the image of Mata'ke's holy weapon."
 	icon = 'icons/obj/tajara_items.dmi'
 	icon_state = "matake_spear"

--- a/code/modules/client/preference_setup/loadout/items/xeno/tajara.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/tajara.dm
@@ -620,15 +620,15 @@
 	banner["Azubarre Banner"] = /obj/item/flag/azubarre
 	gear_tweaks += new /datum/gear_tweak/path(banner)
 
-/datum/gear/accessory/tajara_god_altars
-	display_name = "ma'ta'ke deity altars"
-	description = "A selection of small altars used to worship the Ma'ta'ke gods."
+/datum/gear/tajara_god_altars
+	display_name = "matakae deity altars"
+	description = "A selection of small altars used to worship the matake gods."
 	path = /obj/item/storage/altar/kraszar
 	whitelisted = list(SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI)
 	sort_category = "Xenowear - Tajara"
 	flags = GEAR_HAS_DESC_SELECTION
 
-/datum/gear/accessory/tajara_god_altars/New()
+/datum/gear/tajara_god_altars/New()
 	..()
 	var/list/altar = list()
 	altar["Kraszar altar"] = /obj/item/storage/altar/kraszar

--- a/html/changelogs/alberyk-loadoutixes.yml
+++ b/html/changelogs/alberyk-loadoutixes.yml
@@ -1,0 +1,6 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed being unable to select different matake god altars in the loadout."


### PR DESCRIPTION
-fixes being unable to select a matake god altar
-fixes the matake spear being called a sword