### PR TITLE
Add technomancer initiate to antags list.

### DIFF
--- a/code/game/gamemodes/technomancer/assistance/assistance.dm
+++ b/code/game/gamemodes/technomancer/assistance/assistance.dm
@@ -54,6 +54,10 @@
 	user.drop_from_inventory(src, user_turf)
 	user.visible_message(SPAN_DANGER("<b>[user]</b> crushes \the [src] in their hand with a shower of sparks! A small bracelet appears on their wrist, and a catalog flies into their hand."), SPAN_DANGER("You crush \the [src] in your hand with a shower of sparks! A small bracelet appears on your wrist, and a catalog flies into your hand."))
 	spark(user_turf, 4, alldirs)
+	var/initiate_welcome_text = "You will need to purchase <b>functions</b> and perhaps some <b>equipment</b> from your initiate's catalogue. \
+	Choose your technological arsenal carefully.  Remember that without the <b>core</b> on your wrist, your functions are \
+	powerless, and therefore you will be as well."
+	technomancers.add_antagonist_mind(user.mind, 1, "Technomancer Initiate", initiate_welcome_text)
 	if(user.wrists)
 		user.drop_from_inventory(user.wrists, get_turf(user_turf))
 	var/obj/item/technomancer_core/bracelet/bracelet = new(user_turf)

--- a/html/changelogs/AlaunusLuxtechnomancerinitiatefix.yml
+++ b/html/changelogs/AlaunusLuxtechnomancerinitiatefix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Alaunus_Lux
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Add technomancer initiates to antagonists so they won't instability themselves to death."


### PR DESCRIPTION
This way they won't get instabilitied to death.

I do want to note the message comes out as "You are Technomancer Initiate" without an a, not sure whether to manually add it or why the /a isn't working there.

Should initiate_welcome_text mention that they can do whatever they want with their powers?

https://github.com/Aurorastation/Aurora.3/issues/17085