### PR TITLE
Group antagonists ready counter

### DIFF
--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -44,11 +44,37 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 		. += "Time To Start: [SSticker.pregame_timeleft][round_progressing ? "" : " (DELAYED)"]"
 		. += "Players: [length(player_list)] Players Ready: [SSticker.total_players_ready]"
 		if(LAZYLEN(SSticker.ready_player_jobs))
+			. += ""
+			. += ""
+			. += "Group antagonists ready:"
+
+			var/list/ready_special_roles = list()
+
+			//Get the list of all the players, if they are ready, get their special roles (aka antagonists) preferences and count them up in a list
+			for(var/mob/abstract/new_player/player in player_list)
+				if(!player.ready)
+					continue
+				for(var/special_role in player.client.prefs.be_special_role)
+					ready_special_roles[special_role] += 1
+
+			//Get the list of all antagonist types, if they require more than one person to spawn, check that there's at least one candidate and if so list the number of candidates for it
+			for(var/antag_type in all_antag_types)
+				var/datum/antagonist/possible_antag_type = all_antag_types[antag_type]
+
+				if(possible_antag_type.initial_spawn_req > 1)
+					if(ready_special_roles[possible_antag_type.role_type])
+						. += "[possible_antag_type.role_text_plural]: [ready_special_roles[possible_antag_type.role_type]]"
+
+
+			. += ""
+			. += ""
+			. += "Characters ready:"
 			for(var/dept in SSticker.ready_player_jobs)
 				if(LAZYLEN(SSticker.ready_player_jobs[dept]))
 					. += "[uppertext(dept)]"
 				for(var/char in SSticker.ready_player_jobs[dept])
 					. += "[copytext_char(char, 1, 18)]: [SSticker.ready_player_jobs[dept][char]]"
+
 
 /mob/abstract/new_player/Topic(href, href_list[])
 	if(!client)	return 0

--- a/code/modules/mob/abstract/new_player/new_player.dm
+++ b/code/modules/mob/abstract/new_player/new_player.dm
@@ -54,7 +54,7 @@ INITIALIZE_IMMEDIATE(/mob/abstract/new_player)
 			for(var/mob/abstract/new_player/player in player_list)
 				if(!player.ready)
 					continue
-				for(var/special_role in player.client.prefs.be_special_role)
+				for(var/special_role in player?.client?.prefs?.be_special_role)
 					ready_special_roles[special_role] += 1
 
 			//Get the list of all antagonist types, if they require more than one person to spawn, check that there's at least one candidate and if so list the number of candidates for it

--- a/html/changelogs/fluffyghost-groupantagsreadycounter.yml
+++ b/html/changelogs/fluffyghost-groupantagsreadycounter.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a group antagonists ready counter, it lists how many people are ready for antagonists that require more than one person to roll."
+  - tweak: "Tweaked formatting of the ready screen in statpanel a bit to increase visual clarity."


### PR DESCRIPTION
Added a group antagonists ready counter, it lists how many people are ready for antagonists that require more than one person to roll.
Tweaked formatting of the ready screen in statpanel a bit to increase visual clarity.