### PR TITLE
Beefier Powergrid, Tajaran smuggler edition

### DIFF
--- a/html/changelogs/LynxSolstice-Tajara-Smuggler-Power-Fix.yml
+++ b/html/changelogs/LynxSolstice-Tajara-Smuggler-Power-Fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: LynxSolstice
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Added a beefier SMES to the Tajaran Smuggler ship to keep the engines from turning off and as recommended by HazelMouse, a breakerbox."

--- a/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dmm
+++ b/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dmm
@@ -1716,6 +1716,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -2175,7 +2178,12 @@
 	},
 /area/tajaran_smuggler/dorms)
 "luH" = (
-/obj/machinery/power/smes/buildable/horizon_shuttle,
+/obj/machinery/power/smes/buildable/main_engine,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
@@ -2516,6 +2524,12 @@
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/atmos)
+"neJ" = (
+/obj/machinery/power/breakerbox,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/tajaran_smuggler/power)
 "nny" = (
 /obj/structure/largecrate/animal/adhomai/rafama,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3488,6 +3502,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -36655,8 +36674,8 @@ xRX
 kJl
 fji
 kJl
-izs
-izs
+neJ
+erW
 vgW
 bYG
 izs


### PR DESCRIPTION
Added a beefier, one megawatt SMES and breaker box to the Tajaran smuggler ship because it's powerdraw was far higher than what the 200 megawatt smes could handle (about 3 to 4 times heavier of a load)
