### PR TITLE
No Free Loadout Items

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/items/accessories.dm
@@ -475,7 +475,7 @@
 /datum/gear/accessory/passcard
 	display_name = "human passcard selection"
 	path = /obj/item/clothing/accessory/badge/passcard
-	cost = 0
+	cost = 1
 
 /datum/gear/accessory/passcard/New()
 	..()
@@ -504,12 +504,12 @@
 	display_name = "republic of biesel work visa"
 	description = "A work visa issued to those who work in the Republic of Biesel, but who do not have a Biesellite citizenship."
 	path = /obj/item/clothing/accessory/badge/passcard/workvisa
-	cost = 0
+	cost = 1
 
 /datum/gear/accessory/passport
 	display_name = "human passport selection"
 	path = /obj/item/clothing/accessory/badge/passport
-	cost = 0
+	cost = 1
 
 /datum/gear/accessory/passport/New()
 	..()
@@ -572,7 +572,7 @@
 	display_name = "generic flagpatch selection"
 	path = /obj/item/clothing/accessory/flagpatch/rectangular
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
-	cost = 0
+	cost = 1
 
 /datum/gear/accessory/flagpatch/New()
 	..()
@@ -586,7 +586,7 @@
 /datum/gear/accessory/flagpatch_national
 	display_name = "flagpatch selection"
 	path = /obj/item/clothing/accessory/flagpatch/biesel
-	cost = 0
+	cost = 1
 
 /datum/gear/accessory/flagpatch_national/New()
 	..()

--- a/code/modules/client/preference_setup/loadout/items/belt.dm
+++ b/code/modules/client/preference_setup/loadout/items/belt.dm
@@ -28,7 +28,7 @@
 /datum/gear/belt/toolbelt_alt
 	display_name = "tool-belt, alt"
 	description = "An alternative look to a standard toolbelt."
-	cost = 0
+	cost = 1
 	path = /obj/item/storage/belt/utility/alt
 	allowed_roles = list("Engineer", "Atmospheric Technician", "Chief Engineer", "Engineering Apprentice", "Machinist", "Research Director")
 	flags = null

--- a/code/modules/client/preference_setup/loadout/items/factions.dm
+++ b/code/modules/client/preference_setup/loadout/items/factions.dm
@@ -56,7 +56,7 @@
 	display_name = "idris custodial jumpsuit, alternative"
 	path = /obj/item/clothing/under/rank/janitor/idris/alt
 	slot = slot_w_uniform
-	cost = 0
+	cost = 1
 	faction = "Idris Incorporated"
 	allowed_roles = list("Janitor")
 
@@ -595,7 +595,7 @@
 	display_name = "nanotrasen custodial jumpsuit, alternative"
 	path = /obj/item/clothing/under/rank/janitor/alt
 	slot = slot_w_uniform
-	cost = 0
+	cost = 1
 	faction = "NanoTrasen"
 	allowed_roles = list("Janitor")
 

--- a/code/modules/client/preference_setup/loadout/items/xeno/diona.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/diona.dm
@@ -2,7 +2,7 @@
 	display_name = "dionae sol passcard"
 	description = "A passport issued to Dionae citizens of the Sol Alliance who have completed their assigned contract."
 	path = /obj/item/clothing/accessory/badge/passcard/sol_diona
-	cost = 0
+	cost = 1
 	whitelisted = list(SPECIES_DIONA, SPECIES_DIONA_COEUS)
 	sort_category = "Xenowear - Diona"
 	flags = GEAR_NO_SELECTION
@@ -128,7 +128,7 @@
 	path = /obj/item/clothing/accessory/badge/passport/nralakk
 	whitelisted = list(SPECIES_DIONA, SPECIES_DIONA_COEUS)
 	sort_category = "Xenowear - Diona"
-	cost = 0
+	cost = 1
 	flags = GEAR_NO_SELECTION
 	culture_restriction = list(/singleton/origin_item/culture/dionae_nralakk, /singleton/origin_item/culture/eum, /singleton/origin_item/culture/xrim)
 

--- a/code/modules/client/preference_setup/loadout/items/xeno/machine.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/machine.dm
@@ -172,7 +172,7 @@
 	display_name = "synthetic residence card"
 	description = "An identification card given to free IPC residents within the Republic of Biesel."
 	path = /obj/item/clothing/accessory/badge/passcard/synthetic
-	cost = 0
+	cost = 1
 	whitelisted = list(SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL)
 
 /datum/gear/accessory/ipcmantle

--- a/code/modules/client/preference_setup/loadout/items/xeno/skrell.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/skrell.dm
@@ -199,7 +199,7 @@
 	sort_category = "Xenowear - Skrell"
 	whitelisted = list(SPECIES_SKRELL, SPECIES_SKRELL_AXIORI, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_WORKER, SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER)
 	flags = GEAR_NO_SELECTION
-	cost = 0
+	cost = 1
 
 /datum/gear/accessory/skrell_residency
 	display_name = "starlight residency card"
@@ -207,7 +207,7 @@
 	sort_category = "Xenowear - Skrell"
 	whitelisted = list(SPECIES_SKRELL, SPECIES_SKRELL_AXIORI)
 	flags = GEAR_NO_SELECTION
-	cost = 0
+	cost = 1
 
 /datum/gear/accessory/skrell_passport/New()
 	. = ..()
@@ -408,7 +408,7 @@ var/datum/gear_tweak/social_credit/social_credit_tweak = new()
 	whitelisted = list(SPECIES_SKRELL, SPECIES_SKRELL_AXIORI)
 	sort_category = "Xenowear - Skrell"
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
-	cost = 0
+	cost = 1
 
 /datum/gear/ears/skrell/tailband/New()
 	..()

--- a/code/modules/client/preference_setup/loadout/items/xeno/tajara.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/tajara.dm
@@ -377,7 +377,7 @@
 	sort_category = "Xenowear - Tajara"
 	whitelisted = list(SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI)
 	flags = GEAR_HAS_DESC_SELECTION
-	cost = 0
+	cost = 1
 
 /datum/gear/tajaran_passports/New()
 	..()

--- a/code/modules/client/preference_setup/loadout/items/xeno/unathi.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/unathi.dm
@@ -324,7 +324,7 @@
 	description = "A rune inscribed mirror or piece of glass placed behind the eyes. Believed to \
 	be the 'Window to the Soul' and house the concentrated spirit of an individual."
 	path = /obj/item/organ/internal/anchor
-	cost = 0
+	cost = 1
 	whitelisted = list(SPECIES_UNATHI)
 	culture_restriction = list(/singleton/origin_item/culture/autakh)
 	sort_category = "Xenowear - Unathi"

--- a/code/modules/client/preference_setup/loadout/items/xeno/vaurca.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/vaurca.dm
@@ -174,7 +174,7 @@
 	display_name = "language processor"
 	description = "An augment that allows a vaurca to speak and understand a related language. These are only used by their respective Hives."
 	path = /obj/item/organ/internal/augment/language/klax
-	cost = 0
+	cost = 1
 	sort_category = "Xenowear - Vaurca"
 	whitelisted = list(SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_BREEDER, SPECIES_VAURCA_BULWARK)
 	flags = GEAR_NO_SELECTION
@@ -274,7 +274,7 @@
 	sort_category = "Xenowear - Vaurca"
 	allowed_roles = list("Physician", "Surgeon", "First Responder", "Medical Intern", "Psychiatrist", "Chemist")
 	flags = GEAR_NO_SELECTION
-  
+
 /datum/gear/augment/vaurcamag
 	display_name = "vaurca integrated mag-claws"
 	description = "An integrated magnetic grip system, designed for Vaurcae without easy access to magboots."

--- a/html/changelogs/arrow768-no-free-items.yml
+++ b/html/changelogs/arrow768-no-free-items.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Increases the point cost of all free loadout items to 1 due to technical limitations."


### PR DESCRIPTION
Increases the cost of all free loadout items to 1.

Currently all loadout items in all possible loadout variants (3) are json_encoded into a single string. Somewhere along the way to the db server the query string is cut off after a certain length. -> Thats why we have a limit of 3 loadout variants and dont allow 0 point loadout items as they can cause errors when saving due to exceeding that query string length.