### PR TITLE
Mining Vendor Tweak

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -5,60 +5,60 @@
 //Think up of lots of items. Not everything needs to be unique or even mining-special, but it should be neat. Convert most of /tg/'s items. 25% of this at least
 //	should be bling. Things that shorten the distance between base and mining. Instant-teleporters should be one use.
 var/global/list/minevendor_list = list( //keep in order of price
-	new /datum/data/mining_equipment("Food Ration",					/obj/item/reagent_containers/food/snacks/liquidfood,		10,					5),
-	new /datum/data/mining_equipment("Poster",						/obj/item/contraband/poster,								10,					20),
-	new /datum/data/mining_equipment("Ore Scanner Pad",				/obj/item/ore_radar,										10,					50),
-	new /datum/data/mining_equipment("5 Red Flags",					/obj/item/stack/flag/red,									10,					50),
-	new /datum/data/mining_equipment("5 Green Flags",				/obj/item/stack/flag/green,									10,					50),
-	new /datum/data/mining_equipment("5 Yellow Flags",				/obj/item/stack/flag/yellow,								10,					50),
-	new /datum/data/mining_equipment("5 Purple Flags",				/obj/item/stack/flag/purple,								10,					50),
-	new /datum/data/mining_equipment("Ore-bag",						/obj/item/storage/bag/ore,									25,					50),
-	new /datum/data/mining_equipment("Meat Pizza",					/obj/item/pizzabox/meat,									25,					50),
-	new /datum/data/mining_equipment("Lantern",						/obj/item/device/flashlight/lantern,						10,					75),
-	new /datum/data/mining_equipment("Shovel",						/obj/item/shovel,											15,					100),
-	new /datum/data/mining_equipment("Pickaxe",						/obj/item/pickaxe,											10,					100),
-	new /datum/data/mining_equipment("Compressed matter cartridge",	/obj/item/rfd_ammo,											50,					100),
-	new /datum/data/mining_equipment("Class E Kinetic Accelerator",	/obj/item/gun/custom_ka/frame01/prebuilt,					12,					200),
-	new /datum/data/mining_equipment("Ore Box",						/obj/structure/ore_box,										-1,					150,	1),
-	new /datum/data/mining_equipment("Emergency Floodlight",		/obj/item/deployable_kit, 									-1,					150,	1),
-	new /datum/data/mining_equipment("Premium Cigar",				/obj/item/clothing/mask/smokable/cigarette/cigar/havana, 	30,					150),
-	new /datum/data/mining_equipment("Seismic Charge",				/obj/item/plastique/seismic,								25,					150),
-	new /datum/data/mining_equipment("Deployable Ladder",			/obj/item/ladder_mobile,									5,					200),
-	new /datum/data/mining_equipment("Deployable Hoist Kit",		/obj/item/hoist_kit,										5,					200),
-	new /datum/data/mining_equipment("Mining Drill",				/obj/item/pickaxe/drill,									10,					200),
-	new /datum/data/mining_equipment("Deep Ore Scanner",			/obj/item/mining_scanner,									10,					250),
-	new /datum/data/mining_equipment("Magboots",					/obj/item/clothing/shoes/magboots,							10,					300),
-	new /datum/data/mining_equipment("Class D Kinetic Accelerator", /obj/item/gun/custom_ka/frame02/prebuilt,					12,					400),
-	new /datum/data/mining_equipment("Autochisel",					/obj/item/autochisel,										10,					400),
-	new /datum/data/mining_equipment("Jetpack",						/obj/item/tank/jetpack,										10,					400),
-	new /datum/data/mining_equipment("Drone Drill Upgrade",			/obj/item/device/mine_bot_upgrade,							10,					400),
-	new /datum/data/mining_equipment("Industrial Drill Brace",		/obj/machinery/mining/brace,								-1,					500,	1),
-	new /datum/data/mining_equipment("Point Transfer Card",			/obj/item/card/mining_point_card,							-1,					500),
-	new /datum/data/mining_equipment("Explorer's Belt",				/obj/item/storage/belt/mining,								10,					500),
-	new /datum/data/mining_equipment("Item-Warp Beacon",			/obj/item/warp_core,										25,					500),
-	new /datum/data/mining_equipment("Item-Warp Pack",				/obj/item/extraction_pack,									25,					600),
-	new /datum/data/mining_equipment("Drone Health Upgrade", 		/obj/item/device/mine_bot_upgrade/health,					20,					600),
-	new /datum/data/mining_equipment("RFD M-Class",             	/obj/item/rfd/mining,										10,					600),
-	new /datum/data/mining_equipment("Trauma First-Aid Kit",		/obj/item/storage/firstaid/trauma,							30,					600),
-	new /datum/data/mining_equipment("Ore Magnet",					/obj/item/oremagnet,										10,					600),
-	new /datum/data/mining_equipment("Minecart",					/obj/vehicle/train/cargo/trolley/mining,					-1,					600,	1),
-	new /datum/data/mining_equipment("Resonator",					/obj/item/resonator,										10,					700),
-	new /datum/data/mining_equipment("Jaunter",						/obj/item/device/wormhole_jaunter,							20,					750),
-	new /datum/data/mining_equipment("Mining RIG",					/obj/item/rig/industrial,									5,					1000),
-	new /datum/data/mining_equipment("Mass Driver",					/obj/item/mass_driver_diy,									5,					800),
-	new /datum/data/mining_equipment("Mining Drone",				/mob/living/silicon/robot/drone/mining,						15,					800),
-	new /datum/data/mining_equipment("Minecart Engine",				/obj/vehicle/train/cargo/engine/mining,						-1,					800,	1),
-	new /datum/data/mining_equipment("Drone KA Upgrade",			/obj/item/device/mine_bot_upgrade/ka,						10,					800),
-	new /datum/data/mining_equipment("Ore Summoner",				/obj/item/oreportal,										35,					800),
-	new /datum/data/mining_equipment("Lazarus Injector",			/obj/item/lazarus_injector,									25,					1000),
-	new /datum/data/mining_equipment("Power Cell Backpack",			/obj/item/storage/backpack/cell,							5,					1000),
-	new /datum/data/mining_equipment("Industrial Drill Head",		/obj/machinery/mining/drill,								-1,					1000,	1),
-	new /datum/data/mining_equipment("Super Resonator",				/obj/item/resonator/upgraded,								10,					1250),
-	new /datum/data/mining_equipment("Diamond Pickaxe",				/obj/item/pickaxe/diamond,									10,					1500),
-	new /datum/data/mining_equipment("Thermal Drill",				/obj/item/gun/energy/vaurca/thermaldrill,					5,					1750),
-	new /datum/data/mining_equipment("Orbital Minecart Dropper",	/obj/item/device/orbital_dropper/minecart,					5,					2000),
-	new /datum/data/mining_equipment("Orbital Drill Dropper",		/obj/item/device/orbital_dropper/drill,						10,					3250),
-	new /datum/data/mining_equipment("Orbital Mecha Dropper",		/obj/item/device/orbital_dropper/mecha/miner,				2,					3500)
+	new /datum/data/mining_equipment(/obj/item/reagent_containers/food/snacks/liquidfood,		10,					5),
+	new /datum/data/mining_equipment(/obj/item/contraband/poster,								10,					20),
+	new /datum/data/mining_equipment(/obj/item/ore_radar,										10,					50),
+	new /datum/data/mining_equipment(/obj/item/stack/flag/red,									10,					50),
+	new /datum/data/mining_equipment(/obj/item/stack/flag/green,								10,					50),
+	new /datum/data/mining_equipment(/obj/item/stack/flag/yellow,								10,					50),
+	new /datum/data/mining_equipment(/obj/item/stack/flag/purple,								10,					50),
+	new /datum/data/mining_equipment(/obj/item/storage/bag/ore,									25,					50),
+	new /datum/data/mining_equipment(/obj/item/pizzabox/meat,									25,					50),
+	new /datum/data/mining_equipment(/obj/item/device/flashlight/lantern,						10,					75),
+	new /datum/data/mining_equipment(/obj/item/shovel,											15,					100),
+	new /datum/data/mining_equipment(/obj/item/pickaxe,											10,					100),
+	new /datum/data/mining_equipment(/obj/item/rfd_ammo,										50,					100),
+	new /datum/data/mining_equipment(/obj/item/gun/custom_ka/frame01/prebuilt,					12,					200),
+	new /datum/data/mining_equipment(/obj/structure/ore_box,									-1,					150,	1),
+	new /datum/data/mining_equipment(/obj/item/deployable_kit, 									-1,					150,	1),
+	new /datum/data/mining_equipment(/obj/item/clothing/mask/smokable/cigarette/cigar/havana, 	30,					150),
+	new /datum/data/mining_equipment(/obj/item/plastique/seismic,								25,					150),
+	new /datum/data/mining_equipment(/obj/item/ladder_mobile,									5,					200),
+	new /datum/data/mining_equipment(/obj/item/hoist_kit,										5,					200),
+	new /datum/data/mining_equipment(/obj/item/pickaxe/drill,									10,					200),
+	new /datum/data/mining_equipment(/obj/item/mining_scanner,									10,					250),
+	new /datum/data/mining_equipment(/obj/item/clothing/shoes/magboots,							10,					300),
+	new /datum/data/mining_equipment(/obj/item/gun/custom_ka/frame02/prebuilt,					12,					400),
+	new /datum/data/mining_equipment(/obj/item/autochisel,										10,					400),
+	new /datum/data/mining_equipment(/obj/item/tank/jetpack,									10,					400),
+	new /datum/data/mining_equipment(/obj/item/device/mine_bot_upgrade,							10,					400),
+	new /datum/data/mining_equipment(/obj/machinery/mining/brace,								-1,					500,	1),
+	new /datum/data/mining_equipment(/obj/item/card/mining_point_card,							-1,					500),
+	new /datum/data/mining_equipment(/obj/item/storage/belt/mining,								10,					500),
+	new /datum/data/mining_equipment(/obj/item/warp_core,										25,					500),
+	new /datum/data/mining_equipment(/obj/item/extraction_pack,									25,					600),
+	new /datum/data/mining_equipment(/obj/item/device/mine_bot_upgrade/health,					20,					600),
+	new /datum/data/mining_equipment(/obj/item/rfd/mining,										10,					600),
+	new /datum/data/mining_equipment(/obj/item/storage/firstaid/trauma,							30,					600),
+	new /datum/data/mining_equipment(/obj/item/oremagnet,										10,					600),
+	new /datum/data/mining_equipment(/obj/vehicle/train/cargo/trolley/mining,					-1,					600,	1),
+	new /datum/data/mining_equipment(/obj/item/resonator,										10,					700),
+	new /datum/data/mining_equipment(/obj/item/device/wormhole_jaunter,							20,					750),
+	new /datum/data/mining_equipment(/obj/item/rig/industrial,									5,					1000),
+	new /datum/data/mining_equipment(/obj/item/mass_driver_diy,									5,					800),
+	new /datum/data/mining_equipment(/mob/living/silicon/robot/drone/mining,					15,					800),
+	new /datum/data/mining_equipment(/obj/vehicle/train/cargo/engine/mining,					-1,					800,	1),
+	new /datum/data/mining_equipment(/obj/item/device/mine_bot_upgrade/ka,						10,					800),
+	new /datum/data/mining_equipment(/obj/item/oreportal,										35,					800),
+	new /datum/data/mining_equipment(/obj/item/lazarus_injector,								25,					1000),
+	new /datum/data/mining_equipment(/obj/item/storage/backpack/cell,							5,					1000),
+	new /datum/data/mining_equipment(/obj/machinery/mining/drill,								-1,					1000,	1),
+	new /datum/data/mining_equipment(/obj/item/resonator/upgraded,								10,					1250),
+	new /datum/data/mining_equipment(/obj/item/pickaxe/diamond,									10,					1500),
+	new /datum/data/mining_equipment(/obj/item/gun/energy/vaurca/thermaldrill,					5,					1750),
+	new /datum/data/mining_equipment(/obj/item/device/orbital_dropper/minecart,					5,					2000),
+	new /datum/data/mining_equipment(/obj/item/device/orbital_dropper/drill,					10,					3250),
+	new /datum/data/mining_equipment(/obj/item/device/orbital_dropper/mecha/miner,				2,					3500)
 	)
 
 /obj/machinery/mineral/equipment_vendor
@@ -72,17 +72,20 @@ var/global/list/minevendor_list = list( //keep in order of price
 
 /datum/data/mining_equipment
 	var/equipment_name = "generic"
+	var/equipment_description = ""
 	var/equipment_path = null
 	var/amount = 0 // -1 is the special number for infinite items like things that can be ordered from the shuttle
 	var/cost = 0
-	var/shuttle
+	var/shuttle = FALSE
 
-/datum/data/mining_equipment/New(name, path, amount, cost, shuttle)
-	src.equipment_name = name
-	src.equipment_path = path
-	src.amount = amount
-	src.cost = cost
-	src.shuttle = shuttle
+/datum/data/mining_equipment/New(set_path, set_amount, set_cost, set_shuttle)
+	var/atom/equipment = set_path
+	equipment_name = capitalize_first_letters(initial(equipment.name))
+	equipment_description = initial(equipment.desc)
+	equipment_path = set_path
+	amount = set_amount
+	cost = set_cost
+	shuttle = set_shuttle
 
 /obj/item/circuitboard/machine/mining_equipment_vendor
 	name = "circuit board (Mining Equipment Vendor)"
@@ -146,7 +149,7 @@ var/global/list/minevendor_list = list( //keep in order of price
 		data["hasId"] = FALSE
 	var/list/prize_list = list()
 	for(var/datum/data/mining_equipment/prize as anything in minevendor_list)
-		prize_list += list(list("name" = prize.equipment_name, "cost" = prize.cost, "stock" = prize.amount, "ref" = "\ref[prize]"))
+		prize_list += list(list("name" = prize.equipment_name, "desc" = prize.equipment_description, "cost" = prize.cost, "stock" = prize.amount, "ref" = "\ref[prize]"))
 	data["prizeList"] = prize_list
 	return data
 

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/robot/drone/mining
-	name = "NT-MD-000"
+	name = "Autonomous Mining Drone"
 	desc_flavor = "It's a small mining drone. The casing is stamped with an corporate logo and the subscript: '%MAPNAME% Automated Pickaxe!'<br><br><b>OOC Info:</b><br><br>Mining drones are player-controlled synthetics which are lawed to serve the crew and excavate for ore.<br><br>They hold a wide array of tools to explore mining sites and extract ore. They function similarly to other synthetics, in that they require recharging regularly, have laws, and are resilient to many hazards, such as fire, radiation, vacuum, and more.<br><br>Ghosts can join the round as a mining drone by accessing the 'Ghost Spawner' menu in the 'Ghost' tab. An inactive drone can be rebooted by swiping an ID card on it with mining or robotics access, and an active drone can be shut down in the same manner.<br><br>An antagonist can use an Electromagnetic Sequencer to corrupt their laws and make them follow their orders."
 	icon_state = "miningdrone"
 	mod_type = "Mining"

--- a/html/changelogs/geeves-mining_vendor_tweak.yml
+++ b/html/changelogs/geeves-mining_vendor_tweak.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "The mining vendor Purchase button now has a tooltip describing what the item does, captured from the item's actual description."
+  - tweak: "The mining vendor's item list now has the same names as the actual spawned items."

--- a/tgui/packages/tgui/interfaces/MiningVendor.tsx
+++ b/tgui/packages/tgui/interfaces/MiningVendor.tsx
@@ -4,6 +4,7 @@ import { Window } from '../layouts';
 
 export type PrizeListData = {
   name: string;
+  desc: string;
   cost: number;
   stock: number;
   ref: string;
@@ -57,6 +58,7 @@ export const MiningVendor = (props, context) => {
                 <Table.Cell>
                   <Button
                     content="Purchase"
+                    tooltip={prize.desc}
                     disabled={prize.stock === 0}
                     onClick={() => act('purchase', { purchase: prize.ref })}
                   />


### PR DESCRIPTION
* The mining vendor Purchase button now has a tooltip describing what the item does, captured from the item's actual description.
* The mining vendor's item list now has the same names as the actual spawned items.

![image](https://github.com/Aurorastation/Aurora.3/assets/22774890/ff036e6f-b5a7-4cab-9fb3-89fbbcaacf41)