### PR TITLE
Multiple Consular/Representative Framework

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -97,6 +97,8 @@ SUBSYSTEM_DEF(jobs)
 			return FALSE
 		if(jobban_isbanned(player, rank))
 			return FALSE
+		if(!player.IsJobAvailable(rank))
+			return FALSE
 
 		if(!(player.client.prefs.GetPlayerAltTitle(job) in player.client.prefs.GetValidTitles(job)))
 			to_chat(player, "<span class='warning'>Your character is too young!</span>")
@@ -111,6 +113,7 @@ SUBSYSTEM_DEF(jobs)
 			player.mind.role_alt_title = GetPlayerAltTitle(player, rank)
 			unassigned -= player
 			job.current_positions++
+			job.pre_spawn(player)
 			return TRUE
 	Debug("AR has failed, Player: [player], Rank: [rank]")
 	return FALSE

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -119,7 +119,6 @@ SUBSYSTEM_DEF(jobs)
 	var/datum/job/job = GetJob(rank)
 	if(!istype(job))
 		return
-
 	job.current_positions--
 
 /datum/controller/subsystem/jobs/proc/FindOccupationCandidates(datum/job/job, level, flag)
@@ -327,7 +326,7 @@ SUBSYSTEM_DEF(jobs)
 		Debug("ER/([H]): Equipping custom loadout.")
 		job.pre_equip(H)
 		job.setup_account(H)
-
+		job.after_spawn(H)
 		EquipCustom(H, job, H.client.prefs, custom_equip_leftovers, spawn_in_storage, custom_equip_slots)
 
 		job.equip(H)
@@ -635,10 +634,10 @@ SUBSYSTEM_DEF(jobs)
 
 	//Handle job slot/tater cleanup.
 	if (H.mind)
-		var/job = H.mind.assigned_role
-
-		FreeRole(job)
-
+		var/role = H.mind.assigned_role
+		var/datum/job/job = GetJob(H.mind.assigned_role)
+		job.on_despawn(H)
+		FreeRole(role)
 		if(H.mind.objectives.len)
 			qdel(H.mind.objectives)
 			H.mind.special_role = null

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -48,7 +48,7 @@
 /datum/job/proc/after_spawn(mob/living/carbon/human/H)
 
 /datum/job/proc/on_despawn(mob/living/carbon/human/H)
-
+	return
 /datum/job/proc/announce(mob/living/carbon/human/H)
 
 /datum/job/proc/get_outfit(mob/living/carbon/human/H, alt_title=null)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -42,9 +42,12 @@
 	var/datum/outfit/outfit = null
 	var/list/alt_outfits = null           // A list of special outfits for the alt titles list("alttitle" = /datum/outfit)
 	var/list/blacklisted_species = null   // A blacklist of species that can't be this job
+	var/list/blacklisted_citizenship = list() //A blacklist of citizenships that can't be this job
 
 //Only override this proc
 /datum/job/proc/after_spawn(mob/living/carbon/human/H)
+
+/datum/job/proc/on_despawn(mob/living/carbon/human/H)
 
 /datum/job/proc/announce(mob/living/carbon/human/H)
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -45,6 +45,8 @@
 	var/list/blacklisted_citizenship = list() //A blacklist of citizenships that can't be this job
 
 //Only override this proc
+/datum/job/proc/pre_spawn(mob/abstract/new_player/player)
+
 /datum/job/proc/after_spawn(mob/living/carbon/human/H)
 
 /datum/job/proc/on_despawn(mob/living/carbon/human/H)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -46,6 +46,7 @@
 
 //Only override this proc
 /datum/job/proc/pre_spawn(mob/abstract/new_player/player)
+	return
 
 /datum/job/proc/after_spawn(mob/living/carbon/human/H)
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -52,6 +52,7 @@
 
 /datum/job/proc/on_despawn(mob/living/carbon/human/H)
 	return
+
 /datum/job/proc/announce(mob/living/carbon/human/H)
 
 /datum/job/proc/get_outfit(mob/living/carbon/human/H, alt_title=null)

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -26,6 +26,14 @@
 	outfit = /datum/outfit/job/representative
 	blacklisted_species = list(SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER)
 
+/datum/job/representative/after_spawn(mob/living/carbon/human/H)
+	var/datum/faction/faction = SSjobs.GetFaction(H)
+	LAZYREMOVE(faction.allowed_role_types, REPRESENTATIVE_ROLE)
+
+/datum/job/representative/on_despawn(mob/living/carbon/human/H)
+	var/datum/faction/faction = SSjobs.GetFaction(H)
+	LAZYADD(faction.allowed_role_types, REPRESENTATIVE_ROLE)
+
 /datum/outfit/job/representative
 	name = "NanoTrasen Corporate Liaison"
 	var/fax_department = "Representative's Office"

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -26,6 +26,10 @@
 	outfit = /datum/outfit/job/representative
 	blacklisted_species = list(SPECIES_VAURCA_BULWARK, SPECIES_VAURCA_BREEDER)
 
+/datum/job/consular/pre_spawn(mob/abstract/new_player/player)
+	var/datum/faction/faction = SSjobs.name_factions[player.client.prefs.faction]
+	LAZYREMOVE(faction.allowed_role_types, REPRESENTATIVE_ROLE)
+
 /datum/job/representative/after_spawn(mob/living/carbon/human/H)
 	var/datum/faction/faction = SSjobs.GetFaction(H)
 	LAZYREMOVE(faction.allowed_role_types, REPRESENTATIVE_ROLE)
@@ -151,6 +155,10 @@
 	if(citizenship)
 		rep_objectives = citizenship.get_objectives(mission_level, H)
 	return rep_objectives
+
+/datum/job/consular/pre_spawn(mob/abstract/new_player/player)
+	var/datum/citizenship/citizenship = SSrecords.citizenships[player.client.prefs.citizenship]
+	LAZYADD(blacklisted_citizenship, citizenship.name)
 
 /datum/job/consular/after_spawn(mob/living/carbon/human/H)
 	var/datum/citizenship/citizenship = SSrecords.citizenships[H.citizenship]

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -116,6 +116,7 @@
 	minimal_access = list(access_consular)
 	outfit = /datum/outfit/job/representative/consular
 	blacklisted_species = list(SPECIES_VAURCA_BULWARK)
+	blacklisted_citizenship = list(CITIZENSHIP_SOL)
 
 /datum/job/consular/get_outfit(mob/living/carbon/human/H, alt_title = null)
 	var/datum/citizenship/citizenship = SSrecords.citizenships[H.citizenship]
@@ -142,3 +143,11 @@
 	if(citizenship)
 		rep_objectives = citizenship.get_objectives(mission_level, H)
 	return rep_objectives
+
+/datum/job/consular/after_spawn(mob/living/carbon/human/H)
+	var/datum/citizenship/citizenship = SSrecords.citizenships[H.citizenship]
+	LAZYADD(blacklisted_citizenship, citizenship.name)
+
+/datum/job/consular/on_despawn(mob/living/carbon/human/H)
+	var/datum/citizenship/citizenship = SSrecords.citizenships[H.citizenship]
+	LAZYREMOVE(blacklisted_citizenship, citizenship.name)

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -116,7 +116,7 @@
 	minimal_access = list(access_consular)
 	outfit = /datum/outfit/job/representative/consular
 	blacklisted_species = list(SPECIES_VAURCA_BULWARK)
-	blacklisted_citizenship = list(CITIZENSHIP_SOL)
+	blacklisted_citizenship = list(CITIZENSHIP_SOL, CITIZENSHIP_ERIDANI, CITIZENSHIP_ELYRA_NCP, CITIZENSHIP_ZORA, CITIZENSHIP_KLAX, CITIZENSHIP_CTHUR, CITIZENSHIP_NONE, CITIZENSHIP_FREE_COUNCIL)
 
 /datum/job/consular/get_outfit(mob/living/carbon/human/H, alt_title = null)
 	var/datum/citizenship/citizenship = SSrecords.citizenships[H.citizenship]

--- a/code/game/jobs/job/outsider/representative.dm
+++ b/code/game/jobs/job/outsider/representative.dm
@@ -116,7 +116,7 @@
 	minimal_access = list(access_consular)
 	outfit = /datum/outfit/job/representative/consular
 	blacklisted_species = list(SPECIES_VAURCA_BULWARK)
-	blacklisted_citizenship = list(CITIZENSHIP_SOL, CITIZENSHIP_ERIDANI, CITIZENSHIP_ELYRA_NCP, CITIZENSHIP_ZORA, CITIZENSHIP_KLAX, CITIZENSHIP_CTHUR, CITIZENSHIP_NONE, CITIZENSHIP_FREE_COUNCIL)
+	blacklisted_citizenship = list(CITIZENSHIP_SOL, CITIZENSHIP_ERIDANI, CITIZENSHIP_ELYRA_NCP, CITIZENSHIP_NONE, CITIZENSHIP_FREE_COUNCIL)
 
 /datum/job/consular/get_outfit(mob/living/carbon/human/H, alt_title = null)
 	var/datum/citizenship/citizenship = SSrecords.citizenships[H.citizenship]

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -196,6 +196,10 @@
 		if(C.job_species_blacklist[job.title] && (pref.species in C.job_species_blacklist[job.title]))
 			dat += "<del>[dispRank]</del></td><td><b> \[SPECIES RESTRICTED]</b></td></tr>"
 			continue
+		if(job.blacklisted_citizenship)
+			if(C.name in job.blacklisted_citizenship)
+				dat += "<del>[dispRank]</del></td><td><b> \[BACKGROUND RESTRICTED]</b></td></tr>"
+				continue
 		if(job.alt_titles && (LAZYLEN(pref.GetValidTitles(job)) > 1))
 			dispRank = "<span width='60%' align='center'>&nbsp<a href='?src=\ref[src];select_alt_title=\ref[job]'>\[[pref.GetPlayerAltTitle(job)]\]</a></span>"
 		if((pref.job_civilian_low & ASSISTANT) && (rank != "Assistant"))

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -208,6 +208,11 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 		if(S.name in job.blacklisted_species)
 			return FALSE
 
+	if(job.blacklisted_citizenship)
+		var/datum/citizenship/C = SSrecords.citizenships[client.prefs.citizenship]
+		if(C.name in job.blacklisted_citizenship)
+			return FALSE
+
 	var/datum/faction/faction = SSjobs.name_factions[client.prefs.faction] || SSjobs.default_faction
 	var/list/faction_allowed_roles = unpacklist(faction.allowed_role_types)
 	if (!(job.type in faction_allowed_roles))

--- a/html/changelogs/RustingWithYou - diplomacy.yml
+++ b/html/changelogs/RustingWithYou - diplomacy.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Adds framework for jobs being prohibited by citizenship."

--- a/html/changelogs/RustingWithYou - diplomacy.yml
+++ b/html/changelogs/RustingWithYou - diplomacy.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Adds framework for jobs being prohibited by citizenship."
+  - tweak: "Adds framework for multiple consular and liason slots."


### PR DESCRIPTION
Adds a framework for prohibiting jobs by citizenship, and makes it so that multiple consular officers with the same citizenship cannot spawn. This PR does not increase the number of consular slots, as that will require a remap which is currently WIP by @Eyeveri.

Also adds a similar framework based on faction for corporate liaisons. 