### PR TITLE
Update github labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,4 @@
 # Folder Rules
-'Changelog Required':
-- '!html/changelogs/*.yml'
-
 Database:
 - SQL/**
 


### PR DESCRIPTION
The GitHub labeler no longer applies the changelog required action.