### PR TITLE
Fireman Stair Fixes

### DIFF
--- a/code/controllers/subsystems/falling.dm
+++ b/code/controllers/subsystems/falling.dm
@@ -85,6 +85,9 @@ SUBSYSTEM_DEF(falling)
 				if (falling[victim] <= 1)	// Just moving down a flight, skip damage.
 					victim.multiz_falling = 0
 					falling -= victim
+					for(var/obj/item/grab/grab in victim)
+						if(grab.affecting)
+							grab.affecting.forceMove(victim.loc)
 				else
 					// Falling more than a level, fuck 'em up.
 					victim.fall_impact(falling[victim], FALSE)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -447,7 +447,7 @@
 
 	H.visible_message("<b>[H]</b> starts lifting \the [affecting] onto their shoulders...", SPAN_NOTICE("You start lifting \the [affecting] onto your shoulders..."))
 
-	if(!do_after(H, 3 SECONDS, TRUE))
+	if(!do_after(H, 1 SECONDS, affecting))
 		return
 
 	if(affecting.buckled_to)

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -233,20 +233,23 @@
 
 	return ..()
 
-/obj/structure/stairs/CollidedWith(atom/movable/A)
+/obj/structure/stairs/CollidedWith(atom/movable/moving_atom)
 	// This is hackish but whatever.
-	var/turf/target = get_step(GetAbove(A), dir)
+	var/turf/target = get_step(GetAbove(moving_atom), dir)
 	if(!target)
 		return
 	if(target.z > (z + 1)) //Prevents wheelchair fuckery. Basically, you teleport twice because both the wheelchair + your mob collide with the stairs.
 		return
-	if(target.Enter(A, src) && A.dir == dir)
-		A.forceMove(target)
-		if(isliving(A))
-			var/mob/living/L = A
-			if(L.pulling)
-				L.pulling.forceMove(target)
-			if(ishuman(A))
+	if(target.Enter(moving_atom, src) && moving_atom.dir == dir)
+		moving_atom.forceMove(target)
+		if(isliving(moving_atom))
+			var/mob/living/living_mob = moving_atom
+			if(living_mob.pulling)
+				living_mob.pulling.forceMove(target)
+			for(var/obj/item/grab/grab in living_mob)
+				if(grab.affecting)
+					grab.affecting.forceMove(target)
+			if(ishuman(living_mob))
 				playsound(src, 'sound/effects/stairs_step.ogg', 50)
 				playsound(target, 'sound/effects/stairs_step.ogg', 50)
 

--- a/html/changelogs/geeves-stair_carrying.yml
+++ b/html/changelogs/geeves-stair_carrying.yml
@@ -3,5 +3,6 @@ author: Geeves
 delete-after: True
 
 changes:
-  - bugfix: "Fixed fireman carrying up and down stairs."
-  - bugfix: "Fixed lifting someone into a fireman carry being instant, but lowered the time to 1 second from 3 seconds."
+  - bugfix: "Fixed grabbing / fireman carrying up and down stairs."
+  - bugfix: "Fixed lifting someone into a fireman carry being instant."
+  - tweak: "Lowered fireman carrying time to 1 second from 3 seconds."

--- a/html/changelogs/geeves-stair_carrying.yml
+++ b/html/changelogs/geeves-stair_carrying.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed fireman carrying up and down stairs."
+  - bugfix: "Fixed lifting someone into a fireman carry being instant, but lowered the time to 1 second from 3 seconds."


### PR DESCRIPTION
* Fixed grabbing / fireman carrying up and down stairs.
* Fixed lifting someone into a fireman carry being instant.
* Lowered fireman carrying time to 1 second from 3 seconds.

Decided to reduce the time whilst also doing the fix, I think I made it a bit too long when I first implemented it, and the faster pick-up feels nice.