### PR TITLE
Fixes a few organ mending surgery oddities.

### DIFF
--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -36,6 +36,9 @@
 	var/is_organ_damaged = FALSE
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
 		if(I.is_damaged())
+			if(BP_IS_ROBOTIC(I))
+				to_chat(user, SPAN_NOTICE("You notice that \the [I] in [user]'s [affected] is a mechanical organ, and is also damaged."))
+				continue
 			is_organ_damaged = TRUE
 			break
 	return is_organ_damaged
@@ -56,8 +59,6 @@
 			user.visible_message("[user] starts treating damage to [target]'s [I.name] with [tool_name].", \
 			"You start treating damage to [target]'s [I.name] with [tool_name]." )
 	target.custom_pain("The pain in your [affected.name] is living hell!",100, affecting = affected)
-
-	..()
 
 /singleton/surgery_step/internal/fix_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/tool_name = "\the [tool]"
@@ -123,7 +124,10 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/is_organ_damaged = 0
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
-		if(I.is_damaged() && I.robotic >= 2)
+		if(I.is_damaged())
+			if(!BP_IS_ROBOTIC(I))
+				to_chat(user, SPAN_NOTICE("You notice that \the [I] in [user]'s [affected] is a biological organ, and is also damaged."))
+				continue
 			is_organ_damaged = TRUE
 			break
 	return is_organ_damaged && IS_ORGAN_FULLY_OPEN
@@ -172,7 +176,6 @@
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
 		if(I)
 			I.take_damage(rand(3,5),0)
-
 
 /singleton/surgery_step/internal/detach_organ
 	name = "Separate Organ"

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -37,10 +37,9 @@
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
 		if(I.is_damaged())
 			if(BP_IS_ROBOTIC(I))
-				to_chat(user, SPAN_NOTICE("You notice that \the [I] in [user]'s [affected] is a mechanical organ, and is also damaged."))
+				to_chat(user, SPAN_NOTICE("You notice that \the [I] in [user]'s [affected.name] is a mechanical organ, and is also damaged."))
 				continue
 			is_organ_damaged = TRUE
-			break
 	return is_organ_damaged
 
 /singleton/surgery_step/internal/fix_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -126,10 +125,9 @@
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
 		if(I.is_damaged())
 			if(!BP_IS_ROBOTIC(I))
-				to_chat(user, SPAN_NOTICE("You notice that \the [I] in [user]'s [affected] is a biological organ, and is also damaged."))
+				to_chat(user, SPAN_NOTICE("You notice that \the [I] in [user]'s [affected.name] is a biological organ, and is also damaged."))
 				continue
 			is_organ_damaged = TRUE
-			break
 	return is_organ_damaged && IS_ORGAN_FULLY_OPEN
 
 /singleton/surgery_step/internal/fix_organ_robotic/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -66,7 +66,7 @@
 			H.bloody_hands(target,0)
 		if(blood_level > 1)
 			H.bloody_body(target,0)
-	return
+	return TRUE
 
 // does stuff to end the step, which is normally print a message + do whatever this step changes
 /singleton/surgery_step/proc/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/html/changelogs/mattatlas-organrepair.yml
+++ b/html/changelogs/mattatlas-organrepair.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "You can no longer try to repair a mechanical organ with an ATK."
+  - bugfix: "When trying to repair mechanical or biological organs, you will get a notification in your chat if there are damaged organs for which you need a different tool to mend."
+  - bugfix: "Fixed surgery start messages for organ mending."


### PR DESCRIPTION
  - bugfix: "You can no longer try to repair a mechanical organ with an ATK."
  - bugfix: "When trying to repair mechanical or biological organs, you will get a notification in your chat if there are damaged organs for which you need a different tool to mend."
  - bugfix: "Fixed surgery start messages for organ mending."
