### PR TITLE
Small G1 and G2 industrial IPC nerfs

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -131,11 +131,11 @@
 
 	unarmed_types = list(/datum/unarmed_attack/industrial, /datum/unarmed_attack/palm/industrial)
 
-	brute_mod = 0.8
+	brute_mod = 0.85
 	burn_mod = 1.1
 
 	grab_mod = 0.8 // Big, easy to grab onto
-	resist_mod = 10 // Good luck wrestling against this powerhouse.
+	resist_mod = 9 // Good luck wrestling against this powerhouse.
 
 	slowdown = 4
 
@@ -314,9 +314,9 @@
 	unarmed_types = list(/datum/unarmed_attack/industrial/heavy, /datum/unarmed_attack/palm/industrial)
 
 	slowdown = 6
-	brute_mod = 0.7
+	brute_mod = 0.8
 	grab_mod = 0.7 // Bulkier and bigger than the G1
-	resist_mod = 12 // Overall stronger than G1
+	resist_mod = 10 // Overall stronger than G1
 
 	heat_level_1 = 1000
 	heat_level_2 = 2000

--- a/html/changelogs/wezzy_G2-G1nerfs.yml
+++ b/html/changelogs/wezzy_G2-G1nerfs.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Wowzewow (Wezzy)
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Nerfs the G2 and G1 industrial IPCs."


### PR DESCRIPTION
Title. Resist mod for the G2 is now equal to the Tesla Rejuvenation Suit, and the G1 has been balanced accordingly.

Nothing too drastic, but they now should be more in-line balance wise.
