### PR TITLE
Scarab Ship Convenience Tweaks and Bugfixes

### DIFF
--- a/html/changelogs/RustingWithYou - ihatemylife.yml
+++ b/html/changelogs/RustingWithYou - ihatemylife.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes non-functional shuttle airlocks on the Scarab ship."
+  - maptweak: "Several changes for convenience and utility on the Scarab ship."

--- a/html/changelogs/RustingWithYou - ihatemylife.yml
+++ b/html/changelogs/RustingWithYou - ihatemylife.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: RustingWithYou
+author: RustingWithYou, Hazelmouse
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dm
@@ -186,3 +186,14 @@
 
 /obj/machinery/light/colored/decayed/dimmed
 	brightness_power = 0.2
+
+/obj/item/paper/fluff/scarab
+	name = "Technician's Notice"
+	info = "NOTICE FOR ALL TECHNICIANS! If a single one of you melts ANY portion of our ship EVER again, I will see you summarily released at our nearest port with as little of our food as I can POSSIBLY spare you! Since wasting paper on this matter has apparently become essential, you will now keep this notice adjacent to the combustion engine AT ALL TIMES! This is our ship's combustion engine. We burn a fire in the chamber, let it fully burn out, and then run the superheated gas through a vent, into our thermoelectric generator, and back into the chamber. This produces a lot of power, and will be required to keep our SMES topped up in the long term. It will slowly cool down, and may occasionally need more burner mix to be injected to keep it hot enough for our needs. Repairing the inside of the chamber may occasionally become necessary, as a particularly hot burn will damage the walls and windows. GUIDE FOR USE: Step one: configure the mixer to output a 60% oxygen and 40% hydrogen mix. Inject a few hundred kPa of this mix into the chamber. Step 2: cut injection, and ignite the mix. Do not panic when the glass makes a noise, that is normal. Step 3: once the fire has fully burned out, enable injection and output, so the gas begins to circulate through the thermoelectric generator. Feel at liberty to diverge from these intructions, ingenuity and invention is at the heart of our fleet - but be careful!"
+
+/obj/item/paper/fluff/scarab/Initialize()
+	. = ..()
+	var/languagetext = "\[lang=3\]"
+	languagetext += "[info]\[/lang\]"
+	info = parsepencode(languagetext)
+	icon_state = "paper_words"

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dm
@@ -177,8 +177,8 @@
 	landmark_tag = "nav_scarab_transit"
 	base_turf = /turf/space/transit/north
 
-	// CUSTOM STUFF
-	// dimmed yellow lights
+// CUSTOM STUFF
+// dimmed yellow lights
 /obj/machinery/light/floor/decayed
 	brightness_color = "#fabd6d"
 	randomize_color = FALSE

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dm
@@ -132,6 +132,7 @@
 /obj/effect/shuttle_landmark/coc_scarab/harvester_start
 	name = "Scarab Salvage Vessel - Harvester Dock"
 	landmark_tag = "nav_scarab_harvester_start"
+	docking_controller = "scarab_harvester"
 
 /obj/effect/shuttle_landmark/coc_scarab/harvester_transit
 	name = "In transit"
@@ -171,6 +172,7 @@
 /obj/effect/shuttle_landmark/coc_scarab/shuttle_start
 	name = "Scarab Salvage Vessel - Shuttle Dock"
 	landmark_tag = "nav_scarab_start"
+	docking_controller = "scarab_shuttle"
 
 /obj/effect/shuttle_landmark/coc_scarab/shuttle_transit
 	name = "In transit"

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dm
@@ -132,7 +132,6 @@
 /obj/effect/shuttle_landmark/coc_scarab/harvester_start
 	name = "Scarab Salvage Vessel - Harvester Dock"
 	landmark_tag = "nav_scarab_harvester_start"
-	docking_controller = "scarab_harvester"
 
 /obj/effect/shuttle_landmark/coc_scarab/harvester_transit
 	name = "In transit"
@@ -172,9 +171,18 @@
 /obj/effect/shuttle_landmark/coc_scarab/shuttle_start
 	name = "Scarab Salvage Vessel - Shuttle Dock"
 	landmark_tag = "nav_scarab_start"
-	docking_controller = "scarab_shuttle"
 
 /obj/effect/shuttle_landmark/coc_scarab/shuttle_transit
 	name = "In transit"
 	landmark_tag = "nav_scarab_transit"
 	base_turf = /turf/space/transit/north
+
+	// CUSTOM STUFF
+	// dimmed yellow lights
+/obj/machinery/light/floor/decayed
+	brightness_color = "#fabd6d"
+	randomize_color = FALSE
+	brightness_power = 0.3
+
+/obj/machinery/light/colored/decayed/dimmed
+	brightness_power = 0.2

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dmm
@@ -3,6 +3,8 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
 	},
+/obj/machinery/meter,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
 "ab" = (
@@ -16,8 +18,8 @@
 /obj/machinery/body_scanconsole{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner_wide/paleblue/full,
+/turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "ah" = (
 /obj/structure/railing/mapped{
@@ -46,6 +48,7 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
+/obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "an" = (
@@ -100,7 +103,9 @@
 "aS" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/fancy/tray,
-/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/effect/floor_decal/corner_wide/lime/full{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "aT" = (
@@ -126,8 +131,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
 /area/coc_scarab/medical)
 "aX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
@@ -153,7 +158,7 @@
 /obj/item/clothing/shoes/workboots,
 /obj/item/clothing/shoes/workboots,
 /obj/item/clothing/shoes/workboots,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "bg" = (
 /obj/structure/cable/yellow{
@@ -172,11 +177,11 @@
 /turf/simulated/floor/reinforced/airless,
 /area/coc_scarab/engine)
 "bo" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/effect/floor_decal/corner_wide/paleblue/diagonal,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "bp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
@@ -190,6 +195,7 @@
 /area/shuttle/coc_scarab)
 "bt" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/structure/curtain/open/medical,
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "bu" = (
@@ -222,6 +228,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
 /turf/simulated/floor/airless,
 /area/space)
 "bJ" = (
@@ -230,6 +240,10 @@
 "bL" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate/loot,
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 8
+	},
 /turf/simulated/floor/airless,
 /area/space)
 "bN" = (
@@ -268,6 +282,7 @@
 /turf/space/dynamic,
 /area/space)
 "bR" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/coc_scarab/armory)
 "bT" = (
@@ -282,14 +297,25 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	layer = 2.71
+	},
 /turf/simulated/floor/airless,
 /area/space)
+"bV" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "cc" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "ck" = (
@@ -298,9 +324,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/railing/mapped{
-	dir = 8
 	},
 /obj/effect/shuttle_landmark/coc_scarab/shuttle_start{
 	dir = 8
@@ -387,7 +410,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "cE" = (
@@ -421,7 +444,14 @@
 "cN" = (
 /obj/effect/floor_decal/spline/plain/black,
 /obj/structure/table/steel,
-/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_y = 4;
+	pixel_x = -10
+	},
+/obj/item/reagent_containers/glass/rag{
+	pixel_y = 3;
+	pixel_x = 4
+	},
 /turf/simulated/floor/lino,
 /area/coc_scarab/mess)
 "cR" = (
@@ -446,33 +476,46 @@
 	dir = 4;
 	name = "Operating Theatre"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "di" = (
 /obj/item/storage/box/masks{
-	pixel_x = 4;
-	pixel_y = 4
+	pixel_x = -4;
+	pixel_y = 10
 	},
-/obj/item/storage/box/gloves,
+/obj/item/storage/box/gloves{
+	pixel_x = -5;
+	pixel_y = -4
+	},
 /obj/structure/table/standard,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/effect/floor_decal/corner_wide/lime/full{
+	dir = 1
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	icon_state = "sterilesprayblue";
+	name = "surgery cleaner";
+	pixel_w = 6;
+	pixel_x = 7
+	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "dn" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/valve{
 	dir = 8;
 	name = "Fuel Line Merge"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/space/dynamic,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/airless,
 /area/space)
 "dt" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
@@ -513,8 +556,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner_wide/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "dx" = (
 /obj/structure/lattice/catwalk/indoor,
@@ -533,6 +576,10 @@
 	layer = 2.8
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "dE" = (
@@ -559,6 +606,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/thrust2)
+"dL" = (
+/obj/structure/lattice,
+/obj/structure/sign/securearea{
+	pixel_x = 32
+	},
+/turf/template_noop,
+/area/space)
+"dM" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"dR" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 8
+	},
+/turf/template_noop,
+/area/space)
 "dS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -566,6 +634,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
 "dV" = (
@@ -577,15 +646,24 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/siphon/atmos{
 	dir = 4;
-	id_tag = "scarab_harvest_vent"
+	id_tag = "scavver_harvester_in";
+	frequency = 1442
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/scarab_harvester)
+"ea" = (
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
 "eb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "ec" = (
@@ -593,10 +671,17 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /turf/simulated/floor/airless,
 /area/space)
 "ee" = (
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
 	dir = 8
 	},
 /turf/simulated/floor/airless,
@@ -623,7 +708,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "ey" = (
@@ -632,7 +718,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+/obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
 	},
 /obj/structure/lattice/catwalk/indoor,
@@ -660,14 +746,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "eH" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible/black,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "eK" = (
@@ -675,6 +759,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
+"eL" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "eN" = (
@@ -695,17 +783,22 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/airless,
 /area/space)
 "fa" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 5
-	},
 /obj/machinery/alarm/north{
 	req_one_access = null
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
@@ -726,8 +819,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
 /area/coc_scarab/ammo)
 "fg" = (
 /obj/machinery/atmospherics/unary/engine,
@@ -772,17 +865,14 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/coc_scarab/ammo)
 "fp" = (
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/corner/yellow/full{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "ft" = (
@@ -813,22 +903,16 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "fD" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/airless,
+/turf/template_noop,
 /area/space)
 "fF" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -837,6 +921,11 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/coc_scarab/grauwolf)
+"fQ" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "fS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -853,17 +942,12 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/medical)
 "fU" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+/obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor,
@@ -875,12 +959,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
+"gb" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
 "gc" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless,
 /area/space)
@@ -894,13 +988,24 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
 /turf/simulated/floor/airless,
 /area/space)
 "gi" = (
 /obj/machinery/atmospherics/binary/pump/high_power,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
+"gn" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "go" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable/green{
@@ -921,6 +1026,10 @@
 "gu" = (
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -3;
+	pixel_y = 7
 	},
 /turf/simulated/floor/grass,
 /area/coc_scarab/hydroponics)
@@ -943,9 +1052,6 @@
 /turf/simulated/floor/airless,
 /area/shuttle/coc_scarab)
 "gA" = (
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 5
-	},
 /obj/machinery/power/apc/high/north{
 	req_access = null
 	},
@@ -953,15 +1059,16 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 9
-	},
 /obj/machinery/vending/engivend{
 	req_access = null
 	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/yellow/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "gE" = (
@@ -981,6 +1088,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "gI" = (
@@ -1019,8 +1127,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/valve,
-/obj/effect/floor_decal/industrial/outline/red,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "hb" = (
@@ -1030,11 +1139,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "hg" = (
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "hk" = (
@@ -1044,6 +1156,23 @@
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
 /obj/machinery/alarm/north{
 	req_one_access = null
+	},
+/obj/structure/table/reinforced/steel,
+/obj/item/storage/firstaid/toxin{
+	pixel_y = 16;
+	pixel_x = -3
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_y = 12;
+	pixel_x = -4
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_y = 8;
+	pixel_x = -2
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_y = 4;
+	pixel_x = -5
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
@@ -1087,7 +1216,10 @@
 /area/coc_scarab/equipment)
 "hF" = (
 /obj/structure/table/steel,
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "hI" = (
@@ -1096,8 +1228,8 @@
 /obj/machinery/door/airlock/highsecurity{
 	name = "Ammunition Storage"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/full,
 /area/coc_scarab/ammo)
 "hJ" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
@@ -1111,6 +1243,7 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "hW" = (
@@ -1138,6 +1271,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/hydroponics)
+"ij" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
 "il" = (
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
@@ -1151,7 +1292,10 @@
 /area/coc_scarab/thrust2)
 "is" = (
 /obj/machinery/light,
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "iu" = (
@@ -1216,13 +1360,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/engineering{
-	name = "Equipment Storage"
+/obj/machinery/door/airlock/hatch{
+	name = "Aft Hallway"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
 /area/coc_scarab/medical)
 "iH" = (
 /obj/structure/cable{
@@ -1241,6 +1385,7 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "iI" = (
@@ -1248,9 +1393,20 @@
 	dir = 10
 	},
 /obj/structure/table/steel,
-/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
+/obj/item/reagent_containers/food/drinks/cans/beetle_milk{
+	pixel_x = 11;
+	pixel_y = 3
+	},
 /turf/simulated/floor/lino,
 /area/coc_scarab/mess)
+"iQ" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/sign/drop{
+	desc = "A warning sign which reads 'DANGER: MASS EJECTOR PATH ON THIS SIGN'.";
+	name = "\improper DANGER: MASS EJECTOR PATH sign"
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "iS" = (
 /obj/machinery/power/solar,
 /obj/structure/cable/yellow{
@@ -1263,12 +1419,8 @@
 "iU" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
-	target_pressure = 15000
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	target_pressure = 15000;
+	name = "Gas Mixer to Chamber"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
@@ -1285,13 +1437,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/coc_scarab/ammo)
 "ja" = (
 /obj/structure/table/steel,
-/obj/effect/floor_decal/corner_wide/white/diagonal,
-/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
+/obj/item/reagent_containers/food/drinks/cans/beetle_milk{
+	pixel_y = 4;
+	pixel_x = 9
+	},
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/obj/item/reagent_containers/food/drinks/cans/beetle_milk{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/cans/beetle_milk{
+	pixel_x = 3;
+	pixel_y = -1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "jb" = (
@@ -1307,13 +1472,23 @@
 /obj/machinery/alarm/west{
 	req_one_access = null
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "jh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/computer/general_air_control/large_tank_control/terminal{
+	name = "Fuel Injection Control";
+	frequency = 1442;
+	input_tag = "scavver_teg_fuel_in";
+	sensors = list("scav_sensor"="Combustion Chamber")
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "jk" = (
@@ -1350,14 +1525,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/coc_scarab/grauwolf)
 "jG" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1;
 	layer = 2.8
 	},
+/obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "jM" = (
@@ -1376,13 +1551,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/orange{
+/obj/effect/floor_decal/corner/brown{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
+"jU" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/alarm/west,
+/turf/simulated/floor/grass,
+/area/coc_scarab/hydroponics)
 "jY" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "ka" = (
@@ -1433,7 +1616,7 @@
 /obj/item/clothing/mask/offworlder{
 	color = "#942a15"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "kc" = (
 /obj/effect/map_effect/marker_helper/airlock/out,
@@ -1485,7 +1668,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "kk" = (
@@ -1523,6 +1706,8 @@
 /area/shuttle/scarab_harvester)
 "kz" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "kD" = (
@@ -1538,10 +1723,18 @@
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/coc_scarab)
+"kG" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "kH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "kN" = (
@@ -1549,6 +1742,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "kP" = (
@@ -1579,14 +1773,10 @@
 "lg" = (
 /mob/living/heavy_vehicle/premade/light/salvage,
 /obj/machinery/light,
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/brown/full,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "ln" = (
@@ -1594,12 +1784,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "lq" = (
@@ -1637,17 +1822,20 @@
 	name = "Armory";
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/full,
 /area/coc_scarab/armory)
 "lB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/tank,
+/obj/machinery/atmospherics/pipe/tank{
+	name = "Pressure Tank (Waste)"
+	},
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 5
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "lE" = (
@@ -1674,17 +1862,17 @@
 	dir = 8;
 	frequency = 1442;
 	icon_state = "map_injector";
-	id = "scavver_teg_in"
+	id = "scavver_teg_fuel_in"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/reinforced/airless,
 /area/coc_scarab/engine)
 "lU" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 8
 	},
-/turf/space/dynamic,
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor/airless,
 /area/space)
 "lX" = (
 /obj/structure/railing/mapped{
@@ -1706,6 +1894,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "ml" = (
@@ -1730,6 +1919,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
+"mp" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "ms" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot,
 /turf/simulated/floor/tiled/dark,
@@ -1753,11 +1953,19 @@
 /obj/machinery/mining/brace{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "mw" = (
 /obj/structure/table/steel,
-/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
+/obj/item/reagent_containers/food/drinks/cans/beetle_milk{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/wrench{
+	name = "lucky wrench";
+	pixel_y = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "mE" = (
@@ -1770,12 +1978,11 @@
 /area/coc_scarab/armory)
 "mJ" = (
 /obj/structure/closet/secure_closet/custodial/offship,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/mop,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/massdriver)
 "mK" = (
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -1787,6 +1994,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "mM" = (
@@ -1801,6 +2012,7 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/equipment)
 "mY" = (
@@ -1809,13 +2021,21 @@
 	},
 /turf/space/transit/north,
 /area/space)
+"mZ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 9
+	},
+/turf/template_noop,
+/area/space)
 "nd" = (
 /obj/machinery/button/mass_driver{
 	dir = 4;
 	id = "scarab_corpsechucker";
 	name = "Mass Driver";
 	pixel_x = -24;
-	pixel_y = 10
+	pixel_y = 10;
+	_wifi_id = "scarab_corpsechucker"
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -1865,8 +2085,7 @@
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/coc_scarab/armory)
 "nJ" = (
 /obj/effect/landmark/entry_point/aft,
@@ -1895,11 +2114,7 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/hydrogen,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "nX" = (
@@ -1993,8 +2208,16 @@
 /area/coc_scarab/thrust1)
 "oK" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/purple,
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
+"oM" = (
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
+/area/space)
 "oW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/purple,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -2020,7 +2243,7 @@
 /turf/simulated/floor/airless,
 /area/coc_scarab/solars)
 "pa" = (
-/obj/effect/floor_decal/corner_wide/orange{
+/obj/effect/floor_decal/corner/brown{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2028,10 +2251,9 @@
 "pi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	icon_state = "map-scrubbers"
+	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "pl" = (
@@ -2065,8 +2287,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/coc_scarab/grauwolf)
 "pw" = (
 /obj/structure/cable/green{
@@ -2079,6 +2301,7 @@
 /obj/machinery/door/airlock{
 	name = "Cryogenics"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "px" = (
@@ -2088,6 +2311,7 @@
 "py" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
 "pz" = (
@@ -2126,9 +2350,18 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/effect/floor_decal/corner_wide/lime/full{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
+"pK" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/equipment)
 "pL" = (
 /obj/machinery/computer/ship/sensors/terminal{
 	dir = 1
@@ -2147,8 +2380,21 @@
 	},
 /obj/structure/table/steel,
 /obj/item/reagent_containers/cooking_container/board,
-/obj/item/material/hatchet/butch,
-/obj/item/reagent_containers/food/condiment/shaker/peppermill,
+/obj/item/material/hatchet/butch{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/condiment/shaker/peppermill{
+	pixel_x = -10;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/condiment/shaker/salt{
+	pixel_y = 13;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/condiment/shaker/spacespice{
+	pixel_y = 14;
+	pixel_x = 3
+	},
 /turf/simulated/floor/lino,
 /area/coc_scarab/mess)
 "pS" = (
@@ -2162,6 +2408,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
 "pZ" = (
@@ -2171,7 +2418,8 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/siphon/atmos{
 	dir = 8;
-	id_tag = "scarab_harvest_vent"
+	id_tag = "scavver_harvester_in";
+	frequency = 1442
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/scarab_harvester)
@@ -2204,11 +2452,13 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "qe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/purple,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "qj" = (
@@ -2285,7 +2535,8 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/siphon/atmos{
 	dir = 8;
-	id_tag = "scarab_harvest_vent"
+	id_tag = "scavver_harvester_in";
+	frequency = 1442
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/scarab_harvester)
@@ -2312,7 +2563,6 @@
 /turf/simulated/floor/grass,
 /area/coc_scarab/hydroponics)
 "qQ" = (
-/obj/machinery/vending/hydroseeds,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -2321,6 +2571,9 @@
 	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
+	},
+/obj/machinery/seed_storage/garden{
+	name = "Hydroponics Seed Storage"
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/hydroponics)
@@ -2345,11 +2598,11 @@
 /obj/item/pickaxe/drill,
 /obj/random/prebuilt_ka,
 /obj/random/custom_ka,
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
@@ -2400,6 +2653,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/securearea{
+	pixel_x = 32
+	},
+/obj/structure/sign/securearea{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/equipment)
 "rk" = (
@@ -2439,6 +2699,9 @@
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate/loot,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /turf/simulated/floor/airless,
 /area/space)
 "rx" = (
@@ -2447,17 +2710,17 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "rB" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor,
@@ -2473,13 +2736,19 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/airless,
 /area/space)
 "rP" = (
-/obj/effect/floor_decal/corner_wide/orange,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner_wide/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "rV" = (
@@ -2491,8 +2760,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/coc_scarab/ammo)
 "sd" = (
 /obj/structure/lattice/catwalk/indoor,
@@ -2553,10 +2821,11 @@
 /turf/space/transit/north,
 /area/space)
 "sH" = (
-/obj/machinery/atmospherics/binary/passive_gate{
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	name = "Air to Distribution";
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "sI" = (
@@ -2585,20 +2854,18 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/west,
 /turf/simulated/floor/plating,
 /area/coc_scarab/mess)
 "sL" = (
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 6
-	},
 /obj/structure/table/reinforced/steel,
 /obj/item/stack/material/steel/full,
 /obj/item/stack/material/glass/full,
 /obj/item/stack/material/glass/full,
 /obj/item/stack/material/steel/full,
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "sR" = (
@@ -2611,6 +2878,8 @@
 "te" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/valve,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "th" = (
@@ -2657,6 +2926,7 @@
 /area/space)
 "ty" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/massdriver)
 "tE" = (
@@ -2665,17 +2935,12 @@
 /turf/simulated/floor/lino,
 /area/coc_scarab/mess)
 "tF" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+/obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 6
 	},
 /obj/structure/lattice/catwalk/indoor,
@@ -2725,6 +2990,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "ue" = (
@@ -2749,10 +3015,11 @@
 /turf/template_noop,
 /area/space)
 "uu" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 5
 	},
-/turf/simulated/floor/airless,
+/turf/template_noop,
 /area/space)
 "ux" = (
 /obj/machinery/atmospherics/pipe/tank/air{
@@ -2762,19 +3029,22 @@
 /area/coc_scarab/engine)
 "uI" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "uJ" = (
 /obj/machinery/mineral/rigpress,
-/obj/effect/floor_decal/corner_wide/orange{
+/obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "uK" = (
 /obj/machinery/mass_driver{
 	dir = 8;
-	id = "scarab_corpsechucker"
+	id = "scarab_corpsechucker";
+	_wifi_id = "scarab_corpsechucker"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/reinforced,
@@ -2799,18 +3069,14 @@
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "uN" = (
-/obj/structure/closet/walllocker/medical/secure{
-	name = "Theatre Locker";
-	pixel_x = -32;
-	req_access = null
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 9
 	},
-/obj/item/reagent_containers/blood/OMinus{
-	pixel_x = -7
+/obj/structure/sink/kitchen{
+	dir = 4;
+	name = "surgical sink";
+	pixel_x = -20
 	},
-/obj/item/reagent_containers/blood/OMinus{
-	pixel_x = -7
-	},
-/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "uO" = (
@@ -2836,7 +3102,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 10
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "vj" = (
@@ -2851,7 +3117,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "vm" = (
@@ -2878,6 +3145,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
+"vs" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
+	pixel_x = -4;
+	pixel_y = -8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "vt" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/mining/drill,
@@ -2888,12 +3171,32 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
+"vx" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71
+	},
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "vy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
+"vz" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "vD" = (
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -2901,6 +3204,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/thrust1)
+"vG" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "vI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2918,24 +3229,31 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "vK" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "vQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/valve{
+	name = "Thermal Relief Valve"
 	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "vV" = (
@@ -2975,13 +3293,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/glass_medical{
 	name = "Medical Bay"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/full,
 /area/coc_scarab/mess)
 "wl" = (
 /obj/structure/closet/firecloset/full,
@@ -3004,6 +3322,10 @@
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
+"wq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/lino,
+/area/coc_scarab/mess)
 "wr" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3032,9 +3354,23 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
+"wx" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
 "wB" = (
 /obj/machinery/light{
 	dir = 8
@@ -3043,6 +3379,7 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "wD" = (
@@ -3058,8 +3395,24 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
+"wG" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/coc_scarab/equipment)
 "wI" = (
 /obj/machinery/atmospherics/unary/engine,
 /turf/simulated/floor/airless,
@@ -3067,6 +3420,7 @@
 "wT" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
 "wY" = (
@@ -3075,7 +3429,8 @@
 /area/shuttle/coc_scarab)
 "xe" = (
 /obj/machinery/atmospherics/binary/pump/fuel{
-	dir = 4
+	dir = 4;
+	name = "Fuel to Thrusters"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3111,13 +3466,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "xr" = (
-/obj/effect/floor_decal/corner_wide/paleblue/diagonal,
 /obj/machinery/bodyscanner{
 	dir = 8
+	},
+/obj/effect/floor_decal/corner_wide/paleblue{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
@@ -3140,6 +3500,9 @@
 /turf/simulated/floor/reinforced,
 /area/coc_scarab/massdriver)
 "xI" = (
+/obj/machinery/computer/cryopod{
+	pixel_x = -28
+	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/bunks)
 "xJ" = (
@@ -3221,29 +3584,36 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
+"ym" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/shuttle/scarab_harvester)
 "yo" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "scav_combustion_blast";
+	name = "Combustion ChamberBlast Doors"
 	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor,
-/turf/simulated/floor/airless,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "yu" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/coc_scarab/thrust2)
 "yw" = (
 /obj/machinery/power/smes/buildable/main_engine,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
 /obj/structure/cable/green{
-	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "yL" = (
@@ -3260,6 +3630,7 @@
 /obj/machinery/atmospherics/portables_connector/fuel{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "yQ" = (
@@ -3303,7 +3674,10 @@
 /obj/structure/bed/stool/chair{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "zk" = (
@@ -3316,9 +3690,13 @@
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "zs" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 9
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "zw" = (
@@ -3344,6 +3722,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "zy" = (
@@ -3352,6 +3731,7 @@
 	layer = 2.8
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
 "zB" = (
@@ -3390,6 +3770,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
+"zQ" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/mining/brace{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
 "zU" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/airless,
@@ -3446,8 +3834,7 @@
 /obj/machinery/power/apc/high/north{
 	req_access = null
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/coc_scarab/armory)
 "Av" = (
 /obj/structure/cable{
@@ -3491,6 +3878,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "AL" = (
@@ -3498,6 +3886,7 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "AR" = (
@@ -3523,7 +3912,8 @@
 "AY" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	target_pressure = 15000
+	target_pressure = 15000;
+	name = "Connectors to Cold Loop"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
@@ -3547,9 +3937,13 @@
 /turf/simulated/floor/lino,
 /area/coc_scarab/mess)
 "Be" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
+"Bf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/airless,
+/area/coc_scarab/thrust2)
 "Bh" = (
 /obj/machinery/mineral/processing_unit,
 /obj/effect/floor_decal/industrial/warning{
@@ -3598,7 +3992,8 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/siphon/atmos{
 	dir = 8;
-	id_tag = "scarab_harvest_vent"
+	id_tag = "scavver_harvester_in";
+	frequency = 1442
 	},
 /obj/item/reagent_containers/food/drinks/cans/beetle_milk,
 /turf/simulated/floor/airless,
@@ -3609,11 +4004,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "Bu" = (
@@ -3636,14 +4036,13 @@
 /turf/simulated/floor/grass,
 /area/coc_scarab/hydroponics)
 "BM" = (
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 6
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
 	},
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 10
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/coc_scarab/bridge)
+/area/coc_scarab/mess)
 "BN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
@@ -3665,13 +4064,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/hatch{
 	name = "Engine Room"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "BV" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
@@ -3693,7 +4092,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/structure/sign/fire{
+	name = "\improper DANGER: COMBUSTION CHAMBER sign";
+	pixel_y = -33
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Cj" = (
@@ -3703,6 +4110,7 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "Cm" = (
@@ -3711,6 +4119,7 @@
 	layer = 2.8
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "Co" = (
@@ -3719,6 +4128,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "Cs" = (
@@ -3742,17 +4152,24 @@
 	},
 /turf/simulated/floor/airless,
 /area/space)
-"CD" = (
+"Cz" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	name = "pump to waste"
+	name = "Cooling Array to Generator"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
+"CD" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 8;
+	name = "Scrubbers to Waste"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "CE" = (
@@ -3783,6 +4200,7 @@
 "CP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "CW" = (
@@ -3797,6 +4215,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
+"CX" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "Dj" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -3808,30 +4237,41 @@
 /area/space)
 "Dk" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 5
+/obj/effect/floor_decal/corner/brown/full{
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "Dl" = (
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
-/obj/structure/closet/walllocker/medical{
-	pixel_x = 32;
-	name = "stabilization kit closet"
+/obj/item/reagent_containers/inhaler/pneumalin,
+/obj/item/reagent_containers/inhaler/pneumalin,
+/obj/structure/closet/walllocker/medical/secure{
+	name = "Stabilization Kit";
+	req_access = null;
+	pixel_y = 32
 	},
-/obj/item/reagent_containers/inhaler/pneumalin,
-/obj/item/reagent_containers/inhaler/pneumalin,
+/obj/effect/floor_decal/industrial/outline/red,
 /obj/machinery/light{
-	dir = 1
+	dir = 4;
+	icon_state = "tube_empty"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71
+	},
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/tank/oxygen,
+/obj/item/tank/oxygen,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "Dm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "Dr" = (
@@ -3846,6 +4286,7 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "Dv" = (
@@ -3854,10 +4295,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
+"Dx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "Dz" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
-	layer = 8
+	layer = 8;
+	name = "Scrubbers to Waste"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
@@ -3890,6 +4336,7 @@
 	dir = 4;
 	icon_state = "warning"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/reinforced,
 /area/coc_scarab/grauwolf)
 "DI" = (
@@ -3897,7 +4344,7 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "DN" = (
-/obj/effect/floor_decal/corner_wide/orange{
+/obj/effect/floor_decal/corner/brown{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3909,8 +4356,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
 /area/coc_scarab/armory)
 "Eg" = (
 /obj/machinery/computer/shuttle_control/explore/terminal/scarab_shuttle{
@@ -3942,6 +4389,9 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3976,6 +4426,7 @@
 	dir = 8;
 	name = "Engineering Storage"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "Ew" = (
@@ -3993,6 +4444,7 @@
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "Ex" = (
@@ -4000,15 +4452,15 @@
 	dir = 9
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
 "Ey" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/power/breakerbox,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Ez" = (
@@ -4021,9 +4473,19 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
+"ED" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor/airless,
+/area/space)
 "EG" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/tiled/dark,
@@ -4040,12 +4502,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/maintenance_hatch{
 	dir = 4;
 	name = "Mass Driver"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
 /area/coc_scarab/medical)
 "EN" = (
 /obj/machinery/recharger/wallcharger{
@@ -4064,7 +4526,8 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/siphon/atmos{
 	dir = 4;
-	id_tag = "scarab_harvest_vent"
+	id_tag = "scavver_harvester_in";
+	frequency = 1442
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/scarab_harvester)
@@ -4089,13 +4552,18 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "Fc" = (
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/machinery/iv_drip,
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "Fe" = (
@@ -4103,6 +4571,10 @@
 	dir = 4
 	},
 /obj/structure/table/steel,
+/obj/item/storage/bag/circuits/basic{
+	pixel_x = -10;
+	pixel_y = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "Fh" = (
@@ -4127,7 +4599,10 @@
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 10
 	},
-/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
+/obj/item/reagent_containers/food/drinks/cans/beetle_milk{
+	pixel_y = 10;
+	pixel_x = -11
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
 "Fs" = (
@@ -4144,10 +4619,25 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "Fy" = (
-/obj/machinery/light,
+/obj/effect/floor_decal/corner_wide/paleblue/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/loading/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/coc_scarab/medical)
+"FD" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/loot,
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 4
+	},
 /turf/simulated/floor/airless,
 /area/space)
 "FE" = (
@@ -4160,8 +4650,8 @@
 	name = "Ammunition Storage";
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/full,
 /area/coc_scarab/ammo)
 "FF" = (
 /obj/machinery/computer/general_air_control/large_tank_control/terminal{
@@ -4171,6 +4661,8 @@
 	name = "Carbon Dioxide Supply Monitor";
 	frequency = 1336
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "FG" = (
@@ -4179,6 +4671,10 @@
 	},
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 5
+	},
+/obj/machinery/button/distress{
+	pixel_x = 5;
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
@@ -4191,12 +4687,20 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/lattice/catwalk/indoor/grate/light,
 /turf/simulated/floor/plating,
 /area/coc_scarab/medical)
+"FO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "FP" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -4231,8 +4735,8 @@
 	name = "Flak Battery";
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
 /area/coc_scarab/ammo)
 "Gl" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -4241,6 +4745,15 @@
 /obj/structure/ship_weapon_dummy,
 /turf/simulated/floor/reinforced,
 /area/coc_scarab/grauwolf)
+"Gr" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "Gt" = (
 /obj/machinery/computer/ship/helm/terminal{
 	dir = 1
@@ -4254,6 +4767,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Gv" = (
@@ -4263,9 +4780,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/corner_wide/orange{
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "GA" = (
@@ -4331,15 +4849,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/massdriver)
 "GR" = (
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 10
-	},
 /obj/machinery/light,
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 9
-	},
 /obj/machinery/autolathe,
 /obj/machinery/light,
+/obj/effect/floor_decal/corner/yellow/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "GT" = (
@@ -4354,12 +4868,8 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/airless,
+/obj/structure/lattice,
+/turf/template_noop,
 /area/space)
 "GX" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -4393,9 +4903,19 @@
 /obj/machinery/power/apc/high/east{
 	req_access = null
 	},
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
+"Hs" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/grauwolf)
 "Hu" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4422,6 +4942,7 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "HL" = (
@@ -4453,6 +4974,7 @@
 "HY" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light,
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/airless,
 /area/space)
 "Ia" = (
@@ -4465,13 +4987,24 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "Id" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Ie" = (
@@ -4479,7 +5012,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Il" = (
@@ -4489,12 +5022,32 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "It" = (
 /turf/simulated/floor/airless,
 /area/space)
+"Iu" = (
+/obj/effect/floor_decal/spline/plain/black,
+/obj/structure/table/steel,
+/obj/machinery/reagentgrinder{
+	pixel_y = 11
+	},
+/turf/simulated/floor/lino,
+/area/coc_scarab/mess)
+"Iv" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/obj/item/trash/tray,
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "Iw" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
@@ -4505,13 +5058,12 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/bridge)
 "Ix" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/loading/yellow{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/coc_scarab/engine)
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "IB" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -4527,7 +5079,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor/grate/light,
 /turf/simulated/floor/plating,
 /area/coc_scarab/medical)
 "ID" = (
@@ -4572,15 +5124,15 @@
 /turf/simulated/floor/airless,
 /area/shuttle/coc_scarab)
 "IN" = (
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 6
-	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/high/east{
 	req_access = null
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
@@ -4592,20 +5144,26 @@
 /turf/simulated/floor/reinforced/airless,
 /area/coc_scarab/engine)
 "IZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
+	},
+/obj/structure/lattice/catwalk/indoor/grate/light,
 /turf/simulated/floor/plating,
-/area/coc_scarab/engine)
+/area/coc_scarab/medical)
 "Jc" = (
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/effect/floor_decal/corner_wide/white/diagonal,
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "Je" = (
@@ -4620,6 +5178,7 @@
 	name = "Carbon Dioxide Supply Monitor";
 	frequency = 1339
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
 "Ji" = (
@@ -4637,9 +5196,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner_wide/orange{
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "Js" = (
@@ -4654,8 +5214,15 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
+"Jt" = (
+/obj/structure/lattice,
+/obj/structure/sign/securearea{
+	pixel_x = -32
+	},
+/turf/template_noop,
+/area/space)
 "Jx" = (
 /obj/machinery/computer/ship/targeting,
 /obj/effect/floor_decal/corner_wide/paleblue{
@@ -4664,19 +5231,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
 "Jy" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner_wide/paleblue/diagonal,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/airless,
-/area/space)
+/turf/simulated/floor/tiled/white,
+/area/coc_scarab/medical)
 "JF" = (
 /obj/machinery/power/smes/buildable/horizon_shuttle,
 /obj/structure/cable,
@@ -4691,6 +5251,10 @@
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/machinery/iv_drip,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "JM" = (
@@ -4713,9 +5277,6 @@
 "Kl" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/storage/toolbox/mechanical,
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 10
-	},
 /obj/machinery/cell_charger,
 /obj/machinery/recharger{
 	pixel_x = -6;
@@ -4724,6 +5285,9 @@
 /obj/machinery/recharger{
 	pixel_x = 6;
 	pixel_y = 10
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
@@ -4747,13 +5311,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "Ku" = (
 /obj/structure/table/steel,
-/obj/item/wrench{
-	name = "lucky wrench"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "Kv" = (
@@ -4765,7 +5327,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/full,
 /area/coc_scarab/hydroponics)
 "KA" = (
 /obj/structure/cable/green{
@@ -4784,7 +5347,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "KD" = (
@@ -4807,8 +5373,26 @@
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/coc_scarab/equipment)
+"KJ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/plating,
+/area/coc_scarab/equipment)
 "KR" = (
-/obj/machinery/atmospherics/binary/pump/fuel,
+/obj/machinery/atmospherics/binary/pump/fuel{
+	name = "Fuel to Thrusters"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "KT" = (
@@ -4841,16 +5425,16 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/space/dynamic,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless,
 /area/space)
 "Lf" = (
 /obj/structure/dispenser/oxygen,
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 9
-	},
+/obj/effect/floor_decal/corner/brown/full,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
@@ -4872,17 +5456,17 @@
 /area/space)
 "Lt" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "Lw" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/random,
-/obj/effect/ghostspawpoint{
-	name = "igs - coc_scarab";
-	identifier = "coc_scarab"
+/obj/structure/undies_wardrobe{
+	pixel_y = 1
 	},
-/obj/structure/curtain/open/bed,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "Lx" = (
@@ -4899,6 +5483,13 @@
 	pixel_y = 26;
 	specialfunctions = 4
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/sign/fire{
+	name = "\improper DANGER: COMBUSTION CHAMBER sign";
+	pixel_x = 32
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "LE" = (
@@ -4910,6 +5501,7 @@
 	req_access = null
 	},
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "LI" = (
@@ -4927,7 +5519,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "LM" = (
@@ -4935,6 +5530,7 @@
 	dir = 4;
 	pixel_x = 15
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/lino,
 /area/coc_scarab/mess)
 "LX" = (
@@ -4983,6 +5579,8 @@
 	dir = 1;
 	layer = 2.8
 	},
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
 "Mt" = (
@@ -4993,14 +5591,31 @@
 /turf/simulated/floor/airless,
 /area/shuttle/scarab_harvester)
 "Mv" = (
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 5
-	},
 /obj/machinery/vending/engineering{
 	req_access = null
 	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
+"Mw" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "MC" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5010,6 +5625,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "MD" = (
@@ -5052,22 +5668,19 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "MT" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/coc_scarab/bunks)
 "MV" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/binary/circulator{
-	anchored = 1;
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
+/obj/structure/cable/yellow{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "MW" = (
@@ -5090,6 +5703,11 @@
 /mob/living/heavy_vehicle/premade/ripley/loader,
 /turf/simulated/floor/tiled,
 /area/coc_scarab/ammo)
+"Na" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/airless,
+/area/space)
 "Nb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
@@ -5110,7 +5728,8 @@
 	dir = 4;
 	name = "Crew Quarters"
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "Nd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
@@ -5136,19 +5755,56 @@
 /obj/structure/ship_weapon_dummy,
 /turf/template_noop,
 /area/space)
+"Nr" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/obj/item/trash/snack_bowl{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/item/material/kitchen/utensil/spoon{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "Nz" = (
 /obj/structure/bed/stool/chair{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
+"ND" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor,
+/obj/structure/sign/securearea{
+	pixel_y = -32
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "NR" = (
 /obj/machinery/air_sensor{
 	id_tag = "scarab_thrust1_sensor";
 	frequency = 1336
 	},
-/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
+/obj/item/reagent_containers/food/drinks/cans/beetle_milk{
+	pixel_y = -7;
+	pixel_x = 9
+	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/coc_scarab/thrust1)
 "NT" = (
@@ -5158,6 +5814,7 @@
 "Ob" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
 "Od" = (
@@ -5187,8 +5844,14 @@
 /area/coc_scarab/mess)
 "Og" = (
 /obj/structure/table/reinforced/steel,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/device/binoculars,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/obj/item/device/binoculars{
+	pixel_x = 8;
+	pixel_y = -3
+	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
@@ -5196,7 +5859,10 @@
 /obj/machinery/power/apc/high/north{
 	req_access = null
 	},
-/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
+/obj/item/reagent_containers/food/drinks/cans/beetle_milk{
+	pixel_y = 13;
+	pixel_x = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/grauwolf)
 "Oi" = (
@@ -5212,6 +5878,7 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 5
 	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "Ok" = (
@@ -5223,39 +5890,26 @@
 /area/shuttle/scarab_harvester)
 "Oq" = (
 /obj/item/reagent_containers/blood/OMinus{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/blood/OMinus{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/blood/OMinus{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/blood/OMinus{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/blood/OMinus{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/blood/OMinus{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/blood/OMinus{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/blood/OMinus{
-	pixel_x = -7
+	pixel_x = 1
 	},
 /obj/structure/closet/walllocker/medical/secure{
 	name = "O- Blood Locker";
 	req_access = null;
 	pixel_y = 32
 	},
-/obj/item/reagent_containers/blood/OMinus{
-	pixel_x = -7
-	},
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71
+	},
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/blood/OMinus{
+	pixel_x = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "Os" = (
@@ -5263,12 +5917,12 @@
 	active_power_usage = 7500;
 	tag_east = 1;
 	tag_north = 1;
-	tag_north_con = 0.33;
-	tag_south = 2;
+	tag_north_con = 0;
 	tag_west = 1;
-	tag_west_con = 0.33;
-	tag_east_con = 0.33
+	tag_west_con = 0;
+	tag_east_con = 0
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Ot" = (
@@ -5278,7 +5932,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Ou" = (
@@ -5302,6 +5956,7 @@
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/massdriver)
 "Ov" = (
@@ -5316,9 +5971,6 @@
 /obj/item/plastique/seismic,
 /obj/item/plastique/seismic,
 /obj/item/plastique/seismic,
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 5
-	},
 /obj/item/device/flashlight/lantern,
 /obj/item/device/flashlight/lantern,
 /obj/item/device/flashlight/lantern,
@@ -5327,12 +5979,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 6
+/obj/item/storage/bag/inflatable,
+/obj/item/storage/bag/inflatable,
+/obj/item/storage/bag/inflatable,
+/obj/effect/floor_decal/corner/brown/full{
+	dir = 1
 	},
-/obj/item/storage/bag/inflatable,
-/obj/item/storage/bag/inflatable,
-/obj/item/storage/bag/inflatable,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "Oy" = (
@@ -5342,7 +5995,8 @@
 /obj/structure/railing/mapped,
 /obj/machinery/atmospherics/unary/vent_pump/siphon/atmos{
 	dir = 4;
-	id_tag = "scarab_harvest_vent"
+	id_tag = "scavver_harvester_in";
+	frequency = 1442
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/scarab_harvester)
@@ -5360,15 +6014,14 @@
 /turf/simulated/wall/shuttle/dark/cardinal/red,
 /area/shuttle/scarab_harvester)
 "OM" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/simulated/floor/airless,
-/area/coc_scarab/thrust2)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "OP" = (
 /obj/effect/landmark{
 	name = "carpspawn"
@@ -5387,8 +6040,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/coc_scarab/ammo)
 "Pa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
@@ -5421,6 +6073,10 @@
 /area/shuttle/coc_scarab)
 "Pq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Ps" = (
@@ -5429,7 +6085,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Pv" = (
@@ -5440,25 +6096,43 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
 	},
+/obj/machinery/meter,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "PA" = (
-/obj/effect/floor_decal/spline/plain/black,
-/obj/structure/table/steel,
-/obj/item/reagent_containers/food/drinks/shaker_cup,
-/turf/simulated/floor/lino,
-/area/coc_scarab/mess)
+/obj/effect/floor_decal/corner_wide/paleblue/diagonal,
+/obj/structure/bed/roller,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/turf/simulated/floor/tiled/white,
+/area/coc_scarab/medical)
+"PC" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/shuttle/scarab_harvester)
 "PJ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/corner_wide/white/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/mess)
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/binary/circulator{
+	anchored = 1;
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "PP" = (
 /obj/machinery/chemical_dispenser/coffee/full{
 	pixel_y = 6
 	},
 /obj/structure/table/steel,
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "PR" = (
@@ -5485,7 +6159,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Qb" = (
@@ -5504,6 +6179,7 @@
 	dir = 8;
 	name = "Equipment Storage"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "Qd" = (
@@ -5527,6 +6203,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "Qj" = (
@@ -5541,6 +6218,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
+"Qk" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/obj/item/trash/plate{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/material/kitchen/utensil/fork{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "Ql" = (
 /obj/machinery/door/window/eastleft,
 /turf/simulated/floor/grass,
@@ -5565,8 +6258,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner_wide/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "QA" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -5620,6 +6313,7 @@
 /obj/machinery/portable_atmospherics/canister/empty{
 	name = "waste canister"
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "QO" = (
@@ -5661,6 +6355,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Rc" = (
@@ -5668,6 +6363,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
 "Re" = (
@@ -5755,16 +6451,18 @@
 	dir = 9;
 	pixel_y = 0
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "RA" = (
-/obj/effect/floor_decal/corner_wide/paleblue/diagonal,
 /obj/structure/sign/flag/scarab/large/east{
 	pixel_x = 32
 	},
 /obj/machinery/sleeper{
 	dir = 8
+	},
+/obj/effect/floor_decal/corner_wide/paleblue{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
@@ -5780,11 +6478,31 @@
 "RD" = (
 /obj/machinery/computer/general_air_control/large_tank_control/terminal{
 	name = "Harvesting Vent Control";
-	output_tag = "scarab_harvest_vent";
-	frequency = 1439
+	frequency = 1442;
+	input_tag = "scavver_harvester_in"
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
+"RE" = (
+/obj/effect/floor_decal/corner_wide/lime/full{
+	dir = 4
+	},
+/obj/structure/table/standard,
+/obj/item/reagent_containers/hypospray{
+	pixel_y = -7;
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/glass/bottle/coagzolug{
+	pixel_y = 8;
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/glass/bottle/inaprovaline{
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/coc_scarab/medical)
 "RL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
@@ -5807,9 +6525,31 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
+"RP" = (
+/obj/structure/bed/padded,
+/obj/item/bedsheet/random,
+/obj/effect/ghostspawpoint{
+	name = "igs - coc_scarab";
+	identifier = "coc_scarab"
+	},
+/obj/structure/curtain/open/bed,
+/obj/item/bedsheet/random{
+	pixel_y = 16
+	},
+/obj/effect/ghostspawpoint{
+	name = "igs - coc_scarab";
+	identifier = "coc_scarab"
+	},
+/obj/structure/bed/padded/bunk,
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/bunks)
 "RS" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	layer = 2.71
+	},
 /turf/simulated/floor/airless,
 /area/space)
 "RT" = (
@@ -5837,13 +6577,17 @@
 	pixel_x = -4;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
+/obj/item/reagent_containers/food/drinks/cans/beetle_milk{
+	pixel_x = 5;
+	pixel_y = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "Sb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "Sc" = (
@@ -5866,13 +6610,21 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 5
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "Sf" = (
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
+"Sg" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "Sj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Sm" = (
@@ -5896,6 +6648,21 @@
 /obj/machinery/portable_atmospherics/canister/hydrogen,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
+"SA" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/coc_scarab/mess)
 "SB" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/bar_soft/full{
@@ -5904,18 +6671,20 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/white/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "SD" = (
-/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
 	},
-/turf/simulated/floor/plating,
-/area/coc_scarab/engine)
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "SH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5925,14 +6694,29 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "SM" = (
-/obj/effect/floor_decal/corner_wide/orange{
+/obj/effect/floor_decal/corner/brown{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "SR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/structure/table/reinforced/steel,
+/obj/item/paper{
+	desc = "An old and half-crumpled piece of paper. It's clear that it's seen much use.";
+	name = "Technician's Notice";
+	info = "[lang=3]NOTICE FOR ALL TECHNICIANS! If a single one of you melts ANY portion of our ship EVER again, I will see you summarily released at our nearest port with as little of our food as I can POSSIBLY spare you! Since wasting paper on this matter has apparently become essential, you will now keep this notice adjacent to the combustion engine AT ALL TIMES! This is our ship's combustion engine. We burn a fire in the chamber, let it fully burn out, and then run the superheated gas through a vent, into our thermoelectric generator, and back into the chamber. This produces a lot of power, and will be required to keep our SMES topped up in the long term. It will slowly cool down, and may occasionally need more burner mix to be injected to keep it hot enough for our needs. Repairing the inside of the chamber may occasionally become necessary, as a particularly hot burn will damage the walls and windows. GUIDE FOR USE: Step one: configure the mixer to output a 60% oxygen and 40% hydrogen mix. Inject a few hundred kPa of this mix into the chamber. Step 2: cut injection, and ignite the mix. Do not panic when the glass makes a noise, that is normal. Step 3: once the fire has fully burned out, enable injection and output, so the gas begins to circulate through the thermoelectric generator. Feel at liberty to diverge from these intructions, ingenuity and invention is at the heart of our fleet - but be careful![/lang]";
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/item/pipewrench{
+	pixel_x = 6;
+	pixel_y = 5
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "SV" = (
@@ -5971,6 +6755,10 @@
 	input_tag = "scavver_teg_in";
 	sensors = list("scav_sensor"="Combustion Chamber")
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Tc" = (
@@ -5980,12 +6768,18 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
+"Th" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
+/area/space)
 "Ti" = (
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Tj" = (
@@ -6012,15 +6806,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/generic,
+/obj/structure/extinguisher_cabinet/west,
 /turf/simulated/floor/plating,
 /area/coc_scarab/equipment)
 "Tw" = (
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 5
-	},
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "Tx" = (
@@ -6108,6 +6905,7 @@
 /area/coc_scarab/engine)
 "TN" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
 "TP" = (
@@ -6124,13 +6922,21 @@
 /obj/machinery/power/apc/high/south{
 	req_access = null
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/structure/sign/fire{
+	name = "\improper DANGER: COMBUSTION CHAMBER sign";
+	pixel_y = -33
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "TS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "TT" = (
@@ -6192,6 +6998,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
+"Ue" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/structure/sign/securearea{
+	pixel_y = 32
+	},
+/turf/space/dynamic,
+/area/space)
 "Ug" = (
 /obj/machinery/mineral/processing_unit_console{
 	pixel_y = 28
@@ -6219,6 +7032,10 @@
 	pixel_x = 23;
 	id = "scav_igni"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Um" = (
@@ -6258,17 +7075,14 @@
 /area/coc_scarab/solars)
 "UP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/atmospherics/binary/passive_gate,
+/obj/machinery/atmospherics/binary/passive_gate{
+	name = "Air to Distribution"
+	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "UW" = (
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 10
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
 "UY" = (
@@ -6313,19 +7127,15 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/equipment)
 "Vh" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
-/turf/simulated/floor/airless,
-/area/space)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "Vi" = (
 /obj/machinery/power/solar,
 /obj/structure/cable/yellow,
@@ -6419,24 +7229,22 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/multi_tile/glass{
-	autoclose = 0;
 	dir = 2;
 	name = "Hydroponics"
 	},
-/turf/simulated/floor/tiled,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/full,
 /area/coc_scarab/hydroponics)
 "VN" = (
-/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9
+	dir = 8
 	},
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "scav_combustion_blast";
-	name = "Combustion ChamberBlast Doors"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/coc_scarab/engine)
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor/airless,
+/area/space)
 "VQ" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 8
@@ -6445,7 +7253,9 @@
 /area/shuttle/coc_scarab)
 "VR" = (
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
-/obj/structure/table/rack,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "VS" = (
@@ -6465,13 +7275,10 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/light,
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 10
+/obj/effect/floor_decal/corner/brown/full{
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "Wl" = (
@@ -6485,6 +7292,15 @@
 /obj/structure/bed/roller,
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
+"Ww" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/ore_box,
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "Wx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -6501,6 +7317,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
 "WF" = (
@@ -6513,6 +7330,9 @@
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
@@ -6529,17 +7349,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "WQ" = (
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 6
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/floor_decal/corner/yellow/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "Xe" = (
@@ -6573,6 +7390,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
+"Xm" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/mining/drill,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
 "Xq" = (
 /obj/machinery/atmospherics/portables_connector/fuel{
 	dir = 4
@@ -6581,6 +7409,7 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
+/obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "Xt" = (
@@ -6611,17 +7440,40 @@
 /obj/item/clothing/mask/breath/offworlder/jagmask,
 /obj/item/device/gps/mining,
 /obj/item/clothing/shoes/magboots,
-/obj/effect/floor_decal/corner_wide/orange{
-	dir = 5
-	},
 /obj/item/clothing/shoes/magboots,
 /obj/item/device/gps/mining,
 /obj/item/clothing/mask/breath/offworlder/jagmask,
 /obj/item/tank/jetpack/carbondioxide,
 /obj/random/voidsuit/freebooter,
 /obj/random/voidsuit/freebooter,
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
+"XC" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet/west{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
+"XI" = (
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "XM" = (
 /obj/effect/map_effect/marker_helper/airlock/out,
 /obj/effect/map_effect/marker/airlock/shuttle{
@@ -6635,9 +7487,10 @@
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "XS" = (
-/obj/effect/floor_decal/corner_wide/orange{
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "XU" = (
@@ -6652,17 +7505,16 @@
 	dir = 8
 	},
 /obj/structure/table/steel,
-/obj/item/reagent_containers/food/condiment/shaker/spacespice,
 /obj/item/material/knife{
 	layer = 2.99;
-	pixel_x = -4
+	pixel_x = 10;
+	pixel_y = 5
 	},
 /obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_x = -12;
+	pixel_x = -10;
 	pixel_y = 7
 	},
 /obj/item/material/kitchen/rollingpin,
-/obj/item/reagent_containers/food/condiment/shaker/salt,
 /turf/simulated/floor/lino,
 /area/coc_scarab/mess)
 "Yk" = (
@@ -6672,6 +7524,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
+"Yp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/airless,
+/area/coc_scarab/thrust1)
+"Ys" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
 "Yz" = (
 /obj/machinery/light,
 /turf/simulated/floor/grass,
@@ -6752,13 +7618,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/command{
-	name = "Bridge"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_command{
+	id_tag = null;
+	name = "Bridge";
+	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
 "YY" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
@@ -6788,7 +7656,7 @@
 /obj/machinery/alarm/south{
 	req_one_access = null
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Zl" = (
@@ -6806,6 +7674,14 @@
 "Zp" = (
 /obj/structure/railing/mapped{
 	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"Zu" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
 	},
 /turf/simulated/floor/airless,
 /area/space)
@@ -6856,6 +7732,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "ZI" = (
@@ -6890,10 +7767,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "ZS" = (
@@ -6910,6 +7787,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "ZT" = (
@@ -6931,6 +7809,7 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 
@@ -33262,9 +34141,9 @@ Bm
 gL
 GT
 cV
+XI
 Lo
-Lo
-Lo
+oM
 cV
 gL
 GT
@@ -33516,15 +34395,15 @@ IR
 IR
 px
 ec
-bL
+FD
 GJ
 zU
-It
+FO
 gh
-It
+kG
 zU
 zU
-zU
+Na
 ru
 px
 cn
@@ -33776,9 +34655,9 @@ Il
 bH
 zU
 zU
-Fy
+vz
 Il
-uu
+vG
 zU
 Rr
 HY
@@ -34030,12 +34909,12 @@ jO
 IR
 px
 bU
-Rr
+Ww
 zU
 zU
-It
+mp
 ee
-It
+Zu
 zU
 zU
 bL
@@ -34282,17 +35161,17 @@ vK
 Dm
 MC
 MS
-kg
+Yp
 jO
-px
+Ue
 px
 dE
 ah
 by
 re
+dM
 It
-It
-It
+Th
 re
 by
 re
@@ -34308,7 +35187,7 @@ VK
 VK
 VK
 VK
-tr
+iQ
 VK
 px
 px
@@ -35336,16 +36215,16 @@ bT
 It
 It
 Zp
-ZI
+Ix
 Hm
 mM
 mM
 mM
-qN
-RU
+mM
+mM
 YY
 KT
-Fj
+Hs
 GX
 GP
 Gl
@@ -35597,7 +36476,7 @@ ak
 Sw
 mM
 Uv
-RU
+jU
 RU
 Yz
 YY
@@ -35845,7 +36724,7 @@ lb
 lb
 px
 px
-lb
+dL
 lb
 lb
 lb
@@ -37112,23 +37991,23 @@ Qe
 YF
 UN
 lU
-fD
+oE
 GW
-SD
-Ix
+DI
+Dx
 nV
 iU
-Ix
-IZ
+Eq
+RL
 CD
-Ix
-Ey
+Eq
+fQ
 sH
 ny
 XB
 SM
 pa
-pa
+pK
 jP
 lg
 VS
@@ -37151,10 +38030,10 @@ qK
 BJ
 ab
 ab
-ab
 yR
 yR
 ab
+cB
 cB
 cB
 cB
@@ -37373,13 +38252,13 @@ oE
 cM
 Hp
 LD
-Eq
+bV
 Gu
 Ul
-RL
+Vh
 Rb
-Eq
-Ps
+gn
+fQ
 kN
 ny
 XB
@@ -37391,7 +38270,7 @@ Kl
 VS
 aS
 jY
-jY
+RE
 VS
 fS
 mM
@@ -37410,8 +38289,8 @@ ab
 mt
 RN
 zN
-UW
-Iw
+ab
+ab
 cB
 cB
 cB
@@ -37628,8 +38507,8 @@ UN
 lU
 oE
 cM
-Vl
-ua
+Hp
+Hp
 TC
 pr
 Vl
@@ -37887,9 +38766,9 @@ oE
 cM
 ib
 xJ
-Ay
+Vn
 lO
-Sm
+yo
 Pq
 Id
 vQ
@@ -38140,30 +39019,30 @@ bg
 qp
 bg
 dn
-Vh
+oE
 cM
 ib
 IU
 bj
 IU
-VN
-Eq
-rk
+Sm
+vx
+PJ
 ud
-MV
+rk
 vI
 BS
 rj
 Tu
 cv
-Tu
+KJ
 mS
-rj
+wG
 iG
 Qz
 IC
 FJ
-IC
+IZ
 dw
 wf
 AU
@@ -38173,7 +39052,7 @@ Js
 AU
 sK
 wr
-Js
+SA
 Vp
 AU
 AU
@@ -38396,18 +39275,18 @@ cR
 sV
 jM
 sV
-lU
-Jy
-cM
+VN
+oE
+dR
 ib
 IU
 IU
-Vn
+Ay
 nX
-Pq
+CX
 zs
 gU
-uI
+Cz
 Cb
 kd
 kd
@@ -38418,22 +39297,22 @@ kd
 kd
 VS
 LE
-xh
 bo
-xh
+bo
+Jy
 xh
 Up
 XX
 pQ
 iI
-hg
+BM
 hg
 xp
 Nz
 Nz
 Nz
 Nz
-hg
+BM
 ab
 LY
 hr
@@ -38653,11 +39532,11 @@ cR
 Qe
 ya
 UN
-lU
+VN
 tF
-pl
-Vl
-ua
+mZ
+Hp
+Hp
 ua
 ua
 Vl
@@ -38675,25 +39554,25 @@ XS
 GR
 VS
 Oq
-xh
+Fy
 ae
-Wq
+PA
 Wq
 Up
 TT
-AR
+wq
 cN
 hg
 Lt
 Ia
-hF
-hF
-hF
-hF
-hg
+vs
+Qk
+Iv
+Gr
+BM
 ab
 lE
-vV
+UW
 fY
 zw
 Iw
@@ -38910,7 +39789,7 @@ cR
 sV
 jM
 sV
-lU
+VN
 fU
 Hp
 Hp
@@ -38918,7 +39797,7 @@ Hp
 WF
 dy
 SR
-Sj
+OM
 Sj
 hb
 uI
@@ -38939,11 +39818,11 @@ Fc
 Up
 Of
 AR
-PA
+tE
 hg
-PJ
+BM
 Br
-hF
+Nr
 hF
 ja
 hF
@@ -38952,8 +39831,8 @@ ab
 wl
 Tj
 CW
-BM
-Iw
+ab
+ab
 cB
 cB
 cB
@@ -39167,7 +40046,7 @@ cR
 Qe
 ya
 UN
-lU
+ED
 rB
 uO
 kf
@@ -39176,7 +40055,7 @@ ZS
 ZO
 ww
 et
-Be
+Sg
 vk
 AY
 Ps
@@ -39196,21 +40075,21 @@ VS
 Up
 LX
 AR
-tE
+Iu
 hg
-hg
-xp
+SD
+Mw
 zh
 zh
 zh
 zh
 hg
-ab
 ab
 ab
 yR
 yR
 ab
+cB
 cB
 cB
 cB
@@ -39425,13 +40304,13 @@ sV
 jM
 sV
 lU
-yo
+ND
 Hp
 Hp
 Hp
 Hp
-RL
-Eq
+XC
+MV
 cs
 si
 Oe
@@ -39683,12 +40562,12 @@ ya
 UN
 lU
 ey
-Qd
-DI
+uu
+Hp
 kD
 ue
 AI
-Eq
+Ey
 yw
 TL
 Bn
@@ -39940,7 +40819,7 @@ jM
 sV
 lU
 oE
-cM
+fD
 Hp
 Hp
 Hp
@@ -40214,7 +41093,7 @@ lb
 lb
 ML
 gK
-lb
+Jt
 lb
 cB
 cB
@@ -40743,7 +41622,7 @@ Ru
 MT
 Lw
 ka
-Lw
+RP
 ba
 Ra
 Je
@@ -41734,12 +42613,12 @@ Ob
 pW
 py
 WD
-OM
+dS
 dS
 Lg
 QK
 gc
-VK
+eY
 Lc
 Lc
 Lc
@@ -41988,13 +42867,13 @@ cB
 cB
 fg
 wT
-lc
+Bf
 Jg
 in
 lc
-lc
+Bf
 yu
-px
+Ue
 px
 cn
 lb
@@ -42245,7 +43124,7 @@ cB
 cB
 Ge
 Ex
-lc
+Bf
 yu
 dG
 HL
@@ -42786,7 +43665,7 @@ Kk
 cn
 cB
 wY
-wb
+wx
 bG
 Nd
 eX
@@ -43036,7 +43915,7 @@ AL
 AL
 vy
 RM
-ml
+PC
 fz
 cB
 Kk
@@ -43051,7 +43930,7 @@ fn
 Cj
 fm
 Av
-EW
+ea
 eX
 eX
 aE
@@ -43561,9 +44440,9 @@ HW
 En
 EG
 KY
-KY
-EG
-En
+zQ
+gb
+eL
 SH
 ms
 Gt
@@ -43798,7 +44677,7 @@ Kk
 cn
 pz
 nZ
-il
+ym
 eN
 kR
 MN
@@ -43818,9 +44697,9 @@ Se
 Co
 an
 vt
-vt
-an
-an
+Xm
+Ys
+Ys
 eE
 ms
 Eg
@@ -44062,7 +44941,7 @@ yP
 Fv
 HF
 HF
-il
+ym
 RM
 ml
 fz
@@ -44078,7 +44957,7 @@ xo
 mu
 EG
 En
-En
+eL
 Fh
 pL
 tZ
@@ -44585,13 +45464,13 @@ Kk
 cn
 cB
 wY
-wb
+ij
 DD
 eX
 Ug
 eX
 xR
-En
+eL
 En
 VQ
 IJ

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dmm
@@ -132,7 +132,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/medical)
 "aX" = (
@@ -737,6 +739,7 @@
 	},
 /obj/effect/overmap/visitable/ship/landable/scarab_shuttle,
 /obj/machinery/hologram/holopad/long_range,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "eH" = (
@@ -1122,6 +1125,7 @@
 	name = "Fuel to Thrusters";
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "gK" = (
@@ -1263,10 +1267,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/light/floor/decayed{
+/obj/machinery/light/floor{
 	dir = 8
 	},
-/obj/machinery/light/floor/decayed{
+/obj/machinery/light/floor{
 	dir = 4
 	},
 /turf/simulated/floor/airless,
@@ -1522,14 +1526,17 @@
 /turf/simulated/floor/airless,
 /area/space)
 "iS" = (
-/obj/machinery/power/solar,
-/obj/structure/cable/yellow{
+/obj/structure/cable/green{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/space/dynamic,
-/area/coc_scarab/solars)
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/alarm/west,
+/turf/simulated/floor/plating,
+/area/coc_scarab/mess)
 "iU" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -1957,7 +1964,9 @@
 	name = "Armory";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/coc_scarab/armory)
 "lB" = (
@@ -2831,10 +2840,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light/floor/decayed{
+/obj/machinery/light/floor{
 	dir = 8
 	},
-/obj/machinery/light/floor/decayed{
+/obj/machinery/light/floor{
 	dir = 4
 	},
 /turf/simulated/floor/airless,
@@ -2957,11 +2966,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/light/floor/decayed{
-	dir = 4
-	},
-/obj/machinery/light/floor/decayed{
+/obj/machinery/light/floor{
 	dir = 8
+	},
+/obj/machinery/light/floor{
+	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/coc_scarab/solars)
@@ -4383,6 +4392,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "Cb" = (
@@ -4751,7 +4761,9 @@
 	dir = 8;
 	name = "Engineering Storage"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "Ew" = (
@@ -4832,7 +4844,9 @@
 	dir = 4;
 	name = "Mass Driver"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/massdriver)
 "EJ" = (
@@ -4988,7 +5002,9 @@
 	name = "Ammunition Storage";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/coc_scarab/ammo)
 "FF" = (
@@ -5071,7 +5087,9 @@
 	name = "Flak Battery";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/ammo)
 "Gl" = (
@@ -5521,6 +5539,9 @@
 /obj/structure/flora/ausbushes/sparsegrass{
 	layer = 2
 	},
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 8
+	},
 /turf/simulated/floor/grass,
 /area/coc_scarab/hydroponics)
 "Ji" = (
@@ -5691,7 +5712,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/coc_scarab/hydroponics)
 "KA" = (
@@ -6131,7 +6154,9 @@
 	dir = 4;
 	name = "Crew Quarters"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "Nd" = (
@@ -6515,13 +6540,13 @@
 /area/coc_scarab/engine)
 "PP" = (
 /obj/structure/table/rack,
-/obj/item/soap/plant,
 /obj/effect/floor_decal/corner_wide/grey/diagonal,
 /obj/machinery/light/small{
 	dir = 4;
 	must_start_working = 1
 	},
 /obj/machinery/alarm/south,
+/obj/random/soap,
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/washroom)
 "PR" = (
@@ -6582,7 +6607,9 @@
 	dir = 8;
 	name = "Equipment Storage"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "Qd" = (
@@ -7614,10 +7641,23 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Vi" = (
-/obj/machinery/power/solar,
-/obj/structure/cable/yellow,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/space/dynamic,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk/indoor,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless,
 /area/coc_scarab/solars)
 "Vl" = (
 /turf/simulated/wall/r_wall,
@@ -7639,7 +7679,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -7651,7 +7690,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled,
 /area/coc_scarab/mess)
 "Vr" = (
 /obj/machinery/seed_extractor,
@@ -7722,7 +7763,9 @@
 	dir = 2;
 	name = "Hydroponics"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/coc_scarab/hydroponics)
 "VN" = (
@@ -38480,7 +38523,7 @@ cB
 cB
 cB
 lb
-iS
+Qe
 YF
 UN
 cR
@@ -38996,7 +39039,7 @@ cB
 lb
 Qe
 YF
-Vi
+UN
 cR
 Qe
 YF
@@ -39556,7 +39599,7 @@ wr
 hL
 Vp
 Lt
-AU
+iS
 YV
 xO
 aG
@@ -40280,7 +40323,7 @@ cB
 cB
 lb
 Qe
-YF
+Vi
 UN
 cR
 Qe

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dmm
@@ -73,15 +73,14 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Shuttle"
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
 /obj/machinery/light,
 /obj/machinery/airlock_sensor{
 	pixel_y = -25
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/shuttle/coc_scarab)
 "aE" = (
 /obj/structure/sign/flag/scarab{
@@ -99,6 +98,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
 "aS" = (
@@ -152,13 +152,13 @@
 /obj/structure/closet,
 /obj/item/rig/light/offworlder,
 /obj/item/rig/light/offworlder,
-/obj/machinery/light{
+/obj/item/clothing/shoes/workboots,
+/obj/item/clothing/shoes/workboots,
+/obj/item/clothing/shoes/workboots,
+/obj/item/clothing/shoes/workboots,
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 4
 	},
-/obj/item/clothing/shoes/workboots,
-/obj/item/clothing/shoes/workboots,
-/obj/item/clothing/shoes/workboots,
-/obj/item/clothing/shoes/workboots,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "bg" = (
@@ -202,9 +202,6 @@
 "bu" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/mech_recharger,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
@@ -226,12 +223,12 @@
 /area/shuttle/coc_scarab)
 "bH" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	layer = 2.71
+	},
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 1
 	},
 /turf/simulated/floor/airless,
 /area/space)
@@ -263,8 +260,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Shuttle"
 	},
 /obj/machinery/access_button{
 	pixel_x = 8;
@@ -285,6 +281,9 @@
 /area/space)
 "bR" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/coc_scarab/armory)
 "bT" = (
@@ -367,9 +366,6 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "cu" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack,
 /obj/item/ship_ammunition/grauwolf_bundle,
@@ -400,7 +396,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
-/area/coc_scarab/equipment)
+/area/coc_scarab/hallway)
 "cw" = (
 /obj/effect/landmark/entry_point/port,
 /turf/simulated/wall/shuttle/dark/cardinal/khaki,
@@ -420,11 +416,11 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 8
+	},
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/coc_scarab/grauwolf)
@@ -446,14 +442,6 @@
 "cN" = (
 /obj/effect/floor_decal/spline/plain/black,
 /obj/structure/table/steel,
-/obj/item/reagent_containers/food/drinks/shaker{
-	pixel_y = 4;
-	pixel_x = -10
-	},
-/obj/item/reagent_containers/glass/rag{
-	pixel_y = 3;
-	pixel_x = 4
-	},
 /turf/simulated/floor/lino,
 /area/coc_scarab/mess)
 "cR" = (
@@ -479,6 +467,12 @@
 	name = "Operating Theatre"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "di" = (
@@ -491,9 +485,6 @@
 	pixel_y = -4
 	},
 /obj/structure/table/standard,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner_wide/lime/full{
 	dir = 1
 	},
@@ -503,6 +494,12 @@
 	name = "surgery cleaner";
 	pixel_w = 6;
 	pixel_x = 7
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
@@ -526,9 +523,6 @@
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /obj/machinery/power/apc/high/west{
 	req_access = null
@@ -584,6 +578,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
+"dC" = (
+/obj/effect/floor_decal/spline/plain/black,
+/obj/structure/table/steel,
+/obj/machinery/chemical_dispenser/bar_soft/full{
+	dir = 1;
+	pixel_y = 7
+	},
+/turf/simulated/floor/lino,
+/area/coc_scarab/mess)
 "dE" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -608,20 +611,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/thrust2)
-"dL" = (
-/obj/structure/lattice,
-/obj/structure/sign/securearea{
-	pixel_x = 32
-	},
-/turf/template_noop,
-/area/space)
-"dM" = (
-/obj/effect/floor_decal/industrial/warning{
+"dI" = (
+/obj/structure/toilet{
 	dir = 1;
-	layer = 2.71
+	pixel_y = -1
 	},
-/turf/simulated/floor/airless,
-/area/space)
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/coc_scarab/washroom)
 "dR" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
@@ -653,13 +650,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/scarab_harvester)
-"ea" = (
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/coc_scarab)
 "eb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
@@ -679,11 +669,11 @@
 /turf/simulated/floor/airless,
 /area/space)
 "ee" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
+	dir = 8
+	},
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 8
 	},
 /turf/simulated/floor/airless,
@@ -699,11 +689,10 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Shuttle"
 	},
 /obj/effect/landmark/entry_point/starboard,
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/shuttle/coc_scarab)
 "et" = (
 /obj/structure/cable/yellow{
@@ -729,12 +718,14 @@
 /area/space)
 "eD" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/machinery/light,
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/hydroponics)
@@ -764,10 +755,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
-"eL" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/coc_scarab)
 "eN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -794,9 +781,6 @@
 /turf/simulated/floor/airless,
 /area/space)
 "fa" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
@@ -823,6 +807,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/handrail{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/coc_scarab/ammo)
 "fg" = (
@@ -844,13 +831,13 @@
 	layer = 2.8
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "fn" = (
@@ -879,10 +866,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "ft" = (
-/obj/machinery/light{
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "fz" = (
@@ -924,11 +911,24 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/coc_scarab/grauwolf)
-"fQ" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/coc_scarab/engine)
+"fK" = (
+/obj/structure/bed/padded,
+/obj/item/bedsheet/random,
+/obj/effect/ghostspawpoint{
+	name = "igs - coc_scarab";
+	identifier = "coc_scarab"
+	},
+/obj/structure/curtain/open/bed,
+/obj/item/bedsheet/random{
+	pixel_y = 16
+	},
+/obj/effect/ghostspawpoint{
+	name = "igs - coc_scarab";
+	identifier = "coc_scarab"
+	},
+/obj/structure/bed/padded/bunk,
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/bunks)
 "fS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -942,6 +942,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/coc_scarab/medical)
 "fU" = (
@@ -960,13 +961,9 @@
 /obj/structure/bed/stool/chair/office/bridge/pilot{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/paleblue,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
-"gb" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/coc_scarab)
 "gc" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/cable/green{
@@ -981,6 +978,10 @@
 	},
 /turf/simulated/floor/airless,
 /area/space)
+"gd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/shuttle/scarab_harvester)
 "gf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
@@ -988,11 +989,11 @@
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "gh" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
+	dir = 4
+	},
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 4
 	},
 /turf/simulated/floor/airless,
@@ -1003,6 +1004,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
+"gj" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "gn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -1010,7 +1022,9 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "go" = (
-/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Starboard Propulsion"
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -1026,6 +1040,15 @@
 	},
 /turf/template_noop,
 /area/space)
+"gt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/bunks)
 "gu" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1033,6 +1056,9 @@
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = -3;
 	pixel_y = 7
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	layer = 2
 	},
 /turf/simulated/floor/grass,
 /area/coc_scarab/hydroponics)
@@ -1046,8 +1072,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Shuttle"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -1066,9 +1091,6 @@
 /obj/machinery/vending/engivend{
 	req_access = null
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/yellow/full{
 	dir = 8
 	},
@@ -1084,8 +1106,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Shuttle"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab)
@@ -1097,10 +1118,10 @@
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "gI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 10
+/obj/machinery/atmospherics/binary/pump/fuel{
+	name = "Fuel to Thrusters";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "gK" = (
@@ -1137,6 +1158,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
+"gX" = (
+/obj/structure/cable/green,
+/obj/machinery/power/apc/west,
+/obj/structure/bed/handrail{
+	dir = 1;
+	pixel_y = -2;
+	name = "table handrail";
+	buckle_dir = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/bunks)
 "hb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/structure/cable{
@@ -1147,17 +1179,56 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
+"hd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/high/north{
+	req_access = null
+	},
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/structure/bed/handrail,
+/turf/simulated/floor/tiled/white,
+/area/coc_scarab/washroom)
+"he" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/coc_scarab/medical)
 "hg" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	color = "#647252";
 	name = "green corner"
 	},
+/obj/structure/bed/handrail{
+	dir = 1;
+	pixel_y = -2;
+	name = "table handrail";
+	buckle_dir = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "hk" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
 /obj/machinery/alarm/north{
 	req_one_access = null
@@ -1192,17 +1263,16 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/light/floor{
-	dir = 4
-	},
-/obj/machinery/light/floor{
+/obj/machinery/light/floor/decayed{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/floor/decayed{
+	dir = 4
+	},
 /turf/simulated/floor/airless,
 /area/coc_scarab/solars)
 "hr" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1220,13 +1290,18 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/equipment)
 "hF" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/mess)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/sink{
+	pixel_y = 31
+	},
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/coc_scarab/washroom)
 "hI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1241,8 +1316,30 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, crew quarters"
 	},
+/obj/machinery/door/blast/regular/open{
+	id = "scarab_quarters_shutters";
+	dir = 4;
+	_wifi_id = "scarab_quarters_shutters";
+	name = "Safety Blast Doors"
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/bunks)
+"hL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8;
+	must_start_working = 1
+	},
+/turf/simulated/floor/plating,
+/area/coc_scarab/mess)
 "hN" = (
 /obj/machinery/atmospherics/portables_connector/aux{
 	dir = 4
@@ -1267,7 +1364,6 @@
 /area/coc_scarab/engine)
 "ie" = (
 /obj/machinery/vending/hydronutrients,
-/obj/machinery/light,
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
@@ -1276,14 +1372,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/hydroponics)
-"ij" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/coc_scarab)
 "il" = (
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
@@ -1296,17 +1384,40 @@
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
 "is" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/mess)
+/obj/structure/table/standard,
+/obj/item/reagent_containers/toothpaste{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/toothbrush/green{
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/toothbrush/green{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/toothbrush/green{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/toothbrush/green{
+	pixel_y = 8
+	},
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/machinery/light/colored/decayed/dimmed,
+/turf/simulated/floor/tiled/white,
+/area/coc_scarab/washroom)
 "iu" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/high/north{
+	req_access = null
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/hydroponics)
@@ -1322,8 +1433,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Gas Harvester"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -1332,23 +1442,17 @@
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "iA" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/coc_scarab/armory)
 "iD" = (
 /obj/machinery/portable_atmospherics/hydroponics,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/high/north{
-	req_access = null
-	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
+	},
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/hydroponics)
@@ -1372,7 +1476,7 @@
 	name = "Aft Hallway"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/coc_scarab/medical)
 "iH" = (
 /obj/structure/cable{
@@ -1399,9 +1503,13 @@
 	dir = 10
 	},
 /obj/structure/table/steel,
-/obj/item/reagent_containers/food/drinks/cans/beetle_milk{
-	pixel_x = 11;
-	pixel_y = 3
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/rag{
+	pixel_y = 3;
+	pixel_x = 4
 	},
 /turf/simulated/floor/lino,
 /area/coc_scarab/mess)
@@ -1495,6 +1603,10 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/button/ignition{
+	id = "scav_igni";
+	pixel_y = 26
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "jk" = (
@@ -1504,6 +1616,16 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/space)
+"jp" = (
+/obj/machinery/alarm/west,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	layer = 2
+	},
+/turf/simulated/floor/grass,
+/area/coc_scarab/hydroponics)
 "jq" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/cable/green{
@@ -1529,6 +1651,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light/floor/decayed{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -1564,13 +1689,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "jU" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/alarm/west,
-/turf/simulated/floor/grass,
-/area/coc_scarab/hydroponics)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/lino,
+/area/coc_scarab/mess)
 "jY" = (
 /obj/effect/floor_decal/corner_wide/lime{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
@@ -1622,6 +1752,9 @@
 /obj/item/clothing/mask/offworlder{
 	color = "#942a15"
 	},
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "kc" = (
@@ -1629,8 +1762,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Gas Harvester"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
@@ -1639,9 +1771,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/airlock_sensor{
-	pixel_y = -25
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
@@ -1668,6 +1797,9 @@
 	master_tag = "scarab_engine";
 	name = "scarab_engine"
 	},
+/obj/structure/bed/handrail{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "kg" = (
@@ -1682,11 +1814,11 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "kk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/hydroponics)
@@ -1733,26 +1865,19 @@
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/coc_scarab)
-"kG" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning/corner{
+"kH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
-/area/space)
-"kH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "kN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
-/obj/machinery/light,
 /obj/machinery/meter,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "kP" = (
@@ -1782,11 +1907,11 @@
 /area/coc_scarab/thrust2)
 "lg" = (
 /mob/living/heavy_vehicle/premade/light/salvage,
-/obj/machinery/light,
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/corner/brown/full,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/colored/decayed/dimmed,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "ln" = (
@@ -1833,7 +1958,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled,
 /area/coc_scarab/armory)
 "lB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -1849,9 +1974,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "lE" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 5
 	},
@@ -1914,7 +2036,6 @@
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "mm" = (
-/obj/machinery/light,
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1929,17 +2050,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
-"mp" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	layer = 2.71
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 8
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "ms" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot,
 /turf/simulated/floor/tiled/dark,
@@ -1990,6 +2100,9 @@
 /obj/structure/closet/secure_closet/custodial/offship,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/mop,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/massdriver)
 "mK" = (
@@ -2013,6 +2126,14 @@
 "mM" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/coc_scarab/hydroponics)
+"mP" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/mining/brace{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
 "mS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2023,8 +2144,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green,
+/obj/machinery/power/apc/west,
+/obj/structure/bed/handrail{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/coc_scarab/equipment)
+/area/coc_scarab/hallway)
 "mY" = (
 /obj/effect/shuttle_landmark/coc_scarab/harvester_transit{
 	dir = 8
@@ -2058,6 +2184,9 @@
 	dir = 5
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/bed/handrail{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/massdriver)
 "ni" = (
@@ -2119,6 +2248,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/coc_scarab/mess)
+"nQ" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "nV" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
@@ -2139,6 +2274,9 @@
 /area/coc_scarab/engine)
 "nZ" = (
 /obj/machinery/computer/shuttle_control/explore/terminal/scarab_gas_harvester,
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "oa" = (
@@ -2149,6 +2287,9 @@
 /obj/machinery/light,
 /obj/machinery/airlock_sensor{
 	pixel_y = -25
+	},
+/obj/structure/bed/handrail{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/equipment)
@@ -2217,17 +2358,11 @@
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "oK" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/purple,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
-"oM" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/airless,
-/area/space)
 "oW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/purple,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -2255,6 +2390,12 @@
 "pa" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
+	},
+/obj/structure/bed/handrail{
+	dir = 4
+	},
+/obj/machinery/light/floor/decayed{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
@@ -2309,11 +2450,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock{
-	name = "Cryogenics"
+	name = "Cryogenics Bay"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
-/area/coc_scarab/bunks)
+/area/coc_scarab/cryogenics)
 "px" = (
 /obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
@@ -2332,14 +2473,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 6
+	},
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
@@ -2357,21 +2498,14 @@
 /area/shuttle/coc_scarab)
 "pG" = (
 /obj/machinery/optable,
-/obj/machinery/light{
+/obj/effect/floor_decal/corner_wide/lime/full{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner_wide/lime/full{
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
-"pK" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/equipment)
 "pL" = (
 /obj/machinery/computer/ship/sensors/terminal{
 	dir = 1
@@ -2411,8 +2545,18 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/grauwolf)
+"pT" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/loot,
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "pW" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4
@@ -2466,9 +2610,10 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "qe" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/purple,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "qj" = (
@@ -2492,33 +2637,19 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = -25
 	},
+/obj/structure/bed/handrail{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engistorage)
 "qp" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/floor{
-	dir = 8
-	},
-/obj/machinery/light/floor{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor,
-/turf/simulated/floor/airless,
-/area/coc_scarab/solars)
+/obj/machinery/light/colored/decayed/dimmed,
+/turf/simulated/floor/tiled/white,
+/area/coc_scarab/hydroponics)
 "qq" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2550,6 +2681,20 @@
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/scarab_harvester)
+"qw" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/turf/simulated/floor/airless,
+/area/space)
+"qx" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/structure/sign/securearea{
+	pixel_y = 32
+	},
+/turf/space/dynamic,
+/area/space)
 "qF" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
@@ -2563,19 +2708,18 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/bridge)
 "qK" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/coc_scarab/armory)
 "qN" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/grass,
 /area/coc_scarab/hydroponics)
 "qQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
@@ -2660,18 +2804,9 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/securearea{
-	pixel_x = 32
-	},
-/obj/structure/sign/securearea{
-	pixel_x = -32
-	},
 /turf/simulated/floor/plating,
-/area/coc_scarab/equipment)
+/area/coc_scarab/hallway)
 "rk" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/binary/circulator{
@@ -2696,13 +2831,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light/floor{
-	dir = 4
-	},
-/obj/machinery/light/floor{
+/obj/machinery/light/floor/decayed{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/floor/decayed{
+	dir = 4
+	},
 /turf/simulated/floor/airless,
 /area/coc_scarab/solars)
 "ru" = (
@@ -2736,6 +2870,10 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/space)
+"rK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "rL" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/cable/green{
@@ -2759,8 +2897,20 @@
 	},
 /obj/effect/floor_decal/corner_wide/yellow,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/obj/machinery/light/floor/decayed{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
+"rU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/bridge)
 "rV" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2782,11 +2932,18 @@
 	},
 /turf/space/dynamic,
 /area/space)
+"sf" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/reinforced,
+/area/coc_scarab/grauwolf)
 "sg" = (
-/obj/machinery/light{
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
 "sh" = (
@@ -2800,13 +2957,12 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/light/floor{
+/obj/machinery/light/floor/decayed{
 	dir = 4
 	},
-/obj/machinery/light/floor{
+/obj/machinery/light/floor/decayed{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/coc_scarab/solars)
 "si" = (
@@ -2830,6 +2986,13 @@
 /obj/effect/step_trigger/teleporter,
 /turf/space/transit/north,
 /area/space)
+"sw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/bridge)
 "sH" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/binary/passive_gate/on{
@@ -2839,16 +3002,16 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "sI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor/decayed{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/coc_scarab/hydroponics)
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "sK" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2865,6 +3028,9 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/west,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/mess)
 "sL" = (
@@ -2878,6 +3044,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
+"sN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/handrail{
+	dir = 4
+	},
+/obj/machinery/light/floor/decayed{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/coc_scarab/thrust1)
 "sR" = (
 /obj/effect/shuttle_landmark/coc_scarab/nav4,
 /turf/template_noop,
@@ -2885,6 +3061,16 @@
 "sV" = (
 /turf/space/dynamic,
 /area/coc_scarab/solars)
+"sZ" = (
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "te" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/valve,
@@ -2934,6 +3120,14 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/airless,
 /area/space)
+"tu" = (
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "ty" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt,
@@ -2942,6 +3136,10 @@
 "tE" = (
 /obj/effect/floor_decal/spline/plain/black,
 /obj/structure/table/steel,
+/obj/machinery/reagentgrinder{
+	pixel_y = 9;
+	pixel_x = 7
+	},
 /turf/simulated/floor/lino,
 /area/coc_scarab/mess)
 "tF" = (
@@ -2956,8 +3154,26 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/space)
+"tG" = (
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
+"tI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor/decayed{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/grauwolf)
 "tM" = (
 /mob/living/simple_animal/hakhma,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/grass,
 /area/coc_scarab/hydroponics)
 "tO" = (
@@ -2967,8 +3183,11 @@
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "tP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/hydroponics)
@@ -3005,7 +3224,7 @@
 /area/coc_scarab/engine)
 "ue" = (
 /obj/machinery/door/airlock/hatch{
-	name = "Telecomms"
+	name = "Telecommunications Server"
 	},
 /obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/plating,
@@ -3024,6 +3243,18 @@
 /obj/effect/shuttle_landmark/coc_scarab/nav3,
 /turf/template_noop,
 /area/space)
+"up" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
+"ut" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/coc_scarab/cryogenics)
 "uu" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -3066,14 +3297,22 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Gas Harvester"
 	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_y = 28;
+	pixel_x = 6
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
+"uM" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/airless,
+/area/space)
 "uN" = (
 /obj/effect/floor_decal/corner_wide/lime{
 	dir = 9
@@ -3083,6 +3322,10 @@
 	name = "surgical sink";
 	pixel_x = -20
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/alarm/west,
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "uO" = (
@@ -3104,6 +3347,14 @@
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/airless,
 /area/coc_scarab/engine)
+"uV" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "uW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 10
@@ -3138,8 +3389,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Gas Harvester"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
@@ -3152,22 +3402,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
-"vs" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
-	pixel_x = -4;
-	pixel_y = -8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/mess)
 "vt" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/mining/drill,
@@ -3194,16 +3428,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
-"vz" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	layer = 2.71
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "vD" = (
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -3211,14 +3435,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/thrust1)
-"vG" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	layer = 2.71
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "vI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3251,6 +3467,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
+"vO" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/ore_box,
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "vQ" = (
 /obj/machinery/atmospherics/valve{
 	name = "Thermal Relief Valve"
@@ -3263,6 +3488,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
+"vT" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
 "vV" = (
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
@@ -3306,7 +3536,7 @@
 	name = "Medical Bay"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled,
 /area/coc_scarab/mess)
 "wl" = (
 /obj/structure/closet/firecloset/full,
@@ -3323,16 +3553,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
-/obj/machinery/light{
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
-"wq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/lino,
-/area/coc_scarab/mess)
 "wr" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3354,7 +3580,7 @@
 	dir = 2
 	},
 /turf/simulated/floor/plating,
-/area/coc_scarab/bunks)
+/area/coc_scarab/cryogenics)
 "ww" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -3369,15 +3595,6 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
-"wx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/coc_scarab)
 "wB" = (
 /obj/machinery/light{
 	dir = 8
@@ -3395,6 +3612,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "wE" = (
@@ -3405,21 +3623,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
-"wG" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/coc_scarab/equipment)
 "wI" = (
 /obj/machinery/atmospherics/unary/engine,
 /turf/simulated/floor/airless,
@@ -3447,8 +3650,24 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
+"xf" = (
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/obj/structure/closet/crate/bin,
+/obj/machinery/power/apc/high/east{
+	req_access = null
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "xh" = (
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/obj/machinery/light/colored/decayed/dimmed,
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "xo" = (
@@ -3462,20 +3681,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "xp" = (
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
+/obj/structure/bed/handrail{
+	dir = 8;
+	name = "table handrail";
+	pixel_x = 1;
+	buckle_dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
@@ -3510,8 +3733,14 @@
 /obj/machinery/computer/cryopod{
 	pixel_x = -28
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/bed/handrail{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
-/area/coc_scarab/bunks)
+/area/coc_scarab/cryogenics)
 "xJ" = (
 /obj/machinery/sparker{
 	id = "scav_igni";
@@ -3551,12 +3780,23 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/engistorage)
 "xV" = (
-/obj/machinery/light{
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
+"xY" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/toilet{
+	dir = 1;
+	pixel_y = -1
+	},
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/coc_scarab/washroom)
 "ya" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -3594,10 +3834,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
-"ym" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/shuttle/scarab_harvester)
 "yo" = (
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
 /obj/machinery/door/blast/regular/open{
@@ -3658,8 +3894,15 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/bridge)
 "yU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/bed/handrail{
+	dir = 4;
+	name = "table handrail";
+	pixel_x = -1;
+	pixel_y = 6;
+	buckle_dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "zd" = (
@@ -3677,17 +3920,32 @@
 /obj/item/ship_ammunition/grauwolf_probe,
 /turf/simulated/floor/tiled,
 /area/coc_scarab/ammo)
-"zh" = (
-/obj/structure/bed/stool/chair{
-	dir = 8
+"ze" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/shuttle/scarab_harvester)
+"zh" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	color = "#647252";
 	name = "green corner"
 	},
+/obj/structure/bed/handrail{
+	dir = 4;
+	name = "table handrail";
+	pixel_x = -1;
+	pixel_y = 6;
+	buckle_dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "zk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/hydroponics)
 "zm" = (
@@ -3713,8 +3971,11 @@
 	id = "scarab_bridge";
 	dir = 1
 	},
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 10
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/paleblue/full{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
@@ -3741,6 +4002,13 @@
 /obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
+"zz" = (
+/obj/structure/lattice,
+/obj/structure/sign/securearea{
+	pixel_x = 32
+	},
+/turf/template_noop,
+/area/space)
 "zB" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/ore_box,
@@ -3769,18 +4037,13 @@
 /obj/machinery/computer/ship/sensors{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 9
-	},
+/obj/effect/floor_decal/corner_wide/paleblue/full,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
-"zQ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/mining/brace{
-	dir = 4
+"zS" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -3822,11 +4085,11 @@
 /obj/structure/cryofeed{
 	dir = 2
 	},
-/obj/machinery/light{
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/coc_scarab/bunks)
+/area/coc_scarab/cryogenics)
 "Ac" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3841,6 +4104,7 @@
 /obj/machinery/power/apc/high/north{
 	req_access = null
 	},
+/obj/structure/bed/handrail,
 /turf/simulated/floor/tiled,
 /area/coc_scarab/armory)
 "Av" = (
@@ -3852,6 +4116,7 @@
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "Ay" = (
@@ -3879,13 +4144,13 @@
 /turf/simulated/floor/reinforced,
 /area/coc_scarab/grauwolf)
 "AI" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "AL" = (
@@ -3896,6 +4161,19 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
+"AO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71
+	},
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "AR" = (
 /turf/simulated/floor/lino,
 /area/coc_scarab/mess)
@@ -3941,16 +4219,15 @@
 /obj/machinery/alarm/east{
 	req_one_access = null
 	},
+/obj/structure/bed/handrail{
+	dir = 8
+	},
 /turf/simulated/floor/lino,
 /area/coc_scarab/mess)
 "Be" = (
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
-"Bf" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/airless,
-/area/coc_scarab/thrust2)
 "Bh" = (
 /obj/machinery/mineral/processing_unit,
 /obj/effect/floor_decal/industrial/warning{
@@ -3988,7 +4265,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/portable_atmospherics/canister/hydrogen,
-/obj/machinery/light{
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -4006,20 +4283,21 @@
 /turf/simulated/floor/airless,
 /area/shuttle/scarab_harvester)
 "Br" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
-	},
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
@@ -4029,12 +4307,32 @@
 	},
 /turf/simulated/wall/shuttle/dark/cardinal/red,
 /area/shuttle/scarab_harvester)
+"BI" = (
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/obj/machinery/light/floor/decayed{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "BJ" = (
 /obj/structure/sign/flag/scarab/large/south{
 	pixel_y = -32
 	},
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/coc_scarab/armory)
+"BK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
 "BL" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -4043,25 +4341,22 @@
 /turf/simulated/floor/grass,
 /area/coc_scarab/hydroponics)
 "BM" = (
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
-	},
+/obj/structure/lattice/catwalk/indoor,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/mess)
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "BN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 5
+	},
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
@@ -4077,8 +4372,8 @@
 	name = "Engine Room"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/equipment)
+/turf/simulated/floor/tiled,
+/area/coc_scarab/engine)
 "BV" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/coc_scarab/armory)
@@ -4108,6 +4403,9 @@
 	pixel_y = -33
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/handrail{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Cj" = (
@@ -4138,6 +4436,25 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
+"Cq" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	must_start_working = 1
+	},
+/turf/simulated/floor/plating,
+/area/coc_scarab/hallway)
 "Cs" = (
 /obj/machinery/air_sensor{
 	id_tag = "scarab_thrust2_sensor";
@@ -4200,10 +4517,9 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Shuttle"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/shuttle/coc_scarab)
 "CP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
@@ -4215,11 +4531,8 @@
 /obj/machinery/computer/ship/targeting{
 	dir = 8
 	},
-/obj/machinery/light{
+/obj/effect/floor_decal/corner_wide/paleblue/full{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
@@ -4261,10 +4574,6 @@
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube_empty"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71
 	},
@@ -4274,6 +4583,9 @@
 /obj/item/tank/oxygen,
 /obj/item/clothing/mask/breath/medical,
 /obj/item/clothing/mask/breath/medical,
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "Dm" = (
@@ -4288,13 +4600,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "Dv" = (
@@ -4303,10 +4615,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
-"Dx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/coc_scarab/engine)
 "Dz" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
@@ -4345,6 +4653,9 @@
 	icon_state = "warning"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/handrail{
+	dir = 8
+	},
 /turf/simulated/floor/reinforced,
 /area/coc_scarab/grauwolf)
 "DI" = (
@@ -4354,6 +4665,12 @@
 "DN" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
+	},
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/obj/machinery/light/floor/decayed{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
@@ -4453,6 +4770,7 @@
 	req_one_access = null
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/handrail,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "Ex" = (
@@ -4516,7 +4834,17 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
-/area/coc_scarab/medical)
+/area/coc_scarab/massdriver)
+"EJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "EN" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -28;
@@ -4525,6 +4853,9 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -28;
 	pixel_y = -6
+	},
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/coc_scarab/armory)
@@ -4564,20 +4895,27 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
+"EY" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/bed/handrail{
+	pixel_y = 7;
+	name = "table handrail";
+	buckle_dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/bunks)
 "Fc" = (
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/machinery/iv_drip,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube_empty"
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "Fe" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/table/steel,
 /obj/item/storage/bag/circuits/basic{
 	pixel_x = -10;
@@ -4604,13 +4942,14 @@
 /obj/structure/table/steel,
 /obj/item/paper_bin,
 /obj/item/pen/black,
-/obj/effect/floor_decal/corner_wide/paleblue{
-	dir = 10
-	},
 /obj/item/reagent_containers/food/drinks/cans/beetle_milk{
 	pixel_y = 10;
 	pixel_x = -11
 	},
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_wide/paleblue/full,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
 "Fs" = (
@@ -4639,15 +4978,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
-"FD" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/loot,
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "FE" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4659,7 +4989,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled,
 /area/coc_scarab/ammo)
 "FF" = (
 /obj/machinery/computer/general_air_control/large_tank_control/terminal{
@@ -4674,9 +5004,6 @@
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "FG" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 5
 	},
@@ -4699,16 +5026,6 @@
 /obj/structure/lattice/catwalk/indoor/grate/light,
 /turf/simulated/floor/plating,
 /area/coc_scarab/medical)
-"FO" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	layer = 2.71
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "FP" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -4722,7 +5039,18 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/coc_scarab/bunks)
+/area/coc_scarab/cryogenics)
+"FS" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/mining/drill,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
 "Ge" = (
 /obj/machinery/atmospherics/unary/engine,
 /turf/simulated/floor/plating,
@@ -4753,15 +5081,6 @@
 /obj/structure/ship_weapon_dummy,
 /turf/simulated/floor/reinforced,
 /area/coc_scarab/grauwolf)
-"Gr" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/mess)
 "Gt" = (
 /obj/machinery/computer/ship/helm/terminal{
 	dir = 1
@@ -4792,6 +5111,9 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/generic,
+/obj/structure/bed/handrail{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "GA" = (
@@ -4800,14 +5122,25 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/hydroponics)
+"GB" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "airlock_scarab_stbd";
+	master_tag = "airlock_scarab_stbd"
+	},
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/coc_scarab/equipment)
 "GD" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4817,15 +5150,13 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Gas Harvester"
+	},
+/obj/machinery/airlock_sensor{
+	pixel_y = -25
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	pixel_y = -20;
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
@@ -4846,7 +5177,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/light{
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 8
 	},
 /turf/simulated/floor/reinforced,
@@ -4859,11 +5190,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/massdriver)
 "GR" = (
-/obj/machinery/light,
 /obj/machinery/autolathe,
-/obj/machinery/light,
 /obj/effect/floor_decal/corner/yellow/full,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/colored/decayed/dimmed,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "GT" = (
@@ -4891,8 +5221,18 @@
 /obj/structure/sign/flag/scarab/large/west{
 	pixel_x = -32
 	},
+/obj/structure/bed/handrail{
+	dir = 4
+	},
 /turf/simulated/floor/reinforced,
 /area/coc_scarab/grauwolf)
+"Hi" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/equipment)
 "Hm" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -4906,26 +5246,16 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/coc_scarab/engine)
 "Hq" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/high/east{
-	req_access = null
-	},
 /obj/effect/floor_decal/corner/grey/diagonal{
 	color = "#647252";
 	name = "green corner"
 	},
-/obj/structure/closet/crate/bin{
-	name = "trashbin"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/handrail{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
-"Hs" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/grauwolf)
 "Hu" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4983,26 +5313,15 @@
 /area/shuttle/coc_scarab)
 "HY" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 0
+	},
 /turf/simulated/floor/airless,
 /area/space)
 "Ia" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/mess)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/coc_scarab/washroom)
 "Id" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
@@ -5029,35 +5348,19 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/space)
 "Im" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/grey/diagonal{
 	color = "#647252";
 	name = "green corner"
+	},
+/obj/structure/sign/poster{
+	pixel_y = null;
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "It" = (
 /turf/simulated/floor/airless,
 /area/space)
-"Iu" = (
-/obj/effect/floor_decal/spline/plain/black,
-/obj/structure/table/steel,
-/obj/machinery/reagentgrinder{
-	pixel_y = 11
-	},
-/turf/simulated/floor/lino,
-/area/coc_scarab/mess)
-"Iv" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
-	},
-/obj/item/trash/tray,
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/mess)
 "Iw" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
@@ -5087,9 +5390,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/lattice/catwalk/indoor/grate/light,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/medical)
 "ID" = (
@@ -5144,6 +5452,9 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
 	},
+/obj/structure/bed/handrail{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "IR" = (
@@ -5168,16 +5479,28 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/medical)
 "Jc" = (
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
+/obj/machinery/door/window/northleft{
+	name = "Shower";
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/mess)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/structure/mirror{
+	pixel_y = 30
+	},
+/obj/structure/bed/handrail,
+/turf/simulated/floor/tiled/white,
+/area/coc_scarab/washroom)
 "Je" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/machinery/door/blast/regular/open{
+	id = "scarab_quarters_shutters";
+	dir = 4;
+	_wifi_id = "scarab_quarters_shutters";
+	name = "Safety Blast Doors"
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/bunks)
 "Jg" = (
@@ -5191,12 +5514,31 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
-"Ji" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 6
+"Jh" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/shuttle/scarab_harvester)
+/obj/structure/flora/ausbushes/sparsegrass{
+	layer = 2
+	},
+/turf/simulated/floor/grass,
+/area/coc_scarab/hydroponics)
+"Ji" = (
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/obj/structure/bed/handrail{
+	pixel_y = 7;
+	name = "table handrail";
+	buckle_dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
+"Jl" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
+/area/space)
 "Jq" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5221,18 +5563,11 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/bed/handrail{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/coc_scarab/mess)
-"Jt" = (
-/obj/structure/lattice,
-/obj/structure/sign/securearea{
-	pixel_x = -32
-	},
-/turf/template_noop,
-/area/space)
 "Jx" = (
 /obj/machinery/computer/ship/targeting,
 /obj/effect/floor_decal/corner_wide/paleblue{
@@ -5268,12 +5603,30 @@
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "JM" = (
-/obj/structure/bed/stool/chair,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/bed/handrail{
+	dir = 1;
+	pixel_y = -2;
+	name = "table handrail";
+	buckle_dir = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
+"Kc" = (
+/obj/structure/lattice,
+/obj/structure/sign/securearea{
+	pixel_x = -32
+	},
+/turf/template_noop,
+/area/space)
 "Ke" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/hydroponics)
@@ -5314,14 +5667,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "Kt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/bed/handrail{
+	dir = 4;
+	name = "table handrail";
+	pixel_x = -1;
+	pixel_y = 6;
+	buckle_dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "Ku" = (
@@ -5338,18 +5692,13 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled,
 /area/coc_scarab/hydroponics)
 "KA" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -5360,6 +5709,11 @@
 /obj/effect/floor_decal/corner/grey/diagonal{
 	color = "#647252";
 	name = "green corner"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
@@ -5383,26 +5737,10 @@
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/coc_scarab/equipment)
-"KJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/plating,
-/area/coc_scarab/equipment)
 "KR" = (
-/obj/machinery/atmospherics/binary/pump/fuel{
-	name = "Fuel to Thrusters"
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/omni/filter,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "KT" = (
@@ -5415,9 +5753,6 @@
 	dir = 8
 	},
 /obj/machinery/door/window/southleft,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/grauwolf)
 "KY" = (
@@ -5427,6 +5762,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
+"Lb" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "Lc" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/railing/mapped{
@@ -5449,7 +5800,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "Lg" = (
-/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Port Propulsion"
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -5465,17 +5818,32 @@
 /turf/simulated/floor/airless,
 /area/space)
 "Lt" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	icon_state = "map-scrubbers"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/bed/handrail{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/coc_scarab/mess)
 "Lw" = (
 /obj/structure/undies_wardrobe{
-	pixel_y = 1
+	pixel_y = 15
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
@@ -5489,16 +5857,15 @@
 /obj/machinery/button/remote/airlock{
 	id = "scarab_combustion";
 	name = "Door Bolt Control";
-	pixel_x = 8;
-	pixel_y = 26;
-	specialfunctions = 4
+	specialfunctions = 4;
+	dir = 4;
+	pixel_x = 25
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/sign/fire{
-	name = "\improper DANGER: COMBUSTION CHAMBER sign";
-	pixel_x = 32
+/obj/structure/bed/handrail{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
@@ -5512,29 +5879,38 @@
 	},
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/bed/handrail,
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
+"LG" = (
+/obj/machinery/button/remote/airlock{
+	id = "scarab_combustion";
+	name = "Door Bolt Control";
+	specialfunctions = 4;
+	dir = 4;
+	pixel_x = 25
+	},
+/turf/template_noop,
+/area/space)
 "LI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
-/obj/machinery/light{
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "LK" = (
-/obj/machinery/vending/dinnerware,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/shower{
+	pixel_y = 16
 	},
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/mess)
+/obj/structure/curtain/open/shower,
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/structure/bed/handrail,
+/turf/simulated/floor/tiled/white,
+/area/coc_scarab/washroom)
 "LM" = (
 /obj/structure/sink{
 	dir = 4;
@@ -5557,6 +5933,10 @@
 	},
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 5
+	},
+/obj/structure/bed/handrail,
+/obj/machinery/light/floor/decayed{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
@@ -5611,21 +5991,39 @@
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "Mw" = (
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/bed/handrail{
+	dir = 4;
+	name = "table handrail";
+	pixel_x = -1;
+	pixel_y = 6;
+	buckle_dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
+"My" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
 "MC" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5645,8 +6043,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Gas Harvester"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -5695,30 +6092,25 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "MW" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/hydroponics)
 "MZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/mech_recharger,
 /mob/living/heavy_vehicle/premade/ripley/loader,
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/coc_scarab/ammo)
-"Na" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/airless,
-/area/space)
 "Nb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
@@ -5741,7 +6133,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark,
-/area/coc_scarab/mess)
+/area/coc_scarab/bunks)
 "Nd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /obj/effect/floor_decal/corner_wide/yellow{
@@ -5766,47 +6158,19 @@
 /obj/structure/ship_weapon_dummy,
 /turf/template_noop,
 /area/space)
-"Nr" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
-	},
-/obj/item/trash/snack_bowl{
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/obj/item/material/kitchen/utensil/spoon{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/mess)
 "Nz" = (
-/obj/structure/bed/stool/chair{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/grey/diagonal{
 	color = "#647252";
 	name = "green corner"
 	},
+/obj/structure/bed/handrail{
+	dir = 8;
+	name = "table handrail";
+	pixel_x = 1;
+	buckle_dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
-"ND" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/sign/securearea{
-	pixel_y = -32
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "NR" = (
 /obj/machinery/air_sensor{
 	id_tag = "scarab_thrust1_sensor";
@@ -5845,9 +6209,6 @@
 /area/coc_scarab/engine)
 "Of" = (
 /obj/machinery/appliance/cooker/oven,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/sign/flag/scarab/large/north{
 	pixel_y = 32
 	},
@@ -5937,15 +6298,12 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Ot" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor/decayed{
+	dir = 4
 	},
-/obj/machinery/light,
-/obj/structure/lattice/catwalk/indoor,
-/turf/simulated/floor/plating,
-/area/coc_scarab/engine)
+/turf/simulated/floor/airless,
+/area/coc_scarab/thrust2)
 "Ou" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 8;
@@ -5961,13 +6319,13 @@
 	name = "Internal Blast Door";
 	id = "scarabdriver_in"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/handrail{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/massdriver)
 "Ov" = (
@@ -5987,9 +6345,6 @@
 /obj/item/device/flashlight/lantern,
 /obj/item/device/flashlight/lantern,
 /obj/item/storage/box/flares,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/storage/bag/inflatable,
 /obj/item/storage/bag/inflatable,
 /obj/item/storage/bag/inflatable,
@@ -5997,6 +6352,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "Oy" = (
@@ -6018,6 +6376,19 @@
 	},
 /turf/template_noop,
 /area/space)
+"OD" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/handrail{
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/coc_scarab/thrust2)
 "OE" = (
 /obj/effect/landmark/entry_point/starboard{
 	name = "port"
@@ -6053,6 +6424,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/coc_scarab/ammo)
+"OX" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "Pa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/machinery/power/apc/high/west{
@@ -6071,14 +6450,9 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Shuttle"
 	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	pixel_y = -20;
-	dir = 1
-	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/shuttle/coc_scarab)
 "Pm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -6106,6 +6480,12 @@
 /area/coc_scarab/engine)
 "Pv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/bed/handrail{
+	dir = 8
+	},
+/obj/machinery/light/floor/decayed{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "Pw" = (
@@ -6125,13 +6505,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
-"PC" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/shuttle/scarab_harvester)
 "PJ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/binary/circulator{
@@ -6141,16 +6514,16 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "PP" = (
-/obj/machinery/chemical_dispenser/coffee/full{
-	pixel_y = 6
+/obj/structure/table/rack,
+/obj/item/soap/plant,
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/machinery/light/small{
+	dir = 4;
+	must_start_working = 1
 	},
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/mess)
+/obj/machinery/alarm/south,
+/turf/simulated/floor/tiled/white,
+/area/coc_scarab/washroom)
 "PR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -6168,15 +6541,29 @@
 	},
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
+"PT" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor,
+/obj/structure/sign/securearea{
+	pixel_y = -32
+	},
+/turf/simulated/floor/airless,
+/area/space)
 "PU" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/lattice/catwalk/indoor,
-/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Qb" = (
@@ -6234,24 +6621,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
-"Qk" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner/grey/diagonal{
-	color = "#647252";
-	name = "green corner"
-	},
-/obj/item/trash/plate{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/material/kitchen/utensil/fork{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/mess)
 "Ql" = (
 /obj/machinery/door/window/eastleft,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/grass,
 /area/coc_scarab/hydroponics)
 "Qo" = (
@@ -6261,6 +6636,13 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
+"Qv" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/shuttle/scarab_harvester)
 "Qz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6296,10 +6678,13 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Shuttle"
 	},
-/turf/simulated/floor/airless,
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/turf/simulated/floor/plating,
 /area/shuttle/coc_scarab)
 "QJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -6324,13 +6709,13 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/portable_atmospherics/canister/empty{
 	name = "waste canister"
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "QO" = (
@@ -6407,11 +6792,11 @@
 /obj/machinery/power/apc/high/south{
 	req_access = null
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/coc_scarab/bunks)
+/area/coc_scarab/cryogenics)
 "Rj" = (
 /obj/machinery/door/airlock/external{
 	dir = 8
@@ -6435,8 +6820,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Gas Harvester"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
@@ -6457,8 +6841,16 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/machinery/alarm/north{
+	dir = 4;
+	pixel_y = 0;
+	pixel_x = 10
+	},
+/obj/structure/bed/handrail{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
-/area/coc_scarab/bunks)
+/area/coc_scarab/cryogenics)
 "Ry" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6470,6 +6862,7 @@
 	pixel_y = 0
 	},
 /obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "RA" = (
@@ -6519,8 +6912,29 @@
 	pixel_y = 9;
 	pixel_x = 8
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
+"RI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/securearea{
+	pixel_x = 32
+	},
+/obj/structure/sign/securearea{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plating,
+/area/coc_scarab/hallway)
 "RL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
@@ -6543,24 +6957,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
-"RP" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/random,
-/obj/effect/ghostspawpoint{
-	name = "igs - coc_scarab";
-	identifier = "coc_scarab"
-	},
-/obj/structure/curtain/open/bed,
-/obj/item/bedsheet/random{
-	pixel_y = 16
-	},
-/obj/effect/ghostspawpoint{
-	name = "igs - coc_scarab";
-	identifier = "coc_scarab"
-	},
-/obj/structure/bed/padded/bunk,
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/bunks)
 "RS" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -6584,12 +6980,12 @@
 /area/coc_scarab/engine)
 "RU" = (
 /obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
 /turf/simulated/floor/grass,
 /area/coc_scarab/hydroponics)
 "RW" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/table/steel,
 /obj/item/deck/cards{
 	pixel_x = -4;
@@ -6598,6 +6994,9 @@
 /obj/item/reagent_containers/food/drinks/cans/beetle_milk{
 	pixel_x = 5;
 	pixel_y = 2
+	},
+/obj/structure/sign/flag/scarab/large/west{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
@@ -6614,6 +7013,9 @@
 	master_tag = "airlock_scarab_port"
 	},
 /obj/machinery/light,
+/obj/structure/bed/handrail{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engistorage)
 "Se" = (
@@ -6632,17 +7034,29 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "Sf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
-"Sg" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/coc_scarab/engine)
 "Sj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
+"Sk" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet/west{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 28
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Sm" = (
@@ -6657,49 +7071,49 @@
 "So" = (
 /mob/living/simple_animal/hakhma,
 /obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/bed/handrail{
+	dir = 1
+	},
 /turf/simulated/floor/grass,
 /area/coc_scarab/hydroponics)
 "Sw" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/coc_scarab/massdriver)
-"Sy" = (
-/obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/simulated/floor/plating,
-/area/coc_scarab/engine)
-"SA" = (
-/obj/structure/cable/green{
+"Sx" = (
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_scarab)
+"Sy" = (
+/obj/machinery/portable_atmospherics/canister/hydrogen,
 /turf/simulated/floor/plating,
-/area/coc_scarab/mess)
+/area/coc_scarab/engine)
 "SB" = (
-/obj/structure/table/steel,
-/obj/machinery/chemical_dispenser/bar_soft/full{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/grey/diagonal{
 	color = "#647252";
 	name = "green corner"
 	},
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
 "SD" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/grey/diagonal{
 	color = "#647252";
 	name = "green corner"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/bed/handrail{
+	dir = 4;
+	name = "table handrail";
+	pixel_x = -1;
+	pixel_y = 6;
+	buckle_dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/mess)
@@ -6709,8 +7123,18 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
+"SK" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/structure/bed/handrail,
+/turf/simulated/floor/airless,
+/area/space)
 "SM" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 8
@@ -6735,6 +7159,13 @@
 	pixel_x = 6;
 	pixel_y = 5
 	},
+/obj/structure/bed/handrail{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	must_start_working = 1
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "SV" = (
@@ -6745,12 +7176,22 @@
 /turf/space/dynamic,
 /area/space)
 "SX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 9
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/turf/simulated/floor/plating,
-/area/shuttle/scarab_harvester)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster{
+	pixel_y = -32
+	},
+/obj/structure/bed/handrail{
+	pixel_y = 7;
+	name = "table handrail";
+	buckle_dir = 1
+	},
+/obj/machinery/light/colored/decayed/dimmed,
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "SZ" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
@@ -6780,24 +7221,20 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Tc" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
-"Th" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/airless,
-/area/space)
 "Ti" = (
-/obj/machinery/light{
+/obj/effect/decal/cleanable/blood/oil,
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Tj" = (
@@ -6826,8 +7263,11 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/decal/cleanable/generic,
 /obj/structure/extinguisher_cabinet/west,
+/obj/structure/bed/handrail{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
-/area/coc_scarab/equipment)
+/area/coc_scarab/hallway)
 "Tw" = (
 /obj/machinery/alarm/north{
 	req_one_access = null
@@ -6899,13 +7339,22 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Gas Harvester"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
+"TI" = (
+/obj/effect/floor_decal/corner_wide/paleblue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/coc_scarab/medical)
 "TJ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -6952,10 +7401,10 @@
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "TS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/omni/filter,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "TT" = (
@@ -6977,6 +7426,9 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/storage/box/fancy/egg_box,
 /obj/item/storage/box/fancy/egg_box,
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 1
+	},
 /turf/simulated/floor/lino,
 /area/coc_scarab/mess)
 "TU" = (
@@ -6989,8 +7441,21 @@
 /turf/simulated/floor/airless,
 /area/shuttle/scarab_harvester)
 "TW" = (
-/obj/structure/bed/stool/chair{
-	dir = 1
+/obj/structure/bed/handrail{
+	pixel_y = 7;
+	name = "table handrail";
+	buckle_dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	pixel_x = -24;
+	id = "scarab_quarters_shutters";
+	_wifi_id = "scarab_quarters_shutters";
+	name = "Safety Blast Doors Control"
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	must_start_working = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
@@ -6999,9 +7464,6 @@
 /area/shuttle/coc_scarab)
 "Uc" = (
 /obj/machinery/atmospherics/binary/pump/high_power,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust2)
@@ -7017,13 +7479,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
-"Ue" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/sign/securearea{
-	pixel_y = 32
-	},
-/turf/space/dynamic,
-/area/space)
 "Ug" = (
 /obj/machinery/mineral/processing_unit_console{
 	pixel_y = 28
@@ -7044,17 +7499,18 @@
 	dir = 2
 	},
 /turf/simulated/floor/tiled/white,
-/area/coc_scarab/bunks)
+/area/coc_scarab/cryogenics)
 "Ul" = (
-/obj/machinery/button/ignition{
-	dir = 8;
-	pixel_x = 23;
-	id = "scav_igni"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/handrail{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "Um" = (
@@ -7067,11 +7523,13 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/coc_scarab/mess)
 "Uv" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /mob/living/simple_animal/hakhma,
-/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/floor/decayed{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	layer = 2
+	},
 /turf/simulated/floor/grass,
 /area/coc_scarab/hydroponics)
 "UB" = (
@@ -7102,13 +7560,13 @@
 /area/shuttle/coc_scarab)
 "UW" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/coc_scarab/bridge)
+/turf/simulated/floor/airless,
+/area/coc_scarab/thrust2)
 "UY" = (
-/obj/machinery/light{
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/airless,
 /area/coc_scarab/thrust1)
 "Vb" = (
@@ -7208,6 +7666,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
+"Vx" = (
+/obj/machinery/door/airlock{
+	dir = 4;
+	name = "Washroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/coc_scarab/washroom)
 "VF" = (
 /obj/machinery/atmospherics/pipe/tank{
 	dir = 4
@@ -7226,11 +7702,10 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Shuttle"
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/shuttle/coc_scarab)
 "VK" = (
 /obj/structure/lattice/catwalk/indoor,
@@ -7248,7 +7723,7 @@
 	name = "Hydroponics"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled,
 /area/coc_scarab/hydroponics)
 "VN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -7271,14 +7746,31 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/bed/handrail{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "VS" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/coc_scarab/medical)
+"VY" = (
+/obj/effect/floor_decal/corner/grey/diagonal{
+	color = "#647252";
+	name = "green corner"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/bed/handrail{
+	dir = 8;
+	name = "table handrail";
+	pixel_x = 1;
+	buckle_dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/coc_scarab/mess)
 "Wa" = (
 /obj/machinery/computer/ship/sensors/terminal,
-/obj/machinery/light{
+/obj/machinery/light/colored/decayed/dimmed{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
@@ -7289,11 +7781,11 @@
 	layer = 2.8
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/light,
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/machinery/light/colored/decayed/dimmed,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
 "Wl" = (
@@ -7308,14 +7800,12 @@
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/medical)
 "Ww" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/ore_box,
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/turf/simulated/floor/airless,
-/area/space)
+/turf/simulated/floor/plating,
+/area/coc_scarab/engine)
 "Wx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -7364,14 +7854,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab)
 "WQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/corner/yellow/full{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/engistorage)
 "Xe" = (
@@ -7386,14 +7876,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bunks)
 "Xi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/purple{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/atmospherics/omni/filter,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
 "Xl" = (
@@ -7403,19 +7896,12 @@
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
+/obj/structure/bed/handrail,
+/obj/machinery/light/floor/decayed{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
-"Xm" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/mining/drill,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/coc_scarab)
 "Xq" = (
 /obj/machinery/atmospherics/portables_connector/fuel{
 	dir = 4
@@ -7433,12 +7919,12 @@
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab)
 "Xz" = (
-/obj/machinery/light,
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = null
 	},
 /obj/random/civgun/rifle,
 /obj/random/civgun,
+/obj/machinery/light/colored/decayed/dimmed,
 /turf/simulated/floor/tiled,
 /area/coc_scarab/armory)
 "XA" = (
@@ -7467,35 +7953,12 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/equipment)
-"XC" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet/west{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/turf/simulated/floor/plating,
-/area/coc_scarab/engine)
-"XI" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	layer = 2.71
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "XM" = (
 /obj/effect/map_effect/marker_helper/airlock/out,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester";
-	cycle_to_external_air = 1
+	shuttle_tag = "Scarab Gas Harvester"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
@@ -7531,6 +7994,9 @@
 	pixel_y = 7
 	},
 /obj/item/material/kitchen/rollingpin,
+/obj/machinery/vending/dinnerware{
+	pixel_y = 22
+	},
 /turf/simulated/floor/lino,
 /area/coc_scarab/mess)
 "Yk" = (
@@ -7540,22 +8006,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
-"Yp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/airless,
-/area/coc_scarab/thrust1)
-"Ys" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"Yv" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/coc_scarab)
+/turf/simulated/floor/airless,
+/area/space)
 "Yz" = (
-/obj/machinery/light,
+/obj/machinery/light/floor/decayed{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	layer = 2
+	},
 /turf/simulated/floor/grass,
 /area/coc_scarab/hydroponics)
 "YA" = (
@@ -7617,15 +8081,13 @@
 /obj/structure/closet/crate/hydroponics/prespawned,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/material/hatchet,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/coc_scarab/hydroponics)
 "YV" = (
@@ -7647,8 +8109,22 @@
 "YY" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/coc_scarab/grauwolf)
+"YZ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light/small{
+	dir = 8;
+	must_start_working = 1
+	},
+/turf/simulated/floor/plating,
+/area/coc_scarab/mess)
 "Zb" = (
-/obj/machinery/light,
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = null
 	},
@@ -7660,6 +8136,7 @@
 /obj/item/clothing/accessory/holster/hip,
 /obj/item/clothing/accessory/holster/hip,
 /obj/item/clothing/accessory/holster/waist/brown,
+/obj/machinery/light/colored/decayed/dimmed,
 /turf/simulated/floor/tiled,
 /area/coc_scarab/armory)
 "Zd" = (
@@ -7693,12 +8170,11 @@
 	},
 /turf/simulated/floor/airless,
 /area/space)
-"Zu" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
+"Zs" = (
+/obj/structure/railing/mapped{
+	dir = 8
 	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/airless,
 /area/space)
 "ZA" = (
@@ -7734,6 +8210,9 @@
 "ZG" = (
 /obj/machinery/door/window/eastright,
 /obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/grass,
 /area/coc_scarab/hydroponics)
 "ZH" = (
@@ -7775,6 +8254,9 @@
 /obj/structure/bed/stool/chair/office/bridge/pilot{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner_wide/paleblue{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_scarab/bridge)
 "ZO" = (
@@ -7804,6 +8286,9 @@
 	icon_state = "1-8"
 	},
 /obj/structure/lattice/catwalk/indoor,
+/obj/structure/bed/handrail{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)
 "ZT" = (
@@ -34157,9 +34642,9 @@ Bm
 gL
 GT
 cV
-XI
+sZ
 Lo
-oM
+Zs
 cV
 gL
 GT
@@ -34411,15 +34896,15 @@ IR
 IR
 px
 ec
-FD
+pT
 GJ
 zU
-FO
+EJ
 gh
-kG
+Yv
 zU
 zU
-Na
+uM
 ru
 px
 cn
@@ -34671,9 +35156,9 @@ Il
 bH
 zU
 zU
-vz
+AO
 Il
-vG
+SK
 zU
 Rr
 HY
@@ -34925,12 +35410,12 @@ jO
 IR
 px
 bU
-Ww
+vO
 zU
 zU
-mp
+gj
 ee
-Zu
+uV
 zU
 zU
 bL
@@ -35177,17 +35662,17 @@ vK
 Dm
 MC
 MS
-Yp
+sN
 jO
-Ue
+qx
 px
 dE
 ah
 by
 re
-dM
+qw
 It
-Th
+Jl
 re
 by
 re
@@ -36240,7 +36725,7 @@ mM
 mM
 YY
 KT
-Hs
+tI
 GX
 GP
 Gl
@@ -36492,13 +36977,13 @@ ak
 Sw
 mM
 Uv
-jU
-RU
+jp
+Jh
 Yz
 YY
 qS
 Fj
-Wl
+sf
 AD
 kP
 kP
@@ -36740,7 +37225,7 @@ lb
 lb
 px
 px
-dL
+zz
 lb
 lb
 lb
@@ -36755,7 +37240,7 @@ So
 YY
 Vo
 pS
-Wl
+sf
 kP
 kP
 kP
@@ -37224,17 +37709,17 @@ cB
 cB
 cB
 lb
-sV
-jM
-sV
+Qe
+YF
+UN
 cR
-sV
-jM
-sV
+Qe
+YF
+UN
 cR
-sV
-jM
-sV
+Qe
+YF
+UN
 lU
 oE
 cM
@@ -37248,7 +37733,7 @@ Hp
 Hp
 Hp
 Hp
-ny
+Hp
 ny
 ny
 ny
@@ -37263,7 +37748,7 @@ ty
 nd
 mM
 qQ
-Ke
+tP
 Ke
 ie
 YY
@@ -37505,12 +37990,12 @@ VF
 QL
 ux
 qd
-ny
+Hp
 Dk
 Lf
 ny
 Re
-Re
+GB
 ny
 Sw
 Sw
@@ -37521,7 +38006,7 @@ Vb
 mM
 co
 zk
-zk
+Fs
 Vr
 fo
 fo
@@ -37738,17 +38223,17 @@ cB
 cB
 cB
 lb
-sV
-jM
-sV
+Qe
+YF
+UN
 cR
-sV
-jM
-sV
+Qe
+YF
+UN
 cR
-sV
-jM
-sV
+Qe
+YF
+UN
 lU
 oE
 cM
@@ -37762,7 +38247,7 @@ EA
 cC
 uW
 kz
-ny
+Hp
 fa
 DN
 ny
@@ -37778,7 +38263,7 @@ EI
 mM
 YL
 zk
-zk
+Fs
 DF
 fo
 cu
@@ -38010,20 +38495,20 @@ lU
 oE
 GW
 DI
-Dx
+rK
 nV
 iU
 Eq
 RL
 CD
 Eq
-fQ
+BM
 sH
-ny
+Hp
 XB
 SM
 pa
-pK
+Hi
 jP
 lg
 VS
@@ -38031,12 +38516,12 @@ pG
 uN
 di
 VS
-fS
+he
 mM
 iD
-sI
-tP
-DF
+zk
+Fs
+qp
 fo
 YD
 OQ
@@ -38252,17 +38737,17 @@ cB
 cB
 cB
 lb
-sV
-jM
-sV
+Qe
+YF
+UN
 cR
-sV
-jM
-sV
+Qe
+YF
+UN
 cR
-sV
-jM
-sV
+Qe
+YF
+UN
 lU
 oE
 cM
@@ -38274,9 +38759,9 @@ Ul
 Vh
 Rb
 gn
-fQ
+BM
 kN
-ny
+Hp
 XB
 Nb
 mh
@@ -38533,7 +39018,7 @@ Ie
 pi
 ln
 Zd
-ny
+Hp
 Ov
 IN
 mK
@@ -38560,7 +39045,7 @@ cK
 Xz
 ab
 FG
-vV
+Dv
 ZM
 Fr
 Iw
@@ -38790,7 +39275,7 @@ Id
 vQ
 eH
 TP
-ny
+Hp
 ny
 ny
 Qb
@@ -38799,7 +39284,7 @@ ny
 ny
 VS
 hk
-xh
+TI
 Wx
 VR
 mm
@@ -38817,7 +39302,7 @@ BV
 BV
 ab
 Xl
-Dv
+rU
 vV
 Od
 Iw
@@ -39028,11 +39513,11 @@ rt
 bg
 bg
 bg
-qp
+rt
 bg
 bg
 bg
-qp
+rt
 bg
 dn
 oE
@@ -39048,12 +39533,12 @@ ud
 rk
 vI
 BS
-rj
+RI
 Tu
 cv
-KJ
+Cq
 mS
-wG
+rj
 iG
 Qz
 IC
@@ -39065,12 +39550,12 @@ AU
 nP
 qq
 Js
-AU
+YZ
 sK
 wr
-SA
+hL
 Vp
-AU
+Lt
 AU
 YV
 xO
@@ -39304,7 +39789,7 @@ zs
 gU
 Cz
 Cb
-kd
+Hp
 kd
 kd
 Ev
@@ -39321,14 +39806,14 @@ Up
 XX
 pQ
 iI
-BM
-hg
+sI
+VY
 xp
 Nz
-Nz
-Nz
-Nz
-BM
+BI
+Ia
+Vx
+Ia
 ab
 LY
 hr
@@ -39557,11 +40042,11 @@ ua
 ua
 Vl
 SZ
-Be
+Ww
 PU
 kj
 Ry
-kd
+Hp
 gA
 Gv
 Em
@@ -39576,19 +40061,19 @@ PA
 Wq
 Up
 TT
-wq
+jU
 cN
 hg
-Lt
+Lb
+Br
+OX
+SX
 Ia
-vs
-Qk
-Iv
-Gr
-BM
+hd
+dI
 ab
 lE
-UW
+sw
 fY
 zw
 Iw
@@ -39794,17 +40279,17 @@ cB
 cB
 cB
 lb
-sV
-jM
-sV
+Qe
+YF
+UN
 cR
-sV
-jM
-sV
+Qe
+ya
+UN
 cR
-sV
-jM
-sV
+Qe
+ya
+UN
 VN
 fU
 Hp
@@ -39817,8 +40302,8 @@ OM
 Sj
 hb
 uI
-Ot
-kd
+Ps
+Hp
 Mv
 Tn
 Pv
@@ -39836,11 +40321,11 @@ Of
 AR
 tE
 hg
-BM
+OX
 Br
-Nr
-hF
 ja
+Ji
+Ia
 hF
 is
 ab
@@ -40071,11 +40556,11 @@ ZS
 ZO
 ww
 et
-Sg
+nQ
 vk
 AY
 Ps
-kd
+Hp
 Tw
 rP
 kd
@@ -40091,15 +40576,15 @@ VS
 Up
 LX
 AR
-Iu
-hg
+dC
+tu
 SD
 Mw
 zh
-zh
-zh
-zh
-hg
+tu
+Ia
+Jc
+xY
 ab
 ab
 yR
@@ -40308,31 +40793,31 @@ cB
 cB
 cB
 lb
-sV
-jM
-sV
+Qe
+ya
+UN
 cR
-sV
-jM
-sV
+Qe
+ya
+UN
 cR
-sV
-jM
-sV
+Qe
+ya
+UN
 lU
-ND
+PT
 Hp
 Hp
 Hp
 Hp
-XC
+Sk
 MV
 cs
 si
 Oe
 oX
 QO
-kd
+Hp
 WQ
 fp
 kd
@@ -40352,11 +40837,11 @@ Bd
 Im
 Hq
 KA
-Jc
+xf
 SB
-PP
+Ia
 LK
-Up
+PP
 ab
 IB
 lb
@@ -40589,7 +41074,7 @@ TL
 Bn
 RT
 cc
-kd
+Hp
 kd
 kd
 kd
@@ -40603,18 +41088,18 @@ lb
 lb
 lb
 Up
-Up
-Up
-Up
-Up
-Up
+ut
+ut
+ut
+ut
+ut
 Nc
-Up
-Up
-Up
-Up
-Up
-lb
+MT
+MT
+MT
+MT
+MT
+ab
 lb
 lb
 cB
@@ -40822,17 +41307,17 @@ cB
 cB
 cB
 lb
-sV
-jM
-sV
+Qe
+ya
+UN
 cR
-sV
-jM
-sV
+Qe
+ya
+UN
 cR
-sV
-jM
-sV
+Qe
+ya
+UN
 lU
 oE
 fD
@@ -40846,7 +41331,7 @@ Hp
 Hp
 Hp
 Hp
-kd
+Hp
 lb
 lb
 kd
@@ -40860,19 +41345,19 @@ lb
 lb
 lb
 lb
-MT
+ut
 Aa
 Uk
 xI
-MT
+ut
 Xe
-JM
+gX
 mw
 RW
 TW
 Je
 lb
-cB
+lb
 cB
 cB
 cB
@@ -41109,7 +41594,7 @@ lb
 lb
 ML
 gK
-Jt
+Kc
 lb
 cB
 cB
@@ -41117,16 +41602,16 @@ cB
 lb
 lb
 lb
-MT
+ut
 ws
 Uk
 Rg
-MT
+ut
 Ew
 JM
 Ku
 Fe
-TW
+EY
 Je
 cB
 cB
@@ -41374,13 +41859,13 @@ cB
 lb
 lb
 lb
-MT
+ut
 ws
 Uk
 FP
 pw
 Hu
-yU
+gt
 yU
 Kt
 Sf
@@ -41631,14 +42116,14 @@ cB
 cB
 lb
 lb
-MT
+ut
 Aa
 Uk
 Ru
-MT
+ut
 Lw
 ka
-RP
+fK
 ba
 Ra
 Je
@@ -41888,11 +42373,11 @@ cB
 cB
 lb
 lb
-MT
-MT
-MT
-MT
-MT
+ut
+ut
+ut
+ut
+ut
 MT
 MT
 MT
@@ -42630,7 +43115,7 @@ pW
 py
 WD
 dS
-dS
+OD
 Lg
 QK
 gc
@@ -42883,13 +43368,13 @@ cB
 cB
 fg
 wT
-Bf
+UW
 Jg
 in
 lc
-Bf
+Ot
 yu
-Ue
+qx
 px
 cn
 lb
@@ -43140,7 +43625,7 @@ cB
 cB
 Ge
 Ex
-Bf
+UW
 yu
 dG
 HL
@@ -43681,7 +44166,7 @@ Kk
 cn
 cB
 wY
-wx
+up
 bG
 Nd
 eX
@@ -43931,7 +44416,7 @@ AL
 AL
 vy
 RM
-PC
+Qv
 fz
 cB
 Kk
@@ -43946,7 +44431,7 @@ fn
 Cj
 fm
 Av
-ea
+tG
 eX
 eX
 aE
@@ -43955,7 +44440,7 @@ cB
 cB
 Kk
 cn
-cB
+LG
 kV
 cB
 cB
@@ -44183,9 +44668,9 @@ tO
 Rf
 ZH
 Pa
-gI
 qe
-SX
+qe
+qe
 HU
 RM
 MN
@@ -44456,9 +44941,9 @@ HW
 En
 EG
 KY
-zQ
-gb
-eL
+mP
+vT
+BK
 SH
 ms
 Gt
@@ -44693,16 +45178,16 @@ Kk
 cn
 pz
 nZ
-ym
+gd
 eN
 kR
-MN
-Ji
+gI
+oK
 oK
 kH
 il
 RM
-MN
+ze
 bJ
 cB
 Kk
@@ -44713,9 +45198,9 @@ Se
 Co
 an
 vt
-Xm
-Ys
-Ys
+FS
+Sx
+My
 eE
 ms
 Eg
@@ -44957,7 +45442,7 @@ yP
 Fv
 HF
 HF
-ym
+gd
 RM
 ml
 fz
@@ -44972,8 +45457,8 @@ Dz
 xo
 mu
 EG
-En
-eL
+BK
+BK
 Fh
 pL
 tZ
@@ -45230,7 +45715,7 @@ Pm
 Qg
 EG
 EG
-En
+BK
 EW
 eX
 eX
@@ -45480,13 +45965,13 @@ Kk
 cn
 cB
 wY
-ij
+zS
 DD
 eX
 Ug
 eX
 xR
-eL
+BK
 En
 VQ
 IJ

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dmm
@@ -73,14 +73,15 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
 /obj/machinery/light,
 /obj/machinery/airlock_sensor{
 	pixel_y = -25
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/shuttle/coc_scarab)
 "aE" = (
 /obj/structure/sign/flag/scarab{
@@ -262,7 +263,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /obj/machinery/access_button{
 	pixel_x = 8;
@@ -697,10 +699,11 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /obj/effect/landmark/entry_point/starboard,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/shuttle/coc_scarab)
 "et" = (
 /obj/structure/cable/yellow{
@@ -1043,7 +1046,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -1080,7 +1084,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab)
@@ -1317,7 +1322,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester"
+	shuttle_tag = "Scarab Gas Harvester";
+	cycle_to_external_air = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -1623,7 +1629,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester"
+	shuttle_tag = "Scarab Gas Harvester";
+	cycle_to_external_air = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
@@ -1632,6 +1639,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/airlock_sensor{
+	pixel_y = -25
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
@@ -3056,12 +3066,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester"
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
+	shuttle_tag = "Scarab Gas Harvester";
+	cycle_to_external_air = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -3132,7 +3138,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester"
+	shuttle_tag = "Scarab Gas Harvester";
+	cycle_to_external_air = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
@@ -4193,9 +4200,10 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/shuttle/coc_scarab)
 "CP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
@@ -4809,13 +4817,15 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester"
-	},
-/obj/machinery/airlock_sensor{
-	pixel_y = -25
+	shuttle_tag = "Scarab Gas Harvester";
+	cycle_to_external_air = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_y = -20;
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/scarab_harvester)
@@ -5635,7 +5645,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester"
+	shuttle_tag = "Scarab Gas Harvester";
+	cycle_to_external_air = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -6060,9 +6071,14 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_y = -20;
+	dir = 1
+	},
+/turf/simulated/floor/airless,
 /area/shuttle/coc_scarab)
 "Pm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -6280,9 +6296,10 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/shuttle/coc_scarab)
 "QJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -6418,7 +6435,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester"
+	shuttle_tag = "Scarab Gas Harvester";
+	cycle_to_external_air = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
@@ -6881,7 +6899,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester"
+	shuttle_tag = "Scarab Gas Harvester";
+	cycle_to_external_air = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux,
@@ -7207,15 +7226,11 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/shuttle/coc_scarab)
 "VK" = (
 /obj/structure/lattice/catwalk/indoor,
@@ -7479,7 +7494,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "scarab_harvester";
 	name = "airlock_scarab_harvester";
-	shuttle_tag = "Scarab Gas Harvester"
+	shuttle_tag = "Scarab Gas Harvester";
+	cycle_to_external_air = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dmm
@@ -7172,13 +7172,6 @@
 "SR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/structure/table/reinforced/steel,
-/obj/item/paper{
-	desc = "An old and half-crumpled piece of paper. It's clear that it's seen much use.";
-	name = "Technician's Notice";
-	info = "[lang=3]NOTICE FOR ALL TECHNICIANS! If a single one of you melts ANY portion of our ship EVER again, I will see you summarily released at our nearest port with as little of our food as I can POSSIBLY spare you! Since wasting paper on this matter has apparently become essential, you will now keep this notice adjacent to the combustion engine AT ALL TIMES! This is our ship's combustion engine. We burn a fire in the chamber, let it fully burn out, and then run the superheated gas through a vent, into our thermoelectric generator, and back into the chamber. This produces a lot of power, and will be required to keep our SMES topped up in the long term. It will slowly cool down, and may occasionally need more burner mix to be injected to keep it hot enough for our needs. Repairing the inside of the chamber may occasionally become necessary, as a particularly hot burn will damage the walls and windows. GUIDE FOR USE: Step one: configure the mixer to output a 60% oxygen and 40% hydrogen mix. Inject a few hundred kPa of this mix into the chamber. Step 2: cut injection, and ignite the mix. Do not panic when the glass makes a noise, that is normal. Step 3: once the fire has fully burned out, enable injection and output, so the gas begins to circulate through the thermoelectric generator. Feel at liberty to diverge from these intructions, ingenuity and invention is at the heart of our fleet - but be careful![/lang]";
-	pixel_x = -6;
-	pixel_y = 2
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
@@ -7192,6 +7185,10 @@
 /obj/machinery/light/small{
 	dir = 8;
 	must_start_working = 1
+	},
+/obj/item/paper/fluff/scarab{
+	pixel_y = 2;
+	pixel_x = -6
 	},
 /turf/simulated/floor/plating,
 /area/coc_scarab/engine)

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_areas.dm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_areas.dm
@@ -20,6 +20,21 @@
 	name = "Scarab Salvage Vessel - Mess Hall"
 	icon_state = "cafeteria"
 
+/area/coc_scarab/cryogenics
+	name = "Scarab Salvage Vessel - Cryogenics Bay"
+	icon_state = "Sleep"
+	sound_env = SMALL_ENCLOSED
+
+/area/coc_scarab/washroom
+	name = "Scarab Salvage Vessel - Washroom"
+	icon_state = "washroom"
+	sound_env = SMALL_ENCLOSED
+
+/area/coc_scarab/hallway
+	name = "Scarab Salvage Vessel - Aft Hallway"
+	icon_state = "maintcentral"
+	sound_env = TUNNEL_ENCLOSED
+
 /area/coc_scarab/armory
 	name = "Scarab Salvage Vessel - Armory"
 	icon_state = "armory"
@@ -43,6 +58,7 @@
 /area/coc_scarab/massdriver
 	name = "Scarab Salvage Vessel - Mass Driver"
 	icon_state = "morgue"
+	sound_env = TUNNEL_ENCLOSED
 
 /area/coc_scarab/equipment
 	name = "Scarab Salvage Vessel - Equipment Storage"
@@ -55,6 +71,7 @@
 /area/coc_scarab/engine
 	name = "Scarab Salvage Vessel - Engine Room"
 	icon_state = "engine"
+	ambience = AMBIENCE_ATMOS
 
 /area/coc_scarab/solars
 	name = "Scarab Salvage Vessel - Solar Array"


### PR DESCRIPTION
One must imagine Rusting happy. Many of the smaller tweaks made by hazelmouse, Scarab lore's strongest soldier.
List of changes:

Fixes occasionally non-functional shuttle airlocks
Added wifi variables to mass driver apparatus, so it can fire. You can finally chuck corpses.
Added a cryogenic oversight console to the cryo-bay, so they actually work.
Partially fixed (?) the gas harvester. 4 out of 6 of the vents now respond to the injection toggle on the console - not sure why the two don't, their IDs seem to line up. Maybe it's capped at four per console? Unsure.
Streamlined power grid design by linking the thruster subgrid line to the EVA subgrid line connecting to the shuttles, rather than running a whole new line under a window outside from the engine room. This means you can lose power to thrusters if that line is cut at any point - interdependency is good, it makes disasters more interesting.
Added a breaker box so you can toggle whether the grid is bypassed, rather than it being always bypassed.
Realigned the combustion engine atmos apparatus and TEG to face the proper direction. I've tested the engine several times, it works pretty much perfectly now - previously, the hot loop injector wasn't even connected.
Replaced a stretch of windows towards the back of the combustion chamber with walls to resolve a visual bug.
Added a second atmospherics control console specifically to control the burner mix air injector, rather than both being hooked up to the same injection toggle. This was a really annoying part of the old design.
Removed a shaker cap from the kitchen. The shaker already comes with a cap.
Removed some excessive grates that didn't need to be there mechanically. They're a useful tool, but there were SO many that it being visually distracting.
Made the back wall of hydroponics straight, rather than jagged.
Reorganised medical a little.
Replaced grates under airlocks with appropriate tiles throughout the ship, so that you can click on the tile to easily close the airlock behind you - you can't do this when there's a grate there.
Removed the window behind the new telecommunications server, since it's not much use tucked in the back of a server closet.
Added medkits and some stabilisation kit to medical, and removed some of their blood bags - still more than enough. They shouldn't be very well supplied, this is essentials only.
Set the hydroponics airlock to autoclose, it stayed open forever before.
Named a bunch of atmos devices for clarity, and included a written IC guide for the engine.
Replaced the grates in the engine chamber with catwalks, since I feel they're more visually interesting and work better in this kind of chamber - see deck one gas mixing on the Horizon.
Grimed the place up a little, and added a lot more decals to hopefully make it more visually interesting and more intuitive to navigate.
Altered the floor tiles of engineering storage, EVA storage, and the cafeteria, to be a little easier on the eyes.
Slightly altered the bridge layout for there to be less wasted space.
Added a few fire extinguishers, in case anyone has a moment with the engine.
Added several meters around atmos elements, to make things easier to read.
Both the waste pump and the air distro regulator now start enabled, as seems to be normal. Weirdly, the waste pump's sprite doesn't show that it's on, even though it is.
Added a distress beacon launcher. I have checked, it is functional - apparently it requires no ID or identifier, it just works based on the map it's on.
Added an air alarm to the lil aft hallway, and to the hakhma pen, so breaches are picked up in those areas. Ideally, the hallway should be a separate area imo, and so should the living quarters be from cryogenics, but I'm not ready to jump into custom areas quite yet.
Added a pipe wrench to the engine room.
Added an underwear closet the crew quarters. I had to make all four beds into two bunk beds for it to work - oddly, the bedsheets don't seem to be getting offset properly, so the top bed has no sheets.
Added a circuit kit to the crew quarters, cus I think it's fun and I think it works with them being salvagers.
Added a grinder to the kitchen, so you can get medicine out of hydroponics if you like.