### PR TITLE
Tricord Recipe Revert

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -298,7 +298,7 @@
 	name = "Tricordrazine"
 	id = "tricordrazine"
 	result = /singleton/reagent/tricordrazine
-	required_reagents = list(/singleton/reagent/water = 1, /singleton/reagent/inaprovaline = 1, /singleton/reagent/dylovene = 1)
+	required_reagents = list(/singleton/reagent/inaprovaline = 1, /singleton/reagent/dylovene = 1)
 	result_amount = 3
 
 /datum/chemical_reaction/alkysine

--- a/html/changelogs/wickedcybs_tricord.yml
+++ b/html/changelogs/wickedcybs_tricord.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - tweak: "Reverted the tricord recipe back to tricord being created if dylo and inaprov mix."


### PR DESCRIPTION
Reverts the tricord recipe back to inaprov and dylo, so it can potentially mix again in the bloodstream.

When I queried medical players they tended to like how it was before and I have to agree with them, it did add another variable slim as those are and in some cases may have even been desired by medical if they did want rapid tricord production. 

Water is pretty easy to add though if someone wants a specific bottle of this stuff. I'm mainly putting this PR out there and letting it sit for a bit to see what opinions it collects.