### PR TITLE
Unit Tests consolidation and exception catch

### DIFF
--- a/code/unit_tests/ss_test.dm
+++ b/code/unit_tests/ss_test.dm
@@ -2,7 +2,7 @@
 // It initializes last in the subsystem order, and queues
 // the tests to start about 20 seconds after init is done.
 
-/**
+/*
  * Wondering if you should change this to run the tests? NO!
  * Because the preproc checks for this in other areas too, set it in code\__defines\manual_unit_testing.dm instead!
  */
@@ -18,7 +18,7 @@ var/datum/controller/subsystem/unit_tests_config/SSunit_tests_config = new
 	init_order = SS_INIT_PERSISTENT_CONFIG
 	flags = SS_NO_FIRE
 
-	var/datum/unit_test/UT = new // Logging/output
+	var/datum/unit_test/UT = new // Logging/output, use this to log things from outside where a specific unit_test is defined
 
 	///What is our identifier, what pod are we, and hence what are we supposed to run
 	var/identifier = null
@@ -111,7 +111,6 @@ var/datum/controller/subsystem/unit_tests_config/SSunit_tests_config = new
 */
 /datum/controller/subsystem/unit_tests
 	name = "Unit Tests"
-	var/datum/unit_test/UT = new // Use this to log things from outside where a specific unit_test is defined
 	init_order = -1e6	// last.
 	var/list/queue = list()
 	var/list/async_tests = list()
@@ -122,7 +121,7 @@ var/datum/controller/subsystem/unit_tests_config/SSunit_tests_config = new
 
 
 /datum/controller/subsystem/unit_tests/Initialize(timeofday)
-	UT.notice("Initializing Unit Testing", __FILE__, __LINE__)
+	SSunit_tests_config.UT.notice("Initializing Unit Testing", __FILE__, __LINE__)
 
 	//
 	//Start the Round.
@@ -136,7 +135,7 @@ var/datum/controller/subsystem/unit_tests_config/SSunit_tests_config = new
 			continue
 
 		if(!length(D.groups))
-			UT.fail("**** Unit Test has no group assigned! [D.name] ****")
+			SSunit_tests_config.UT.fail("**** Unit Test has no group assigned! [D.name] ****")
 			del world
 
 		for(var/group in D.groups)
@@ -144,17 +143,17 @@ var/datum/controller/subsystem/unit_tests_config/SSunit_tests_config = new
 				queue += D
 				break
 
-	UT.notice("[queue.len] unit tests loaded.", __FILE__, __LINE__)
+	SSunit_tests_config.UT.notice("[queue.len] unit tests loaded.", __FILE__, __LINE__)
 	..()
 
 /datum/controller/subsystem/unit_tests/proc/start_game()
 	if (SSticker.current_state == GAME_STATE_PREGAME)
 		SSticker.current_state = GAME_STATE_SETTING_UP
 
-		UT.debug("Round has been started.", __FILE__, __LINE__)
+		SSunit_tests_config.UT.debug("Round has been started.", __FILE__, __LINE__)
 		stage++
 	else
-		UT.fail("Unable to start testing; SSticker.current_state=[SSticker.current_state]!", __FILE__, __LINE__)
+		SSunit_tests_config.UT.fail("Unable to start testing; SSticker.current_state=[SSticker.current_state]!", __FILE__, __LINE__)
 		del world
 
 /datum/controller/subsystem/unit_tests/proc/handle_tests()
@@ -176,8 +175,15 @@ var/datum/controller/subsystem/unit_tests_config/SSunit_tests_config = new
 			continue
 
 		TEST_GROUP_OPEN("[test.name]")
-		if (test.start_test() == null)	// Runtimed.
-			test.fail("Test Runtimed: [test.name]", __FILE__, __LINE__)
+
+		var/current_test_result = null
+
+		current_test_result = test.start_test()
+
+		//If the result is still null, the test have runtimed or not returned a valid result, either way rise an error
+		if (isnull(current_test_result))
+			test.fail("Unit Test runtimed or returned an illicit result: [test.name]", __FILE__, __LINE__)
+
 		TEST_GROUP_CLOSE("[test.name]")
 
 		if (test.async)
@@ -186,7 +192,7 @@ var/datum/controller/subsystem/unit_tests_config/SSunit_tests_config = new
 		total_unit_tests++
 
 		if(unit_tests_failures && SSunit_tests_config.fail_fast)
-			UT.fail("**** Fail fast is enabled and an unit test failed! Aborting... ****", __FILE__, __LINE__)
+			SSunit_tests_config.UT.fail("**** Fail fast is enabled and an unit test failed! Aborting... ****", __FILE__, __LINE__)
 			handle_tests_ending(TRUE)
 			break
 
@@ -234,10 +240,10 @@ var/datum/controller/subsystem/unit_tests_config/SSunit_tests_config = new
 
 		if (4)	// Finalization.
 			if(all_unit_tests_passed)
-				UT.pass("**** All Unit Tests Passed \[[total_unit_tests]\] ****", __FILE__, __LINE__)
+				SSunit_tests_config.UT.pass("**** All Unit Tests Passed \[[total_unit_tests]\] ****", __FILE__, __LINE__)
 				handle_tests_ending(FALSE)
 			else
-				UT.fail("**** \[[unit_tests_failures]\] Errors Encountered! Read the logs above! ****", __FILE__, __LINE__)
+				SSunit_tests_config.UT.fail("**** \[[unit_tests_failures]\] Errors Encountered! Read the logs above! ****", __FILE__, __LINE__)
 				handle_tests_ending(TRUE)
 
 /datum/controller/subsystem/unit_tests/proc/handle_tests_ending(is_failure = FALSE)
@@ -246,5 +252,20 @@ var/datum/controller/subsystem/unit_tests_config/SSunit_tests_config = new
 		world.Reboot("Restarting for another UT try, remaining tries: [SSunit_tests_config.retries]", TRUE)
 	else
 		del world
+
+//This is only valid during unit tests
+/world/Error(var/exception/e)
+
+	var/datum/unit_test/UT
+
+	//Try to use the SSunit_tests_config.UT, but if for some god forsaken reason it doesn't exist, make a new one
+	if(SSunit_tests_config?.UT)
+		UT = SSunit_tests_config?.UT
+	else
+		UT = new
+
+	UT.fail("**** !!! Encountered a world exception during unit testing !!! - Exception name: [e.name] → @@@ [e.file]:[e.line] ****", __FILE__, __LINE__)
+
+	return ..(e)
 
 #endif

--- a/html/changelogs/FluffyGhost-unittests_consolidation_exception_catch.yml
+++ b/html/changelogs/FluffyGhost-unittests_consolidation_exception_catch.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Reworked SSunit_test to use SSunit_test_config UT for logging."
+  - rscadd: "Added an exception catcher, defined only during unit tests, that fails the CI in case an exception is rised."


### PR DESCRIPTION
Reworked SSunit_test to use SSunit_test_config UT for logging.
Added an exception catcher, defined only during unit tests, that fails the CI in case an exception is rised.