### PR TITLE
Fix 17408

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -24,7 +24,7 @@
 	icon = 'icons/obj/structure/beds.dmi'
 	icon_state = "bed"
 	anchored = TRUE
-	buckle_dir = EAST
+	buckle_dir = SOUTH
 	buckle_lying = 1
 	build_amt = 2
 	var/material/padding_material

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -142,7 +142,7 @@ There are several things that need to be remembered:
 			var/matrix/M = matrix()
 
 			switch(src.dir)
-				if(NORTH,EAST)
+				if(SOUTH,EAST)
 					M.Turn(90)
 				else
 					M.Turn(-90)

--- a/html/changelogs/fluffyghost-fix17408.yml
+++ b/html/changelogs/fluffyghost-fix17408.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Mobs are now right-rotated when laying down facing south (instead of left rotated)."
+  - bugfix: "Buckling to beds now orientate the mob south, thus making the mob face 'up'."


### PR DESCRIPTION
Mobs are now right-rotated when laying down facing south (instead of left rotated).
Buckling to beds now orientate the mob south, thus making the mob face 'up'.

Fixes #17408 