### PR TITLE
Security Badge Names Fixes

### DIFF
--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -158,22 +158,22 @@
 	..()
 
 /obj/item/clothing/accessory/badge/officer
-	name = "officer's badge"
-	desc = "A bronze corporate security badge. Stamped with the words 'Security Officer.'"
+	name = "security officer's badge"
+	desc = "A bronze security badge."
 	icon_state = "bronzebadge"
 	overlay_state = "bronzebadge"
 	slot_flags = SLOT_TIE
 
 /obj/item/clothing/accessory/badge/warden
 	name = "warden's badge"
-	desc = "A silver corporate security badge. Stamped with the words 'Brig Officer.'"
+	desc = "A silver security badge."
 	icon_state = "silverbadge"
 	overlay_state = "silverbadge"
 	slot_flags = SLOT_TIE
 
 /obj/item/clothing/accessory/badge/hos
-	name = "commander's badge"
-	desc = "An immaculately polished gold security badge. Labeled 'Commander.'"
+	name = "head of security's badge"
+	desc = "An immaculately polished gold security badge."
 	icon_state = "goldbadge"
 	overlay_state = "goldbadge"
 	slot_flags = SLOT_TIE

--- a/html/changelogs/SleepyGemmy-badges.yml
+++ b/html/changelogs/SleepyGemmy-badges.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed some security badges not being named after the actual roles."


### PR DESCRIPTION
this PR fixes some security badges not being named after the actual roles.