### PR TITLE
Fix Aiming and shooting 

### DIFF
--- a/code/modules/projectiles/targeting/targeting_triggers.dm
+++ b/code/modules/projectiles/targeting/targeting_triggers.dm
@@ -11,8 +11,6 @@
 				AO.update_aiming_deferred()
 
 /mob/living/proc/aim_at(atom/target, obj/item/with)
-	if(QDELETED(target))
-		return FALSE
 
 	if(!ismob(target) || !istype(with) || incapacitated())
 		return FALSE


### PR DESCRIPTION
I was assured a check for `qdeleted` wouldn't break anything. Apparently this is an exception.

Fixes firing and aiming. 