### PR TITLE
Restricts loadout holographic suits to elyran culture

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/uniform.dm
+++ b/code/modules/client/preference_setup/loadout/items/uniform.dm
@@ -315,6 +315,7 @@
 	description = "A marvel of Elyran technology, uses hardlight fabric and masks to transform a skin-tight, cozy suit into cultural apparel of your choosing. Has a dial for Midenean, Aemaqii and Persepolis clothes respectively."
 	path = /obj/item/clothing/under/elyra_holo
 	flags = GEAR_HAS_DESC_SELECTION
+	culture_restriction = list(/singleton/origin_item/culture/elyran, /singleton/origin_item/culture/ipc_elyra)
 
 /datum/gear/uniform/elyra_holo/New()
 	..()

--- a/html/changelogs/DreamySkrell--holoclothes-elyran.yml
+++ b/html/changelogs/DreamySkrell--holoclothes-elyran.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Restricts loadout holographic suits to elyran culture."


### PR DESCRIPTION
changes:
  - bugfix: "Restricts loadout holographic suits to elyran culture."

I believe this is fixing an oversight. Elyran holoclothes are described to be a "marvel of Elyran technology", they're literally named "elyran holographic suit", and have variations based on places in elyra. So just any random non-elyran should not be wearing this expensive piece of clothing.

A lot of other cultural items have similar restrictions too, so this PR makes it consistent with those.