### PR TITLE
Energy rifle buff

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -4,6 +4,7 @@
 	ping_effect = "ping_s"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSRAILING
 	damage = 30
+	armor_penetration = 10
 	damage_type = DAMAGE_BURN
 	impact_sounds = list(BULLET_IMPACT_MEAT = SOUNDS_LASER_MEAT, BULLET_IMPACT_METAL = SOUNDS_LASER_METAL)
 	check_armor = "laser"
@@ -20,6 +21,7 @@
 /obj/item/projectile/beam/practice
 	name = "laser"
 	damage = 5
+	armor_penetration = 0
 	damage_type = DAMAGE_PAIN
 	eyeblur = 0
 

--- a/html/changelogs/GeneralCamo - ER Buff.yml
+++ b/html/changelogs/GeneralCamo - ER Buff.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Increased the NT ER-2 energy rifle's kill beam armor penetration from 0 to 10."


### PR DESCRIPTION
Per request in #17153

The energy rifle previously had -no- armor penetration. Even the energy pistol has a token 5 penetration.

This is still worse than a dedicated laser rifle, but this has more shots and can fire stun beams, so I feel this is more than fair.
Before:
![image](https://github.com/Aurorastation/Aurora.3/assets/1779662/72bea502-c84f-4983-81dd-0b95dd1a7987)

After:
![image](https://github.com/Aurorastation/Aurora.3/assets/1779662/ed67f6fe-6917-4e06-a36d-1cfbd42cb974)

Comparison with laser rifle:
![image](https://github.com/Aurorastation/Aurora.3/assets/1779662/3693b661-89a1-470f-9120-747d67676224)
