### PR TITLE
Bridge helm tweaks

### DIFF
--- a/html/changelogs/changelog.yml
+++ b/html/changelogs/changelog.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ReadThisNamePlz
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Adds more folders, clipboards and pens to the Bridge Helm area"
+  - maptweak: "Moves the Captains Rubber stamp to be by their fax machine, and gives the Captain a "DENIED" stamp."
+  - maptweak: "Makes the command conference room radiation proof."

--- a/html/changelogs/changelog.yml
+++ b/html/changelogs/changelog.yml
@@ -39,5 +39,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - maptweak: "Adds more folders, clipboards and pens to the Bridge Helm area"
-  - maptweak: "Moves the Captains Rubber stamp to be by their fax machine, and gives the Captain a "DENIED" stamp."
+  - maptweak: "Moves the Captains Rubber stamp to be by their fax machine, and gives the Captain a DENIED stamp."
   - maptweak: "Makes the command conference room radiation proof."

--- a/maps/_common/areas/station/command.dm
+++ b/maps/_common/areas/station/command.dm
@@ -43,6 +43,7 @@
 	ambience = list()
 	sound_env = MEDIUM_SOFTFLOOR
 	area_blurb = "A place for behind-closed-doors meetings to get things done, or argue for hours in..."
+	area_flags = AREA_FLAG_RAD_SHIELDED
 
 /area/bridge/selfdestruct
 	name = "Command - Station Authentication Terminal Safe"

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -6563,7 +6563,6 @@
 	},
 /obj/machinery/light,
 /obj/structure/table/reinforced/wood,
-/obj/item/aicard,
 /obj/item/stamp/denied{
 	pixel_x = -8
 	},
@@ -15512,6 +15511,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
+/obj/item/aicard,
 /turf/simulated/floor/carpet/rubber,
 /area/bridge/controlroom)
 "lIN" = (

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -6563,6 +6563,11 @@
 	},
 /obj/machinery/light,
 /obj/structure/table/reinforced/wood,
+/obj/item/aicard,
+/obj/item/stamp/denied{
+	pixel_x = -8
+	},
+/obj/item/stamp/captain,
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
 "fll" = (
@@ -12799,7 +12804,6 @@
 /area/bridge/aibunker)
 "jOz" = (
 /obj/structure/table/reinforced/wood,
-/obj/item/stamp/captain,
 /obj/item/paper/monitorkey,
 /obj/machinery/case_button/shuttle{
 	pixel_x = 37;
@@ -14621,9 +14625,31 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/device/taperecorder,
+/obj/item/device/taperecorder{
+	pixel_x = -9;
+	pixel_y = -5
+	},
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 6
+	},
+/obj/item/clipboard{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/folder/blue{
+	pixel_y = 7;
+	pixel_x = 5
+	},
+/obj/item/folder/blue{
+	pixel_y = 7;
+	pixel_x = 5
+	},
+/obj/item/pen/red{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/pen/blue{
+	pixel_x = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/controlroom)
@@ -15839,7 +15865,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/aicard,
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 1
 	},
@@ -15848,6 +15873,25 @@
 	layer = 2.7
 	},
 /obj/structure/table/reinforced,
+/obj/item/folder/blue{
+	pixel_y = 7;
+	pixel_x = 5
+	},
+/obj/item/folder/blue{
+	pixel_y = 7;
+	pixel_x = 5
+	},
+/obj/item/pen/red{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/pen/blue{
+	pixel_x = 5
+	},
+/obj/item/clipboard{
+	pixel_x = -8;
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/controlroom)
 "mbm" = (


### PR DESCRIPTION
- Adds four more folders to the bridge and two more clipboards, along with two blue pens and two red pens. 
- Moves the Captain's stamp to be by their fax machine and gives the Captain a DENIED stamp
- Moves the bridge intelli card to the lower tables by the ship controls
- Makes the conference room radiation proof, at the request of CCIA Lead

![bridgetweaks](https://github.com/Aurorastation/Aurora.3/assets/98699252/0d4d37ef-3c57-4e31-866e-650ac4d3dc0e)
