### PR TITLE
Overmap Tooltip

### DIFF
--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -144,6 +144,26 @@
 							V.target(src, H.machine)
 			GS.targeting = FALSE //Extra safety.
 
+/obj/effect/overmap/MouseEntered(location, control, params)
+	. = ..()
+	var/list/modifiers = params2list(params)
+	if(modifiers["shift"])
+		params = replacetext(params, "shift=1;", "") // tooltip doesn't appear unless this is stripped
+		var/description = get_tooltip_description()
+		openToolTip(usr, src, params, name, description)
+
+/obj/effect/overmap/proc/get_tooltip_description()
+	if(!desc)
+		return ""
+	var/description = "<ul>"
+	description += "<li>[desc]</li>"
+	description += "</ul>"
+	return description
+
+/obj/effect/overmap/MouseExited(location, control, params)
+	. = ..()
+	closeToolTip(usr)
+
 /obj/effect/overmap/visitable/proc/target(var/obj/effect/overmap/O, var/obj/machinery/computer/ship/C)
 	C.targeting = TRUE
 	usr.visible_message(SPAN_WARNING("[usr] starts calibrating the targeting systems, swiping around the holographic screen..."), SPAN_WARNING("You start calibrating the targeting systems, swiping around the screen as you focus..."))

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -109,6 +109,15 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 	. += "<br><center><b>Native Database Notes</b></center>"
 	. += "<br><small>[desc]</small>"
 
+/obj/effect/overmap/visitable/ship/get_tooltip_description()
+	var/description = "<ul>"
+	description += "<li><b>Manufacturer:</b> [designer]</li>"
+	description += "<li><b>Class Designation:</b> [sizeclass]</li>"
+	description += "<li><b>Designated Purpose:</b> [shiptype]</li>"
+	description += "<li><b>Weapons Estimation:</b> [weapons]</li>"
+	description += "</ul>"
+	return description
+
 //Projected acceleration based on information from engines
 /obj/effect/overmap/visitable/ship/proc/get_acceleration()
 	return round(get_total_thrust()/get_vessel_mass(), SHIP_MOVE_RESOLUTION)

--- a/html/changelogs/geeves-overmap_tooltip.yml
+++ b/html/changelogs/geeves-overmap_tooltip.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Added tooltips to overmap objects, hold shift while hovering over them to see more info."


### PR DESCRIPTION
* Added tooltips to overmap objects, hold shift while hovering over them to see more info.

Ideological port of: https://github.com/Baystation12/Baystation12/pull/33768