### PR TITLE
Ghost Spawner Manifest - follow mob button

### DIFF
--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -179,7 +179,7 @@ SUBSYSTEM_DEF(ghostroles)
 			. = TRUE
 
 		if("jump_to")
-			var/spawner_id = params["jump_to"]
+			var/spawner_id = params["spawner_id"]
 			var/datum/ghostspawner/human/spawner = spawners[spawner_id]
 			var/mob/abstract/observer/observer = usr
 			if(spawner && istype(observer) && spawner.can_jump_to(observer))
@@ -187,6 +187,19 @@ SUBSYSTEM_DEF(ghostroles)
 				if(isturf(turf))
 					observer.on_mob_jump()
 					observer.forceMove(turf)
+
+		if("follow_manifest_entry")
+			var/spawner_id = params["spawner_id"]
+			var/spawned_mob_name = params["spawned_mob_name"]
+			var/datum/ghostspawner/human/spawner = spawners[spawner_id]
+			var/mob/abstract/observer/observer = usr
+			if(istype(observer) && spawner.can_jump_to(observer) && spawner && LAZYLEN(spawner.spawned_mobs))
+				for(var/datum/weakref/mob_ref in spawner.spawned_mobs)
+					var/mob/spawned_mob = mob_ref.resolve()
+					if(spawned_mob && spawned_mob.real_name == spawned_mob_name)
+						observer.ManualFollow(spawned_mob)
+						break
+
 		if("enable")
 			var/datum/ghostspawner/S = spawners[params["enable"]]
 			if(!S)

--- a/html/changelogs/DreamySkrell-ghostspawner-manifest-follow-mob.yml
+++ b/html/changelogs/DreamySkrell-ghostspawner-manifest-follow-mob.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Mobs listed in ghost spawner manifest can be followed."

--- a/tgui/packages/tgui/interfaces/GhostSpawner.tsx
+++ b/tgui/packages/tgui/interfaces/GhostSpawner.tsx
@@ -43,17 +43,21 @@ const ManifestTable = function (act, spawner: Spawner) {
             return (
               <TableCell>
                 {' - ' + spawned_mob_name + ' '}
-                <Tooltip content="Follow mob">
-                  <Button
-                    content="F"
-                    onClick={() =>
-                      act('follow_manifest_entry', {
-                        spawner_id: spawner.short_name,
-                        spawned_mob_name: spawned_mob_name,
-                      })
-                    }
-                  />
-                </Tooltip>
+                {spawner.can_jump_to ? (
+                  <Tooltip content="Follow mob">
+                    <Button
+                      content="F"
+                      onClick={() =>
+                        act('follow_manifest_entry', {
+                          spawner_id: spawner.short_name,
+                          spawned_mob_name: spawned_mob_name,
+                        })
+                      }
+                    />
+                  </Tooltip>
+                ) : (
+                  ''
+                )}
               </TableCell>
             );
           } else {

--- a/tgui/packages/tgui/interfaces/GhostSpawner.tsx
+++ b/tgui/packages/tgui/interfaces/GhostSpawner.tsx
@@ -1,6 +1,7 @@
+import { paginate } from 'common/collections';
 import { BooleanLike } from '../../common/react';
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, Input, Section, Table, Tabs } from '../components';
+import { Box, Button, Input, Section, Table, Tabs, Tooltip } from '../components';
 import { TableCell, TableRow } from '../components/Table';
 import { Window } from '../layouts';
 
@@ -24,6 +25,51 @@ type Spawner = {
   tags: string[];
   spawnpoints: string[];
   manifest: string[];
+};
+
+const ManifestTable = function (act, spawner: Spawner) {
+  return (
+    <Table>
+      {paginate(spawner.manifest, 2).map((page) => {
+        const spawned_mob_name_1 = page[0];
+        const spawned_mob_name_2 = page[1];
+
+        const ManifestCell = function (
+          act,
+          spawner: Spawner,
+          spawned_mob_name: string
+        ) {
+          if (spawned_mob_name) {
+            return (
+              <TableCell>
+                {' - ' + spawned_mob_name + ' '}
+                <Tooltip content="Follow mob">
+                  <Button
+                    content="F"
+                    onClick={() =>
+                      act('follow_manifest_entry', {
+                        spawner_id: spawner.short_name,
+                        spawned_mob_name: spawned_mob_name,
+                      })
+                    }
+                  />
+                </Tooltip>
+              </TableCell>
+            );
+          } else {
+            return '';
+          }
+        };
+
+        return (
+          <TableRow pb={1} key={page} overflow="hidden">
+            {ManifestCell(act, spawner, spawned_mob_name_1)}
+            {ManifestCell(act, spawner, spawned_mob_name_2)}
+          </TableRow>
+        );
+      })}
+    </Table>
+  );
 };
 
 export const GhostSpawner = (props, context) => {
@@ -99,20 +145,7 @@ export const GhostSpawner = (props, context) => {
                               <Box fontSize="1.2rem" textAlign="center">
                                 Manifest
                               </Box>
-                              <Table>
-                                {spawner.manifest.map((spawned_mob_name) => {
-                                  return (
-                                    <TableRow
-                                      pb={1}
-                                      key={spawned_mob_name}
-                                      overflow="hidden">
-                                      <TableCell>
-                                        {' - ' + spawned_mob_name}
-                                      </TableCell>
-                                    </TableRow>
-                                  );
-                                })}
-                              </Table>
+                              {ManifestTable(act, spawner)}
                             </Box>
                           ) : null}
                         </Box>
@@ -139,7 +172,7 @@ export const GhostSpawner = (props, context) => {
                           <Button
                             content="J"
                             onClick={() =>
-                              act('jump_to', { jump_to: spawner.short_name })
+                              act('jump_to', { spawner_id: spawner.short_name })
                             }
                           />
                         ) : (


### PR DESCRIPTION

![image](https://github.com/Aurorastation/Aurora.3/assets/107256943/430c8853-2632-4466-b83f-c0ca3631a07f)

changes:
  - rscadd: "Mobs listed in ghost spawner manifest can be followed."
