### PR TITLE
Ship Sensor View Fix

### DIFF
--- a/code/__defines/dcs/signals.dm
+++ b/code/__defines/dcs/signals.dm
@@ -84,4 +84,7 @@
 /// updates sprites
 #define COMSIG_ITEM_ICON_UPDATE "icon_update"
 
+// tgui signals
+#define COMSIG_TGUI_CLOSE "tgui_close"
+
 /*******Component Specific Signals*******/

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1408,6 +1408,7 @@
 		machine_has_equipment_vision = machine.grants_equipment_vision(src)
 	if(eyeobj && eyeobj.owner != src)
 		reset_view(null)
+
 	if((mRemote in mutations) && remoteview_target && remoteview_target.stat != CONSCIOUS)
 		remoteview_target = null
 		reset_view(null, 0)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1404,21 +1404,17 @@
 		if(viewflags < 0)
 			reset_view(null, 0)
 		else if(viewflags)
-			set_sight(sight, viewflags)
+			set_sight(sight|viewflags)
 		machine_has_equipment_vision = machine.grants_equipment_vision(src)
-	else if(eyeobj)
-		if(eyeobj.owner != src)
-			reset_view(null)
-	else
-		var/isRemoteObserve = 0
-		if(z_eye && client?.eye == z_eye && !is_physically_disabled())
-			isRemoteObserve = 1
-		if(remoteview_target)
-			if(remoteview_target.stat==CONSCIOUS)
-				isRemoteObserve = 1
-		if(!isRemoteObserve && client && !client.adminobs)
-			remoteview_target = null
-			reset_view(null, 0)
+	if(eyeobj && eyeobj.owner != src)
+		reset_view(null)
+	if((mRemote in mutations) && remoteview_target && remoteview_target.stat != CONSCIOUS)
+		remoteview_target = null
+		reset_view(null, 0)
+
+	update_equipment_vision()
+	species.handle_vision(src)
+
 
 	update_equipment_vision(machine_has_equipment_vision)
 	species.handle_vision(src)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1412,10 +1412,6 @@
 		remoteview_target = null
 		reset_view(null, 0)
 
-	update_equipment_vision()
-	species.handle_vision(src)
-
-
 	update_equipment_vision(machine_has_equipment_vision)
 	species.handle_vision(src)
 

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -116,6 +116,7 @@
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "Helm", capitalize_first_letters(name))
+		RegisterSignal(ui, COMSIG_TGUI_CLOSE, PROC_REF(handle_unlook_signal))
 		ui.open()
 
 /obj/machinery/computer/ship/helm/ui_data(mob/user)

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -84,6 +84,7 @@
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "Sensors", capitalize_first_letters(name))
+		RegisterSignal(ui, COMSIG_TGUI_CLOSE, PROC_REF(handle_unlook_signal))
 		ui.open()
 
 /obj/machinery/computer/ship/sensors/ui_data(mob/user)

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -60,6 +60,11 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 		LAZYDISTINCTADD(linked.navigation_viewers, WEAKREF(user))
 	ADD_TRAIT(user, TRAIT_COMPUTER_VIEW, ref(src))
 
+/obj/machinery/computer/ship/proc/handle_unlook_signal(var/datum/source, var/mob/user)
+	SIGNAL_HANDLER
+
+	unlook(user)
+
 /obj/machinery/computer/ship/proc/unlook(var/mob/user)
 	user.reset_view()
 	var/client/c = user.client

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -60,6 +60,7 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 		LAZYDISTINCTADD(linked.navigation_viewers, WEAKREF(user))
 	ADD_TRAIT(user, TRAIT_COMPUTER_VIEW, ref(src))
 
+/// Handles disabling the user's overmap view when a signal comes in, primarily used when the TGUI is closed, see helm.dm and sensors.dm
 /obj/machinery/computer/ship/proc/handle_unlook_signal(var/datum/source, var/mob/user)
 	SIGNAL_HANDLER
 

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -143,6 +143,7 @@
 		window.release_lock()
 		window.close(can_be_suspended)
 		src_object.ui_close(user)
+		SEND_SIGNAL(src, COMSIG_TGUI_CLOSE, user)
 		SStgui.on_close(src)
 	state = null
 	qdel(src)

--- a/html/changelogs/geeves-ship_sensor_view_fix.yml
+++ b/html/changelogs/geeves-ship_sensor_view_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Interacting with other ship UIs will no longer drop the sensor view randomly."


### PR DESCRIPTION
* Interacting with other ship UIs will no longer drop the sensor view randomly.

The `handle_vision` changes were ported from Nebula.