### PR TITLE
Idris/Orion Express Corporate Reporter uniform + faction bag fix

### DIFF
--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -58,6 +58,7 @@
 		"Librarian" = /datum/outfit/job/librarian/idris,
 		"Curator" = /datum/outfit/job/librarian/idris/curator,
 		"Tech Support" = /datum/outfit/job/librarian/idris/tech_support,
+		"Corporate Reporter" = /datum/outfit/job/journalist/idris,
 		"Corporate Liaison" = /datum/outfit/job/representative/idris,
 		"Off-Duty Crew Member" = /datum/outfit/job/visitor/idris
 	)
@@ -198,6 +199,17 @@
 	r_hand = /obj/item/storage/bag/circuits/basic
 	l_hand = /obj/item/modular_computer/laptop/preset
 	gloves = /obj/item/modular_computer/handheld/wristbound/preset/advanced/civilian
+
+/datum/outfit/job/journalist/idris
+	name = "Corporate Reporter - Idris"
+
+	uniform = /obj/item/clothing/under/librarian/idris
+	id = /obj/item/card/id/idris
+
+	backpack_faction = /obj/item/storage/backpack/idris
+	satchel_faction = /obj/item/storage/backpack/satchel/idris
+	dufflebag_faction = /obj/item/storage/backpack/duffel/idris
+	messengerbag_faction = /obj/item/storage/backpack/messenger/idris
 
 /datum/outfit/job/representative/idris
 	name = "Idris Corporate Liaison"

--- a/code/game/jobs/faction/orion_express.dm
+++ b/code/game/jobs/faction/orion_express.dm
@@ -46,6 +46,7 @@
 		"Librarian" = /datum/outfit/job/librarian/orion,
 		"Curator" = /datum/outfit/job/librarian/orion/curator,
 		"Tech Support" = /datum/outfit/job/librarian/orion/tech_support,
+		"Corporate Reporter" = /datum/outfit/job/journalist/orion,
 		"Corporate Liaison" = /datum/outfit/job/representative/orion,
 		"Off-Duty Crew Member" = /datum/outfit/job/visitor/orion
 	)
@@ -175,6 +176,17 @@
 	r_hand = /obj/item/storage/bag/circuits/basic
 	l_hand = /obj/item/modular_computer/laptop/preset
 	gloves = /obj/item/modular_computer/handheld/wristbound/preset/advanced/civilian
+
+/datum/outfit/job/journalist/orion
+	name = "Corporate Reporter - Orion Express"
+
+	uniform = /obj/item/clothing/under/librarian/orion
+	id = /obj/item/card/id/orion
+
+	backpack_faction = /obj/item/storage/backpack/orion
+	satchel_faction = /obj/item/storage/backpack/satchel/orion
+	dufflebag_faction = /obj/item/storage/backpack/duffel/orion
+	messengerbag_faction = /obj/item/storage/backpack/messenger/orion
 
 
 /datum/outfit/job/visitor/orion

--- a/html/changelogs/SimpleMaroon-orionreporterbagfix.yml
+++ b/html/changelogs/SimpleMaroon-orionreporterbagfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: SimpleMaroon
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed Orion Express and Idris Incorporated corporate reporters having no unique uniform and defaulting to NanoTrasen bags."


### PR DESCRIPTION
Orion Express and Idris Incorporate Corporate Reporters had no faction outfit defined for them, and so received the default red suit and NanoTrasen faction bags. This fixes that.