### PR TITLE
Fixed device assemblies

### DIFF
--- a/code/__defines/wires.dm
+++ b/code/__defines/wires.dm
@@ -83,3 +83,23 @@
 #define AI_WIRE_DISABLED 1
 #define AI_WIRE_HACKED 2
 #define AI_WIRE_DISABLED_HACKED -1
+
+/*################################
+	Wires for the assembly
+	/obj/item/device/assembly
+################################*/
+
+///Allows Pulsed(0) to call Activate()
+#define WIRE_RECEIVE_ASSEMBLY BITFLAG(1)
+
+///Allows Pulse(0) to act on the holder
+#define WIRE_PULSE_ASSEMBLY BITFLAG(2)
+
+/// Allows Pulse(0) to act on the holders special assembly
+#define WIRE_PULSE_SPECIAL BITFLAG(3)
+
+///Allows Pulsed(1) to call Activate()
+#define WIRE_RADIO_RECEIVE BITFLAG(4)
+
+///Allows Pulse(1) to send a radio message
+#define WIRE_RADIO_PULSE BITFLAG(5)

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -18,13 +18,20 @@
 	var/list/attached_overlays = null
 	var/obj/item/device/assembly_holder/holder = null
 	var/cooldown = 0 //To prevent spam
-	var/wires = WIRE_RECEIVE_ASSEMBLY | WIRE_PULSE_ASSEMBLY
 
-	var/const/WIRE_RECEIVE_ASSEMBLY = 1			//Allows Pulsed(0) to call Activate()
-	var/const/WIRE_PULSE_ASSEMBLY = 2				//Allows Pulse(0) to act on the holder
-	var/const/WIRE_PULSE_SPECIAL = 4		//Allows Pulse(0) to act on the holders special assembly
-	var/const/WIRE_RADIO_RECEIVE = 8		//Allows Pulsed(1) to call Activate()
-	var/const/WIRE_RADIO_PULSE = 16		//Allows Pulse(1) to send a radio message
+	/**
+	 * Wires that the assembly has installed
+	 *
+	 * Refer to `code\__defines\wires.dm` in the dedicated section for the supported wires, which _must_ be bitflags
+	 *
+	 * At the time of writing this, it supports:
+	 * * WIRE_RECEIVE_ASSEMBLY
+	 * * WIRE_PULSE_ASSEMBLY
+	 * * WIRE_PULSE_SPECIAL
+	 * * WIRE_RADIO_RECEIVE
+	 * * WIRE_RADIO_PULSE
+	 */
+	var/wires = WIRE_RECEIVE_ASSEMBLY | WIRE_PULSE_ASSEMBLY
 
 /obj/item/device/assembly/proc/holder_movement()
 	return

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -8,7 +8,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 500, MATERIAL_GLASS = 50)
 
 	secured = TRUE
-	wires = WIRE_RECEIVE
+	wires = WIRE_RECEIVE_ASSEMBLY
 
 /obj/item/device/assembly/igniter/activate()
 	. = ..()

--- a/html/changelogs/fluffyghost_fixdeviceassembly.yml
+++ b/html/changelogs/fluffyghost_fixdeviceassembly.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed device assemblies, which also fixes some chem grenades like the cleaner grenades, that were using wrong wires."
+  - backend: "Moved the wires from constant vars to defines, moved inside the wires define file, DMdoc'd them from the comments they had."


### PR DESCRIPTION
Fixed device assemblies, which also fixes some chem grenades like the cleaner grenades, that were using wrong wires.
Moved the wires from constant vars to defines, moved inside the wires define file, DMdoc'd them from the comments they had.