### PR TITLE
Extend spacemandmm & opendream linters coverage

### DIFF
--- a/code/__linters.dm
+++ b/code/__linters.dm
@@ -9,8 +9,19 @@ Nothing should ever be included before this file.
 //Defines to extend SpacemanDMM code coverage
 #if defined(SPACEMAN_DMM)
 
+#define DEBUG
+#define TIMER_DEBUG
+#define TESTING
 #define UNIT_TEST
+#define ZASDBG
+#define DO_NOT_DEFER_ASSETS
+#define SQL_PREF_DEBUG
+#define REFERENCE_TRACKING
+#define REFERENCE_TRACKING_DEBUG
 #define MANUAL_UNIT_TEST
+#define AMAP
+#define ENABLE_SUNLIGHT
+#define AO_USE_LIGHTING_OPACITY
 
 #endif //SPACEMAN_DMM
 
@@ -21,14 +32,18 @@ Nothing should ever be included before this file.
 #include "___linters\odlint.dm"
 
 //Defines to extend OpenDream code coverage
+#define DEBUG
 #define TIMER_DEBUG
 #define TESTING
 #define UNIT_TEST
 #define ZASDBG
-#define GC_FAILURE_HARD_LOOKUP
 #define DO_NOT_DEFER_ASSETS
 #define SQL_PREF_DEBUG
+#define REFERENCE_TRACKING
 #define REFERENCE_TRACKING_DEBUG
 #define MANUAL_UNIT_TEST
+#define AMAP
+#define ENABLE_SUNLIGHT
+#define AO_USE_LIGHTING_OPACITY
 
 #endif //OPENDREAM

--- a/code/__linters.dm
+++ b/code/__linters.dm
@@ -6,7 +6,29 @@ Nothing should ever be included before this file.
 //SpacemanDMM suite, always included as its definitions are used downstream directly, and just nulled if SPACEMAN_DMM is not defined
 #include "___linters\spaceman_dmm.dm"
 
+//Defines to extend SpacemanDMM code coverage
+#if defined(SPACEMAN_DMM)
+
+#define UNIT_TEST
+#define MANUAL_UNIT_TEST
+
+#endif //SPACEMAN_DMM
+
+
+#if defined(OPENDREAM)
+
 //OpenDream, only included if OPENDREAM is defined, as otherwise SpacemanDMM isn't happy about the pragma directives
-#ifdef OPENDREAM
 #include "___linters\odlint.dm"
-#endif
+
+//Defines to extend OpenDream code coverage
+#define TIMER_DEBUG
+#define TESTING
+#define UNIT_TEST
+#define ZASDBG
+#define GC_FAILURE_HARD_LOOKUP
+#define DO_NOT_DEFER_ASSETS
+#define SQL_PREF_DEBUG
+#define REFERENCE_TRACKING_DEBUG
+#define MANUAL_UNIT_TEST
+
+#endif //OPENDREAM

--- a/code/controllers/subsystems/sunlight.dm
+++ b/code/controllers/subsystems/sunlight.dm
@@ -6,7 +6,7 @@ SUBSYSTEM_DEF(sunlight)
 	init_order = SS_INIT_SUNLIGHT
 
 	var/list/light_points = list()
-	var/config.sun_target_z = 7
+	var/config/sun_target_z = 7
 
 	var/list/presets
 

--- a/code/game/machinery/overview.dm
+++ b/code/game/machinery/overview.dm
@@ -121,7 +121,7 @@
 
 			if(!colour2 && isturf(T) && !T.density)
 				var/datum/gas_mixture/environment = T.return_air()
-				var/turf_total = environment.total_moles()
+				var/turf_total = environment.get_total_moles()
 				//var/turf_total = T.co2 + T.oxygen + T.poison + T.sl_gas + T.n2
 
 

--- a/html/changelogs/FluffyGhost-extend_spacemandmm_opendream_linters_coverage.yml
+++ b/html/changelogs/FluffyGhost-extend_spacemandmm_opendream_linters_coverage.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Extended OpenDream and SpacemanDMM linting coverage to the main defines used in the codebase."
+  - bugfix: "Fixed a warning for path definition and an old reference to a renamed function in ZAS."


### PR DESCRIPTION
Extended OpenDream and SpacemanDMM linting coverage to the main defines used in the codebase.
Fixed a warning for path definition and an old reference to a renamed function in ZAS.