### PR TITLE
Replace all mentions of Gorlex Marauders with Hammertail Smiths

### DIFF
--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -1,7 +1,7 @@
 //Syndicate rig
 /obj/item/clothing/head/helmet/space/void/merc
 	name = "blood-red voidsuit helmet"
-	desc = "An advanced helmet designed for work in special operations. Property of Gorlex Marauders."
+	desc = "An advanced helmet designed for work in special operations. Property of Hammertail Smiths."
 	icon_state = "rig0-syndie"
 	item_state = "syndie_helm"
 	item_state_slots = list(
@@ -26,7 +26,7 @@
 
 /obj/item/clothing/suit/space/void/merc
 	name = "blood-red voidsuit"
-	desc = "An advanced suit that protects against injuries during special operations. Property of Gorlex Marauders."
+	desc = "An advanced suit that protects against injuries during special operations. Property of Hammertail Smiths."
 	icon_state = "rig-syndie"
 	item_state = "rig-syndie"
 	item_state_slots = list(

--- a/code/modules/economy/Events.dm
+++ b/code/modules/economy/Events.dm
@@ -70,7 +70,7 @@
 			if(PIRATES)
 				body = "[pick("Pirates","Criminal elements","A [pick("mercenary","Donk Co.","Waffle Co.","\'REDACTED\'")] strike force")] have [pick("raided","blockaded","attempted to blackmail","attacked")] [affected_dest.name] today. Security has been tightened, but many valuable minerals were taken."
 			if(CORPORATE_ATTACK)
-				body = "A small [pick("pirate","Cybersun Industries","Gorlex Marauders","mercenary")] fleet has precise-jumped into proximity with [affected_dest.name], [pick("for a smash-and-grab operation","in a hit and run attack","in an overt display of hostilities")]. Much damage was done, and security has been tightened since the incident."
+				body = "A small [pick("pirate","Cybersun Industries","Hammertail Smiths","mercenary")] fleet has precise-jumped into proximity with [affected_dest.name], [pick("for a smash-and-grab operation","in a hit and run attack","in an overt display of hostilities")]. Much damage was done, and security has been tightened since the incident."
 			if(ALIEN_RAIDERS)
 				if(prob(20))
 					body = "The Tiger Co-operative have raided [affected_dest.name] today, no doubt on orders from their enigmatic masters. Stealing wildlife, farm animals, medical research materials and kidnapping civilians. [current_map.company_name] authorities are standing by to counter attempts at bio-terrorism."

--- a/html/changelogs/GeneralCamo - Hammertail Smiths.yml
+++ b/html/changelogs/GeneralCamo - Hammertail Smiths.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."

--- a/html/changelogs/GeneralCamo - Hammertail Smiths.yml
+++ b/html/changelogs/GeneralCamo - Hammertail Smiths.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - tweak: "Replace all mentions of Gorlex Marauders with Hammertail Smiths."


### PR DESCRIPTION
Per [this post,](https://forums.aurorastation.org/topic/18955-the-gorlex-marauders-a-polite-galaxy-is-an-armed-galaxy/page/2/#comment-169694) the intended canonization app for Gorlex Marauders has a new name. This reflects that by replacing all mentions of Gorlex Marauders with Hammertail Smiths.