### PR TITLE
Allows business cards to be renamed in the loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/utility.dm
+++ b/code/modules/client/preference_setup/loadout/items/utility.dm
@@ -121,7 +121,7 @@
 	display_name = "business card"
 	description = "A selection of business cards." // I'm not smart enough to make it spawn inside the holders and carry over the text so we'll have to live with this
 	path = /obj/item/paper/business_card
-	flags = GEAR_HAS_COLOR_SELECTION
+	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
 
 /datum/gear/utility/business_card/New()
 	..()

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -183,6 +183,7 @@
 	info += copied
 	info += "</font>"//</font>
 	pname = copy.name // -- Doohl
+	c.desc = copy.desc
 	if(istype(copy, /obj/item/paper/business_card))
 		c.color = copy.color
 	else


### PR DESCRIPTION
See title.
Also adds a single line of code that allows business cards with custom descriptions to be photocopied normally. (Can be nudged upwards to fall into the `if(istype` check if necessary.)
