### PR TITLE
TGUI Lint Fix

### DIFF
--- a/html/changelogs/SleepyGemmy-tgui_lint_fix.yml
+++ b/html/changelogs/SleepyGemmy-tgui_lint_fix.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed a TGUI lint issue."

--- a/tgui/packages/tgui/interfaces/FlavorText.tsx
+++ b/tgui/packages/tgui/interfaces/FlavorText.tsx
@@ -11,7 +11,7 @@ export type FlavorTextData = {
 const Linkify = ({ text }) => {
   const isUrl = (word) => {
     const urlPattern =
-      /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/gm;
+      /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/gm;
     return word.match(urlPattern);
   };
 


### PR DESCRIPTION
this PR fixes a TGUI lint issue that produces a warning message in all PRs checks.

```
Check warning on line 14 in tgui/packages/tgui/interfaces/FlavorText.tsx
[GitHub Actions / Lint TGUI]

Unnecessary escape character: \-
Unnecessary escape character: \.
```