### PR TITLE
Hulks no longer wield two-handed melee weapons

### DIFF
--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -134,11 +134,15 @@
 			O.unwield()
 
 	else //Trying to wield it
+		var/mob/living/M = user
 		var/obj/item/offhand_item = user.get_inactive_hand()
 		if(offhand_item)
 			user.unEquip(offhand_item, FALSE, user.loc)
 		if(user.get_inactive_hand())
 			to_chat(user, "<span class='warning'>You need your other hand to be empty.</span>")
+			return
+		if(HAS_FLAG(M.mutations, HULK))
+			to_chat(user, "<span class='warning'>This is too complicated for your frenzied mind to handle.</span>")
 			return
 		wield()
 		to_chat(user, "<span class='notice'>You grip the [base_name] with both hands.</span>")

--- a/html/changelogs/CampinKiller24-bulk.yml
+++ b/html/changelogs/CampinKiller24-bulk.yml
@@ -1,0 +1,6 @@
+author: CampinKiller24
+
+delete-after: True
+
+changes:
+  - rscdel: "Vampire hulks can no longer wield two-handed weapons."


### PR DESCRIPTION
title

A vamp hulk one-hit kills unarmored mobs while wielding an axe, two-hit kills if they are wearing a helmet. Both instantly down/disable the person. This is neither balanced nor conducive to roleplay since they can just bonzai charge with an axe in way less time than they can be killed when frenzied.
