### PR TITLE
Removes atmospheric technicians' insulated gloves

### DIFF
--- a/html/changelogs/omicega-sneakysneaky.yml
+++ b/html/changelogs/omicega-sneakysneaky.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omi
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Removed atmospheric technicians' lockers' insulated gloves (they weren't supposed to have them!)"

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -231,7 +231,6 @@
 "aem" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/closet/secure_closet/atmos_personal,
-/obj/item/clothing/gloves/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "aeC" = (
@@ -4757,7 +4756,6 @@
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/fireaxecabinet/east,
 /obj/structure/closet/secure_closet/atmos_personal,
-/obj/item/clothing/gloves/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "cdv" = (
@@ -49632,7 +49630,6 @@
 "xBU" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/closet/secure_closet/atmos_personal,
-/obj/item/clothing/gloves/yellow,
 /obj/machinery/light{
 	dir = 4
 	},


### PR DESCRIPTION
In #14325, adding easy access to insulated gloves for atmospheric technicians was shot down with the following reasoning:

![image](https://github.com/Aurorastation/Aurora.3/assets/57604458/203b9d97-a4bd-4c29-a1e5-1fcb5cdc9c5d)

However, a set of standard gloves was directly mapped in underneath each locker by #16195 without being added to the changelog, and it looks like this was missed in the review.

![image](https://github.com/Aurorastation/Aurora.3/assets/57604458/92456ec0-1f2a-473a-aaf1-c7df369df159)

I'm reverting this since it appears to have been sneakily slipped past the maintainers, and basically allows atmospheric technicians to play like engineers with a bonus RFD-P.