### PR TITLE
Moves Telecomms - Part 1 of Command Remapping

### DIFF
--- a/html/changelogs/changelog.yml
+++ b/html/changelogs/changelog.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ReadThisNamePlz
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Moves Telecommunications to be closer to D3 Engineering. Part one of a two part command remap."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -44,14 +44,11 @@
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/tcommsat/chamber)
 "aca" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, telecomms"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/turf/simulated/floor/reinforced/airless,
+/area/template_noop)
 "ach" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/warning,
@@ -231,26 +228,13 @@
 /turf/simulated/floor/plating,
 /area/medical/equipment)
 "agn" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green,
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/airlock/maintenance{
-	dir = 4;
-	req_one_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/turf/simulated/floor/reinforced/airless,
+/area/tcommsat/chamber)
 "agp" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/polarized/firedoor{
 	id = "holodecktint_a"
@@ -430,6 +414,18 @@
 "akQ" = (
 /turf/simulated/floor/tiled/dark,
 /area/horizon/longbow)
+"ale" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "amy" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -2414,6 +2410,15 @@
 /obj/effect/shuttle_landmark/horizon/exterior/deck_3/portaft,
 /turf/template_noop,
 /area/template_noop)
+"bVd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "bVX" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -2748,10 +2753,10 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "cih" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -2983,18 +2988,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/holodeck_control/beta)
-"cxo" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
 "cyz" = (
 /turf/simulated/floor/beach/water/alt,
 /area/horizon/hallway/deck_three/primary/starboard)
@@ -3060,9 +3053,12 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/substation/command)
 "cBq" = (
-/obj/machinery/bluespacerelay,
-/turf/simulated/floor/bluegrid,
-/area/tcommsat/chamber)
+/obj/machinery/computer/telecomms/traffic,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/tcommsat/entrance)
 "cBs" = (
 /obj/item/hullbeacon/red,
 /obj/structure/sign/securearea{
@@ -3148,26 +3144,6 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/command)
-"cGa" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8;
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	icon_state = "map_vent_in";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 1
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
 "cGh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/platform_stairs/full/south_north_cap,
@@ -3648,6 +3624,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
+"dcq" = (
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/turf/simulated/floor/tiled/dark/full,
+/area/tcommsat/chamber)
 "dcJ" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -3834,9 +3817,23 @@
 /turf/simulated/floor/wood,
 /area/journalistoffice)
 "diz" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/item/device/radio/intercom/south,
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "djp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -4375,23 +4372,8 @@
 /turf/simulated/wall,
 /area/maintenance/substation/civilian_east)
 "dHD" = (
-/obj/item/device/radio/intercom/south,
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor,
+/area/bridge)
 "dHJ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5045,15 +5027,14 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "eih" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/structure/curtain/black,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "eiD" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -5741,11 +5722,20 @@
 /turf/simulated/open,
 /area/horizon/hallway/deck_three/primary/central)
 "eEX" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/entrance)
@@ -5801,12 +5791,24 @@
 /turf/simulated/floor/carpet/rubber,
 /area/bridge/controlroom)
 "eGa" = (
-/obj/effect/floor_decal/spline/plain{
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/maintenance/engineering_ladder)
 "eGq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
@@ -7106,8 +7108,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/storage/shields)
 "fCi" = (
-/turf/simulated/floor/wood,
-/area/bridge)
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "fCl" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/cable/green{
@@ -7353,14 +7359,8 @@
 /turf/simulated/open,
 /area/horizon/hallway/deck_three/primary/central)
 "fLs" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/turf/simulated/wall/r_wall,
+/area/storage/shields)
 "fMl" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -7757,25 +7757,8 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "fZX" = (
-/obj/machinery/camera/motion{
-	c_tag = "Telecommunications - Starboard";
-	dir = 4;
-	network = list("Command","Security","Telecommunications")
-	},
-/obj/effect/floor_decal/spline/plain/corner,
-/obj/effect/floor_decal/spline/plain/corner{
+/obj/effect/floor_decal/spline/plain/cee{
 	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	external_pressure_bound = 140;
-	external_pressure_bound_default = 140;
-	icon_state = "map_vent_out";
-	pressure_checks = 0;
-	pressure_checks_default = 0;
-	use_power = 1
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 9
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -7919,6 +7902,27 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/port)
+"gfG" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4;
+	req_one_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "ggl" = (
 /obj/machinery/camera/network/command{
 	c_tag = "Bridge - Corridor Camera 1"
@@ -8128,13 +8132,12 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop/xo)
 "gny" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/closet/crate,
+/obj/item/stack/rods/full,
+/obj/item/stack/rods/full,
+/obj/item/stack/rods/full,
+/obj/item/stack/rods/full,
+/turf/simulated/floor/wood,
 /area/bridge)
 "gnL" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -8648,24 +8651,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/evidence_storage)
 "gIh" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/stool/bar/padded/red,
 /turf/simulated/floor,
-/area/maintenance/engineering_ladder)
+/area/horizon/maintenance/deck_three/aft/starboard)
 "gIr" = (
 /obj/structure/grille/broken,
 /obj/effect/floor_decal/industrial/warning{
@@ -9213,17 +9202,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office_aux)
-"hdE" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/black,
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
 "hed" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -9852,8 +9830,20 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -10369,13 +10359,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/holodeck_control/beta)
 "hSu" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/tcommsat/chamber)
+/turf/simulated/floor/tiled/dark,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "hTq" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -10422,18 +10411,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "hVM" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/hatch{
+	dir = 4;
+	name = "Telecommunications";
+	req_access = list(11,24)
+	},
+/turf/simulated/floor/tiled/full,
+/area/tcommsat/entrance)
 "hWx" = (
 /obj/machinery/ringer_button{
 	id = "Representative";
@@ -10708,26 +10703,11 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/port/docks)
 "ilv" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	icon_state = "map_vent_in";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 1
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor/tiled,
+/area/bridge)
 "ilx" = (
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 1
@@ -11102,22 +11082,13 @@
 /area/horizon/crew_quarters/cryo/washroom)
 "izr" = (
 /obj/effect/floor_decal/spline/plain{
-	dir = 10
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/spline/plain/corner{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/area/tcommsat/chamber)
 "izu" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -11326,12 +11297,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "iGb" = (
-/obj/machinery/computer/telecomms/traffic,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/entrance)
+/turf/simulated/floor/plating,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "iGt" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/white,
@@ -11516,8 +11483,11 @@
 /turf/simulated/floor,
 /area/maintenance/bridge)
 "iMI" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -11525,6 +11495,13 @@
 /obj/effect/floor_decal/spline/plain/corner,
 /obj/effect/floor_decal/spline/plain/corner{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/sign/b{
+	pixel_x = -10;
+	pixel_y = 4
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -11658,19 +11635,11 @@
 /turf/simulated/floor/tiled/full,
 /area/horizon/hallway/deck_three/primary/port)
 "iQF" = (
-/obj/effect/floor_decal/spline/plain{
+/obj/structure/bed/stool/chair/padded/beige{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/sign/a{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor/tiled,
+/area/bridge)
 "iQH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -11757,22 +11726,13 @@
 /turf/simulated/floor/lino,
 /area/horizon/security/investigators_office)
 "iUc" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/sign/d{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/structure/closet/crate,
+/obj/item/stack/rods/full,
+/obj/item/stack/rods/full,
+/obj/item/stack/rods/full,
+/obj/item/stack/rods/full,
+/turf/simulated/floor/tiled,
+/area/bridge)
 "iUf" = (
 /obj/structure/table/standard,
 /obj/machinery/power/apc/north,
@@ -12045,11 +12005,9 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "jdC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "jdI" = (
 /obj/machinery/newscaster/south,
@@ -12482,14 +12440,14 @@
 /turf/simulated/floor/wood,
 /area/horizon/security/meeting_room)
 "jzc" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 6
-	},
-/obj/effect/floor_decal/spline/plain/corner{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge)
 "jzd" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -12648,8 +12606,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering_ladder)
 "jFu" = (
-/obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/rubber,
@@ -13287,20 +13248,14 @@
 /turf/simulated/floor/reinforced/airless,
 /area/horizon/exterior)
 "kgW" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 4;
-	pixel_x = -20
-	},
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_horizon_deck_3_aft_1";
-	name = "airlock_horizon_deck_3_aft_1";
-	frequency = 1001
-	},
+/obj/structure/closet/crate,
+/obj/item/stack/rods/full,
+/obj/item/stack/rods/full,
+/obj/item/stack/rods/full,
+/obj/item/stack/rods/full,
+/obj/item/stack/rods/full,
 /turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/area/bridge)
 "khe" = (
 /obj/structure/closet/walllocker/emerglocker/south,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
@@ -13314,12 +13269,10 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/heads/cmo)
 "khy" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain/corner,
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/structure/table,
+/obj/item/stack/rods/full,
+/turf/simulated/floor/tiled,
+/area/bridge)
 "khK" = (
 /obj/structure/bed/stool/chair/padded/beige{
 	dir = 1
@@ -13389,11 +13342,9 @@
 /turf/simulated/floor/marble/dark,
 /area/bridge/minibar)
 "kkU" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/shuttle/scc_space_ship,
-/turf/simulated/floor/plating,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/machinery/bluespacerelay,
+/turf/simulated/floor/bluegrid,
+/area/tcommsat/chamber)
 "klQ" = (
 /turf/simulated/wall,
 /area/horizon/security/interrogation/monitoring)
@@ -13520,19 +13471,22 @@
 /turf/simulated/floor/wood,
 /area/lawoffice/representative)
 "kqe" = (
+/obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain,
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/sign/m{
-	pixel_x = -10;
-	pixel_y = 4
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -14404,12 +14358,11 @@
 /turf/simulated/wall/r_wall,
 /area/bridge/aibunker)
 "kVK" = (
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/chamber)
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/shuttle/scc_space_ship,
+/turf/simulated/floor/plating,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "kVQ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -14784,6 +14737,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled,
 /area/bridge)
 "lfy" = (
@@ -14824,16 +14778,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
-"lhX" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
 "lhY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -16082,8 +16026,8 @@
 /area/horizon/security/investigations_hallway)
 "mcT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/stool/bar/padded/red,
-/turf/simulated/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "mdb" = (
 /obj/structure/table/reinforced,
@@ -16330,6 +16274,22 @@
 	},
 /turf/simulated/floor/carpet/art,
 /area/crew_quarters/lounge)
+"mnR" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "mop" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/small/south,
@@ -16765,18 +16725,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "mDS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/standard,
-/obj/item/deck/cards,
-/obj/item/storage/box/fancy/cigarettes{
-	pixel_y = 10;
-	pixel_x = -6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "mEf" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/cups,
@@ -17059,15 +17013,8 @@
 /turf/simulated/floor,
 /area/maintenance/security_starboard)
 "mSs" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain/corner,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor/wood,
+/area/bridge)
 "mST" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -19273,11 +19220,12 @@
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "ouv" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/shuttle/scc_space_ship,
-/turf/simulated/floor/plating,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/tcommsat/chamber)
 "ouM" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -19637,14 +19585,11 @@
 /turf/simulated/floor,
 /area/horizon/hallway/deck_three/primary/port/docks)
 "oJa" = (
-/obj/machinery/camera/motion{
-	c_tag = "Telecommunications - Starboard";
-	dir = 4;
-	network = list("Command","Security","Telecommunications");
-	pixel_y = 18
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
-/obj/effect/floor_decal/spline/plain/cee{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -19863,8 +19808,17 @@
 /turf/simulated/floor/tiled/full,
 /area/operations/office_aux)
 "oSn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_horizon_deck_3_aft_1";
+	name = "airlock_horizon_deck_3_aft_1";
+	frequency = 1001
+	},
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "oSL" = (
@@ -20114,11 +20068,14 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical/upper)
 "pcj" = (
-/obj/structure/bed/stool/chair/padded/beige{
+/obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/bridge)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "pcZ" = (
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 6
@@ -20168,6 +20125,21 @@
 /obj/structure/bed/stool/padded/blue,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/evidence_storage)
+"pfn" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = 12;
+	dir = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_horizon_deck_3_aft_1";
+	name = "airlock_horizon_deck_3_aft_1";
+	frequency = 1001
+	},
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "pfL" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -20332,9 +20304,15 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/security/autopsy_laboratory)
 "ppg" = (
-/obj/structure/table,
-/turf/simulated/floor/tiled,
-/area/bridge)
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "ppy" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -21211,11 +21189,21 @@
 /turf/simulated/floor/reinforced/airless,
 /area/horizon/exterior)
 "qkd" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/turf/simulated/floor,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/sign/d{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "qkD" = (
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -21652,20 +21640,11 @@
 /turf/simulated/floor/tiled,
 /area/bridge/bridge_crew)
 "qDx" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 4
-	},
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/structure/cable/green{
-	icon_state = "1-4"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/rubber,
+/turf/simulated/floor/reinforced/airless,
 /area/tcommsat/chamber)
 "qDU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
@@ -21938,6 +21917,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/longbow)
+"qQF" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "qQY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -21952,11 +21942,12 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "qSd" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/bridge)
+/obj/machinery/alarm/tcom/north,
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "qSG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -21971,24 +21962,9 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical/upper)
 "qSY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/airlock/hatch{
-	dir = 4;
-	name = "Telecommunications";
-	req_access = list(11,24)
-	},
-/turf/simulated/floor/tiled/full,
-/area/tcommsat/entrance)
+/obj/structure/sign/electricshock,
+/turf/simulated/wall/r_wall,
+/area/tcommsat/chamber)
 "qTN" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -22323,22 +22299,9 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/bridge/aibunker)
 "rlN" = (
-/obj/effect/floor_decal/sign/c{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "rmh" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
@@ -22361,22 +22324,19 @@
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
 "rml" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/effect/floor_decal/sign/a{
+	pixel_x = -10;
+	pixel_y = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "rmQ" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
@@ -22498,15 +22458,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/holodeck_control/beta)
 "rpI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/machinery/meter,
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/chamber)
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "rpL" = (
 /obj/machinery/power/apc/low/east,
 /obj/structure/cable/green{
@@ -22528,16 +22489,15 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/cafeteria)
 "rqM" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	external_pressure_bound = 140;
-	external_pressure_bound_default = 140;
-	icon_state = "map_vent_out";
-	pressure_checks = 0;
-	pressure_checks_default = 0;
-	use_power = 1
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 8
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -22810,11 +22770,27 @@
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/port/docks)
 "rzm" = (
-/turf/simulated/wall/r_wall,
-/area/storage/shields)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/standard,
+/obj/item/deck/cards,
+/obj/item/storage/box/fancy/cigarettes{
+	pixel_y = 10;
+	pixel_x = -6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "rzs" = (
-/obj/structure/sign/electricshock,
-/turf/simulated/wall/r_wall,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "rzG" = (
 /obj/structure/disposalpipe/segment{
@@ -23278,16 +23254,14 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "rQB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
 	},
-/obj/machinery/meter,
-/obj/effect/floor_decal/spline/plain{
-	dir = 9
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "rQI" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
 /obj/machinery/light/spot{
@@ -23296,9 +23270,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/holodeck_control)
 "rQO" = (
-/obj/effect/floor_decal/spline/plain/cee{
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain/corner{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "rRe" = (
@@ -23488,14 +23471,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
 "rYv" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/full,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "rYH" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
@@ -23579,18 +23566,14 @@
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "scd" = (
-/obj/machinery/power/apc/super/critical/north,
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/rubber,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/turf/simulated/floor/tiled/dark/full,
 /area/tcommsat/chamber)
 "scL" = (
 /obj/effect/floor_decal/corner/brown{
@@ -23887,11 +23870,19 @@
 /turf/simulated/floor/tiled/freezer,
 /area/horizon/crew_quarters/fitness/showers)
 "skx" = (
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, telecomms"
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/obj/machinery/atmospherics/unary/vent_pump{
+	external_pressure_bound = 140;
+	external_pressure_bound_default = 140;
+	icon_state = "map_vent_out";
+	pressure_checks = 0;
+	pressure_checks_default = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "slc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -24136,12 +24127,13 @@
 /turf/simulated/floor/tiled/full,
 /area/journalistoffice)
 "stN" = (
-/obj/machinery/door/airlock/external,
-/obj/machinery/access_button{
-	pixel_x = 28
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 4;
+	pixel_x = -20
+	},
 /obj/effect/map_effect/marker/airlock{
 	master_tag = "airlock_horizon_deck_3_aft_1";
 	name = "airlock_horizon_deck_3_aft_1";
@@ -24794,14 +24786,9 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "sVD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/stool/bar/padded/red,
-/turf/simulated/floor/tiled/dark,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/structure/table,
+/turf/simulated/floor/tiled,
+/area/bridge)
 "sVV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25002,23 +24989,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
-"teU" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
 "tfg" = (
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 6
@@ -25054,14 +25024,11 @@
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/entrance)
 "tfE" = (
-/obj/structure/curtain/black,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/turf/simulated/floor/tiled,
+/area/bridge)
 "thi" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/engineering/break_room)
@@ -25151,12 +25118,9 @@
 /turf/simulated/floor/lino,
 /area/horizon/cafeteria)
 "tka" = (
-/obj/effect/floor_decal/spline/plain/cee{
-	dir = 1
-	},
-/obj/machinery/alarm/tcom/north,
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "tkE" = (
 /obj/machinery/blackbox_recorder,
 /turf/simulated/floor/bluegrid,
@@ -25541,24 +25505,24 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "tyQ" = (
-/obj/machinery/light/small/emergency,
-/turf/simulated/floor,
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/shuttle/scc_space_ship,
+/turf/simulated/floor/plating,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "tzE" = (
-/obj/machinery/door/airlock/external,
-/obj/machinery/access_button{
-	pixel_x = -28;
-	pixel_y = 12;
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_horizon_deck_3_aft_1";
-	name = "airlock_horizon_deck_3_aft_1";
-	frequency = 1001
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "tzM" = (
 /obj/machinery/power/apc/west,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -25592,6 +25556,15 @@
 	dir = 5
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
+"tAC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "tAY" = (
@@ -26289,6 +26262,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
+"tYH" = (
+/obj/machinery/camera/motion{
+	c_tag = "Telecommunications - Starboard";
+	dir = 4;
+	network = list("Command","Security","Telecommunications");
+	pixel_y = 18
+	},
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "tZE" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
@@ -26697,7 +26682,19 @@
 /turf/simulated/floor/tiled,
 /area/horizon/stairwell/central)
 "utv" = (
-/obj/effect/decal/remains/rat,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
@@ -27239,18 +27236,10 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/investigations_hallway)
 "uMW" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/effect/decal/remains/rat,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "uNc" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -27624,10 +27613,17 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
 /obj/effect/floor_decal/spline/plain,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/sign/m{
+	pixel_x = -10;
+	pixel_y = 4
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "vcJ" = (
@@ -28042,18 +28038,10 @@
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
 "vpR" = (
-/obj/effect/floor_decal/spline/plain/corner,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain/corner{
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/black,
+/obj/effect/floor_decal/spline/plain/corner,
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "vrD" = (
@@ -28441,8 +28429,19 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop/xo)
 "vEP" = (
-/turf/simulated/floor,
-/area/bridge)
+/obj/machinery/power/apc/super/critical/north,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "vFz" = (
 /turf/simulated/wall,
 /area/horizon/hallway/deck_three/primary/central)
@@ -28733,7 +28732,11 @@
 /area/bridge/controlroom)
 "vPA" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/stool/bar/padded/red,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "vQi" = (
@@ -29370,8 +29373,15 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/port)
 "wqk" = (
-/turf/simulated/floor/plating,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "wqn" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -29763,11 +29773,21 @@
 /turf/simulated/floor/reinforced/airless,
 /area/template_noop)
 "wGR" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "wHl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -29991,25 +30011,25 @@
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice)
 "wOl" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/machinery/camera/motion{
+	c_tag = "Telecommunications - Starboard";
+	dir = 4;
+	network = list("Command","Security","Telecommunications")
 	},
 /obj/effect/floor_decal/spline/plain/corner,
 /obj/effect/floor_decal/spline/plain/corner{
-	dir = 8
+	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_pump{
+	external_pressure_bound = 140;
+	external_pressure_bound_default = 140;
+	icon_state = "map_vent_out";
+	pressure_checks = 0;
+	pressure_checks_default = 0;
+	use_power = 1
 	},
-/obj/effect/floor_decal/sign/b{
-	pixel_x = -10;
-	pixel_y = 4
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -30310,13 +30330,18 @@
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
 "wWk" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
+/obj/effect/floor_decal/sign/c{
+	pixel_x = -10;
+	pixel_y = 4
 	},
-/obj/effect/floor_decal/spline/plain/corner{
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain{
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/rubber,
@@ -30555,6 +30580,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/controlroom)
+"xfK" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "xfV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45974,9 +46011,9 @@ wGH
 wGH
 wGH
 oXs
-kkU
-ouv
-ouv
+tyQ
+kVK
+kVK
 oXs
 oXs
 oXs
@@ -46177,7 +46214,7 @@ oXs
 oXs
 oXs
 kLs
-oSn
+jdC
 bOL
 lsr
 nwE
@@ -46376,15 +46413,15 @@ wGH
 wGH
 oXs
 niZ
-kgW
+stN
 oXs
 rvi
-tyQ
+tka
 cGI
-mDS
-mcT
+rzm
+gIh
 pAw
-diz
+rlN
 fWM
 pAw
 pAw
@@ -46576,14 +46613,14 @@ wGH
 wGH
 wGH
 wGH
-tzE
+pfn
 jZS
 bOz
-stN
+oSn
 qDU
-utv
+uMW
 eZu
-sVD
+vPA
 jZN
 pAw
 myt
@@ -46782,10 +46819,10 @@ oXs
 nJR
 ecm
 oXs
-fLs
-aca
-vPA
-jdC
+pcj
+tAC
+mcT
+hSu
 eZu
 pAw
 lzQ
@@ -46985,9 +47022,9 @@ abZ
 rRe
 oXs
 ail
-rYv
+rQB
 wjr
-jdC
+hSu
 pAw
 pAw
 pAw
@@ -47179,7 +47216,7 @@ wGH
 wGH
 wGH
 abZ
-fZX
+wOl
 cIn
 cIn
 wUx
@@ -47189,7 +47226,7 @@ wIu
 wIu
 wIu
 wIu
-tfE
+eih
 pAw
 cuy
 aCw
@@ -47381,10 +47418,10 @@ wGH
 wGH
 wGH
 abZ
-eih
+jFu
 wug
 xSg
-iQF
+rml
 qUt
 sCe
 hIp
@@ -47586,8 +47623,8 @@ abZ
 dgI
 fZq
 pUC
-lhX
-kVK
+ppg
+dcq
 hSf
 ldS
 xSp
@@ -47785,14 +47822,14 @@ wGH
 wGH
 abZ
 abZ
+vEP
+oJa
+oJa
+mnR
 scd
-hxX
-hxX
-qDx
-rpI
 ime
 tfz
-eEX
+bVd
 ood
 wIu
 cNX
@@ -47987,12 +48024,12 @@ cOf
 whh
 abZ
 tkE
-khy
-rqM
-eGa
-hdE
-rzs
-iGb
+vpR
+skx
+mDS
+qQF
+qSY
+cBq
 uJY
 dED
 wnD
@@ -48189,12 +48226,12 @@ coC
 wGH
 abZ
 nMa
-vcD
+wqk
 aNM
 kxn
-wOl
+iMI
 sUT
-rQB
+rpI
 aQZ
 bYI
 wUL
@@ -48390,11 +48427,11 @@ wGH
 coC
 wGH
 abZ
-cBq
-vcD
+kkU
+wqk
 guk
 mUk
-hVM
+tzE
 qUt
 pVj
 jaU
@@ -48593,10 +48630,10 @@ raS
 wGH
 abZ
 ieD
-mSs
+rzs
 ekB
 ekB
-dHD
+diz
 qUt
 wIu
 mxO
@@ -48795,16 +48832,16 @@ wGH
 wGH
 abZ
 abZ
-jFu
+fCi
 wlV
 qmy
-rlN
+wWk
 qUt
 vIy
-izr
+eEX
 qNB
 wIu
-rml
+utv
 ygn
 fsw
 pAw
@@ -49001,7 +49038,7 @@ hCP
 hvY
 gEi
 mxB
-hSu
+agn
 dCR
 atW
 ssd
@@ -49199,11 +49236,11 @@ wGH
 wGH
 wGH
 abZ
-iMI
-ilv
+rqM
+hxX
 cIn
-vpR
-wGR
+rQO
+qDx
 uCC
 wbR
 vSg
@@ -49247,17 +49284,17 @@ jOD
 jOD
 jOD
 lbL
-ppg
-fCi
+sVD
+mSs
 cNU
 cNU
-qSd
+tfE
 cNU
-vEP
-vEP
-vEP
-vEP
-qSd
+dHD
+dHD
+dHD
+dHD
+tfE
 ylG
 vQU
 fQA
@@ -49401,10 +49438,10 @@ wGH
 wGH
 wGH
 abZ
-oJa
+tYH
 sHH
 hDQ
-iUc
+qkd
 qUt
 lyA
 eVA
@@ -49449,17 +49486,17 @@ wyk
 nkG
 izo
 lbL
-ppg
-vEP
-fCi
-fCi
+sVD
+dHD
+mSs
+mSs
 cNU
 cNU
 cNU
-fCi
-fCi
-fCi
-fCi
+mSs
+mSs
+mSs
+mSs
 lbL
 soE
 soE
@@ -49606,13 +49643,13 @@ abZ
 abZ
 kpN
 tUy
-uMW
+rYv
 qUt
 wIu
-qSY
+hVM
 wIu
 wIu
-agn
+gfG
 pAw
 pAw
 jbh
@@ -49651,17 +49688,17 @@ edN
 jOD
 jOD
 lbL
-lfv
+ilv
 cNU
-vEP
-vEP
-ppg
-ppg
+dHD
+dHD
+sVD
+khy
+iUc
 cNU
-cNU
-ppg
-fCi
-vEP
+sVD
+gny
+dHD
 lbL
 rqN
 sVv
@@ -49806,14 +49843,14 @@ wGH
 wGH
 wGH
 abZ
-tka
-wWk
-teU
+qSd
+xfK
+wGR
 qUt
 wIu
 jFn
 hPy
-wqk
+iGb
 kVQ
 pAw
 pAw
@@ -49853,17 +49890,17 @@ tfi
 sum
 sRf
 lbL
-ppg
+sVD
 cNU
-fCi
-fCi
-ppg
+mSs
+mSs
+sVD
 tjC
 cNU
 cNU
-ppg
-fCi
-vEP
+sVD
+mSs
+dHD
 lbL
 qEI
 ipX
@@ -50006,11 +50043,11 @@ wGH
 wGH
 wGH
 wGH
-skx
+aca
 abZ
 fmB
 fHi
-kqe
+vcD
 mYf
 vtf
 kIk
@@ -50055,16 +50092,16 @@ cBm
 cBm
 cBm
 lbL
-ppg
-pcj
-vEP
-vEP
+sVD
+iQF
+dHD
+dHD
 cNU
 cNU
 cNU
 cNU
-ppg
-fCi
+sVD
+mSs
 cNU
 lbL
 ugJ
@@ -50212,7 +50249,7 @@ wGH
 abZ
 vvm
 sdc
-cGa
+kqe
 mzs
 afj
 bbm
@@ -50257,16 +50294,16 @@ cQL
 tdH
 uBr
 lbL
-ppg
+sVD
 cNU
-vEP
-fCi
-vEP
+dHD
+mSs
+dHD
 cNU
 cNU
 cNU
-vEP
-vEP
+dHD
+dHD
 cNU
 lbL
 dIk
@@ -50415,9 +50452,9 @@ abZ
 eBt
 iLf
 dgI
-qkd
+ouv
 afj
-gIh
+eGa
 qLy
 pWR
 pWR
@@ -50463,9 +50500,9 @@ lfv
 cNU
 cNU
 cNU
-vEP
-vEP
-vEP
+dHD
+dHD
+dHD
 cNU
 cNU
 cNU
@@ -50614,12 +50651,12 @@ feY
 hBq
 wGH
 abZ
-rQO
-cxo
-jzc
+fZX
+ale
+izr
 qUt
 afj
-gIh
+eGa
 qLy
 aiX
 xbM
@@ -50663,14 +50700,14 @@ vIv
 vIv
 vIv
 lbL
-ppg
+sVD
 cNU
-vEP
-vEP
+dHD
+dHD
 kHy
-ppg
-ppg
-vEP
+sVD
+sVD
+kgW
 cNU
 lbL
 soE
@@ -50821,7 +50858,7 @@ qUt
 qUt
 qUt
 lMh
-gIh
+eGa
 aaz
 kTG
 kTG
@@ -50865,14 +50902,14 @@ ozN
 wxR
 fTY
 lbL
-ppg
-pcj
-vEP
-vEP
-vEP
+sVD
+iQF
+dHD
+dHD
+dHD
 cNU
 cNU
-vEP
+dHD
 cNU
 lbL
 vpB
@@ -51017,13 +51054,13 @@ feY
 feY
 hBq
 ilL
-rzm
-rzm
-rzm
-rzm
-rzm
+fLs
+fLs
+fLs
+fLs
+fLs
 qLy
-gIh
+eGa
 qLy
 isK
 hCT
@@ -51067,14 +51104,14 @@ wMV
 fWo
 jdI
 lbL
-ppg
+sVD
 cNU
-vEP
-vEP
+dHD
+dHD
 cNU
 cNU
 cNU
-vEP
+dHD
 cNU
 uZE
 vcu
@@ -51225,7 +51262,7 @@ tNk
 raP
 eoQ
 qLy
-gIh
+eGa
 qLy
 bpD
 bpD
@@ -51269,7 +51306,7 @@ xDX
 hig
 uPp
 lbL
-lfv
+ilv
 cNU
 cNU
 cNU
@@ -51882,7 +51919,7 @@ eeW
 cPM
 qWk
 szZ
-gny
+cih
 kYP
 lbL
 kSF
@@ -52084,7 +52121,7 @@ dMl
 tav
 uow
 svL
-cih
+jzc
 htr
 lbL
 caX

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -44,36 +44,14 @@
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/tcommsat/chamber)
 "aca" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 6
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
 	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8;
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	icon_state = "map_vent_in";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 1
-	},
-/obj/machinery/light,
-/obj/machinery/camera/motion{
-	c_tag = "Telecommunications - Port";
-	dir = 8;
-	network = list("Command","Security","Telecommunications")
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "ach" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/warning,
@@ -253,9 +231,24 @@
 /turf/simulated/floor/plating,
 /area/medical/equipment)
 "agn" = (
-/obj/structure/closet/crate,
-/obj/random/junk,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4;
+	req_one_access = list(12)
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "agp" = (
@@ -326,7 +319,12 @@
 "ail" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "aiv" = (
 /obj/structure/disposalpipe/segment{
@@ -375,8 +373,7 @@
 /obj/effect/floor_decal/corner/dark_green/diagonal,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/sign/directions/cryo{
-	pixel_y = 29;
-	dir = 2
+	pixel_y = 29
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/crew_quarters/fitness/changing)
@@ -817,8 +814,11 @@
 /turf/simulated/floor/tiled/full,
 /area/horizon/hallway/deck_three/primary/starboard)
 "aCw" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/rack,
+/obj/random/loot,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "aCy" = (
@@ -875,9 +875,7 @@
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "airlock_horizon_dock_deck_3_port_2";
 	name = "airlock_horizon_dock_deck_3_port_2";
@@ -897,8 +895,7 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/access_button{
 	pixel_x = -22;
-	pixel_y = 32;
-	dir = 2
+	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/port/docks)
@@ -1150,18 +1147,24 @@
 /turf/simulated/floor/tiled/full,
 /area/horizon/security/meeting_room)
 "aQZ" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 4;
-	name = "Distro to Airlock";
-	target_pressure = 200
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/obj/machinery/alarm/north,
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "aRy" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -1503,6 +1506,9 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "bbA" = (
@@ -1631,9 +1637,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/break_room)
 "bgx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
 	},
@@ -1723,9 +1726,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
 	},
 /obj/structure/platform{
 	dir = 4
@@ -2137,7 +2137,7 @@
 	name = "Viewing Shutter"
 	},
 /turf/simulated/floor,
-/area/tcommsat/entrance)
+/area/bridge)
 "bJR" = (
 /obj/machinery/power/portgen/basic,
 /obj/item/stack/material/graphite/full,
@@ -2296,10 +2296,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/longbow)
 "bOL" = (
-/obj/structure/filingcabinet/filingcabinet{
-	pixel_x = -9;
-	pixel_y = 1
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
@@ -2475,9 +2473,17 @@
 /turf/simulated/floor,
 /area/maintenance/security_starboard)
 "bYI" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "bZx" = (
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 8
@@ -2630,9 +2636,7 @@
 /area/bridge/minibar)
 "ceE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
 	pixel_x = -28;
 	pixel_y = 12;
@@ -2666,6 +2670,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/storage/shields)
 "cfr" = (
@@ -2686,12 +2693,11 @@
 /turf/simulated/floor/tiled/full,
 /area/maintenance/security_starboard)
 "cfB" = (
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/entrance)
+/turf/simulated/floor/tiled,
+/area/bridge)
 "cfP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2742,9 +2748,6 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "cih" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2925,6 +2928,9 @@
 /obj/random/loot,
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "cuP" = (
@@ -2977,6 +2983,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/holodeck_control/beta)
+"cxo" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "cyz" = (
 /turf/simulated/floor/beach/water/alt,
 /area/horizon/hallway/deck_three/primary/starboard)
@@ -3042,15 +3060,8 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/substation/command)
 "cBq" = (
-/obj/effect/floor_decal/sign/d{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain,
-/turf/simulated/floor/carpet/rubber,
+/obj/machinery/bluespacerelay,
+/turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "cBs" = (
 /obj/item/hullbeacon/red,
@@ -3137,6 +3148,26 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/substation/command)
+"cGa" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "cGh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/platform_stairs/full/south_north_cap,
@@ -3182,8 +3213,8 @@
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
 "cGI" = (
-/obj/structure/bed/stool/padded/black,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/stool/bar/padded/red,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "cGU" = (
@@ -3343,7 +3374,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/low/north,
 /obj/structure/cable/green{
 	d2 = 2;
@@ -3804,12 +3834,8 @@
 /turf/simulated/floor/wood,
 /area/journalistoffice)
 "diz" = (
-/obj/structure/window/shuttle/scc_space_ship,
-/obj/machinery/door/firedoor,
-/obj/structure/grille/diagonal{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "djp" = (
 /obj/structure/disposalpipe/segment{
@@ -4075,9 +4101,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/railing/mapped{
 	dir = 4
 	},
@@ -4254,10 +4277,17 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/crew_quarters/fitness/changing)
 "dED" = (
-/turf/simulated/floor/tiled/ramp{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 6
 	},
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "dEE" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4345,21 +4375,23 @@
 /turf/simulated/wall,
 /area/maintenance/substation/civilian_east)
 "dHD" = (
-/obj/item/device/radio/intercom/east,
-/obj/effect/floor_decal/spline/plain{
-	dir = 5
+/obj/item/device/radio/intercom/south,
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
 	},
-/obj/structure/coatrack{
-	pixel_x = -10;
-	pixel_y = 25
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
 	},
-/obj/machinery/computer/arcade/battle,
-/obj/machinery/camera/motion{
-	c_tag = "Telecommunications - Spare Parts Room";
-	network = list("Command","Security","Telecommunications")
+/obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/area/tcommsat/chamber)
 "dHJ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4520,9 +4552,6 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/investigations_hallway)
 "dOU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/corner/dark_blue/full,
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
@@ -4596,12 +4625,9 @@
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/port/docks)
 "dSv" = (
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
-	pixel_x = -28;
-	dir = 2
+	pixel_x = -28
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/map_effect/marker/airlock/docking{
@@ -5019,19 +5045,15 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "eih" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/freezer{
-	dir = 1;
-	icon_state = "freezer_1";
-	use_power = 1
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/sign/nosmoking_2{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/tcommsat/entrance)
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "eiD" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -5242,9 +5264,7 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "enU" = (
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "airlock_horizon_dock_deck_3_port_4";
 	name = "airlock_horizon_dock_deck_3_port_4";
@@ -5721,11 +5741,14 @@
 /turf/simulated/open,
 /area/horizon/hallway/deck_three/primary/central)
 "eEX" = (
-/obj/machinery/computer/robotics{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/chamber)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "eFa" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/vending/coffee,
@@ -5778,15 +5801,12 @@
 /turf/simulated/floor/carpet/rubber,
 /area/bridge/controlroom)
 "eGa" = (
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 1
-	},
 /obj/effect/floor_decal/spline/plain{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/alarm/east,
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/area/tcommsat/chamber)
 "eGq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
@@ -6084,7 +6104,6 @@
 	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	dir = 4;
-	pixel_y = 0;
 	pixel_x = -20
 	},
 /obj/effect/map_effect/marker/airlock{
@@ -6361,12 +6380,9 @@
 /area/bridge/controlroom)
 "ffL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
-	pixel_x = -24;
-	dir = 2
+	pixel_x = -24
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/map_effect/marker/airlock/docking{
@@ -6762,6 +6778,10 @@
 	dir = 8
 	},
 /obj/machinery/light/small/emergency,
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "ftz" = (
@@ -6925,16 +6945,13 @@
 "fxj" = (
 /obj/machinery/door/firedoor,
 /obj/effect/map_effect/door_helper/unres,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/airlock/glass_command{
 	dir = 1;
 	id_tag = "sbridgedoor";
 	name = "Bridge";
 	req_one_access = list(19,38,72)
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/bridge)
 "fxk" = (
@@ -7089,17 +7106,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/storage/shields)
 "fCi" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor/wood,
+/area/bridge)
 "fCl" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/cable/green{
@@ -7215,6 +7223,9 @@
 /obj/machinery/door/airlock/maintenance{
 	dir = 1;
 	req_one_access = list(11,24)
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/maintenance/engineering_ladder)
@@ -7342,12 +7353,14 @@
 /turf/simulated/open,
 /area/horizon/hallway/deck_three/primary/central)
 "fLs" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/spline/plain{
+/obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "fMl" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -7522,9 +7535,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
@@ -7747,14 +7757,28 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "fZX" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/camera/motion{
+	c_tag = "Telecommunications - Starboard";
+	dir = 4;
+	network = list("Command","Security","Telecommunications")
 	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 8
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/horizon/hallway/deck_three/primary/central)
+/obj/machinery/atmospherics/unary/vent_pump{
+	external_pressure_bound = 140;
+	external_pressure_bound_default = 140;
+	icon_state = "map_vent_out";
+	pressure_checks = 0;
+	pressure_checks_default = 0;
+	use_power = 1
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "gae" = (
 /obj/structure/bed/stool/chair/padded/black{
 	dir = 4
@@ -8107,8 +8131,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge)
 "gnL" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -8523,8 +8550,7 @@
 	},
 /obj/machinery/access_button{
 	pixel_x = 24;
-	pixel_y = 32;
-	dir = 2
+	pixel_y = 32
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/map_effect/marker/airlock/docking{
@@ -8622,12 +8648,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/evidence_storage)
 "gIh" = (
-/obj/machinery/light/small/emergency{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/area/maintenance/engineering_ladder)
 "gIr" = (
 /obj/structure/grille/broken,
 /obj/effect/floor_decal/industrial/warning{
@@ -8740,9 +8778,7 @@
 /area/horizon/crew_armoury/foyer)
 "gMl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "airlock_horizon_dock_deck_3_port_4";
 	name = "airlock_horizon_dock_deck_3_port_4";
@@ -8759,9 +8795,6 @@
 "gMr" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /obj/structure/platform_deco{
 	dir = 1
@@ -9180,6 +9213,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office_aux)
+"hdE" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "hed" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -9270,7 +9314,7 @@
 /area/horizon/maintenance/deck_three/aft/starboard)
 "hfB" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
-/area/tcommsat/entrance)
+/area/bridge)
 "hhb" = (
 /obj/effect/floor_decal/corner/green/diagonal{
 	dir = 8
@@ -9674,7 +9718,8 @@
 "hsg" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light/small/emergency{
-	dir = 4
+	dir = 8;
+	pixel_x = 16
 	},
 /obj/machinery/alarm/north,
 /turf/simulated/floor,
@@ -9804,15 +9849,14 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "hxX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/obj/effect/decal/remains/rat,
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "hzh" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/dark_green{
@@ -10061,11 +10105,21 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
 "hIp" = (
-/obj/machinery/light/small/emergency{
-	dir = 8
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
+	},
+/obj/machinery/power/apc/west,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "hJD" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /turf/simulated/floor/tiled/dark/full,
@@ -10160,9 +10214,7 @@
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice)
 "hNX" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/machinery/airlock_sensor{
 	pixel_x = 20;
 	dir = 8;
@@ -10227,7 +10279,6 @@
 /area/horizon/crew_armoury)
 "hOD" = (
 /obj/machinery/airlock_sensor{
-	dir = 2;
 	pixel_y = 28;
 	pixel_x = 6
 	},
@@ -10237,14 +10288,13 @@
 	landmark_tag = "nav_horizon_dock_deck_3_port_5"
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 2;
 	pixel_y = 28;
 	pixel_x = -6
 	},
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/port/docks)
 "hPy" = (
-/turf/simulated/wall/shuttle/scc_space_ship/cardinal,
+/turf/simulated/floor/plating,
 /area/maintenance/engineering_ladder)
 "hQh" = (
 /obj/structure/cable/green{
@@ -10319,10 +10369,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/holodeck_control/beta)
 "hSu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/trash_pile,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/tcommsat/chamber)
 "hTq" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -10369,15 +10422,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "hVM" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/entrance)
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "hWx" = (
 /obj/machinery/ringer_button{
 	id = "Representative";
@@ -10409,7 +10465,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/controlroom)
 "hYG" = (
-/obj/structure/girder,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "hYI" = (
@@ -10650,13 +10709,22 @@
 /area/horizon/hallway/deck_three/primary/port/docks)
 "ilv" = (
 /obj/effect/floor_decal/spline/plain{
-	dir = 5
-	},
-/obj/effect/floor_decal/spline/plain/corner{
 	dir = 8
 	},
-/obj/machinery/light{
+/obj/effect/floor_decal/spline/plain{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -10763,6 +10831,9 @@
 "isu" = (
 /obj/structure/table/rack,
 /obj/random/loot,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "isB" = (
@@ -11030,19 +11101,22 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/crew_quarters/cryo/washroom)
 "izr" = (
-/obj/machinery/door/airlock/hatch{
-	dir = 1;
-	name = "Telecommunications - Server Hall";
-	req_access = list(61)
+/obj/effect/floor_decal/spline/plain{
+	dir = 10
 	},
-/obj/structure/plasticflaps/airtight,
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 10
+	},
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/carpet/rubber,
 /area/tcommsat/entrance)
 "izu" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -11213,9 +11287,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/firing_range)
 "iEF" = (
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "airlock_horizon_dock_deck_3_starboard_3";
@@ -11254,17 +11326,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "iGb" = (
-/obj/effect/floor_decal/spline/plain{
+/obj/machinery/computer/telecomms/traffic,
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor/tiled/dark/full,
+/area/tcommsat/entrance)
 "iGt" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/white,
@@ -11386,9 +11453,7 @@
 /turf/simulated/floor/wood,
 /area/horizon/cafeteria)
 "iJS" = (
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "airlock_horizon_dock_deck_3_port_4";
 	name = "airlock_horizon_dock_deck_3_port_4";
@@ -11396,8 +11461,7 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/access_button{
-	pixel_x = -28;
-	dir = 2
+	pixel_x = -28
 	},
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/port/docks)
@@ -11452,15 +11516,15 @@
 /turf/simulated/floor,
 /area/maintenance/bridge)
 "iMI" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 1
 	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 8
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -11594,26 +11658,19 @@
 /turf/simulated/floor/tiled/full,
 /area/horizon/hallway/deck_three/primary/port)
 "iQF" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/sign/a{
+	pixel_x = -10;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/airlock/maintenance{
-	dir = 4;
-	req_one_access = list(12)
-	},
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "iQH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -11700,11 +11757,21 @@
 /turf/simulated/floor/lino,
 /area/horizon/security/investigators_office)
 "iUc" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/obj/machinery/bluespacerelay,
-/turf/simulated/floor/bluegrid,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/sign/d{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "iUf" = (
 /obj/structure/table/standard,
@@ -11978,11 +12045,10 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "jdC" = (
-/obj/item/device/flashlight/lamp/lava/red{
-	pixel_x = 5;
-	pixel_y = -2
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "jdI" = (
@@ -12416,9 +12482,14 @@
 /turf/simulated/floor/wood,
 /area/horizon/security/meeting_room)
 "jzc" = (
-/obj/structure/sign/electricshock,
-/turf/simulated/wall/r_wall,
-/area/tcommsat/entrance)
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "jzd" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -12564,22 +12635,25 @@
 /turf/simulated/floor/wood,
 /area/lawoffice/consular)
 "jFn" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle/scc_space_ship,
-/obj/machinery/door/firedoor{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering_ladder)
 "jFu" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/table/steel,
-/obj/random/loot,
-/obj/machinery/light/small/emergency{
-	dir = 8
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/maintenance/engineering_ladder)
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "jFO" = (
 /obj/effect/landmark/start{
 	name = "Chief Medical Officer"
@@ -13213,26 +13287,20 @@
 /turf/simulated/floor/reinforced/airless,
 /area/horizon/exterior)
 "kgW" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 4;
+	pixel_x = -20
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 10
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_horizon_deck_3_aft_1";
+	name = "airlock_horizon_deck_3_aft_1";
+	frequency = 1001
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "khe" = (
 /obj/structure/closet/walllocker/emerglocker/south,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
@@ -13246,16 +13314,10 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/heads/cmo)
 "khy" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
+/obj/effect/floor_decal/spline/plain/corner,
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "khK" = (
@@ -13327,13 +13389,11 @@
 /turf/simulated/floor/marble/dark,
 /area/bridge/minibar)
 "kkU" = (
-/obj/machinery/computer/telecomms/traffic,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/device/radio/intercom/east,
-/turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/entrance)
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/shuttle/scc_space_ship,
+/turf/simulated/floor/plating,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "klQ" = (
 /turf/simulated/wall,
 /area/horizon/security/interrogation/monitoring)
@@ -13351,9 +13411,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/holodeck_control)
 "kmt" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "airlock_horizon_dock_deck_3_port_5";
 	name = "airlock_horizon_dock_deck_3_port_5";
@@ -13462,10 +13520,22 @@
 /turf/simulated/floor/wood,
 /area/lawoffice/representative)
 "kqe" = (
-/obj/random/junk,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/sign/m{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "kqx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13980,13 +14050,9 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "kHy" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green,
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/entrance)
+/obj/structure/table,
+/turf/simulated/floor,
+/area/bridge)
 "kHX" = (
 /obj/machinery/power/apc/low/east,
 /obj/structure/cable/green{
@@ -14014,15 +14080,16 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/random/junk,
-/obj/random/dirt_75,
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "kIy" = (
@@ -14091,7 +14158,10 @@
 /turf/simulated/floor/wood,
 /area/bridge/minibar)
 "kLs" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "kLF" = (
@@ -14319,6 +14389,9 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "kUz" = (
@@ -14331,11 +14404,12 @@
 /turf/simulated/wall/r_wall,
 /area/bridge/aibunker)
 "kVK" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle/scc_space_ship,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/turf/simulated/floor/tiled/dark/full,
+/area/tcommsat/chamber)
 "kVQ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -14409,9 +14483,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "kYO" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "airlock_horizon_dock_deck_3_starboard_2";
 	name = "airlock_horizon_dock_deck_3_starboard_2";
@@ -14477,7 +14549,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/chamber)
+/area/bridge)
 "kZM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -14541,8 +14613,10 @@
 /turf/simulated/floor,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
 "lbC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "lbI" = (
@@ -14659,12 +14733,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/controlroom)
 "ldS" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "ldT" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -14704,14 +14781,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/holodeck_control/beta)
 "lfv" = (
-/obj/effect/floor_decal/spline/plain/cee{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor/tiled,
+/area/bridge)
 "lfy" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/tiled/dark/full/airless,
@@ -14750,6 +14824,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
+"lhX" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "lhY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -15036,11 +15120,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/evidence_storage)
 "lsr" = (
-/obj/structure/closet/crate,
-/obj/random/loot,
-/obj/random/loot,
-/obj/random/junk,
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/stool/bar/padded/red,
+/turf/simulated/floor/tiled/dark,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "lsB" = (
 /obj/structure/bed/stool/chair{
@@ -15060,7 +15145,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/chamber)
+/area/bridge)
 "lsZ" = (
 /obj/effect/floor_decal/corner_wide/green/full,
 /obj/machinery/light,
@@ -15101,6 +15186,9 @@
 "ltG" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/storage/shields)
@@ -15993,13 +16081,10 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/investigations_hallway)
 "mcT" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green,
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/entrance)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/stool/bar/padded/red,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "mdb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -16340,9 +16425,7 @@
 /obj/effect/shuttle_landmark/horizon/dock/deck_3/port_2{
 	dir = 1
 	},
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "airlock_horizon_dock_deck_3_port_4";
 	name = "airlock_horizon_dock_deck_3_port_4";
@@ -16350,8 +16433,7 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/access_button{
-	pixel_x = 28;
-	dir = 2
+	pixel_x = 28
 	},
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/port/docks)
@@ -16558,40 +16640,66 @@
 /turf/simulated/floor/reinforced/airless,
 /area/horizon/exterior)
 "mxB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/horizon/hallway/deck_three/primary/central)
-"mxO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
+"mxO" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/hatch{
+	dir = 4;
+	name = "Telecommunications - Control Room";
+	req_access = list(11,24)
+	},
+/turf/simulated/floor/tiled/full,
+/area/tcommsat/entrance)
 "myt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "mzm" = (
 /turf/simulated/wall,
 /area/crew_quarters/lounge/secondary)
 "mzs" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle/scc_space_ship,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/maintenance/engineering_ladder)
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/tcommsat/chamber)
 "mzI" = (
 /obj/machinery/vending/snack,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -16657,21 +16765,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "mDS" = (
-/obj/effect/floor_decal/spline/plain/corner,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/plain/corner{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/standard,
+/obj/item/deck/cards,
+/obj/item/storage/box/fancy/cigarettes{
+	pixel_y = 10;
+	pixel_x = -6
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor/tiled/dark,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "mEf" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/cups,
@@ -16954,18 +17059,15 @@
 /turf/simulated/floor,
 /area/maintenance/security_starboard)
 "mSs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/area/tcommsat/chamber)
 "mST" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -17161,11 +17263,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/longbow)
 "mYf" = (
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, recreational area"
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/turf/simulated/wall/shuttle/scc_space_ship/cardinal,
-/area/maintenance/engineering_ladder)
+/turf/simulated/floor,
+/area/tcommsat/chamber)
 "mYH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -18137,10 +18241,12 @@
 /turf/simulated/open,
 /area/hallway/medical/upper)
 "nHY" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light/small/emergency,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/machinery/alarm/east,
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "nIt" = (
 /obj/machinery/newscaster/south,
 /turf/simulated/floor/lino,
@@ -18656,9 +18762,7 @@
 /area/horizon/longbow)
 "obP" = (
 /obj/effect/shuttle_landmark/horizon/dock/deck_3/starboard_2,
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
 	pixel_x = -28;
 	pixel_y = 12;
@@ -19170,26 +19274,10 @@
 /area/maintenance/engineering_ladder)
 "ouv" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	dir = 4;
-	name = "Telecommunications - Spare Parts";
-	req_access = list(61)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/full,
-/area/tcommsat/entrance)
+/obj/structure/grille,
+/obj/structure/window/shuttle/scc_space_ship,
+/turf/simulated/floor/plating,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "ouM" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -19549,15 +19637,13 @@
 /turf/simulated/floor,
 /area/horizon/hallway/deck_three/primary/port/docks)
 "oJa" = (
-/obj/effect/floor_decal/sign/b{
-	pixel_x = -10;
-	pixel_y = 4
+/obj/machinery/camera/motion{
+	c_tag = "Telecommunications - Starboard";
+	dir = 4;
+	network = list("Command","Security","Telecommunications");
+	pixel_y = 18
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
+/obj/effect/floor_decal/spline/plain/cee{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/rubber,
@@ -19744,12 +19830,9 @@
 /obj/effect/shuttle_landmark/horizon/dock/deck_3/starboard_3{
 	dir = 1
 	},
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
-	pixel_x = 28;
-	dir = 2
+	pixel_x = 28
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/map_effect/marker/airlock/docking{
@@ -19780,20 +19863,10 @@
 /turf/simulated/floor/tiled/full,
 /area/operations/office_aux)
 "oSn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 6
-	},
-/obj/effect/landmark{
-	name = "borerstart"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "oSL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -20041,19 +20114,10 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical/upper)
 "pcj" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "bridge blast";
-	name = "Bridge Blast Doors";
-	opacity = 0
+/obj/structure/bed/stool/chair/padded/beige{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled,
 /area/bridge)
 "pcZ" = (
 /obj/effect/floor_decal/corner_wide/green{
@@ -20268,15 +20332,9 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/security/autopsy_laboratory)
 "ppg" = (
-/obj/machinery/firealarm/west,
-/obj/effect/floor_decal/spline/plain/cee{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/structure/table,
+/turf/simulated/floor/tiled,
+/area/bridge)
 "ppy" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -20329,9 +20387,7 @@
 /area/horizon/security/evidence_storage)
 "pwL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
 	pixel_x = -28;
 	pixel_y = 12;
@@ -20620,9 +20676,6 @@
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/platform{
 	dir = 4
 	},
@@ -20818,23 +20871,16 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "pVj" = (
-/obj/machinery/door/airlock/external{
-	dir = 2
+/obj/item/device/radio/intercom/east,
+/obj/effect/floor_decal/spline/plain{
+	dir = 5
 	},
-/obj/machinery/access_button{
-	pixel_x = 28;
-	pixel_y = 0;
-	dir = 2
+/obj/machinery/camera/motion{
+	c_tag = "Telecommunications - Spare Parts Room";
+	network = list("Command","Security","Telecommunications")
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_horizon_deck_3_aft_1";
-	name = "airlock_horizon_deck_3_aft_1";
-	frequency = 1001
-	},
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "pWL" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -20861,6 +20907,9 @@
 /area/horizon/security/forensic_laboratory)
 "pXu" = (
 /obj/structure/reagent_dispensers/extinguisher,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "pYC" = (
@@ -21162,17 +21211,11 @@
 /turf/simulated/floor/reinforced/airless,
 /area/horizon/exterior)
 "qkd" = (
-/obj/effect/floor_decal/spline/plain/corner,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 8
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/rubber,
+/turf/simulated/floor,
 /area/tcommsat/chamber)
 "qkD" = (
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -21609,25 +21652,18 @@
 /turf/simulated/floor/tiled,
 /area/bridge/bridge_crew)
 "qDx" = (
-/obj/machinery/camera/motion{
-	c_tag = "Telecommunications - Starboard";
-	dir = 4;
-	network = list("Command","Security","Telecommunications")
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	external_pressure_bound = 140;
-	external_pressure_bound_default = 140;
-	icon_state = "map_vent_out";
-	pressure_checks = 0;
-	pressure_checks_default = 0;
-	use_power = 1
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -21874,13 +21910,16 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/firing_range)
 "qNB" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/full,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/machinery/atmospherics/unary/freezer{
+	dir = 1;
+	icon_state = "freezer_1";
+	use_power = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tcommsat/entrance)
 "qOO" = (
 /obj/structure/bed/stool/chair/padded/brown{
 	dir = 4
@@ -21913,15 +21952,11 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "qSd" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/obj/structure/railing/mapped{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/railing/mapped,
-/turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/turf/simulated/floor/tiled,
+/area/bridge)
 "qSG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -21936,23 +21971,24 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical/upper)
 "qSY" = (
-/obj/item/device/radio/intercom/south,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain/corner{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light,
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/hatch{
+	dir = 4;
+	name = "Telecommunications";
+	req_access = list(11,24)
+	},
+/turf/simulated/floor/tiled/full,
+/area/tcommsat/entrance)
 "qTN" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -22287,12 +22323,22 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/bridge/aibunker)
 "rlN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/emergency{
+/obj/effect/floor_decal/sign/c{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/full,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "rmh" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
@@ -22315,13 +22361,22 @@
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
 "rml" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/alarm/tcom/north,
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "rmQ" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
@@ -22443,15 +22498,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/holodeck_control/beta)
 "rpI" = (
-/obj/machinery/light,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled,
-/area/horizon/hallway/deck_three/primary/central)
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/turf/simulated/floor/tiled/dark/full,
+/area/tcommsat/chamber)
 "rpL" = (
 /obj/machinery/power/apc/low/east,
 /obj/structure/cable/green{
@@ -22473,10 +22528,19 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/cafeteria)
 "rqM" = (
-/obj/structure/closet/crate,
-/obj/random/loot,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	external_pressure_bound = 140;
+	external_pressure_bound_default = 140;
+	icon_state = "map_vent_out";
+	pressure_checks = 0;
+	pressure_checks_default = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "rqN" = (
 /obj/random/pottedplant,
 /obj/machinery/alarm/west,
@@ -22596,7 +22660,12 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/hop/xo)
 "rvi" = (
-/obj/random/junk,
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 4;
+	name = "Distro to Airlock";
+	target_pressure = 200
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "rvn" = (
@@ -22741,24 +22810,12 @@
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/port/docks)
 "rzm" = (
-/obj/effect/floor_decal/spline/plain/cee{
-	dir = 1
-	},
-/obj/machinery/power/apc/super/critical/north,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/wall/r_wall,
+/area/storage/shields)
 "rzs" = (
-/obj/structure/table/steel,
-/obj/random/smokable{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/structure/sign/electricshock,
+/turf/simulated/wall/r_wall,
+/area/tcommsat/chamber)
 "rzG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23221,22 +23278,16 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "rQB" = (
-/obj/machinery/door/airlock/external{
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/machinery/access_button{
-	pixel_x = -28;
-	pixel_y = 12;
-	dir = 1
+/obj/machinery/meter,
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
 	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_horizon_deck_3_aft_1";
-	name = "airlock_horizon_deck_3_aft_1";
-	frequency = 1001
-	},
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "rQI" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
 /obj/machinery/light/spot{
@@ -23245,11 +23296,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/holodeck_control)
 "rQO" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 1
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -23440,11 +23488,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
 "rYv" = (
-/obj/effect/floor_decal/spline/plain{
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "rYH" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
@@ -23528,23 +23579,14 @@
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "scd" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
-	dir = 1
-	},
+/obj/machinery/power/apc/super/critical/north,
 /obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/effect/floor_decal/sign/a{
-	pixel_x = -10;
-	pixel_y = 4
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain/corner,
 /obj/effect/floor_decal/spline/plain/corner{
 	dir = 8
 	},
@@ -23845,12 +23887,11 @@
 /turf/simulated/floor/tiled/freezer,
 /area/horizon/crew_quarters/fitness/showers)
 "skx" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, telecomms"
 	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/turf/simulated/floor/reinforced/airless,
+/area/template_noop)
 "slc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -24095,12 +24136,19 @@
 /turf/simulated/floor/tiled/full,
 /area/journalistoffice)
 "stN" = (
-/obj/structure/cable/green{
-	icon_state = "0-4"
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = 28
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/entrance)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_horizon_deck_3_aft_1";
+	name = "airlock_horizon_deck_3_aft_1";
+	frequency = 1001
+	},
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "stP" = (
 /obj/structure/sink/kitchen{
 	name = "water fountain";
@@ -24722,21 +24770,20 @@
 /turf/simulated/floor/lino,
 /area/horizon/security/investigators_office)
 "sUT" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
+/obj/machinery/door/airlock/hatch{
+	dir = 1;
+	name = "Telecommunications - Server Hall";
+	req_access = list(61)
 	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 4;
-	pixel_y = 0;
-	pixel_x = -20
+/obj/structure/plasticflaps/airtight,
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_horizon_deck_3_aft_1";
-	name = "airlock_horizon_deck_3_aft_1";
-	frequency = 1001
-	},
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/full,
+/area/tcommsat/chamber)
 "sVv" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -24747,16 +24794,14 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "sVD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/stool/bar/padded/red,
+/turf/simulated/floor/tiled/dark,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "sVV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24893,9 +24938,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/evidence_storage)
 "tcb" = (
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "airlock_horizon_dock_deck_3_starboard_2";
@@ -24959,6 +25002,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
+"teU" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "tfg" = (
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 6
@@ -24984,20 +25044,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/holodeck_control)
 "tfz" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
+"tfE" = (
+/obj/structure/curtain/black,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
-"tfE" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/airlock/maintenance{
-	dir = 1;
-	req_one_access = list(5,12)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "thi" = (
@@ -25072,24 +25134,11 @@
 /turf/simulated/floor/tiled/full,
 /area/horizon/hallway/deck_three/primary/starboard)
 "tjC" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/bed/stool/chair/padded/beige{
+	dir = 8
 	},
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor/tiled,
+/area/bridge)
 "tjN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -25102,10 +25151,12 @@
 /turf/simulated/floor/lino,
 /area/horizon/cafeteria)
 "tka" = (
-/obj/structure/curtain/black,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 1
+	},
+/obj/machinery/alarm/tcom/north,
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "tkE" = (
 /obj/machinery/blackbox_recorder,
 /turf/simulated/floor/bluegrid,
@@ -25490,16 +25541,21 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "tyQ" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain{
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
+"tzE" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = 12;
 	dir = 1
 	},
-/obj/machinery/firealarm/north,
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
-"tzE" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_horizon_deck_3_aft_1";
+	name = "airlock_horizon_deck_3_aft_1";
+	frequency = 1001
 	},
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
@@ -25601,7 +25657,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "tDB" = (
@@ -25663,11 +25718,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop/xo)
 "tFM" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2
-	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/machinery/airlock_sensor{
-	dir = 2;
 	pixel_y = 28;
 	pixel_x = 6
 	},
@@ -25677,7 +25729,6 @@
 	landmark_tag = "nav_horizon_dock_deck_3_starboard_1"
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 2;
 	pixel_y = 28;
 	pixel_x = -6
 	},
@@ -26429,9 +26480,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
 	},
@@ -26649,17 +26697,10 @@
 /turf/simulated/floor/tiled,
 /area/horizon/stairwell/central)
 "utv" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/effect/decal/remains/rat,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "uut" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
@@ -27083,16 +27124,17 @@
 /turf/simulated/floor/carpet/rubber,
 /area/bridge/controlroom)
 "uJY" = (
-/obj/structure/railing/mapped{
-	dir = 4
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/railing/mapped,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "uKi" = (
 /obj/machinery/door/blast/shutters/open{
 	dir = 2;
@@ -27197,18 +27239,18 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/investigations_hallway)
 "uMW" = (
-/obj/structure/bed/stool/chair/office/dark{
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 9
-	},
-/obj/machinery/power/apc/west,
 /obj/structure/cable/green{
-	icon_state = "0-2"
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/area/tcommsat/chamber)
 "uNc" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -27363,12 +27405,9 @@
 /turf/simulated/open/airless,
 /area/template_noop)
 "uRU" = (
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
-	pixel_x = 28;
-	dir = 2
+	pixel_x = 28
 	},
 /obj/effect/map_effect/marker/airlock{
 	master_tag = "airlock_horizon_deck_3_fore_starboard_1";
@@ -27520,12 +27559,12 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
 	dir = 1;
-	name = "Telecommunications - Control Room";
+	name = "UNDER CONSTRUCTION";
 	req_access = list(61)
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
-/area/tcommsat/entrance)
+/area/bridge)
 "vai" = (
 /obj/structure/table/reinforced/steel,
 /obj/effect/floor_decal/corner/dark_blue/diagonal,
@@ -27582,9 +27621,15 @@
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
 "vcD" = (
-/obj/effect/floor_decal/industrial/warning/cee,
-/turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "vcJ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/railing/mapped,
@@ -27622,7 +27667,7 @@
 "vdC" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
-	name = "Telecommunications - Control Room";
+	name = "UNDER CONSTRUCTION";
 	req_access = list(61)
 	},
 /obj/structure/cable{
@@ -27636,8 +27681,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/item/tape/engineering,
 /turf/simulated/floor/tiled/full,
-/area/tcommsat/entrance)
+/area/bridge)
 "vdY" = (
 /obj/machinery/disposal/small/south,
 /obj/structure/disposalpipe/trunk{
@@ -27943,7 +27989,7 @@
 	pixel_y = -19
 	},
 /turf/simulated/floor/tiled,
-/area/engineering/break_room)
+/area/tcommsat/chamber)
 "vnb" = (
 /obj/machinery/turretid/lethal{
 	ailock = 1;
@@ -27996,9 +28042,20 @@
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
 "vpR" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "vrD" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -28131,11 +28188,15 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
 "vwX" = (
-/obj/structure/closet,
-/obj/random/mre,
-/obj/random/junk,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/item/device/radio/intercom/east{
+	dir = 8;
+	pixel_x = -8
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "vxf" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Deck 3 Civilian Substation"
@@ -28380,16 +28441,8 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop/xo)
 "vEP" = (
-/obj/effect/floor_decal/sign/c{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain,
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor,
+/area/bridge)
 "vFz" = (
 /turf/simulated/wall,
 /area/horizon/hallway/deck_three/primary/central)
@@ -28541,9 +28594,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/platform{
 	dir = 4
 	},
@@ -28609,9 +28659,7 @@
 /turf/simulated/floor/tiled,
 /area/bridge)
 "vNF" = (
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "airlock_horizon_dock_deck_3_port_2";
 	name = "airlock_horizon_dock_deck_3_port_2";
@@ -28684,7 +28732,8 @@
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
 "vPA" = (
-/obj/structure/bed/stool/padded/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "vQi" = (
@@ -28827,13 +28876,7 @@
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -28913,9 +28956,6 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical/upper)
 "vXw" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
 /obj/machinery/alarm/west,
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
@@ -29240,9 +29280,7 @@
 /turf/simulated/floor/carpet,
 /area/lawoffice/consular)
 "wmW" = (
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
 	pixel_x = 28;
 	pixel_y = 12;
@@ -29332,25 +29370,8 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/port)
 "wqk" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/sign/m{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor/plating,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "wqn" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -29742,14 +29763,12 @@
 /turf/simulated/floor/reinforced/airless,
 /area/template_noop)
 "wGR" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 6
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/bridge)
+/turf/simulated/floor/reinforced/airless,
+/area/tcommsat/chamber)
 "wHl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -29972,11 +29991,26 @@
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice)
 "wOl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain/cee,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/sign/b{
+	pixel_x = -10;
+	pixel_y = 4
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "wOZ" = (
@@ -30157,9 +30191,6 @@
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 6
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -30190,9 +30221,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
@@ -30282,11 +30310,17 @@
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
 "wWk" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain/corner{
 	dir = 1
 	},
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "wWA" = (
 /obj/machinery/iv_drip,
 /obj/effect/floor_decal/corner_wide/green{
@@ -30462,9 +30496,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "airlock_horizon_dock_deck_3_port_2";
 	name = "airlock_horizon_dock_deck_3_port_2";
@@ -30472,18 +30504,13 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/access_button{
-	pixel_x = 28;
-	dir = 2
+	pixel_x = 28
 	},
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/port/docks)
 "xek" = (
-/obj/effect/shuttle_landmark/horizon/dock/deck_3/port_1{
-	dir = 2
-	},
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/effect/shuttle_landmark/horizon/dock/deck_3/port_1,
+/obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "airlock_horizon_dock_deck_3_port_2";
 	name = "airlock_horizon_dock_deck_3_port_2";
@@ -30570,9 +30597,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/obj/machinery/door/airlock/external{
-	dir = 2
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "airlock_horizon_dock_deck_3_port_2";
 	name = "airlock_horizon_dock_deck_3_port_2";
@@ -31619,9 +31644,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
 "ygn" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "ygv" = (
@@ -31704,7 +31743,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/crew_quarters/captain)
+/area/bridge)
 "ymi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
@@ -45934,13 +45973,13 @@ wGH
 wGH
 wGH
 wGH
-diz
-kVK
-kVK
+oXs
+kkU
+ouv
+ouv
 oXs
 oXs
 oXs
-kVK
 oXs
 onG
 oXs
@@ -46133,17 +46172,17 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-kVK
+oXs
+oXs
+oXs
+oXs
 kLs
-jZN
+oSn
 bOL
 lsr
+nwE
 pAw
-aCw
-eZu
+bEk
 aIC
 pAw
 byu
@@ -46335,17 +46374,17 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-kVK
+oXs
+niZ
+kgW
+oXs
 rvi
-eZu
+tyQ
 cGI
-eZu
+mDS
+mcT
 pAw
-bEk
-eZu
+diz
 fWM
 pAw
 pAw
@@ -46537,15 +46576,15 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-oXs
-gIh
-vPA
-rzs
-vPA
-pAw
+tzE
+jZS
+bOz
+stN
+qDU
+utv
+eZu
+sVD
+jZN
 pAw
 myt
 fWM
@@ -46739,15 +46778,15 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
 oXs
-jZN
-nwE
+nJR
+ecm
+oXs
+fLs
+aca
 vPA
 jdC
-hYG
+eZu
 pAw
 lzQ
 fWM
@@ -46937,18 +46976,18 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-wGH
-iUA
-wGH
-wGH
+abZ
+abZ
+abZ
+abZ
+abZ
+abZ
+rRe
 oXs
 ail
-jZN
+rYv
 wjr
-hSu
+jdC
 pAw
 pAw
 pAw
@@ -47139,18 +47178,18 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-oXs
-oXs
-oXs
-pAw
-tka
-pAw
-pAw
+abZ
+fZX
+cIn
+cIn
+wUx
+qUt
+wIu
+wIu
+wIu
+wIu
+wIu
+tfE
 pAw
 cuy
 aCw
@@ -47341,21 +47380,21 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-oXs
-kLs
+abZ
+eih
+wug
+xSg
+iQF
+qUt
+sCe
 hIp
 vwX
-agn
-pAw
+vvp
+wIu
 hYG
-hYG
-oJA
-tzE
+jZN
+jZN
+jZN
 fWM
 jDK
 nud
@@ -47543,20 +47582,20 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-wGH
-wGH
+abZ
+dgI
+fZq
+pUC
+lhX
 kVK
-kqe
+hSf
 ldS
-lbC
-lbC
-tfE
+xSp
+mbR
+wIu
 lbC
 tAA
-fWM
+jZN
 fWM
 owI
 nud
@@ -47744,18 +47783,18 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-oXs
-rqM
+abZ
+abZ
+scd
+hxX
+hxX
+qDx
+rpI
+ime
 tfz
-fWM
-rlN
-pAw
+eEX
+ood
+wIu
 cNX
 uPO
 vzK
@@ -47946,18 +47985,18 @@ wGH
 wGH
 cOf
 whh
-whh
-fVL
-leE
-wGH
-oXs
-oXs
-oXs
-oXs
+abZ
+tkE
+khy
+rqM
+eGa
+hdE
+rzs
+iGb
 uJY
 dED
-pAw
-pAw
+wnD
+wIu
 hsg
 iDn
 xEY
@@ -48148,18 +48187,18 @@ wGH
 wGH
 coC
 wGH
-wGH
-wGH
-wGH
-wGH
-oXs
-niZ
+abZ
+nMa
+vcD
+aNM
+kxn
+wOl
 sUT
-oXs
+rQB
 aQZ
 bYI
-pAw
-pAw
+wUL
+wIu
 pAw
 hnK
 pAw
@@ -48350,18 +48389,18 @@ wGH
 wGH
 coC
 wGH
-wGH
-wGH
-muk
+abZ
+cBq
 vcD
-rQB
-jZS
-bOz
+guk
+mUk
+hVM
+qUt
 pVj
-qDU
+jaU
 nHY
-pAw
-oJA
+lCW
+wIu
 vXw
 iDn
 tDq
@@ -48552,19 +48591,19 @@ whh
 whh
 raS
 wGH
-wGH
-wGH
-wGH
-wGH
-oXs
-nJR
-ecm
-oXs
+abZ
+ieD
+mSs
+ekB
+ekB
+dHD
+qUt
+wIu
 mxO
-hxX
-pAw
+wIu
+wIu
+wIu
 fBA
-nVK
 eBZ
 nVK
 nVK
@@ -48754,18 +48793,18 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-wGH
-oXs
-oXs
-oXs
-oXs
+abZ
+abZ
+jFu
+wlV
+qmy
+rlN
+qUt
+vIy
+izr
 qNB
-qNB
-pAw
-kVQ
+wIu
+rml
 ygn
 fsw
 pAw
@@ -48954,21 +48993,21 @@ wGH
 wGH
 wGH
 wGH
-uFC
-uFC
-qSd
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-oXs
-oXs
-oXs
-oXs
+abZ
+hCP
+hvY
+gEi
+mxB
+hSu
+dCR
+atW
+ssd
+wIu
 nBJ
-wWk
+jZN
 isu
 jbh
 awA
@@ -49005,14 +49044,14 @@ nhw
 mRd
 kjE
 kjE
-qUt
-qUt
-qUt
-qUt
-qUt
-qUt
-qUt
-abZ
+lbL
+lbL
+lbL
+lbL
+lbL
+lbL
+lbL
+hfB
 hfB
 hfB
 bJM
@@ -49158,19 +49197,19 @@ wGH
 wGH
 wGH
 wGH
-coC
 wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-oXs
+abZ
+iMI
+ilv
+cIn
+vpR
+wGR
+uCC
+wbR
+vSg
+wIu
 kVQ
-eVm
+jZN
 isu
 jbh
 mri
@@ -49207,18 +49246,18 @@ jOD
 jOD
 jOD
 jOD
-qUt
+lbL
 ppg
-rQO
-qDx
-cIn
-cIn
-wUx
-tkE
-wIu
-vIy
-rYv
-vvp
+fCi
+cNU
+cNU
+qSd
+cNU
+vEP
+vEP
+vEP
+vEP
+qSd
 ylG
 vQU
 fQA
@@ -49361,18 +49400,18 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-kVK
+abZ
+oJa
+sHH
+hDQ
+iUc
+qUt
+lyA
+eVA
+gar
+wIu
 kVQ
-eVm
+jZN
 pXu
 jbh
 oEL
@@ -49409,19 +49448,19 @@ rPW
 wyk
 nkG
 izo
-qUt
-sHH
-hDQ
-cBq
-wug
-xSg
-oJa
-nMa
-stN
-dCR
-xSp
-mbR
-wIu
+lbL
+ppg
+vEP
+fCi
+fCi
+cNU
+cNU
+cNU
+fCi
+fCi
+fCi
+fCi
+lbL
 soE
 soE
 hGZ
@@ -49563,19 +49602,19 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-wGH
-wGH
-iUA
-wGH
-wGH
-wGH
-oXs
-kVQ
-wWk
-vpR
+abZ
+abZ
+kpN
+tUy
+uMW
+qUt
+wIu
+qSY
+wIu
+wIu
+agn
+pAw
+pAw
 jbh
 cSJ
 eXj
@@ -49611,19 +49650,19 @@ fxh
 edN
 jOD
 jOD
-qUt
-kpN
-tUy
-dgI
-fZq
-pUC
-khy
-iUc
-mcT
-uCC
-gny
-ood
-wIu
+lbL
+lfv
+cNU
+vEP
+vEP
+ppg
+ppg
+cNU
+cNU
+ppg
+fCi
+vEP
+lbL
 rqN
 sVv
 cBj
@@ -49766,16 +49805,16 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-wGH
-hPy
-hPy
+abZ
+tka
+wWk
+teU
+qUt
+wIu
 jFn
 hPy
-oXs
-iQF
+wqk
+kVQ
 pAw
 pAw
 jbh
@@ -49813,19 +49852,19 @@ hMD
 tfi
 sum
 sRf
-qUt
-rzm
-iGb
-mDS
+lbL
+ppg
+cNU
 fCi
 fCi
+ppg
 tjC
-ieD
-jzc
-lyA
-oSn
-wnD
-wIu
+cNU
+cNU
+ppg
+fCi
+vEP
+lbL
 qEI
 ipX
 xAE
@@ -49967,13 +50006,13 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-wGH
-wGH
+skx
+abZ
+fmB
+fHi
+kqe
 mYf
-jFu
+vtf
 kIk
 aZl
 aZl
@@ -50015,19 +50054,19 @@ cBm
 cBm
 cBm
 cBm
-qUt
-wlV
-qmy
+lbL
+ppg
+pcj
 vEP
-aNM
-kxn
-scd
-wOl
-izr
-sVD
-mSs
-wUL
-wIu
+vEP
+cNU
+cNU
+cNU
+cNU
+ppg
+fCi
+cNU
+lbL
 ugJ
 lrg
 nxm
@@ -50170,10 +50209,10 @@ wGH
 wGH
 wGH
 wGH
-wGH
-wGH
-wGH
-wGH
+abZ
+vvm
+sdc
+cGa
 mzs
 afj
 bbm
@@ -50217,19 +50256,19 @@ aBq
 cQL
 tdH
 uBr
-qUt
-hvY
-gEi
-dgI
-guk
-mUk
-iMI
-eEX
-wIu
-dHD
-jaU
-lCW
-wIu
+lbL
+ppg
+cNU
+vEP
+fCi
+vEP
+cNU
+cNU
+cNU
+vEP
+vEP
+cNU
+lbL
 dIk
 jiq
 njP
@@ -50372,13 +50411,13 @@ fJy
 fJy
 kCw
 wGH
-wGH
-wGH
-wGH
-wGH
-mzs
+abZ
+eBt
+iLf
+dgI
+qkd
 afj
-fwo
+gIh
 qLy
 pWR
 pWR
@@ -50419,19 +50458,19 @@ sfS
 pxf
 rsW
 rIE
-qUt
+lbL
 lfv
-rQO
-qkd
-ekB
-ekB
-qSY
-wIu
-wIu
-wIu
-ouv
-wIu
-wIu
+cNU
+cNU
+cNU
+vEP
+vEP
+vEP
+cNU
+cNU
+cNU
+cNU
+lbL
 kST
 fIa
 olw
@@ -50574,13 +50613,13 @@ feY
 feY
 hBq
 wGH
-wGH
-wGH
-wGH
-wGH
-mzs
+abZ
+rQO
+cxo
+jzc
+qUt
 afj
-fwo
+gIh
 qLy
 aiX
 xbM
@@ -50623,17 +50662,17 @@ lkl
 vIv
 vIv
 vIv
-qUt
-tyQ
-fmB
-fHi
-wqk
+lbL
+ppg
+cNU
+vEP
+vEP
 kHy
-sCe
-uMW
-kgW
-eih
-wIu
+ppg
+ppg
+vEP
+cNU
+lbL
 soE
 emz
 soE
@@ -50775,14 +50814,14 @@ feY
 feY
 feY
 hBq
-wGH
-wGH
-wGH
-wGH
-wGH
-hPy
+abZ
+abZ
+qUt
+qUt
+qUt
+qUt
 lMh
-fwo
+gIh
 aaz
 kTG
 kTG
@@ -50825,17 +50864,17 @@ wKC
 ozN
 wxR
 fTY
-qUt
-hCP
-vvm
-sdc
-iMI
-hVM
-hSf
-skx
-atW
-ssd
-wIu
+lbL
+ppg
+pcj
+vEP
+vEP
+vEP
+cNU
+cNU
+vEP
+cNU
+lbL
 vpB
 nsq
 asO
@@ -50978,13 +51017,13 @@ feY
 feY
 hBq
 ilL
-ilL
-ilL
-ilL
-ilL
-ilL
+rzm
+rzm
+rzm
+rzm
+rzm
 qLy
-fwo
+gIh
 qLy
 isK
 hCT
@@ -51027,16 +51066,16 @@ qKM
 wMV
 fWo
 jdI
-qUt
-rml
-eBt
-iLf
-iMI
-hVM
-ime
-fLs
-wbR
-vSg
+lbL
+ppg
+cNU
+vEP
+vEP
+cNU
+cNU
+cNU
+vEP
+cNU
 uZE
 vcu
 tYp
@@ -51186,7 +51225,7 @@ tNk
 raP
 eoQ
 qLy
-fwo
+gIh
 qLy
 bpD
 bpD
@@ -51229,17 +51268,17 @@ lIT
 xDX
 hig
 uPp
-qUt
-ilv
-rQO
-utv
-aca
+lbL
+lfv
+cNU
+cNU
+cNU
 cfB
-kkU
-eGa
-eVA
-gar
-wIu
+cNU
+cNU
+cNU
+cNU
+lbL
 rCl
 nVG
 pFY
@@ -51431,17 +51470,17 @@ gji
 esb
 doF
 doF
-qUt
-qUt
+lbL
+lbL
 lsV
 kZD
-qUt
-wIu
-wIu
-wIu
+lbL
+lbL
+lbL
+lbL
 vdC
-wIu
-wIu
+lbL
+lbL
 qgM
 tYp
 cqp
@@ -51843,7 +51882,7 @@ eeW
 cPM
 qWk
 szZ
-cih
+gny
 kYP
 lbL
 kSF
@@ -52231,7 +52270,7 @@ wzB
 dHs
 dHs
 kLR
-mxB
+seF
 iJd
 gJz
 aDg
@@ -52433,7 +52472,7 @@ kjD
 gPf
 gPf
 fJB
-rpI
+vkZ
 iJd
 pZQ
 pZQ
@@ -52635,16 +52674,16 @@ dHs
 dHs
 dHs
 kLR
-fZX
+kTE
 bgx
 bgx
 bgx
 dOU
 fxj
-pcj
-fxj
-wGR
-wGR
+rnK
+fBZ
+bsg
+bsg
 gMr
 wTy
 pNF

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -17,6 +17,9 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "aaF" = (
@@ -44,11 +47,10 @@
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/tcommsat/chamber)
 "aca" = (
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, telecomms"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/template_noop)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "ach" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/warning,
@@ -95,6 +97,24 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/horizon/hallway/deck_three/primary/central)
+"acV" = (
+/obj/item/device/radio/intercom/south,
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "adi" = (
 /obj/machinery/button/remote/airlock{
 	dir = 8;
@@ -192,6 +212,10 @@
 "afj" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/railing/mapped,
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "afn" = (
@@ -228,12 +252,11 @@
 /turf/simulated/floor/plating,
 /area/medical/equipment)
 "agn" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/obj/effect/floor_decal/spline/plain/corner,
+/turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "agp" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/polarized/firedoor{
@@ -414,18 +437,6 @@
 "akQ" = (
 /turf/simulated/floor/tiled/dark,
 /area/horizon/longbow)
-"ale" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
 "amy" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -1146,7 +1157,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -1226,6 +1236,15 @@
 /obj/structure/grille,
 /turf/simulated/floor/tiled/dark/full/airless,
 /area/bridge/controlroom)
+"aUA" = (
+/obj/structure/curtain/black,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "aVh" = (
 /obj/structure/table/reinforced/wood,
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -1488,25 +1507,28 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
 "bbm" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/camera/motion{
+	c_tag = "Telecommunications - Starboard";
+	dir = 4;
+	network = list("Command","Security","Telecommunications")
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump{
+	external_pressure_bound = 140;
+	external_pressure_bound_default = 140;
+	icon_state = "map_vent_out";
+	pressure_checks = 0;
+	pressure_checks_default = 0;
+	use_power = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/random/dirt_75,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/maintenance/engineering_ladder)
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "bbA" = (
 /obj/machinery/recharge_station,
 /obj/structure/railing/mapped{
@@ -2410,15 +2432,6 @@
 /obj/effect/shuttle_landmark/horizon/exterior/deck_3/portaft,
 /turf/template_noop,
 /area/template_noop)
-"bVd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
 "bVX" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
@@ -2478,14 +2491,14 @@
 /turf/simulated/floor,
 /area/maintenance/security_starboard)
 "bYI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/entrance)
@@ -2677,6 +2690,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/storage/shields)
@@ -3053,12 +3069,8 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/substation/command)
 "cBq" = (
-/obj/machinery/computer/telecomms/traffic,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/entrance)
+/turf/simulated/floor/wood,
+/area/bridge)
 "cBs" = (
 /obj/item/hullbeacon/red,
 /obj/structure/sign/securearea{
@@ -3377,6 +3389,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
+"cPa" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "cPk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3624,13 +3656,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/starboard/docks)
-"dcq" = (
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/chamber)
 "dcJ" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -3817,23 +3842,11 @@
 /turf/simulated/floor/wood,
 /area/journalistoffice)
 "diz" = (
-/obj/item/device/radio/intercom/south,
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain/corner{
+/obj/structure/bed/stool/chair/padded/beige{
 	dir = 1
 	},
-/obj/machinery/light,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor/tiled,
+/area/bridge)
 "djp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -3868,6 +3881,9 @@
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/horizon/crew_quarters/fitness/changing)
@@ -5027,14 +5043,15 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "eih" = (
-/obj/structure/curtain/black,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "eiD" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -5288,13 +5305,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/longbow)
 "eoQ" = (
-/obj/effect/floor_decal/corner_wide/yellow/full,
-/obj/machinery/light/small,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Shield Room";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/wall/r_wall,
 /area/storage/shields)
 "epz" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -5722,23 +5733,17 @@
 /turf/simulated/open,
 /area/horizon/hallway/deck_three/primary/central)
 "eEX" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 10
+/obj/machinery/camera/motion{
+	c_tag = "Telecommunications - Port";
+	dir = 4;
+	network = list("Command","Security","Telecommunications");
+	pixel_y = 18
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/spline/plain/cee{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/area/tcommsat/chamber)
 "eFa" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/vending/coffee,
@@ -5791,24 +5796,15 @@
 /turf/simulated/floor/carpet/rubber,
 /area/bridge/controlroom)
 "eGa" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/maintenance/engineering_ladder)
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "eGq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
@@ -5823,6 +5819,11 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/bridge)
+"eGx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/stool/bar/padded/red,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "eHB" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet,
@@ -7108,9 +7109,16 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/storage/shields)
 "fCi" = (
-/obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/spline/plain{
-	dir = 1
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	external_pressure_bound = 140;
+	external_pressure_bound_default = 140;
+	icon_state = "map_vent_out";
+	pressure_checks = 0;
+	pressure_checks_default = 0;
+	use_power = 1
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -7359,8 +7367,22 @@
 /turf/simulated/open,
 /area/horizon/hallway/deck_three/primary/central)
 "fLs" = (
-/turf/simulated/wall/r_wall,
-/area/storage/shields)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "fMl" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -7757,11 +7779,10 @@
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "fZX" = (
-/obj/effect/floor_decal/spline/plain/cee{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "gae" = (
 /obj/structure/bed/stool/chair/padded/black{
 	dir = 4
@@ -7902,27 +7923,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/port)
-"gfG" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/airlock/maintenance{
-	dir = 4;
-	req_one_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
 "ggl" = (
 /obj/machinery/camera/network/command{
 	c_tag = "Bridge - Corridor Camera 1"
@@ -8396,6 +8396,23 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/carpet/rubber,
 /area/bridge/controlroom)
+"gyw" = (
+/obj/effect/floor_decal/sign/c{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "gyx" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/table/wood,
@@ -8651,10 +8668,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/evidence_storage)
 "gIh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/stool/bar/padded/red,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/machinery/computer/telecomms/traffic,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/tcommsat/entrance)
 "gIr" = (
 /obj/structure/grille/broken,
 /obj/effect/floor_decal/industrial/warning{
@@ -9330,9 +9349,6 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/junction/yjunction,
@@ -9400,6 +9416,12 @@
 /obj/random/pottedplant,
 /turf/simulated/floor/tiled,
 /area/horizon/security/investigations_hallway)
+"hiT" = (
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, telecomms"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/template_noop)
 "hja" = (
 /obj/structure/bed/stool/chair/padded/brown{
 	dir = 1
@@ -9827,26 +9849,12 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "hxX" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	icon_state = "map_vent_in";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 1
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor/tiled/white,
+/area/horizon/crew_quarters/fitness/changing)
 "hzh" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/dark_green{
@@ -10359,12 +10367,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/holodeck_control/beta)
 "hSu" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/airlock/hatch{
+	dir = 4;
+	name = "Telecommunications";
+	req_access = list(11,24)
+	},
+/turf/simulated/floor/tiled/full,
+/area/tcommsat/entrance)
 "hTq" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -10411,24 +10431,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "hVM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/airlock/hatch{
-	dir = 4;
-	name = "Telecommunications";
-	req_access = list(11,24)
-	},
-/turf/simulated/floor/tiled/full,
-/area/tcommsat/entrance)
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "hWx" = (
 /obj/machinery/ringer_button{
 	id = "Representative";
@@ -10496,6 +10506,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
+"iaX" = (
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/turf/simulated/floor/tiled/dark/full,
+/area/tcommsat/chamber)
 "ibd" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 36;
@@ -11081,14 +11101,14 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/crew_quarters/cryo/washroom)
 "izr" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 6
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
 	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/full,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "izu" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -11297,8 +11317,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/break_room)
 "iGb" = (
-/turf/simulated/floor/plating,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "iGt" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/white,
@@ -11483,28 +11513,26 @@
 /turf/simulated/floor,
 /area/maintenance/bridge)
 "iMI" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain/corner,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/sign/b{
-	pixel_x = -10;
-	pixel_y = 4
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4;
+	req_one_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "iNg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
@@ -11635,11 +11663,17 @@
 /turf/simulated/floor/tiled/full,
 /area/horizon/hallway/deck_three/primary/port)
 "iQF" = (
-/obj/structure/bed/stool/chair/padded/beige{
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain/corner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/bridge)
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "iQH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -11706,6 +11740,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/cmo)
+"iTb" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "iTU" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
@@ -11925,23 +11975,18 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/port/docks)
 "jaU" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/standard,
+/obj/item/deck/cards,
+/obj/item/storage/box/fancy/cigarettes{
+	pixel_y = 10;
+	pixel_x = -6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/turf/simulated/floor/tiled/dark,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "jbg" = (
 /obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Deck 3 Civilian"
@@ -12005,9 +12050,11 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "jdC" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "jdI" = (
 /obj/machinery/newscaster/south,
@@ -12440,14 +12487,21 @@
 /turf/simulated/floor/wood,
 /area/horizon/security/meeting_room)
 "jzc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/bridge)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/maintenance/engineering_ladder)
 "jzd" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -12606,15 +12660,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering_ladder)
 "jFu" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/structure/railing/mapped,
+/turf/simulated/floor,
+/area/maintenance/engineering_ladder)
 "jFO" = (
 /obj/effect/landmark/start{
 	name = "Chief Medical Officer"
@@ -13143,6 +13195,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/crew_quarters/fitness/changing)
 "kbg" = (
@@ -13342,8 +13397,10 @@
 /turf/simulated/floor/marble/dark,
 /area/bridge/minibar)
 "kkU" = (
-/obj/machinery/bluespacerelay,
-/turf/simulated/floor/bluegrid,
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "klQ" = (
 /turf/simulated/wall,
@@ -13475,18 +13532,15 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8;
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
-	icon_state = "map_vent_in";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 1
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/sign/d{
+	pixel_x = -10;
+	pixel_y = 4
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -14041,7 +14095,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
@@ -14301,6 +14355,9 @@
 	name = "JoinLateCryo"
 	},
 /obj/effect/floor_decal/corner/dark_green/diagonal,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/crew_quarters/fitness/changing)
 "kTP" = (
@@ -14336,16 +14393,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "kUz" = (
@@ -14358,11 +14412,12 @@
 /turf/simulated/wall/r_wall,
 /area/bridge/aibunker)
 "kVK" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/shuttle/scc_space_ship,
-/turf/simulated/floor/plating,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/turf/simulated/floor/tiled/dark/full,
+/area/tcommsat/chamber)
 "kVQ" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -14381,6 +14436,9 @@
 /area/horizon/maintenance/deck_three/aft/starboard)
 "kWj" = (
 /obj/effect/floor_decal/corner/green/diagonal,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/horizon/crew_quarters/fitness/changing)
 "kWx" = (
@@ -15128,12 +15186,15 @@
 /turf/simulated/floor/reinforced,
 /area/bridge/selfdestruct)
 "ltG" = (
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Shield Room";
+	dir = 4
+	},
+/obj/machinery/light/small,
+/obj/effect/floor_decal/corner_wide/yellow/full,
 /turf/simulated/floor/tiled/dark/full,
 /area/storage/shields)
 "ltH" = (
@@ -15606,12 +15667,15 @@
 /turf/simulated/floor/tiled,
 /area/bridge)
 "lMh" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/structure/table/rack,
-/obj/random/loot,
-/obj/random/dirt_75,
-/turf/simulated/floor,
-/area/maintenance/engineering_ladder)
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "lMA" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
 /obj/structure/table/wood,
@@ -16025,10 +16089,19 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/investigations_hallway)
 "mcT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/machinery/power/apc/super/critical/north,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "mdb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -16274,22 +16347,6 @@
 	},
 /turf/simulated/floor/carpet/art,
 /area/crew_quarters/lounge)
-"mnR" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
 "mop" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/small/south,
@@ -16600,21 +16657,13 @@
 /turf/simulated/floor/reinforced/airless,
 /area/horizon/exterior)
 "mxB" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain,
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/structure/railing/mapped,
+/turf/simulated/floor,
+/area/maintenance/engineering_ladder)
 "mxO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -16658,6 +16707,18 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/camera/motion{
+	c_tag = "Telecommunications - Port";
+	dir = 4;
+	network = list("Command","Security","Telecommunications");
+	pixel_y = 18
+	},
+/obj/machinery/camera/motion{
+	c_tag = "Telecommunications - Port";
+	dir = 4;
+	network = list("Command","Security","Telecommunications");
+	pixel_y = 18
+	},
 /turf/simulated/floor,
 /area/tcommsat/chamber)
 "mzI" = (
@@ -16665,6 +16726,13 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/cafeteria)
+"mAm" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "mBw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16726,9 +16794,19 @@
 /area/engineering/break_room)
 "mDS" = (
 /obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/effect/floor_decal/sign/m{
+	pixel_x = -10;
+	pixel_y = 4
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "mEf" = (
@@ -17013,8 +17091,19 @@
 /turf/simulated/floor,
 /area/maintenance/security_starboard)
 "mSs" = (
-/turf/simulated/floor/wood,
-/area/bridge)
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_horizon_deck_3_aft_1";
+	name = "airlock_horizon_deck_3_aft_1";
+	frequency = 1001
+	},
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "mST" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -18192,6 +18281,9 @@
 	dir = 4
 	},
 /obj/machinery/alarm/east,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 9
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/entrance)
 "nIt" = (
@@ -19220,12 +19312,22 @@
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
 "ouv" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/structure/table/rack,
+/obj/item/circuitboard/telecomms/processor,
+/obj/item/circuitboard/telecomms/processor,
+/obj/item/circuitboard/telecomms/receiver,
+/obj/item/circuitboard/telecomms/server,
+/obj/item/circuitboard/telecomms/server,
+/obj/item/circuitboard/telecomms/bus,
+/obj/item/circuitboard/telecomms/bus,
+/obj/item/circuitboard/telecomms/broadcaster,
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
 	},
-/turf/simulated/floor,
-/area/tcommsat/chamber)
+/obj/item/circuitboard/ntnet_relay,
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "ouM" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -19586,10 +19688,15 @@
 /area/horizon/hallway/deck_three/primary/port/docks)
 "oJa" = (
 /obj/effect/floor_decal/spline/plain{
-	dir = 8
+	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/sign/a{
+	pixel_x = -10;
+	pixel_y = 4
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -19808,17 +19915,8 @@
 /turf/simulated/floor/tiled/full,
 /area/operations/office_aux)
 "oSn" = (
-/obj/machinery/door/airlock/external,
-/obj/machinery/access_button{
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_horizon_deck_3_aft_1";
-	name = "airlock_horizon_deck_3_aft_1";
-	frequency = 1001
-	},
+/obj/effect/decal/remains/rat,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "oSL" = (
@@ -20068,13 +20166,10 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical/upper)
 "pcj" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor,
+/obj/machinery/door/firedoor,
+/obj/structure/grille,
+/obj/structure/window/shuttle/scc_space_ship,
+/turf/simulated/floor/plating,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "pcZ" = (
 /obj/effect/floor_decal/corner_wide/green{
@@ -20125,21 +20220,6 @@
 /obj/structure/bed/stool/padded/blue,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/security/evidence_storage)
-"pfn" = (
-/obj/machinery/door/airlock/external,
-/obj/machinery/access_button{
-	pixel_x = -28;
-	pixel_y = 12;
-	dir = 1
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_horizon_deck_3_aft_1";
-	name = "airlock_horizon_deck_3_aft_1";
-	frequency = 1001
-	},
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
 "pfL" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -20304,14 +20384,8 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/security/autopsy_laboratory)
 "ppg" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
+/obj/structure/sign/electricshock,
+/turf/simulated/wall/r_wall,
 /area/tcommsat/chamber)
 "ppy" = (
 /obj/structure/railing/mapped{
@@ -20381,8 +20455,8 @@
 /area/maintenance/bridge)
 "pwO" = (
 /obj/effect/floor_decal/corner/green/diagonal,
-/obj/structure/closet/secure_closet/personal,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled/white,
 /area/horizon/crew_quarters/fitness/changing)
 "pxf" = (
@@ -20857,6 +20931,9 @@
 	c_tag = "Telecommunications - Spare Parts Room";
 	network = list("Command","Security","Telecommunications")
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 10
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/entrance)
 "pWL" = (
@@ -21189,22 +21266,20 @@
 /turf/simulated/floor/reinforced/airless,
 /area/horizon/exterior)
 "qkd" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/floor_decal/sign/d{
-	pixel_x = -10;
-	pixel_y = 4
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 4;
+	pixel_x = -20
 	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_horizon_deck_3_aft_1";
+	name = "airlock_horizon_deck_3_aft_1";
+	frequency = 1001
+	},
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "qkD" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/structure/cable/green{
@@ -21640,12 +21715,18 @@
 /turf/simulated/floor/tiled,
 /area/bridge/bridge_crew)
 "qDx" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/tcommsat/chamber)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/maintenance/engineering_ladder)
 "qDU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -21917,17 +21998,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/longbow)
-"qQF" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/black,
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
 "qQY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -21942,10 +22012,26 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "qSd" = (
-/obj/effect/floor_decal/spline/plain/cee{
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
 	dir = 1
 	},
-/obj/machinery/alarm/tcom/north,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/sign/b{
+	pixel_x = -10;
+	pixel_y = 4
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "qSG" = (
@@ -21962,8 +22048,16 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/medical/upper)
 "qSY" = (
-/obj/structure/sign/electricshock,
-/turf/simulated/wall/r_wall,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "qTN" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -22098,9 +22192,7 @@
 /obj/machinery/shield_gen/external{
 	anchored = 1
 	},
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 9
-	},
+/obj/effect/floor_decal/corner_wide/yellow/full,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/storage/shields)
@@ -22299,9 +22391,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/bridge/aibunker)
 "rlN" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 1
+	},
+/obj/machinery/alarm/tcom/north,
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "rmh" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
@@ -22325,18 +22420,22 @@
 /area/horizon/hallway/deck_three/primary/starboard/docks)
 "rml" = (
 /obj/effect/floor_decal/spline/plain{
-	dir = 1
+	dir = 10
 	},
-/obj/effect/floor_decal/spline/plain,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/sign/a{
-	pixel_x = -10;
-	pixel_y = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/area/tcommsat/entrance)
 "rmQ" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
@@ -22458,16 +22557,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/holodeck_control/beta)
 "rpI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
 	},
-/obj/machinery/meter,
-/obj/effect/floor_decal/spline/plain{
-	dir = 9
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/area/tcommsat/chamber)
 "rpL" = (
 /obj/machinery/power/apc/low/east,
 /obj/structure/cable/green{
@@ -22489,17 +22594,11 @@
 /turf/simulated/floor/tiled/white,
 /area/horizon/cafeteria)
 "rqM" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green{
+	icon_state = "0-8"
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain/corner,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/rubber,
+/turf/simulated/floor,
 /area/tcommsat/chamber)
 "rqN" = (
 /obj/random/pottedplant,
@@ -22770,19 +22869,27 @@
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_three/primary/port/docks)
 "rzm" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/standard,
-/obj/item/deck/cards,
-/obj/item/storage/box/fancy/cigarettes{
-	pixel_y = 10;
-	pixel_x = -6
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "rzs" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
@@ -23254,14 +23361,14 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "rQB" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector{
+/obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/full,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "rQI" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
 /obj/machinery/light/spot{
@@ -23270,20 +23377,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/holodeck_control)
 "rQO" = (
-/obj/effect/floor_decal/spline/plain/corner,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain/corner{
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = 12;
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_horizon_deck_3_aft_1";
+	name = "airlock_horizon_deck_3_aft_1";
+	frequency = 1001
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/black,
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "rRe" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/template_noop)
@@ -23471,18 +23578,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
 "rYv" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/shuttle/scc_space_ship,
+/turf/simulated/floor/plating,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "rYH" = (
 /obj/structure/window/shuttle/scc_space_ship,
 /obj/structure/grille,
@@ -23566,15 +23666,8 @@
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
 "scd" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/tiled/dark/full,
-/area/tcommsat/chamber)
+/turf/simulated/floor/plating,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "scL" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -23870,18 +23963,8 @@
 /turf/simulated/floor/tiled/freezer,
 /area/horizon/crew_quarters/fitness/showers)
 "skx" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	external_pressure_bound = 140;
-	external_pressure_bound_default = 140;
-	icon_state = "map_vent_out";
-	pressure_checks = 0;
-	pressure_checks_default = 0;
-	use_power = 1
-	},
-/turf/simulated/floor/carpet/rubber,
+/obj/machinery/bluespacerelay,
+/turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "slc" = (
 /obj/machinery/door/firedoor,
@@ -24127,20 +24210,11 @@
 /turf/simulated/floor/tiled/full,
 /area/journalistoffice)
 "stN" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 4;
-	pixel_x = -20
-	},
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_horizon_deck_3_aft_1";
-	name = "airlock_horizon_deck_3_aft_1";
-	frequency = 1001
-	},
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/turf/simulated/floor/tiled,
+/area/bridge)
 "stP" = (
 /obj/structure/sink/kitchen{
 	name = "water fountain";
@@ -24246,6 +24320,22 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/maintenance/engineering_ladder)
+"syl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/maintenance/engineering_ladder)
@@ -24786,9 +24876,13 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "sVD" = (
-/obj/structure/table,
-/turf/simulated/floor/tiled,
-/area/bridge)
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/railing/mapped,
+/turf/simulated/floor,
+/area/maintenance/engineering_ladder)
 "sVV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25024,11 +25118,14 @@
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/entrance)
 "tfE" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/floor_decal/spline/plain{
+	dir = 6
 	},
-/turf/simulated/floor/tiled,
-/area/bridge)
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
 "thi" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/engineering/break_room)
@@ -25118,9 +25215,21 @@
 /turf/simulated/floor/lino,
 /area/horizon/cafeteria)
 "tka" = (
-/obj/machinery/light/small/emergency,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
+"tki" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/entrance)
 "tkE" = (
 /obj/machinery/blackbox_recorder,
 /turf/simulated/floor/bluegrid,
@@ -25505,21 +25614,29 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "tyQ" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/shuttle/scc_space_ship,
-/turf/simulated/floor/plating,
-/area/horizon/maintenance/deck_three/aft/starboard)
-"tzE" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
+/turf/simulated/floor/carpet/rubber,
+/area/tcommsat/chamber)
+"tzE" = (
+/obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -25556,15 +25673,6 @@
 	dir = 5
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
-"tAC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
 "tAY" = (
@@ -26262,18 +26370,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
-"tYH" = (
-/obj/machinery/camera/motion{
-	c_tag = "Telecommunications - Starboard";
-	dir = 4;
-	network = list("Command","Security","Telecommunications");
-	pixel_y = 18
-	},
-/obj/effect/floor_decal/spline/plain/cee{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
 "tZE" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
@@ -26682,22 +26778,12 @@
 /turf/simulated/floor/tiled,
 /area/horizon/stairwell/central)
 "utv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	icon_state = "0-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/turf/simulated/floor/reinforced/airless,
+/area/tcommsat/chamber)
 "uut" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
@@ -27236,10 +27322,9 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/investigations_hallway)
 "uMW" = (
-/obj/effect/decal/remains/rat,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/horizon/maintenance/deck_three/aft/starboard)
+/obj/structure/table,
+/turf/simulated/floor/tiled,
+/area/bridge)
 "uNc" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -27455,6 +27540,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
+"uVu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "uVB" = (
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 1
@@ -27610,22 +27704,18 @@
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
 "vcD" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain,
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "1-2"
+	},
+/obj/machinery/meter,
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/obj/effect/floor_decal/sign/m{
-	pixel_x = -10;
-	pixel_y = 4
+	dir = 5
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/area/tcommsat/entrance)
 "vcJ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/railing/mapped,
@@ -28041,7 +28131,13 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "vrD" = (
@@ -28429,19 +28525,9 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop/xo)
 "vEP" = (
-/obj/machinery/power/apc/super/critical/north,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "vFz" = (
 /turf/simulated/wall,
 /area/horizon/hallway/deck_three/primary/central)
@@ -28495,29 +28581,21 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/heads/hop/xo)
 "vIy" = (
-/obj/structure/table/rack,
-/obj/item/circuitboard/telecomms/processor,
-/obj/item/circuitboard/telecomms/processor,
-/obj/item/circuitboard/telecomms/receiver,
-/obj/item/circuitboard/telecomms/server,
-/obj/item/circuitboard/telecomms/server,
-/obj/item/circuitboard/telecomms/bus,
-/obj/item/circuitboard/telecomms/bus,
-/obj/item/circuitboard/telecomms/broadcaster,
-/obj/effect/floor_decal/spline/plain{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "shutters_deck3_tcom";
-	name = "Viewing Shutter";
-	pixel_x = -23;
-	pixel_y = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/item/circuitboard/ntnet_relay,
-/obj/machinery/firealarm/north,
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/entrance)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/maintenance/engineering_ladder)
 "vJc" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -29373,14 +29451,12 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/port)
 "wqk" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain,
-/turf/simulated/floor/carpet/rubber,
+/turf/simulated/floor/reinforced/airless,
 /area/tcommsat/chamber)
 "wqn" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -29690,6 +29766,10 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/maintenance/bridge)
+"wEm" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/horizon/maintenance/deck_three/aft/starboard)
 "wEU" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
@@ -29750,9 +29830,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/smoking)
 "wGt" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -29773,19 +29850,12 @@
 /turf/simulated/floor/reinforced/airless,
 /area/template_noop)
 "wGR" = (
-/obj/effect/floor_decal/spline/plain,
-/obj/effect/floor_decal/spline/plain/corner{
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
+/obj/effect/floor_decal/spline/plain,
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -30011,25 +30081,23 @@
 /turf/simulated/floor/tiled,
 /area/security/vacantoffice)
 "wOl" = (
-/obj/machinery/camera/motion{
-	c_tag = "Telecommunications - Starboard";
-	dir = 4;
-	network = list("Command","Security","Telecommunications")
-	},
-/obj/effect/floor_decal/spline/plain/corner,
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	external_pressure_bound = 140;
-	external_pressure_bound_default = 140;
-	icon_state = "map_vent_out";
-	pressure_checks = 0;
-	pressure_checks_default = 0;
-	use_power = 1
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
 /obj/effect/floor_decal/spline/plain{
-	dir = 9
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
@@ -30330,20 +30398,18 @@
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
 "wWk" = (
-/obj/effect/floor_decal/sign/c{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/effect/floor_decal/spline/plain/corner,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 4
 	},
 /obj/effect/floor_decal/spline/plain,
+/obj/effect/floor_decal/spline/plain/corner{
+	dir = 1
+	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /turf/simulated/floor/carpet/rubber,
 /area/tcommsat/chamber)
 "wWA" = (
@@ -30580,18 +30646,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/controlroom)
-"xfK" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/tcommsat/chamber)
 "xfV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31762,6 +31816,15 @@
 	},
 /turf/simulated/open,
 /area/horizon/hallway/deck_three/primary/central)
+"ykJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/bridge)
 "ylG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -46011,9 +46074,9 @@ wGH
 wGH
 wGH
 oXs
-tyQ
-kVK
-kVK
+rYv
+pcj
+pcj
 oXs
 oXs
 oXs
@@ -46214,7 +46277,7 @@ oXs
 oXs
 oXs
 kLs
-jdC
+fZX
 bOL
 lsr
 nwE
@@ -46413,15 +46476,15 @@ wGH
 wGH
 oXs
 niZ
-stN
+qkd
 oXs
 rvi
-tka
+vEP
 cGI
-rzm
-gIh
+jaU
+eGx
 pAw
-rlN
+wEm
 fWM
 pAw
 pAw
@@ -46613,12 +46676,12 @@ wGH
 wGH
 wGH
 wGH
-pfn
+rQO
 jZS
 bOz
-oSn
+mSs
 qDU
-uMW
+oSn
 eZu
 vPA
 jZN
@@ -46819,10 +46882,10 @@ oXs
 nJR
 ecm
 oXs
-pcj
-tAC
-mcT
-hSu
+hVM
+uVu
+aca
+jdC
 eZu
 pAw
 lzQ
@@ -47022,9 +47085,9 @@ abZ
 rRe
 oXs
 ail
-rQB
+izr
 wjr
-hSu
+jdC
 pAw
 pAw
 pAw
@@ -47216,7 +47279,7 @@ wGH
 wGH
 wGH
 abZ
-wOl
+bbm
 cIn
 cIn
 wUx
@@ -47226,7 +47289,7 @@ wIu
 wIu
 wIu
 wIu
-eih
+aUA
 pAw
 cuy
 aCw
@@ -47418,10 +47481,10 @@ wGH
 wGH
 wGH
 abZ
-jFu
+wGR
 wug
 xSg
-rml
+oJa
 qUt
 sCe
 hIp
@@ -47623,8 +47686,8 @@ abZ
 dgI
 fZq
 pUC
-ppg
-dcq
+eGa
+kVK
 hSf
 ldS
 xSp
@@ -47822,14 +47885,14 @@ wGH
 wGH
 abZ
 abZ
-vEP
-oJa
-oJa
-mnR
-scd
+mcT
+rQB
+rQB
+tzE
+iaX
 ime
 tfz
-bVd
+tki
 ood
 wIu
 cNX
@@ -48024,12 +48087,12 @@ cOf
 whh
 abZ
 tkE
-vpR
-skx
-mDS
-qQF
-qSY
-cBq
+agn
+fCi
+mAm
+tyQ
+ppg
+gIh
 uJY
 dED
 wnD
@@ -48226,12 +48289,12 @@ coC
 wGH
 abZ
 nMa
-wqk
+eih
 aNM
 kxn
-iMI
+qSd
 sUT
-rpI
+vcD
 aQZ
 bYI
 wUL
@@ -48427,14 +48490,14 @@ wGH
 coC
 wGH
 abZ
-kkU
-wqk
+skx
+eih
 guk
 mUk
-tzE
+vpR
 qUt
 pVj
-jaU
+rzm
 nHY
 lCW
 wIu
@@ -48630,10 +48693,10 @@ raS
 wGH
 abZ
 ieD
-rzs
+lMh
 ekB
 ekB
-diz
+acV
 qUt
 wIu
 mxO
@@ -48832,16 +48895,16 @@ wGH
 wGH
 abZ
 abZ
-fCi
+tka
 wlV
 qmy
-wWk
+gyw
 qUt
-vIy
-eEX
+ouv
+rml
 qNB
 wIu
-utv
+fLs
 ygn
 fsw
 pAw
@@ -49037,8 +49100,8 @@ abZ
 hCP
 hvY
 gEi
-mxB
-agn
+iTb
+wqk
 dCR
 atW
 ssd
@@ -49236,11 +49299,11 @@ wGH
 wGH
 wGH
 abZ
-rqM
-hxX
+rzs
+wOl
 cIn
-rQO
-qDx
+wWk
+utv
 uCC
 wbR
 vSg
@@ -49284,17 +49347,17 @@ jOD
 jOD
 jOD
 lbL
-sVD
-mSs
+uMW
+cBq
 cNU
 cNU
-tfE
+stN
 cNU
 dHD
 dHD
 dHD
 dHD
-tfE
+stN
 ylG
 vQU
 fQA
@@ -49438,10 +49501,10 @@ wGH
 wGH
 wGH
 abZ
-tYH
+eEX
 sHH
 hDQ
-qkd
+kqe
 qUt
 lyA
 eVA
@@ -49486,17 +49549,17 @@ wyk
 nkG
 izo
 lbL
-sVD
+uMW
 dHD
-mSs
-mSs
+cBq
+cBq
 cNU
 cNU
 cNU
-mSs
-mSs
-mSs
-mSs
+cBq
+cBq
+cBq
+cBq
 lbL
 soE
 soE
@@ -49643,13 +49706,13 @@ abZ
 abZ
 kpN
 tUy
-rYv
+iGb
 qUt
 wIu
-hVM
+hSu
 wIu
 wIu
-gfG
+iMI
 pAw
 pAw
 jbh
@@ -49692,11 +49755,11 @@ ilv
 cNU
 dHD
 dHD
-sVD
+uMW
 khy
 iUc
 cNU
-sVD
+uMW
 gny
 dHD
 lbL
@@ -49843,14 +49906,14 @@ wGH
 wGH
 wGH
 abZ
-qSd
-xfK
-wGR
+rlN
+iQF
+rpI
 qUt
 wIu
 jFn
 hPy
-iGb
+scd
 kVQ
 pAw
 pAw
@@ -49890,16 +49953,16 @@ tfi
 sum
 sRf
 lbL
-sVD
+uMW
 cNU
-mSs
-mSs
-sVD
+cBq
+cBq
+uMW
 tjC
 cNU
 cNU
-sVD
-mSs
+uMW
+cBq
 dHD
 lbL
 qEI
@@ -50043,13 +50106,13 @@ wGH
 wGH
 wGH
 wGH
-aca
+hiT
 abZ
 fmB
 fHi
-vcD
+mDS
 mYf
-vtf
+jFu
 kIk
 aZl
 aZl
@@ -50092,16 +50155,16 @@ cBm
 cBm
 cBm
 lbL
-sVD
-iQF
+uMW
+diz
 dHD
 dHD
 cNU
 cNU
 cNU
 cNU
-sVD
-mSs
+uMW
+cBq
 cNU
 lbL
 ugJ
@@ -50249,10 +50312,10 @@ wGH
 abZ
 vvm
 sdc
-kqe
+cPa
 mzs
 afj
-bbm
+fwo
 qLy
 qLy
 qLy
@@ -50294,10 +50357,10 @@ cQL
 tdH
 uBr
 lbL
-sVD
+uMW
 cNU
 dHD
-mSs
+cBq
 dHD
 cNU
 cNU
@@ -50452,9 +50515,9 @@ abZ
 eBt
 iLf
 dgI
-ouv
+rqM
 afj
-eGa
+fwo
 qLy
 pWR
 pWR
@@ -50651,12 +50714,12 @@ feY
 hBq
 wGH
 abZ
-fZX
-ale
-izr
+kkU
+qSY
+tfE
 qUt
-afj
-eGa
+mxB
+fwo
 qLy
 aiX
 xbM
@@ -50700,13 +50763,13 @@ vIv
 vIv
 vIv
 lbL
-sVD
+uMW
 cNU
 dHD
 dHD
 kHy
-sVD
-sVD
+uMW
+uMW
 kgW
 cNU
 lbL
@@ -50857,8 +50920,8 @@ qUt
 qUt
 qUt
 qUt
-lMh
-eGa
+afj
+syl
 aaz
 kTG
 kTG
@@ -50902,8 +50965,8 @@ ozN
 wxR
 fTY
 lbL
-sVD
-iQF
+uMW
+diz
 dHD
 dHD
 dHD
@@ -51054,17 +51117,17 @@ feY
 feY
 hBq
 ilL
-fLs
-fLs
-fLs
-fLs
-fLs
-qLy
-eGa
+eoQ
+eoQ
+eoQ
+eoQ
+eoQ
+sVD
+jzc
 qLy
 isK
 hCT
-kWj
+hxX
 kWj
 kWj
 kWj
@@ -51104,7 +51167,7 @@ wMV
 fWo
 jdI
 lbL
-sVD
+uMW
 cNU
 dHD
 dHD
@@ -51262,7 +51325,7 @@ tNk
 raP
 eoQ
 qLy
-eGa
+vIy
 qLy
 bpD
 bpD
@@ -51666,7 +51729,7 @@ qii
 sdT
 iHB
 qLy
-fwo
+qDx
 qLy
 ouq
 bpD
@@ -52121,7 +52184,7 @@ dMl
 tav
 uow
 svL
-jzc
+ykJ
 htr
 lbL
 caX


### PR DESCRIPTION
This moves Telecommunications from it's original spot in the Bridge, to besides the Shield Generator in D3 maintenance. This is to open up the command area for a command-area remap that I have planned. 

this also converts the old area into a "construction zone" that will be filled in just a few days after this PR is merged. 


New Telecommunications Area
![image_2023-11-20_174926540](https://github.com/Aurorastation/Aurora.3/assets/98699252/e630b6b5-d160-4d71-bdf9-9c3cdf19b3ba)

Under construction area: 
![image](https://github.com/Aurorastation/Aurora.3/assets/98699252/c75c6ce5-204a-4681-8ea9-cbd4b7e99f85)
