### PR TITLE
Fixes Federation Consular Guns

### DIFF
--- a/code/modules/background/citizenship/skrell.dm
+++ b/code/modules/background/citizenship/skrell.dm
@@ -71,9 +71,14 @@
 	name = "Nralakk Consular Officer"
 
 	uniform = /obj/item/clothing/under/skrell
+	backpack_contents = list(
+		/obj/item/device/camera = 1
+	)
 
 /datum/outfit/job/representative/consular/nralakk/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(H)
+		if(isskrell(H))
+			H.equip_to_slot_or_del(new /obj/item/gun/energy/psipistol(H), slot_belt)
 		if(isvaurca(H)) // there should be a system for this but for now this will have to do i guess
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/gearharness(H), slot_w_uniform)
 			H.equip_to_slot_or_del(new /obj/item/clothing/head/vaurca_breeder/nralakk(H), slot_head)
@@ -81,11 +86,9 @@
 			H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vaurca/filter(H), slot_wear_mask)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/vaurca/breeder/nralakk(H), slot_wear_suit)
 			H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec/cthur(H), slot_back)
-		else if(isskrell(H))
-			backpack_contents = list(
-				/obj/item/device/camera = 1,
-				/obj/item/gun/energy/psipistol = 1
-			)
+			H.equip_to_slot_or_del(new /obj/item/gun/energy/pistol(H), slot_belt)
+		else
+			H.equip_to_slot_or_del(new /obj/item/gun/energy/pistol(H), slot_belt)
 		if(!visualsOnly)
 			addtimer(CALLBACK(src, PROC_REF(send_representative_mission), H), 5 MINUTES)
 	return TRUE

--- a/html/changelogs/RustingWithYou - warbleinhell.yml
+++ b/html/changelogs/RustingWithYou - warbleinhell.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Skrell Nralakk Federation Consular officers will now spawn correctly with the psi pistol."


### PR DESCRIPTION
Skrell Federation consulars will now spawn with the psi pistol, while non-Skrell will spawn with a normal energy pistol.