### PR TITLE
Exosuit Turn Fix

### DIFF
--- a/code/modules/heavy_vehicle/mech_interaction.dm
+++ b/code/modules/heavy_vehicle/mech_interaction.dm
@@ -283,13 +283,16 @@
 	if(hallucination >= EMP_MOVE_DISRUPT && prob(30))
 		direction = pick(cardinal)
 
-	if(user.facing_dir == null && dir != direction)
+	var/do_strafe = user.facing_dir != null && (legs.turn_delay <= legs.move_delay)
+	if(!do_strafe && dir != direction)
 		use_cell_power(legs.power_use * CELLRATE)
 		if(legs && legs.mech_turn_sound)
 			playsound(src.loc,legs.mech_turn_sound,40,1)
 		if(world.time + legs.turn_delay > next_mecha_move)
 			next_mecha_move = world.time + legs.turn_delay
 		set_dir(direction)
+		for(var/mob/pilot in pilots)
+			pilot.set_dir(direction)
 		if(istype(hardpoints[HARDPOINT_BACK], /obj/item/mecha_equipment/shield))
 			var/obj/item/mecha_equipment/shield/S = hardpoints[HARDPOINT_BACK]
 			if(S.aura)
@@ -310,7 +313,8 @@
 			use_cell_power(legs.power_use * CELLRATE)
 			user.client.Process_Incorpmove(direction, src)
 		else
-			Move(target_loc, user.facing_dir || direction)
+			var/new_direction = do_strafe ? user.facing_dir || direction : direction
+			Move(target_loc, new_direction)
 
 /mob/living/heavy_vehicle/Move()
 	if(..() && !istype(loc, /turf/space))

--- a/code/modules/heavy_vehicle/mech_interaction.dm
+++ b/code/modules/heavy_vehicle/mech_interaction.dm
@@ -283,7 +283,7 @@
 	if(hallucination >= EMP_MOVE_DISRUPT && prob(30))
 		direction = pick(cardinal)
 
-	var/do_strafe = user.facing_dir != null && (legs.turn_delay <= legs.move_delay)
+	var/do_strafe = !isnull(user.facing_dir) && (legs.turn_delay <= legs.move_delay)
 	if(!do_strafe && dir != direction)
 		use_cell_power(legs.power_use * CELLRATE)
 		if(legs && legs.mech_turn_sound)

--- a/code/modules/heavy_vehicle/premade/light.dm
+++ b/code/modules/heavy_vehicle/premade/light.dm
@@ -28,7 +28,7 @@
 	exosuit_desc_string = "aerodynamic electromechanic legs"
 	icon_state = "light_legs"
 	move_delay = 2
-	turn_delay = 3
+	turn_delay = 2
 	max_damage = 100
 	power_use = 1500
 	desc = "The electrical systems driving these legs are almost totally silent. Unfortunately slamming a plate of metal against the ground is not."

--- a/html/changelogs/geeves-exosuit_turn_fix.yml
+++ b/html/changelogs/geeves-exosuit_turn_fix.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed strafing enabling you to ignore the turn delay of some exosuit propulsion systems, such as tracks. You can now only strafe is the turn delay is smaller or equal to the move delay."
+  - tweak: "Tweaked the turn delay of light exosuit propulsion legs to be the same as the move delay."


### PR DESCRIPTION
* Fixed strafing enabling you to ignore the turn delay of some exosuit propulsion systems, such as tracks. You can now only strafe is the turn delay is smaller or equal to the move delay.
* Tweaked the turn delay of light exosuit propulsion legs to be the same as the move delay.