### PR TITLE
Suit sensors monitoring now only fits on consoles.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
+++ b/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
@@ -9,7 +9,7 @@
 	requires_ntnet = TRUE
 	network_destination = "crew lifesigns monitoring system"
 	size = 11
-	usage_flags = PROGRAM_ALL_REGULAR | PROGRAM_STATIONBOUND
+	usage_flags = PROGRAM_CONSOLE | PROGRAM_STATIONBOUND
 	color = LIGHT_COLOR_CYAN
 	tgui_id = "SuitSensors"
 	tgui_theme = "zenghu"

--- a/html/changelogs/mattatlas-yoursweetembrace.yml
+++ b/html/changelogs/mattatlas-yoursweetembrace.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Suit sensors no longer fit on PDAs, laptops or tablets."


### PR DESCRIPTION
Currently, basically the entirety of medical can (and usually, does) have the suit sensors monitoring program up on another monitor or just on part of the screen at all times, since they can have it on their PDA. Essentially it removes all possible user error and makes medical a near-perfect machine in sensors checking, shooting antags in the foot far too often.

This fixes that by making suit sensors only fit on full-sized consoles.