### PR TITLE
Dominia Major L (AI interaction with APC power channels fix)

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -267,7 +267,10 @@ var/list/ai_verbs_default = list(
 		health = maxHealth - getFireLoss() - getBruteLoss() // Oxyloss is not part of health as it represents AIs backup power. AI is immune against ToxLoss as it is machine.
 
 /mob/living/silicon/ai/proc/setup_icon()
-	var/datum/custom_synth/sprite = robot_custom_icons[name]
+	var/datum/custom_synth/sprite = null
+	if(robot_custom_icons)
+		sprite = robot_custom_icons[name]
+
 	if(istype(sprite) && sprite.synthckey == ckey)
 		custom_sprite = TRUE
 		icon = CUSTOM_ITEM_SYNTH

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1158,6 +1158,7 @@
 	data["power_cell_charge"] = cell?.percent()
 	data["fail_time"] = failure_timer * 2
 	data["silicon_user"] = isAdmin || issilicon(user)
+	data["is_AI"] = isAI(user)
 	data["total_load"] = round(lastused_total)
 	data["total_charging"] = round(lastused_charging)
 	data["is_operating"] = operating

--- a/html/changelogs/fluffyghost-fixaiapcpowerchannels.yml
+++ b/html/changelogs/fluffyghost-fixaiapcpowerchannels.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed AI not being able to interact with APC power channels, the borgs still remain locked out of it."
+  - bugfix: "Resolved a runtime on AI spawn when trying to pick a custom sprite from an empty list of custom sprites."

--- a/tgui/packages/tgui/interfaces/Apc.tsx
+++ b/tgui/packages/tgui/interfaces/Apc.tsx
@@ -9,6 +9,7 @@ export type APCData = {
   power_cell_charge: number;
   fail_time: number;
   silicon_user: BooleanLike;
+  is_AI: BooleanLike;
   total_load: number;
   total_charging: number;
   is_operating: BooleanLike;
@@ -170,7 +171,7 @@ export const APCWindow = (props, context) => {
                 [{channelStatus(channel.status)}] | [
                 {channelPower(channel.status)}] | {channel.power_load} W
               </Box>
-              {!data.locked && !data.silicon_user ? (
+              {(!data.locked && !data.silicon_user) || data.is_AI ? (
                 <Section>
                   <Button
                     content="Auto"
@@ -224,7 +225,7 @@ export const APCWindow = (props, context) => {
           </LabeledList.Item>
         </LabeledList>
       </Section>
-      {data.silicon_user ? (
+      {data.silicon_user || data.is_AI ? (
         <Section title="System Overrides">
           <Button
             content="Overload Lighting Circuit"


### PR DESCRIPTION
"I'm sorry, Zhao, I can't do that" _turns off the lights_

Fixed AI not being able to interact with APC power channels, the borgs still remain locked out of it.
Resolved a runtime on AI spawn when trying to pick a custom sprite from an empty list of custom sprites.

Fixes #16880 