### PR TITLE
Fixed air controller temperature input

### DIFF
--- a/code/__defines/math_physics.dm
+++ b/code/__defines/math_physics.dm
@@ -16,9 +16,14 @@
 #define RADIATOR_EXPOSED_SURFACE_AREA_RATIO 0.04 // (3 cm + 100 cm * sin(3deg))/(2*(3+100 cm)). Unitless ratio.
 #define HUMAN_EXPOSED_SURFACE_AREA          5.2 //m^2, surface area of 1.7m (H) x 0.46m (D) cylinder
 
-#define T0C  273.15 //    0.0 degrees celcius
-#define T20C 293.15 //   20.0 degrees celcius
-#define TCMB 2.7    // -270.3 degrees celcius
+/// 0.0 Degrees celsius, in Kelvin
+#define T0C  273.15
+
+/// 20.0 Degrees celsius, in Kelvin
+#define T20C 293.15
+
+/// -270.3 degrees celsius, in Kelvin
+#define TCMB 2.7
 
 #define QUANTIZE(variable) (round(variable,0.0001))
 #define ROUND_UP(x) ( -round(-(x)))

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -779,7 +779,7 @@ pixel_x = 10;
 		var/list/selected = TLV["temperature"]
 		var/max_temperature = min(selected[3] - T0C, MAX_TEMPERATURE)
 		var/min_temperature = max(selected[2] - T0C, MIN_TEMPERATURE)
-		var/input_temperature = tgui_input_number(usr, "What temperature would you like the system to mantain?", "Thermostat Controls", target_temperature - T0C, max_temperature - T0C, min_temperature - T0C)
+		var/input_temperature = tgui_input_number(usr, "What temperature would you like the system to mantain?", "Thermostat Controls", target_temperature - T0C, max_temperature, min_temperature)
 		if(isnum(input_temperature))
 			var/temp = Clamp(input_temperature, min_temperature, max_temperature)
 			if(input_temperature > max_temperature || input_temperature < min_temperature)

--- a/html/changelogs/fluffyghost-fixaircontrollertempinput.yml
+++ b/html/changelogs/fluffyghost-fixaircontrollertempinput.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed air controller temperature input."
+  - backend: "DMdoc for the temperature defines that are used to convert to/from Kelvin to/from Celsius."


### PR DESCRIPTION
Fixed air controller temperature input.
DMdoc for the temperature defines that are used to convert to/from Kelvin to/from Celsius.

Fixes #17778 