### PR TITLE
Buffs Stinger Grenades

### DIFF
--- a/code/game/objects/items/weapons/grenades/stinger.dm
+++ b/code/game/objects/items/weapons/grenades/stinger.dm
@@ -1,7 +1,7 @@
 ///Stinger grenade projectile
 /obj/item/projectile/bullet/rubberball/stinger_ball
 	damage = 2
-	agony = 50
+	agony = 40
 	armor_penetration = 10
 	range_step = 2
 	embed = FALSE
@@ -18,7 +18,7 @@
 	desc = "A stinger grenade, designed to explode and expel rubber balls over an area for less-lethal takedowns. Popular with many law enforcement agencies."
 	icon_state = "stinger"
 
-	var/num_fragments = 70  ///total number of balls produced by the grenade
+	var/num_fragments = 100  ///total number of balls produced by the grenade
 	var/fragment_damage = 2
 	var/damage_step = 2      //projectiles lose a fragment each time they travel this distance. Can be a non-integer.
 	var/explosion_size = 1   ///size of the center explosion

--- a/code/game/objects/items/weapons/grenades/stinger.dm
+++ b/code/game/objects/items/weapons/grenades/stinger.dm
@@ -1,7 +1,7 @@
 ///Stinger grenade projectile
 /obj/item/projectile/bullet/rubberball/stinger_ball
 	damage = 2
-	agony = 40
+	agony = 50
 	armor_penetration = 10
 	range_step = 2
 	embed = FALSE
@@ -20,7 +20,7 @@
 
 	var/num_fragments = 100  ///total number of balls produced by the grenade
 	var/fragment_damage = 2
-	var/damage_step = 2      //projectiles lose a fragment each time they travel this distance. Can be a non-integer.
+	var/damage_step = 3      //projectiles lose a fragment each time they travel this distance. Can be a non-integer.
 	var/explosion_size = 1   ///size of the center explosion
 
 	//The radius of the circle used to launch projectiles. Lower values mean less projectiles are used but if set too low gaps may appear in the spread pattern

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -122,7 +122,7 @@
 	name = "rubber ball"
 	icon_state = "pellets"
 	damage = 2
-	agony = 45
+	agony = 40
 	embed = FALSE
 	var/balls = 4
 	///projectile will lose a fragment each time it travels this distance. Can be a non-integer.

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -122,11 +122,11 @@
 	name = "rubber ball"
 	icon_state = "pellets"
 	damage = 2
-	agony = 40
+	agony = 50
 	embed = FALSE
 	var/balls = 4
 	///projectile will lose a fragment each time it travels this distance. Can be a non-integer.
-	var/range_step = 2
+	var/range_step = 3
 	var/base_spread = 90
 	var/spread_step = 10
 

--- a/html/changelogs/CampinKiller24-clear.yml
+++ b/html/changelogs/CampinKiller24-clear.yml
@@ -1,0 +1,6 @@
+author: CampinKiller24
+
+delete-after: True
+
+changes:
+  - tweak: "Buffs stinger grenades by increasing their area of effectiveness."


### PR DESCRIPTION
Stinger grenades aren't currently very useful outside of the affected target being right next to the explosion. Changed the number of balls and drop-off for them so it's got a small circle where it's more effective.
