### PR TITLE
Decreases minimum age for engineers to 22, increases minimum age for engineering interns to 21

### DIFF
--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -88,7 +88,7 @@
 	economic_modifier = 5
 
 	minimum_character_age = list(
-		SPECIES_HUMAN = 25,
+		SPECIES_HUMAN = 22,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -156,7 +156,7 @@
 	economic_modifier = 5
 
 	minimum_character_age = list(
-		SPECIES_HUMAN = 25,
+		SPECIES_HUMAN = 22,
 		SPECIES_SKRELL = 60,
 		SPECIES_SKRELL_AXIORI = 60
 	)
@@ -228,9 +228,9 @@
 	blacklisted_species = list(SPECIES_VAURCA_BREEDER)
 
 	minimum_character_age = list(
-		SPECIES_HUMAN = 18,
-		SPECIES_SKRELL = 50,
-		SPECIES_SKRELL_AXIORI = 50
+		SPECIES_HUMAN = 21,
+		SPECIES_SKRELL = 58,
+		SPECIES_SKRELL_AXIORI = 58
 	)
 
 /datum/outfit/job/intern_eng

--- a/html/changelogs/GeneralCamo - Engineering Change.yml
+++ b/html/changelogs/GeneralCamo - Engineering Change.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Decreased the minimum age ff engineers and atmospheric technicians to 22. (skrell remain at 60)"
+  - tweak: "Increased the minimum age of engineering and atmospheric interns to 21. (58 for skrell)"


### PR DESCRIPTION
A compromise PR to #17184.

This decreases the minimum age of engineers and atmospheric technicians to 22, to reflect the typical age where one receives a bachelor's degree. However, the age of interns has been increased to 21 to reflect a college internship program for a student in their final year. Skrell instead had their intern age raised to 58, but the minimum age for engineers remains at 60 as this is where a skrell will receive their first degree. 

The ideal age has not been changed. Older engineers will still be preferred if too many engineers ready up. But this should provide a compromise in allowing realistically young engineers on the ship, while not having unrealistically young engineers hogging the intern slots. 