### PR TITLE
Async as define

### DIFF
--- a/code/__defines/callback.dm
+++ b/code/__defines/callback.dm
@@ -1,3 +1,19 @@
 #define CALLBACK new /datum/callback
 
-#define INVOKE_ASYNC ImmediateInvokeAsync
+///Per the DM reference, spawn(-1) will execute the spawned code immediately until a block is met.
+#define MAKE_SPAWN_ACT_LIKE_WAITFOR -1
+///Create a codeblock that will not block the callstack if a block is met.
+#define ASYNC spawn(MAKE_SPAWN_ACT_LIKE_WAITFOR)
+
+#define INVOKE_ASYNC(proc_owner, proc_path, proc_arguments...) \
+	if ((proc_owner) == GLOBAL_PROC) { \
+		ASYNC { \
+			call(proc_path)(##proc_arguments); \
+		}; \
+	} \
+	else { \
+		ASYNC { \
+			/* Written with `0 ||` to avoid the compiler seeing call("string"), and thinking it's a deprecated DLL */ \
+			call(0 || proc_owner, proc_path)(##proc_arguments); \
+		}; \
+	}

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -290,16 +290,14 @@
 		if(!C.signal_enabled)
 			return NONE
 		var/proctype = C.signal_procs[src][sigtype]
-		arguments = list(C, proctype) + arguments
-		return NONE | INVOKE_ASYNC(arglist(arguments))
+		return NONE | call(C, proctype)(arglist(arguments))
 	. = NONE
 	for(var/I in target)
 		var/datum/C = I
 		if(!C.signal_enabled)
 			continue
 		var/proctype = C.signal_procs[src][sigtype]
-		arguments = list(C, proctype) + arguments
-		. |= INVOKE_ASYNC(arglist(arguments))
+		. |= call(C, proctype)(arglist(arguments))
 
 // The type arg is casted so initial works, you shouldn't be passing a real instance into this
 /**

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -1,4 +1,5 @@
 /atom
+	///Whether /atom/Initialize() has already run for the object
 	var/initialized = FALSE
 	var/update_icon_on_init	// Default to 'no'.
 
@@ -89,5 +90,17 @@
 			var/datum/orbit/O = thing
 			if (O.orbiter)
 				O.orbiter.stop_orbit()
+
+	if(length(overlays))
+		overlays.Cut()
+
+	if(light)
+		QDEL_NULL(light)
+
+	if (length(light_sources))
+		light_sources.Cut()
+
+	if(smoothing_flags & SMOOTH_QUEUED)
+		SSicon_smooth.remove_from_queues(src)
 
 	return ..()

--- a/code/game/atoms_init.dm
+++ b/code/game/atoms_init.dm
@@ -1,5 +1,4 @@
 /atom
-	///Whether /atom/Initialize() has already run for the object
 	var/initialized = FALSE
 	var/update_icon_on_init	// Default to 'no'.
 
@@ -90,17 +89,5 @@
 			var/datum/orbit/O = thing
 			if (O.orbiter)
 				O.orbiter.stop_orbit()
-
-	if(length(overlays))
-		overlays.Cut()
-
-	if(light)
-		QDEL_NULL(light)
-
-	if (length(light_sources))
-		light_sources.Cut()
-
-	if(smoothing_flags & SMOOTH_QUEUED)
-		SSicon_smooth.remove_from_queues(src)
 
 	return ..()

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -248,7 +248,7 @@
 				. = TRUE
 
 	signal.data["sigtype"] = "command"
-	INVOKE_ASYNC(radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA))
+	INVOKE_ASYNC(radio_connection, TYPE_PROC_REF(/datum/radio_frequency, post_signal), src, signal, filter = RADIO_ATMOSIA)
 
 /obj/machinery/computer/general_air_control/supermatter_core
 	icon = 'icons/obj/machinery/modular_console.dmi'

--- a/html/changelogs/FluffyGhost-async_as_define.yml
+++ b/html/changelogs/FluffyGhost-async_as_define.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Turned the INVOKE_ASYNC into a define, copied from TG."
+  - backend: "Adjusted signal sending to use the new format via direct call invocation (TG backport)."
+  - backend: "Adjusted atmos control tank to use the new format."


### PR DESCRIPTION
Turned the INVOKE_ASYNC into a define, copied from TG.
Adjusted signal sending to use the new format via direct call invocation (TG backport).
Adjusted atmos control tank to use the new format.