### PR TITLE
Add search to traitor uplink

### DIFF
--- a/code/datums/outfits/outfit_antag.dm
+++ b/code/datums/outfits/outfit_antag.dm
@@ -40,7 +40,7 @@
 		U.hidden_uplink.uplink_owner = H.mind
 		U.hidden_uplink.telecrystals = uplink_uses
 		U.hidden_uplink.bluecrystals = round(uplink_uses / 2)
-		U.hidden_uplink.nanoui_menu = 1
+		U.hidden_uplink.tgui_menu = 1
 
 /datum/outfit/admin/syndicate/get_id_access()
 	return get_syndicate_access(id_access)

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -149,29 +149,41 @@ Then check if it's true, if true return. This will stop the normal menu appearin
 
 	return 1
 
+/obj/item/device/uplink/hidden/proc/new_nanoui_item_data(var/datum/uplink_item/item){
+	var/tc_cost = item.telecrystal_cost(telecrystals)
+	var/bc_cost = item.bluecrystal_cost(bluecrystals)
+	var/can_buy = item.can_buy_telecrystals(src) || item.can_buy_bluecrystals(src)
+	var/newItem = list(
+		"name" = item.name,
+		"description" = replacetext(item.description(), "\n", "<br>"),
+		"can_buy" = can_buy,
+		"tc_cost" = tc_cost,
+		"bc_cost" = bc_cost,
+		"left" = item.items_left(src),
+		"ref" = "\ref[item]"
+	)
+	return newItem
+}
+
 /obj/item/device/uplink/hidden/proc/update_nano_data()
 	if(nanoui_menu == 0)
 		var/categories[0]
+		var/items[0]
 		for(var/datum/uplink_category/category in uplink.categories)
 			if(category.can_view(src))
 				categories[++categories.len] = list("name" = category.name, "ref" = "\ref[category]")
+				for(var/datum/uplink_item/item in category.items) {
+					if(item.can_view(src)) {
+						items[++items.len] = new_nanoui_item_data(item)
+					}
+				}
 		nanoui_data["categories"] = categories
+		nanoui_data["items"] = items
 	else if(nanoui_menu == 1)
 		var/items[0]
 		for(var/datum/uplink_item/item in category.items)
 			if(item.can_view(src))
-				var/tc_cost = item.telecrystal_cost(telecrystals)
-				var/bc_cost = item.bluecrystal_cost(bluecrystals)
-				var/can_buy = item.can_buy_telecrystals(src) || item.can_buy_bluecrystals(src)
-				items[++items.len] = list(
-					"name" = item.name,
-					"description" = replacetext(item.description(), "\n", "<br>"),
-					"can_buy" = can_buy,
-					"tc_cost" = tc_cost,
-					"bc_cost" = bc_cost,
-					"left" = item.items_left(src),
-					"ref" = "\ref[item]"
-				)
+				items[++items.len] = new_nanoui_item_data(item)
 		nanoui_data["items"] = items
 	else if(nanoui_menu == 2)
 		var/permanentData[0]

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -21,12 +21,12 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	var/list/ItemsCategory
 	/// List of references with an associated item.
 	var/list/ItemsReference
-	/// List of items for NanoUI use.
-	var/list/nanoui_items
+	/// List of items for TGUI use.
+	var/list/tgui_items
 	/// The current menu we are in.
-	var/nanoui_menu = 0
-	/// Additional data for NanoUI use.
-	var/list/nanoui_data = list()
+	var/tgui_menu = 0
+	/// Additional data for TGUI use.
+	var/list/tgui_data = list()
 	// Assoc list of item to times bought; shared/referenced by child uplinks
 	var/list/purchase_log = list()
 	/// Mind of the uplink's owner.
@@ -75,8 +75,8 @@ Then check if it's true, if true return. This will stop the normal menu appearin
 		if(!istype(loc, /obj/item))
 			qdel(src)
 	..()
-	nanoui_data = list()
-	update_nano_data()
+	tgui_data = list()
+	update_tgui_data()
 
 // Toggles the uplink on and off. Normally this will bypass the item's normal functions and go to the uplink menu, if activated.
 /obj/item/device/uplink/hidden/proc/toggle()
@@ -111,9 +111,9 @@ Then check if it's true, if true return. This will stop the normal menu appearin
 	data["welcome"] = welcome
 	data["telecrystals"] = telecrystals
 	data["bluecrystals"] = bluecrystals
-	data["menu"] = nanoui_menu
-	update_nano_data()
-	data += nanoui_data
+	data["menu"] = tgui_menu
+	update_tgui_data()
+	data += tgui_data
 	return data
 
 // Interaction code. Gathers a list of items purchasable from the paren't uplink and displays it. It also adds a lock button.
@@ -131,9 +131,9 @@ Then check if it's true, if true return. This will stop the normal menu appearin
 		toggle()
 		SStgui.close_uis(src)
 	else if(action == "return")
-		nanoui_menu = round(nanoui_menu/10)
+		tgui_menu = round(tgui_menu/10)
 	else if(action == "menu")
-		nanoui_menu = text2num(params["menu"])
+		tgui_menu = text2num(params["menu"])
 		if(params["id"])
 			exploit_id = params["id"]
 		if(params["category"])
@@ -142,14 +142,14 @@ Then check if it's true, if true return. This will stop the normal menu appearin
 		var/list/params_webint = list("location" = "contract_details", "contract" = params["contract_interact"])
 		usr.client.process_webint_link("interface/login/sso_server", list2params(params_webint))
 	if(action == "contract_page")
-		nanoui_data["contracts_current_page"] = text2num(params["contract_page"])
+		tgui_data["contracts_current_page"] = text2num(params["contract_page"])
 	if(action == "contract_view")
-		nanoui_data["contracts_view"] = text2num(params["contract_view"])
-		nanoui_data["contracts_current_page"] = 1
+		tgui_data["contracts_view"] = text2num(params["contract_view"])
+		tgui_data["contracts_current_page"] = 1
 
 	return 1
 
-/obj/item/device/uplink/hidden/proc/new_nanoui_item_data(var/datum/uplink_item/item){
+/obj/item/device/uplink/hidden/proc/new_tgui_item_data(var/datum/uplink_item/item)
 	var/tc_cost = item.telecrystal_cost(telecrystals)
 	var/bc_cost = item.bluecrystal_cost(bluecrystals)
 	var/can_buy = item.can_buy_telecrystals(src) || item.can_buy_bluecrystals(src)
@@ -163,77 +163,75 @@ Then check if it's true, if true return. This will stop the normal menu appearin
 		"ref" = "\ref[item]"
 	)
 	return newItem
-}
 
-/obj/item/device/uplink/hidden/proc/update_nano_data()
-	if(nanoui_menu == 0)
-		var/categories[0]
-		var/items[0]
+/obj/item/device/uplink/hidden/proc/update_tgui_data()
+	if(tgui_menu == 0)
+		var/list/categories = list()
+		var/list/items = list()
 		for(var/datum/uplink_category/category in uplink.categories)
 			if(category.can_view(src))
 				categories[++categories.len] = list("name" = category.name, "ref" = "\ref[category]")
-				for(var/datum/uplink_item/item in category.items) {
-					if(item.can_view(src)) {
-						items[++items.len] = new_nanoui_item_data(item)
-					}
-				}
-		nanoui_data["categories"] = categories
-		nanoui_data["items"] = items
-	else if(nanoui_menu == 1)
+				for(var/datum/uplink_item/item in category.items)
+					if(item.can_view(src))
+						items[++items.len] = new_tgui_item_data(item)
+
+		tgui_data["categories"] = categories
+		tgui_data["items"] = items
+	else if(tgui_menu == 1)
 		var/items[0]
 		for(var/datum/uplink_item/item in category.items)
 			if(item.can_view(src))
-				items[++items.len] = new_nanoui_item_data(item)
-		nanoui_data["items"] = items
-	else if(nanoui_menu == 2)
+				items[++items.len] = new_tgui_item_data(item)
+		tgui_data["items"] = items
+	else if(tgui_menu == 2)
 		var/permanentData[0]
 		for(var/datum/record/general/locked/record in SSrecords.records_locked)
 			permanentData[++permanentData.len] = list("name" = record.name,"id" = record.id, "has_exploitables" = !!record.exploit_record)
-		nanoui_data["exploit_records"] = permanentData
-	else if(nanoui_menu == 21)
-		nanoui_data["exploit_exists"] = 0
+		tgui_data["exploit_records"] = permanentData
+	else if(tgui_menu == 21)
+		tgui_data["exploit_exists"] = 0
 
 		for(var/datum/record/general/locked/L in SSrecords.records_locked)
 			if(L.id == exploit_id)
-				nanoui_data["exploit"] = list()  // Setting this to equal L.fields passes it's variables that are lists as reference instead of value.
+				tgui_data["exploit"] = list()  // Setting this to equal L.fields passes it's variables that are lists as reference instead of value.
 												// We trade off being able to automatically add shit for more control over what gets passed to json
 												// and if it's sanitized for html.
-				nanoui_data["exploit"]["nanoui_exploit_record"] = html_encode(L.exploit_record) // Change stuff into html
-				nanoui_data["exploit"]["nanoui_exploit_record"] = replacetext(nanoui_data["exploit"]["nanoui_exploit_record"], "\n", "<br>") // change line breaks into <br>
-				nanoui_data["exploit"]["name"] = html_encode(L.name)
-				nanoui_data["exploit"]["sex"] = html_encode(L.sex)
-				nanoui_data["exploit"]["age"] = html_encode(L.age)
-				nanoui_data["exploit"]["species"] = html_encode(L.species)
-				nanoui_data["exploit"]["rank"] = html_encode(L.rank)
-				nanoui_data["exploit"]["citizenship"] = html_encode(L.citizenship)
-				nanoui_data["exploit"]["employer"] = html_encode(L.employer)
-				nanoui_data["exploit"]["religion"] = html_encode(L.religion)
-				nanoui_data["exploit"]["fingerprint"] = html_encode(L.fingerprint)
+				tgui_data["exploit"]["tgui_exploit_record"] = html_encode(L.exploit_record) // Change stuff into html
+				tgui_data["exploit"]["tgui_exploit_record"] = replacetext(tgui_data["exploit"]["tgui_exploit_record"], "\n", "<br>") // change line breaks into <br>
+				tgui_data["exploit"]["name"] = html_encode(L.name)
+				tgui_data["exploit"]["sex"] = html_encode(L.sex)
+				tgui_data["exploit"]["age"] = html_encode(L.age)
+				tgui_data["exploit"]["species"] = html_encode(L.species)
+				tgui_data["exploit"]["rank"] = html_encode(L.rank)
+				tgui_data["exploit"]["citizenship"] = html_encode(L.citizenship)
+				tgui_data["exploit"]["employer"] = html_encode(L.employer)
+				tgui_data["exploit"]["religion"] = html_encode(L.religion)
+				tgui_data["exploit"]["fingerprint"] = html_encode(L.fingerprint)
 
-				nanoui_data["exploit_exists"] = 1
+				tgui_data["exploit_exists"] = 1
 				break
 
-	else if(nanoui_menu == 3)
-		nanoui_data["contracts_found"] = 0
+	else if(tgui_menu == 3)
+		tgui_data["contracts_found"] = 0
 
 		if(establish_db_connection(dbcon))
-			nanoui_data["contracts"] = list()
+			tgui_data["contracts"] = list()
 
-			if (!nanoui_data["contracts_current_page"])
-				nanoui_data["contracts_current_page"] = 1
+			if (!tgui_data["contracts_current_page"])
+				tgui_data["contracts_current_page"] = 1
 
-			if (!nanoui_data["contracts_view"])
-				nanoui_data["contracts_view"] = 1
+			if (!tgui_data["contracts_view"])
+				tgui_data["contracts_view"] = 1
 
 			var/query_details[0]
 
-			switch (nanoui_data["contracts_view"])
+			switch (tgui_data["contracts_view"])
 				if (1)
 					query_details["status"] = "open"
 				if (2)
 					query_details["status"] = "closed"
 				else
-					nanoui_data["contracts_view"] = 1
+					tgui_data["contracts_view"] = 1
 					query_details["status"] = "open"
 
 			var/DBQuery/index_query = dbcon.NewQuery("SELECT count(*) as Total_Contracts FROM ss13_syndie_contracts WHERE deleted_at IS NULL AND status = :status:")
@@ -258,12 +256,12 @@ Then check if it's true, if true return. This will stop the normal menu appearin
 
 				for (var/a in contracts_pages)
 
-				nanoui_data["contracts_pages"] = contracts_pages
+				tgui_data["contracts_pages"] = contracts_pages
 
-				if (nanoui_data["contracts_current_page"] > pages)
+				if (tgui_data["contracts_current_page"] > pages)
 					return
 
-				query_details["offset"] = (nanoui_data["contracts_current_page"] - 1) * 10
+				query_details["offset"] = (tgui_data["contracts_current_page"] - 1) * 10
 
 				var/DBQuery/list_query = dbcon.NewQuery("SELECT contract_id, contractee_name, title FROM ss13_syndie_contracts WHERE deleted_at IS NULL AND status = :status: LIMIT 10 OFFSET :offset:")
 				list_query.Execute(query_details)
@@ -274,21 +272,21 @@ Then check if it's true, if true return. This will stop the normal menu appearin
 											"contractee" = list_query.item[2],
 											"title" = list_query.item[3])))
 
-				nanoui_data["contracts"] = contracts
+				tgui_data["contracts"] = contracts
 
-				nanoui_data["contracts_found"] = 1
+				tgui_data["contracts_found"] = 1
 
-	if(nanoui_menu == 31)
-		nanoui_data["contracts_found"] = 0
+	if(tgui_menu == 31)
+		tgui_data["contracts_found"] = 0
 
 		if (config.sql_enabled && establish_db_connection(dbcon))
-			nanoui_data["contracts"] = list()
+			tgui_data["contracts"] = list()
 
-			if (!nanoui_data["contracts_current_page"])
-				nanoui_data["contracts_current_page"] = 1
+			if (!tgui_data["contracts_current_page"])
+				tgui_data["contracts_current_page"] = 1
 
-			if (!nanoui_data["contracts_view"])
-				nanoui_data["contracts_view"] = 1
+			if (!tgui_data["contracts_view"])
+				tgui_data["contracts_view"] = 1
 
 			var/query_details[0]
 			query_details["contract_id"] = exploit_id
@@ -297,7 +295,7 @@ Then check if it's true, if true return. This will stop the normal menu appearin
 			select_query.Execute(query_details)
 
 			if (select_query.NextRow())
-				nanoui_data["contracts_found"] = 1
+				tgui_data["contracts_found"] = 1
 
 				var/contract[0]
 				contract["id"] = select_query.item[1]
@@ -317,7 +315,7 @@ Then check if it's true, if true return. This will stop the normal menu appearin
 				contract["description"] = replacetext(contract["description"], ascii2text(13), "")
 				contract["reward_other"] = select_query.item[6]
 
-				nanoui_data["contract"] = contract
+				tgui_data["contract"] = contract
 
 // I placed this here because of how relevant it is.
 // You place this in your uplinkable item to check if an uplink is active or not.
@@ -378,7 +376,7 @@ Then check if it's true, if true return. This will stop the normal menu appearin
 	hidden_uplink = new(src, mind)
 	hidden_uplink.telecrystals = 0
 	hidden_uplink.bluecrystals = 0
-	hidden_uplink.nanoui_menu = 3
+	hidden_uplink.tgui_menu = 3
 
 /obj/item/device/contract_uplink/attack_self(mob/user as mob)
 	if (hidden_uplink)
@@ -435,7 +433,7 @@ Then check if it's true, if true return. This will stop the normal menu appearin
 		hidden_uplink.bluecrystals = DEFAULT_BLUECRYSTAL_AMOUNT
 	else
 		hidden_uplink.bluecrystals = DEFAULT_BLUECRYSTAL_AMOUNT
-	hidden_uplink.nanoui_menu = 1
+	hidden_uplink.tgui_menu = 1
 
 /obj/item/device/special_uplink/attack_self(mob/user as mob)
 	if(hidden_uplink)

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -38,7 +38,7 @@
 				I.hidden_uplink.telecrystals += amount
 			else if(crystal_type == CRYSTAL_TYPE_BLUECRYSTAL)
 				I.hidden_uplink.bluecrystals += amount
-			I.hidden_uplink.update_nano_data()
+			I.hidden_uplink.update_tgui_data()
 			SSnanoui.update_uis(I.hidden_uplink)
 			use(amount)
 			to_chat(user, SPAN_NOTICE("You slot \the [src] into \the [I] and charge its internal uplink."))

--- a/html/changelogs/AlaunusLux-taitor-uplink-search.yml
+++ b/html/changelogs/AlaunusLux-taitor-uplink-search.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: AlaunusLux
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a search feature to Traitor Uplink."

--- a/tgui/packages/tgui/interfaces/Uplink.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink.tsx
@@ -1,6 +1,6 @@
 import { BooleanLike } from '../../common/react';
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, Section, LabeledList, Table } from '../components';
+import { Box, Button, Input, Section, LabeledList, Table } from '../components';
 import { Window } from '../layouts';
 
 export type UplinkData = {
@@ -105,7 +105,7 @@ export const Uplink = (props, context) => {
             </Table.Row>
           </Table>
         </Section>
-        {data.menu === 0 ? ItemCategoriesSection(act, data) : ''}
+        {data.menu === 0 ? ItemCategoriesSection(context, act, data) : ''}
         {data.menu === 1 ? ItemSection(context, act, data) : ''}
         {data.menu === 2 ? ExploitSection(act, data) : ''}
         {data.menu === 21 ? ExploitRecordSection(act, data) : ''}
@@ -116,21 +116,58 @@ export const Uplink = (props, context) => {
   );
 };
 
-const ItemCategoriesSection = function (act: any, data: UplinkData) {
+const ItemCategoriesSection = function (
+  context: any,
+  act: any,
+  data: UplinkData
+) {
+  const [searchTerm, setSearchTerm] = useLocalState<string>(
+    context,
+    `searchTerm`,
+    ``
+  );
+
   return (
-    <Section title="Gear categories">
-      <LabeledList>
-        {data.categories?.map((category) => (
-          <LabeledList.Item key={category.name}>
-            <Button
-              content={category.name}
-              color={'purple'}
-              onClick={() => act('menu', { menu: 1, category: category.ref })}
-            />
-          </LabeledList.Item>
-        ))}
-      </LabeledList>
+    <Section
+      title={'Gear ' + (!searchTerm ? 'categories' : 'search')}
+      buttons={ItemSearch(context)}>
+      {!searchTerm
+        ? CategoriesList(act, data)
+        : ItemSection(context, act, data)}
     </Section>
+  );
+};
+
+const ItemSearch = function (context: any) {
+  const [searchTerm, setSearchTerm] = useLocalState<string>(
+    context,
+    `searchTerm`,
+    ``
+  );
+  return (
+    <Input
+      value={searchTerm}
+      placeholder="Search"
+      onInput={(e, value) => {
+        setSearchTerm(value);
+      }}
+    />
+  );
+};
+
+const CategoriesList = function (act: any, data: UplinkData) {
+  return (
+    <LabeledList>
+      {data.categories?.map((category) => (
+        <LabeledList.Item key={category.name}>
+          <Button
+            content={category.name}
+            color={'purple'}
+            onClick={() => act('menu', { menu: 1, category: category.ref })}
+          />
+        </LabeledList.Item>
+      ))}
+    </LabeledList>
   );
 };
 
@@ -140,6 +177,22 @@ const ItemSection = function (context: any, act: any, data: UplinkData) {
     `sortDesc`,
     true
   );
+
+  const [searchTerm] = useLocalState<string>(context, `searchTerm`, ``);
+
+  if (searchTerm) {
+    if (data.menu === 0 && searchTerm.length <= 2) {
+      return (
+        <span class="white">
+          <i>Three characters required for all search.</i>
+        </span>
+      );
+    }
+    data.items = data.items?.filter(
+      (i) =>
+        i.name.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1 ||
+        i.description.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1
+    );
 
   // sort by item cost first
   data.items?.sort((a, b) => {
@@ -163,7 +216,9 @@ const ItemSection = function (context: any, act: any, data: UplinkData) {
   });
 
   return (
-    <Section title="Request Gear">
+    <Section
+      title="Request Gear"
+      buttons={data.menu === 1 ? ItemSearch(context) : ''}>
       <span class="white">
         <i>
           Each item costs a number of telecrystals or bluecrystals as indicated

--- a/tgui/packages/tgui/interfaces/Uplink.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink.tsx
@@ -193,7 +193,7 @@ const ItemSection = function (context: any, act: any, data: UplinkData) {
         i.name.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1 ||
         i.description.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1
     );
-
+  }
   // sort by item cost first
   data.items?.sort((a, b) => {
     const a_cost = Math.max(a.bc_cost, a.tc_cost, 0);

--- a/tgui/packages/tgui/interfaces/Uplink.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink.tsx
@@ -35,7 +35,7 @@ type ItemData = {
 
 type ExploitData = {
   id: number;
-  nanoui_exploit_record: string;
+  tgui_exploit_record: string;
   name: string;
   sex: string;
   age: string;
@@ -334,8 +334,8 @@ const ExploitRecordSection = function (act: any, data: UplinkData) {
           </LabeledList.Item>
           <LabeledList.Item label="Acquired Information" />
         </LabeledList>
-        {exploit.nanoui_exploit_record
-          ? exploit.nanoui_exploit_record
+        {exploit.tgui_exploit_record
+          ? exploit.tgui_exploit_record
           : 'No additional information acquired.'}
       </Section>
     );


### PR DESCRIPTION
Very annoying knowing what you want but not which category it's in. Not anymore! 

This adds an overall search on the categories screen that searches descriptions and names of each item, as well as a category search that searches only the category you've selected.

Maybe this should have been a separate view with a button to take you there, but it's pretty seamless this way.

Ideally there would be a check in the DM side, to only add items to the data if searching and search length > 2. It could also then filter on the DM side. I couldn't get it to work when I tried switching it to that method, maybe I'll tinker with it again though.