### PR TITLE
Spark Teleporter

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -165,14 +165,9 @@
 
 		else
 			for(var/atom/movable/A in destturf)
-				if(A != teleatom && A.density && A.anchored  && !istype(A, /obj/effect/portal))
-					if(A.flags & ON_BORDER)
-						if(prob(10))
-							impediment = A
-							break
-					else
-						impediment = A
-						break
+				if(!A.is_safe_to_teleport_on(teleatom))
+					impediment = A
+					break
 
 		if(impediment)
 			var/turf/newdest

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -607,3 +607,8 @@
 
 /atom/movable/proc/show_message(msg, type, alt, alt_type) //Message, type of message (1 or 2), alternative message, alt message type (1 or 2)
 	return
+
+/atom/movable/proc/is_safe_to_teleport_on(var/atom/teleporter_atom)
+	if(!anchored || !density || HAS_FLAG(flags, ON_BORDER) || teleporter_atom == src)
+		return TRUE
+	return FALSE

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -183,10 +183,7 @@
 		minor_dir = dx
 		minor_dist = dist_x
 
-	while(src && target && src.throwing && istype(src.loc, /turf) \
-		  && ((abs(target.x - src.x)+abs(target.y - src.y) > 0 && dist_travelled < range) \
-		  	   || (a && a.has_gravity == 0) \
-			   || istype(src.loc, /turf/space)))
+	while(src && target && src.throwing && istype(src.loc, /turf) && ((abs(target.x - src.x)+abs(target.y - src.y) > 0 && dist_travelled < range) || (a && a.has_gravity == 0) || istype(src.loc, /turf/space)))
 		// only stop when we've gone the whole distance (or max throw range) and are on a non-space tile, or hit something, or hit the end of the map, or someone picks it up
 		var/atom/step
 		if(error >= 0)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -90,6 +90,9 @@
 		HT.remove_portal(src)
 	return ..()
 
+/obj/effect/portal/is_safe_to_teleport_on()
+	return TRUE
+
 /obj/effect/portal/spawner
 	name = "portal"
 	desc = "A bluespace tear in space, reaching directly to another point within this region. This one looks like a one-way portal to here, don't come too close."

--- a/html/changelogs/geeves-two_way_teleporter.yml
+++ b/html/changelogs/geeves-two_way_teleporter.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a two-way teleporter to the Spark and the Horizon refinery, it has a seven tile overmap range."
+  - tweak: "Teleporting onto a tile with windows/railings no longer cause you to explode."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -14375,6 +14375,20 @@
 /obj/effect/floor_decal/corner/brown/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/eva)
+"klM" = (
+/obj/machinery/teleport/pad/two_way{
+	target_id = "spark_teleporter";
+	teleporter_id = "refinery_teleporter"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/southleft{
+	name = "Two-Way Teleporter Access";
+	req_access = list(48)
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/outpost/mining_main/refinery)
 "klR" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -15291,6 +15305,10 @@
 	},
 /obj/machinery/door/window/northleft,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/bed/handrail{
+	dir = 4;
+	pixel_x = 4
+	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/mining)
 "kOp" = (
@@ -25830,6 +25848,10 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/teleport/pad/two_way{
+	target_id = "refinery_teleporter";
+	teleporter_id = "spark_teleporter"
+	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/mining)
 "soD" = (
@@ -31239,6 +31261,10 @@
 	},
 /obj/machinery/door/window/northright,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/bed/handrail{
+	dir = 8;
+	pixel_x = -4
+	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/mining)
 "vZT" = (
@@ -49651,7 +49677,7 @@ vqU
 oDv
 tIS
 wkD
-gKG
+klM
 qOf
 mTJ
 rPo


### PR DESCRIPTION
* Added a two-way teleporter to the Spark and the Horizon refinery, it has a seven tile overmap range.
* Teleporting onto a tile with windows/railings no longer cause you to explode.

Flying the Spark is very fun, and getting to your destination and scouting out the landing zone is also fun, but having to constantly make trips back and forth, and having to come back / wait for the Spark to come back for / as a latejoining miner is a massive pain.

By using a two-way teleportation system, the mining team still has to fly to the destination (potentially avoiding hazards), and then get a good landing zone, before they can start teleporting around.

This also makes it easier to do multiple mining trips after getting better equipment from the vendor in the refinery.

The teleporter is located on the outside of the ship, so if a traitor decides to attack while the shuttle is in-flight, the miner inside can't just jump into a teleporter to get away.


![image](https://github.com/Aurorastation/Aurora.3/assets/22774890/5465aa6f-4c2e-4608-9fe6-e3f015c1a53c)
![image](https://github.com/Aurorastation/Aurora.3/assets/22774890/47127695-e2f7-4014-87fa-eed3ed868e76)
