### PR TITLE
Adds suit sensors to most clothing

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1057,7 +1057,7 @@
 	equip_sound = 'sound/items/equip/jumpsuit.ogg'
 
 	///SUIT_NO_SENSORS = No sensors, SUIT_HAS_SENSORS = Sensors, SUIT_LOCKED_SENSORS = Locked sensors
-	var/has_sensor = SUIT_NO_SENSORS
+	var/has_sensor = SUIT_HAS_SENSORS
 
 	///SUIT_SENSOR_OFF = Off, SUIT_SENSOR_BINARY = Report living/dead, SUIT_SENSOR_VITAL = Report detailed damages, SUIT_SENSOR_TRACKING = Report location
 	var/sensor_mode = SUIT_SENSOR_OFF

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1217,6 +1217,9 @@
 			if(SUIT_SENSOR_TRACKING)
 				to_chat(user, "Its vitals tracker and tracking beacon appear to be enabled.")
 
+/obj/item/clothing/under/AltClick(mob/user)
+	set_sensors(user)
+
 /obj/item/clothing/under/proc/set_sensors(mob/user as mob)
 	var/mob/M = user
 	if (isobserver(M) || user.incapacitated())

--- a/code/modules/clothing/sets/captain.dm
+++ b/code/modules/clothing/sets/captain.dm
@@ -36,7 +36,6 @@
 	icon_state = "uniform"
 	item_state = "uniform"
 	worn_state = "uniform"
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	var/is_open = FALSE
 
@@ -70,7 +69,6 @@
 	icon_state = "uniform_fem"
 	item_state = "uniform_fem"
 	worn_state = "uniform_fem"
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	var/is_open = FALSE
@@ -196,7 +194,6 @@
 	icon_state = "uniform"
 	item_state = "uniform"
 	worn_state = "uniform"
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 
 /obj/item/clothing/suit/captunic
@@ -231,5 +228,4 @@
 	icon = 'icons/obj/item/clothing/department_uniforms/command.dmi'
 	icon_state = "captain"
 	item_state = "captain"
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -3,7 +3,6 @@
 /obj/item/clothing/under/rank/bartender
 	name = "bartender's uniform"
 	desc = "It looks like it could use some more flair."
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	icon = 'icons/obj/item/clothing/department_uniforms/service.dmi'
 
@@ -21,7 +20,6 @@
 /obj/item/clothing/under/rank/chaplain
 	name = "chaplain's jumpsuit"
 	desc = "It's a black jumpsuit, often worn by religious folk."
-	has_sensor = SUIT_HAS_SENSORS
 	icon_state = "chaplain"
 	item_state = "bl_suit"
 	worn_state = "chapblack"
@@ -29,7 +27,6 @@
 /obj/item/clothing/under/rank/chef
 	name = "chef's uniform"
 	desc = "It's an apron which is given only to the most <b>hardcore</b> chefs in space."
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	icon = 'icons/obj/item/clothing/department_uniforms/service.dmi'
 	icon_state = "nt_chef"
@@ -48,7 +45,6 @@
 /obj/item/clothing/under/rank/hydroponics
 	name = "botanist's jumpsuit"
 	desc = "It's a jumpsuit designed to protect against minor plant-related hazards."
-	has_sensor = SUIT_HAS_SENSORS
 	icon = 'icons/obj/item/clothing/department_uniforms/service.dmi'
 	icon_state = "nt_gardener"
 	item_state = "nt_gardener"
@@ -68,7 +64,6 @@
 /obj/item/clothing/under/rank/liaison
 	name = "corporate liaison uniform"
 	desc = "The plain, professional attire of a corporate liaison. The collar is <i>immaculately</i> starched."
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	icon = 'icons/obj/item/clothing/department_uniforms/service.dmi'
 	icon_state = "nt_liaison"
@@ -102,7 +97,6 @@
 /obj/item/clothing/under/rank/janitor
 	name = "janitor's jumpsuit"
 	desc = "It's the official uniform of the station's janitor. It has minor protection from biohazards."
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	icon = 'icons/obj/item/clothing/department_uniforms/service.dmi'
 	icon_state = "nt_janitor"
@@ -150,7 +144,6 @@
 /obj/item/clothing/under/librarian
 	name = "sensible suit"
 	desc = "It's very... sensible."
-	has_sensor = SUIT_HAS_SENSORS
 	icon = 'icons/obj/item/clothing/department_uniforms/service.dmi'
 	contained_sprite = TRUE
 	icon_state = "nt_librarian"
@@ -169,7 +162,6 @@
 /obj/item/clothing/under/rank/miner
 	name = "miner's jumpsuit"
 	desc = "It's a snappy miner's jumpsuit, complete with overalls and caked-on dirt."
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	icon = 'icons/obj/item/clothing/department_uniforms/operations.dmi'
 	icon_state = "nt_miner"
@@ -186,7 +178,6 @@
 /obj/item/clothing/under/rank/operations_manager
 	name = "operations manager's jumpsuit"
 	desc = "A uniform worn by the operations manager. It has the SCC insignia on it."
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	icon = 'icons/obj/item/clothing/department_uniforms/command.dmi'
 	icon_state = "operations_manager"
@@ -195,7 +186,6 @@
 /obj/item/clothing/under/rank/hangar_technician
 	name = "hangar technician's jumpsuit"
 	desc = "The future of hangar tech apparel: long, stuffy slacks. We never said it was a bright future."
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	icon = 'icons/obj/item/clothing/department_uniforms/operations.dmi'
 	icon_state = "nt_tech"
@@ -212,7 +202,6 @@
 /obj/item/clothing/under/rank/bridge_crew
 	name = "bridge crew's jumpsuit"
 	desc = "The uniform worn by the SCC's bridge crew."
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	icon = 'icons/obj/item/clothing/department_uniforms/command.dmi'
 	icon_state = "bridge_crew"
@@ -248,7 +237,6 @@
 /obj/item/clothing/under/rank/xo
 	name = "executive officer's jumpsuit"
 	desc = "The uniform worn by the SCC's executive officers."
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	icon = 'icons/obj/item/clothing/department_uniforms/command.dmi'
 	icon_state = "executive_officer"
@@ -257,7 +245,6 @@
 /obj/item/clothing/under/rank/machinist
 	name = "machinist's jumpsuit"
 	desc = "A practical uniform designed for industrial work."
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	icon = 'icons/obj/item/clothing/department_uniforms/operations.dmi'
 	icon_state = "nt_machinist"
@@ -274,7 +261,6 @@
 /obj/item/clothing/under/rank/captain/hephaestus
 	name = "hephaestus captain's jumpsuit"
 	desc = "It's a green-and-orange jumpsuit with some gold markings denoting the rank of \"Captain\" used by Hephaestus Industries."
-	has_sensor = SUIT_NO_SENSORS
 	icon = 'icons/clothing/under/uniforms/cyclops_uniforms.dmi'
 	icon_state = "heph_captain"
 	item_state = "heph_captain"

--- a/code/modules/clothing/under/jobs/engineering.dm
+++ b/code/modules/clothing/under/jobs/engineering.dm
@@ -5,7 +5,6 @@
 	icon = 'icons/obj/item/clothing/department_uniforms/command.dmi'
 	icon_state = "chief_engineer"
 	item_state = "chief_engineer"
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	armor = list(
 		rad = ARMOR_RAD_MINOR
@@ -18,7 +17,6 @@
 	icon = 'icons/obj/item/clothing/department_uniforms/engineering.dmi'
 	icon_state = "nt_atmos"
 	item_state = "nt_atmos"
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	siemens_coefficient = 0.75
 
@@ -36,7 +34,6 @@
 	icon = 'icons/obj/item/clothing/department_uniforms/engineering.dmi'
 	icon_state = "nt_engineer"
 	item_state = "nt_engineer"
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	armor = list(
 		rad = ARMOR_RAD_MINOR

--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -7,7 +7,6 @@
 	icon = 'icons/obj/item/clothing/department_uniforms/command.dmi'
 	icon_state = "research_director"
 	item_state = "research_director"
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	armor = list(
 		bio = ARMOR_BIO_MINOR
@@ -24,7 +23,6 @@
 	armor = list(
 		bio = ARMOR_BIO_MINOR
 	)
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 
 /obj/item/clothing/under/rank/scientist/zeng
@@ -109,7 +107,6 @@
 	icon = 'icons/obj/item/clothing/department_uniforms/command.dmi'
 	icon_state = "chief_medical_officer"
 	item_state = "chief_medical_officer"
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	permeability_coefficient = 0.50
 	armor = list(
@@ -122,7 +119,6 @@
 	icon = 'icons/clothing/under/uniforms/iac_uniform.dmi'
 	icon_state = "iac"
 	item_state = "iac"
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	permeability_coefficient = 0.50
 	armor = list(
@@ -137,7 +133,6 @@
 	icon = 'icons/obj/item/clothing/department_uniforms/medical.dmi'
 	icon_state = "nt_phys"
 	item_state = "nt_phys"
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	permeability_coefficient = 0.50
 	armor = list(
@@ -216,7 +211,6 @@
 	desc = "It's made of a special fiber that provides minor protection against biohazards. Specially fitted to ensure surgical precision."
 	icon_state = "nt_surgeon"
 	item_state = "nt_surgeon"
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 
 /obj/item/clothing/under/rank/medical/surgeon/zeng

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -19,7 +19,6 @@
 		melee = ARMOR_MELEE_SMALL
 		)
 	siemens_coefficient = 0.75
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 
 /obj/item/clothing/under/rank/security/zavod
@@ -84,7 +83,6 @@
 		melee = ARMOR_MELEE_SMALL
 		)
 	siemens_coefficient = 0.75
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 
 /obj/item/clothing/under/rank/cadet/zavod
@@ -108,7 +106,6 @@
 	icon = 'icons/clothing/under/uniforms/cyclops_uniforms.dmi'
 	icon_state = "heph_security"
 	item_state = "heph_security"
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 
 /obj/item/clothing/under/rank/warden
@@ -121,7 +118,6 @@
 		melee = ARMOR_MELEE_SMALL
 		)
 	siemens_coefficient = 0.75
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 
 /obj/item/clothing/under/rank/warden/remote
@@ -162,7 +158,6 @@
 		melee = ARMOR_MELEE_SMALL
 		)
 	siemens_coefficient = 0.75
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 
 /obj/item/clothing/under/det/zavod
@@ -205,7 +200,6 @@
 	icon = 'icons/obj/item/clothing/department_uniforms/command.dmi'
 	icon_state = "head_of_security"
 	item_state = "head_of_security"
-	has_sensor = SUIT_HAS_SENSORS
 	contained_sprite = TRUE
 	armor = list(
 		melee = ARMOR_MELEE_SMALL

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -4,7 +4,7 @@
 	icon_state = "syndicate"
 	item_state = "bl_suit"
 	worn_state = "syndicate"
-	has_sensor = 0
+	has_sensor = SUIT_NO_SENSORS
 	armor = list(
 		melee = ARMOR_MELEE_MINOR
 		)

--- a/html/changelogs/RustingWithYou - curseofra.yml
+++ b/html/changelogs/RustingWithYou - curseofra.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "All clothing now has suit sensors by default."


### PR DESCRIPTION
Clothing now has suit sensors enabled by default again. While most of the nerfs made in #17607 are reasonable balance tweaks, this change in particular is, to be honest, a bad idea in a rebalance that was otherwise pretty good. If everyone having suit sensors on all the time is bad, we should either remove them altogether or do some of the things that have already been done such as locking sensors by security level. We're a roleplaying server and shouldn't be mechanically discouraging character customisation.

Also restores alt-clicking uniforms to set sensors. Why was that removed in the first place?