### PR TITLE
Triglyceride bottle

### DIFF
--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -254,5 +254,5 @@
 	reagents_to_add = list(/singleton/reagent/drink/syrup_caramel = 50)
 
 /obj/item/reagent_containers/glass/bottle/triglyceride
-	name = "Triglyceride Bottle"
+	name = "triglyceride bottle"
 	reagents_to_add = list(/singleton/reagent/nutriment/triglyceride = 60)

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -252,3 +252,7 @@
 /obj/item/reagent_containers/glass/bottle/syrup/caramel
 	name = "caramel syrup dispenser"
 	reagents_to_add = list(/singleton/reagent/drink/syrup_caramel = 50)
+
+/obj/item/reagent_containers/glass/bottle/triglyceride
+	name = "Triglyceride Bottle"
+	reagents_to_add = list(/singleton/reagent/nutriment/triglyceride = 60)

--- a/html/changelogs/fluffyghost-triglyceridebottle.yml
+++ b/html/changelogs/fluffyghost-triglyceridebottle.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a triglyceride bottle."


### PR DESCRIPTION
Added a triglyceride bottle.

Cargo DB insertion:

```
name;supplier;description;categories;price;items;item_mul;access;container_type;groupable;order_by;error_message
triglyceride bottle;vfc;A small bottle. Contains triglyceride.;["medical","hospitality","science"];50;{"triglyceride bottle":{"path":"/obj/item/reagent_containers/glass/bottle/triglyceride","vars":[]}};1;0;crate;1;\N;\N
```
(@Arrow768 )

Implements suggestion https://forums.aurorastation.org/topic/17789-add-triglyceride-chemical-canisters-to-operations-ordering/