### PR TITLE
Prevent icon reprocessing on deleted mob

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -106,7 +106,7 @@ There are several things that need to be remembered:
 
 // Updates overlays from overlays_raw.
 /mob/living/carbon/human/update_icon(var/forceDirUpdate = FALSE)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return	// No point.
 
 	update_hud()		//TODO: remove the need for this
@@ -205,7 +205,7 @@ There are several things that need to be remembered:
 	var/damage_appearance = ""
 
 	for(var/obj/item/organ/external/O in organs)
-		if(isnull(O) || O.is_stump())
+		if(QDELETED(O) || O.is_stump())
 			continue
 		//if(O.status & ORGAN_DESTROYED) damage_appearance += "d" //what is this?
 		//else
@@ -223,7 +223,7 @@ There are several things that need to be remembered:
 
 	// blend the individual damage states with our icons
 	for(var/obj/item/organ/external/O in organs)
-		if(isnull(O) || O.is_stump())
+		if(QDELETED(O) || O.is_stump())
 			continue
 
 		O.update_icon()
@@ -312,7 +312,7 @@ There are several things that need to be remembered:
 
 //BASE MOB SPRITE
 /mob/living/carbon/human/proc/update_body(var/update_icons=1, var/force_base_icon = FALSE)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	var/husk_color_mod = rgb(96,88,80)
@@ -474,7 +474,7 @@ There are several things that need to be remembered:
 
 //HAIR OVERLAY
 /mob/living/carbon/human/proc/update_hair(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	//Reset our hair
@@ -512,7 +512,7 @@ There are several things that need to be remembered:
 		update_icon()
 
 /mob/living/carbon/human/update_mutations(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	var/fat
@@ -545,10 +545,11 @@ There are several things that need to be remembered:
 /* --------------------------------------- */
 //For legacy support.
 /mob/living/carbon/human/regenerate_icons()
-	if (QDELING(src))
+	..()
+
+	if(QDELETED(src))
 		return
 
-	..()
 
 	if(transforming)
 		return
@@ -587,7 +588,7 @@ There are several things that need to be remembered:
 //vvvvvv UPDATE_INV PROCS vvvvvv
 
 /mob/living/carbon/human/update_inv_w_uniform(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	if(check_draw_underclothing())
@@ -633,7 +634,7 @@ There are several things that need to be remembered:
 		update_icon()
 
 /mob/living/carbon/human/update_inv_wear_id(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	overlays_raw[ID_LAYER] = null
@@ -676,7 +677,7 @@ There are several things that need to be remembered:
 		update_icon()
 
 /mob/living/carbon/human/update_inv_gloves(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 
@@ -713,7 +714,7 @@ There are several things that need to be remembered:
 		update_icon()
 
 /mob/living/carbon/human/update_inv_glasses(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	if(check_draw_glasses())
@@ -755,7 +756,7 @@ There are several things that need to be remembered:
 		update_icon()
 
 /mob/living/carbon/human/update_inv_l_ear(var/update_icons=1)
-	if(QDELING(src))
+	if(QDELETED(src))
 		return
 
 	if(check_draw_left_ear())
@@ -787,7 +788,7 @@ There are several things that need to be remembered:
 		update_icon()
 
 /mob/living/carbon/human/update_inv_r_ear(var/update_icons=1)
-	if(QDELING(src))
+	if(QDELETED(src))
 		return
 
 	if(check_draw_right_ear())
@@ -819,7 +820,7 @@ There are several things that need to be remembered:
 		update_icon()
 
 /mob/living/carbon/human/update_inv_shoes(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	if(check_draw_shoes())
@@ -878,7 +879,7 @@ There are several things that need to be remembered:
 		update_icon()
 
 /mob/living/carbon/human/update_inv_s_store(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	if(s_store)
@@ -901,7 +902,7 @@ There are several things that need to be remembered:
 		update_icon()
 
 /mob/living/carbon/human/update_inv_head(update_icons = TRUE, recurse = TRUE)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	overlays_raw[HEAD_LAYER] = null
@@ -938,7 +939,7 @@ There are several things that need to be remembered:
 		update_icon()
 
 /mob/living/carbon/human/update_inv_belt(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	if(belt)
@@ -979,7 +980,7 @@ There are several things that need to be remembered:
 		update_icon()
 
 /mob/living/carbon/human/update_inv_wear_suit(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	if(wear_suit)
@@ -1016,7 +1017,7 @@ There are several things that need to be remembered:
 
 
 /mob/living/carbon/human/update_inv_pockets(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	if(update_icons)
@@ -1024,7 +1025,7 @@ There are several things that need to be remembered:
 
 
 /mob/living/carbon/human/update_inv_wear_mask(update_icons = TRUE, recurse = TRUE)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	overlays_raw[FACEMASK_LAYER] = null
@@ -1063,7 +1064,7 @@ There are several things that need to be remembered:
 
 
 /mob/living/carbon/human/update_inv_back(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	if(back)
@@ -1116,7 +1117,7 @@ There are several things that need to be remembered:
 		hud_used.r_hand_hud_object.update_icon()
 
 /mob/living/carbon/human/update_inv_handcuffed(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	if(handcuffed)
@@ -1141,7 +1142,7 @@ There are several things that need to be remembered:
 		update_icon()
 
 /mob/living/carbon/human/update_inv_legcuffed(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	if(legcuffed)
@@ -1167,7 +1168,7 @@ There are several things that need to be remembered:
 		update_icon()
 
 /mob/living/carbon/human/update_inv_l_hand(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 
@@ -1204,7 +1205,7 @@ There are several things that need to be remembered:
 		update_icon(forceDirUpdate = TRUE)
 
 /mob/living/carbon/human/update_inv_r_hand(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	if(r_hand)
@@ -1240,7 +1241,7 @@ There are several things that need to be remembered:
 		update_icon(forceDirUpdate = TRUE)
 
 /mob/living/carbon/human/update_inv_wrists(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	overlays_raw[WRISTS_LAYER] = null
@@ -1291,7 +1292,7 @@ There are several things that need to be remembered:
 
 /mob/living/carbon/human/proc/update_tail_showing(var/update_icons=1)
 
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	overlays_raw[TAIL_NORTH_LAYER] = null
@@ -1309,7 +1310,7 @@ There are several things that need to be remembered:
 		update_icon()
 
 /mob/living/carbon/human/proc/get_tail_icon()
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	var/icon_key = "[species.race_key][r_skin][g_skin][b_skin][r_hair][g_hair][b_hair]"
@@ -1404,7 +1405,7 @@ There are several things that need to be remembered:
 //Adds a collar overlay above the helmet layer if the suit has one
 //	Suit needs an identically named sprite in icons/mob/collar.dmi
 /mob/living/carbon/human/proc/update_collar(var/update_icons=1)
-	if (QDELING(src))
+	if (QDELETED(src))
 		return
 
 	var/list/collar_mapping	= SSicon_cache.collar_states
@@ -1421,7 +1422,7 @@ There are several things that need to be remembered:
 
 // update_fire()
 /mob/living/carbon/human/update_fire(var/update_icons = TRUE)
-	if(QDELING(src))
+	if(QDELETED(src))
 		return
 
 	var/image/fire_image_lower = on_fire ? image(species.onfire_overlay, "lower", layer = FIRE_LAYER_LOWER) : null

--- a/html/changelogs/FluffyGhost-prevent_icon_reprocessing_on_deleted_mob.yml
+++ b/html/changelogs/FluffyGhost-prevent_icon_reprocessing_on_deleted_mob.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Turned QDELING to QDELETED, preventing reprocessing on deleted mobs, not only the ones currently being Destroy'd."


### PR DESCRIPTION
Turned QDELING to QDELETED, preventing reprocessing on deleted mobs, not only the ones currently being Destroy'd