### PR TITLE
Cameras refdrop fix

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -65,10 +65,15 @@
 	SSmachinery.all_cameras -= src
 	deactivate(null, 0) //kick anyone viewing out
 	if(assembly)
-		qdel(assembly)
-		assembly = null
-	qdel(wires)
-	wires = null
+		QDEL_NULL(assembly)
+
+	cancelCameraAlarm(force = TRUE)
+
+	QDEL_NULL(wires)
+
+	cameranet.remove_source(src)
+	cameranet.cameras -= src
+
 	return ..()
 
 /obj/machinery/camera/set_pixel_offsets()
@@ -310,8 +315,8 @@
 	alarm_on = 1
 	camera_alarm.triggerAlarm(loc, src, duration)
 
-/obj/machinery/camera/proc/cancelCameraAlarm()
-	if(wires.IsIndexCut(CAMERA_WIRE_ALARM))
+/obj/machinery/camera/proc/cancelCameraAlarm(var/force = FALSE)
+	if(wires.IsIndexCut(CAMERA_WIRE_ALARM) && !force)
 		return
 
 	alarm_on = 0

--- a/html/changelogs/FluffyGhost-cameras_refdrop_fix.yml
+++ b/html/changelogs/FluffyGhost-cameras_refdrop_fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Resolved an harddel with cameras that had an alarm active and were destroyed, remaining referenced in the list of active alarms."


### PR DESCRIPTION
Resolved an harddel with cameras that had an alarm active and were destroyed, remaining referenced in the list of active alarms