### PR TITLE
Aut'akh Integrated Ethanol Burner Augment

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -168,6 +168,7 @@
 #define BP_AUG_FUEL_CELL       "integrated fuel cell"
 #define BP_AUG_AIR_ANALYZER    "integrated air analyzer"
 #define BP_AUG_LANGUAGE        "integrated language processor"
+#define BP_AUG_ETHANOL_BURNER  "integrated ethanol burner"
 #define BP_AUG_PSI             "psionic receiver"
 #define BP_AUG_CALF_OVERRIDE   "calf overdrive"
 #define BP_AUG_MEMORY          "memory inhibitor"

--- a/code/modules/client/preference_setup/loadout/items/xeno/unathi.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/unathi.dm
@@ -350,6 +350,12 @@
 	path = /obj/item/organ/internal/augment/venomous_rest
 	cost = 1
 
+/datum/gear/augment/autakh/ethanol_burner
+	display_name = "integrated ethanol burner"
+	description = "An augment spearheaded by the Dreg Aut'akh beneath Eridani, and perfected by the Razortails on Biesel, this burner lets Unathi consume ethanol with no health complications."
+	path = /obj/item/organ/internal/augment/ethanol_burner
+	cost = 1
+
 /datum/gear/augment/autakh/eyes
 	display_name = "eye augment selection"
 	description = "A selection of au'takh eye augments."

--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -425,6 +425,10 @@
 	name = "integrated fuel cell"
 	organ_tag = BP_AUG_FUEL_CELL
 
+/obj/item/organ/internal/augment/ethanol_burner
+	name = "integrated ethanol burner"
+	organ_tag = BP_AUG_ETHANOL_BURNER
+
 // Geeves!
 /obj/item/organ/internal/augment/language
 	name = "language processor"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -197,14 +197,20 @@
 /singleton/reagent/alcohol/affect_ingest(var/mob/living/carbon/human/M, var/alien, var/removed, var/datum/reagents/holder)
 	if(!istype(M))
 		return
+
+	var/has_valid_aug = FALSE
+	var/obj/item/organ/internal/augment/ethanol_burner/aug = M.internal_organs_by_name[BP_AUG_ETHANOL_BURNER]
+	if(aug && !aug.is_broken())
+		has_valid_aug = TRUE
+
 	var/obj/item/organ/internal/parasite/P = M.internal_organs_by_name["blackkois"]
-	if((alien == IS_VAURCA) || (istype(P) && P.stage >= 3))//Vaurca are damaged instead of getting nutrients, but they can still get drunk
+	if(!has_valid_aug && (alien == IS_VAURCA || (istype(P) && P.stage >= 3)))//Vaurca are damaged instead of getting nutrients, but they can still get drunk
 		M.adjustToxLoss(1.5 * removed * (strength / 100))
 	else
 		M.adjustNutritionLoss(-nutriment_factor * removed)
 		M.adjustHydrationLoss(-hydration_factor * removed)
 
-	if (alien == IS_UNATHI)//unathi are poisoned by alcohol as well
+	if (!has_valid_aug && alien == IS_UNATHI)//unathi are poisoned by alcohol as well
 		M.adjustToxLoss(1.5 * removed * (strength / 100))
 
 	..()

--- a/html/changelogs/geeves-ethanol_aug.yml
+++ b/html/changelogs/geeves-ethanol_aug.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Added an Aut'akh Ethanol Burner cell that lets Aut'akh Unathi drink alcohol without taking tox damage."


### PR DESCRIPTION
* Added an Aut'akh Ethanol Burner cell that lets Aut'akh Unathi drink alcohol without taking tox damage.

permission granted by rusting