### PR TITLE
Space Fauna Lethality Tweak

### DIFF
--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -51,7 +51,7 @@
 		slot_r_hand_str = "mining_helm"
 	)
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT,
+		melee = ARMOR_MELEE_MAJOR,
 		bullet = ARMOR_BALLISTIC_MINOR,
 		laser = ARMOR_LASER_MINOR,
 		bomb = ARMOR_BOMB_RESISTANT,
@@ -71,7 +71,7 @@
 	item_state = "rig-mining"
 	icon_state = "rig-mining"
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT,
+		melee = ARMOR_MELEE_MAJOR,
 		bullet = ARMOR_BALLISTIC_MINOR,
 		laser = ARMOR_LASER_MINOR,
 		bomb = ARMOR_BOMB_RESISTANT,

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -51,7 +51,7 @@
 		slot_r_hand_str = "mining_helm"
 	)
 	armor = list(
-		melee = ARMOR_MELEE_MAJOR,
+		melee = ARMOR_MELEE_RESISTANT,
 		bullet = ARMOR_BALLISTIC_MINOR,
 		laser = ARMOR_LASER_MINOR,
 		bomb = ARMOR_BOMB_RESISTANT,
@@ -71,7 +71,7 @@
 	item_state = "rig-mining"
 	icon_state = "rig-mining"
 	armor = list(
-		melee = ARMOR_MELEE_MAJOR,
+		melee = ARMOR_MELEE_RESISTANT,
 		bullet = ARMOR_BALLISTIC_MINOR,
 		laser = ARMOR_LASER_MINOR,
 		bomb = ARMOR_BOMB_RESISTANT,

--- a/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
@@ -26,7 +26,7 @@
 	harm_intent_damage = 4
 	melee_damage_lower = 15
 	melee_damage_upper = 15
-	armor_penetration = 10
+	armor_penetration = 5
 	attack_flags = DAMAGE_FLAG_EDGE
 	attacktext = "bitten"
 	attack_sound = 'sound/weapons/bite.ogg'
@@ -49,6 +49,8 @@
 
 	flying = TRUE
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
+
+	smart_melee = FALSE
 
 /mob/living/simple_animal/hostile/carp/update_icon()
 	..()
@@ -170,7 +172,7 @@
 
 	melee_damage_lower = 20
 	melee_damage_upper = 20
-	armor_penetration = 15
+	armor_penetration = 10
 	var/image/eye_overlay
 
 /mob/living/simple_animal/hostile/carp/shark/reaver/eel/Initialize()

--- a/html/changelogs/geeves-space_fauna_lethality.yml
+++ b/html/changelogs/geeves-space_fauna_lethality.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Space fauna, such as carp and reavers, have slightly less armor penetration and no longer have smart melee, meaning they won't dodge attacks anymore."
+  - tweak: "Increased the melee armor of mining voidsuits."
+  - rscadd: "Added metal rods, a medkit, and machetes to the Spark and mining bay."

--- a/html/changelogs/geeves-space_fauna_lethality.yml
+++ b/html/changelogs/geeves-space_fauna_lethality.yml
@@ -4,5 +4,4 @@ delete-after: True
 
 changes:
   - tweak: "Space fauna, such as carp and reavers, have slightly less armor penetration and no longer have smart melee, meaning they won't dodge attacks anymore."
-  - tweak: "Increased the melee armor of mining voidsuits."
   - rscadd: "Added metal rods, a medkit, and machetes to the Spark and mining bay."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -5613,6 +5613,7 @@
 	c_tag = "Mining - Suit Storage";
 	dir = 1
 	},
+/obj/item/stack/rods/full,
 /turf/simulated/floor/tiled/dark/full,
 /area/outpost/mining_main/refinery)
 "dWL" = (
@@ -25632,6 +25633,7 @@
 	name = "Tools Access";
 	req_access = list(48)
 	},
+/obj/item/stack/rods/full,
 /turf/simulated/floor/tiled/dark/full,
 /area/outpost/mining_main/refinery)
 "rRE" = (
@@ -28760,6 +28762,11 @@
 /obj/machinery/alarm/west{
 	pixel_y = 14
 	},
+/obj/item/storage/firstaid/regular,
+/obj/item/material/hatchet/machete/steel,
+/obj/item/material/hatchet/machete/steel,
+/obj/item/clothing/accessory/holster/utility/machete,
+/obj/item/clothing/accessory/holster/utility/machete,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
 "ucG" = (


### PR DESCRIPTION
* Space fauna, such as carp and reavers, have slightly less armor penetration and no longer have smart melee, meaning they won't dodge attacks anymore.
* Added metal rods, a medkit, and machetes to the Spark and mining bay.

I believe space fauna are overtuned still, even after the nerfs. The 0.5s thinking, combined with high damage and dodging made them unfairly punishing for miners who stumble around in the dark, far from any medbay. This seeks to resolve that issue by reducing the damage while buffing the defense.

The focus should be on mining instead of bootleg DOOM gameplay. If you believe these changes are a little too heavy-handed, try spawning and fighting two reavers in a mining voidsuit on your private server.