### PR TITLE
Breacher Suit Buffs & Hegemony Corvette Tweaks

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -45,16 +45,30 @@
 	vision_restriction = 0
 	slowdown = 4
 	vision_restriction = TINT_NONE
+	glove_type = /obj/item/clothing/gloves/powerfist
 
 	allowed_module_types = MODULE_GENERAL | MODULE_LIGHT_COMBAT | MODULE_HEAVY_COMBAT | MODULE_SPECIAL
 
-/obj/item/rig/unathi/fancy/ninja
+/obj/item/rig/unathi/fancy/equipped
+	req_access = list(access_kataphract)
+	initial_modules = list(
+		/obj/item/rig_module/vision/nvg,
+		/obj/item/rig_module/actuators/combat,
+		/obj/item/rig_module/maneuvering_jets,
+		/obj/item/rig_module/device/drill,
+		/obj/item/rig_module/chem_dispenser/combat
+	)
 
+/obj/item/rig/unathi/fancy/ninja
+	req_access = list(access_syndicate)
 	initial_modules = list(
 		/obj/item/rig_module/vision/thermal,
 		/obj/item/rig_module/chem_dispenser/combat,
 		/obj/item/rig_module/device/drill,
-		/obj/item/rig_module/device/door_hack
+		/obj/item/rig_module/actuators/combat,
+		/obj/item/rig_module/maneuvering_jets,
+		/obj/item/rig_module/device/door_hack,
+		/obj/item/rig_module/mounted/energy_blade
 		)
 
 	allowed_module_types = MODULE_GENERAL | MODULE_LIGHT_COMBAT | MODULE_HEAVY_COMBAT | MODULE_MEDICAL | MODULE_UTILITY

--- a/html/changelogs/RustingWithYou - breachin.yml
+++ b/html/changelogs/RustingWithYou - breachin.yml
@@ -39,4 +39,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Adds an equipped variant of the breacher suit to the Hegemony corvette."
+  - tweak: "Adds a power fist to the breacher suit."
   - maptweak: "Fixes the Hegemony corvette shuttle dock."

--- a/html/changelogs/RustingWithYou - breachin.yml
+++ b/html/changelogs/RustingWithYou - breachin.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds an equipped variant of the breacher suit to the Hegemony corvette."
+  - maptweak: "Fixes the Hegemony corvette shuttle dock."

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dm
@@ -109,7 +109,7 @@
 	shuttle_area = list(/area/shuttle/hegemony)
 	current_location = "nav_hegemony_corvette_shuttle"
 	landmark_transition = "nav_transit_hegemony_corvette"
-	dock_target = "hegemony_shuttle"
+	dock_target = "airlock_hegemony_shuttle"
 	range = 1
 	fuel_consumption = 2
 	logging_home_tag = "nav_hegemony_corvette_shuttle"
@@ -123,7 +123,7 @@
 /obj/effect/shuttle_landmark/hegemony_shuttle/dock
 	name = "Hegemony Corvette - Shuttle Dock"
 	landmark_tag = "nav_hegemony_corvette_shuttle"
-	docking_controller = "hegemony_shuttle_dock"
+	docking_controller = "airlock_hegemony_dock"
 	base_area = /area/space
 	base_turf = /turf/space
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
@@ -994,10 +994,9 @@
 	pixel_y = 28
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
-	req_one_access = null;
+	req_one_access = list(113);
 	shuttle_tag = "Hegemony Shuttle"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
@@ -1674,10 +1673,9 @@
 	id_tag = "hegemony_shuttle_pump_in"
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
-	req_one_access = null;
+	req_one_access = list(113);
 	shuttle_tag = "Hegemony Shuttle"
 	},
 /turf/simulated/floor,
@@ -1714,10 +1712,9 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
 /obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
-	req_one_access = null;
+	req_one_access = list(113);
 	shuttle_tag = "Hegemony Shuttle"
 	},
 /turf/simulated/floor/airless,
@@ -2950,10 +2947,9 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
-	req_one_access = null;
+	req_one_access = list(113);
 	shuttle_tag = "Hegemony Shuttle"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
@@ -3862,10 +3858,9 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
-	req_one_access = null;
+	req_one_access = list(113);
 	shuttle_tag = "Hegemony Shuttle"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
@@ -5237,10 +5232,9 @@
 	pixel_y = -28
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
-	req_one_access = null;
+	req_one_access = list(113);
 	shuttle_tag = "Hegemony Shuttle"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
@@ -5423,10 +5417,9 @@
 	id_tag = "hegemony_shuttle_pump_in"
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
-	req_one_access = null;
+	req_one_access = list(113);
 	shuttle_tag = "Hegemony Shuttle"
 	},
 /turf/simulated/floor,
@@ -7113,12 +7106,6 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "Qu" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1385;
-	id_tag = "hegemony_shuttle_chamber_sensor";
-	pixel_y = -23;
-	dir = 1
-	},
 /obj/structure/fuel_port/hydrogen{
 	pixel_y = -32
 	},
@@ -7126,13 +7113,13 @@
 	dir = 8
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
-	req_one_access = null;
+	req_one_access = list(113);
 	shuttle_tag = "Hegemony Shuttle"
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
+/obj/machinery/light,
 /turf/simulated/floor,
 /area/shuttle/hegemony)
 "Qv" = (
@@ -7343,10 +7330,9 @@
 	pixel_y = 28
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
-	req_one_access = null;
+	req_one_access = list(113);
 	shuttle_tag = "Hegemony Shuttle"
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
@@ -990,15 +990,25 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "hegemony_shuttle_out";
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 6
 	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 28
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_hegemony_shuttle";
+	name = "airlock_hegemony_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Hegemony Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor,
 /area/shuttle/hegemony)
 "gm" = (
@@ -1199,8 +1209,23 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner_wide/red/diagonal,
-/turf/simulated/floor/tiled,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "nav_hegemony_corvette_shuttle";
+	master_tag = "airlock_hegemony_dock";
+	name = "airlock_hegemony_dock"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_x = -6;
+	pixel_y = 28
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = 6;
+	pixel_y = 28
+	},
+/turf/simulated/floor,
 /area/hegemony_ship/docking_port)
 "hL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1652,6 +1677,13 @@
 	frequency = 1385;
 	id_tag = "hegemony_shuttle_pump_in"
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_hegemony_shuttle";
+	name = "airlock_hegemony_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Hegemony Shuttle"
+	},
 /turf/simulated/floor,
 /area/shuttle/hegemony)
 "ly" = (
@@ -1684,10 +1716,13 @@
 	frequency = 1385;
 	layer = 2.8
 	},
-/obj/machinery/airlock_sensor/airlock_exterior{
-	frequency = 1385;
-	id_tag = "hegemony_shuttle_exterior_sensor";
-	pixel_y = 30
+/obj/effect/map_effect/marker_helper/airlock/out,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_hegemony_shuttle";
+	name = "airlock_hegemony_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Hegemony Shuttle"
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/hegemony)
@@ -1940,6 +1975,7 @@
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(113)
 	},
+/obj/item/gun/energy/rifle/hegemony,
 /turf/simulated/floor/tiled/dark/full,
 /area/hegemony_ship/armory)
 "mX" = (
@@ -2905,27 +2941,23 @@
 /turf/simulated/floor,
 /area/hegemony_ship/engineering)
 "sI" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "hegemony_shuttle_out";
-	dir = 4
-	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1385;
-	master_tag = "hegemony_shuttle";
-	name = "exterior access button";
-	pixel_x = -9;
-	pixel_y = -23;
-	dir = 8
-	},
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, airlock"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 8
 	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_hegemony_shuttle";
+	name = "airlock_hegemony_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Hegemony Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor,
 /area/shuttle/hegemony)
 "sJ" = (
@@ -3752,13 +3784,17 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
-/obj/effect/shuttle_landmark/hegemony_shuttle/dock,
-/obj/machinery/door/window{
+/obj/machinery/door/airlock/external{
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "nav_hegemony_corvette_shuttle";
+	master_tag = "airlock_hegemony_dock";
+	name = "airlock_hegemony_dock"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/shuttle_landmark/hegemony_shuttle/dock{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/docking_port)
@@ -3788,22 +3824,6 @@
 	icon_state = "map_scrubber_on"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/airlock_sensor/airlock_interior{
-	dir = 4;
-	pixel_x = -23;
-	pixel_y = 5;
-	id_tag = "hegemony_shuttle_interior_sensor";
-	frequency = 1385
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1385;
-	master_tag = "hegemony_shuttle";
-	name = "interior access button";
-	pixel_x = -24;
-	pixel_y = -5;
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/shuttle/hegemony)
 "xF" = (
@@ -3840,11 +3860,16 @@
 	dir = 10
 	},
 /obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "hegemony_shuttle_in";
 	dir = 4
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_hegemony_shuttle";
+	name = "airlock_hegemony_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Hegemony Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor,
 /area/shuttle/hegemony)
 "xL" = (
@@ -4318,8 +4343,8 @@
 "Af" = (
 /obj/structure/table/rack,
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/item/rig/unathi/fancy,
 /obj/structure/sign/flag/hegemony/large/north,
+/obj/item/rig/unathi/fancy/equipped,
 /turf/simulated/floor,
 /area/hegemony_ship/armory)
 "Ai" = (
@@ -4524,11 +4549,10 @@
 /area/hegemony_ship/engineering)
 "Bh" = (
 /obj/machinery/light,
-/obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "hegemony_dock_doors";
-	dir = 4
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "nav_hegemony_corvette_shuttle";
+	master_tag = "airlock_hegemony_dock";
+	name = "airlock_hegemony_dock"
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/docking_port)
@@ -4681,8 +4705,18 @@
 /turf/simulated/floor,
 /area/hegemony_ship/engineering)
 "Cr" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/hegemony_ship)
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "nav_hegemony_corvette_shuttle";
+	master_tag = "airlock_hegemony_dock";
+	name = "airlock_hegemony_dock"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor,
+/area/hegemony_ship/docking_port)
 "Cw" = (
 /obj/effect/landmark/entry_point/aft{
 	name = "aft engines, starboard 2"
@@ -5181,11 +5215,21 @@
 "FO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "hegemony_shuttle_in";
 	dir = 4
 	},
+/obj/machinery/access_button{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = -28
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_hegemony_shuttle";
+	name = "airlock_hegemony_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Hegemony Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor,
 /area/shuttle/hegemony)
 "FQ" = (
@@ -5360,6 +5404,13 @@
 	dir = 4;
 	frequency = 1385;
 	id_tag = "hegemony_shuttle_pump_in"
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_hegemony_shuttle";
+	name = "airlock_hegemony_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Hegemony Shuttle"
 	},
 /turf/simulated/floor,
 /area/shuttle/hegemony)
@@ -5962,11 +6013,12 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "JX" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/floor_decal/corner_wide/red/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
-/turf/template_noop,
-/area/space)
+/turf/simulated/floor/tiled,
+/area/hegemony_ship/docking_port)
 "Kd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -6078,18 +6130,27 @@
 /turf/simulated/floor,
 /area/hegemony_ship/trophy_room)
 "KN" = (
-/obj/effect/floor_decal/corner_wide/red/diagonal,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1385;
-	id_tag = "hegemony_shuttle_dock";
-	req_one_access = list(113);
-	tag_door = "hegemony_dock_doors";
-	pixel_y = 25
+/obj/machinery/door/airlock/external{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "nav_hegemony_corvette_shuttle";
+	master_tag = "airlock_hegemony_dock";
+	name = "airlock_hegemony_dock"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/machinery/access_button{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 28
+	},
+/turf/simulated/floor,
 /area/hegemony_ship/docking_port)
 "KR" = (
 /obj/structure/sign/radiation,
@@ -6789,9 +6850,19 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "OF" = (
-/obj/structure/window/reinforced,
-/obj/machinery/door/window{
+/obj/machinery/door/airlock/external{
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "nav_hegemony_corvette_shuttle";
+	master_tag = "airlock_hegemony_dock";
+	name = "airlock_hegemony_dock"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = -28
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/docking_port)
@@ -6816,11 +6887,10 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "hegemony_dock_doors";
-	dir = 4
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "nav_hegemony_corvette_shuttle";
+	master_tag = "airlock_hegemony_dock";
+	name = "airlock_hegemony_dock"
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/docking_port)
@@ -7043,11 +7113,16 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	id_tag = "hegemony_shuttle_pump_out_internal";
-	frequency = 1385;
-	layer = 2.8
+	dir = 8
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_hegemony_shuttle";
+	name = "airlock_hegemony_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Hegemony Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor,
 /area/shuttle/hegemony)
 "Qv" = (
@@ -7169,9 +7244,16 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/docking_port)
 "RG" = (
-/obj/structure/window/reinforced,
-/turf/template_noop,
-/area/space)
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "nav_hegemony_corvette_shuttle";
+	master_tag = "airlock_hegemony_dock";
+	name = "airlock_hegemony_dock"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/hegemony_ship/docking_port)
 "RI" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -7239,24 +7321,25 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
-	id_tag = "hegemony_shuttle";
-	master_tag = "hegemony_shuttle";
-	pixel_y = 25;
-	tag_interior_door = "hegemony_shuttle_in";
-	tag_exterior_door = "hegemony_shuttle_out";
-	tag_interior_sensor = "hegemony_shuttle_interior_sensor";
-	tag_exterior_sensor = "hegemony_shuttle_exterior_sensor";
-	tag_chamber_sensor = "hegemony_shuttle_chamber_sensor";
-	tag_airpump = "hegemony_shuttle_pump_in";
-	frequency = 1385
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	id_tag = "hegemony_shuttle_pump_out_internal";
-	frequency = 1385;
-	layer = 2.8
+	dir = 8
 	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_x = -6;
+	pixel_y = 28
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = 6;
+	pixel_y = 28
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_hegemony_shuttle";
+	name = "airlock_hegemony_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Hegemony Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor,
 /area/shuttle/hegemony)
 "Se" = (
@@ -8163,8 +8246,14 @@
 /turf/simulated/floor,
 /area/space)
 "XU" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/hegemony_ship/aux_cic)
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/red/diagonal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled,
+/area/hegemony_ship/docking_port)
 "XX" = (
 /obj/machinery/appliance/cooker/stove,
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -19144,7 +19233,7 @@ wQ
 wQ
 wQ
 wQ
-Cr
+wQ
 wQ
 wQ
 Ev
@@ -20768,7 +20857,7 @@ lU
 eq
 VW
 lU
-XU
+lU
 Xa
 Xa
 Xa
@@ -21916,8 +22005,8 @@ yW
 Rw
 Rw
 om
-Rw
-Rw
+JX
+XU
 bk
 iO
 WH
@@ -22078,7 +22167,7 @@ yW
 oP
 bk
 KN
-Rw
+Cr
 bk
 bk
 cF
@@ -22240,7 +22329,7 @@ yW
 bk
 bk
 hK
-Rw
+RG
 bk
 bk
 lP
@@ -22562,10 +22651,10 @@ aJ
 aJ
 aJ
 aJ
-RG
+bk
 xu
 OF
-JX
+bk
 aJ
 aJ
 aJ

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
@@ -21,9 +21,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -35,6 +32,9 @@
 /obj/machinery/door/blast/regular/open{
 	id = "hegemony2";
 	name = "blast door"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -49,9 +49,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -63,6 +60,9 @@
 /obj/machinery/door/blast/regular/open{
 	id = "hegemony1";
 	name = "blast door"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -85,10 +85,7 @@
 /turf/simulated/floor/wood,
 /area/hegemony_ship/canteen)
 "ap" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor,
 /area/hegemony_ship/starboard_propulsion)
 "aw" = (
@@ -103,12 +100,6 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "ax" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Engineering";
-	req_one_access = list(113);
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/noid,
@@ -116,6 +107,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/door/airlock/hatch{
+	name = "Engineering";
+	req_one_access = list(113);
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/engineering)
@@ -511,9 +508,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -521,6 +515,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -562,9 +559,6 @@
 /turf/simulated/floor,
 /area/hegemony_ship/trophy_room)
 "dL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
 /obj/machinery/firealarm/west{
 	dir = 2;
 	pixel_x = 0;
@@ -766,9 +760,6 @@
 /area/hegemony_ship/canteen)
 "fh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10;
 	pixel_y = 0
@@ -778,6 +769,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor,
 /area/hegemony_ship/starboard_propulsion)
 "fi" = (
@@ -811,10 +803,10 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
 "fn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/hegemony_ship/starboard_propulsion)
 "fo" = (
@@ -1047,10 +1039,6 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/hegemony)
 "gE" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4;
-	icon_state = "map"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -1067,6 +1055,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
@@ -1202,7 +1193,7 @@
 /turf/simulated/floor/wood,
 /area/hegemony_ship/warpriests_quarters)
 "hJ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /turf/simulated/floor,
 /area/hegemony_ship/port_propulsion)
 "hK" = (
@@ -1273,7 +1264,9 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
 "ic" = (
-/obj/effect/shuttle_landmark/hegemony_corvette/dock2,
+/obj/effect/shuttle_landmark/hegemony_corvette/dock2{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/hegemony_ship)
 "ie" = (
@@ -1598,11 +1591,10 @@
 /turf/simulated/floor/tiled/white,
 /area/hegemony_ship/restroom)
 "kQ" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 4;
-	layer = 2.8
-	},
 /obj/machinery/firealarm/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/hegemony_ship/engineering)
 "kR" = (
@@ -1616,7 +1608,6 @@
 /area/hegemony_ship/temple)
 "kU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -1624,6 +1615,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
@@ -1804,8 +1800,7 @@
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
-/obj/machinery/atmospherics/portables_connector{
-	layer = 2.8;
+/obj/machinery/atmospherics/portables_connector/fuel{
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -1832,15 +1827,11 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/hegemony_ship/gun_deck_flak)
 "ml" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
 /obj/machinery/power/apc/south,
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/hegemony_ship/starboard_propulsion)
 "mm" = (
@@ -1856,13 +1847,13 @@
 /area/hegemony_ship)
 "mv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/hegemony_ship)
@@ -2122,6 +2113,7 @@
 "oe" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor,
 /area/hegemony_ship/starboard_propulsion)
 "og" = (
@@ -2192,7 +2184,6 @@
 /area/hegemony_ship/restroom)
 "or" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/noid,
 /obj/structure/cable/green{
@@ -2200,6 +2191,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/door/airlock/hatch{
 	name = "Propulsion";
 	req_one_access = list(113);
@@ -2451,13 +2443,12 @@
 /turf/template_noop,
 /area/space)
 "pF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/starboard_propulsion)
@@ -2576,12 +2567,27 @@
 /turf/simulated/floor/tiled/white,
 /area/hegemony_ship/medbay)
 "qr" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor,
-/area/hegemony_ship/starboard_propulsion)
+/area/hegemony_ship)
 "qs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2833,13 +2839,6 @@
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/gun_deck_bruiser)
-"sh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/hegemony_ship/port_propulsion)
 "sl" = (
 /obj/effect/floor_decal/corner_wide/red/diagonal,
 /obj/structure/closet/crate/freezer/rations,
@@ -3248,8 +3247,8 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/brig)
 "ue" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/port_propulsion)
@@ -3387,7 +3386,7 @@
 /turf/simulated/floor/tiled/white,
 /area/hegemony_ship/restroom)
 "uS" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /turf/simulated/floor,
 /area/hegemony_ship/starboard_propulsion)
 "uW" = (
@@ -3405,9 +3404,6 @@
 /area/hegemony_ship)
 "va" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3415,6 +3411,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -4062,11 +4061,25 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
 "yQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/hegemony_ship/port_propulsion)
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hegemony_ship)
 "yV" = (
 /obj/effect/floor_decal/industrial/warning/cee,
 /obj/machinery/atmospherics/portables_connector{
@@ -4146,19 +4159,19 @@
 /turf/simulated/floor/reinforced,
 /area/hegemony_ship/engineering)
 "zs" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Propulsion";
-	req_one_access = list(113);
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/noid,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/door/airlock/hatch{
+	name = "Propulsion";
+	req_one_access = list(113);
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/starboard_propulsion)
@@ -4302,7 +4315,6 @@
 /turf/simulated/floor,
 /area/hegemony_ship/engineering)
 "zR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/meter,
 /turf/simulated/floor,
 /area/hegemony_ship/starboard_propulsion)
@@ -4414,7 +4426,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -4431,6 +4442,7 @@
 /obj/effect/floor_decal/corner/black{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "Ay" = (
@@ -4724,8 +4736,8 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/hegemony_ship/starboard_propulsion)
 "Cx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/starboard_propulsion)
@@ -4772,6 +4784,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/noid,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -4783,11 +4796,11 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/hegemony_ship/gun_deck_bruiser)
 "CP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/hegemony_ship/starboard_propulsion)
 "CQ" = (
@@ -4963,6 +4976,7 @@
 "DQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor,
 /area/hegemony_ship/port_propulsion)
 "DU" = (
@@ -4978,8 +4992,8 @@
 /turf/simulated/floor,
 /area/shuttle/hegemony)
 "DZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/port_propulsion)
@@ -5293,7 +5307,6 @@
 /turf/simulated/floor/tiled/white,
 /area/hegemony_ship/restroom)
 "Gh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/meter,
 /turf/simulated/floor,
 /area/hegemony_ship/port_propulsion)
@@ -5316,12 +5329,16 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/hegemony)
 "Gn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
-/area/hegemony_ship/port_propulsion)
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled,
+/area/hegemony_ship)
 "Go" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -5336,9 +5353,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -5346,6 +5360,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -5353,9 +5370,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -5363,6 +5377,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
@@ -5460,9 +5477,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -5470,6 +5484,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -5482,9 +5499,6 @@
 "Hb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -5507,6 +5521,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
@@ -5553,13 +5570,14 @@
 /area/hegemony_ship/bridge)
 "Hl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "Hn" = (
@@ -5683,9 +5701,6 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/hegemony)
 "In" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
 /obj/machinery/alarm/north{
 	pixel_y = -32;
 	req_one_access = null
@@ -5925,8 +5940,10 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/hegemony_ship/canteen)
 "Jv" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/hegemony_ship/port_propulsion)
 "Jz" = (
@@ -6021,9 +6038,6 @@
 /area/hegemony_ship/docking_port)
 "Kd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -6031,6 +6045,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor,
 /area/hegemony_ship/port_propulsion)
 "Kf" = (
@@ -6056,12 +6071,12 @@
 /turf/simulated/floor,
 /area/hegemony_ship/bridge)
 "Kt" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/starboard_propulsion)
@@ -6085,8 +6100,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /turf/simulated/floor,
 /area/hegemony_ship/engineering)
 "KB" = (
@@ -6094,9 +6108,6 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "KD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
@@ -6382,9 +6393,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -6392,6 +6400,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -6518,12 +6529,11 @@
 /turf/simulated/floor/carpet/red,
 /area/hegemony_ship/temple)
 "MQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/port_propulsion)
@@ -6638,8 +6648,8 @@
 /turf/simulated/floor,
 /area/hegemony_ship/atmos_waste)
 "Ng" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /turf/simulated/floor,
 /area/hegemony_ship/starboard_propulsion)
 "Ni" = (
@@ -6732,9 +6742,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6744,6 +6751,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/noid,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "NR" = (
@@ -6839,7 +6849,6 @@
 /area/hegemony_ship/engineering)
 "OA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6847,6 +6856,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/noid,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "OF" = (
@@ -6993,7 +7003,6 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
 "PI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7004,6 +7013,7 @@
 	dir = 8;
 	icon_state = "map-scrubbers"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/hegemony_ship)
@@ -7582,6 +7592,7 @@
 "Td" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor,
 /area/hegemony_ship/port_propulsion)
 "Tf" = (
@@ -7725,9 +7736,6 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/crew_quarters)
 "Uk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
 /obj/machinery/firealarm/south,
 /turf/simulated/floor,
 /area/hegemony_ship/port_propulsion)
@@ -7746,9 +7754,6 @@
 /turf/simulated/floor/tiled/white,
 /area/hegemony_ship/medbay)
 "Uo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
 /obj/machinery/alarm/north{
 	pixel_y = -32;
 	req_one_access = null
@@ -8025,7 +8030,6 @@
 /area/hegemony_ship/engineering)
 "VQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -8042,11 +8046,12 @@
 /obj/effect/floor_decal/corner/black{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -8094,9 +8099,6 @@
 /area/hegemony_ship/bridge)
 "Ww" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8107,6 +8109,9 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
@@ -8135,13 +8140,12 @@
 /turf/simulated/floor,
 /area/shuttle/hegemony)
 "WR" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/port_propulsion)
@@ -8164,9 +8168,9 @@
 /turf/simulated/floor,
 /area/hegemony_ship/engineering)
 "Xi" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4;
+	layer = 2.8
 	},
 /turf/simulated/floor,
 /area/hegemony_ship/engineering)
@@ -8186,12 +8190,26 @@
 /turf/simulated/floor,
 /area/hegemony_ship/port_propulsion)
 "Xr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor,
-/area/hegemony_ship/starboard_propulsion)
+/area/hegemony_ship)
 "Xs" = (
 /obj/effect/landmark/entry_point/port{
 	name = "port, armory"
@@ -8342,10 +8360,6 @@
 /area/hegemony_ship)
 "Yw" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -8361,6 +8375,9 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
@@ -18085,12 +18102,12 @@ aJ
 aJ
 bd
 fn
-Qp
+ap
 oe
 fh
 zs
 Av
-Hl
+Gn
 OA
 mv
 Yw
@@ -18735,7 +18752,7 @@ hm
 Ng
 ii
 Qp
-fn
+Qp
 eC
 UF
 di
@@ -18896,8 +18913,8 @@ aJ
 Cw
 Cx
 ii
-ap
-qr
+ii
+Qp
 eC
 TW
 zw
@@ -19058,7 +19075,7 @@ aJ
 hm
 Kt
 zR
-Xr
+ii
 rq
 eC
 rZ
@@ -21981,7 +21998,7 @@ Jj
 wO
 wO
 Vc
-Ww
+qr
 SB
 nG
 qY
@@ -22143,7 +22160,7 @@ nX
 ao
 oI
 xI
-GA
+Xr
 SB
 nG
 qY
@@ -22305,7 +22322,7 @@ nX
 ao
 oI
 xI
-Mi
+yQ
 sB
 nG
 qY
@@ -23270,7 +23287,7 @@ aJ
 Uv
 WR
 Gh
-yQ
+bo
 Xq
 oB
 pW
@@ -23432,8 +23449,8 @@ aJ
 IL
 ue
 yf
-DZ
-Gn
+bo
+yf
 oB
 DJ
 Vn
@@ -23595,7 +23612,7 @@ Uv
 hJ
 yf
 jt
-sh
+yf
 oB
 MW
 gm
@@ -24240,7 +24257,7 @@ aJ
 aJ
 aJ
 pK
-ue
+DZ
 Td
 DQ
 Kd


### PR DESCRIPTION
Adds a module-equipped version of the Breacher suit, similar to that which other combat hardsuits have. This has been placed on the Hegemony corvette. While I was doing this I also noticed the dock wasn't working right, so I updated it with new docking stuff.

The ninja version of the breacher suit has been updated with some more modules as well, including an energy blade because come on, Unathi are _the_ melee combat species.

The breacher suit has also been given the power fist functionality that similar hardsuits such as the bunker and Dominian combat suit had, for aforementioned reason of come on, these are the melee guys.