### PR TITLE
Shortwave Radio Buff

### DIFF
--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -48,7 +48,7 @@
 	if(!source.loc)
 		// It's an announcer message, just send it to the horizon's receiver
 		for(var/obj/machinery/telecomms/receiver/R in SSmachinery.all_receivers)
-			if(R.z in current_map.station_levels)
+			if((R.z in current_map.station_levels) && R.use_power && R.operable())
 				R.receive_signal(src)
 				return TRUE
 
@@ -60,6 +60,9 @@
 	for(var/obj/machinery/telecomms/R in SSmachinery.all_receivers)
 		t_range = R.receive_range(src)
 		if(t_range <= -1)
+			continue
+
+		if(!R.operable() || !R.use_power)
 			continue
 
 		if(t_range < closest_range)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -456,14 +456,17 @@ var/global/list/default_interrogation_channels = list(
 	var/datum/signal/subspace/vocal/signal = new(src, connection.frequency, speaker_weakref, speaking, message, say_verb)
 
 	// All radios attempt to use the subspace system
-	. = signal.send_to_receivers()
+	var/reached_receiver = signal.send_to_receivers()
 
 	// If it's subspace only, that's all we can do
 	if(subspace_transmission)
 		return
 
-	// Non-subspace radios will check in a couple of seconds, and if the signal was never received, we send a mundane broadcast
-	addtimer(CALLBACK(src, PROC_REF(backup_transmission), signal), 2 SECONDS)
+	if(reached_receiver)
+		// Non-subspace radios will check in a couple of seconds, and if the signal was never received, we send a mundane broadcast
+		addtimer(CALLBACK(src, PROC_REF(backup_transmission), signal), 2 SECONDS)
+	else
+		backup_transmission(signal)
 
 /obj/item/device/radio/proc/backup_transmission(datum/signal/subspace/vocal/signal)
 	var/turf/T = get_turf(src)

--- a/html/changelogs/geeves-signalled_radios.yml
+++ b/html/changelogs/geeves-signalled_radios.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Shortwave radios now instantly broadcast their non-subspace message if a working receiver could not be found."


### PR DESCRIPTION
* Shortwave radios now instantly broadcast their non-subspace message if a working receiver could not be found.