### PR TITLE
Fixes Some Shuttles Having Old Windows

### DIFF
--- a/html/changelogs/SleepyGemmy-shuttles_windows_fix.yml
+++ b/html/changelogs/SleepyGemmy-shuttles_windows_fix.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes some shuttles having old windows."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -1245,7 +1245,7 @@
 /area/maintenance/engineering)
 "aWx" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle/scc,
+/obj/structure/window/shuttle/scc_space_ship,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod/pod1)
 "aWz" = (
@@ -11701,7 +11701,7 @@
 /area/hangar/canary)
 "ifU" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle/scc,
+/obj/structure/window/shuttle/scc_space_ship,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod/pod4)
 "ifX" = (
@@ -21757,7 +21757,7 @@
 /area/maintenance/research_port)
 "pos" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle/scc,
+/obj/structure/window/shuttle/scc_space_ship,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod/pod3)
 "poM" = (
@@ -29563,7 +29563,7 @@
 /area/engineering/atmos)
 "uKW" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle/scc,
+/obj/structure/window/shuttle/scc_space_ship,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod/pod2)
 "uLM" = (
@@ -45401,9 +45401,9 @@ dqy
 vJT
 noz
 eSV
-xDY
+oYQ
 ifU
-xDY
+oYQ
 eSV
 eSV
 eSV
@@ -65904,15 +65904,15 @@ iUg
 jKT
 xst
 eSV
-xDY
+mUk
 uKW
-xDY
+mUk
 eSV
 eSV
 eSV
-xDY
+jzw
 aWx
-xDY
+jzw
 eSV
 eSV
 eSV

--- a/maps/sccv_horizon/sccv_horizon-4_centcomm.dmm
+++ b/maps/sccv_horizon/sccv_horizon-4_centcomm.dmm
@@ -5876,9 +5876,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/supply/dock)
 "ang" = (
-/obj/structure/window/reinforced/crescent{
-	dir = 1
-	},
 /obj/effect/decal/fake_object{
 	density = 1;
 	desc = "An automatic shuttle's mainframe.";
@@ -5904,9 +5901,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/supply/dock)
 "anl" = (
-/obj/structure/window/reinforced/crescent{
-	dir = 1
-	},
 /obj/effect/decal/fake_object{
 	density = 1;
 	desc = "An automatic shuttle's mainframe.";
@@ -15517,12 +15511,6 @@
 /area/centcom/start{
 	name = "Romanovich Cloud, Tau Ceti"
 	})
-"aOh" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/unsimulated/floor/plating,
-/area/centcom/suppy)
 "aOi" = (
 /turf/unsimulated/floor/plating,
 /area/centcom/suppy)
@@ -16660,7 +16648,9 @@
 	name = "Romanovich Cloud, Tau Ceti"
 	})
 "aQY" = (
-/obj/structure/window/shuttle/scc,
+/obj/structure/grille,
+/obj/structure/window/shuttle/scc_space_ship/cardinal,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/supply/dock)
 "aRa" = (
@@ -16783,9 +16773,6 @@
 /turf/simulated/floor,
 /area/tdome/tdome1)
 "aRx" = (
-/obj/structure/window/reinforced/crescent{
-	dir = 1
-	},
 /obj/effect/decal/fake_object{
 	density = 1;
 	desc = "An automatic shuttle's mainframe.";
@@ -41190,12 +41177,6 @@
 	},
 /turf/simulated/floor/holofloor/tiled,
 /area/horizon/holodeck/source_emptycourt)
-"xND" = (
-/obj/structure/window/reinforced/crescent{
-	dir = 1
-	},
-/turf/simulated/wall/shuttle/scc,
-/area/supply/dock)
 "xNG" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -50097,19 +50078,19 @@ tnF
 aJs
 aJs
 aNR
-aOh
 aOU
 aOi
 aOi
 aOi
 aOi
+aOi
+aOi
+aOi
+aOi
+aOi
+aOi
+aOi
 aOU
-aOi
-aOi
-aOi
-aOi
-aOU
-aSm
 aNR
 aaa
 aaa
@@ -50621,7 +50602,7 @@ aQJ
 anh
 aQJ
 aPv
-xND
+aMt
 aMt
 aOi
 aNR
@@ -51649,7 +51630,7 @@ aQJ
 aQK
 aQJ
 ani
-xND
+aMt
 aMt
 aOi
 aNR
@@ -52153,19 +52134,19 @@ tDg
 aJx
 aJs
 aNR
-aOh
 aPc
 aOi
 aOi
 aOi
 aOi
-aPc
-aOi
-aOi
-aOi
 aOi
 aPc
-aSm
+aOi
+aOi
+aOi
+aOi
+aOi
+aPc
 aNR
 aaa
 aaa


### PR DESCRIPTION
this PR fixes some shuttles having old windows. an intermediate fix until sprites are made in the same hue as the shuttles' hull.
fixes #17667.