### PR TITLE
Cult Stun/Incapacitation Adjustments

### DIFF
--- a/code/game/gamemodes/cult/runes/stun.dm
+++ b/code/game/gamemodes/cult/runes/stun.dm
@@ -1,30 +1,39 @@
 /datum/rune/stun
 	name = "incapacitation rune"
-	desc = "This rune is used to deafen, silence, flash and confuse the unbelievers in a radius around us."
+	desc = "This rune is used to deafen, silence, flash and confuse the unbelievers in a radius around us. The talisman variant will be less effective against eye protection."
 	rune_flags = HAS_SPECIAL_TALISMAN_ACTION
 
-/datum/rune/stun/do_rune_action(mob/living/user, atom/movable/A)
-	do_stun(user, A, 5, TRUE)
+/datum/rune/stun/do_rune_action(mob/living/user, atom/movable/rune_object)
+	do_stun(user, rune_object, 5, TRUE)
 
-/datum/rune/stun/do_talisman_action(mob/living/user, atom/movable/A)
-	do_stun(user, A, 3, FALSE)
+/datum/rune/stun/do_talisman_action(mob/living/user, atom/movable/rune_object)
+	do_stun(user, rune_object, 3, FALSE)
 
-/datum/rune/stun/proc/do_stun(mob/living/user, atom/movable/A, radius, is_rune)
+/datum/rune/stun/proc/do_stun(mob/living/user, atom/movable/rune_object, radius, is_rune)
 	user.say("Fuu ma'jin!")
-	for(var/mob/living/L in viewers(radius, get_turf(A)))
-		if(iscultist(L))
+	for(var/mob/living/rune_target in viewers(radius, get_turf(rune_object)))
+		if(iscultist(rune_target))
 			continue
-		if(iscarbon(L))
-			L.stuttering = max(L.stuttering, 1)
-			L.confused = 10
-			L.Weaken(3)
-			L.Stun(3)
-		else if(issilicon(L))
-			L.Weaken(5)
 
-		to_chat(L, SPAN_DANGER("The rune explodes in a bright flash!"))
-		L.flash_act()
-		L.silent += 15
-		admin_attack_log(user, L, "Used a stun rune.", "Was victim of a stun rune.", "used a stun rune on")
+		var/flash_intensity = is_rune ? FLASH_PROTECTION_MAJOR : FLASH_PROTECTION_MODERATE
+		var/has_flashed = rune_target.flash_act(intensity = flash_intensity, affect_silicon = TRUE)
+		if(has_flashed)
+			to_chat(rune_target, SPAN_DANGER("You are blinded by a bright flash of light flaring from \the [rune_object]!"))
+			if(iscarbon(rune_target))
+				rune_target.stuttering = max(rune_target.stuttering, 1)
+				rune_target.confused = 10
+				if(is_rune)
+					rune_target.Weaken(8)
+					rune_target.Stun(8)
+				else
+					rune_target.Weaken(5)
+					rune_target.Stun(5)
+			else if(issilicon(rune_target))
+				rune_target.Weaken(5)
+		else
+			to_chat(rune_target, SPAN_WARNING("You see a flash of light flaring from \the [rune_object], but your vision is shielded!"))
 
-	qdel(A)
+		rune_target.silent += 15
+		admin_attack_log(user, rune_target, "Used a stun rune.", "Was victim of a stun rune.", "used a stun rune on")
+
+	qdel(rune_object)

--- a/html/changelogs/geeves-stun_tweak.yml
+++ b/html/changelogs/geeves-stun_tweak.yml
@@ -3,5 +3,5 @@ author: Geeves
 delete-after: True
 
 changes:
-  - tweak: "CULT: Adjusted stun/incapacitation runes to be blockable by flssh-resistant eyewear. Talismans are blocked by sunglasses, while larger runes are only blocked by welding goggles or voidsuits."
-  - tweak: "CULT: Stun/Incapitation runes now flash borgs as well, and the stuns last for longer, especially for the non-talisman variant."
+  - tweak: "CULT: Adjusted stun/incapacitation runes to be blockable by flash-resistant eyewear. Talismans are blocked by sunglasses, while larger runes are only blocked by welding goggles or voidsuits."
+  - tweak: "CULT: Stun/Incapacitation runes now flash borgs as well, and the stuns last for longer, especially for the non-talisman variant."

--- a/html/changelogs/geeves-stun_tweak.yml
+++ b/html/changelogs/geeves-stun_tweak.yml
@@ -4,4 +4,4 @@ delete-after: True
 
 changes:
   - tweak: "CULT: Adjusted stun/incapacitation runes to be blockable by flssh-resistant eyewear. Talismans are blocked by sunglasses, while larger runes are only blocked by welding goggles or voidsuits."
-  - tweak: "CULT: Stun/Incapitation runes now flash borgs as well, and the stuns last for longer for the non-talisman variant."
+  - tweak: "CULT: Stun/Incapitation runes now flash borgs as well, and the stuns last for longer, especially for the non-talisman variant."

--- a/html/changelogs/geeves-stun_tweak.yml
+++ b/html/changelogs/geeves-stun_tweak.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "CULT: Adjusted stun/incapacitation runes to be blockable by flssh-resistant eyewear. Talismans are blocked by sunglasses, while larger runes are only blocked by welding goggles or voidsuits."
+  - tweak: "CULT: Stun/Incapitation runes now flash borgs as well, and the stuns last for longer for the non-talisman variant."


### PR DESCRIPTION
* Adjusted stun/incapacitation runes to be blockable by flash-resistant eyewear. Talismans are blocked by sunglasses, while larger runes are only blocked by welding goggles or voidsuits.
* Stun/Incapacitation runes now flash borgs as well, and the stuns last for longer, especially for the non-talisman variant.

\-

I'm not 100% sure about this one, but I felt that deploying an uncounterable stun that can be repeated as soon as the target stands up was a bit much, but I still understand that the cult needs some sort of way to stun and forcefully recruit people.

So, with this change, crew that are prepared and combat ready (sunglasses / goggles / voidsuits) can combat the cult without being stunned immediately, while people going about their business on the station can still be nabbed and recruited.

The runes being more effective than the talismans also encourages a slightly more defensive playstyle, with the cult building up a base of operations.

\-

The first iteration I tried gave the receiver temporary immunity to the talisman's stun for a few seconds, while also increasing the stun length, but communicating the immunity wasn't very clear and felt bad on both sides, so I went with this one instead.