### PR TITLE
Drill Dropper Shortwave

### DIFF
--- a/code/game/objects/items/devices/drop_targeter/_droptargeter.dm
+++ b/code/game/objects/items/devices/drop_targeter/_droptargeter.dm
@@ -17,10 +17,11 @@
 	var/does_explosion = TRUE
 	var/emagged = FALSE // If emagged, things can be dropped in on station areas
 
+	var/drop_message_language = LANGUAGE_TCB
 	var/drop_message = "Orbital package inbound, clear the targetted area immediately!"
 	var/drop_message_emagged = "O*b$ital p&ck@ge in#)und, c-c-c-!"
-	var/announcer_name = "Mining Requests Console"
-	var/announcer_channel = "Operations" // If not emagged, will announce to this channel. If emagged, will always announce on the common channel.
+	var/announcer_name = "Operations Long Range Package Delivery System"
+	var/announcer_frequency = SUP_FREQ // If not emagged, will announce to this channel. If emagged, will always announce on the common channel.
 
 	var/datum/map_template/map
 
@@ -69,13 +70,20 @@
 
 	to_chat(user, SPAN_NOTICE("You paint the target at [target]."))
 
-	var/obj/item/device/radio/intercom/announcer = new /obj/item/device/radio/intercom(null)
-	announcer.config(list("Common" = FALSE, "Entertainment" = FALSE, "Response Team" = FALSE, "Science" = FALSE, "Command" = FALSE, "Medical" = FALSE, "Engineering" = FALSE, "Security" = FALSE, "Penal" = FALSE, "Operations" = FALSE, "Service" = FALSE, "Mercenary" = FALSE, "Raider" = FALSE, "Ninja" = FALSE, "AI Private" = FALSE))
-	if(announcer)
-		if(!emagged)
-			announcer.autosay(drop_message, announcer_name, announcer_channel)
-		else
-			announcer.autosay(drop_message_emagged, announcer_name, "Common")
+	var/datum/language/language = all_languages[drop_message_language]
+
+	if(!istype(global_announcer.announcer))
+		global_announcer.announcer = new()
+	global_announcer.announcer.PrepareBroadcast(announcer_name, language, announcer_name)
+
+	var/turf/current_turf = get_turf(src)
+	var/datum/signal/subspace/vocal/signal = new(src, emagged ? PUB_FREQ : announcer_frequency, WEAKREF(global_announcer.announcer), language, emagged ? drop_message_emagged : drop_message, "says")
+	signal.data["compression"] = 0
+	signal.transmission_method = TRANSMISSION_SUBSPACE
+	signal.levels = GetConnectedZlevels(current_turf.z)
+	signal.broadcast()
+
+	global_announcer.announcer.ResetAfterBroadcast()
 
 	has_dropped++
 	if(does_explosion)

--- a/code/game/objects/items/devices/drop_targeter/orbital_drops.dm
+++ b/code/game/objects/items/devices/drop_targeter/orbital_drops.dm
@@ -26,7 +26,7 @@
 	drop_message = "Mech coming in hot!"
 	drop_message_emagged = "Mech comin- SHIT! WHO PAINTED THAT?"
 	announcer_name = "Respawn Mech Industries"
-	announcer_channel = "Common"
+	announcer_frequency = PUB_FREQ
 
 	map = new /datum/map_template/mecha
 
@@ -51,14 +51,14 @@
 	drop_message = "The cavalry has arrived!"
 	drop_message_emagged = "The cav-cav-cav-BzzzZZTTT!"
 	announcer_name = "GunCourier Industries Autodrone"
-	announcer_channel = "Common"
+	announcer_frequency = PUB_FREQ
 
 	map = new /datum/map_template/armory
 
 /obj/item/device/orbital_dropper/armory/syndicate
 	desc_antag = "This is a stealthy variant of the standard armory orbital drop. It will not report itself dropping on common, unless emagged."
 	announcer_name = "Syndicate Autodrone"
-	announcer_channel = "Mercenary"
+	announcer_frequency = SYND_FREQ
 
 /obj/item/device/orbital_dropper/icarus_drones
 	name = "icarus painter"

--- a/html/changelogs/geeves-drill_dropper_shortwave.yml
+++ b/html/changelogs/geeves-drill_dropper_shortwave.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Changed the mining orbital droppers to use a shortwave broadcasting system, no longer requiring telecomms to announce the drops."


### PR DESCRIPTION
* Changed the mining orbital droppers to use a shortwave broadcasting system, no longer requiring telecomms to announce the drops.