### PR TITLE
The AI can now spawn at roundstart correctly

### DIFF
--- a/code/game/antagonist/station/thrall.dm
+++ b/code/game/antagonist/station/thrall.dm
@@ -40,6 +40,8 @@ var/datum/antagonist/thrall/thralls = null
 
 /datum/antagonist/thrall/remove_antagonist(datum/mind/player, show_message, implanted)
 	var/datum/vampire/vampire = player.antag_datums[MODE_VAMPIRE]
-	vampire.lose_master(player.current)
+
+	if(vampire)
+		vampire.lose_master(player.current)
 	player.antag_datums -= MODE_VAMPIRE
 	return ..()

--- a/code/game/antagonist/station/vampire.dm
+++ b/code/game/antagonist/station/vampire.dm
@@ -67,6 +67,9 @@ var/datum/antagonist/vampire/vamp = null
 
 /datum/antagonist/vampire/remove_antagonist(var/datum/mind/player, var/show_message = TRUE, var/implanted)
 	var/datum/vampire/vampire = player.antag_datums[MODE_VAMPIRE]
+	if(!vampire)
+		return
+
 	if(player.current.client)
 		player.current.client.screen -= vampire.blood_hud
 		player.current.client.screen -= vampire.frenzy_hud

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -1,8 +1,10 @@
 var/global/list/empty_playable_ai_cores = list()
 
-/hook/roundstart/proc/spawn_empty_ai()
-	if("AI" in SSticker.mode.disabled_jobs)
-		return 1	// Don't make empty AI's if you can't have them (also applies to Malf)
+/hook/pregame_start/proc/spawn_empty_ai()
+	//No gamemode disables the AI anyways, and this would prevent this hook from working correctly, so it's a problem for whoever might want to implement a gamemode that doesn't
+	//allow an AI in the future, which is likely (hopefully?) never
+	// if("AI" in SSticker.mode.disabled_jobs)
+	// 	return 1	// Don't make empty AI's if you can't have them (also applies to Malf)
 	for(var/obj/effect/landmark/start/S in landmarks_list)
 		if(S.name != "AI")
 			continue

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -106,16 +106,11 @@
 /mob/proc/AIize(move=1)
 	if(client)
 		src << sound(null, repeat = 0, wait = 0, volume = 85, channel = 1) // stop the jams for AIs)
-	var/mob/living/silicon/ai/O = new (loc, base_law_type,,1)//No MMI but safety is in effect.
-	O.set_invisibility(0)
-	O.ai_restore_power_routine = 0
 
-	if(mind)
-		mind.transfer_to(O)
-		O.mind.original = O
-	else
-		O.key = key
+	//The destination the mob will be spawned at
+	var/final_destination = loc
 
+	//If it's requested to move, select a location to spawn/move the mob to
 	if(move)
 		var/obj/loc_landmark
 		for(var/obj/effect/landmark/start/sloc in landmarks_list)
@@ -131,12 +126,23 @@
 						continue
 					loc_landmark = tripai
 		if (!loc_landmark)
-			to_chat(O, "Oh god sorry we can't find an unoccupied AI spawn location, so we're spawning you on top of someone.")
 			for(var/obj/effect/landmark/start/sloc in landmarks_list)
 				if (sloc.name == "AI")
 					loc_landmark = sloc
 
-		O.forceMove(loc_landmark.loc)
+		if(loc_landmark.loc)
+			final_destination = loc_landmark.loc
+
+
+	var/mob/living/silicon/ai/O = new (final_destination, base_law_type,,1)//No MMI but safety is in effect.
+	O.set_invisibility(0)
+	O.ai_restore_power_routine = 0
+
+	if(mind)
+		mind.transfer_to(O)
+		O.mind.original = O
+	else
+		O.key = key
 
 	O.on_mob_init()
 

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -49,7 +49,7 @@
 		crash_with("Comp was not sent for [src.filename]")
 
 /datum/computer_file/program/Destroy()
-	if(computer)
+	if(!QDELETED(computer))
 		computer.idle_threads -= src
 		computer.enabled_services -= src
 		computer = null

--- a/html/changelogs/fluffyghost-fixairoundstartspawn.yml
+++ b/html/changelogs/fluffyghost-fixairoundstartspawn.yml
@@ -1,0 +1,45 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The AI can now spawn at roundstart correctly."
+  - bugfix: "Solved various roundtimes when the AI core is wiped."
+  - bugfix: "Solved a runtime with programs when the computer was GCd."
+  - bugfix: "Solved an issue that runtimed the AI mob initialization due to it being created in nullspace at roundstart, for the atmos monitoring program."
+  - rscdel: "Removed the ability to disable the AI in a gamemode, noone used it anyways and it gave issues with the fix for the roundstart initialization."


### PR DESCRIPTION
The AI can now spawn at roundstart correctly.
Solved various roundtimes when the AI core is wiped.
Solved a runtime with programs when the computer was GCd.
Solved an issue that runtimed the AI mob initialization due to it being created in nullspace at roundstart, for the atmos monitoring program.
Removed the ability to disable the AI in a gamemode, noone used it anyways and it gave issues with the fix for the roundstart initialization.

Fixes #17942 