### PR TITLE
Removes scrubber surge from event rotation

### DIFF
--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -196,7 +196,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Lotto",					/datum/event/money_lotto, 			0, 		list(ASSIGNMENT_ANY = 1), TRUE, 5, 15),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Mundane News", 					/datum/event/mundane_news, 			300),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",						/datum/event/wallrot, 				75,		list(ASSIGNMENT_ENGINEER = 5, ASSIGNMENT_GARDENER = 20)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Clogged Vents",					/datum/event/vent_clog, 			55),
+		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Clogged Vents",					/datum/event/vent_clog, 			0),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "False Alarm",					/datum/event/false_alarm, 			100),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Supply Drop",					/datum/event/supply_drop, 			80),
 		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "CCIA General Notice",			/datum/event/ccia_general_notice, 	300),

--- a/html/changelogs/nauticall-scrubbereventremoval.yml
+++ b/html/changelogs/nauticall-scrubbereventremoval.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Removed scrubber backpressure surge from event rotation. Code is still there."

--- a/html/changelogs/nauticall-scrubbereventremoval.yml
+++ b/html/changelogs/nauticall-scrubbereventremoval.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: nauticall
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True


### PR DESCRIPTION
What it says on the tin. Scrubber surge was one of the most egregiously LRP events inn the game and provides no benefit or gameplay at all to anyone, besides choking on drugs or pepperspray.

The code and event itself is still there, just with the weight set to 0. If there's a better way to do this then lemme know.