### PR TITLE
Fluke Parasite Tweak/Fix

### DIFF
--- a/code/modules/organs/subtypes/parasite.dm
+++ b/code/modules/organs/subtypes/parasite.dm
@@ -439,7 +439,7 @@
 	if (!owner)
 		return
 
-	if(prob(10))
+	if(prob(4))
 		owner.adjustNutritionLoss(10)
 
 	if(stage >= 2) //after ~5 minutes
@@ -490,7 +490,11 @@
 	if (!owner)
 		return
 
-	if(prob(10))
+	if(BP_IS_ROBOTIC(heart))
+		recession = 10
+		return
+
+	if(prob(4))
 		owner.adjustNutritionLoss(10)
 
 	if(stage >= 2) //after ~7.5 minutes

--- a/html/changelogs/kermit-fluke-fix.yml
+++ b/html/changelogs/kermit-fluke-fix.yml
@@ -1,0 +1,7 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - bugfix: "Heart parasites can no longer eat metal hearts."
+  - tweak: "Reduces speed of parasite hunger drain."


### PR DESCRIPTION
- Fixes an oversight where heart fluke parasites could damage robotic hearts. They now just slowly die/enter recession straight away.
- Reduces the speed at which fluke parasites drain nutrition. This makes them less immediately impactful but also less immediately noticable.