### PR TITLE
Off-Duty crew now spawn with their faction gear

### DIFF
--- a/code/game/jobs/faction/hephaestus.dm
+++ b/code/game/jobs/faction/hephaestus.dm
@@ -45,7 +45,8 @@
 		"Atmospheric Technician" = /datum/outfit/job/atmos/hephaestus,
 		"Engineering Apprentice" = /datum/outfit/job/intern_eng/hephaestus,
 		"Atmospherics Apprentice" = /datum/outfit/job/intern_atmos/hephaestus,
-		"Corporate Liaison" = /datum/outfit/job/representative/hephaestus
+		"Corporate Liaison" = /datum/outfit/job/representative/hephaestus,
+		"Off-Duty Crew Member" = /datum/outfit/job/visitor/hephaestus
 	)
 
 /datum/outfit/job/hangar_tech/hephaestus
@@ -149,3 +150,13 @@
 		/obj/item/gun/energy/pistol = 1,
 		/obj/item/stamp/hephaestus = 1
 	)
+
+/datum/outfit/job/visitor/hephaestus
+	name = "Off-Duty Crew Member - Hephaestus"
+
+	id = /obj/item/card/id/hephaestus
+
+	backpack_faction = /obj/item/storage/backpack/heph
+	satchel_faction = /obj/item/storage/backpack/satchel/heph
+	dufflebag_faction = /obj/item/storage/backpack/duffel/heph
+	messengerbag_faction = /obj/item/storage/backpack/messenger/heph

--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -58,7 +58,8 @@
 		"Librarian" = /datum/outfit/job/librarian/idris,
 		"Curator" = /datum/outfit/job/librarian/idris/curator,
 		"Tech Support" = /datum/outfit/job/librarian/idris/tech_support,
-		"Corporate Liaison" = /datum/outfit/job/representative/idris
+		"Corporate Liaison" = /datum/outfit/job/representative/idris,
+		"Off-Duty Crew Member" = /datum/outfit/job/visitor/idris
 	)
 
 /datum/outfit/job/officer/idris
@@ -218,3 +219,13 @@
 		/obj/item/gun/energy/pistol = 1,
 		/obj/item/stamp/idris = 1
 	)
+
+/datum/outfit/job/visitor/idris
+	name = "Off-Duty Crew Member - Idris"
+
+	id = /obj/item/card/id/idris
+
+	backpack_faction = /obj/item/storage/backpack/idris
+	satchel_faction = /obj/item/storage/backpack/satchel/idris
+	dufflebag_faction = /obj/item/storage/backpack/duffel/idris
+	messengerbag_faction = /obj/item/storage/backpack/messenger/idris

--- a/code/game/jobs/faction/nanotrasen.dm
+++ b/code/game/jobs/faction/nanotrasen.dm
@@ -26,6 +26,10 @@
 		)
 	)
 
+	titles_to_loadout = list(
+		"Off-Duty Crew Member" = /datum/outfit/job/visitor/nanotrasen
+	)
+
 
 	allowed_role_types = NT_ROLES
 
@@ -46,3 +50,11 @@
 						"Have [rand(3,10)] crewmembers buy Getmore products from the vendors")
 
 	return objective
+
+/datum/outfit/job/visitor/nanotrasen
+	name = "Off-Duty Crew Member - NanoTrasen"
+
+	backpack_faction = /obj/item/storage/backpack/nt
+	satchel_faction = /obj/item/storage/backpack/satchel/nt
+	dufflebag_faction = /obj/item/storage/backpack/duffel/nt
+	messengerbag_faction = /obj/item/storage/backpack/messenger/nt

--- a/code/game/jobs/faction/orion_express.dm
+++ b/code/game/jobs/faction/orion_express.dm
@@ -38,7 +38,8 @@
 		"Hangar Technician" = /datum/outfit/job/hangar_tech/orion,
 		"Shaft Miner" = /datum/outfit/job/mining/orion,
 		"Machinist" = /datum/outfit/job/machinist/orion,
-		"Corporate Liaison" = /datum/outfit/job/representative/orion
+		"Corporate Liaison" = /datum/outfit/job/representative/orion,
+		"Off-Duty Crew Member" = /datum/outfit/job/visitor/orion
 	)
 
 /datum/outfit/job/hangar_tech/orion
@@ -83,6 +84,16 @@
 	id = /obj/item/card/id/orion
 	accessory = /obj/item/clothing/accessory/tie/corporate/orion
 	suit_accessory = /obj/item/clothing/accessory/pin/corporate/orion
+
+	backpack_faction = /obj/item/storage/backpack/orion
+	satchel_faction = /obj/item/storage/backpack/satchel/orion
+	dufflebag_faction = /obj/item/storage/backpack/duffel/orion
+	messengerbag_faction = /obj/item/storage/backpack/messenger/orion
+
+/datum/outfit/job/visitor/orion
+	name = "Off-Duty Crew Member - Orion Express"
+
+	id = /obj/item/card/id/orion
 
 	backpack_faction = /obj/item/storage/backpack/orion
 	satchel_faction = /obj/item/storage/backpack/satchel/orion

--- a/code/game/jobs/faction/pmc.dm
+++ b/code/game/jobs/faction/pmc.dm
@@ -50,7 +50,8 @@
 		"Psychologist" = /datum/outfit/job/psychiatrist/pmc,
 		"First Responder" = /datum/outfit/job/med_tech/pmc,
 		"Medical Intern" = /datum/outfit/job/intern_med/pmc,
-		"Corporate Liaison" = /datum/outfit/job/representative/pmc
+		"Corporate Liaison" = /datum/outfit/job/representative/pmc,
+		"Off-Duty Crew Member" = /datum/outfit/job/visitor/pmc
 	)
 
 /datum/outfit/job/officer/pmc
@@ -201,6 +202,16 @@
 	id = /obj/item/card/id/pmc
 	accessory = /obj/item/clothing/accessory/tie/corporate/pmc
 	suit_accessory = /obj/item/clothing/accessory/pin/corporate/pmc
+
+	backpack_faction = /obj/item/storage/backpack/pmcg
+	satchel_faction = /obj/item/storage/backpack/satchel/pmcg
+	dufflebag_faction = /obj/item/storage/backpack/duffel/pmcg
+	messengerbag_faction = /obj/item/storage/backpack/messenger/pmcg
+
+/datum/outfit/job/visitor/pmc
+	name = "Off-Duty Crew Member - PMC"
+
+	id = /obj/item/card/id/pmc
 
 	backpack_faction = /obj/item/storage/backpack/pmcg
 	satchel_faction = /obj/item/storage/backpack/satchel/pmcg

--- a/code/game/jobs/faction/zavodskoi.dm
+++ b/code/game/jobs/faction/zavodskoi.dm
@@ -61,7 +61,8 @@
 		"Atmospheric Technician" = /datum/outfit/job/atmos/zavodskoi,
 		"Engineering Apprentice" = /datum/outfit/job/intern_eng/zavodskoi,
 		"Atmospherics Apprentice" = /datum/outfit/job/intern_atmos/zavodskoi,
-		"Corporate Liaison" = /datum/outfit/job/representative/zavodskoi
+		"Corporate Liaison" = /datum/outfit/job/representative/zavodskoi,
+		"Off-Duty Crew Member" = /datum/outfit/job/visitor/zavodskoi
 	)
 
 /datum/outfit/job/officer/zavodskoi
@@ -250,3 +251,14 @@
 		/obj/item/gun/projectile/pistol = 1,
 		/obj/item/stamp/zavodskoi = 1
 	)
+
+/datum/outfit/job/visitor/zavodskoi
+	name = "Off-Duty Crew Member - Zavodskoi Interstellar"
+
+	id = /obj/item/card/id/zavodskoi
+
+	backpack_faction = /obj/item/storage/backpack/zavod
+	satchel_faction = /obj/item/storage/backpack/satchel/zavod
+	dufflebag_faction = /obj/item/storage/backpack/duffel/zavod
+	messengerbag_faction = /obj/item/storage/backpack/messenger/zavod
+

--- a/code/game/jobs/faction/zeng_hu.dm
+++ b/code/game/jobs/faction/zeng_hu.dm
@@ -52,7 +52,8 @@
 		"Xenobotanist" = /datum/outfit/job/scientist/xenobotanist/zeng_hu,
 		"Lab Assistant" = /datum/outfit/job/intern_sci/zeng_hu,
 		"Xenoarchaeologist"= /datum/outfit/job/scientist/xenoarchaeologist/zeng_hu,
-		"Corporate Liaison" = /datum/outfit/job/representative/zeng_hu
+		"Corporate Liaison" = /datum/outfit/job/representative/zeng_hu,
+		"Off-Duty Crew Member" = /datum/outfit/job/visitor/zeng_hu
 	)
 
 /datum/outfit/job/doctor/zeng_hu
@@ -220,3 +221,13 @@
 		/obj/item/gun/energy/pistol = 1,
 		/obj/item/stamp/zeng_hu = 1
 	)
+
+/datum/outfit/job/visitor/zeng_hu
+	name = "Off-Duty Crew Member - Zeng-Hu"
+
+	id = /obj/item/card/id/zeng_hu
+
+	backpack_faction = /obj/item/storage/backpack/zeng
+	satchel_faction = /obj/item/storage/backpack/satchel/zeng
+	dufflebag_faction = /obj/item/storage/backpack/duffel/zeng
+	messengerbag_faction = /obj/item/storage/backpack/messenger/zeng

--- a/html/changelogs/FactionGearFix - GeneralCamo.yml
+++ b/html/changelogs/FactionGearFix - GeneralCamo.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Off-duty crew members now spawn with their factional ID cards and (if selected) their factional bags."


### PR DESCRIPTION
Off-Duty crew previously did not spawn with their factional gear. This doesn't really make sense for ID cards at all, and for factional bags, if you spawn with them it would make sense that you would use them if you're off-duty, especially since you're spawning with them from cryo/residential. I assumed this was an oversight and have corrected this.