### PR TITLE
Added plate carrier holsters to the security officers locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -265,6 +265,7 @@
 	//Belts
 	new /obj/item/clothing/accessory/storage/black_vest(src)
 	new /obj/item/clothing/accessory/holster/hip(src)
+	new /obj/item/clothing/accessory/holster/modular(src)
 	new /obj/item/storage/belt/security/full(src)
 	new /obj/item/clothing/suit/storage/hazardvest/security/officer(src)
 

--- a/code/modules/clothing/suits/modular_armor.dm
+++ b/code/modules/clothing/suits/modular_armor.dm
@@ -271,16 +271,6 @@
 	item_state = "modular_pouch_l"
 	slots = 3
 
-/obj/item/clothing/accessory/holster/modular
-	name = "plate carrier holster"
-	desc = "A special holster with rigging able to attach to modern modular plate carriers."
-	icon = 'icons/clothing/kit/modular_armor.dmi'
-	icon_state = "modular_holster"
-	item_state = "modular_holster"
-	contained_sprite = TRUE
-	slot = ACCESSORY_SLOT_ARMOR_POCKETS
-	flippable = FALSE
-
 /obj/item/clothing/accessory/armor_plate/heavy/sec
 	name = "heavy corporate armor plate"
 	desc = "A heavy and stylish armor plate with blue highlights. That prevents teamkills, right?"

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -142,6 +142,10 @@
 	else
 		H.unholster(usr)
 
+/*###################
+	Holster Subtypes
+###################*/
+
 /obj/item/clothing/accessory/holster/armpit
 	name = "black armpit holster"
 	desc = "A worn-out handgun holster. Mostly seen in cheesy cop flicks, used to keep the actor's face in the shot."
@@ -188,7 +192,17 @@
 	icon_state = "holster_brown_thigh"
 	item_state = "holster_brown_thigh"
 
-/********** Utility Holsters Start **********/
+/obj/item/clothing/accessory/holster/modular
+	name = "plate carrier holster"
+	desc = "A special holster with rigging able to attach to modern modular plate carriers."
+	icon = 'icons/clothing/kit/modular_armor.dmi'
+	icon_state = "modular_holster"
+	item_state = "modular_holster"
+	contained_sprite = TRUE
+	slot = ACCESSORY_SLOT_ARMOR_POCKETS
+	flippable = FALSE
+
+/*##### Utility Holsters Start #####*/
 // Utility Holster
 /obj/item/clothing/accessory/holster/utility
 	name = "utility holster"

--- a/html/changelogs/fluffyghost-secofficersplatecarrierholsters.yml
+++ b/html/changelogs/fluffyghost-secofficersplatecarrierholsters.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added plate carrier holsters to the security officers locker, they can be attached to the plate carrier if another accessory is removed from it (eg the pouches)."
+  - refactor: "Moved the modular plate carrier holster back into the holster files, some comments cleanup inside it."


### PR DESCRIPTION
Added plate carrier holsters to the security officers locker, they can be attached to the plate carrier if another accessory is removed from it (eg the pouches).
Moved the modular plate carrier holster back into the holster files, some comments cleanup inside it.