### PR TITLE
Changeling gender and auto accent

### DIFF
--- a/code/game/gamemodes/changeling/helpers/_framework.dm
+++ b/code/game/gamemodes/changeling/helpers/_framework.dm
@@ -101,7 +101,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 		absorbDNA(newDNA)
 		changeling.mimiced_accent = H.accent
 
-if(changeling.has_entered_stasis)
+	if(changeling.has_entered_stasis)
 		remove_verb(src, /mob/proc/changeling_fakedeath)
 
 	return TRUE

--- a/code/game/gamemodes/changeling/helpers/_framework.dm
+++ b/code/game/gamemodes/changeling/helpers/_framework.dm
@@ -20,7 +20,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	var/mimiced_accent = "Biesellite"
 	var/justate
 	var/can_respec = FALSE
-	/// if they've entered stasis before, then we don't want to give them stasis again
+/// if they've entered stasis before, then we don't want to give them stasis again
 	var/has_entered_stasis = FALSE
 
 /datum/changeling/New(var/gender=FEMALE)
@@ -97,11 +97,11 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 
 	var/mob/living/carbon/human/H = src
 	if(istype(H))
-		var/datum/absorbed_dna/newDNA = new(H.real_name, H.dna, H.species.get_cloning_variant(), H.languages)
+		var/datum/absorbed_dna/newDNA = new(H.real_name, H.dna, H.species.get_cloning_variant(), H.languages, H.height, H.gender, H.pronouns, H.accent)
 		absorbDNA(newDNA)
 		changeling.mimiced_accent = H.accent
 
-	if(changeling.has_entered_stasis)
+if(changeling.has_entered_stasis)
 		remove_verb(src, /mob/proc/changeling_fakedeath)
 
 	return TRUE
@@ -209,14 +209,20 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	var/speciesName
 	var/list/languages
 	var/height
+	var/gender
+	var/pronouns
+	var/accent
 
-/datum/absorbed_dna/New(var/newName, var/newDNA, var/newSpecies, var/newLanguages, newHeight)
+/datum/absorbed_dna/New(var/newName, var/newDNA, var/newSpecies, var/newLanguages, var/newHeight, var/newGender, var/newPronouns, var/newAccent)
 	..()
 	name = newName
 	dna = newDNA
 	speciesName = newSpecies
 	languages = newLanguages
 	height = newHeight
+	gender = newGender
+	pronouns = newPronouns
+	accent = newAccent
 
 //Helper for stingcode
 

--- a/code/game/gamemodes/changeling/helpers/_framework.dm
+++ b/code/game/gamemodes/changeling/helpers/_framework.dm
@@ -20,7 +20,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	var/mimiced_accent = "Biesellite"
 	var/justate
 	var/can_respec = FALSE
-/// if they've entered stasis before, then we don't want to give them stasis again
+	/// if they've entered stasis before, then we don't want to give them stasis again
 	var/has_entered_stasis = FALSE
 
 /datum/changeling/New(var/gender=FEMALE)

--- a/code/game/gamemodes/changeling/helpers/_store.dm
+++ b/code/game/gamemodes/changeling/helpers/_store.dm
@@ -30,15 +30,6 @@ var/list/datum/power/changeling/powerinstances = list()
 	genomecost = 0
 	verbpath = /mob/proc/changeling_absorb_dna
 
-// Accent Mimicry
-
-/datum/power/changeling/mimic_accent
-	name = "Mimic Accent"
-	desc = "Allows us to shape our vocal glands to adopt a specific accent."
-	helptext = "Allows you to pick any accent from the list of all accents. Be mindful that you need to match the correct accent to pretend to be your victim."
-	genomecost = 0
-	verbpath = /mob/proc/changeling_mimic_accent
-
 //Transformation
 
 /datum/power/changeling/transform

--- a/code/game/gamemodes/changeling/implements/powers/body.dm
+++ b/code/game/gamemodes/changeling/implements/powers/body.dm
@@ -42,6 +42,7 @@
 	if(ishuman(src))
 		src.visible_message("<span class='warning'>[src] transforms!</span>")
 		var/mob/living/carbon/human/H = src
+		var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
 		var/newSpecies = chosen_dna.speciesName
 		H.set_species(newSpecies, 1)
 
@@ -50,6 +51,10 @@
 		H.sync_organ_dna()
 		H.flavor_text = ""
 		H.height = chosen_dna.height
+		H.gender = chosen_dna.gender
+		H.pronouns = chosen_dna.pronouns
+		H.accent = chosen_dna.accent
+		changeling.mimiced_accent = chosen_dna.accent
 		domutcheck(H, null) //donut check heh heh heh - Geeves
 		H.UpdateAppearance()
 

--- a/code/game/gamemodes/changeling/implements/powers/body.dm
+++ b/code/game/gamemodes/changeling/implements/powers/body.dm
@@ -53,7 +53,6 @@
 		H.height = chosen_dna.height
 		H.gender = chosen_dna.gender
 		H.pronouns = chosen_dna.pronouns
-		H.accent = chosen_dna.accent
 		changeling.mimiced_accent = chosen_dna.accent
 		domutcheck(H, null) //donut check heh heh heh - Geeves
 		H.UpdateAppearance()
@@ -413,22 +412,6 @@
 	feedback_add_details("changeling_powers", "RR")
 	return TRUE
 
-/mob/proc/changeling_mimic_accent()
-	set category = "Changeling"
-	set name = "Mimic Accent"
-	set desc = "Shape our vocal glands to mimic any accent we choose."
-
-	var/datum/changeling/changeling = changeling_power()
-	if(!changeling)
-		return
-
-	var/chosen_accent = tgui_input_list(src, "Choose an accent to mimic.", "Accent Mimicry", SSrecords.accents)
-	if(!chosen_accent)
-		return
-
-	changeling.mimiced_accent = chosen_accent
-	to_chat(src, SPAN_NOTICE("We have chosen to mimic the [chosen_accent] accent."))
-
 // Fake Voice
 /mob/proc/changeling_mimicvoice()
 	set category = "Changeling"
@@ -440,7 +423,9 @@
 		return
 
 	if(changeling.mimicing)
+		var/datum/absorbed_dna/current_dna = changeling.GetDNA(real_name)
 		changeling.mimicing = ""
+		changeling.mimiced_accent = current_dna.accent
 		to_chat(src, "<span class='notice'>We return our vocal glands to their original form.</span>")
 		return
 
@@ -448,9 +433,14 @@
 	if(!mimic_voice)
 		return
 
-	changeling.mimicing = mimic_voice
+	var/chosen_accent = tgui_input_list(src, "Choose an accent to mimic.", "Accent Mimicry", SSrecords.accents)
+	if(!chosen_accent)
+		return
 
-	to_chat(src, "<span class='notice'>We shape our glands to take the voice of <b>[mimic_voice]</b>, this will stop us from regenerating chemicals while active.</span>")
+	changeling.mimicing = mimic_voice
+	changeling.mimiced_accent = chosen_accent
+
+	to_chat(src, "<span class='notice'>We shape our glands to take the voice of <b>[mimic_voice]</b>, using the <b>[chosen_accent]</b> accent. This will stop us from regenerating chemicals while active.</span>")
 	to_chat(src, "<span class='notice'>Use this power again to return to our original voice and reproduce chemicals again.</span>")
 
 	feedback_add_details("changeling_powers","MV")

--- a/code/game/gamemodes/changeling/implements/powers/body.dm
+++ b/code/game/gamemodes/changeling/implements/powers/body.dm
@@ -53,7 +53,8 @@
 		H.height = chosen_dna.height
 		H.gender = chosen_dna.gender
 		H.pronouns = chosen_dna.pronouns
-		changeling.mimiced_accent = chosen_dna.accent
+		if(!changeling.mimicing)
+			changeling.mimiced_accent = chosen_dna.accent
 		domutcheck(H, null) //donut check heh heh heh - Geeves
 		H.UpdateAppearance()
 

--- a/code/game/gamemodes/changeling/implements/powers/stings.dm
+++ b/code/game/gamemodes/changeling/implements/powers/stings.dm
@@ -251,7 +251,7 @@
 
 /datum/changeling_sting/dna_extract/do_sting(mob/living/carbon/human/target)
 	..()
-	var/datum/absorbed_dna/newDNA = new(target.real_name, target.dna, target.species.get_cloning_variant(), target.languages)
+	var/datum/absorbed_dna/newDNA = new(target.real_name, target.dna, target.species.get_cloning_variant(), target.languages, target.height, target.gender, target.pronouns, target.accent)
 	owner.absorbDNA(newDNA)
 
 //Boosts the range of your next sting attack by 1

--- a/code/game/gamemodes/changeling/implements/powers/suck.dm
+++ b/code/game/gamemodes/changeling/implements/powers/suck.dm
@@ -77,7 +77,7 @@
 
 	changeling_update_languages(changeling.absorbed_languages)
 
-	var/datum/absorbed_dna/newDNA = new(T.real_name, T.dna, T.species.get_cloning_variant(), T.languages, T.height)
+	var/datum/absorbed_dna/newDNA = new(T.real_name, T.dna, T.species.get_cloning_variant(), T.languages, T.height, T.gender, T.pronouns, T.accent)
 	absorbDNA(newDNA)
 
 	var/datum/changeling/changeling_check = T.get_antag_datum(MODE_CHANGELING)

--- a/html/changelogs/AlaunusLux-changeling-gender-accent-changes.yml
+++ b/html/changelogs/AlaunusLux-changeling-gender-accent-changes.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - tweak: "Transforming now changes gender and pronouns, as well as automatically changing accent."
+  - tweak: "Mimic Accent is no longer a separate ability. Mimic Voice now asks which accent to use after asking for a name."

--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: AlaunusLux
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Transforming now changes gender and pronouns, as well as automatically changing accent."


### PR DESCRIPTION
Being examined now shows the proper gender and pronouns of the person you transformed into, and it also automatically changes the accent.

There's no reason the gender and pronouns shouldn't be changed, as it gives you away when being examined. Additionally, having to manually change the accent just adds a lot of fiddling that gets in the way of gameplay. I will miss the RP potential in having an incorrect accent and blowing your cover, but usually I just forget it's something else I have to do on top of transforming. 

I've also combined the mimic accent and mimic voice ability. Now it will ask what accent to mimic after asking for the voice name, and will revert to whichever DNA the changeling is using at the time when they revert.  I almost didn't combine them because I didn't want to take away any flexibility, but it just makes sense to me and reduces fiddling/chance of forgetting for those that want to use the mimic voice ability.