### PR TITLE
Adds Expedition Shotguns And Machetes to Mining

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -58,13 +58,3 @@
 /obj/structure/closet/secure_closet/guncabinet/exped
 	name = "expedition gun cabinet"
 	req_access = list(access_mining, access_xenoarch)
-
-/obj/structure/closet/secure_closet/guncabinet/exped/fill()
-	new /obj/item/gun/energy/laser/shotgun/research(src)
-	new /obj/item/gun/energy/laser/shotgun/research(src)
-	new /obj/item/material/hatchet/machete(src)
-	new /obj/item/material/hatchet/machete(src)
-	new /obj/item/material/hatchet/machete(src)
-	new /obj/item/clothing/accessory/holster/utility/machete(src)
-	new /obj/item/clothing/accessory/holster/utility/machete(src)
-	new /obj/item/clothing/accessory/holster/utility/machete(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -64,5 +64,7 @@
 	new /obj/item/gun/energy/laser/shotgun/research(src)
 	new /obj/item/material/hatchet/machete(src)
 	new /obj/item/material/hatchet/machete(src)
+	new /obj/item/material/hatchet/machete(src)
+	new /obj/item/clothing/accessory/holster/utility/machete(src)
 	new /obj/item/clothing/accessory/holster/utility/machete(src)
 	new /obj/item/clothing/accessory/holster/utility/machete(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/guncabinet.dm
@@ -54,3 +54,15 @@
 	new /obj/item/gun/projectile/peac(src)
 	for(var/i = 1 to 3)
 		new /obj/item/ammo_casing/peac(src)
+
+/obj/structure/closet/secure_closet/guncabinet/exped
+	name = "expedition gun cabinet"
+	req_access = list(access_mining, access_xenoarch)
+
+/obj/structure/closet/secure_closet/guncabinet/exped/fill()
+	new /obj/item/gun/energy/laser/shotgun/research(src)
+	new /obj/item/gun/energy/laser/shotgun/research(src)
+	new /obj/item/material/hatchet/machete(src)
+	new /obj/item/material/hatchet/machete(src)
+	new /obj/item/clothing/accessory/holster/utility/machete(src)
+	new /obj/item/clothing/accessory/holster/utility/machete(src)

--- a/html/changelogs/Lavillastrangiato - eelbgone.yml
+++ b/html/changelogs/Lavillastrangiato - eelbgone.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: Lavillastrangiato
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/Lavillastrangiato - eelbgone.yml
+++ b/html/changelogs/Lavillastrangiato - eelbgone.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: DreamySkrell
+author: ChangeMe
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - maptweak: "Xenobotany maint door."
+  - rscadd: "Adds two expedition shotguns and two machetes to mining, accessible only by miners."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -16623,6 +16623,16 @@
 /obj/machinery/camera/network/mining{
 	c_tag = "Mining - Locker Room"
 	},
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Emergency Weaponry";
+	req_access = list(48)
+	},
+/obj/item/gun/energy/laser/shotgun/research,
+/obj/item/gun/energy/laser/shotgun/research,
+/obj/item/material/hatchet/machete/steel,
+/obj/item/material/hatchet/machete/steel,
+/obj/item/clothing/accessory/holster/utility/machete,
+/obj/item/clothing/accessory/holster/utility/machete,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/eva)
 "lIE" = (
@@ -25031,22 +25041,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/loading)
-"rpw" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 10
-	},
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Emergency Weaponry";
-	req_access = list(48)
-	},
-/obj/item/gun/energy/laser/shotgun/research,
-/obj/item/gun/energy/laser/shotgun/research,
-/obj/item/clothing/accessory/holster/utility/machete,
-/obj/item/clothing/accessory/holster/utility/machete,
-/obj/item/material/hatchet/machete/steel,
-/obj/item/material/hatchet/machete/steel,
-/turf/simulated/floor/tiled,
-/area/outpost/mining_main/refinery)
 "rpB" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
@@ -51127,7 +51121,7 @@ hhO
 tgR
 uBi
 tgR
-rpw
+wCx
 dNk
 gZP
 dJT

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -12618,7 +12618,7 @@
 	frequency = 1442;
 	input_tag = "port_prop_in";
 	output_tag = "port_prop_out";
-	sensors = list("port_prop_sensor"="Port Propulsion Sensor")
+	sensors = list("port_prop_sensor"="Port  Propulsion  Sensor")
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
@@ -12945,7 +12945,7 @@
 	frequency = 1442;
 	input_tag = "starboard_prop_in";
 	output_tag = "starboard_prop_out";
-	sensors = list("starboard_prop_sensor"="Starboard  Propulsion  Sensor")
+	sensors = list("starboard_prop_sensor"="Starboard    Propulsion    Sensor")
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion/starboard)
@@ -25031,6 +25031,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/loading)
+"rpw" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	name = "Emergency Weaponry";
+	req_access = list(48)
+	},
+/obj/item/gun/energy/laser/shotgun/research,
+/obj/item/gun/energy/laser/shotgun/research,
+/obj/item/clothing/accessory/holster/utility/machete,
+/obj/item/clothing/accessory/holster/utility/machete,
+/obj/item/material/hatchet/machete/steel,
+/obj/item/material/hatchet/machete/steel,
+/turf/simulated/floor/tiled,
+/area/outpost/mining_main/refinery)
 "rpB" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
@@ -51111,7 +51127,7 @@ hhO
 tgR
 uBi
 tgR
-wCx
+rpw
 dNk
 gZP
 dJT

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -12618,7 +12618,7 @@
 	frequency = 1442;
 	input_tag = "port_prop_in";
 	output_tag = "port_prop_out";
-	sensors = list("port_prop_sensor"="Port    Propulsion    Sensor")
+	sensors = list("port_prop_sensor"="Port Propulsion Sensor")
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
@@ -12945,7 +12945,7 @@
 	frequency = 1442;
 	input_tag = "starboard_prop_in";
 	output_tag = "starboard_prop_out";
-	sensors = list("starboard_prop_sensor"="Starboard        Propulsion        Sensor")
+	sensors = list("starboard_prop_sensor"="Starboard Propulsion Sensor")
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion/starboard)

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -12618,7 +12618,7 @@
 	frequency = 1442;
 	input_tag = "port_prop_in";
 	output_tag = "port_prop_out";
-	sensors = list("port_prop_sensor"="Port  Propulsion  Sensor")
+	sensors = list("port_prop_sensor"="Port    Propulsion    Sensor")
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
@@ -12945,7 +12945,7 @@
 	frequency = 1442;
 	input_tag = "starboard_prop_in";
 	output_tag = "starboard_prop_out";
-	sensors = list("starboard_prop_sensor"="Starboard    Propulsion    Sensor")
+	sensors = list("starboard_prop_sensor"="Starboard        Propulsion        Sensor")
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion/starboard)
@@ -16623,16 +16623,15 @@
 /obj/machinery/camera/network/mining{
 	c_tag = "Mining - Locker Room"
 	},
-/obj/structure/closet/secure_closet/guncabinet{
-	name = "Emergency Weaponry";
-	req_access = list(48)
-	},
-/obj/item/gun/energy/laser/shotgun/research,
-/obj/item/gun/energy/laser/shotgun/research,
-/obj/item/material/hatchet/machete/steel,
-/obj/item/material/hatchet/machete/steel,
+/obj/structure/closet/secure_closet/guncabinet/exped,
+/obj/item/material/hatchet/machete,
+/obj/item/material/hatchet/machete,
+/obj/item/material/hatchet/machete,
 /obj/item/clothing/accessory/holster/utility/machete,
 /obj/item/clothing/accessory/holster/utility/machete,
+/obj/item/clothing/accessory/holster/utility/machete,
+/obj/item/gun/energy/laser/shotgun/research,
+/obj/item/gun/energy/laser/shotgun/research,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/mining_main/eva)
 "lIE" = (


### PR DESCRIPTION
* See title. Two of each are in a locker in mining.
* "Why not buckshot?" Moderately impractical in a vacuum. Also, you can't shoot the expedition shotguns on the Horizon.
* I am not sufficiently skilled at coding to edit simplemob AI, or make certain mobs only spawn in certain sectors (seeing as some space fauna like carp and eels are native to the Romanovich Cloud). If that's desired over giving mining the guns, feel free to close this PR and make that one.