### PR TITLE
Elevator walls no longer bring inexistant green decals with them.

### DIFF
--- a/code/_helpers/icon_smoothing.dm
+++ b/code/_helpers/icon_smoothing.dm
@@ -101,12 +101,6 @@
 /turf/simulated/wall/shuttle
 	smooth_underlays = TRUE
 
-/turf/simulated/wall
-	smooth_underlays = TRUE
-
-/turf/unsimulated/wall
-	smooth_underlays = TRUE
-
 /atom/proc/calculate_adjacencies()
 	if (!loc)
 		return 0

--- a/html/changelogs/mattatlas-icons.yml
+++ b/html/changelogs/mattatlas-icons.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Elevator walls no longer bring inexistant green decals with them."


### PR DESCRIPTION
Default walls should not have underlays smoothed.