### PR TITLE
Cultist teleport rune improvements

### DIFF
--- a/code/game/gamemodes/cult/items/talisman.dm
+++ b/code/game/gamemodes/cult/items/talisman.dm
@@ -18,7 +18,7 @@
 /obj/item/paper/talisman/examine(mob/user)
 	. = ..()
 	if(iscultist(user) && rune)
-	var/network_text = ""
+		var/network_text = ""
 		if(network)
 			network_text = " This spell's network tag reads: <span class='cult'><b><i>[network]</i></b></span>."
 		to_chat(user, "The spell inscription reads: <span class='cult'><b><i>[rune.name]</i></b></span>.")

--- a/code/game/gamemodes/cult/items/talisman.dm
+++ b/code/game/gamemodes/cult/items/talisman.dm
@@ -18,6 +18,9 @@
 /obj/item/paper/talisman/examine(mob/user)
 	. = ..()
 	if(iscultist(user) && rune)
+	var/network_text = ""
+		if(network)
+			network_text = " This spell's network tag reads: <span class='cult'><b><i>[network]</i></b></span>."
 		to_chat(user, "The spell inscription reads: <span class='cult'><b><i>[rune.name]</i></b></span>.")
 
 /obj/item/paper/talisman/attack_self(mob/living/user)

--- a/code/game/gamemodes/cult/items/talisman.dm
+++ b/code/game/gamemodes/cult/items/talisman.dm
@@ -20,8 +20,8 @@
 	if(iscultist(user) && rune)
 		var/network_text = ""
 		if(network)
-			network_text = " This spell's network tag reads: <span class='cult'><b><i>[network]</i></b></span>."
-		to_chat(user, "The spell inscription reads: <span class='cult'><b><i>[rune.name]</i></b></span>.[network_text]")
+			network_text = " This spell's network tag reads: [SPAN_CULT(network)]."
+		to_chat(user, "The spell inscription reads: [SPAN_CULT(rune.name)].[network_text]")
 
 /obj/item/paper/talisman/attack_self(mob/living/user)
 	if(iscultist(user))

--- a/code/game/gamemodes/cult/items/talisman.dm
+++ b/code/game/gamemodes/cult/items/talisman.dm
@@ -21,7 +21,7 @@
 		var/network_text = ""
 		if(network)
 			network_text = " This spell's network tag reads: <span class='cult'><b><i>[network]</i></b></span>."
-		to_chat(user, "The spell inscription reads: <span class='cult'><b><i>[rune.name]</i></b></span>.")
+		to_chat(user, "The spell inscription reads: <span class='cult'><b><i>[rune.name]</i></b></span>.[network_text]")
 
 /obj/item/paper/talisman/attack_self(mob/living/user)
 	if(iscultist(user))

--- a/code/game/gamemodes/cult/items/talisman.dm
+++ b/code/game/gamemodes/cult/items/talisman.dm
@@ -2,6 +2,7 @@
 	icon_state = "paper_talisman"
 	can_change_icon_state = FALSE
 	var/uses = 1
+	var/network
 	var/datum/rune/rune
 	info = "<center><img src='talisman.png'></center><br/><br/>"
 

--- a/code/game/gamemodes/cult/runes/create_talisman.dm
+++ b/code/game/gamemodes/cult/runes/create_talisman.dm
@@ -29,6 +29,9 @@
 		var/obj/item/paper/talisman/T = new /obj/item/paper/talisman(get_turf(A))
 		imbued_from = R
 		T.rune = new R.rune.type
+		if(istype(R.rune, /datum/rune/teleport))
+			var/datum/rune/teleport/teleport_rune = R.rune
+			T.network = teleport_rune.network
 		break
 	if(imbued_from)
 		A.visible_message(SPAN_CULT("The blood from \the [imbued_from] floods into a talisman!"))

--- a/code/game/gamemodes/cult/runes/rune.dm
+++ b/code/game/gamemodes/cult/runes/rune.dm
@@ -26,8 +26,8 @@
 	. = ..()
 	if(iscultist(user) || isobserver(user))
 		to_chat(user, rune.get_cultist_fluff_text())
-		to_chat(user, "This rune [rune.can_be_talisman() ? "<span class='cult'><b><i>can</i></b></span>" : "<span class='warning'><b><i>cannot</i></b></span>"] be turned into a talisman.")
-		to_chat(user, "This rune [rune.can_memorize() ? "<span class='cult'><b><i>can</i></b></span>" : "<span class='warning'><b><i>cannot</i></b></span>"] be memorized to be scribed without a tome.")
+		to_chat(user, "This rune [rune.can_be_talisman() ? SPAN_CULT("can") : "[SPAN_CULT("cannot")]"] be turned into a talisman.")
+		to_chat(user, "This rune [rune.can_memorize() ? SPAN_CULT("can") : "[SPAN_CULT("cannot")]"] be memorized to be scribed without a tome.")
 	else
 		to_chat(user, rune.get_normal_fluff_text())
 

--- a/code/game/gamemodes/cult/runes/teleport.dm
+++ b/code/game/gamemodes/cult/runes/teleport.dm
@@ -17,7 +17,7 @@
 /datum/rune/teleport/get_cultist_fluff_text()
 	. = ..()
 	if(network)
-		. += " This rune's network tag reads: <span class='cult'><b><i>[network]</i></b></span>."
+		. += " This rune's network tag reads: [SPAN_CULT(network)]."
 
 /datum/rune/teleport/proc/random_network()
 	if(!network) // check if it hasn't been assigned yet
@@ -43,7 +43,7 @@
 /datum/rune/teleport/do_rune_action(mob/living/user, atom/movable/A)
 	teleport(user, A, TRUE)
 
-/datum/rune/teleport/proc/teleport(mob/living/user, atom/movable/A, is_rune)
+/datum/rune/teleport/proc/teleport(mob/living/user, atom/movable/A, is_rune = FALSE)
 	var/turf/T = get_turf(user)
 	if(isNotStationLevel(T.z))
 		to_chat(user, SPAN_WARNING("You are too far from the station, Nar'sie is unable to reach you here."))

--- a/code/game/gamemodes/cult/runes/teleport.dm
+++ b/code/game/gamemodes/cult/runes/teleport.dm
@@ -17,7 +17,7 @@
 /datum/rune/teleport/get_cultist_fluff_text()
 	. = ..()
 	if(network)
-		. += "This rune's network tag reads: <span class='cult'><b><i>[network]</i></b></span>."
+		. += " This rune's network tag reads: <span class='cult'><b><i>[network]</i></b></span>."
 
 /datum/rune/teleport/proc/random_network()
 	if(!network) // check if it hasn't been assigned yet

--- a/html/changelogs/AlaunusLux-cultist-rune-improvements.yml
+++ b/html/changelogs/AlaunusLux-cultist-rune-improvements.yml
@@ -8,3 +8,4 @@ changes:
   - bugfix: "The proper proc is now called for the teleport talisman."
   - bugfix: "Added a null parent check, no more teleporting to nowhere."
   - bugfix: "Teleportation rune and talisman will only sizzle if they can't teleport."
+  - tweak: "Examining teleportation talismans will tell you what network it is keyed to."

--- a/html/changelogs/AlaunusLux-cultist-rune-improvements.yml
+++ b/html/changelogs/AlaunusLux-cultist-rune-improvements.yml
@@ -1,0 +1,10 @@
+
+author: AlaunusLux
+
+delete-after: True
+
+changes:
+  - bugfix: "Teleport talismans now work consistently, taking on the network of their infused rune."
+  - bugfix: "The proper proc is now called for the teleport talisman."
+  - bugfix: "Added a null parent check, no more teleporting to nowhere."
+  - bugfix: "Teleportation rune and talisman will only sizzle if they can't teleport."

--- a/html/changelogs/AlaunusLux-cultist-rune-improvements.yml
+++ b/html/changelogs/AlaunusLux-cultist-rune-improvements.yml
@@ -8,4 +8,4 @@ changes:
   - bugfix: "The proper proc is now called for the teleport talisman."
   - bugfix: "Added a null parent check, no more teleporting to nowhere."
   - bugfix: "Teleportation rune and talisman will only sizzle if they can't teleport."
-  - tweak: "Examining teleportation talismans will tell you what network it is keyed to."
+  - tweak: "Examining a teleportation talisman will now tell you what network it is keyed to."


### PR DESCRIPTION
I noticed during a game that the teleportation talisman was inconsistent. I can't remember if I was able to make it work during that game, but during testing I wasn't able to get them to work at all. 

This adds a `network` variable to the talisman, which is only set if the infusing rune is a teleportation rune.

This annoyingly will now delete the talisman properly upon use. I was tempted to fix the teleportation but not the proc call ;)

There is also at least one phantom teleportation rune, which has a null parent, so would 'use' the rune and set its cooldown without being able to teleport the user, so there's a check for that now. I believe the phantom/orphan runes are created when a talisman is created. Will look into a fix, but it doesn't affect rune count, just makes the for loop work a bit harder.

This also stops the rune and talisman from sending a "sizzled with no result" message even when it works.

Also will show which network the talisman is keyed to on examination. Added a missing space in the rune examine text.