### PR TITLE
Area blurb fixes

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -6,6 +6,9 @@
 #define VOLUME_AMBIENT_HUM 18
 #define VOLUME_MUSIC 30
 
+/// This list of names is here to make sure we don't state our descriptive blurb to a person more than once.
+var/global/list/area_blurb_stated_to = list()
+
 /area
 	var/global/global_uid = 0
 	var/uid
@@ -66,8 +69,8 @@
 
 	/// A text-based description of the area, can be used for sounds, notable things in the room, etc.
 	var/area_blurb
-	/// This list of ckeys is here to make sure we don't state our descriptive blurb to a person more than once.
-	var/list/blurbed_stated_to = list()
+	/// Used to filter description showing across subareas.
+	var/area_blurb_category
 
 // Don't move this to Initialize(). Things in here need to run before SSatoms does.
 /area/New()
@@ -76,6 +79,8 @@
 		areas_by_type[type] = src
 	// Atmos code needs this, so we need to make sure this is done by the time they initialize.
 	uid = ++global_uid
+	if(isnull(area_blurb_category))
+		area_blurb_category = type
 	. = ..()
 
 /area/Initialize(mapload)
@@ -486,8 +491,8 @@ var/list/mob/living/forced_ambiance_list = new
 			to_chat(target_mob, SPAN_NOTICE("No blurb set for this area."))
 		return
 
-	if(!(target_mob.ckey in blurbed_stated_to) || override)
-		blurbed_stated_to |= target_mob.ckey
+	if(!(target_mob.ckey in global.area_blurb_stated_to[area_blurb_category]) || override)
+		LAZYADD(global.area_blurb_stated_to[area_blurb_category], target_mob.ckey)
 		to_chat(target_mob, SPAN_NOTICE("[area_blurb]"))
 
 /// A verb to view an area's blurb on demand. Overrides the check for if you have seen the blurb before so you can always see it when used.

--- a/html/changelogs/greenjoe12345 - blurbfixes.yml
+++ b/html/changelogs/greenjoe12345 - blurbfixes.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Greenjoe12345
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Area blurbs now only show once per blurb, rather then showing each time you enter a subtype of the area they are defined on."
+  - bugfix: "Medical's area blurb is now set on the correct area."

--- a/maps/_common/areas/station/command.dm
+++ b/maps/_common/areas/station/command.dm
@@ -7,6 +7,7 @@
 	station_area = 1
 	holomap_color = HOLOMAP_AREACOLOR_COMMAND
 	area_blurb = "The sound here seems to carry more than others, every click of a shoe or clearing of a throat amplified. The smell of ink wafts notably through the air."
+	area_blurb_category = "command"
 
 /area/bridge/upperdeck
 	name = "Command Atrium Upper Deck"
@@ -47,6 +48,7 @@
 	ambience = list()
 	sound_env = MEDIUM_SOFTFLOOR
 	area_blurb = "A place for behind-closed-doors meetings to get things done, or argue for hours in..."
+	area_blurb_category = "command_meeting"
 	area_flags = AREA_FLAG_RAD_SHIELDED
 
 /area/bridge/cciaroom
@@ -54,6 +56,7 @@
 	icon_state = "hr"
 	sound_env = MEDIUM_SOFTFLOOR
 	area_blurb = "You feel severe existential dread when you enter this room.."
+	area_blurb_category = "hr_meeting"
 	area_flags = AREA_FLAG_RAD_SHIELDED
 
 /area/bridge/cciaroom/lounge
@@ -61,6 +64,7 @@
 	icon_state = "hrlounge"
 	sound_env = SMALL_SOFTFLOOR
 	area_blurb = "A place that worsens the slightest anxieties surrounding meetings with your bosses boss."
+	area_blurb_category = "hr_lounge"
 	area_flags = AREA_FLAG_RAD_SHIELDED
 
 /area/bridge/selfdestruct
@@ -70,6 +74,7 @@
 /area/bridge/controlroom // Horizon.
 	name = "Command - Control Room"
 	area_blurb = "The full expanse of space lies beyond a thick pane of glass, all that protects you from a cold death. The computers all hum with various displays and holographic signs, overwhelming if you were not used to such an environment. Even at full power, the sensors fail to map even a fraction of the dots of light making up the cosmic filament."
+	area_blurb_category = "bridge"
 	area_flags = AREA_FLAG_RAD_SHIELDED
 
 /area/crew_quarters/captain

--- a/maps/_common/areas/station/engineering.dm
+++ b/maps/_common/areas/station/engineering.dm
@@ -15,6 +15,7 @@
 	no_light_control = 1
 	ambience = list(AMBIENCE_ENGINEERING, AMBIENCE_ATMOS)
 	area_blurb = "Many tanks are here, providing life support systems for the vessel."
+	area_blurb_category = "atmos"
 
 /area/engineering/atmos/monitoring
 	name = "Engineering - Atmospherics Monitoring Room"
@@ -96,6 +97,7 @@
 	icon_state = "engineering_break"
 	sound_env = MEDIUM_SOFTFLOOR
 	area_blurb = "The smells of coffee and motor oil linger in the air."
+	area_blurb_category = "engi_breakroom"
 
 /area/engineering/engine_eva
 	name = "Engineering - Engine EVA"

--- a/maps/_common/areas/station/maintenance.dm
+++ b/maps/_common/areas/station/maintenance.dm
@@ -7,6 +7,7 @@
 	ambience = AMBIENCE_MAINTENANCE
 	station_area = 1
 	area_blurb = "Dark, tight, and filled with barely filtered air. This place feels alien compared to the interior of the ship, a place where one could get lost or badly hurt. Around you hisses compressed air through pipes, a buzz of electrical charge through wires, and rumbles of the hull settling through damp maintenance corridors."
+	area_blurb_category = "maint"
 
 /area/maintenance/civ
 	name = "Civilian Maintenance"
@@ -255,6 +256,7 @@
 	sound_env = SMALL_ENCLOSED
 	ambience = AMBIENCE_SUBSTATION
 	area_blurb = "Clearly a substation, designed to downgrade voltage to departments in case of electrical hazards, and to act as an emergency battery in case of engine failure. Unlike the maintenance corridors, these stations are far less dusty."
+	area_blurb_category = "substation"
 
 /area/maintenance/substation/engineering // Engineering
 	name = "Engineering Substation"

--- a/maps/_common/areas/station/medical.dm
+++ b/maps/_common/areas/station/medical.dm
@@ -4,6 +4,8 @@
 /area/medical
 	station_area = 1
 	holomap_color = HOLOMAP_AREACOLOR_MEDICAL
+	area_blurb = "The smells of a hospital waft through the air: strong sterilizing agents, various medicines, and sterile gloves. It's not a pleasant smell, but one you could grow to ignore."
+	area_blurb_category = "mecical"
 
 //Medbay is a large area, these additional areas help level out APC load.
 
@@ -12,7 +14,6 @@
 	lightswitch = TRUE
 	icon_state = "medbay"
 	ambience = list('sound/ambience/signal.ogg')
-	area_blurb = "The smells of a hospital waft through the air: strong sterilizing agents, various medicines, and sterile gloves. It's not a pleasant smell, but one you could grow to ignore."
 
 /area/medical/medbay2
 	name = "Medbay Hallway - Starboard"
@@ -54,6 +55,7 @@
 	name = "Medical - Psych Room"
 	icon_state = "medbay3"
 	area_blurb = "With wooden floors and carpets, this room has a warmer feeling compared to the sterility of the rest of the medical wing."
+	area_blurb_category = "psych"
 
 /area/medical/upperlevel
 	name = "Medical - Upper-Level Hallway"
@@ -127,6 +129,7 @@
 	icon_state = "morgue"
 	ambience = AMBIENCE_GHOSTLY
 	area_blurb = "Morgue trays sit within this room to hold the deceased until their postmortem wishes can be attended to."
+	area_blurb_category = "morgue"
 
 /area/medical/pharmacy
 	name = "Medical - Pharmacy"
@@ -183,6 +186,7 @@
 	name = "Medical - Intensive Care Unit"
 	icon_state = "cryo"
 	area_blurb = "The sounds of life support equipment can be heard within the room."
+	area_blurb_category = "icu"
 
 /area/medical/triage
 	name = "Medical - Triage Room"

--- a/maps/away/away_site/konyang/point_verdant/point_verdant_areas.dm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant_areas.dm
@@ -15,6 +15,7 @@
 	name = "Point Verdant - Waterside"
 	ambience = AMBIENCE_KONYANG_WATER
 	area_blurb = "The crashing sounds of waves on the shore punctuates the air. The vast ocean spreads out as far as the eye can see, looking almost flat."
+	area_blurb_category = "verdant_shore"
 
 /area/point_verdant/reservoir
 	name = "Point Verdant - Reservoir"
@@ -25,7 +26,7 @@
 	name = "Point Verdant - Sewers"
 	sound_env = SEWER_PIPE
 	area_blurb = "Tainted water flows through these dark and grimy sewers, it smells utterly horrible down here. It's best not to think what you are breathing in, or touching."
-
+	area_blurb_category = "verdant_sewers"
 //All walls and interior stuff uses this area, otherwise rain will appear over walls. suboptimal!
 /area/point_verdant/interior
 	name = "Point Verdant - Indoors"
@@ -49,6 +50,7 @@
 /area/point_verdant/interior/arcade
 	name = "Point Verdant - Arcade"
 	area_blurb = "The deafening avalanche of arcade machines begging for your attention fill the air, all promising fantastic gaming experiences for fun and prizes."
+	area_blurb_category = "verdant_arcade"
 
 /area/point_verdant/interior/police
 	name = "Point Verdant - Police Department"
@@ -66,6 +68,7 @@
 /area/point_verdant/interior/decrepit
 	name = "Point Verdant - Decrepit Apartments"
 	area_blurb = "A damp smell lingers in the air inside these dusty apartments, it might be wise to keep an eye out for mould."
+	area_blurb_category = "verdant_decrepit_apartment"
 
 /area/point_verdant/interior/pharmacy
 	name = "Point Verdant - Pharmacy"
@@ -86,6 +89,7 @@
 /area/point_verdant/interior/tunnels
 	name = "Point Verdant - Tunnels"
 	area_blurb = "Sounds echo impressively through these tunnels."
+	area_blurb_category = "verdant_tunnels"
 
 /area/point_verdant/interior/shallow//For open-walled areas, like awnings and balconies
 	sound_env = CITY
@@ -96,6 +100,7 @@
 	name = "Point Verdant - Outdoors"
 	ambience = AMBIENCE_KONYANG_RAIN
 	area_blurb = "The sounds and smells of Point Verdant bombard you from all directions. Skyscrapers tower up further into the city. Rain batters down on your body, encouraging you to seek shelter." //alter this if a dynamic weather system is added, so its isn't always raining.
+	area_blurb_category = "verdant_outdoors"
 
 /area/point_verdant/outdoors/Initialize()
 	. = ..()

--- a/maps/sccv_horizon/code/sccv_horizon_areas.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_areas.dm
@@ -63,6 +63,7 @@
 /area/medical/ward/isolation
 	name = "Medical - Isolation Ward"
 	area_blurb = "This seldom-used ward somehow smells sterile and musty at the same time."
+	area_blurb_category = "medical_isolation"
 
 /area/medical/emergency_storage
 	name = "Medical - Lower Deck Emergency Storage"
@@ -79,6 +80,7 @@
 /area/medical/smoking
 	name = "Medical - Smoking Lounge"
 	area_blurb = "The smell of cigarette smoke lingers within this room."
+	area_blurb_category = "medical_smoking"
 
 /area/medical/washroom
 	name = "Medical - Washroom"
@@ -124,6 +126,7 @@
 /area/hangar/intrepid
 	name = "Intrepid Hangar"
 	area_blurb = "A big, open room, often housing the Horizon's largest shuttle, the Intrepid."
+	area_blurb_category = "intrepid_hanger"
 
 /area/hangar/intrepid/interstitial
 	name = "Intrepid Hangar Access"
@@ -162,11 +165,13 @@
 	icon_state = "dark160"
 	sound_env = LARGE_ENCLOSED
 	area_blurb = "Scuff marks scar the floor from the movement of many crates and stored goods."
+	area_blurb_category = "ops_warehouse"
 
 /area/operations/lower/machinist
 	name = "Machinist Workshop"
 	icon_state = "machinist_workshop"
 	area_blurb = "The scents of oil and machine lubricant fill the air in this workshop."
+	area_blurb_category = "robotics"
 
 /area/operations/lobby
 	name = "Operations Lobby"
@@ -678,6 +683,7 @@
 	icon_state = "cafeteria"
 	holomap_color = HOLOMAP_AREACOLOR_CIVILIAN
 	area_blurb = "The smell of coffee wafts over from the cafe. Patience the tree stands proudly in the centre of the atrium."
+	area_blurb_category = "d3_cafe"
 
 // Custodial
 /area/horizon/custodial
@@ -688,12 +694,14 @@
 	ambience = list(AMBIENCE_FOREBODING, AMBIENCE_ENGINEERING)
 	holomap_color = HOLOMAP_AREACOLOR_CIVILIAN
 	area_blurb = "A strong, concentrated smell of many cleaning supplies sits within this room."
+	area_blurb_category = "janitor"
 
 /area/horizon/custodial/disposals
 	name = "Horizon - Disposals and Recycling"
 	icon_state = "disposal"
 	ambience = list(AMBIENCE_ENGINEERING, AMBIENCE_ATMOS) // Industrial sounds.
 	area_blurb = "A large trash compactor takes up much of the room, ready to crush the ship's rubbish."
+	area_blurb_category = "trash_compactor"
 
 /area/horizon/custodial/auxiliary
 	name = "Horizon - Auxiliary Custodial Closet"
@@ -837,6 +845,7 @@
 	sound_env = LARGE_ENCLOSED
 	ambience = AMBIENCE_SINGULARITY
 	area_blurb = "A gargantuan machine dominates the room, covered in components and moving parts. Its name is befitting of its size."
+	area_blurb_category = "leviathan"
 	area_flags = AREA_FLAG_HIDE_FROM_HOLOMAP
 
 // Longbow


### PR DESCRIPTION
Fixes area blurbs repeatedly showing in subtypes of the area they are defined for.
Fixes medical's area blurb being set on the wrong area.
Fix is from https://github.com/NebulaSS13/Nebula/pull/3533