### PR TITLE
Golden Deep Appearance Fixes & Plating Decals

### DIFF
--- a/code/__defines/_layers.dm
+++ b/code/__defines/_layers.dm
@@ -4,7 +4,7 @@
 #define PLANE_SPACE_DUST (PLANE_SPACE_PARALLAX + 1) // -96
 #define PLANE_ABOVE_PARALLAX (PLANE_SPACE_DUST + 1) // -95
 #define PLANE_DEFAULT 0
-#define DECAL_PLATING_LAYER         1.02
+#define DECAL_PLATING_LAYER (TURF_LAYER + 0.01)
 // TURF_LAYER 			2
 #define LOWER_ON_TURF_LAYER (TURF_LAYER + 0.05)	// under the below
 #define ON_TURF_LAYER (TURF_LAYER + 0.1)	// sitting on the turf - should be preferred over direct use of TURF_LAYER

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -16,7 +16,7 @@
 	var/turf/T = get_turf(src)
 	var/list/floor_decals = SSicon_cache.floor_decals
 	if(istype(T, /turf/simulated/floor) || istype(T, /turf/unsimulated/floor))
-		layer = T.is_plating() ? DECAL_PLATING_LAYER : ON_TURF_LAYER
+		layer = ON_TURF_LAYER
 		var/cache_key = "[name]-[alpha]-[color]-[dir]-[icon_state]-[layer]-[blend_state ? blend_state : ""]-[blend_process]-[T.icon]-[T.icon_state]-[T.tile_outline ? T.tile_outline : ""]-[T.tile_outline_blend_process]"
 		if(!floor_decals[cache_key])
 			var/icon/decal_icon

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -16,7 +16,7 @@
 	var/turf/T = get_turf(src)
 	var/list/floor_decals = SSicon_cache.floor_decals
 	if(istype(T, /turf/simulated/floor) || istype(T, /turf/unsimulated/floor))
-		layer = ON_TURF_LAYER
+		layer = T.is_plating() ? DECAL_PLATING_LAYER : ON_TURF_LAYER
 		var/cache_key = "[name]-[alpha]-[color]-[dir]-[icon_state]-[layer]-[blend_state ? blend_state : ""]-[blend_process]-[T.icon]-[T.icon_state]-[T.tile_outline ? T.tile_outline : ""]-[T.tile_outline_blend_process]"
 		if(!floor_decals[cache_key])
 			var/icon/decal_icon

--- a/code/game/turfs/simulated/shuttle_turfs.dm
+++ b/code/game/turfs/simulated/shuttle_turfs.dm
@@ -54,6 +54,9 @@
 /turf/simulated/wall/shuttle/dark/cardinal/blue
 	color = "#6176a1"
 
+/turf/simulated/wall/shuttle/dark/cardinal/gold
+	color = COLOR_GOLD
+
 /turf/simulated/wall/shuttle/dark/long_diagonal_2
 	name = "test diagonal"
 	icon_state = "d2-we-1"

--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -110,12 +110,6 @@
 	. = ..(mapload, MATERIAL_TITANIUM, MATERIAL_TITANIUM)
 	canSmoothWith = list(src.type)
 
-/turf/simulated/wall/gold_reinforced/Initialize(mapload)
-	canSmoothWith = list(src.type)
-	. = ..(mapload, MATERIAL_GOLD, MATERIAL_PLASTEEL)
-	canSmoothWith = list(src.type)
-	color = COLOR_GOLD
-
 /turf/simulated/wall/wood
 	icon = 'icons/turf/smooth/wall_preview.dmi'
 	icon_state = "wood"

--- a/html/changelogs/RustingWithYou - gold2thegoldening.yml
+++ b/html/changelogs/RustingWithYou - gold2thegoldening.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Fixes wall sprites on Golden Deep ship."
+  - bugfix: "Floor decals will now show up correctly on plating."

--- a/maps/away/ships/golden_deep/golden_deep_merchant.dmm
+++ b/maps/away/ships/golden_deep/golden_deep_merchant.dmm
@@ -49,7 +49,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/golden_deep)
 "aQ" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/secure)
 "aR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
@@ -92,7 +92,7 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, crew quarters"
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/storage)
 "bp" = (
 /obj/machinery/atmospherics/unary/engine{
@@ -229,7 +229,7 @@
 /turf/simulated/floor/gold,
 /area/golden_deep)
 "ct" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/storage)
 "cv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -382,11 +382,11 @@
 /turf/simulated/floor/plating,
 /area/golden_deep/storage)
 "ek" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/warehouse)
 "en" = (
 /obj/effect/map_effect/airlock/s_to_n/long/square,
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/hangar)
 "ex" = (
 /obj/machinery/door/window{
@@ -490,7 +490,7 @@
 /area/golden_deep/starboardprop)
 "fO" = (
 /obj/effect/map_effect/airlock/long/square,
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/dock)
 "fU" = (
 /obj/structure/cable/green{
@@ -694,6 +694,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/golden_deep/atmos)
+"hA" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/floor{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/golden_deep/warehouse)
 "hB" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light{
@@ -835,6 +842,7 @@
 /obj/item/spacecash/c1000{
 	pixel_x = 2
 	},
+/obj/machinery/light,
 /turf/simulated/floor/gold,
 /area/golden_deep/office)
 "ja" = (
@@ -871,7 +879,7 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, thrusters"
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/starboardprop)
 "js" = (
 /obj/effect/decal/cleanable/dirt,
@@ -934,7 +942,7 @@
 /obj/effect/landmark/entry_point/port{
 	name = "port, thruster"
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/portprop)
 "kg" = (
 /obj/structure/closet/secure_closet/guncabinet,
@@ -996,7 +1004,7 @@
 /turf/simulated/floor/plating,
 /area/golden_deep/secure)
 "kA" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/bridge)
 "kM" = (
 /obj/structure/table/rack,
@@ -1207,7 +1215,7 @@
 /obj/effect/landmark/entry_point/port{
 	name = "port, warehouse"
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/warehouse)
 "mg" = (
 /obj/structure/cable/green{
@@ -1254,7 +1262,7 @@
 /turf/simulated/floor/gold,
 /area/golden_deep/dock)
 "mv" = (
-/turf/simulated/wall/gold_reinforced{
+/turf/simulated/wall/shuttle/dark/cardinal/gold{
 	can_open = 1
 	},
 /area/golden_deep/engineering)
@@ -1633,7 +1641,7 @@
 /turf/simulated/floor/gold,
 /area/golden_deep/dock)
 "pZ" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/hangar)
 "qa" = (
 /obj/structure/table/wood,
@@ -1673,7 +1681,7 @@
 /area/golden_deep/office)
 "qz" = (
 /obj/effect/map_effect/airlock/long/square,
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/starboardprop)
 "qD" = (
 /obj/machinery/computer/ship/navigation{
@@ -1723,7 +1731,7 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, bridge"
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/bridge)
 "rn" = (
 /turf/simulated/floor/reinforced/carbon_dioxide,
@@ -1823,7 +1831,7 @@
 /area/golden_deep/atmos)
 "sm" = (
 /obj/machinery/light,
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/engineering)
 "st" = (
 /turf/space,
@@ -1868,6 +1876,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/golden_deep/hangar)
+"ta" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/structure/curtain/open/bed,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood/mahogany,
+/area/golden_deep/captain)
 "tp" = (
 /obj/machinery/light{
 	dir = 4
@@ -1928,7 +1945,6 @@
 /area/golden_deep)
 "tQ" = (
 /obj/structure/bookcase/libraryspawn/nonfiction,
-/obj/machinery/light,
 /turf/simulated/floor/wood/mahogany,
 /area/golden_deep/captain)
 "tU" = (
@@ -1938,7 +1954,7 @@
 /turf/simulated/floor/gold,
 /area/golden_deep/hangar)
 "tZ" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/dock/aux)
 "ua" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -2024,7 +2040,7 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, engineering"
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/engineering)
 "vi" = (
 /obj/structure/table/steel,
@@ -2079,13 +2095,13 @@
 /turf/simulated/floor/plating,
 /area/golden_deep/portprop)
 "vB" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/engineering)
 "vC" = (
 /obj/effect/landmark/entry_point/port{
 	name = "port, cargo office"
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/office)
 "vH" = (
 /obj/structure/table/steel,
@@ -2109,6 +2125,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/machinery/light,
 /turf/simulated/floor/gold,
 /area/golden_deep/office)
 "vR" = (
@@ -2144,13 +2161,13 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, fuel bay"
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/eva)
 "wp" = (
 /obj/effect/landmark/entry_point/aft{
 	name = "starboard"
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/shuttle/golden_deep)
 "wr" = (
 /obj/structure/cable/green{
@@ -2292,7 +2309,7 @@
 /turf/simulated/floor/tiled,
 /area/golden_deep/eva)
 "xz" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/custodial)
 "xB" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
@@ -2375,6 +2392,7 @@
 /obj/item/cane/concealed,
 /obj/item/clothing/accessory/holster,
 /obj/item/clothing/accessory/holster,
+/obj/machinery/light,
 /turf/simulated/floor/wood/mahogany,
 /area/golden_deep/captain)
 "ym" = (
@@ -2395,8 +2413,16 @@
 /turf/simulated/floor/tiled,
 /area/golden_deep/eva)
 "ys" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/portprop)
+"yu" = (
+/obj/effect/floor_decal/spline/fancy/wood/full,
+/obj/machinery/recharge_station,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood/mahogany,
+/area/golden_deep/captain)
 "yA" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -2461,7 +2487,7 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, storage"
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/secure)
 "yZ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2730,7 +2756,7 @@
 /turf/simulated/floor/plating,
 /area/golden_deep/dock)
 "BW" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/office)
 "Cb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2754,7 +2780,7 @@
 /obj/effect/landmark/entry_point/port{
 	name = "port, bridge"
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/bridge)
 "CC" = (
 /obj/structure/cable/green{
@@ -2806,7 +2832,7 @@
 /turf/simulated/floor/gold,
 /area/shuttle/golden_deep)
 "Di" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/captain)
 "Dn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -2888,7 +2914,7 @@
 /turf/simulated/floor/plating,
 /area/golden_deep/storage)
 "DZ" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/atmos)
 "Eh" = (
 /obj/structure/table/rack,
@@ -3109,7 +3135,7 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, cargo office"
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/warehouse)
 "Gx" = (
 /obj/structure/closet/secure_closet/guncabinet,
@@ -3206,11 +3232,12 @@
 /turf/simulated/floor/plating,
 /area/golden_deep/portprop)
 "Hg" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/floor{
+	dir = 4
 	},
-/turf/simulated/floor/wood/mahogany,
-/area/golden_deep/captain)
+/turf/simulated/floor/plating,
+/area/golden_deep/warehouse)
 "Hj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3401,6 +3428,7 @@
 /area/shuttle/golden_deep)
 "JQ" = (
 /obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light,
 /turf/simulated/floor/wood/mahogany,
 /area/golden_deep/captain)
 "JS" = (
@@ -3471,7 +3499,7 @@
 /area/golden_deep/dock)
 "Kj" = (
 /obj/effect/map_effect/airlock/w_to_e/long/square,
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/dock/aux)
 "Kq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -3655,7 +3683,7 @@
 /turf/simulated/floor/plating,
 /area/golden_deep/portprop)
 "Mr" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/dock)
 "Mz" = (
 /obj/structure/table/wood,
@@ -3677,7 +3705,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/office)
 "MN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3864,7 +3892,7 @@
 /turf/simulated/floor/gold,
 /area/golden_deep/dock)
 "PM" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/eva)
 "PR" = (
 /obj/machinery/light,
@@ -4047,7 +4075,9 @@
 /area/golden_deep/dock)
 "RH" = (
 /obj/machinery/door/airlock/multi_tile{
-	dir = 2
+	dir = 2;
+	door_color = "#ffcc33";
+	name = "Fuel Bay"
 	},
 /turf/simulated/floor/tiled,
 /area/golden_deep/atmos)
@@ -4110,7 +4140,7 @@
 /turf/simulated/floor/plating,
 /area/golden_deep/engineering)
 "Sy" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/starboardprop)
 "SA" = (
 /obj/effect/floor_decal/spline/fancy{
@@ -4494,7 +4524,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/shuttle/golden_deep)
 "WT" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -4549,7 +4579,7 @@
 /turf/simulated/floor/tiled,
 /area/golden_deep/engineering)
 "Xd" = (
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/shuttle/golden_deep)
 "Xg" = (
 /obj/effect/floor_decal/spline/fancy{
@@ -4732,7 +4762,7 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, warehouse"
 	},
-/turf/simulated/wall/gold_reinforced,
+/turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/warehouse)
 "Zn" = (
 /obj/structure/cable/green{
@@ -17166,16 +17196,16 @@ xz
 JS
 gb
 jY
-ER
+Hg
 gb
 gb
-ER
+Hg
 jY
 oR
-ER
+Hg
 jY
 gb
-ER
+Hg
 gb
 gb
 gb
@@ -17490,16 +17520,16 @@ vB
 vo
 gb
 gb
-ER
+hA
 gb
 jY
-ER
+hA
 jY
 QB
-ER
+hA
 gb
 jY
-ER
+hA
 gb
 gb
 gb
@@ -17832,7 +17862,7 @@ rJ
 WZ
 WZ
 BW
-Zj
+ta
 LG
 Wc
 Mo
@@ -18156,7 +18186,7 @@ Ds
 WZ
 iY
 BW
-Hg
+YX
 hk
 Ab
 Ab
@@ -18480,7 +18510,7 @@ gz
 xP
 gn
 BW
-Sg
+yu
 YX
 No
 bd


### PR DESCRIPTION
The walls on the Golden Deep ship should now actually appear gold, and not have the weird question mark overlays on them. Also adds lights where they were missing to keep the ship from being too dark.

Plating can also now show floor decals, as they were previously layered _under_ the plating for some reason.