### PR TITLE
Konyang: Adds guns to away sites

### DIFF
--- a/html/changelogs/RustingWithYou - konyangsiteguns.yml
+++ b/html/changelogs/RustingWithYou - konyangsiteguns.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds relevant Konyang guns to Konyang away sites."

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
@@ -1194,19 +1194,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/dirt_konyang,
 /area/point_verdant/interior/tunnels)
-"eq" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	req_access = list(217)
-	},
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/gun/projectile/pistol/sol,
-/obj/item/gun/projectile/pistol/sol,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled/dark,
-/area/point_verdant/interior/police)
 "et" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -2012,9 +1999,9 @@
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(217)
 	},
-/obj/item/gun/projectile/pistol/sol,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
+/obj/item/ammo_magazine/c45/revolver,
+/obj/item/ammo_magazine/c45/revolver,
+/obj/item/gun/projectile/revolver/konyang/police,
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/police)
 "hX" = (
@@ -4905,12 +4892,13 @@
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(217)
 	},
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/gun/projectile/pistol/sol,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
 /obj/random/dirt_75,
+/obj/item/gun/projectile/revolver/konyang/police,
+/obj/item/gun/projectile/revolver/konyang/police,
+/obj/item/ammo_magazine/c45/revolver,
+/obj/item/ammo_magazine/c45/revolver,
+/obj/item/ammo_magazine/c45/revolver,
+/obj/item/ammo_magazine/c45/revolver,
 /turf/simulated/floor/tiled/dark,
 /area/point_verdant/interior/police)
 "tT" = (
@@ -5004,6 +4992,9 @@
 /area/point_verdant/interior/tunnels)
 "uj" = (
 /obj/structure/closet/cabinet,
+/obj/item/clothing/head/konyang/police/lieutenant,
+/obj/item/clothing/under/rank/konyang/police/lieutenant,
+/obj/item/clothing/shoes/jackboots,
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/police)
 "um" = (
@@ -22092,7 +22083,7 @@ rf
 rf
 rf
 Ir
-eq
+tS
 ch
 mO
 mO

--- a/maps/random_ruins/exoplanets/konyang/pirate_moonshine.dmm
+++ b/maps/random_ruins/exoplanets/konyang/pirate_moonshine.dmm
@@ -82,10 +82,19 @@
 /area/konyang_pirate_moonshine)
 "t" = (
 /obj/structure/closet/crate/secure/weapon/alt,
-/obj/random/civgun,
-/obj/random/civgun,
-/obj/random/civgun/rifle,
 /obj/machinery/light,
+/obj/item/ammo_magazine/c762,
+/obj/item/ammo_magazine/c38,
+/obj/item/ammo_magazine/c38,
+/obj/item/ammo_magazine/c38,
+/obj/item/ammo_magazine/smg10mm,
+/obj/item/ammo_magazine/smg10mm,
+/obj/item/ammo_magazine/smg10mm,
+/obj/item/gun/projectile/automatic/konyang_pirate,
+/obj/item/gun/projectile/automatic/konyang_pirate,
+/obj/item/gun/projectile/revolver/konyang/pirate,
+/obj/item/gun/projectile/automatic/rifle/konyang/pirate_rifle,
+/obj/item/gun/projectile/revolver/konyang/pirate,
 /turf/simulated/floor/wood,
 /area/konyang_pirate_moonshine)
 "v" = (

--- a/maps/random_ruins/exoplanets/konyang/pirate_outpost.dmm
+++ b/maps/random_ruins/exoplanets/konyang/pirate_outpost.dmm
@@ -289,9 +289,17 @@
 "pB" = (
 /obj/random/dirt_75,
 /obj/structure/closet/crate/weapon,
-/obj/random/civgun/rifle,
-/obj/random/civgun/rifle,
-/obj/random/civgun/rifle,
+/obj/item/gun/projectile/automatic/konyang_pirate,
+/obj/item/gun/projectile/automatic/konyang_pirate,
+/obj/item/gun/projectile/revolver/konyang/pirate,
+/obj/item/gun/projectile/revolver/konyang/pirate,
+/obj/item/gun/projectile/revolver/konyang/pirate,
+/obj/item/ammo_magazine/c38,
+/obj/item/ammo_magazine/c38,
+/obj/item/ammo_magazine/c38,
+/obj/item/ammo_magazine/smg10mm,
+/obj/item/ammo_magazine/smg10mm,
+/obj/item/ammo_magazine/smg10mm,
 /turf/simulated/floor/wood,
 /area/konyang_pirate_outpost)
 "pG" = (
@@ -698,9 +706,8 @@
 "Wn" = (
 /obj/random/dirt_75,
 /obj/structure/closet/crate/weapon,
-/obj/random/civgun,
-/obj/random/civgun,
-/obj/random/civgun,
+/obj/item/gun/projectile/automatic/rifle/konyang/pirate_rifle,
+/obj/item/ammo_magazine/c762,
 /turf/simulated/floor/wood,
 /area/konyang_pirate_outpost)
 "Wp" = (


### PR DESCRIPTION
Adds some of the guns from #17851 to existing Konyang away sites. Police revolvers now spawn in the Point Verdant police HQ, and the two pirate sites now both have the pirate guns.