### PR TITLE
Azaziba Tweak

### DIFF
--- a/html/changelogs/geeves-azaziba_tweak.yml
+++ b/html/changelogs/geeves-azaziba_tweak.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Tweaked Sinta'Azaziba to be more readable in darkmode."

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -564,7 +564,7 @@ em {
   color: #c79322;
 }
 .soghun_alt {
-  color: #024402;
+  color: #068b5f;
 }
 .changeling {
   color: #800080;


### PR DESCRIPTION
* Tweaked Sinta'Azaziba to be more readable in darkmode.

Old:
![image](https://github.com/Aurorastation/Aurora.3/assets/22774890/1e6a4b28-2ca0-48d9-a062-87a0d7af4d66)

New:
![image](https://github.com/Aurorastation/Aurora.3/assets/22774890/a8964713-51a2-4e31-95a8-33e1b320bf52)

Sinta'azaziba and Sinta'unathi:
![image](https://github.com/Aurorastation/Aurora.3/assets/22774890/0164d257-a43d-4788-812c-f73134310ebd)
