### PR TITLE
MANUAL_UNIT_TEST compiler warning

### DIFF
--- a/code/__defines/manual_unit_testing.dm
+++ b/code/__defines/manual_unit_testing.dm
@@ -1,3 +1,7 @@
 // !!! For manual use only, remember to recomment before PRing !!!
 // #define UNIT_TEST
 // #define MANUAL_UNIT_TEST
+
+#if defined(MANUAL_UNIT_TEST) && !defined(SPACEMAN_DMM) && !defined(OPENDREAM)
+	#warn Manual unit test is defined, remember to recomment it before PRing!
+#endif // MANUAL_UNIT_TEST

--- a/html/changelogs/FluffyGhost-manualut_warn.yml
+++ b/html/changelogs/FluffyGhost-manualut_warn.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Added a check to ensure that a warning is raised if the manual unit tests are left enable, this should fail the CI and prevent a merge with it being left over."


### PR DESCRIPTION
Added a check to ensure that a warning is raised if the manual unit tests are left enable, this should fail the CI and prevent a merge with it being left over