### PR TITLE
The Shuttle Refactor Pt. 0

### DIFF
--- a/html/changelogs/Lavillastrangiato - theshuttling.yml
+++ b/html/changelogs/Lavillastrangiato - theshuttling.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Lavillastrangiato
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - refactor: "Added atmospheric systems to the SSMD shuttle, the Hailstorm shuttle, and the Freebooter shuttle."
+  - refactor: "Added an APC, SMES, and wiring to the SSMD shuttle."
+  - bugfix: "Fixes windows on the yacht and the Hailstorm ship/shuttle."
+  - bugfix: "Fixes wonky air alarm offsets on the SSMD shuttle and the yacht."

--- a/maps/away/ships/dpra/hailstorm/hailstorm_ship.dmm
+++ b/maps/away/ships/dpra/hailstorm/hailstorm_ship.dmm
@@ -409,8 +409,8 @@
 	},
 /area/hailstorm_ship/barracks)
 "bI" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -589,9 +589,14 @@
 	},
 /area/hailstorm_ship/crew)
 "co" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 5
+	},
 /obj/structure/table/steel,
 /obj/item/storage/bag/inflatable,
+/obj/machinery/alarm/cold/west{
+	req_one_access = list(214)
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -662,13 +667,13 @@
 	},
 /area/hailstorm_ship/barracks)
 "cM" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
 /obj/structure/fuel_port/hydrogen{
 	pixel_y = -32
 	},
 /obj/structure/extinguisher_cabinet/west,
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 4
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -824,7 +829,7 @@
 	},
 /area/hailstorm_ship/armory)
 "ey" = (
-/obj/effect/map_effect/window_spawner/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 8;
 	id = "hailstorm_bridge"
@@ -900,8 +905,11 @@
 	},
 /area/hailstorm_ship/gun_deck)
 "eZ" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/hailstorm_ship/gun_deck)
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/shuttle/hailstorm_shuttle)
 "fc" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -969,7 +977,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/hailstorm_ship/gun_deck/second)
 "ft" = (
-/obj/effect/map_effect/window_spawner/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, crew section"
 	},
@@ -1135,8 +1143,13 @@
 	},
 /area/hailstorm_ship/atmospherics)
 "hc" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/hailstorm_ship/gun_deck/second)
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/binary/passive_gate/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/shuttle/hailstorm_shuttle)
 "hd" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 8
@@ -1214,7 +1227,7 @@
 	},
 /area/hailstorm_ship/gun_deck/second)
 "ig" = (
-/obj/effect/map_effect/window_spawner/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1533,7 +1546,7 @@
 	},
 /area/hailstorm_ship/crew)
 "kz" = (
-/obj/effect/map_effect/window_spawner/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1624,11 +1637,14 @@
 	},
 /area/hailstorm_ship/bridge)
 "lJ" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -1871,7 +1887,7 @@
 	},
 /area/hailstorm_ship/atmospherics)
 "og" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 10
 	},
 /obj/structure/cable/green{
@@ -2132,7 +2148,7 @@
 /turf/simulated/floor/airless,
 /area/hailstorm_ship/bridge)
 "rx" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 5
 	},
 /turf/simulated/floor/tiled{
@@ -2270,6 +2286,17 @@
 	temperature = 278.15
 	},
 /area/hailstorm_ship/crew)
+"ux" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/shuttle/hailstorm_shuttle)
 "uD" = (
 /obj/machinery/computer/ship/sensors{
 	dir = 8
@@ -2298,7 +2325,7 @@
 	},
 /area/hailstorm_ship/gun_deck/second)
 "vp" = (
-/obj/effect/map_effect/window_spawner/reinforced,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, bridge"
 	},
@@ -2391,7 +2418,9 @@
 	},
 /area/hailstorm_ship/armory)
 "wQ" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 9
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2508,13 +2537,19 @@
 /turf/simulated/floor/reinforced/airless,
 /area/hailstorm_ship/gun_deck)
 "yE" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 5
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -2535,12 +2570,10 @@
 	},
 /area/hailstorm_ship)
 "yK" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/hailstorm_shuttle)
 "zd" = (
 /obj/effect/floor_decal/industrial/warning/cee{
@@ -2607,8 +2640,13 @@
 	},
 /area/hailstorm_ship/engine)
 "AU" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/hailstorm_ship/engine)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/shuttle/hailstorm_shuttle)
 "Bv" = (
 /obj/structure/bed/stool/bar/padded/black,
 /obj/item/sign/painting_frame/harrlala{
@@ -3003,7 +3041,12 @@
 	},
 /area/hailstorm_ship/eva)
 "Hi" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
 /area/shuttle/hailstorm_shuttle)
 "Hm" = (
 /turf/simulated/floor/plating{
@@ -3233,7 +3276,7 @@
 	},
 /area/hailstorm_ship/gun_deck)
 "La" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3465,8 +3508,8 @@
 /turf/simulated/floor/airless,
 /area/hailstorm_ship/bridge)
 "OT" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3474,6 +3517,13 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/loading/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3504,9 +3554,6 @@
 	},
 /area/hailstorm_ship)
 "Pb" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
 /obj/machinery/light{
 	dir = 4;
 	status = 2
@@ -3554,6 +3601,10 @@
 /area/space)
 "QL" = (
 /obj/machinery/computer/ship/engines,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3570,6 +3621,14 @@
 	temperature = 278.15
 	},
 /area/hailstorm_ship/barracks)
+"Rc" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 8
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/shuttle/hailstorm_shuttle)
 "Rp" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/brown,
@@ -3649,7 +3708,7 @@
 	},
 /area/hailstorm_ship/gun_deck/second)
 "Tq" = (
-/obj/effect/map_effect/window_spawner/reinforced,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3804,11 +3863,12 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/hailstorm_shuttle)
 "Vy" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -3927,7 +3987,7 @@
 	},
 /area/hailstorm_ship/engine)
 "Xm" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 6
 	},
 /obj/machinery/button/remote/blast_door{
@@ -3961,7 +4021,7 @@
 	},
 /area/hailstorm_ship/bridge)
 "XH" = (
-/obj/effect/map_effect/window_spawner/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 8;
 	id = "hailstorm_bridge"
@@ -14622,7 +14682,7 @@ iB
 in
 in
 in
-AU
+in
 gD
 WG
 wm
@@ -14645,9 +14705,9 @@ cR
 nd
 nd
 fQ
-eZ
+fQ
 mG
-eZ
+fQ
 fQ
 fQ
 fQ
@@ -15781,7 +15841,7 @@ xq
 NM
 qQ
 Eh
-hc
+kv
 rt
 dZ
 dZ
@@ -15940,13 +16000,13 @@ CR
 cK
 CR
 CR
-hc
+kv
 kv
 bh
 kv
-hc
-hc
-hc
+kv
+kv
+kv
 nA
 nA
 iB
@@ -16084,15 +16144,15 @@ cr
 Ml
 in
 iB
-Hi
-Hi
-Hi
-Hi
-Hi
-Hi
+Vw
+Vw
+Vw
+Vw
+Vw
+Vw
 jt
 Sg
-Hi
+Vw
 iB
 iB
 iB
@@ -16108,7 +16168,7 @@ xQ
 jk
 qp
 Wr
-hc
+kv
 dZ
 iB
 iB
@@ -16251,11 +16311,11 @@ Hu
 co
 Vy
 cM
-Hi
+Vw
 aP
 at
-Hi
-Hi
+Vw
+Vw
 Vw
 qn
 iB
@@ -16270,7 +16330,7 @@ kZ
 pC
 ie
 ie
-hc
+kv
 iB
 iB
 iB
@@ -16404,22 +16464,22 @@ iB
 in
 in
 in
-AU
+in
 tC
 in
 iB
 bq
 Hu
-La
+eZ
 bI
-yK
+bI
 Vw
 Ni
 GV
 Vw
 fc
-Hi
-Hi
+Vw
+Vw
 iB
 iB
 CR
@@ -16570,12 +16630,12 @@ cr
 cr
 in
 iB
-Hi
-Hi
-Hi
+Vw
+Vw
+yK
 QL
-kr
-La
+ux
+hc
 yE
 kr
 bs
@@ -16739,7 +16799,7 @@ yr
 Lr
 qE
 OT
-Ev
+AU
 rk
 br
 sF
@@ -16894,14 +16954,14 @@ DD
 Hx
 in
 iB
-Hi
-Hi
-Hi
+Vw
+Vw
+Vw
 Xm
 La
 La
 lJ
-Ev
+Hi
 rk
 Ev
 uD
@@ -16918,7 +16978,7 @@ lh
 uW
 SK
 nx
-hc
+kv
 iB
 iB
 iB
@@ -17058,7 +17118,7 @@ in
 iB
 bq
 Hu
-La
+Rc
 wQ
 ch
 tv
@@ -17067,7 +17127,7 @@ La
 Ig
 rx
 Vw
-Hi
+Vw
 iB
 iB
 iB
@@ -17075,12 +17135,12 @@ iB
 iB
 iB
 iB
-hc
-hc
-hc
+kv
+kv
+kv
 YM
-hc
-hc
+kv
+kv
 iB
 iB
 iB
@@ -17220,7 +17280,7 @@ iB
 iB
 bq
 Hu
-La
+wQ
 Pb
 Ap
 oq
@@ -17228,7 +17288,7 @@ rA
 GS
 ce
 Uy
-Hi
+Vw
 Gk
 iB
 iB
@@ -17380,17 +17440,17 @@ iB
 iB
 iB
 iB
-Hi
-Hi
-Hi
-Hi
-Hi
-Hi
+Vw
+Vw
+Vw
+Vw
+Vw
+Vw
 Dd
-Hi
-Hi
-Hi
-Hi
+Vw
+Vw
+Vw
+Vw
 iB
 iB
 iB

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -922,6 +922,10 @@
 /obj/item/device/multitool,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
+"btW" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "buA" = (
 /obj/structure/flora/pottedplant{
 	dead = 1;
@@ -2627,6 +2631,10 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
+"ghi" = (
+/obj/machinery/alarm/east,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "gji" = (
 /obj/structure/table/rack,
 /obj/item/ship_ammunition/blaster,
@@ -4362,6 +4370,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "kPY" = (
@@ -5512,6 +5523,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "nyh" = (
@@ -7432,8 +7444,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "rAU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
 	},
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -7519,10 +7531,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "rHI" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -7532,6 +7540,9 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/northleft,
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "rJT" = (
@@ -10088,6 +10099,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
+"yeH" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	layer = 2.71
+	},
+/obj/machinery/atmospherics/portables_connector{
+	layer = 2.8;
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "ygA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -44937,7 +44960,7 @@ rQJ
 aEB
 tuB
 fNL
-nRY
+btW
 rAU
 mkb
 syX
@@ -45193,7 +45216,7 @@ atI
 wdp
 dBR
 pob
-nRY
+ghi
 nxF
 kPW
 rDZ
@@ -45452,7 +45475,7 @@ aSb
 aSb
 aSb
 rzA
-aSb
+yeH
 aSb
 kTf
 ugG

--- a/maps/away/ships/sol_ssmd/ssmd_ship.dmm
+++ b/maps/away/ships/sol_ssmd/ssmd_ship.dmm
@@ -481,13 +481,27 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/ssmd_corvette/captain)
 "bgV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 5
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/cell/mecha,
+/obj/item/device/binoculars{
+	pixel_y = 5
 	},
-/obj/structure/railing/mapped{
-	dir = 4
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/inflatable,
+/obj/item/storage/bag/inflatable,
+/obj/machinery/vending/wallmed1{
+	name = "Medical Supplies";
+	pixel_x = 32;
+	req_access = null
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/ssmd_shuttle)
 "bkd" = (
 /obj/machinery/atmospherics/unary/engine,
@@ -548,7 +562,7 @@
 /turf/simulated/wall/shuttle/raider,
 /area/ship/ssmd_corvette/storage)
 "buM" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
 /area/shuttle/ssmd_shuttle)
 "bva" = (
@@ -624,6 +638,12 @@
 	},
 /turf/simulated/floor,
 /area/ship/ssmd_corvette/starboardfoyer)
+"bFs" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/ship/ssmd_corvette/hangar)
 "bKC" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/floor_decal/industrial/warning,
@@ -802,11 +822,8 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/ssmd_shuttle)
 "cnH" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Cockpit";
-	req_access = list(203);
-	dir = 1
-	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/ssmd_shuttle)
 "cpj" = (
@@ -851,6 +868,11 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor,
 /area/ship/ssmd_corvette/hangar)
+"cxm" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/ssmd_shuttle)
 "cCh" = (
 /obj/effect/decal/fake_object{
 	desc = "A general purpose fabricator that can be used to fabricate robotic equipment. This one is in need of some maintenance.";
@@ -868,6 +890,16 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/ssmd_corvette/mechbay)
+"cFy" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 4
+	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/turf/simulated/floor,
+/area/shuttle/ssmd_shuttle)
 "cIL" = (
 /obj/machinery/photocopier{
 	density = 0;
@@ -963,6 +995,13 @@
 	id = "ssmd_driver";
 	layer = 3.2;
 	pixel_y = 7
+	},
+/obj/machinery/alarm/north{
+	req_one_access = null
+	},
+/obj/machinery/power/apc/west,
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/ssmd_shuttle)
@@ -1247,7 +1286,6 @@
 	dir = 8
 	},
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1472,6 +1510,11 @@
 /obj/item/clothing/glasses/safety/goggles/tactical,
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/dorms)
+"dTL" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/ssmd_shuttle)
 "dUd" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
@@ -1548,7 +1591,6 @@
 	dir = 8
 	},
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
@@ -1580,8 +1622,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/alarm/north{
-	pixel_y = -32;
+/obj/machinery/alarm/south{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1738,7 +1779,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/ssmd_corvette/medbay)
 "eCm" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/aft{
 	name = "fore, cockpit"
 	},
@@ -1767,7 +1808,6 @@
 	dir = 9
 	},
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1835,6 +1875,9 @@
 "eJc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/ship/ssmd_corvette/hangar)
@@ -1968,10 +2011,7 @@
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 10
 	},
-/obj/machinery/alarm/north{
-	pixel_y = -32;
-	req_one_access = null
-	},
+/obj/machinery/alarm/south,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -2026,11 +2066,10 @@
 /turf/simulated/floor,
 /area/ship/ssmd_corvette/starboardfoyer)
 "fnY" = (
-/obj/machinery/door/blast/regular{
-	id = "ssmd_slauncher_exterior"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/plasticflaps/airtight,
-/turf/simulated/floor/reinforced,
+/turf/simulated/wall/shuttle/raider,
 /area/shuttle/ssmd_shuttle)
 "foE" = (
 /obj/machinery/computer/ship/targeting{
@@ -2067,7 +2106,6 @@
 	dir = 4
 	},
 /obj/machinery/alarm/west{
-	pixel_x = -32;
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2142,12 +2180,10 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/ssmd_corvette/canteen)
 "fBb" = (
-/obj/machinery/door/blast/regular/open{
-	id = "ssmd_slauncher_interior";
-	name = "blast door"
+/obj/structure/railing/mapped{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor,
 /area/shuttle/ssmd_shuttle)
 "fCf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -2520,9 +2556,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/alarm/north{
-	pixel_y = -32;
-	req_one_access = null
+/obj/machinery/alarm/south{
+	req_one_access = list(203)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/starboardengine)
@@ -2543,7 +2578,6 @@
 	dir = 8
 	},
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /obj/machinery/light/colored/red{
@@ -2736,6 +2770,13 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/ship/ssmd_corvette/portengine)
+"hhb" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/binary/passive_gate/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/ssmd_shuttle)
 "hhf" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -2748,6 +2789,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/ssmd_shuttle)
 "hkU" = (
@@ -2842,13 +2886,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/dorms)
 "hBs" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "ssmd_slauncher_interior";
-	name = "blast door"
-	},
-/turf/simulated/floor/reinforced,
+/obj/machinery/power/smes,
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/ssmd_shuttle)
 "hFX" = (
 /obj/structure/bed/stool/padded/black{
@@ -3541,14 +3581,13 @@
 /area/ship/ssmd_corvette/starboardfoyer)
 "jTo" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/alarm/north{
-	pixel_y = -32;
-	req_one_access = null
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/machinery/light/colored/red,
+/obj/machinery/alarm/server/west{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/grauwolf)
 "jZd" = (
@@ -3825,8 +3864,7 @@
 /obj/structure/bed/stool/chair{
 	dir = 1
 	},
-/obj/machinery/alarm/north{
-	pixel_y = -32;
+/obj/machinery/alarm/south{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/white,
@@ -4039,7 +4077,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4062,6 +4099,7 @@
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/shuttle/ssmd_shuttle)
 "lri" = (
@@ -4078,6 +4116,7 @@
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/shuttle/ssmd_shuttle)
 "lrG" = (
@@ -4119,12 +4158,14 @@
 /turf/simulated/floor,
 /area/shuttle/ssmd_shuttle)
 "lwQ" = (
+/obj/effect/floor_decal/corner/orange{
+	dir = 5
+	},
 /obj/machinery/alarm/north{
-	pixel_y = -32;
 	req_one_access = null
 	},
-/turf/simulated/wall/shuttle/raider,
-/area/ship/ssmd_corvette/starboardengine)
+/turf/simulated/floor/tiled/dark,
+/area/ship/ssmd_corvette/portengine)
 "lCE" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/closet/crate/bin{
@@ -4138,6 +4179,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/portfoyer)
+"lEw" = (
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor,
+/area/shuttle/ssmd_shuttle)
 "lFg" = (
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/mechanical{
@@ -4236,13 +4285,12 @@
 /area/ship/ssmd_corvette/medbay)
 "mdc" = (
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/starboardfoyer)
 "mdD" = (
 /obj/structure/ship_weapon_dummy,
@@ -4270,16 +4318,10 @@
 /area/ship/ssmd_corvette/portengine)
 "mkb" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/vending/wallmed1{
-	name = "Medical Supplies";
-	pixel_x = -26;
-	pixel_y = -1;
-	req_access = null
-	},
-/obj/machinery/light/colored/blue{
-	dir = 8
-	},
 /obj/effect/overmap/visitable/ship/landable/ssmd_shuttle,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/ssmd_shuttle)
 "moE" = (
@@ -4328,12 +4370,6 @@
 /area/shuttle/ssmd_shuttle)
 "mwP" = (
 /obj/machinery/atmospherics/binary/pump/high_power,
-/obj/structure/closet/walllocker{
-	pixel_x = -32
-	},
-/obj/item/storage/bag/inflatable,
-/obj/item/storage/bag/inflatable,
-/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor,
 /area/shuttle/ssmd_shuttle)
 "mxo" = (
@@ -4471,6 +4507,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/dorms)
+"mJS" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/ship/ssmd_corvette/hangar)
 "mKi" = (
 /obj/structure/bed/stool/chair/office/bridge/generic,
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -4774,7 +4816,6 @@
 	dir = 6
 	},
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4901,6 +4942,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/starboardengine)
+"nVK" = (
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/ship/ssmd_corvette/hangar)
 "nWf" = (
 /obj/effect/floor_decal/corner/orange/diagonal,
 /obj/structure/bed/stool/chair/office/dark{
@@ -5050,10 +5100,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/alarm/north{
-	pixel_y = -32;
-	req_one_access = null
-	},
+/obj/machinery/alarm/south,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -5235,8 +5282,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/alarm/north{
-	pixel_y = -32;
+/obj/machinery/alarm/south{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/white,
@@ -5572,7 +5618,6 @@
 	dir = 4
 	},
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /turf/simulated/floor/wood/walnut,
@@ -5802,6 +5847,9 @@
 "rqR" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/hologram/holopad/long_range,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/ssmd_shuttle)
 "rsm" = (
@@ -5937,6 +5985,9 @@
 "scT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/ship/ssmd_corvette/hangar)
@@ -6264,7 +6315,6 @@
 "tgM" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/white,
@@ -6458,7 +6508,6 @@
 	dir = 10
 	},
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -6552,10 +6601,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/alarm/north{
-	pixel_y = -32;
-	req_one_access = null
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/mechbay)
 "ugL" = (
@@ -6622,6 +6667,22 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/francisca)
+"unQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/ship/ssmd_corvette/hangar)
 "unW" = (
 /obj/machinery/door/firedoor/multi_tile{
 	req_one_access = null
@@ -7046,12 +7107,15 @@
 /turf/simulated/wall/shuttle/raider,
 /area/ship/ssmd_corvette/portengine)
 "vxN" = (
-/obj/machinery/mass_driver{
-	_wifi_id = "ssmd_driver";
-	dir = 8;
-	id = "ssmd_driver"
+/obj/machinery/power/terminal{
+	dir = 1;
+	icon_state = "term"
 	},
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
 /area/shuttle/ssmd_shuttle)
 "vyL" = (
 /obj/effect/floor_decal/corner_wide/paleblue/full{
@@ -7274,8 +7338,7 @@
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 10
 	},
-/obj/machinery/alarm/north{
-	pixel_y = -32;
+/obj/machinery/alarm/south{
 	req_one_access = null
 	},
 /obj/structure/table/steel,
@@ -7377,7 +7440,6 @@
 /area/ship/ssmd_corvette/grauwolf)
 "wrc" = (
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -7462,6 +7524,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/starboardfoyer)
+"wLn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/ssmd_shuttle)
 "wLs" = (
 /obj/effect/floor_decal/corner/orange/diagonal,
 /obj/machinery/autolathe,
@@ -7604,8 +7672,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/alarm/west{
-	pixel_x = -32;
+/obj/machinery/alarm/freezer/west{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/freezer{
@@ -7755,15 +7822,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/multi_tile{
-	req_one_access = null
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 8;
-	name = "Starboard Primary Hall";
-	req_access = list(203)
-	},
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/starboardfoyer)
 "xJn" = (
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -7820,6 +7879,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/ssmd_corvette/canteen)
+"xPG" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/ssmd_shuttle)
 "xPN" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -7834,18 +7898,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 10
 	},
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/item/device/gps,
-/obj/item/device/gps,
-/obj/item/device/gps,
-/obj/item/device/gps,
-/obj/item/device/gps,
-/obj/item/device/gps,
-/obj/item/cell/mecha,
-/obj/item/device/binoculars{
-	pixel_y = 5
-	},
+/obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/ssmd_shuttle)
 "xRX" = (
@@ -36589,7 +36642,7 @@ xRX
 piw
 cYw
 gxW
-lwQ
+rmR
 wCo
 aaI
 dqJ
@@ -39164,15 +39217,15 @@ dUd
 wUJ
 wUJ
 wUJ
-wUJ
-dUd
-wUJ
-wUJ
-wUJ
+mJS
+nVK
+bFs
+bFs
+bFs
 scT
-wUJ
+bFs
 eJc
-uKq
+unQ
 xpP
 xpP
 ycB
@@ -39679,7 +39732,7 @@ clV
 cTq
 hBs
 vxN
-hBs
+lEw
 mPM
 mwP
 epB
@@ -39934,11 +39987,11 @@ wUJ
 buM
 epw
 pYB
-clV
+mEc
 fBb
-clV
+wLn
+cFy
 gcq
-bgV
 sof
 clV
 clV
@@ -40191,8 +40244,8 @@ wUJ
 eCm
 wZf
 mEc
-cnH
-mEc
+cxm
+dTL
 mkb
 hiw
 xQS
@@ -40448,9 +40501,9 @@ wUJ
 buM
 krH
 atj
-clV
-mEc
-mEc
+xPG
+cnH
+hhb
 rqR
 mEc
 wBq
@@ -40705,7 +40758,7 @@ wUJ
 clV
 clV
 ewW
-clV
+bgV
 eMT
 vVG
 eMT
@@ -44043,7 +44096,7 @@ cpj
 nXr
 aUQ
 vxp
-vMq
+lwQ
 awG
 oBX
 wLs

--- a/maps/away/ships/yacht/yacht.dmm
+++ b/maps/away/ships/yacht/yacht.dmm
@@ -82,8 +82,8 @@
 /turf/simulated/floor/wood/walnut,
 /area/shuttle/yacht/bridge)
 "ar" = (
-/obj/machinery/alarm/north{
-	pixel_y = -22
+/obj/machinery/alarm/south{
+	req_one_access = null
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/walnut,
@@ -239,7 +239,9 @@
 "aT" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/spider/stickyweb,
-/obj/machinery/alarm/north,
+/obj/machinery/alarm/north{
+	req_one_access = null
+	},
 /turf/simulated/floor/wood/walnut,
 /area/shuttle/yacht/living)
 "aU" = (
@@ -891,7 +893,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/west{
-	pixel_x = -28
+	req_one_access = null
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/yacht/engine)
@@ -932,7 +934,7 @@
 	dir = 8
 	},
 /obj/machinery/alarm/west{
-	pixel_x = -23
+	req_one_access = null
 	},
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/decal/cleanable/dirt,
@@ -988,12 +990,7 @@
 /turf/simulated/floor/wood/yew,
 /area/shuttle/yacht/living)
 "df" = (
-/obj/structure/window/shuttle{
-	health = 150;
-	maxhealth = 150
-	},
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
 /area/shuttle/yacht/bridge)
 "dg" = (
@@ -1364,12 +1361,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/yacht/engine)
 "mL" = (
-/obj/structure/window/shuttle{
-	health = 150;
-	maxhealth = 150
-	},
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
 /area/shuttle/yacht/living)
 "nb" = (
@@ -1399,7 +1391,7 @@
 /area/shuttle/yacht/engine)
 "pb" = (
 /obj/machinery/alarm/east{
-	pixel_x = 24
+	req_one_access = null
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1501,7 +1493,7 @@
 /area/shuttle/yacht/bridge)
 "zA" = (
 /obj/machinery/alarm/west{
-	pixel_x = -28
+	req_one_access = null
 	},
 /turf/simulated/floor/carpet/purple,
 /area/shuttle/yacht/living)
@@ -1517,21 +1509,11 @@
 /turf/simulated/floor/airless,
 /area/shuttle/yacht/engine)
 "Be" = (
-/obj/structure/window/shuttle{
-	health = 150;
-	maxhealth = 150
-	},
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
 /turf/simulated/floor/plating,
 /area/shuttle/yacht/engine)
 "DP" = (
-/obj/structure/window/shuttle{
-	health = 150;
-	maxhealth = 150
-	},
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/west{
 	name = "starboard, luxury cabin"
 	},
@@ -1542,12 +1524,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/yacht/engine)
 "Ge" = (
-/obj/structure/window/shuttle{
-	health = 150;
-	maxhealth = 150
-	},
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/south{
 	name = "fore, bridge"
 	},
@@ -1570,12 +1547,7 @@
 /turf/simulated/floor/wood/yew,
 /area/shuttle/yacht/living)
 "Jw" = (
-/obj/structure/window/shuttle{
-	health = 150;
-	maxhealth = 150
-	},
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/east{
 	name = "port, crew quarters"
 	},
@@ -1583,7 +1555,9 @@
 /area/shuttle/yacht/living)
 "MX" = (
 /obj/effect/spider/stickyweb,
-/obj/machinery/alarm/north,
+/obj/machinery/alarm/north{
+	req_one_access = null
+	},
 /turf/simulated/floor/beach/water/alt,
 /area/shuttle/yacht/living)
 "Nb" = (
@@ -1593,7 +1567,7 @@
 	req_access = null
 	},
 /obj/machinery/alarm/east{
-	pixel_x = 24
+	req_one_access = null
 	},
 /turf/simulated/floor/wood/yew,
 /area/shuttle/yacht/living)


### PR DESCRIPTION
* This PR adds, as something of a test run, functional atmospheric systems and (in the case of the SSMD shuttle) electrical systems to the SSMD shuttle, the Hailstorm shuttle, and the Freebooter ship. This is in preparation for a larger refactor, in which all ships/away sites will be gradually updated to have functional atmos and power systems, and shuttles will require them as well.
* Also fixes wonky air alarm offsets on the yacht away site and the SSMD shuttle.

Notes:
* The APCs attached to any shuttle that doesn't have its requires_power variable edited manually will be perpetually stuck at 90% charge and not draw any power. This is because shuttles as an area in the code do not require power. I plan to change this, so it's gonna look weird for a bit.
* The Freebooter atmos system sucks on purpose. I couldn't find a spot to put another air tank in without massively obstructing everything about the ship. Plus, the pirate shuttle being run on string and a prayer sort of fits!