### PR TITLE
AOOC text is now bold

### DIFF
--- a/html/changelogs/fluffyghost-aoocbold.yml
+++ b/html/changelogs/fluffyghost-aoocbold.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "AOOC text is now bold, to better distinguish it from Security chat."

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -357,6 +357,7 @@ em {
 }
 .aooc {
   color: #d1021e;
+  font-weight: bold;
 }
 
 /* Admin: Private Messages */


### PR DESCRIPTION
AOOC text is now bold, to better distinguish it from Security chat
![image](https://github.com/Aurorastation/Aurora.3/assets/65877598/b05b6bd0-b144-43b4-b001-1e3684f66828)
![image](https://github.com/Aurorastation/Aurora.3/assets/65877598/b7609a0b-8bcc-4711-a63b-6e099414110d)

Based on https://forums.aurorastation.org/topic/19586-aooc-color-change/