### PR TITLE
Hivenet Camera Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -1753,9 +1753,9 @@
 						remoteview_target = null
 						reset_view(0)
 						return
-		to_chat(src, SPAN_NOTICE("Your request to access [target]'s senses has been denied."))
-		remoteview_target = null
-		reset_view(0)
+			to_chat(src, SPAN_NOTICE("Your request to access [target]'s senses has been denied."))
+			remoteview_target = null
+			reset_view(0)
 
 /mob/living/carbon/human/proc/hivenet_neuralshock()
 	set name = "Neural Shock"

--- a/html/changelogs/RustingWithYou - fixes3.yml
+++ b/html/changelogs/RustingWithYou - fixes3.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes Hivenet camera verb."


### PR DESCRIPTION
Some lines were improperly indented in the Hivenet senses access verb, causing it to not work properly. This fixes that. 