### PR TITLE
Qdel find refs skip confirmation

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -252,7 +252,7 @@ SUBSYSTEM_DEF(garbage)
 			if (QDEL_HINT_FINDREFERENCE)//qdel will, if REFERENCE_TRACKING is enabled, display all references to this object, then queue the object for deletion.
 				SSgarbage.QueueForQueuing(D)
 				#ifdef REFERENCE_TRACKING
-				INVOKE_ASYNC(D, TYPE_PROC_REF(/datum, find_references))
+				INVOKE_ASYNC(D, TYPE_PROC_REF(/datum, find_references), TRUE)
 				#endif
 			if (QDEL_HINT_IFFAIL_FINDREFERENCE) // qdel will, if REFERENCE_TRACKING is enabled and the object fails to collect, display all references to this object
 				SSgarbage.QueueForQueuing(D)

--- a/html/changelogs/FluffyGhost-qdel_find_refs_skip_confirmation.yml
+++ b/html/changelogs/FluffyGhost-qdel_find_refs_skip_confirmation.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "If something returns the request to search for refs in Destroy, and all the other reference tracking conditions are met, start the search for the reference without prompting a confirmation box."


### PR DESCRIPTION
If something returns the request to search for refs in Destroy, and all the other reference tracking conditions are met, start the search for the reference without prompting a confirmation box