### PR TITLE
Nerfs Some Simplemob Damage

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot.dm
@@ -9,7 +9,7 @@
 	maxHealth = 15
 	melee_damage_lower = 10
 	melee_damage_upper = 10
-	armor_penetration = 40
+	armor_penetration = 20
 	attack_flags = DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE
 	break_stuff_probability = 25
 	attacktext = "slashed"

--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_beacon_projectiles.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_beacon_projectiles.dm
@@ -3,7 +3,7 @@
 	damage = 20
 	damage_type = DAMAGE_BURN
 	agony = 20
-	armor_penetration = 40
+	armor_penetration = 20
 	muzzle_type = /obj/effect/projectile/muzzle/stun
 	tracer_type = /obj/effect/projectile/tracer/stun
 	impact_type = /obj/effect/projectile/impact/stun

--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_projectiles.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_projectiles.dm
@@ -1,11 +1,11 @@
 /obj/item/projectile/bullet/pistol/hivebotspike
 	name = "spike"
 	damage = 10
-	armor_penetration = 40
+	armor_penetration = 20
 	sharp = 1
 	embed = 0
 
 /obj/item/projectile/bullet/pistol/hivebotspike/needle
 	name = "needle"
 	damage = 5
-	armor_penetration = 60
+	armor_penetration = 30

--- a/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
@@ -26,7 +26,7 @@
 	harm_intent_damage = 4
 	melee_damage_lower = 15
 	melee_damage_upper = 15
-	armor_penetration = 15
+	armor_penetration = 10
 	attack_flags = DAMAGE_FLAG_EDGE
 	attacktext = "bitten"
 	attack_sound = 'sound/weapons/bite.ogg'
@@ -167,11 +167,11 @@
 	maxHealth = 150
 	health = 150
 
-	speed = 9
+	speed = 6
 
 	melee_damage_lower = 20
 	melee_damage_upper = 20
-	armor_penetration = 25
+	armor_penetration = 15
 
 /mob/living/simple_animal/hostile/carp/bloater
 	name = "bloater"

--- a/html/changelogs/Lavillastrangiato - mobnerf.yml
+++ b/html/changelogs/Lavillastrangiato - mobnerf.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Lavillastrangiato
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Lowers damage values and armor penetration on the spectral eel, space carp, and hivebots."


### PR DESCRIPTION
* An alternative to #17810, after I realized editing damage values are actually really easy.
* Spectral eels, carp, and some hivebot projectiles have all had their damage values and armor penetration values nerfed.
* Eels also have a reduced speed value, in keeping with the fact they are supposed to follow you at a slow and creepy pace.
* With simplemob AI being changed to be very aggressive, these will make existing on a mineral asteroid less ridiculously lethal.
* Reavers remain able to do 30 damage, in keeping with them being more rare.