### PR TITLE
Ranger Ship engine fix I guess

### DIFF
--- a/html/changelogs/LynxSolstice-Ranger-engine-power-fix.yml
+++ b/html/changelogs/LynxSolstice-Ranger-engine-power-fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: LynxSolstice
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Changed the Area Power Consoles in the ranger ship to use higher charge cells in order to fix the issue of rangers running out of power in their APCs due to a high powerdraw from the engines."

--- a/maps/away/ships/coc/coc_ranger/coc_ship.dmm
+++ b/maps/away/ships/coc/coc_ranger/coc_ship.dmm
@@ -1395,11 +1395,12 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/machinery/power/apc/north{
-	req_access = null
-	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/north{
+	req_access = null;
+	cell_type = /obj/item/cell/hyper
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/ranger_corvette/engine1)
@@ -2045,11 +2046,12 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/machinery/power/apc/north{
-	req_access = null
-	},
 /obj/structure/cable/green{
 	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/north{
+	req_access = null;
+	cell_type = /obj/item/cell/hyper
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/ranger_corvette/engine2)


### PR DESCRIPTION
Should hopefully fix rangers running out of power while flying because their APCs give out due to powerdraw.

Tweak: Changed the Area Power Consoles in the ranger ship to use higher charge cells in order to fix the issue of rangers running out of power in their APCs due to a high powerdraw from the engines.