### PR TITLE
Psi Grip Tweak

### DIFF
--- a/code/modules/psionics/abilities/grip.dm
+++ b/code/modules/psionics/abilities/grip.dm
@@ -39,7 +39,7 @@
 	if(!.)
 		return
 
-	var/has_line_of_sight = null
+	var/has_line_of_sight = FALSE
 	SPATIAL_CHECK_LOS(has_line_of_sight, user, victim, world.view)
 	if(!has_line_of_sight)
 		to_chat(user, SPAN_WARNING("You don't have a direct line of sight to \the [victim]!"))
@@ -65,7 +65,7 @@
 
 	var/mob/living/M = hit_atom
 
-	var/has_line_of_sight = null
+	var/has_line_of_sight = FALSE
 	SPATIAL_CHECK_LOS(has_line_of_sight, user, M, world.view)
 	if(!has_line_of_sight)
 		to_chat(user, SPAN_WARNING("You don't have a direct line of sight to \the [M]!"))

--- a/code/modules/psionics/abilities/grip.dm
+++ b/code/modules/psionics/abilities/grip.dm
@@ -38,6 +38,11 @@
 	. = ..()
 	if(!.)
 		return
+
+	if(!(victim in view(7, get_turf(user))))
+		to_chat(user, SPAN_WARNING("You don't have a direct line of sight to \the [victim]!"))
+		return
+
 	user.visible_message(SPAN_WARNING("[user] squeezes [user.get_pronoun("his")] hand!"), SPAN_WARNING("You squeeze your hand to tighten the psionic force around [victim]."))
 	log_and_message_admins("[key_name(owner)] has psionically crushed [victim]", owner, get_turf(owner))
 	to_chat(victim, SPAN_DANGER(FONT_HUGE("You are crushed by an invisible force!")))
@@ -55,7 +60,12 @@
 	. = ..()
 	if(!.)
 		return
+
 	var/mob/living/M = hit_atom
+	if(!(M in view(7, get_turf(user))))
+		to_chat(user, SPAN_WARNING("You don't have a direct line of sight to \the [M]!"))
+		return
+
 	user.visible_message(SPAN_DANGER("[user] extends [user.get_pronoun("his")] arm and makes a grab motion towards [M]!"),
 						SPAN_DANGER("You extend your arm and grab [M] with your psionic energy!"))
 	to_chat(M, SPAN_DANGER("You feel an invisible force tighten around you!"))

--- a/code/modules/psionics/abilities/grip.dm
+++ b/code/modules/psionics/abilities/grip.dm
@@ -39,7 +39,9 @@
 	if(!.)
 		return
 
-	if(!(victim in view(7, get_turf(user))))
+	var/has_line_of_sight = null
+	SPATIAL_CHECK_LOS(has_line_of_sight, user, victim, world.view)
+	if(!has_line_of_sight)
 		to_chat(user, SPAN_WARNING("You don't have a direct line of sight to \the [victim]!"))
 		return
 
@@ -62,7 +64,10 @@
 		return
 
 	var/mob/living/M = hit_atom
-	if(!(M in view(7, get_turf(user))))
+
+	var/has_line_of_sight = null
+	SPATIAL_CHECK_LOS(has_line_of_sight, user, M, world.view)
+	if(!has_line_of_sight)
 		to_chat(user, SPAN_WARNING("You don't have a direct line of sight to \the [M]!"))
 		return
 

--- a/html/changelogs/geeves-give_em_an_inch.yml
+++ b/html/changelogs/geeves-give_em_an_inch.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "You now need a direct line of sight to establish and use the Psi Grip (crush) ability. You do not have to maintain line of sight to keep the grip active, however."


### PR DESCRIPTION
* You now need a direct line of sight to establish and use the Psi Grip (crush) ability. You do not have to maintain line of sight to keep the grip active, however.

https://forums.aurorastation.org/topic/19554-add-a-cooldown-remove-or-alter-psionic-head-crush