### PR TITLE
Antagonist Banks

### DIFF
--- a/code/datums/outfits/outfit_antag.dm
+++ b/code/datums/outfits/outfit_antag.dm
@@ -381,7 +381,7 @@
 
 	var/obj/item/storage/wallet/W = H.wear_id
 	var/obj/item/card/id/syndicate/raider/passport = new(H.loc)
-	passport.name = "[H.real_name]'s Passport"
+	imprint_idcard(H, passport)
 	if(W)
 		W.handle_item_insertion(passport)
 
@@ -483,7 +483,7 @@
 
 	var/obj/item/storage/wallet/W = H.wear_id
 	var/obj/item/card/id/syndicate/raider/passport = new(H.loc)
-	passport.name = "[H.real_name]'s Passport"
+	imprint_idcard(H, passport)
 	if(W)
 		W.handle_item_insertion(passport)
 
@@ -543,7 +543,7 @@
 
 	var/obj/item/storage/wallet/W = H.wear_id
 	var/obj/item/card/id/syndicate/raider/passport = new(H.loc)
-	passport.name = "[H.real_name]'s Passport"
+	imprint_idcard(H, passport)
 	if(W)
 		W.handle_item_insertion(passport)
 
@@ -677,7 +677,7 @@
 
 	var/obj/item/storage/wallet/W = H.wear_id
 	var/obj/item/card/id/syndicate/raider/passport = new(H.loc)
-	passport.name = "[H.real_name]'s Passport"
+	imprint_idcard(H, passport)
 	if(W)
 		W.handle_item_insertion(passport)
 

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -74,6 +74,10 @@
 	var/id_type = /obj/item/card/id
 	var/id_card // a reference to the id_card we spawned with
 
+	var/has_idris_account = TRUE
+	var/idris_account_min = 100
+	var/idris_account_max = 500
+
 
 /datum/antagonist/New()
 	..()

--- a/code/game/antagonist/antagonist_equip.dm
+++ b/code/game/antagonist/antagonist_equip.dm
@@ -1,7 +1,6 @@
 /datum/antagonist/proc/equip(var/mob/living/carbon/human/player)
-
 	if(!istype(player))
-		return 0
+		return FALSE
 
 	// This could use work.
 	if(flags & ANTAG_CLEAR_EQUIPMENT)
@@ -9,8 +8,24 @@
 			player.drop_from_inventory(thing)
 			if(thing.loc != player)
 				qdel(thing)
+
 	player.species.before_equip(player)
-	return 1
+
+	if(HAS_FLAG(flags, ANTAG_CLEAR_EQUIPMENT) && has_idris_account)
+		var/datum/money_account/money_account = SSeconomy.create_account("John Doe", rand(idris_account_min, idris_account_max), null, FALSE)
+		if(player.mind)
+			var/remembered_info = ""
+			remembered_info += "<b>Your account number is:</b> #[money_account.account_number]<br>"
+			remembered_info += "<b>Your account pin is:</b> [money_account.remote_access_pin]<br>"
+			remembered_info += "<b>Your account funds are:</b> [money_account.money]电<br>"
+
+			if(money_account.transactions.len)
+				var/datum/transaction/transaction = money_account.transactions[1]
+				remembered_info += "<b>Your account was created:</b> [transaction.time], [transaction.date] at [transaction.source_terminal]<br>"
+			player.mind.store_memory(remembered_info)
+			player.mind.initial_account = money_account
+
+	return TRUE
 
 /datum/antagonist/proc/unequip(var/mob/living/carbon/human/player)
 	if(!istype(player))

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -21,6 +21,9 @@ var/datum/antagonist/mercenary/mercs
 
 	faction = "syndicate"
 
+	idris_account_min = 1200
+	idris_account_max = 2000
+
 /datum/antagonist/mercenary/New()
 	..()
 	mercs = src

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -21,6 +21,8 @@ var/datum/antagonist/raider/raiders
 
 	id_type = /obj/item/card/id/syndicate
 
+	has_idris_account = FALSE
+
 /datum/antagonist/raider/New()
 	..()
 	raiders = src

--- a/code/game/antagonist/outsider/raider_techno.dm
+++ b/code/game/antagonist/outsider/raider_techno.dm
@@ -21,6 +21,8 @@ var/datum/antagonist/raider_techno/raider_techno
 
 	id_type = /obj/item/card/id/syndicate/raider
 
+	has_idris_account = FALSE
+
 /datum/antagonist/raider_techno/New()
 	..()
 	raider_techno = src

--- a/code/game/antagonist/outsider/revenant.dm
+++ b/code/game/antagonist/outsider/revenant.dm
@@ -16,6 +16,8 @@ var/datum/antagonist/revenant/revenants = null
 	var/kill_count = 0
 	var/obj/effect/portal/revenant/revenant_rift
 
+	has_idris_account = FALSE
+
 /datum/antagonist/revenant/New()
 	..()
 

--- a/code/game/antagonist/outsider/technomancer.dm
+++ b/code/game/antagonist/outsider/technomancer.dm
@@ -21,6 +21,8 @@ var/datum/antagonist/technomancer/technomancers
 
 	id_type = /obj/item/card/id/syndicate
 
+	has_idris_account = FALSE
+
 /datum/antagonist/technomancer/New()
 	..()
 	technomancers = src

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -377,6 +377,9 @@ var/const/NO_EMAG_ACT = -50
 	name = "passport"
 	assignment = "Visitor"
 
+/obj/item/card/id/syndicate/raider/update_name()
+	name = "[registered_name]'s Passport"
+
 /obj/item/card/id/highlander
 	name = "highlander identification card"
 	assignment = "Highlander"

--- a/html/changelogs/geeves-antagonist_banks.yml
+++ b/html/changelogs/geeves-antagonist_banks.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "A majority of antags now start with Idris bank accounts connected to their IDs."
+  - bugfix: "Fixed antagonist passport IDs changing into workplace IDs when the change machine is used."


### PR DESCRIPTION
* A majority of antags now start with Idris bank accounts connected to their IDs.
* Fixed antagonist passport IDs changing into workplace IDs when the change machine is used.