### PR TITLE
Gadpathurian Vessel Spawnrate Fix

### DIFF
--- a/html/changelogs/gadship-spawn-weight-fix.yml
+++ b/html/changelogs/gadship-spawn-weight-fix.yml
@@ -1,0 +1,6 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - tweak: "The Gadpathurians have conceded that not EVERY sector of the Weeping Stars requires a patrol ship to be present. (Spawnrate for the Gadpathurian patrol ship is now 1 instead of 10000)"

--- a/maps/away/ships/coc/gadpathur_patrol/gadpathur_patrol.dm
+++ b/maps/away/ships/coc/gadpathur_patrol/gadpathur_patrol.dm
@@ -3,7 +3,7 @@
 	description = "Gadpathur navy patrol ship."
 	suffixes = list("ships/coc/gadpathur_patrol/gadpathur_patrol.dmm")
 	sectors = list(ALL_COALITION_SECTORS) //NOTE: Gadpathur patrols all of the Coalition, however, they are intentionally -not- present in Haneunim. Konyang and Gadpathur are not friendly as of the Amor Patriae arc.
-	spawn_weight = 10000
+	spawn_weight = 1
 	ship_cost = 1
 	id = "gadpathur_patroller"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/gadpathur_shuttle)


### PR DESCRIPTION
Reduced the spawn rate of the Gadpathurian Patrol Ship from 10000 to 1.