### PR TITLE
Fixes pixel offsets of wall-mounted objects

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -80,7 +80,7 @@ pixel_y = 21;
 
 #define PRESET_SOUTH \
 dir = SOUTH; \
-pixel_y = -6;
+pixel_y = -3;
 
 #define PRESET_WEST \
 dir = WEST; \

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -79,7 +79,8 @@ dir = NORTH; \
 pixel_y = 21;
 
 #define PRESET_SOUTH \
-dir = SOUTH;
+dir = SOUTH; \
+pixel_y = -6;
 
 #define PRESET_WEST \
 dir = WEST; \
@@ -332,7 +333,7 @@ pixel_x = 10;
 
 /obj/machinery/alarm/set_pixel_offsets()
 	pixel_x = ((src.dir & (NORTH|SOUTH)) ? 0 : (src.dir == EAST ? 10 : -10))
-	pixel_y = ((src.dir & (NORTH|SOUTH)) ? (src.dir == NORTH ? 21 : 0) : 0)
+	pixel_y = ((src.dir & (NORTH|SOUTH)) ? (src.dir == NORTH ? 21 : -6) : 0)
 
 /obj/machinery/alarm/proc/first_run()
 	alarm_area = get_area(src)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -82,7 +82,7 @@
 
 /obj/machinery/power/apc/south
 	dir = SOUTH
-	pixel_y = 0
+	pixel_y = -8
 
 /obj/machinery/power/apc/critical
 	is_critical = TRUE
@@ -101,7 +101,7 @@
 
 /obj/machinery/power/apc/critical/south
 	dir = SOUTH
-	pixel_y = 0
+	pixel_y = -8
 
 /obj/machinery/power/apc/low
 	cell_type = /obj/item/cell
@@ -120,7 +120,7 @@
 
 /obj/machinery/power/apc/low/south
 	dir = SOUTH
-	pixel_y = 0
+	pixel_y = -8
 
 /obj/machinery/power/apc/high
 	cell_type = /obj/item/cell/high
@@ -139,7 +139,7 @@
 
 /obj/machinery/power/apc/high/south
 	dir = SOUTH
-	pixel_y = 0
+	pixel_y = -8
 
 /obj/machinery/power/apc/isolation
 	cell_type = /obj/item/cell
@@ -160,7 +160,7 @@
 
 /obj/machinery/power/apc/isolation/south
 	dir = SOUTH
-	pixel_y = 0
+	pixel_y = -8
 
 /obj/machinery/power/apc/vault
 	cell_type = /obj/item/cell
@@ -180,7 +180,7 @@
 
 /obj/machinery/power/apc/vault/south
 	dir = SOUTH
-	pixel_y = 0
+	pixel_y = -8
 
 /obj/machinery/power/apc/intrepid
 	cell_type = /obj/item/cell/high
@@ -201,7 +201,7 @@
 
 /obj/machinery/power/apc/intrepid/south
 	dir = SOUTH
-	pixel_y = 0
+	pixel_y = -8
 
 /obj/machinery/power/apc/canary
 	cell_type = /obj/item/cell/high
@@ -222,7 +222,7 @@
 
 /obj/machinery/power/apc/canary/south
 	dir = SOUTH
-	pixel_y = 0
+	pixel_y = -8
 
 /obj/machinery/power/apc/mining_shuttle
 	cell_type = /obj/item/cell/high
@@ -243,7 +243,7 @@
 
 /obj/machinery/power/apc/mining_shuttle/south
 	dir = SOUTH
-	pixel_y = 0
+	pixel_y = -8
 
 // Construction site APC, starts turned off
 /obj/machinery/power/apc/high/inactive
@@ -269,7 +269,7 @@
 
 /obj/machinery/power/apc/canary/south
 	dir = SOUTH
-	pixel_y = 0
+	pixel_y = -8
 
 
 /obj/machinery/power/apc/super
@@ -289,7 +289,7 @@
 
 /obj/machinery/power/apc/super/south
 	dir = SOUTH
-	pixel_y = 0
+	pixel_y = -8
 
 /obj/machinery/power/apc/super/critical
 	is_critical = TRUE
@@ -308,7 +308,7 @@
 
 /obj/machinery/power/apc/super/critical/south
 	dir = SOUTH
-	pixel_y = 0
+	pixel_y = -8
 
 /obj/machinery/power/apc/hyper
 	cell_type = /obj/item/cell/hyper
@@ -327,7 +327,7 @@
 
 /obj/machinery/power/apc/hyper/south
 	dir = SOUTH
-	pixel_y = 0
+	pixel_y = -8
 
 /obj/machinery/power/apc/empty
 	start_charge = 0
@@ -346,7 +346,7 @@
 
 /obj/machinery/power/apc/empty/south
 	dir = SOUTH
-	pixel_y = 0
+	pixel_y = -8
 
 /obj/machinery/power/apc
 	name = "area power controller"
@@ -480,7 +480,7 @@
 
 /obj/machinery/power/apc/set_pixel_offsets()
 	pixel_x = ((src.dir & (NORTH|SOUTH)) ? 0 : (src.dir == EAST ? 12 : -(12)))
-	pixel_y = ((src.dir & (NORTH|SOUTH)) ? (src.dir == NORTH ? 22 : -(0)) : 0)
+	pixel_y = ((src.dir & (NORTH|SOUTH)) ? (src.dir == NORTH ? 22 : -(8)) : 0)
 
 /obj/machinery/power/apc/Destroy()
 	update()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -82,7 +82,7 @@
 
 /obj/machinery/power/apc/south
 	dir = SOUTH
-	pixel_y = -8
+	pixel_y = -4
 
 /obj/machinery/power/apc/critical
 	is_critical = TRUE
@@ -101,7 +101,7 @@
 
 /obj/machinery/power/apc/critical/south
 	dir = SOUTH
-	pixel_y = -8
+	pixel_y = -4
 
 /obj/machinery/power/apc/low
 	cell_type = /obj/item/cell
@@ -120,7 +120,7 @@
 
 /obj/machinery/power/apc/low/south
 	dir = SOUTH
-	pixel_y = -8
+	pixel_y = -4
 
 /obj/machinery/power/apc/high
 	cell_type = /obj/item/cell/high
@@ -139,7 +139,7 @@
 
 /obj/machinery/power/apc/high/south
 	dir = SOUTH
-	pixel_y = -8
+	pixel_y = -4
 
 /obj/machinery/power/apc/isolation
 	cell_type = /obj/item/cell
@@ -160,7 +160,7 @@
 
 /obj/machinery/power/apc/isolation/south
 	dir = SOUTH
-	pixel_y = -8
+	pixel_y = -4
 
 /obj/machinery/power/apc/vault
 	cell_type = /obj/item/cell
@@ -180,7 +180,7 @@
 
 /obj/machinery/power/apc/vault/south
 	dir = SOUTH
-	pixel_y = -8
+	pixel_y = -4
 
 /obj/machinery/power/apc/intrepid
 	cell_type = /obj/item/cell/high
@@ -201,7 +201,7 @@
 
 /obj/machinery/power/apc/intrepid/south
 	dir = SOUTH
-	pixel_y = -8
+	pixel_y = -4
 
 /obj/machinery/power/apc/canary
 	cell_type = /obj/item/cell/high
@@ -222,7 +222,7 @@
 
 /obj/machinery/power/apc/canary/south
 	dir = SOUTH
-	pixel_y = -8
+	pixel_y = -4
 
 /obj/machinery/power/apc/mining_shuttle
 	cell_type = /obj/item/cell/high
@@ -243,7 +243,7 @@
 
 /obj/machinery/power/apc/mining_shuttle/south
 	dir = SOUTH
-	pixel_y = -8
+	pixel_y = -4
 
 // Construction site APC, starts turned off
 /obj/machinery/power/apc/high/inactive
@@ -269,7 +269,7 @@
 
 /obj/machinery/power/apc/canary/south
 	dir = SOUTH
-	pixel_y = -8
+	pixel_y = -4
 
 
 /obj/machinery/power/apc/super
@@ -289,7 +289,7 @@
 
 /obj/machinery/power/apc/super/south
 	dir = SOUTH
-	pixel_y = -8
+	pixel_y = -4
 
 /obj/machinery/power/apc/super/critical
 	is_critical = TRUE
@@ -308,7 +308,7 @@
 
 /obj/machinery/power/apc/super/critical/south
 	dir = SOUTH
-	pixel_y = -8
+	pixel_y = -4
 
 /obj/machinery/power/apc/hyper
 	cell_type = /obj/item/cell/hyper
@@ -327,7 +327,7 @@
 
 /obj/machinery/power/apc/hyper/south
 	dir = SOUTH
-	pixel_y = -8
+	pixel_y = -4
 
 /obj/machinery/power/apc/empty
 	start_charge = 0
@@ -346,7 +346,7 @@
 
 /obj/machinery/power/apc/empty/south
 	dir = SOUTH
-	pixel_y = -8
+	pixel_y = -4
 
 /obj/machinery/power/apc
 	name = "area power controller"

--- a/code/modules/power/lights/fixtures.dm
+++ b/code/modules/power/lights/fixtures.dm
@@ -208,6 +208,10 @@
 	pixel_x = dir & (NORTH|SOUTH) ? 0 : (dir == EAST ? 12 : -12)
 	pixel_y = dir & (NORTH|SOUTH) ? (dir == NORTH ? DEFAULT_WALL_OFFSET : 0) : 0
 
+/obj/machinery/light/small/set_pixel_offsets()
+	pixel_x = dir & (NORTH|SOUTH) ? 0 : (dir == EAST ? 12 : -12)
+	pixel_y = dir & (NORTH|SOUTH) ? (dir == NORTH ? DEFAULT_WALL_OFFSET : -22) : 0
+
 /obj/machinery/light/floor/set_pixel_offsets()
 	pixel_x = pixel_x
 	pixel_y = pixel_y

--- a/code/modules/power/lights/fixtures.dm
+++ b/code/modules/power/lights/fixtures.dm
@@ -206,7 +206,7 @@
 
 /obj/machinery/light/set_pixel_offsets()
 	pixel_x = dir & (NORTH|SOUTH) ? 0 : (dir == EAST ? 12 : -12)
-	pixel_y = dir & (NORTH|SOUTH) ? (dir == NORTH ? DEFAULT_WALL_OFFSET : 0) : 0
+	pixel_y = dir & (NORTH|SOUTH) ? (dir == NORTH ? DEFAULT_WALL_OFFSET : -2) : 0
 
 /obj/machinery/light/small/set_pixel_offsets()
 	pixel_x = dir & (NORTH|SOUTH) ? 0 : (dir == EAST ? 12 : -12)

--- a/html/changelogs/nauticall-offset-tweaks.yml
+++ b/html/changelogs/nauticall-offset-tweaks.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Fixes pixel offsets of wall-mounted objects such as APCs, air alarms, and small (bulb) lights."
+  - bugfix: "Fixes pixel offsets of wall-mounted objects such as APCs, air alarms, and small (bulb) lights."

--- a/html/changelogs/nauticall-offset-tweaks.yml
+++ b/html/changelogs/nauticall-offset-tweaks.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: nauticall
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Fixes pixel offsets of wall-mounted objects such as APCs, air alarms, and small (bulb) lights."


### PR DESCRIPTION
What it says on the tin. Fixes the pixel offsets of APCs, air alarms, and small lightbulbs. This should make it so none of them float anymore.

## Before
![image](https://github.com/Aurorastation/Aurora.3/assets/55491249/729c08f9-9291-4eba-9374-9d4814733bee)
![image](https://github.com/Aurorastation/Aurora.3/assets/55491249/101c0dc7-77c9-45d3-a13a-c47e27db9394)
![image](https://github.com/Aurorastation/Aurora.3/assets/55491249/a0954bf4-487b-4738-ae55-ce5b890b1485)

## After
![image](https://github.com/Aurorastation/Aurora.3/assets/55491249/406d24c7-04ef-4f74-bc5f-436ffb545b01)
![image](https://github.com/Aurorastation/Aurora.3/assets/55491249/33a77586-1894-4fb1-95b4-cd565ae6b524)
![image](https://github.com/Aurorastation/Aurora.3/assets/55491249/0bef777d-8688-4475-bc1e-b76aabb04d9f)
