### PR TITLE
Allows the toy guns that spawn in the warehouse to also spawn as real guns

### DIFF
--- a/code/modules/cargo/random_stock/t3_rare.dm
+++ b/code/modules/cargo/random_stock/t3_rare.dm
@@ -150,7 +150,7 @@ STOCK_ITEM_RARE(megacorp_goods, 0.25)
 	var/obj/item/adv_item = pick(/obj/item/storage/backpack/service, /obj/item/device/advanced_healthanalyzer)
 	new adv_item(L)
 
-STOCK_ITEM_COMMON(pistols, 1)
+STOCK_ITEM_RARE(pistols, 1)
 	var/list/pistols = list(
 		/obj/item/gun/projectile/colt = 1,
 		/obj/item/gun/projectile/silenced = 1,

--- a/code/modules/cargo/random_stock/t3_rare.dm
+++ b/code/modules/cargo/random_stock/t3_rare.dm
@@ -150,4 +150,18 @@ STOCK_ITEM_RARE(megacorp_goods, 0.25)
 	var/obj/item/adv_item = pick(/obj/item/storage/backpack/service, /obj/item/device/advanced_healthanalyzer)
 	new adv_item(L)
 
+STOCK_ITEM_COMMON(pistols, 1)
+	var/list/pistols = list(
+		/obj/item/gun/projectile/colt = 1,
+		/obj/item/gun/projectile/silenced = 1,
+		/obj/item/gun/projectile/pirate = 3,
+		/obj/item/gun/projectile/pistol = 1,
+		/obj/item/gun/projectile/revolver = 0.5,
+		/obj/item/gun/projectile/sec = 1,
+		/obj/item/gun/projectile/tanto = 1
+	)
+
+	var/type = pickweight(pistols)
+	new type(L)
+
 STOCK_ITEM_RARE(nothing, 0)

--- a/html/changelogs/warehousepistols.yml
+++ b/html/changelogs/warehousepistols.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: 4000daniel1
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a chance for the toy/bang guns that spawn in the warehouse to be real, actual guns."


### PR DESCRIPTION
I always thought the bang guns that spawn in warehouse had a very small chance to be real guns, APPARENTLY THEY DON'T. Most of the time these will probably just get sent off to security but since the strongest one that can spawn is the revolver it shouldn't make too much of a difference.

My hope is that it'll enable ops to occasionally get opportunities to do classic funny ops things like negligent bottle shooting contests and what not. (It's been too long since the last one)