### PR TITLE
Ci reftracking, additional debugs, and prevent tgui nobuild

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -13,25 +13,86 @@
 // We want to use external resources. Kthx.
 #define PRELOAD_RSC 0
 
-#ifndef PRELOAD_RSC             //set to:
-#define PRELOAD_RSC 2           //  0 to allow using external resources or on-demand behaviour;
-#endif                          //  1 to use the default behaviour;
+#ifndef PRELOAD_RSC				//set to:
+	#define PRELOAD_RSC 2		//  0 to allow using external resources or on-demand behaviour;
+#endif							//  1 to use the default behaviour;
 								//  2 for preloading absolutely everything;
+
+
+//Since we do not currently use some of the flags that TG uses, we have to perform a bit of an adaptation
+#if defined(UNIT_TEST) && !defined(OPENDREAM) && !defined(SPACEMAN_DMM)
+	#define CIBUILDING
+	#define TESTING
+#endif //UNIT_TEST
+
+
+/*
+	Manual runs area, uncomment the appropriate defines depending on what you want to do
+*/
 
 //#define TESTING // Creates debug feedback messages and enables many optional testing procs/checks
 #ifdef TESTING
-///Used to find the sources of harddels, quite laggy, don't be surpised if it freezes your client for a good while
-//#define REFERENCE_TRACKING
-#ifdef REFERENCE_TRACKING
+	///Used to find the sources of harddels, quite laggy, don't be surpised if it freezes your client for a good while
+	//#define REFERENCE_TRACKING
+	#ifdef REFERENCE_TRACKING
 
-//Run a lookup on things hard deleting by default.
-#define GC_FAILURE_HARD_LOOKUP
+		//Run a lookup on things hard deleting by default.
+		#define GC_FAILURE_HARD_LOOKUP
 
-#ifdef GC_FAILURE_HARD_LOOKUP
-///Don't stop when searching, go till you're totally done
-#define FIND_REF_NO_CHECK_TICK
-#endif //ifdef GC_FAILURE_HARD_LOOKUP
+		#ifdef GC_FAILURE_HARD_LOOKUP
+			///Don't stop when searching, go till you're totally done
+			#define FIND_REF_NO_CHECK_TICK
+		#endif //GC_FAILURE_HARD_LOOKUP
 
-#endif //ifdef REFERENCE_TRACKING
+	#endif //REFERENCE_TRACKING
 
-#endif //ifdef TESTING
+#endif //TESTING
+
+
+
+//Additional code for the above flags.
+//A warning on compile is treated as an error in the CI, therefore unlike TG we must avoid the warn if it's running in the CI
+#if defined(TESTING) && !defined(CIBUILDING) && !defined(OPENDREAM) && !defined(SPACEMAN_DMM)
+	#warn compiling in TESTING mode. testing() debug messages will be visible.
+#endif //TESTING
+
+//CIBUILDING requires UNIT_TEST to be defined, if it isn't, define it here
+#if defined(CIBUILDING) && !defined(UNIT_TEST)
+	#define UNIT_TEST
+#endif //CIBUILDING
+
+
+//Enable various trackings and debugs if we're running the unit tests
+#if defined(UNIT_TEST) && !defined(OPENDREAM) && !defined(SPACEMAN_DMM)
+
+	//Hard del testing defines, if you leave a reference, it will search for it
+	#define REFERENCE_TRACKING
+	#define REFERENCE_TRACKING_DEBUG
+	#define FIND_REF_NO_CHECK_TICK
+	#define GC_FAILURE_HARD_LOOKUP
+
+	//Ensures all early assets can actually load early
+	#define DO_NOT_DEFER_ASSETS
+
+	//Test at full capacity, the extra cost doesn't matter
+	#define TIMER_DEBUG
+
+	#define ZASDBG
+
+	#define SQL_PREF_DEBUG
+#endif //UNIT_TEST
+
+#ifdef TGS
+	// TGS performs its own build of dm.exe, but includes a prepended TGS define.
+	#define CBT
+#endif //TGS
+
+
+//Poor man's code to try to catch people that are running the codebase without compiling tgui, aka in an unsupported way
+//Basically, this tells you to use a supported compilation as defined in the repo's README
+#if !defined(CBT) && !defined(SPACEMAN_DMM) && !defined(OPENDREAM) && !defined(CIBUILDING)
+	#warn Building with Dream Maker is no longer supported and will result in errors.
+	#warn In order to build, run BUILD.bat in the root directory.
+	#warn Consider switching to VSCode editor instead, where you can press Ctrl+Shift+B to build.
+	#error Not compiling in a supported environment! Use Visual Studio Code or BUILD.bat!
+#endif

--- a/html/changelogs/FluffyGhost-ci_reftracking_prevent_tgui_nobuild.yml
+++ b/html/changelogs/FluffyGhost-ci_reftracking_prevent_tgui_nobuild.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Additional debugs and diagnostics are now enabled when the CI is running."
+  - backend: "In case of an harddel, the CI stops to locate where the reference was left now."
+  - backend: "If the codebase is being built in an unsupported environment (eg. without build.bat or VSC), an error is thrown to the compiler."


### PR DESCRIPTION
Additional debugs and diagnostics are now enabled when the CI is running.
In case of an harddel, the CI stops to locate where the reference was left now.
If the codebase is being built in an unsupported environment (eg. without build.bat or VSC), an error is thrown to the compiler.