### PR TITLE
Fix nooses and traps

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -557,9 +557,21 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 	else return get_step(ref, base_dir)
 
+/**
+ * Makes a mob perform an action to another mob, showing a progress bar and over a given time
+ *
+ * * user - The `/mob` that performs the action
+ * * target - The `/mob` that the action is being performed to
+ * * delay - The time it takes for the action to be performed
+ * * needhand - Boolean, if a free hand is needed for the action to be successful
+ * * display_progress - Boolean, if the progress bar is shown
+ * * extra_checks - A `/datum/callback` that is invoked to perform extra checks and validate that the action can continue to be performed,
+ * if it returns `FALSE` or an algebraic equivalent the action is aborted
+ */
 /proc/do_mob(mob/user, mob/target, delay = 30, needhand = TRUE, display_progress = TRUE, datum/callback/extra_checks) //This is quite an ugly solution but i refuse to use the old request system.
 	if(!user || !target)
-		return 0
+		stack_trace("do_mob called without either an user or a target!")
+		return FALSE
 
 	var/user_loc = user.loc
 	var/target_loc = target.loc
@@ -575,7 +587,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	var/endtime = world.time + delay
 	var/starttime = world.time
 
-	. = 1
+	. = TRUE
 
 	while (world.time < endtime)
 		stoplag(1)
@@ -583,11 +595,11 @@ Turf and target are seperate in case you want to teleport some distance from a t
 			progbar.update(world.time - starttime)
 
 		if(QDELETED(user) || QDELETED(target))
-			. = 0
+			. = FALSE
 			break
 
 		if (user.loc != user_loc || target.loc != target_loc || (needhand && user.get_active_hand() != holding) || user.stat || user.weakened || user.stunned || (extra_checks && !extra_checks.Invoke()))
-			. = 0
+			. = FALSE
 			break
 
 	if (progbar)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -628,12 +628,23 @@
 	else
 		return 0
 
-// Show a message to all mobs and objects in sight of this atom.
-// Use for objects performing visible actions.
-// The message is output to anyone who can see, e.g. "The [src] does something!"
-// "blind_message" (optional) is what blind people will hear e.g. "You hear something!"
-/atom/proc/visible_message(var/message, var/blind_message, var/range = world.view, var/intent_message = null, var/intent_range = 7)
-	set waitfor = FALSE
+
+/**
+ * Show a message to all mobs and objects in sight of this one, usually used for visible actions by the `src` mob
+ *
+ * _Implementations differs, basically this is a shitshow, check the params without assuming the order from this description_
+ *
+ * * message - The message output to anyone who can see, a string
+ * * self_message - A message to show to the `src` mob
+ * * blind_message - A message to show to mobs or movable atoms that are in view range but blind
+ * * range - The range that is considered for the view evaluation, defaults to `world.view`
+ * * show_observers - Boolean, if observers sees the message
+ * * intent_message - A message sent via `intent_message()`
+ * * intent_range - The range considered for the evaluation of the `intent_message`
+ */
+/atom/proc/visible_message(message, blind_message, range = world.view, intent_message = null, intent_range = 7)
+	SHOULD_NOT_SLEEP(TRUE)
+
 	var/list/hearers = get_hearers_in_view(range, src)
 
 	for(var/atom/movable/AM as anything in hearers)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -24,30 +24,52 @@
 	return ..()
 
 
+/**
+ * Buckles an `/atom/movable` to this obj, performed by a `/mob`
+ *
+ * Returns `TRUE` if the buckling was successful, `FALSE` otherwise
+ *
+ * * buckling_atom - The `/atom/movable` to buckle
+ * * user - The `/mob` that performs the buclking action
+ */
 /obj/proc/buckle(atom/movable/buckling_atom, mob/user)
+
 	if(!buckling_atom.can_be_buckled || buckling_atom.buckled_to)
 		return FALSE
+
 	if(!is_type_in_list(buckling_atom, can_buckle))
 		return FALSE
+
 	if(buckling_atom.loc != loc)
 		step_towards(buckling_atom, src)
+
 		if(buckling_atom.loc != loc)
 			return FALSE
+
 	if(buckling_atom != user && isliving(buckling_atom))
 		var/mob/living/buckling_mob = buckling_atom
-		if(!buckling_mob.lying && !do_mob(user, buckling_mob, 3 SECONDS))
+
+		//If the mob is not lying, check if there's an user that is performing the action, if there is add 3 seconds to perform the action,
+		//otherwise just continue as do_mob requires an user and a target
+		if(!buckling_mob.lying && !isnull(user) && !do_mob(user, buckling_mob, 3 SECONDS))
 			return FALSE
+
 	buckling_atom.buckled_to = src
 	buckled = buckling_atom
+
 	if(istype(buckling_atom, /mob/living))
 		var/mob/living/buckling_mob = buckling_atom
+
 		if(length(buckling_mob.pinned) || (buckle_require_restraints && !buckling_mob.restrained()))
 			return FALSE
+
 		buckling_mob.set_dir(buckle_dir ? buckle_dir : dir)
 		buckling_mob.facing_dir = null
 		buckling_mob.update_canmove()
+
 	else
 		buckling_atom.anchored = TRUE
+
 	post_buckle(buckling_atom)
 	buckling_atom.layer = layer + 0.1
 	return TRUE

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -206,7 +206,7 @@
 		if(do_after(user, 2 SECONDS, affecting, DO_UNIQUE))
 			affecting.forceMove(loc)
 			spawn(0)
-				if(buckle(affecting))
+				if(buckle(affecting, user))
 					affecting.visible_message(\
 						SPAN_DANGER("[affecting.name] is buckled to [src] by [user.name]!"),\
 						SPAN_DANGER("You are buckled to [src] by [user.name]!"),\

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -137,14 +137,8 @@
 		to_chat(src, msg)
 	return
 
-// Show a message to all mobs and objects in sight of this one
-// This would be for visible actions by the src mob
-// message is the message output to anyone who can see e.g. "[src] does something!"
-// self_message (optional) is what the src mob sees  e.g. "You do something!"
-// blind_message (optional) is what blind people will hear e.g. "You hear something!"
 
-/mob/visible_message(var/message, var/self_message, var/blind_message, var/range = world.view, var/show_observers = TRUE, var/intent_message = null, var/intent_range = 7)
-	set waitfor = FALSE
+/mob/visible_message(message, self_message, blind_message, range = world.view, show_observers = TRUE, intent_message = null, intent_range = 7)
 	var/list/messageturfs = list() //List of turfs we broadcast to.
 	var/list/messagemobs = list() //List of living mobs nearby who can hear it, and distant ghosts who've chosen to hear it
 	var/list/messageobjs = list() //list of objs nearby who can see it

--- a/code/modules/multiz/hoist.dm
+++ b/code/modules/multiz/hoist.dm
@@ -54,7 +54,7 @@
 		AM.forceMove(get_turf(source_hook))
 	hoistee = AM
 	if(ismob(AM))
-		source_hook.buckle(AM)
+		source_hook.buckle(AM, user)
 		if(issilicon(AM))
 			AM.anchored = TRUE
 	source_hook.layer = AM.layer + 0.1

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -1124,35 +1124,42 @@ By design, d1 is the smallest direction and d2 is the highest
 
 	add_fingerprint(user)
 
-	if(M == user && buckle(M))
+	if(M == user && buckle(M, user))
 		M.visible_message(\
 			SPAN_WARNING("[M] ties \the [src] over their neck!"),\
 			SPAN_WARNING("You tie \the [src] over your neck!"))
 		playsound(user.loc, 'sound/effects/noosed.ogg', 50, 1, -1)
 		SSstatistics.IncrementSimpleStat("hangings")
 		return TRUE
+
 	else
-		M.visible_message(\
-			SPAN_DANGER("[user] attempts to tie \the [src] over [M]'s neck!"),\
-			SPAN_DANGER("[user] ties \the [src] over your neck!"))
+		M.visible_message(SPAN_DANGER("[user] attempts to tie \the [src] over [M]'s neck!"),
+							SPAN_DANGER("[user] ties \the [src] over your neck!"))
+
 		to_chat(user, SPAN_NOTICE("It will take 20 seconds and you have to stand still."))
+
 		if(do_after(user, 200))
-			if(buckle(M))
-				M.visible_message(\
-					SPAN_DANGER("[user] ties \the [src] over [M]'s neck!"),\
-					SPAN_DANGER("[user] ties \the [src] over your neck!"))
+			if(buckle(M, user))
+				M.visible_message(SPAN_DANGER("[user] ties \the [src] over [M]'s neck!"),
+									SPAN_DANGER("[user] ties \the [src] over your neck!"))
+
 				playsound(user.loc, 'sound/effects/noosed.ogg', 50, 1, -1)
+
 				SSstatistics.IncrementSimpleStat("hangings")
+
 				return TRUE
+
 			else
-				user.visible_message(\
-					SPAN_WARNING("[user] fails to tie \the [src] over [M]'s neck!"),\
-					SPAN_WARNING("You fail to tie \the [src] over [M]'s neck!"))
+				user.visible_message(SPAN_WARNING("[user] fails to tie \the [src] over [M]'s neck!"),
+										SPAN_WARNING("You fail to tie \the [src] over [M]'s neck!"))
+
 				return FALSE
+
 		else
-			user.visible_message(\
-				SPAN_WARNING("[user] fails to tie \the [src] over [M]'s neck!"),\
-				SPAN_WARNING("You fail to tie \the [src] over [M]'s neck!"))
+
+			user.visible_message(SPAN_WARNING("[user] fails to tie \the [src] over [M]'s neck!"),
+									SPAN_WARNING("You fail to tie \the [src] over [M]'s neck!"))
+
 			return FALSE
 
 /obj/structure/noose/process(mob/living/carbon/human/M, mob/user)

--- a/html/changelogs/fluffyghost-fixnoosestraps.yml
+++ b/html/changelogs/fluffyghost-fixnoosestraps.yml
@@ -1,0 +1,46 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed nooses being untiable."
+  - bugfix: "Fixed traps failing to buckle mobs."
+  - bugfix: "Fixed buckle() failing if the mob is not lying and no user is passed for the action."
+  - backend: "DMDoc'd and minor refactor of buckle()."
+  - backend: "DMDoc'd do_mob() and added a stack_trace when it's called without either needed parameters."
+  - backend: "DMDoc'd visible_message(), it is kind of a mess so it doesn't have 100% coverage, probably will need to be refactored sooner or later."


### PR DESCRIPTION
Fixed nooses being untiable.
Fixed traps failing to buckle mobs.
Fixed buckle() failing if the mob is not lying and no user is passed for the action.
DMDoc'd and minor refactor of buckle().
DMDoc'd do_mob() and added a stack_trace when it's called without either needed parameters.
DMDoc'd visible_message(), it is kind of a mess so it doesn't have 100% coverage, probably will need to be refactored sooner or later.

Fixed #17732 
Fixed #16038 