### PR TITLE
Fixes and reworks panotoxin

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -487,3 +487,7 @@
 
 /mob/living/carbon/proc/should_have_limb(var/organ_check)
 	return FALSE
+
+/mob/living/carbon/proc/update_accumulated_pain(pain_increment)
+	accumulated_pain += pain_increment
+	return

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -42,3 +42,4 @@
 	var/list/stasis_sources = list()
 	var/stasis_value
 	var/pain_immune = FALSE //for special cases where something permanently removes a mob's ability to feel pain
+	var/accumulated_pain = 0 //for healing pain at the end of a panotoxin poisoning

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -413,8 +413,8 @@
 
 /obj/item/reagent_containers/syringe/drugs
 	name = "Syringe (drugs)"
-	desc = "Contains aggressive drugs meant for torture."
-	reagents_to_add = list(/singleton/reagent/toxin/panotoxin = 5, /singleton/reagent/drugs/mindbreaker = 10)
+	desc = "Contains aggressive drugs meant for torture. Markered lines denote points at which to stop injecting."
+	reagents_to_add = list(/singleton/reagent/toxin/panotoxin = 1, /singleton/reagent/drugs/cryptobiolin = 4, /singleton/reagent/drugs/mindbreaker = 10)
 
 /obj/item/reagent_containers/syringe/drugs/Initialize()
 	. = ..()


### PR DESCRIPTION
It didn't work before. Now it does! And I've turned one nonfunctional line of code into 30 mostly functional ones and 10 nonfunctional ones. The overdose does not trigger. I do not know why.
Panotoxin HURTS. 1u is able to cause heart failure. Its LD50 is similar to cyanide, because both are obtained in the xenoflora lab by mutating a plant that can mutate in multiple ways. Unlike cyanide, a stabilizer harness alone can get you through virtually any amount, so long as the overdose doesn't work.
While it has you, enjoy a rapid onset of crippling pain and a small variety of custom messages to describe the life-changing agony your character is enduring!
At the end of it, most of the pain is removed. Without that part, you'll actually be out of the game for like 10 minutes per unit.
The torture drugs syringe has been modified to account for panotoxin's lethality. It now contains much less, and the description signals its user to please not inject the whole thing at once.