### PR TITLE
Warehouse Access

### DIFF
--- a/code/game/jobs/access_datum.dm
+++ b/code/game/jobs/access_datum.dm
@@ -446,6 +446,12 @@ var/const/access_bridge_crew = 74
 	desc = "Ship Weapons"
 	region = ACCESS_REGION_SUPPLY
 
+/var/const/access_warehouse = 76
+/datum/access/access_warehouse
+	id = access_warehouse
+	desc = "Warehouse"
+	region = ACCESS_REGION_SUPPLY
+
 /******************
 * Central Command *
 ******************/

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -408,9 +408,9 @@
 	)
 
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_ship_weapons, access_qm, access_mining, access_mining_station, access_keycard_auth, access_RC_announce, access_heads,
-						access_sec_doors, access_research, access_medical, access_robotics, access_engine, access_teleporter, access_eva, access_intrepid)
+						access_sec_doors, access_research, access_medical, access_robotics, access_engine, access_teleporter, access_eva, access_intrepid, access_warehouse)
 	minimal_access = list(access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_ship_weapons, access_mining_station, access_keycard_auth, access_RC_announce, access_heads,
-						access_sec_doors, access_research, access_medical, access_robotics, access_engine, access_teleporter, access_eva, access_intrepid)
+						access_sec_doors, access_research, access_medical, access_robotics, access_engine, access_teleporter, access_eva, access_intrepid, access_warehouse)
 
 	ideal_character_age = list(
 		SPECIES_HUMAN = 40,
@@ -464,8 +464,8 @@
 		SPECIES_SKRELL_AXIORI = 50
 	)
 
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_ship_weapons, access_cargo_bot, access_mining, access_mining_station)
-	minimal_access = list(access_cargo, access_cargo_bot, access_ship_weapons, access_mailsorting)
+	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_ship_weapons, access_cargo_bot, access_mining, access_mining_station, access_warehouse)
+	minimal_access = list(access_cargo, access_cargo_bot, access_ship_weapons, access_mailsorting, access_warehouse)
 	outfit = /datum/outfit/job/hangar_tech
 
 	blacklisted_species = list(SPECIES_VAURCA_BREEDER)

--- a/html/changelogs/geeves-warehouse_lockdown.yml
+++ b/html/changelogs/geeves-warehouse_lockdown.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "The warehouse is now access locked to the Ops Manager, Hangar Technician, Janitor, and First Responder roles. This means that Shaft Miners and Machinists no longer have access to it."

--- a/html/changelogs/geeves-warehouse_lockdown.yml
+++ b/html/changelogs/geeves-warehouse_lockdown.yml
@@ -4,3 +4,5 @@ delete-after: True
 
 changes:
   - tweak: "The warehouse is now access locked to the Ops Manager, Hangar Technician, Janitor, and First Responder roles. This means that Shaft Miners and Machinists no longer have access to it."
+  - tweak: "Removed the Operations Lift, adjusted all the rooms it used to occupy."
+  - tweak: "Added a few more crates to the warehouse."

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -100,7 +100,6 @@
 
 	map_shuttles = list(
 		/datum/shuttle/autodock/ferry/lift/scc_ship/morgue,
-		/datum/shuttle/autodock/multi/lift/operations,
 		/datum/shuttle/autodock/multi/lift/robotics,
 		/datum/shuttle/autodock/ferry/escape_pod/pod/escape_pod1,
 		/datum/shuttle/autodock/ferry/escape_pod/pod/escape_pod2,

--- a/maps/sccv_horizon/code/sccv_horizon_lifts.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_lifts.dm
@@ -103,49 +103,6 @@
 	sound_env = TUNNEL_ENCLOSED
 	ambience = AMBIENCE_GHOSTLY
 
-//Operations Lift
-/datum/shuttle/autodock/multi/lift/operations
-	name = "Operations Lift"
-	current_location = "nav_operations_lift_second_deck"
-	shuttle_area = /area/turbolift/scc_ship/operations_lift
-	destination_tags = list(
-		"nav_operations_lift_first_deck",
-		"nav_operations_lift_second_deck",
-		"nav_operations_lift_third_deck"
-		)
-
-/obj/effect/shuttle_landmark/lift/operations_first_deck
-	name = "Operations Lift - First Deck"
-	landmark_tag = "nav_operations_lift_first_deck"
-	landmark_flags = SLANDMARK_FLAG_AUTOSET
-	base_area = /area/operations/loading
-	base_turf = /turf/simulated/floor/plating
-
-/obj/effect/shuttle_landmark/lift/operations_second_deck
-	name = "Operations Lift - Second Deck"
-	landmark_tag = "nav_operations_lift_second_deck"
-	base_area = /area/operations/storage
-	base_turf = /turf/simulated/open
-
-/obj/effect/shuttle_landmark/lift/operations_third_deck
-	name = "Operations Lift - Third Deck"
-	landmark_tag = "nav_operations_lift_third_deck"
-	landmark_flags = SLANDMARK_FLAG_AUTOSET
-	base_area = /area/operations/office_aux
-	base_turf = /turf/simulated/open
-
-/obj/machinery/computer/shuttle_control/multi/lift/operations
-	shuttle_tag = "Operations Lift"
-
-/obj/machinery/computer/shuttle_control/multi/lift/wall/operations
-	shuttle_tag = "Operations Lift"
-
-/area/turbolift/scc_ship/operations_lift
-	name = "Operations Lift"
-	sound_env = TUNNEL_ENCLOSED
-	ambience = AMBIENCE_GHOSTLY
-
-
 //Robotics Lift
 /datum/shuttle/autodock/multi/lift/robotics
 	name = "Robotics Lift 2"

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -16984,6 +16984,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/starboard)
+"lUh" = (
+/obj/structure/stairs_lower/stairs_upper,
+/turf/simulated/wall,
+/area/operations/loading)
 "lUr" = (
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
@@ -47854,7 +47858,7 @@ lRO
 tRQ
 xGe
 dAZ
-gvZ
+lUh
 clf
 hRn
 gvZ

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -3973,9 +3973,19 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenoarch_atrium)
 "cOy" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
+/obj/machinery/power/apc/high/east,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "cPq" = (
@@ -7517,15 +7527,18 @@
 /area/maintenance/wing/port/deck1)
 "fiO" = (
 /obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/brown{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -12756,6 +12769,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "iXq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/brown,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
@@ -14511,14 +14526,6 @@
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/window/northright{
-	name = "Warehouse Access";
-	req_access = null;
-	req_one_access = list(26,67,76)
-	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "kmo" = (
@@ -15372,8 +15379,6 @@
 /area/rnd/xenoarch_atrium)
 "kLu" = (
 /obj/effect/floor_decal/industrial/outline/medical,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "kLC" = (
@@ -18949,10 +18954,10 @@
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "njB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -20181,11 +20186,8 @@
 /turf/simulated/floor/plating,
 /area/rnd/xenoarch_atrium)
 "nZy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
@@ -21855,8 +21857,6 @@
 /area/shuttle/escape_pod/pod1)
 "pme" = (
 /obj/effect/floor_decal/industrial/outline/research,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "pmP" = (
@@ -22756,9 +22756,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
 "pSJ" = (
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/structure/table/standard{
+	no_cargo = 1
+	},
+/obj/item/device/hand_labeler,
+/obj/item/device/destTagger,
+/obj/item/stack/packageWrap,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "pTd" = (
@@ -23552,13 +23563,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/hangar/canary)
 "qsC" = (
-/obj/effect/floor_decal/industrial/outline/service,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "qsK" = (
@@ -23766,8 +23774,6 @@
 /area/shuttle/intrepid/crew_compartment)
 "qAY" = (
 /obj/effect/floor_decal/industrial/outline/security,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "qBk" = (
@@ -23890,28 +23896,6 @@
 "qEK" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
-	},
-/obj/structure/table/standard{
-	no_cargo = 1
-	},
-/obj/item/paper_bin{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/device/cratescanner{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/pen{
-	pixel_x = -6
-	},
-/obj/item/stack/packageWrap{
-	pixel_y = -4
-	},
-/obj/item/device/destTagger,
-/obj/item/device/hand_labeler{
-	pixel_x = 8;
-	pixel_y = 6
 	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
@@ -24377,8 +24361,6 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
-/obj/machinery/power/apc/high/east,
-/obj/structure/cable/green,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "qXZ" = (
@@ -28712,15 +28694,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/starboard)
 "ubg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/firealarm/north,
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
@@ -29149,8 +29131,6 @@
 /area/engineering/atmos/propulsion)
 "uoI" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "uoV" = (
@@ -30051,6 +30031,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research_sublevel)
 "uWS" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
 	id = "warehouse4";
@@ -30060,12 +30046,6 @@
 	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
@@ -30471,12 +30451,20 @@
 	},
 /area/maintenance/wing/starboard/deck1)
 "vjx" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table/standard{
+	no_cargo = 1
 	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/device/cratescanner,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "vjA" = (
@@ -32948,10 +32936,6 @@
 	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
-	},
-/obj/machinery/door/window/northleft{
-	name = "Warehouse Access";
-	req_one_access = list(26,67,76)
 	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
@@ -46113,7 +46097,7 @@ nCV
 fvn
 fvn
 sWr
-pSJ
+nCV
 tAP
 nCV
 bqI
@@ -46518,10 +46502,10 @@ uoI
 qsC
 pme
 qAY
-njB
-jKF
-jKF
+sWr
 nZy
+nCV
+nCV
 duN
 jDs
 qdE
@@ -46716,14 +46700,14 @@ jKF
 jKF
 vFL
 uWS
-nCV
-nCV
-thO
-nCV
+jKF
+jKF
+njB
+jKF
 iXq
 cOy
 vjx
-vjx
+pSJ
 fiO
 qYc
 pfb
@@ -46921,7 +46905,7 @@ qdE
 mhb
 fvn
 fvn
-nCV
+thO
 fvn
 jJp
 qdE

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -2199,8 +2199,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/aft)
 "bDQ" = (
-/obj/structure/stairs_railing{
-	dir = 8
+/obj/machinery/power/apc/high/east,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
@@ -3043,7 +3047,10 @@
 /turf/simulated/floor/plating,
 /area/turbolift/research/deck_1)
 "clf" = (
-/obj/effect/shuttle_landmark/lift/operations_first_deck,
+/obj/structure/stairs/west,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/operations/loading)
 "clG" = (
@@ -3275,27 +3282,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "crZ" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 5
-	},
-/obj/machinery/computer/shuttle_control/multi/lift/wall/operations{
-	pixel_x = -31;
-	pixel_y = 26
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/operations/loading)
+/area/operations/storage)
 "cty" = (
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/corner/brown{
@@ -3979,13 +3970,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
-	},
-/obj/machinery/power/apc/high/east,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "cPq" = (
@@ -7526,9 +7510,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/deck1)
 "fiO" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
@@ -11300,12 +11281,9 @@
 	},
 /area/medical/morgue/lower)
 "hRn" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/stairs/west,
+/obj/machinery/light,
+/turf/simulated/floor/plating,
 /area/operations/loading)
 "hRo" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -12768,12 +12746,6 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
-"iXq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/brown,
-/turf/simulated/floor/tiled,
-/area/operations/storage)
 "iXt" = (
 /obj/machinery/door/blast/regular/open{
 	id = "iso_c";
@@ -13901,9 +13873,7 @@
 /area/hangar/canary)
 "jJp" = (
 /obj/structure/closet/crate,
-/obj/effect/floor_decal/corner/brown{
-	dir = 10
-	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "jKF" = (
@@ -14525,6 +14495,9 @@
 	},
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
@@ -20185,12 +20158,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
 /turf/simulated/floor/plating,
 /area/rnd/xenoarch_atrium)
-"nZy" = (
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/operations/storage)
 "oam" = (
 /obj/structure/grille/diagonal{
 	dir = 8
@@ -22756,20 +22723,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
 "pSJ" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
-/obj/structure/table/standard{
-	no_cargo = 1
-	},
-/obj/item/device/hand_labeler,
-/obj/item/device/destTagger,
-/obj/item/stack/packageWrap,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "pTd" = (
@@ -23897,6 +23855,30 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
 	},
+/obj/structure/table/standard{
+	no_cargo = 1
+	},
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/device/cratescanner{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/device/destTagger{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/device/hand_labeler{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/stack/packageWrap,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "qFc" = (
@@ -24876,9 +24858,6 @@
 "rpj" = (
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 8
-	},
-/obj/machinery/computer/shuttle_control/multi/lift/wall/operations{
-	pixel_y = 26
 	},
 /turf/simulated/floor/tiled,
 /area/operations/loading)
@@ -28271,14 +28250,13 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	autoclose = 0;
-	dir = 2;
-	name = "Warehouse Elevator";
-	req_one_access = list(26,29,31,48,67)
-	},
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 1
+	},
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2;
+	name = "Hangar Stairs";
+	req_one_access = list(26,29,31,48,67)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/operations/loading)
@@ -28989,20 +28967,6 @@
 	opacity = 1
 	},
 /area/shuttle/canary)
-"ulE" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	autoclose = 0;
-	name = "Warehouse Elevator";
-	req_one_access = list(26,29,31,48,67)
-	},
-/obj/machinery/door/firedoor/multi_tile,
-/turf/simulated/floor/tiled/dark,
-/area/operations/loading)
 "ulJ" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/tank_wall/carbon_dioxide{
@@ -29458,10 +29422,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/outpost/mining_main/refinery)
-"uBL" = (
-/obj/structure/sign/crush,
-/turf/simulated/wall,
-/area/operations/loading)
 "uBW" = (
 /obj/structure/window/shuttle/unique/scc/scout{
 	icon_state = "4,2"
@@ -29578,17 +29538,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
-"uGI" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/closet/crate,
-/obj/effect/floor_decal/corner/brown/full{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
-/area/operations/storage)
 "uHw" = (
 /obj/machinery/light/small,
 /obj/structure/table/steel,
@@ -30450,23 +30399,6 @@
 	dir = 4
 	},
 /area/maintenance/wing/starboard/deck1)
-"vjx" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
-	},
-/obj/structure/table/standard{
-	no_cargo = 1
-	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/device/cratescanner,
-/turf/simulated/floor/tiled,
-/area/operations/storage)
 "vjA" = (
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark/full,
@@ -33603,13 +33535,6 @@
 /obj/machinery/power/apc/super/south,
 /turf/simulated/floor/tiled,
 /area/horizon/custodial)
-"xqn" = (
-/obj/structure/stairs_railing{
-	dir = 4;
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled,
-/area/operations/storage)
 "xqo" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	layer = 2.8
@@ -34863,7 +34788,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage/tech)
 "yeo" = (
-/obj/structure/stairs/north,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "yeB" = (
@@ -46097,7 +46029,7 @@ nCV
 fvn
 fvn
 sWr
-nCV
+crZ
 tAP
 nCV
 bqI
@@ -46503,8 +46435,8 @@ qsC
 pme
 qAY
 sWr
-nZy
-nCV
+fvn
+fvn
 nCV
 duN
 jDs
@@ -46704,9 +46636,9 @@ jKF
 jKF
 njB
 jKF
-iXq
+jKF
 cOy
-vjx
+jKF
 pSJ
 fiO
 qYc
@@ -46908,9 +46840,9 @@ fvn
 thO
 fvn
 jJp
-qdE
-yeo
-bDQ
+nCV
+fvn
+fvn
 wYX
 nCV
 hLw
@@ -47110,10 +47042,10 @@ nWf
 lNG
 kOJ
 lNG
-uGI
-qdE
+nWf
+bDQ
 yeo
-xqn
+yeo
 klR
 qWW
 abQ
@@ -47720,8 +47652,8 @@ qkh
 qkh
 feY
 gvZ
-qMM
-qMM
+gvZ
+gvZ
 gvZ
 sgp
 buS
@@ -47923,10 +47855,10 @@ tRQ
 xGe
 dAZ
 gvZ
-uzB
-uzB
-ulE
-crZ
+clf
+hRn
+gvZ
+ehD
 qDJ
 wlh
 gvZ
@@ -48126,9 +48058,9 @@ pqh
 qkh
 vqU
 gvZ
-clf
 uzB
-hRn
+uzB
+gvZ
 ehD
 qDJ
 eFe
@@ -48331,7 +48263,7 @@ baV
 gvZ
 yhf
 tMa
-uBL
+gvZ
 fbc
 lNj
 eFe

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -2907,7 +2907,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
-	req_one_access = list(26,29,31,48,67)
+	req_one_access = list(26,67,76)
 	},
 /turf/simulated/floor/tiled/full,
 /area/operations/storage)
@@ -3973,19 +3973,9 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenoarch_atrium)
 "cOy" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
-/obj/machinery/power/apc/high/east,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "cPq" = (
@@ -7527,18 +7517,15 @@
 /area/maintenance/wing/port/deck1)
 "fiO" = (
 /obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
 	icon_state = "2-4"
 	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/brown{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -9713,23 +9700,6 @@
 /obj/item/storage/box/flares,
 /turf/simulated/floor/tiled/dark,
 /area/teleporter)
-"gGg" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
-	},
-/obj/structure/table/standard{
-	no_cargo = 1
-	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/device/cratescanner,
-/turf/simulated/floor/tiled,
-/area/operations/storage)
 "gGE" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
@@ -12786,8 +12756,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "iXq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/brown,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
@@ -14543,6 +14511,14 @@
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/door/window/northright{
+	name = "Warehouse Access";
+	req_access = null;
+	req_one_access = list(26,67,76)
+	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "kmo" = (
@@ -15396,6 +15372,8 @@
 /area/rnd/xenoarch_atrium)
 "kLu" = (
 /obj/effect/floor_decal/industrial/outline/medical,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "kLC" = (
@@ -18971,7 +18949,10 @@
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "njB" = (
-/obj/structure/bed/stool/chair/office/dark{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -20199,6 +20180,15 @@
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
 /turf/simulated/floor/plating,
 /area/rnd/xenoarch_atrium)
+"nZy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/operations/storage)
 "oam" = (
 /obj/structure/grille/diagonal{
 	dir = 8
@@ -21865,6 +21855,8 @@
 /area/shuttle/escape_pod/pod1)
 "pme" = (
 /obj/effect/floor_decal/industrial/outline/research,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "pmP" = (
@@ -22764,11 +22756,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
 "pSJ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/structure/bed/stool/chair/office/dark{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
@@ -23563,10 +23552,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/hangar/canary)
 "qsC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/industrial/outline/service,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/service,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "qsK" = (
@@ -23774,6 +23766,8 @@
 /area/shuttle/intrepid/crew_compartment)
 "qAY" = (
 /obj/effect/floor_decal/industrial/outline/security,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "qBk" = (
@@ -23896,6 +23890,28 @@
 "qEK" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
+	},
+/obj/structure/table/standard{
+	no_cargo = 1
+	},
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/device/cratescanner{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_x = -6
+	},
+/obj/item/stack/packageWrap{
+	pixel_y = -4
+	},
+/obj/item/device/destTagger,
+/obj/item/device/hand_labeler{
+	pixel_x = 8;
+	pixel_y = 6
 	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
@@ -24361,6 +24377,8 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
+/obj/machinery/power/apc/high/east,
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "qXZ" = (
@@ -25757,7 +25775,7 @@
 /obj/machinery/door/airlock/glass_mining{
 	dir = 4;
 	name = "Warehouse";
-	req_one_access = list(26,29,31,48,67)
+	req_one_access = list(26,67,76)
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/map_effect/door_helper/unres{
@@ -28694,15 +28712,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/starboard)
 "ubg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/firealarm/north,
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
@@ -29131,6 +29149,8 @@
 /area/engineering/atmos/propulsion)
 "uoI" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "uoV" = (
@@ -30031,12 +30051,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research_sublevel)
 "uWS" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
 	id = "warehouse4";
@@ -30046,6 +30060,12 @@
 	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
@@ -30284,7 +30304,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
-	req_one_access = list(26,29,31,48,67)
+	req_one_access = list(26,67,76)
 	},
 /turf/simulated/floor/tiled/full,
 /area/operations/storage)
@@ -30451,20 +30471,12 @@
 	},
 /area/maintenance/wing/starboard/deck1)
 "vjx" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
-/obj/structure/table/standard{
-	no_cargo = 1
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/item/device/hand_labeler,
-/obj/item/device/destTagger,
-/obj/item/stack/packageWrap,
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "vjA" = (
@@ -32936,6 +32948,10 @@
 	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
+	},
+/obj/machinery/door/window/northleft{
+	name = "Warehouse Access";
+	req_one_access = list(26,67,76)
 	},
 /turf/simulated/floor/tiled,
 /area/operations/storage)
@@ -46097,7 +46113,7 @@ nCV
 fvn
 fvn
 sWr
-nCV
+pSJ
 tAP
 nCV
 bqI
@@ -46502,10 +46518,10 @@ uoI
 qsC
 pme
 qAY
-sWr
 njB
-nCV
-nCV
+jKF
+jKF
+nZy
 duN
 jDs
 qdE
@@ -46700,13 +46716,13 @@ jKF
 jKF
 vFL
 uWS
-jKF
-jKF
-pSJ
-jKF
+nCV
+nCV
+thO
+nCV
 iXq
 cOy
-gGg
+vjx
 vjx
 fiO
 qYc
@@ -46905,7 +46921,7 @@ qdE
 mhb
 fvn
 fvn
-thO
+nCV
 fvn
 jJp
 qdE

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -749,26 +749,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/hallway/engineering)
-"arK" = (
-/obj/effect/floor_decal/corner/brown/diagonal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	autoclose = 0;
-	dir = 2;
-	name = "Warehouse Elevator";
-	req_one_access = list(26,29,31,48,67)
-	},
-/obj/machinery/door/firedoor/multi_tile{
-	dir = 2
-	},
-/turf/simulated/floor/tiled/dark,
-/area/operations/office)
 "arV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1343,17 +1323,6 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/hallway/primary/central_one)
-"aBq" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
-/obj/effect/shuttle_landmark/lift/operations_second_deck,
-/obj/machinery/computer/shuttle_control/multi/lift/operations{
-	pixel_x = 11;
-	pixel_y = 18
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/turbolift/scc_ship/operations_lift)
 "aBr" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 5
@@ -7294,16 +7263,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/office)
-"drn" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 10
-	},
-/obj/machinery/door/window/southright{
-	name = "Warehouse Access";
-	req_one_access = list(26,67,76)
-	},
-/turf/simulated/floor/tiled,
-/area/operations/office)
 "drw" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -12530,17 +12489,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
 /area/horizon/bar)
-"fRi" = (
-/obj/effect/floor_decal/corner/brown/diagonal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/operations/office)
 "fSg" = (
 /obj/effect/floor_decal/spline/plain/corner,
 /obj/effect/floor_decal/spline/fancy{
@@ -13351,13 +13299,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/bar)
-"giP" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/railing/mapped,
-/turf/simulated/open,
-/area/operations/office)
 "gjl" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -16226,11 +16167,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/telesci)
 "hzm" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
+/obj/structure/railing/mapped{
+	dir = 1;
+	pixel_y = 9
 	},
-/turf/simulated/floor/tiled/dark/full,
-/area/turbolift/scc_ship/operations_lift)
+/turf/simulated/open,
+/area/operations/office)
 "hzC" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -16977,12 +16919,6 @@
 /obj/effect/floor_decal/sign/gtr,
 /turf/simulated/floor/tiled/white,
 /area/medical/gen_treatment)
-"hQE" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/turbolift/scc_ship/operations_lift)
 "hQI" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -17157,10 +17093,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/zta)
 "hUP" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/turf/simulated/open,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/mech_recharger,
+/turf/simulated/floor/tiled,
 /area/operations/office)
 "hUW" = (
 /obj/machinery/door/airlock/glass_service{
@@ -17771,13 +17706,10 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/storage_hard)
 "iku" = (
-/obj/effect/floor_decal/corner/brown/diagonal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/floor_decal/corner/brown/full{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/operations/office)
 "ikB" = (
 /obj/machinery/light,
@@ -22726,10 +22658,6 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
 	},
-/obj/machinery/door/window/southleft{
-	name = "Warehouse Access";
-	req_one_access = list(26,67,76)
-	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "kFa" = (
@@ -23080,9 +23008,6 @@
 	dir = 1;
 	name = "Operations";
 	sortType = "Cargo"
-	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
@@ -23964,11 +23889,9 @@
 /turf/simulated/floor/tiled/full,
 /area/engineering/engine_airlock)
 "llp" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/turbolift/scc_ship/operations_lift)
+/obj/structure/railing/mapped,
+/turf/simulated/open,
+/area/operations/office)
 "llB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -25275,12 +25198,6 @@
 /obj/machinery/smartfridge/foodheater,
 /turf/simulated/floor/tiled/white,
 /area/horizon/kitchen)
-"lSK" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/turf/simulated/open,
-/area/operations/office)
 "lST" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
@@ -27077,11 +26994,6 @@
 /obj/machinery/camera/network/supply{
 	c_tag = "Operations -  Upper Warehouse Port";
 	dir = 8
-	},
-/obj/machinery/computer/shuttle_control/multi/lift/wall/operations{
-	dir = 8;
-	pixel_x = 26;
-	pixel_y = -8
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
@@ -29547,7 +29459,7 @@
 "nOS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/brown{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
@@ -29673,11 +29585,9 @@
 /turf/simulated/floor/plating,
 /area/rnd/hallway)
 "nTB" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/structure/railing/mapped,
-/turf/simulated/open,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled,
 /area/operations/office)
 "nTF" = (
 /obj/structure/disposalpipe/segment{
@@ -29941,9 +29851,6 @@
 	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
@@ -31233,9 +31140,6 @@
 "oDl" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
-	},
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
@@ -36481,12 +36385,7 @@
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
 "rht" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 5
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "rhz" = (
@@ -37146,21 +37045,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
-"ryq" = (
-/obj/effect/floor_decal/corner/brown/diagonal,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	autoclose = 0;
-	name = "Warehouse Elevator";
-	req_one_access = list(26,29,31,48,67)
-	},
-/obj/machinery/door/firedoor/multi_tile,
-/turf/simulated/floor/tiled/dark,
-/area/operations/office)
 "ryu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37491,9 +37375,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
-	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
@@ -40087,9 +39968,6 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "taf" = (
@@ -42382,13 +42260,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
-"ubZ" = (
-/obj/structure/sign/drop{
-	desc = "A warning sign which reads 'DANGER: FALLING HAZARD' and 'THIS EQUIPMENT STARTS AND STOPS AUTOMATICALLY'.";
-	name = "\improper DANGER: FALLING HAZARD sign"
-	},
-/turf/simulated/wall,
-/area/operations/office)
 "uci" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51895,13 +51766,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/corner/brown/full{
-	dir = 1
-	},
-/obj/machinery/computer/shuttle_control/multi/lift/wall/operations{
-	dir = 8;
-	pixel_x = 24;
-	pixel_y = 24
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
@@ -63906,9 +63772,9 @@ hKh
 ecx
 kRZ
 kEY
-lSK
-giP
-rht
+nTB
+hUP
+kRZ
 mUW
 kmc
 kmc
@@ -64107,10 +63973,10 @@ wPj
 hGE
 ciP
 kRZ
-drn
+kEY
 hUP
 nTB
-rht
+kRZ
 mGc
 rVg
 sTu
@@ -64512,7 +64378,7 @@ eDW
 ewb
 mKA
 nOS
-nOS
+rht
 rHw
 kOE
 tsA
@@ -64713,10 +64579,10 @@ rVg
 rVg
 kXS
 rVg
-fRi
-arK
-ubZ
-kRZ
+iku
+oDl
+yhL
+dum
 rtF
 rVg
 pNw
@@ -64916,9 +64782,9 @@ cAb
 sUj
 rVg
 hzm
-hQE
-ryq
+llp
 kRZ
+dum
 rtF
 rVg
 gVs
@@ -65117,7 +64983,7 @@ aML
 gLL
 bgS
 rVg
-aBq
+hzm
 llp
 iku
 yig

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -1227,9 +1227,9 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/airlock/glass_research{
 	dir = 1;
+	id_tag = "xeno_entrance_ext";
 	name = "Xenobiology";
-	req_access = list(55);
-	id_tag = "xeno_entrance_ext"
+	req_access = list(55)
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/rnd/xenobiology)
@@ -5221,12 +5221,12 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/button/remote/airlock{
+	dir = 4;
 	id = "xeno_entrance_int";
 	name = "Xenobiology Internal Access Bolts";
+	pixel_x = 21;
 	req_access = list(55);
-	specialfunctions = 4;
-	dir = 4;
-	pixel_x = 21
+	specialfunctions = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -5785,15 +5785,15 @@
 /obj/machinery/power/apc/low/north,
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp{
-	pixel_y = 12;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 12
 	},
 /obj/effect/floor_decal/corner/mauve/full{
 	dir = 8
 	},
 /obj/machinery/reagentgrinder{
-	pixel_y = 7;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 7
 	},
 /obj/item/stack/material/phoron{
 	pixel_y = 8
@@ -6832,12 +6832,12 @@
 /area/rnd/telesci)
 "dfP" = (
 /obj/machinery/button/remote/airlock{
+	dir = 8;
 	id = "xeno_entrance_int";
 	name = "Xenobiology Internal Access Bolts";
+	pixel_x = -21;
 	req_access = list(55);
-	specialfunctions = 4;
-	dir = 8;
-	pixel_x = -21
+	specialfunctions = 4
 	},
 /obj/effect/floor_decal/corner/mauve{
 	dir = 9
@@ -7294,6 +7294,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/office)
+"drn" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
+/obj/machinery/door/window/southright{
+	name = "Warehouse Access";
+	req_one_access = list(26,67,76)
+	},
+/turf/simulated/floor/tiled,
+/area/operations/office)
 "drw" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -7900,13 +7910,13 @@
 "dHO" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/plasticflaps/airtight{
-	layer = 2.5;
-	dir = 8
+	dir = 8;
+	layer = 2.5
 	},
 /obj/machinery/door/airlock/glass_research{
-	req_access = list(55);
+	dir = 8;
 	name = "Cell";
-	dir = 8
+	req_access = list(55)
 	},
 /obj/machinery/door/blast/regular/open{
 	fail_secure = 1;
@@ -14104,8 +14114,8 @@
 /area/hallway/primary/central_one)
 "gzU" = (
 /obj/machinery/computer/operating{
-	name = "Xenobiology Operating Computer";
-	dir = 8
+	dir = 8;
+	name = "Xenobiology Operating Computer"
 	},
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
@@ -22521,9 +22531,9 @@
 	dir = 8;
 	id = "xeno_entrance_ext";
 	name = "Xenobiology External Access Bolts";
+	pixel_x = -21;
 	req_access = list(55);
-	specialfunctions = 4;
-	pixel_x = -21
+	specialfunctions = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
@@ -22715,6 +22725,10 @@
 "kEY" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
+	},
+/obj/machinery/door/window/southleft{
+	name = "Warehouse Access";
+	req_one_access = list(26,67,76)
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
@@ -29928,6 +29942,9 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "oaQ" = (
@@ -29960,10 +29977,10 @@
 	},
 /obj/effect/map_effect/window_spawner/full/reinforced,
 /obj/machinery/door/blast/regular/open{
+	dir = 2;
 	fail_secure = 1;
 	id = "xenobio";
-	name = "Cell Containment Blast Door";
-	dir = 2
+	name = "Cell Containment Blast Door"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/rnd/xenobiology)
@@ -30059,8 +30076,8 @@
 "ocU" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
-	pixel_y = 1;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 1
 	},
 /obj/item/pen{
 	pixel_x = 6;
@@ -31216,6 +31233,9 @@
 "oDl" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
+	},
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
@@ -33807,8 +33827,8 @@
 	dir = 5
 	},
 /obj/machinery/smartfridge/secure/extract{
-	pixel_y = 32;
-	density = 0
+	density = 0;
+	pixel_y = 32
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/white,
@@ -36460,6 +36480,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/operations/lobby)
+"rht" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/operations/office)
 "rhz" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/industrial/warning{
@@ -38642,19 +38671,19 @@
 "sjV" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/plasticflaps/airtight{
-	layer = 2.5;
-	dir = 4
+	dir = 4;
+	layer = 2.5
 	},
 /obj/machinery/door/airlock/glass_research{
-	req_access = list(55);
+	dir = 4;
 	name = "Cell";
-	dir = 4
+	req_access = list(55)
 	},
 /obj/machinery/door/blast/regular/open{
+	dir = 2;
 	fail_secure = 1;
 	id = "xenobio";
-	name = "Cell Containment Blast Door";
-	dir = 2
+	name = "Cell Containment Blast Door"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/rnd/xenobiology)
@@ -39847,8 +39876,8 @@
 "sVf" = (
 /obj/structure/table/standard,
 /obj/item/folder/yellow{
-	pixel_y = 3;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 3
 	},
 /obj/item/device/hand_labeler{
 	pixel_y = -5
@@ -40057,6 +40086,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office)
@@ -41263,9 +41295,9 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/airlock/glass_research{
 	dir = 4;
+	id_tag = "xeno_entrance_int";
 	name = "Xenobiology";
-	req_access = list(55);
-	id_tag = "xeno_entrance_int"
+	req_access = list(55)
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/rnd/xenobiology)
@@ -42612,24 +42644,24 @@
 	req_one_access = list(24,11,55)
 	},
 /obj/item/storage/box/lights/colored/blue{
-	pixel_y = 10;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 10
 	},
 /obj/item/storage/box/lights/colored/cyan{
-	pixel_y = 10;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 10
 	},
 /obj/item/storage/box/lights/colored/green{
-	pixel_y = 6;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /obj/item/storage/box/lights/colored/magenta{
 	pixel_x = -6;
 	pixel_y = 6
 	},
 /obj/item/storage/box/lights/colored/red{
-	pixel_y = 2;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 2
 	},
 /obj/item/storage/box/lights/colored/yellow{
 	pixel_x = -6;
@@ -51400,12 +51432,12 @@
 	pixel_y = 1
 	},
 /obj/item/device/slime_scanner{
-	pixel_y = 4;
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = 4
 	},
 /obj/item/device/slime_scanner{
-	pixel_y = 4;
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = 4
 	},
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
@@ -63876,7 +63908,7 @@ kRZ
 kEY
 lSK
 giP
-kRZ
+rht
 mUW
 kmc
 kmc
@@ -64075,10 +64107,10 @@ wPj
 hGE
 ciP
 kRZ
-kEY
+drn
 hUP
 nTB
-kRZ
+rht
 mGc
 rVg
 sTu

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -56,12 +56,11 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop/xo)
 "acp" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
 	icon_state = "1-2"
+	},
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office_aux)
@@ -94,8 +93,8 @@
 /obj/effect/map_effect/door_helper/unres,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/map_effect/door_helper/level_access/command_foyer{
-	req_one_access_by_level = list("green","yellow" = list(19,38,72),"blue"=list(19,38,72),"red"=list(19,38,72),"delta"=list(19,38,72));
-	access_by_level = null
+	access_by_level = null;
+	req_one_access_by_level = list("green","yellow" = list(19,38,72),"blue"=list(19,38,72),"red"=list(19,38,72),"delta"=list(19,38,72))
 	},
 /obj/machinery/door/airlock/glass_command{
 	dir = 1;
@@ -1215,10 +1214,10 @@
 /area/horizon/exterior)
 "aTZ" = (
 /obj/machinery/door/airlock/command{
+	dir = 4;
 	id_tag = "rep_office_a";
 	name = "Representative Office Alpha";
-	req_access = list(38);
-	dir = 4
+	req_access = list(38)
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1563,9 +1562,6 @@
 /area/tcommsat/chamber)
 "bbA" = (
 /obj/machinery/recharge_station,
-/obj/structure/railing/mapped{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 8
 	},
@@ -1796,9 +1792,6 @@
 /turf/simulated/floor/tiled/full,
 /area/bridge)
 "bkj" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
 	},
@@ -3444,18 +3437,18 @@
 "cMa" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/cups{
-	pixel_y = 15;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 15
 	},
 /obj/item/storage/box/fancy/donut,
 /obj/item/storage/box/cups{
-	pixel_y = 15;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 15
 	},
 /obj/machinery/alarm/north{
 	dir = 4;
-	pixel_y = 0;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/full,
 /area/bridge/cciaroom)
@@ -3589,8 +3582,8 @@
 	dir = 1
 	},
 /obj/machinery/disposal/small/south{
-	pixel_y = -19;
-	dir = 1
+	dir = 1;
+	pixel_y = -19
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -4512,9 +4505,9 @@
 	dir = 8
 	},
 /obj/machinery/alarm/north{
-	pixel_y = 0;
 	dir = 8;
-	pixel_x = -10
+	pixel_x = -10;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/supply)
@@ -5001,8 +4994,8 @@
 	req_one_access = list(19,38,72)
 	},
 /obj/effect/map_effect/door_helper/level_access/command_foyer{
-	req_one_access_by_level = list("green","yellow" = list(19,38,72),"blue"=list(19,38,72),"red"=list(19,38,72),"delta"=list(19,38,72));
-	access_by_level = null
+	access_by_level = null;
+	req_one_access_by_level = list("green","yellow" = list(19,38,72),"blue"=list(19,38,72),"red"=list(19,38,72),"delta"=list(19,38,72))
 	},
 /turf/simulated/floor/tiled/full,
 /area/horizon/hallway/deck_three/primary/central)
@@ -7145,8 +7138,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
+	dir = 1
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/full,
@@ -7390,30 +7382,24 @@
 	dir = 8
 	},
 /obj/item/storage/secure/safe{
-	pixel_y = 33;
-	pixel_x = 31
+	pixel_x = 31;
+	pixel_y = 33
 	},
 /obj/machinery/button/remote/airlock{
 	dir = 1;
-	pixel_x = 26;
-	name = "Command Foyer Doors";
 	id = "command_foyer";
+	name = "Command Foyer Doors";
+	pixel_x = 26;
 	pixel_y = -3
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
 "fxk" = (
-/obj/machinery/door/window/northleft,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/computer/shuttle_control/multi/lift/operations{
-	pixel_x = -27;
-	pixel_y = 16
 	},
 /turf/simulated/floor/tiled,
 /area/operations/office_aux)
@@ -9817,9 +9803,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/longbow)
 "hdq" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -9828,12 +9811,6 @@
 /obj/machinery/power/apc/low/north,
 /obj/structure/cable/green{
 	icon_state = "0-2"
-	},
-/obj/structure/sign/drop{
-	desc = "A warning sign which reads 'DANGER: FALLING HAZARD' and 'THIS EQUIPMENT STARTS AND STOPS AUTOMATICALLY'.";
-	name = "\improper DANGER: FALLING HAZARD sign";
-	pixel_x = -48;
-	pixel_y = 32
 	},
 /obj/item/folder/yellow{
 	pixel_x = -2;
@@ -11373,8 +11350,8 @@
 /obj/structure/table/wood,
 /obj/machinery/chemical_dispenser/bar_soft/full{
 	dir = 4;
-	pixel_y = 3;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 3
 	},
 /obj/item/storage/box/drinkingglasses{
 	pixel_x = 13;
@@ -11541,15 +11518,15 @@
 "ilv" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
+	dir = 1;
 	pixel_x = -28;
-	pixel_y = 12;
-	dir = 1
+	pixel_y = 12
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/map_effect/marker/airlock{
+	frequency = 1001;
 	master_tag = "airlock_horizon_deck_3_aft_1";
-	name = "airlock_horizon_deck_3_aft_1";
-	frequency = 1001
+	name = "airlock_horizon_deck_3_aft_1"
 	},
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
@@ -11616,10 +11593,10 @@
 /area/horizon/security/interrogation/monitoring)
 "ipH" = (
 /obj/machinery/door/airlock/command{
+	dir = 4;
 	id_tag = "rep_office_b";
 	name = "Representative Office Bravo";
-	req_access = list(38);
-	dir = 4
+	req_access = list(38)
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12162,8 +12139,8 @@
 	pixel_x = 5
 	},
 /obj/item/pen/green{
-	pixel_y = -3;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /turf/simulated/floor/carpet,
 /area/lawoffice/consular)
@@ -12866,9 +12843,9 @@
 	dir = 6
 	},
 /obj/machinery/newscaster/security_unit/north{
-	pixel_y = 4;
 	dir = 8;
-	pixel_x = -10
+	pixel_x = -10;
+	pixel_y = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -12937,9 +12914,9 @@
 	dir = 7
 	},
 /obj/machinery/alarm/north{
-	pixel_y = 0;
 	dir = 8;
-	pixel_x = -43
+	pixel_x = -43;
+	pixel_y = 0
 	},
 /turf/simulated/floor/wood,
 /area/lawoffice/representative_two)
@@ -13138,8 +13115,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/map_effect/door_helper/level_access/command_foyer{
-	req_one_access_by_level = list("green","yellow" = list(19,38,72),"blue"=list(19,38,72),"red"=list(19,38,72),"delta"=list(19,38,72));
-	access_by_level = null
+	access_by_level = null;
+	req_one_access_by_level = list("green","yellow" = list(19,38,72),"blue"=list(19,38,72),"red"=list(19,38,72),"delta"=list(19,38,72))
 	},
 /obj/machinery/door/airlock/glass_command{
 	dir = 1;
@@ -13329,28 +13306,28 @@
 	pixel_y = 4
 	},
 /obj/item/clothing/head/beret/scc{
-	pixel_y = 15;
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = 15
 	},
 /obj/item/clothing/head/beret/scc{
-	pixel_y = 15;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 15
 	},
 /obj/item/clothing/head/beret/scc{
-	pixel_y = 15;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 15
 	},
 /obj/item/clothing/accessory/armband/scc{
-	pixel_y = -8;
-	pixel_x = -12
+	pixel_x = -12;
+	pixel_y = -8
 	},
 /obj/item/clothing/accessory/armband/scc{
-	pixel_y = -8;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = -8
 	},
 /obj/item/clothing/accessory/armband/scc{
-	pixel_y = -10;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = -10
 	},
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -13959,8 +13936,8 @@
 	},
 /obj/machinery/requests_console/south{
 	department = "Conference Room";
-	name = "Conference Room Requests Console";
 	dir = 1;
+	name = "Conference Room Requests Console";
 	pixel_y = 37
 	},
 /turf/simulated/floor/wood,
@@ -14030,12 +14007,12 @@
 	pixel_x = -6
 	},
 /obj/item/pen/green{
-	pixel_y = -3;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /obj/item/folder/blue{
-	pixel_y = 7;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = 7
 	},
 /obj/item/pen/blue{
 	pixel_x = 8;
@@ -15686,12 +15663,12 @@
 	pixel_y = -4
 	},
 /obj/item/folder/blue{
-	pixel_y = 7;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 7
 	},
 /obj/item/folder/blue{
-	pixel_y = 7;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 7
 	},
 /obj/item/pen/red{
 	pixel_x = 7;
@@ -16204,10 +16181,10 @@
 /area/bridge/controlroom)
 "lve" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Emergency Exit";
-	req_access = list(20);
+	id_tag = "cap_escape";
 	locked = 1;
-	id_tag = "cap_escape"
+	name = "Emergency Exit";
+	req_access = list(20)
 	},
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -16260,9 +16237,9 @@
 	dir = 1
 	},
 /obj/machinery/alarm/north{
-	pixel_y = 0;
 	dir = 8;
-	pixel_x = -43
+	pixel_x = -43;
+	pixel_y = 0
 	},
 /turf/simulated/floor/wood,
 /area/lawoffice/representative)
@@ -16994,12 +16971,12 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/folder/blue{
-	pixel_y = 7;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 7
 	},
 /obj/item/folder/blue{
-	pixel_y = 7;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 7
 	},
 /obj/item/pen/red{
 	pixel_x = 7;
@@ -18446,8 +18423,8 @@
 /obj/machinery/computer/security/telescreen{
 	name = "Access Monitor";
 	network = list("XO_Office");
-	pixel_y = 24;
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 24
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/hop/xo)
@@ -18709,8 +18686,8 @@
 /obj/structure/table/standard,
 /obj/item/deck/cards,
 /obj/item/storage/box/fancy/cigarettes{
-	pixel_y = 10;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/maintenance/deck_three/aft/starboard)
@@ -18838,8 +18815,8 @@
 "nkf" = (
 /obj/machinery/alarm/north{
 	dir = 4;
-	pixel_y = 0;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 0
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
@@ -19128,6 +19105,9 @@
 "nsP" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/horizon/longbow)
+"nsZ" = (
+/turf/simulated/floor/tiled,
+/area/operations/office_aux)
 "ntv" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/industrial/warning,
@@ -19294,8 +19274,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube_empty"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/bridge/cciaroom/lounge)
@@ -19600,9 +19579,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/map_effect/marker/airlock{
+	frequency = 1001;
 	master_tag = "airlock_horizon_deck_3_aft_1";
-	name = "airlock_horizon_deck_3_aft_1";
-	frequency = 1001
+	name = "airlock_horizon_deck_3_aft_1"
 	},
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
@@ -19630,12 +19609,12 @@
 	pixel_y = 13
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_y = 13;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = 13
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass{
-	pixel_y = 13;
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = 13
 	},
 /turf/simulated/floor/wood,
 /area/lawoffice/representative_two)
@@ -20263,8 +20242,8 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm/north{
 	dir = 4;
-	pixel_y = 0;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/cciaroom/lounge)
@@ -20432,9 +20411,9 @@
 "olw" = (
 /obj/machinery/door/airlock/command{
 	dir = 1;
+	id_tag = "capoffice";
 	name = "Captain's Office";
-	req_access = list(20);
-	id_tag = "capoffice"
+	req_access = list(20)
 	},
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -20594,21 +20573,19 @@
 	},
 /obj/structure/table/standard,
 /obj/item/storage/box/cups{
-	pixel_y = 15;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 15
 	},
 /obj/item/storage/box/cups{
-	pixel_y = 4;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 4
 	},
 /turf/simulated/floor/wood,
 /area/bridge/upperdeck)
 "opw" = (
-/obj/structure/closet/crate,
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/camera/network/supply{
 	c_tag = "Operations -  Aux Desk";
 	dir = 8
@@ -20637,9 +20614,9 @@
 	dir = 8;
 	id = "consular_office_a";
 	name = "consular door bolts";
-	specialfunctions = 4;
+	pixel_x = -52;
 	pixel_y = -2;
-	pixel_x = -52
+	specialfunctions = 4
 	},
 /obj/machinery/light_switch{
 	dir = 8;
@@ -20649,19 +20626,19 @@
 /obj/machinery/button/switch/windowtint{
 	dir = 8;
 	id = "consularA";
-	pixel_y = 14;
-	pixel_x = -59
+	pixel_x = -59;
+	pixel_y = 14
 	},
 /obj/machinery/button/remote/airlock{
 	dir = 8;
 	id = "consular_office_a";
 	name = "consular door control";
-	pixel_y = 3;
-	pixel_x = -59
+	pixel_x = -59;
+	pixel_y = 3
 	},
 /obj/item/storage/secure/safe{
-	pixel_y = 42;
-	pixel_x = -59
+	pixel_x = -59;
+	pixel_y = 42
 	},
 /turf/simulated/floor/carpet,
 /area/lawoffice/consular)
@@ -21105,7 +21082,6 @@
 /turf/simulated/floor,
 /area/maintenance/bridge)
 "oIL" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -21372,7 +21348,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/operations/office_aux)
 "oSL" = (
@@ -21415,8 +21390,8 @@
 	department = "Bridge";
 	departmentType = 5;
 	name = "Bridge Requests Console";
-	pixel_y = 35;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 35
 	},
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 8
@@ -21916,10 +21891,6 @@
 /obj/random/pottedplant,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/controlroom)
-"prh" = (
-/obj/effect/shuttle_landmark/lift/operations_third_deck,
-/turf/simulated/open,
-/area/operations/office_aux)
 "psa" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 6
@@ -21994,13 +21965,13 @@
 	department = "Captain's Desk";
 	departmentType = 5;
 	name = "Captain RC";
-	pixel_y = 35;
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 35
 	},
 /obj/item/modular_computer/console/preset/command/captain{
+	density = 0;
 	dir = 4;
-	pixel_x = -18;
-	density = 0
+	pixel_x = -18
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/captain)
@@ -23273,8 +23244,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube_empty"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/full,
 /area/bridge/cciaroom)
@@ -23493,9 +23463,9 @@
 	dir = 1
 	},
 /obj/machinery/alarm/north{
-	pixel_y = -7;
+	dir = 2;
 	pixel_x = -1;
-	dir = 2
+	pixel_y = -7
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
@@ -24401,10 +24371,10 @@
 	announcementConsole = 1;
 	department = "Representative's Office Alpha";
 	departmentType = 5;
-	name = "Representative's Office requests console";
-	pixel_y = 5;
 	dir = 8;
-	pixel_x = -49
+	name = "Representative's Office requests console";
+	pixel_x = -49;
+	pixel_y = 5
 	},
 /turf/simulated/floor/carpet,
 /area/lawoffice/representative)
@@ -25213,9 +25183,7 @@
 /obj/effect/floor_decal/spline/fancy/wood/cee{
 	dir = 8
 	},
-/obj/machinery/light{
-	icon_state = "tube_empty"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/bridge/cciaroom)
 "rQE" = (
@@ -25279,7 +25247,6 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -25931,8 +25898,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/controlroom)
 "snv" = (
-/obj/machinery/door/window/northright,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -26213,7 +26178,12 @@
 /turf/simulated/floor/wood,
 /area/horizon/cafeteria)
 "svx" = (
-/turf/simulated/open,
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled,
 /area/operations/office_aux)
 "svK" = (
 /obj/effect/floor_decal/plaque{
@@ -26232,12 +26202,11 @@
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/bar_soft/full{
 	dir = 8;
-	pixel_y = 4;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube_empty"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/full,
 /area/bridge/cciaroom)
@@ -30260,11 +30229,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/button/remote/airlock{
-	name = "Emergency Escape Bolts";
-	specialfunctions = 4;
 	id = "cap_escape";
+	name = "Emergency Escape Bolts";
+	pixel_x = 6;
 	pixel_y = -23;
-	pixel_x = 6
+	specialfunctions = 4
 	},
 /obj/machinery/light,
 /turf/simulated/floor/wood,
@@ -30595,8 +30564,8 @@
 	},
 /obj/machinery/alarm/north{
 	dir = 4;
-	pixel_y = 0;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 0
 	},
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled,
@@ -30818,9 +30787,9 @@
 	pixel_x = -20
 	},
 /obj/effect/map_effect/marker/airlock{
+	frequency = 1001;
 	master_tag = "airlock_horizon_deck_3_aft_1";
-	name = "airlock_horizon_deck_3_aft_1";
-	frequency = 1001
+	name = "airlock_horizon_deck_3_aft_1"
 	},
 /turf/simulated/floor,
 /area/horizon/maintenance/deck_three/aft/starboard)
@@ -31038,8 +31007,7 @@
 	},
 /obj/random/pottedplant,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube_empty"
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/cciaroom/lounge)
@@ -31342,17 +31310,17 @@
 	},
 /obj/machinery/button/remote/airlock{
 	dir = 1;
-	pixel_x = -38;
-	specialfunctions = 4;
-	name = "Office Bolts";
 	id = "capoffice";
-	pixel_y = 31
+	name = "Office Bolts";
+	pixel_x = -38;
+	pixel_y = 31;
+	specialfunctions = 4
 	},
 /obj/machinery/button/remote/airlock{
 	dir = 1;
-	pixel_x = -25;
-	name = "Office Door";
 	id = "capoffice";
+	name = "Office Door";
+	pixel_x = -25;
 	pixel_y = 31
 	},
 /turf/simulated/floor/carpet,
@@ -31919,10 +31887,10 @@
 	pixel_y = 32
 	},
 /obj/machinery/power/apc/north{
-	is_critical = 1;
-	pixel_y = 0;
 	dir = 4;
-	pixel_x = 15
+	is_critical = 1;
+	pixel_x = 15;
+	pixel_y = 0
 	},
 /obj/structure/cable/green{
 	icon_state = "0-8"
@@ -32881,8 +32849,8 @@
 	},
 /obj/machinery/alarm/north{
 	dir = 4;
-	pixel_y = 0;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 0
 	},
 /obj/structure/table/wood,
 /obj/machinery/chemical_dispenser/bar_soft/full{
@@ -33094,8 +33062,8 @@
 	pixel_x = -6
 	},
 /obj/item/pen/green{
-	pixel_y = -3;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /obj/item/pen/red{
 	pixel_x = 5
@@ -33781,10 +33749,10 @@
 	announcementConsole = 1;
 	department = "Representative's Office Bravo";
 	departmentType = 5;
-	name = "Representative's Office requests console";
-	pixel_y = 5;
 	dir = 8;
-	pixel_x = -48
+	name = "Representative's Office requests console";
+	pixel_x = -48;
+	pixel_y = 5
 	},
 /turf/simulated/floor/carpet,
 /area/lawoffice/representative_two)
@@ -33836,17 +33804,17 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/machinery/button/remote/airlock{
 	dir = 1;
-	pixel_x = -5;
-	name = "Office Door";
 	id = "hra_room";
+	name = "Office Door";
+	pixel_x = -5;
 	pixel_y = 39;
 	specialfunctions = 4
 	},
 /obj/machinery/button/remote/blast_door{
 	dir = 10;
+	id = "hra_room_bd";
 	pixel_x = -5;
-	pixel_y = 28;
-	id = "hra_room_bd"
+	pixel_y = 28
 	},
 /obj/machinery/button/switch/windowtint{
 	dir = 1;
@@ -33856,8 +33824,8 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	pixel_y = 26;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 26
 	},
 /turf/simulated/floor/wood,
 /area/bridge/cciaroom)
@@ -46927,7 +46895,7 @@ hzU
 gzJ
 oWf
 svx
-svx
+nsZ
 fxk
 gvG
 rhm
@@ -47128,8 +47096,8 @@ heB
 vLH
 iSt
 oWf
-prh
 svx
+nsZ
 snv
 oRM
 qGg


### PR DESCRIPTION
* The warehouse is now access locked to the Ops Manager, Hangar Technician, Janitor, and First Responder roles. This means that Shaft Miners and Machinists no longer have access to it.
* Removed the Operations Lift, adjusted all the rooms it used to occupy.
* Added a few more crates to the warehouse.

I think this is for the best, as this limits warehouse gameplay (trademark pending) to Hangar Technicians, and prevents roles with already-established gameplay loops from intruding there.

Deck One
![image](https://github.com/Aurorastation/Aurora.3/assets/22774890/2e66cad1-0d0e-4c1e-855c-6af74476345c)

Deck Two
![image](https://github.com/Aurorastation/Aurora.3/assets/22774890/7bf8039b-a2ed-4384-ba7d-8178fe883642)

Deck Three
![image](https://github.com/Aurorastation/Aurora.3/assets/22774890/9b0438b3-fa5a-4e48-a053-1ddfa0992b01)
