### PR TITLE
Added support for larger on-mob and item sprites.

### DIFF
--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -1224,3 +1224,39 @@ lighting determines lighting capturing (optional), suppress_errors suppreses err
 
 	var/icon/I = getFlatIcon(thing)
 	return icon2html(I, target, sourceonly = sourceonly)
+
+/**
+ * Centers an image.
+ * Requires:
+ * The Image
+ * The x dimension of the icon file used in the image
+ * The y dimension of the icon file used in the image
+ * eg: center_image(image_to_center, 32,32)
+ * eg2: center_image(image_to_center, 96,96)
+**/
+/proc/center_image(image/image_to_center, x_dimension = 0, y_dimension = 0)
+	if(!image_to_center)
+		return
+
+	if(!x_dimension || !y_dimension)
+		return
+
+	if((x_dimension == world.icon_size) && (y_dimension == world.icon_size))
+		return image_to_center
+
+	//Offset the image so that its bottom left corner is shifted this many pixels
+	//This makes it infinitely easier to draw larger inhands/images larger than world.iconsize
+	//but still use them in game
+	var/x_offset = -((x_dimension / world.icon_size) - 1) * (world.icon_size * 0.5)
+	var/y_offset = -((y_dimension / world.icon_size) - 1) * (world.icon_size * 0.5)
+
+	//Correct values under world.icon_size
+	if(x_dimension < world.icon_size)
+		x_offset *= -1
+	if(y_dimension < world.icon_size)
+		y_offset *= -1
+
+	image_to_center.pixel_x = x_offset
+	image_to_center.pixel_y = y_offset
+
+	return image_to_center

--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -1227,12 +1227,15 @@ lighting determines lighting capturing (optional), suppress_errors suppreses err
 
 /**
  * Centers an image.
+ *
  * Requires:
- * The Image
- * The x dimension of the icon file used in the image
- * The y dimension of the icon file used in the image
- * eg: center_image(image_to_center, 32,32)
- * eg2: center_image(image_to_center, 96,96)
+ * * The Image
+ * * The x dimension of the icon file used in the image
+ * * The y dimension of the icon file used in the image
+ *
+ * Examples:
+ * * center_image(image_to_center, 32,32)
+ * * center_image(image_to_center, 96,96)
 **/
 /proc/center_image(image/image_to_center, x_dimension = 0, y_dimension = 0)
 	if(!image_to_center)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -18,6 +18,11 @@
 
 	var/storage_cost
 
+	///Dimensions of the icon file used when this item is worn, eg: hats.dmi (32x32 sprite, 64x64 sprite, etc.). Allows inhands/worn sprites to be of any size, but still centered on a mob properly
+	var/worn_x_dimension = 32
+	///Dimensions of the icon file used when this item is worn, eg: hats.dmi (32x32 sprite, 64x64 sprite, etc.). Allows inhands/worn sprites to be of any size, but still centered on a mob properly
+	var/worn_y_dimension = 32
+
 	/**
 	 * Determines which slots an item can fit, eg. `SLOT_BACK`
 	 *

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -20,6 +20,7 @@
 
 	///Dimensions of the icon file used when this item is worn, eg: hats.dmi (32x32 sprite, 64x64 sprite, etc.). Allows inhands/worn sprites to be of any size, but still centered on a mob properly
 	var/worn_x_dimension = 32
+
 	///Dimensions of the icon file used when this item is worn, eg: hats.dmi (32x32 sprite, 64x64 sprite, etc.). Allows inhands/worn sprites to be of any size, but still centered on a mob properly
 	var/worn_y_dimension = 32
 

--- a/code/game/objects/items/items_icon.dm
+++ b/code/game/objects/items/items_icon.dm
@@ -30,6 +30,9 @@ var/list/mob_icon_icon_states = list()
 				final_I.Insert(canvas, dir = use_dir)
 			LAZYINITLIST(H.species.equip_overlays)
 			var/image/final_image = overlay_image(final_I, color = color, flags = RESET_COLOR|RESET_ALPHA)
+			var/offset_x = worn_x_dimension
+			var/offset_y = worn_y_dimension
+			center_image(final_image, offset_x, offset_y)
 			H.species.equip_overlays[image_key] = final_image
 		var/image/I = new() // We return a copy of the cached image, in case downstream procs mutate it.
 		I.appearance = H.species.equip_overlays[image_key]
@@ -46,6 +49,9 @@ var/list/mob_icon_icon_states = list()
 		I.add_overlay(additional_parts)
 	if(has_accents)
 		I.add_overlay(overlay_image(icon,"[UNDERSCORE_OR_NULL(src.icon_species_tag)][item_state][contained_sprite ? slot_str_to_contained_flag(slot) : ""]_acc",accent_color, RESET_COLOR))
+	var/offset_x = worn_x_dimension
+	var/offset_y = worn_y_dimension
+	center_image(I, offset_x, offset_y)
 	return I
 
 /obj/item/proc/get_image_key_mod()

--- a/html/changelogs/GeneralCamo - Larger Sprites.yml
+++ b/html/changelogs/GeneralCamo - Larger Sprites.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added internal support for larger on-mob and item sprites."


### PR DESCRIPTION
Added backend support for larger on-mob and item sprites, such as 64x64 sprites:

![image](https://github.com/Aurorastation/Aurora.3/assets/1779662/d38642d2-c28c-4d23-85c5-34ff3b0b63fd)

Credit: https://github.com/cmss13-devs/cmss13/pull/2452