### PR TITLE
Allows citizenship to give items upon spawning

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -743,6 +743,9 @@ var/datum/controller/subsystem/ticker/SSticker
 			if(!player_is_antag(player.mind, only_offstation_roles = 1))
 				SSjobs.EquipAugments(player, player.client.prefs)
 				SSjobs.EquipRank(player, player.mind.assigned_role, 0)
+				var/datum/citizenship/citizenship = SSrecords.citizenships[player.citizenship]
+				if(citizenship)
+					citizenship.on_apply(player)
 				equip_custom_items(player)
 
 		CHECK_TICK

--- a/code/modules/background/citizenship/citizenship.dm
+++ b/code/modules/background/citizenship/citizenship.dm
@@ -27,4 +27,12 @@
 	if(citizenship_item)
 		var/obj/item/newitem = new citizenship_item
 		H.equip_to_storage(newitem)
+		if(istype(newitem, /obj/item/clothing/accessory/badge))
+			var/obj/item/clothing/accessory/badge/B = newitem
+			B.set_name(H.real_name)
+	if(H.origin)
+		var/singleton/origin_item/OG = GET_SINGLETON(H.origin)
+		if(OG.extra_citizenship_item)
+			var/obj/item/O = new OG.extra_citizenship_item
+			H.equip_to_storage(O)
 	return

--- a/code/modules/background/citizenship/citizenship.dm
+++ b/code/modules/background/citizenship/citizenship.dm
@@ -4,6 +4,7 @@
 	var/datum/outfit/consular_outfit = /datum/outfit/job/representative/consular
 	var/demonym
 	var/list/job_species_blacklist = list()
+	var/citizenship_item = null
 
 /datum/citizenship/proc/get_objectives(mission_level, var/mob/living/carbon/human/H)
 	var/rep_objectives
@@ -21,3 +22,9 @@
 
 
 	return rep_objectives
+
+/datum/citizenship/proc/on_apply(var/mob/living/carbon/human/H)
+	if(citizenship_item)
+		var/obj/item/newitem = new citizenship_item
+		H.equip_to_storage(newitem)
+	return

--- a/code/modules/background/citizenship/human.dm
+++ b/code/modules/background/citizenship/human.dm
@@ -5,7 +5,7 @@
 	its large xeno population which enjoys various privileges compared to other space powers. With a very lax migration policy, virtually everyone is welcome to live here. However, \
 	unrest and gridlock undermine the government, and the aggressive attitude of the Sol Alliance against its former system has made many worried for the future of the Republic."
 	consular_outfit = /datum/outfit/job/representative/consular/ceti
-
+	citizenship_item = /obj/item/clothing/accessory/badge/passport
 	job_species_blacklist = list(
 		"Consular Officer" = list(
 			SPECIES_VAURCA_WORKER,
@@ -83,6 +83,7 @@
 	Presently ruled by a military junta that is gradually giving way to civilian control, the Alliance is also generally xenophobic, and most non-humans find themselves discriminated against in Solarian territory. \
 	Though much of its former possessions are now occupied by warlord statelets and other interstellar powers, the Alliance still maintains a revanchist outlook, refusing to relinquish its claims to its lost territories."
 	consular_outfit = /datum/outfit/job/representative/consular/sol
+	citizenship_item = /obj/item/clothing/accessory/badge/passport/sol
 
 	job_species_blacklist = list(
 		"Consular Officer" = list(
@@ -157,6 +158,7 @@
 	tightly-knit. Almost anything and anyone can be found in these wild, mostly uncharted lands. "
 	demonym = "frontiersman"
 	consular_outfit = /datum/outfit/job/representative/consular/coalition
+	citizenship_item = /obj/item/clothing/accessory/badge/passport/coc
 
 	job_species_blacklist = list(
 		"Consular Officer" = list(
@@ -187,6 +189,7 @@
 	The Republic has mixed relations with NanoTrasen, due to their own possession of phoron."
 	demonym = "elyran"
 	consular_outfit = /datum/outfit/job/representative/consular/elyra
+	citizenship_item = /obj/item/clothing/accessory/badge/passport/elyra
 
 /datum/outfit/job/representative/consular/elyra
 	name = "Elyra Consular Officer"
@@ -237,8 +240,8 @@
 	description = "A heavily religious absolute monarchy with its capital, Nova Luxembourg, on the planet of Moroz in the Mira Sancta system. This autocratic state is ruled by \
 	His Imperial Majesty Boleslaw Keeser. The Empire of Dominia was proclaimed in 2385 by then-Emperor Godwin Keeser, unifying a colony which had been isolated for hundreds of years. \
 	Imperial society is dominated by the Great and Minor Houses under the Emperor and is very socio-economically stratified due to the so-called blood debt, known as the Mor'iz'al."
-
 	consular_outfit = /datum/outfit/job/representative/consular/dominia
+	citizenship_item = /obj/item/clothing/accessory/badge/passport/dominia
 
 	job_species_blacklist = list(
 		"Consular Officer" = list(

--- a/code/modules/background/citizenship/tajara.dm
+++ b/code/modules/background/citizenship/tajara.dm
@@ -6,6 +6,7 @@
 	revolution to the masses. With land reform, enfranchisement of women and peasantry, literacy initiatives, and the collectivization of farms and the means of production, the PRA is \
 	struggling to hold true to its radical ideals while an entrenched upper party stubbornly tries to hold onto power."
 	consular_outfit = /datum/outfit/job/representative/consular/pra
+	citizenship_item = /obj/item/clothing/accessory/badge/pra_passport
 
 	job_species_blacklist = list(
 		"Consular Officer" = list(
@@ -62,6 +63,7 @@
 	insurgency movement, then an organized military, into a modern, democratic nation. With the help of Nated as a government minister going out to negotiate with ruling Juntas to \
 	voluntarily turn over power to civilian governments, the DPRA's future faces many fundamental changes."
 	consular_outfit = /datum/outfit/job/representative/consular/dpra
+	citizenship_item = /obj/item/clothing/accessory/badge/dpra_passport
 
 	job_species_blacklist = list(
 		"Consular Officer" = list(
@@ -119,6 +121,7 @@
 	The lofty titles of the nobles disguise the fact that most of the nobility of this new kingdom remain in squalor only marginally better than the peasants. Life is difficult, and \
 	the Azunja dynasty finds itself struggling to function with their limited constitutional powers and factional in-fighting between the military and the civilian government."
 	consular_outfit = /datum/outfit/job/representative/consular/nka
+	citizenship_item = /obj/item/clothing/accessory/badge/nka_passport
 
 	job_species_blacklist = list(
 		"Consular Officer" = list(
@@ -172,6 +175,7 @@
 	radical principles of equality and communal democracy, the Free Tajaran Council remained relatively isolated from the rest of the Tajaran community until the start of the Adhomian Cold War. \
 	Its population was granted a temporary citizenship status as part of an agreement between the Tajaran nations. While the council struggles to decide its future, some of its members travel \
 	the galaxy in search of aid and new allies for their ultimate masterplan."
+	citizenship_item = /obj/item/clothing/accessory/badge/ftc_passport
 
 	job_species_blacklist = list(
 		"Consular Officer" = ALL_SPECIES

--- a/code/modules/background/origins/_origins.dm
+++ b/code/modules/background/origins/_origins.dm
@@ -6,6 +6,7 @@
 	/// Format for the following list: "Characters from this origin: [list entry], [list entry]."
 	/// One list item per trait.
 	var/list/origin_traits_descriptions = list()
+	var/extra_citizenship_item = null
 
 /singleton/origin_item/culture
 	name = "generic culture"

--- a/code/modules/background/origins/origins/human/biesel.dm
+++ b/code/modules/background/origins/origins/human/biesel.dm
@@ -14,6 +14,7 @@
 	possible_accents = list(ACCENT_CETI)
 	possible_citizenships = list(CITIZENSHIP_BIESEL)
 	possible_religions = RELIGIONS_BIESEL
+	extra_citizenship_item = /obj/item/clothing/accessory/badge/passcard
 
 /singleton/origin_item/origin/new_gibson
 	name = "New Gibson"
@@ -22,6 +23,8 @@
 	possible_accents = list(ACCENT_GIBSON_OVAN, ACCENT_GIBSON_UNDIR)
 	possible_citizenships = list(CITIZENSHIP_BIESEL)
 	possible_religions = RELIGIONS_BIESEL
+
+	extra_citizenship_item = /obj/item/clothing/accessory/badge/passcard
 
 /singleton/origin_item/origin/reade
 	name = "Reade"

--- a/code/modules/background/origins/origins/human/coalition.dm
+++ b/code/modules/background/origins/origins/human/coalition.dm
@@ -21,6 +21,7 @@
 	possible_accents = list(ACCENT_XANU)
 	possible_citizenships = CITIZENSHIPS_COALITION
 	possible_religions = list(RELIGION_NONE, RELIGION_CHRISTIANITY, RELIGION_ISLAM, RELIGION_BUDDHISM, RELIGION_SHINTO, RELIGION_HINDU, RELIGION_TAOISM, RELIGION_JUDAISM, RELIGION_SIKHISM, RELIGION_OTHER, RELIGION_TRINARY, RELIGION_STOLITISM, RELIGION_MOROZ, RELIGION_LUCEISM)
+	extra_citizenship_item = /obj/item/clothing/accessory/badge/passcard/coalition
 
 /singleton/origin_item/origin/himeo
 	name = "United Syndicates of Himeo"
@@ -30,6 +31,7 @@
 	possible_religions = RELIGIONS_COALITION
 	origin_traits = list(TRAIT_ORIGIN_COLD_RESISTANCE, TRAIT_ORIGIN_LIGHT_SENSITIVE)
 	origin_traits_descriptions = list("are more acclimatised to the cold.", "are more sensitive to bright lights")
+	extra_citizenship_item = /obj/item/clothing/accessory/badge/passcard/himeo
 
 /singleton/origin_item/origin/vysoka
 	name = "Free System of Vysoka"
@@ -38,6 +40,7 @@
 	possible_accents = list(ACCENT_VYSOKA)
 	possible_citizenships = CITIZENSHIPS_COALITION
 	possible_religions = list(RELIGION_NONE, RELIGION_STOLITISM, RELIGION_CHRISTIANITY, RELIGION_ISLAM, RELIGION_BUDDHISM, RELIGION_TAOISM, RELIGION_JUDAISM, RELIGION_OTHER)
+	extra_citizenship_item = /obj/item/clothing/accessory/badge/passcard/vysoka
 
 /singleton/origin_item/origin/galatea
 	name = "Federal Technocracy of Galatea"
@@ -53,6 +56,7 @@
 	possible_accents = list(ACCENT_NCF, ACCENT_SCARAB, ACCENT_COC, ACCENT_BURZSIA)
 	possible_citizenships = CITIZENSHIPS_COALITION
 	possible_religions = list(RELIGION_NONE, RELIGION_CHRISTIANITY, RELIGION_ISLAM, RELIGION_BUDDHISM, RELIGION_HINDU, RELIGION_TAOISM, RELIGION_JUDAISM, RELIGION_OTHER, RELIGION_TRINARY, RELIGION_SCARAB)
+	extra_citizenship_item = /obj/item/clothing/accessory/badge/passcard/coalition
 
 /singleton/origin_item/origin/gadpathur
 	name = "United Planetary Defense Council of Gadpathur"
@@ -63,6 +67,7 @@
 	possible_religions = list(RELIGION_NONE, RELIGION_CHRISTIANITY, RELIGION_ISLAM, RELIGION_BUDDHISM, RELIGION_HINDU, RELIGION_TAOISM, RELIGION_JUDAISM, RELIGION_SIKHISM, RELIGION_OTHER)
 	origin_traits = list(TRAIT_ORIGIN_LIGHT_SENSITIVE)
 	origin_traits_descriptions = list("have a small resistance to radiation", "are more sensitive to bright lights")
+	extra_citizenship_item = /obj/item/clothing/accessory/badge/passcard/gad
 
 /singleton/origin_item/origin/gadpathur/on_apply(var/mob/living/carbon/human/H)
 	H.AddComponent(/datum/component/armor, list(rad = ARMOR_RAD_MINOR))
@@ -88,6 +93,7 @@
 	possible_religions = list(RELIGION_LUCEISM)
 	origin_traits = list(TRAIT_ORIGIN_DARK_AFRAID)
 	origin_traits_descriptions = list("tend to feel nervous in the dark")
+	extra_citizenship_item = /obj/item/clothing/accessory/badge/passcard/assu
 
 /singleton/origin_item/origin/ncf
 	name = "Non-Coalition Frontier"

--- a/code/modules/background/origins/origins/human/sol.dm
+++ b/code/modules/background/origins/origins/human/sol.dm
@@ -45,6 +45,7 @@
 	possible_accents = list(ACCENT_LUNA)
 	possible_citizenships = CITIZENSHIPS_SOLARIAN
 	possible_religions = RELIGIONS_SOLARIAN
+	extra_citizenship_item = /obj/item/clothing/accessory/badge/passcard/sol/luna
 
 /singleton/origin_item/origin/venus_c
 	name = "Venus, Cytherea"
@@ -54,6 +55,7 @@
 	possible_religions = RELIGIONS_SOLARIAN
 	origin_traits = list(TRAIT_ORIGIN_ALCOHOL_RESISTANCE, TRAIT_ORIGIN_DRUG_RESISTANCE)
 	origin_traits_descriptions = list("have a higher alcoholic tolerance", "have a higher tolerance to recreative drugs")
+	extra_citizenship_item = /obj/item/clothing/accessory/badge/passcard/sol/cytherean
 
 /singleton/origin_item/origin/venus_j
 	name = "Venus, Jintaria"
@@ -61,6 +63,7 @@
 	possible_accents = list(ACCENT_VENUSJIN)
 	possible_citizenships = CITIZENSHIPS_SOLARIAN
 	possible_religions = RELIGIONS_SOLARIAN
+	extra_citizenship_item = /obj/item/clothing/accessory/badge/passcard/sol/jintarian
 
 /singleton/origin_item/origin/mars
 	name = "Mars"
@@ -83,6 +86,7 @@
 	possible_accents = list(ACCENT_PLUTO)
 	possible_citizenships = CITIZENSHIPS_SOLARIAN
 	possible_religions = RELIGIONS_SOLARIAN
+	extra_citizenship_item = /obj/item/clothing/accessory/badge/passcard/sol/pluto
 
 /singleton/origin_item/origin/eridani
 	name = "Eridani Corporate Federation"
@@ -144,6 +148,7 @@
 	possible_accents = list(ACCENT_KONYAN)
 	possible_citizenships = list(CITIZENSHIP_SOL, CITIZENSHIP_BIESEL, CITIZENSHIP_COALITION)
 	possible_religions = RELIGIONS_SOLARIAN
+	extra_citizenship_item = /obj/item/clothing/accessory/badge/passcard/konyang
 
 /singleton/origin_item/origin/visegrad
 	name = "Visegrad"
@@ -154,6 +159,7 @@
 	possible_religions = RELIGIONS_SOLARIAN
 	origin_traits = list(TRAIT_ORIGIN_IGNORE_CAPSAICIN, TRAIT_ORIGIN_COLD_RESISTANCE)
 	origin_traits_descriptions = list("are not affected by spicy foods", "are more acclimatised to the cold")
+	extra_citizenship_item = /obj/item/clothing/accessory/badge/passcard/sol/visegrad
 
 /singleton/origin_item/origin/mictlan
 	name = "Mictlan"

--- a/code/modules/client/preference_setup/loadout/items/xeno/tajara.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/tajara.dm
@@ -370,24 +370,6 @@
 	card["the new kingdom"] = /obj/item/book/manual/nka_manifesto
 	gear_tweaks += new /datum/gear_tweak/path(card)
 
-/datum/gear/tajaran_passports
-	display_name = "adhomian passports selection"
-	description = "A selection of Adhomian passports."
-	path = /obj/item/clothing/accessory/badge/pra_passport
-	sort_category = "Xenowear - Tajara"
-	whitelisted = list(SPECIES_TAJARA, SPECIES_TAJARA_ZHAN, SPECIES_TAJARA_MSAI)
-	flags = GEAR_HAS_DESC_SELECTION
-	cost = 1
-
-/datum/gear/tajaran_passports/New()
-	..()
-	var/list/passports = list()
-	passports["people's republic of adhomai passport"] = /obj/item/clothing/accessory/badge/pra_passport
-	passports["democratic people's republic of adhomai passport"] = /obj/item/clothing/accessory/badge/dpra_passport
-	passports["new kingdom of adhomai passport"] = /obj/item/clothing/accessory/badge/nka_passport
-	passports["free tajaran council passport"] =/obj/item/clothing/accessory/badge/ftc_passport
-	gear_tweaks += new /datum/gear_tweak/path(passports)
-
 /datum/gear/adhomai_zippo
 	display_name = "adhomian lighter"
 	path = /obj/item/flame/lighter/adhomai

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -246,7 +246,7 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 
 	SSjobs.AssignRole(src, rank, 1)
 
-	var/mob/living/character = create_character()	//creates the human and transfers vars and mind
+	var/mob/living/carbon/human/character = create_character()	//creates the human and transfers vars and mind
 
 	SSjobs.EquipAugments(character, character.client.prefs)
 	character = SSjobs.EquipRank(character, rank, TRUE, spawning_at)					//equips the human
@@ -274,6 +274,10 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 	var/join_message = SSjobs.LateSpawn(character, rank)
 
 	equip_custom_items(character)
+
+	var/datum/citizenship/citizenship = SSrecords.citizenships[character.citizenship]
+	if(citizenship)
+		citizenship.on_apply(character)
 
 	character.lastarea = get_area(loc)
 	// Moving wheelchair if they have one

--- a/html/changelogs/alberyk-papersplease.yml
+++ b/html/changelogs/alberyk-papersplease.yml
@@ -1,0 +1,7 @@
+author: Alberyk
+
+delete-after: True
+
+changes:
+  - rscadd: "Added a system that allows a character's citizenship to grant items when joining."
+  - rscadd: "Tajara will now spawn with passports of their respective citizenships."


### PR DESCRIPTION
This pr adds a system that allows citizenships to give items to characters when they join a round.

TODO:

- [ ] check with the rest of the lore team if they want their species stuff added to it