### PR TITLE
Golden Deep Reactor Fix

### DIFF
--- a/html/changelogs/RustingWithYou - pain.yml
+++ b/html/changelogs/RustingWithYou - pain.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Adds fuel and coolant to the Golden Deep ship."

--- a/maps/away/ships/golden_deep/golden_deep_merchant.dmm
+++ b/maps/away/ships/golden_deep/golden_deep_merchant.dmm
@@ -155,7 +155,9 @@
 /turf/simulated/floor/gold,
 /area/golden_deep/dock/aux)
 "bZ" = (
-/obj/structure/closet/secure_closet/guncabinet,
+/obj/structure/closet/secure_closet/guncabinet{
+	req_access = list(217)
+	},
 /obj/random/civgun,
 /obj/random/civgun,
 /obj/random/civgun,
@@ -958,7 +960,9 @@
 /turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/portprop)
 "kg" = (
-/obj/structure/closet/secure_closet/guncabinet,
+/obj/structure/closet/secure_closet/guncabinet{
+	req_access = list(217)
+	},
 /obj/item/storage/box/frags,
 /obj/item/storage/box/flashbangs,
 /obj/item/storage/box/handcuffs,
@@ -2062,7 +2066,9 @@
 /turf/simulated/floor/tiled,
 /area/golden_deep/custodial)
 "vk" = (
-/obj/structure/closet/secure_closet/guncabinet,
+/obj/structure/closet/secure_closet/guncabinet{
+	req_access = list(217)
+	},
 /obj/item/gun/energy/rifle/laser/noctiluca,
 /obj/item/gun/energy/rifle/laser/noctiluca,
 /obj/item/gun/energy/rifle/laser/noctiluca,
@@ -2527,7 +2533,9 @@
 /turf/simulated/floor/tiled,
 /area/golden_deep/eva)
 "zA" = (
-/obj/structure/closet/secure_closet/guncabinet,
+/obj/structure/closet/secure_closet/guncabinet{
+	req_access = list(217)
+	},
 /obj/item/clothing/suit/armor/carrier/heavy,
 /obj/item/clothing/suit/armor/carrier/heavy,
 /obj/item/clothing/head/helmet/merc,
@@ -3151,7 +3159,9 @@
 /turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/warehouse)
 "Gx" = (
-/obj/structure/closet/secure_closet/guncabinet,
+/obj/structure/closet/secure_closet/guncabinet{
+	req_access = list(217)
+	},
 /obj/random/civgun/rifle,
 /obj/random/civgun/rifle,
 /obj/effect/floor_decal/industrial/outline/security,
@@ -4379,6 +4389,13 @@
 /mob/living/heavy_vehicle/premade/ripley/loader,
 /turf/simulated/floor/plating,
 /area/golden_deep/storage)
+"Vm" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/gold,
+/area/golden_deep)
 "VA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
@@ -17396,19 +17413,19 @@ qw
 jm
 Tx
 Tx
-tO
+Tx
 gr
 Tx
-tO
 Tx
 Tx
-tO
 Tx
 Tx
-tO
+Tx
+Tx
+Tx
 KZ
 Tx
-tO
+Tx
 Tx
 Tx
 tJ
@@ -17558,19 +17575,19 @@ WZ
 BW
 zb
 zb
-zb
+Vm
 vz
 zb
+Vm
 zb
 zb
+Vm
 zb
 zb
-zb
-zb
-zb
+Vm
 Hj
 zb
-zb
+Vm
 zb
 zb
 Mr

--- a/maps/away/ships/golden_deep/golden_deep_merchant.dmm
+++ b/maps/away/ships/golden_deep/golden_deep_merchant.dmm
@@ -177,6 +177,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/golden_deep/eva)
+"cc" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/closet/crate/rad{
+	name = "fuel crate"
+	},
+/obj/item/stack/material/tritium/full,
+/obj/item/stack/material/tritium/full,
+/turf/simulated/floor/tiled,
+/area/golden_deep/engineering)
 "cd" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/autolathe,
@@ -4063,6 +4076,11 @@
 "Ru" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
+	},
+/obj/structure/reagent_dispensers/coolanttank,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_y = -10;
+	pixel_x = -5
 	},
 /turf/simulated/floor/tiled,
 /area/golden_deep/engineering)
@@ -19287,7 +19305,7 @@ aH
 aH
 aH
 vB
-Rm
+cc
 fA
 fA
 fA

--- a/maps/away/ships/golden_deep/golden_deep_merchant.dmm
+++ b/maps/away/ships/golden_deep/golden_deep_merchant.dmm
@@ -1018,6 +1018,7 @@
 /turf/simulated/floor/plating,
 /area/golden_deep/portprop)
 "kt" = (
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/golden_deep/secure)
 "kA" = (
@@ -1171,6 +1172,7 @@
 	dir = 6;
 	pixel_y = 0
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/golden_deep/secure)
 "lS" = (
@@ -1458,6 +1460,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/golden_deep/portprop)
+"ov" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/gold,
+/area/golden_deep)
 "ow" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2722,6 +2731,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/golden_deep/secure)
 "BF" = (
@@ -3108,6 +3118,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/golden_deep/secure)
 "FV" = (
@@ -4389,13 +4400,6 @@
 /mob/living/heavy_vehicle/premade/ripley/loader,
 /turf/simulated/floor/plating,
 /area/golden_deep/storage)
-"Vm" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/gold,
-/area/golden_deep)
 "VA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
@@ -17575,19 +17579,19 @@ WZ
 BW
 zb
 zb
-Vm
+ov
 vz
 zb
-Vm
+ov
 zb
 zb
-Vm
+ov
 zb
 zb
-Vm
+ov
 Hj
 zb
-Vm
+ov
 zb
 zb
 Mr


### PR DESCRIPTION
Reshuffling the engineering bay on the Golden Deep ship deleted the reactor fuel and coolant, and I did not notice this at the time. They're back now.