### PR TITLE
Intrepid dock fix

### DIFF
--- a/html/changelogs/DreamySkrell-intrepid-dock-fix.yml
+++ b/html/changelogs/DreamySkrell-intrepid-dock-fix.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "Fixes wrong frequency on Intrepid hangar dock."
+  - bugfix: "Fixes wrong frequency on Intrepid hangar dock, and the Intrepid doors not opening automatically on round start."
   - maptweak: "Moves the docking controllers of Intrepid hangar and Canary hangar closer to their respective shuttles."

--- a/html/changelogs/DreamySkrell-intrepid-dock-fix.yml
+++ b/html/changelogs/DreamySkrell-intrepid-dock-fix.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes wrong frequency on Intrepid hangar dock."
+  - maptweak: "Moves the docking controllers of Intrepid hangar and Canary hangar closer to their respective shuttles."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -167,6 +167,20 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/security/checkpoint)
+"ahI" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "intrepid_dock";
+	name = "\improper Intrepid docking port controller";
+	req_one_access = list(74);
+	dir = 2;
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "aix" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 8
@@ -2333,15 +2347,6 @@
 /obj/machinery/papershredder{
 	pixel_x = -6
 	},
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	dir = 8;
-	frequency = 1386;
-	id_tag = "canary_dock";
-	name = "\improper Canary docking port controller";
-	pixel_x = 22;
-	pixel_y = -19;
-	tag_door = "canary_out"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "bGQ" = (
@@ -3720,6 +3725,20 @@
 /obj/item/material/shard,
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/deck1)
+"cGd" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	dir = 2;
+	frequency = 1386;
+	id_tag = "canary_dock";
+	name = "\improper Canary docking port controller";
+	pixel_y = 28;
+	tag_door = "canary_out"
+	},
+/turf/simulated/floor/plating,
+/area/hangar/canary)
 "cHx" = (
 /obj/machinery/artifact_scanpad,
 /obj/effect/floor_decal/spline/plain{
@@ -31265,14 +31284,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1385;
-	id_tag = "intrepid_dock";
-	name = "\improper Intrepid docking port controller";
-	pixel_x = -26;
-	pixel_y = -25;
-	req_one_access = list(74)
-	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/control)
 "vJy" = (
@@ -32157,14 +32168,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
-	},
-/obj/machinery/embedded_controller/radio/docking_port_multi{
-	child_names_txt = "Cargo Airlock";
-	child_tags_txt = "intrepid_shuttle_cargo";
-	frequency = 1385;
-	id_tag = "intrepid_shuttle";
-	pixel_x = 13;
-	pixel_y = 23
 	},
 /obj/machinery/camera/network/intrepid{
 	c_tag = "Intrepid - Cockpit";
@@ -55056,7 +55059,7 @@ nAn
 uzZ
 wuD
 wuD
-uRt
+ahI
 uRt
 iAP
 vvK
@@ -60745,7 +60748,7 @@ wce
 hot
 nNh
 pPV
-pEk
+cGd
 mWR
 sck
 wht


### PR DESCRIPTION
changes:
  - bugfix: "Fixes wrong frequency on Intrepid hangar dock, and the Intrepid doors not opening automatically on round start."
  - maptweak: "Moves the docking controllers of Intrepid hangar and Canary hangar closer to their respective shuttles."
