### PR TITLE
Removes mining access requirement from ore redemption consoles

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -123,21 +123,15 @@
 		var/obj/item/card/id/ID = usr.GetIdCard()
 		if(ID)
 			if(params["choice"] == "claim")
-				if(access_mining_station in ID.access)
-					if(points >= 0)
-						ID.mining_points += points
-						if(points != 0)
-							ping("\The [src] pings, \"Point transfer complete! Transaction total: [points] points!\"")
-						points = 0
-					else
-						to_chat(usr, SPAN_WARNING("[station_name()]'s mining division is currently indebted to NanoTrasen. Transaction incomplete until debt is cleared."))
+				if(points >= 0)
+					ID.mining_points += points
+					if(points != 0)
+						ping("\The [src] pings, \"Point transfer complete! Transaction total: [points] points!\"")
+					points = 0
 				else
-					to_chat(usr, SPAN_WARNING("Required access not found."))
+					to_chat(usr, SPAN_WARNING("[station_name()]'s mining division is currently indebted to NanoTrasen. Transaction incomplete until debt is cleared."))
 			if(params["choice"] == "print_report")
-				if(access_mining_station in ID.access)
-					print_report(usr)
-				else
-					to_chat(usr, SPAN_WARNING("Required access not found."))
+				print_report(usr)
 		return TRUE
 
 	if(action == "toggle_smelting")

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -129,7 +129,7 @@
 						ping("\The [src] pings, \"Point transfer complete! Transaction total: [points] points!\"")
 					points = 0
 				else
-					to_chat(usr, SPAN_WARNING("[station_name()]'s mining division is currently indebted to NanoTrasen. Transaction incomplete until debt is cleared."))
+					ping("<b>\The [src]</b> pings, \"Transaction failed due to a negative point value. No transaction can be done until this value has returned to a positive one.\"")
 			if(params["choice"] == "print_report")
 				print_report(usr)
 		return TRUE

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -126,7 +126,7 @@
 				if(points >= 0)
 					ID.mining_points += points
 					if(points != 0)
-						ping("\The [src] pings, \"Point transfer complete! Transaction total: [points] points!\"")
+						ping("<b>\The [src]</b> pings, \"Point transfer complete! Transaction total: [points] points!\"")
 					points = 0
 				else
 					ping("<b>\The [src]</b> pings, \"Transaction failed due to a negative point value. No transaction can be done until this value has returned to a positive one.\"")

--- a/html/changelogs/Nalarac-oreredemptionaccess.yml
+++ b/html/changelogs/Nalarac-oreredemptionaccess.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Nalarac
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Removed mining access requirement to claim points and print yield declarations from ore redemption console."


### PR DESCRIPTION
The claim points and print yield declarations required mining access to use despite the actual functionality of the console requiring no access. I've removed this access requirement so off-ships with these machines can actually claim points from the ore they process.

Fixes #17603 