### PR TITLE
Overmap Edge Fix

### DIFF
--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -69,6 +69,7 @@
 	else if(generic_object == TRUE)
 		return desc
 
+/// Returns the direction the overmap object is moving in, rather than just the way it's facing
 /obj/effect/overmap/proc/get_heading()
 	return dir
 

--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -69,19 +69,24 @@
 	else if(generic_object == TRUE)
 		return desc
 
+/obj/effect/overmap/proc/get_heading()
+	return dir
+
 /obj/effect/overmap/proc/handle_wraparound()
 	var/nx = x
 	var/ny = y
 	var/low_edge = 1
 	var/high_edge = current_map.overmap_size - 1
 
-	if((dir & WEST) && x == low_edge)
+	var/heading = get_heading()
+
+	if((heading & WEST) && x == low_edge)
 		nx = high_edge
-	else if((dir & EAST) && x == high_edge)
+	else if((heading & EAST) && x == high_edge)
 		nx = low_edge
-	if((dir & SOUTH)  && y == low_edge)
+	if((heading & SOUTH)  && y == low_edge)
 		ny = high_edge
-	else if((dir & NORTH) && y == high_edge)
+	else if((heading & NORTH) && y == high_edge)
 		ny = low_edge
 	if((x == nx) && (y == ny))
 		return //we're not flying off anywhere

--- a/code/modules/overmap/ships/ship.dm
+++ b/code/modules/overmap/ships/ship.dm
@@ -138,7 +138,7 @@ var/const/OVERMAP_SPEED_CONSTANT = (1 SECOND)
 /obj/effect/overmap/visitable/ship/proc/get_speed_xy()
 	return list(round(speed[1], SHIP_MOVE_RESOLUTION), round(speed[2], SHIP_MOVE_RESOLUTION))
 
-/obj/effect/overmap/visitable/ship/proc/get_heading()
+/obj/effect/overmap/visitable/ship/get_heading()
 	var/res = 0
 	if(MOVING(speed[1]))
 		if(speed[1] > 0)

--- a/html/changelogs/geeves-overmap_edge_fix.yml
+++ b/html/changelogs/geeves-overmap_edge_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed ships not wrapping around the other side of the overmap when the faced direction was different from the heading."


### PR DESCRIPTION
* Fixed ships not wrapping around the other side of the overmap when the faced direction was different from the heading.