### PR TITLE
Shrapnel removal now queues up all implants at once.

### DIFF
--- a/html/changelogs/mattatlas-loyalty.yml
+++ b/html/changelogs/mattatlas-loyalty.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Implant removal surgery now queues up all the implants for removal at once, with a delay of 0.5 seconds between each removal, meaning you only need to click once. It priorizes shrapnel over implants, so in case you need to remove everything, you'll need to do the surgery once for shrapnel, and a second time to remove implants."


### PR DESCRIPTION
Implant removal surgery now queues up all the implants for removal at once, with a delay of 0.5 seconds between each removal, meaning you only need to click once. It priorizes shrapnel over implants, so in case you need to remove everything, you'll need to do the surgery once for shrapnel, and a second time to remove implants.
