### PR TITLE
Added Vat-grown Humans as a distinct subspecies for protohumans.

### DIFF
--- a/code/__defines/species.dm
+++ b/code/__defines/species.dm
@@ -1,5 +1,6 @@
 #define SPECIES_HUMAN				"Human"
 #define SPECIES_HUMAN_OFFWORLD		"Off-Worlder Human"
+#define SPECIES_HUMAN_VATGROWN		"Vat-Grown Human"
 
 #define SPECIES_UNATHI				"Unathi"
 

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -15,6 +15,10 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy/mannequin)
 	human_mob_list -= src
 	delete_inventory()
 
+/mob/living/carbon/human/vatgrown/Initialize(mapload)
+	. = ..(mapload, SPECIES_HUMAN_VATGROWN)
+	mob_thinks = FALSE
+
 /mob/living/carbon/human/skrell/Initialize(mapload)
 	h_style = "Skrell Average Tentacles"
 	. = ..(mapload, SPECIES_SKRELL)

--- a/code/modules/mob/living/carbon/human/species/station/human/human_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human/human_subspecies.dm
@@ -101,8 +101,7 @@
 	name_plural = "Vat-Grown Humans"
 	blurb = {"The idea of \"flash-cloning\" humans has intrigued humanity for generations. Despite this and the potential for immense profits however, the corporations have stayed away from this citing ethical and moral concerns.<br>
 Yomi Genetics is the only known corporation to produce flash-cloned humans. However, due to the process used, their brains are always undeveloped beyond the brain stem. Their flash-cloned humans are reserved exclusively for medical testing and scientific and academic research.<br>
-Despite the lack of a market for fully developed adult human clones and the claimed immense investment required to make such a thing possible, extranet rumors have been floating for decades that Zeng-Hu's heavy-duty biohazard response teams are fully developed flash-cloned humans,<br>
-but no evidence for this has ever been produced."}
+Despite the lack of a market for fully developed adult human clones and the claimed immense investment required to make such a thing possible, extranet rumors have been floating for decades that Zeng-Hu's heavy-duty biohazard response teams are fully developed flash-cloned humans, but no evidence for this has ever been produced."}
 	hide_name = FALSE
 	icobase = 'icons/mob/human_races/subspecies/r_vatgrown.dmi'
 	deform = 'icons/mob/human_races/subspecies/r_vatgrown.dmi'

--- a/code/modules/mob/living/carbon/human/species/station/human/human_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/human/human_subspecies.dm
@@ -95,3 +95,16 @@
 								"You begin to have trouble standing upright.")
 
 		to_chat(H, "<span class='warning'>[pain_message]</span>")
+
+/datum/species/human/vatgrown
+	name = SPECIES_HUMAN_VATGROWN
+	name_plural = "Vat-Grown Humans"
+	blurb = {"The idea of \"flash-cloning\" humans has intrigued humanity for generations. Despite this and the potential for immense profits however, the corporations have stayed away from this citing ethical and moral concerns.<br>
+Yomi Genetics is the only known corporation to produce flash-cloned humans. However, due to the process used, their brains are always undeveloped beyond the brain stem. Their flash-cloned humans are reserved exclusively for medical testing and scientific and academic research.<br>
+Despite the lack of a market for fully developed adult human clones and the claimed immense investment required to make such a thing possible, extranet rumors have been floating for decades that Zeng-Hu's heavy-duty biohazard response teams are fully developed flash-cloned humans,<br>
+but no evidence for this has ever been produced."}
+	hide_name = FALSE
+	icobase = 'icons/mob/human_races/subspecies/r_vatgrown.dmi'
+	deform = 'icons/mob/human_races/subspecies/r_vatgrown.dmi'
+	spawn_flags = IS_RESTRICTED
+	examine_color = "#c1f961"

--- a/html/changelogs/GeneralCamo-ProtohumanVatgrown.yml
+++ b/html/changelogs/GeneralCamo-ProtohumanVatgrown.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Protohumans ordered from cargo are now a distinct species and use a new icon."


### PR DESCRIPTION
While digging in the mobs icon folder, I found old icons for Bay's Vat-Grown Humans. Rather than wasting them, I figured I would integrate them into the game, using the existing lore for cloned humans.

This subspecies is restricted from spawning, and cannot be normally spawned. The intention is to replace the protohuman mob define in the cargo list with these, for a bit of flavor. As a bonus, this dedicated mob has its AI disabled, as a small optimization.

For Arrow: `/mob/living/carbon/human` should be replaced with `/mob/living/carbon/human/vatgrown` for the protohuman entry in the cargolist.
![image](https://github.com/Aurorastation/Aurora.3/assets/1779662/67e197bd-96d9-4fca-96c1-0643c5d0d15f)
