### PR TITLE
TCFL Papers Update

### DIFF
--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -1519,13 +1519,13 @@
 			</html>
 			"}
 
-/obj/item/book/manual/tcfl_pamphlet
-	name = "tau ceti foreign legion pamphlet"
-	desc = "A simple pamphlet containing information about the Tau Ceti Foreign Legion."
+/obj/item/book/manual/tcaf_pamphlet
+	name = "tau ceti armed forces pamphlet"
+	desc = "A simple pamphlet containing information about the Tau Ceti Armed Forces."
 	icon_state = "tcfl_pamphlet"
 	item_state = "paper"
-	title = "Tau Ceti foreign legion pamphlet"
-	author = "Tau Ceti foreign legion recruitment center"
+	title = "Tau Ceti Armed Forces pamphlet"
+	author = "Tau Ceti Armed Forces recruitment center"
 	pickup_sound = 'sound/items/drop/paper.ogg'
 	drop_sound = 'sound/items/drop/paper.ogg'
 	w_class = ITEMSIZE_SMALL
@@ -1542,17 +1542,45 @@
 				</head>
 				<body>
 				<br>\
-				The Tau Ceti Foreign Legion is the primary armed force of the Republic of Biesel and is comprised of volunteer immigrants. External parties seeking citizenship \
-				often enlist, since the Republic offers citizenship in turn for service. Since 2464 the Legion was promoted to the official armed forces of the Republic, which \
-				resulted in a great boost in popularity, funding and manpower. This happened after President Dorn enacted the People's Protection Act megacorporations are also \
-				able to fund the legion, something the Stellar Corporate Conglomerate immediately did. The Legion's largest deployment currently is throughout the Corporate \
-				Reconstruction Zone, ensuring the SCC's growing influence over the region. To help with this task the Legion also seeks the assistance of the Private Military \
-				Contracting Group.
+				<h2>Introduction</h2><br>
+				The Tau Ceti Armed Forces are the military of the Republic of Biesel, founded in 2465 in order to defend the Republic's borders against the threats of piracy, \
+				terrorism and the devastation of the Solarian warlords. The Tau Ceti Armed Forces has four service branches - the Tau Ceti Minutemen, the Republican Fleets, \
+				the Tau Ceti Foreign Legion and the Auxiliary Corporate Forces. Each of these branches works in its own way to defend the Republic's safety and sovereignty, and to \
+				keep our light of liberty shining!<BR><BR>
+
+				<h2>Tau Ceti Minutemen</h2><br>
+				The Minutemen are the Republic's ground forces, ready to fight for freedom on any of the Republic's worlds. They recently have had great success in the anti-terrorism campaign \
+				on Mictlan, which finally came to an end shortly after the Minutemen were first deployed there. Some of the best and brightest of the Tau Ceti Foreign Legion were recruited into the \
+				Minutemen upon their founding, and already they've been proving themselves worthy of the name - ready at a minute's notice, to protect the Republic and her people. A career in the Minutemen \
+				may take you all across the Republic, offering a competitive salary and access to some of the best-quality training and equipment in the Spur!<BR><BR>
+
+				<h2>Republican Fleets</h2><br>
+				While the Minutemen watch the ground, the Republican Fleets watch the stars! The Republic's primary naval force, the Republican Fleets were founded to ensure that never again will the Republic face \
+				another assault such as the invasion of 2462. Flying top-of-the-line vessels from Zavodskoi Interstellar, and trained by seasoned veterans from across the Spur, the Fleets are rapidly becoming a fixture \
+				of our nation's defences. From the Zoleth Line to the borders of the Corporate Reconstruction Zone, the Republican Fleets ensure that the Republic's travel and trade lanes say safe and free of pirates and marauders. \
+				A career in the Fleets can teach valuable life-long skills for any kind of shipboard work, with positions that can teach you skills to fast-track nearly any career!<BR><BR>
+
+				<h2>Tau Ceti Foreign Legion</h2><br>
+				The oldest branch of the Armed Forces, the Tau Ceti Foreign Legion upholds the values of equity, freedom, and diversity our nation was founded upon. From Sol to Adhomai to Xanu Prime, recruits from anywhere can \
+				be found in the ranks of the TCFL, contributing to the nation they wish to make their home. A year's service with the Foreign Legion will earn full Republic citizenship, and can be the jumping-on point for a career with \
+				the Armed Forces. The branch has a prestigious history, having served with distinction in many of the conflicts of the Republic's history - from the successful repulsion of the Solarian invasion of 2462 to protecting the \
+				people of Mictlan from terrorism and disaster, the TCFL has always fought to protect the Republic and its people. If you are a resident or non-citizen and interested in Republic citizenship, talk to your nearest embassy or \
+				consulate to see if he Foreign Legion is a good fit for you!<BR><BR>
+
+				<h2>Auxiliary Corporate Forces</h2><br>
+				The Auxiliary Corporate Forces are the final branch of the Armed Forces, consisting of seasoned private contractors from the Spur's security corporations. The Auxiliary Corporate Forces are a core of well-disciplined and seasoned \
+				veterans, who act as flexible support units to the other branches in their operations. A position in the Auxiliary Corporate Forces can offer valuable experience in an existing security career, as well as providing a refreshing and \
+				challenging change of pace from the day-to-day work. If you're in the security industry and looking for a challenging new career path among the best of the best, or to put your skills to use for the cause of liberty, talk to your employers about transfer to the ACF today!<BR><BR>
+
+				<h2>Further Information</h2><br>
+				Service with the Tau Ceti Armed Forces renders one eligible for the Tau Ceti Corporate Scholarship, a program for subsidised higher education. In addition, choosing to join the reserve forces after your initial term of enlistment is up \
+				can earn you an income-supplementing stipend, paid for by the Republic of Biesel. If you think that the TCAF might be a good fit for you, contact your nearest recruitment office if in the Republic of Biesel, or your nearest embassy or consulate outside Republic space. \
+				You can also visit biesel.gov/tcaf/careers to learn more about the directions a career with the TCAF can take you, and hear from some of our soldiers and veterans about how their time in the TCAF has changed their lives!\
 				</body>
 			</html>
 			"}
 
-/obj/item/book/manual/tcfl_pamphlet/attack_self(var/mob/user as mob)
+/obj/item/book/manual/tcaf_pamphlet/attack_self(var/mob/user as mob)
 	if(src.dat)
 		user << browse("<TT><I>Penned by [author].</I></TT> <BR>" + "[dat]", "window=book")
 		user.visible_message("[user] opens a pamphlet titled \"[src.title]\" and begins reading intently.")

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -974,10 +974,10 @@
 	starts_with = list(/obj/item/clothing/accessory/badge/sol_visa = 6)
 
 /obj/item/storage/box/ceti_visa
-	name = "TCFL recruitment papers box"
-	desc = "A box full of papers that signify one as a recruit of the Tau Ceti Foreign Legion."
+	name = "TCAF recruitment papers box"
+	desc = "A box full of papers that signify one as a recruit of the Tau Ceti Armed Forces."
 	illustration = "paper"
-	starts_with = list(/obj/item/clothing/accessory/badge/tcfl_papers = 6)
+	starts_with = list(/obj/item/clothing/accessory/badge/tcaf_papers = 6)
 
 /obj/item/storage/box/hadii_card
 	name = "honorary party member card box"
@@ -1009,11 +1009,11 @@
 	illustration = "paper"
 	starts_with = list(/obj/item/book/manual/dominia_honor = 6)
 
-/obj/item/storage/box/tcfl_pamphlet
-	name = "tau ceti foreign legion pamphlets box"
-	desc = "A box full of tau ceti foreign legion pamphlets."
+/obj/item/storage/box/tcaf_pamphlet
+	name = "tau ceti armed forces pamphlets box"
+	desc = "A box full of tau ceti armed forces pamphlets."
 	illustration = "paper"
-	starts_with = list(/obj/item/book/manual/tcfl_pamphlet = 6)
+	starts_with = list(/obj/item/book/manual/tcaf_pamphlet = 6)
 
 /obj/item/storage/box/sharps
 	name = "sharps disposal box"

--- a/code/modules/background/citizenship/human.dm
+++ b/code/modules/background/citizenship/human.dm
@@ -54,7 +54,7 @@
 	accessory = /obj/item/clothing/accessory/tc_pin
 	backpack_contents = list(
 		/obj/item/storage/box/ceti_visa = 1,
-		/obj/item/storage/box/tcfl_pamphlet = 1,
+		/obj/item/storage/box/tcaf_pamphlet = 1,
 		/obj/item/device/versebook/biesel = 1, //constitution
 		/obj/item/stamp/biesel = 1,
 	)

--- a/code/modules/background/citizenship/vaurca.dm
+++ b/code/modules/background/citizenship/vaurca.dm
@@ -66,7 +66,7 @@
 	if(H)
 		if(isvaurca(H))
 			H.equip_to_slot_or_del(new /obj/item/storage/backpack/typec(H), slot_back)
-			H.equip_to_slot_or_del(new /obj/item/storage/box/tcfl_pamphlet(H), slot_in_backpack)
+			H.equip_to_slot_or_del(new /obj/item/storage/box/tcaf_pamphlet(H), slot_in_backpack)
 			H.equip_to_slot_or_del(new /obj/item/gun/energy/vaurca/blaster(H), slot_in_backpack)
 		if(!visualsOnly)
 			addtimer(CALLBACK(src, PROC_REF(send_representative_mission), H), 5 MINUTES)

--- a/code/modules/client/preference_setup/loadout/items/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/items/accessories.dm
@@ -521,17 +521,17 @@
 	passport["passport, coalition"] = /obj/item/clothing/accessory/badge/passport/coc
 	gear_tweaks += new /datum/gear_tweak/path(passport)
 
-/datum/gear/accessory/TCFLcard
-	display_name = "TCFL service cards"
-	description = "Identification cards given to reservists and former members of the Tau Ceti Foreign Legion."
-	path = /obj/item/clothing/accessory/badge/tcfl_papers
+/datum/gear/accessory/TCAFcard
+	display_name = "TCAF service cards"
+	description = "Identification cards given to reservists and former members of the Tau Ceti Armed Forces."
+	path = /obj/item/clothing/accessory/badge/tcaf_papers
 
-/datum/gear/accessory/TCFLcard/New()
+/datum/gear/accessory/TCAFcard/New()
 	..()
-	var/list/TCFLcard = list()
-	TCFLcard["reservist"] = /obj/item/clothing/accessory/badge/tcfl_papers/service/reservist
-	TCFLcard["veteran"] = /obj/item/clothing/accessory/badge/tcfl_papers/service/veteran
-	gear_tweaks += new /datum/gear_tweak/path(TCFLcard)
+	var/list/TCAFcard = list()
+	TCAFcard["reservist"] = /obj/item/clothing/accessory/badge/tcaf_papers/service/reservist
+	TCAFcard["veteran"] = /obj/item/clothing/accessory/badge/tcaf_papers/service/veteran
+	gear_tweaks += new /datum/gear_tweak/path(TCAFcard)
 
 /datum/gear/accessory/kneepads
 	display_name = "kneepads"

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -205,34 +205,34 @@
 	drop_sound = 'sound/items/drop/card.ogg'
 	pickup_sound = 'sound/items/pickup/card.ogg'
 
-/obj/item/clothing/accessory/badge/tcfl_papers
-	name = "\improper TCFL enlistment"
-	desc = "A compact piece of legal paperwork, making one an official recruit of the Tau Ceti Foreign Legion. Go Biesel!"
+/obj/item/clothing/accessory/badge/tcaf_papers
+	name = "\improper TCAF enlistment"
+	desc = "A compact piece of legal paperwork, making one an official recruit of the Tau Ceti Armed Forces. Go Biesel!"
 	icon_state = "tc-visa"
 	overlay_state = "tc-visa"
 	slot_flags = SLOT_TIE
-	badge_string = "Tau Ceti Foreign Legion Recruit"
+	badge_string = "Tau Ceti Armed Forces Recruit"
 
 	drop_sound = 'sound/items/drop/card.ogg'
 	pickup_sound = 'sound/items/pickup/card.ogg'
 
-/obj/item/clothing/accessory/badge/tcfl_papers/service
-	name = "\improper TCFL service card"
-	desc = "A small card identifying one as a current member of the Tau Ceti Foreign Legion. Often used to secure discounts in \
+/obj/item/clothing/accessory/badge/tcaf_papers/service
+	name = "\improper TCAF service card"
+	desc = "A small card identifying one as a current member of the Tau Ceti Armed Forces. Often used to secure discounts in \
 	Republic shops. Go Biesel!"
-	badge_string = "Tau Ceti Foreign Legion Service Member"
+	badge_string = "Tau Ceti Armed Forces Service Member"
 
-/obj/item/clothing/accessory/badge/tcfl_papers/service/veteran
-	name = "\improper TCFL veteran's service card"
-	desc = "A small card identifying one as a former member of the Tau Ceti Foreign Legion. Often used to secure discounts in \
+/obj/item/clothing/accessory/badge/tcaf_papers/service/veteran
+	name = "\improper TCAF veteran's service card"
+	desc = "A small card identifying one as a former member of the Tau Ceti Armed Forces. Often used to secure discounts in \
 	Republic shops. Go Biesel!"
-	badge_string = "Tau Ceti Foreign Legion Veteran"
+	badge_string = "Tau Ceti Armed Forces Veteran"
 
-/obj/item/clothing/accessory/badge/tcfl_papers/service/reservist
-	name = "\improper TCFL reservist's service card"
-	desc = "A small card identifying one as a current reservist of the Tau Ceti Foreign Legion. Often used to secure discounts in \
+/obj/item/clothing/accessory/badge/tcaf_papers/service/reservist
+	name = "\improper TCAF reservist's service card"
+	desc = "A small card identifying one as a current reservist of the Tau Ceti Armed Forces. Often used to secure discounts in \
 	Republic shops. Go Biesel!"
-	badge_string = "Tau Ceti Foreign Legion Reservist"
+	badge_string = "Tau Ceti Armed Forces Reservist"
 
 /obj/item/clothing/accessory/badge/sheriff
 	name = "sheriff badge"

--- a/html/changelogs/RustingWithYou - bieselboysummer.yml
+++ b/html/changelogs/RustingWithYou - bieselboysummer.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Replaces the TCFL enlistment cards and pamphlets with TCAF ones."

--- a/maps/aurora/aurora-1_centcomm.dmm
+++ b/maps/aurora/aurora-1_centcomm.dmm
@@ -8708,7 +8708,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
 	},
-/obj/item/storage/box/tcfl_pamphlet,
+/obj/item/storage/box/tcaf_pamphlet,
 /turf/unsimulated/floor{
 	icon_state = "tiled_preview"
 	},
@@ -33587,7 +33587,7 @@
 /obj/item/flag/biesel{
 	pixel_y = 8
 	},
-/obj/item/storage/box/tcfl_pamphlet,
+/obj/item/storage/box/tcaf_pamphlet,
 /obj/item/material/twohanded/pike/flag,
 /turf/unsimulated/floor,
 /area/centcom/legion/hangar5)
@@ -40204,7 +40204,7 @@
 /obj/item/flag/biesel/l{
 	pixel_y = 8
 	},
-/obj/item/storage/box/tcfl_pamphlet,
+/obj/item/storage/box/tcaf_pamphlet,
 /obj/item/material/twohanded/pike/flag,
 /turf/unsimulated/floor{
 	icon_state = "wood_preview"

--- a/maps/away/away_site/racers/racers.dmm
+++ b/maps/away/away_site/racers/racers.dmm
@@ -1107,7 +1107,7 @@
 /area/racers)
 "fic" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/item/book/manual/tcfl_pamphlet,
+/obj/item/book/manual/tcaf_pamphlet,
 /turf/simulated/floor/tiled/white,
 /area/racers)
 "fjZ" = (

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -14250,7 +14250,7 @@
 "kiq" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/stasis,
-/obj/item/book/manual/tcfl_pamphlet,
+/obj/item/book/manual/tcaf_pamphlet,
 /obj/item/book/manual/psych,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/book/manual/wiki/station_procedure,

--- a/maps/sccv_horizon/sccv_horizon-4_centcomm.dmm
+++ b/maps/sccv_horizon/sccv_horizon-4_centcomm.dmm
@@ -17559,7 +17559,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
 	},
-/obj/item/storage/box/tcfl_pamphlet,
+/obj/item/storage/box/tcaf_pamphlet,
 /turf/unsimulated/floor,
 /area/centcom/legion/hangar5)
 "aTt" = (
@@ -21058,7 +21058,7 @@
 /obj/item/flag/biesel{
 	pixel_y = 8
 	},
-/obj/item/storage/box/tcfl_pamphlet,
+/obj/item/storage/box/tcaf_pamphlet,
 /obj/item/material/twohanded/pike/flag,
 /turf/unsimulated/floor,
 /area/centcom/legion/hangar5)
@@ -24424,7 +24424,7 @@
 /obj/item/flag/biesel/l{
 	pixel_y = 8
 	},
-/obj/item/storage/box/tcfl_pamphlet,
+/obj/item/storage/box/tcaf_pamphlet,
 /obj/item/material/twohanded/pike/flag,
 /turf/unsimulated/floor{
 	icon_state = "wood_preview"
@@ -40472,7 +40472,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
-/obj/item/book/manual/tcfl_pamphlet{
+/obj/item/book/manual/tcaf_pamphlet{
 	pixel_y = 12
 	},
 /turf/simulated/floor/tiled/dark,


### PR DESCRIPTION
Renames the TCFL enlistment papers Biesel consulars spawn with to TCAF. Also replaces the old TCFL pamphlets with new TCAF ones.