### PR TITLE
Hardsuit Slowdown Tweak

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -119,6 +119,9 @@
 	///How much clothing is slowing you down. Negative values speeds you up
 	var/slowdown = 0
 
+	/// A list of slowdown slots. Determines whether slowdown should be applied depending on which slot the item is being worn on
+	var/list/slowdown_slots = null
+
 	///Updated on accessory add/remove. This is how much the current accessories slow you down.
 	var/slowdown_accessory = 0
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -35,6 +35,7 @@
 	permeability_coefficient = 0.1
 	unacidable = 1
 	slowdown = 1 // All rigs by default should have slowdown.
+	slowdown_slots = list(slot_back)
 
 	var/has_sealed_state = FALSE
 	var/has_hidden_jumpsuit = FALSE

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -52,13 +52,21 @@
 
 	tally = max(-2, tally + move_delay_mod)
 
-	var/obj/item/AH = get_active_hand()
-	if(istype(AH))
-		tally += AH.slowdown
+	var/list/carried_items = list()
 
+	var/obj/item/AH = get_active_hand()
+	if(istype(AH) && AH.slowdown)
+		carried_items += AH
 	var/obj/item/IH = get_inactive_hand()
-	if(istype(IH))
-		tally += IH.slowdown
+	if(istype(IH) && IH.slowdown)
+		carried_items += IH
+
+	for(var/obj/item/carried_item in carried_items)
+		if(carried_item.slowdown_slots)
+			var/current_slot = carried_item.get_equip_slot()
+			if(!(current_slot in carried_item.slowdown_slots))
+				continue
+		tally += carried_item.slowdown
 
 	if(isitem(pulling))
 		var/obj/item/P = pulling
@@ -186,9 +194,14 @@
 	return (shoes && shoes.negates_gravity())
 
 /mob/living/carbon/human/proc/ClothesSlowdown()
-	for(var/obj/item/I in list(wear_suit, w_uniform, back, gloves, head, wear_mask, shoes, l_ear, r_ear, glasses, belt))
-		. += I.slowdown
-		. += I.slowdown_accessory
+	for(var/obj/item/worn_item in list(wear_suit, w_uniform, back, gloves, head, wear_mask, shoes, l_ear, r_ear, glasses, belt))
+		if(worn_item.slowdown || worn_item.slowdown_accessory)
+			if(worn_item.slowdown_slots)
+				var/current_slot = worn_item.get_equip_slot()
+				if(!(current_slot in worn_item.slowdown_slots))
+					continue
+			. += worn_item.slowdown
+			. += worn_item.slowdown_accessory
 
 /mob/living/carbon/human/get_pulling_movement_delay()
 	. = ..()

--- a/html/changelogs/geeves-rig_slowdown.yml
+++ b/html/changelogs/geeves-rig_slowdown.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Hardsuit modules now only slow you down when worn on the back."


### PR DESCRIPTION
* Hardsuit modules now only slow you down when worn on the back.

I think it's fine cuz the hardsuit takes a while to put on, and then a while to deploy. The slowdown as it is right now only punishes people transporting it from point A to B while they get no use out of it.