### PR TITLE
exoplanet ban/force ruins functionality & away site blacklisting

### DIFF
--- a/code/modules/maps/ruins.dm
+++ b/code/modules/maps/ruins.dm
@@ -58,6 +58,17 @@ var/list/banned_ruin_ids = list()
 		if(!(ruin.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
 			banned_ruin_ids += ruin.id
 			available -= ruin
+		if(ruin.ban_ruins)
+			for(var/datum/map_template/ruin/banned_ruin in ruin.ban_ruins)
+				banned_ruin_ids += banned_ruin.id
+		if(ruin.force_ruins)
+			for(var/datum/map_template/ruin/forced_ruin in ruin.force_ruins)
+				selected += forced_ruin
+				if(forced_ruin.spawn_cost > 0)
+					remaining -= forced_ruin.spawn_cost
+				if(!(forced_ruin.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
+					banned_ruin_ids += forced_ruin.id
+					available -= forced_ruin
 
 	if (remaining)
 		log_admin("Ruin loader had no ruins to pick from with [budget] left to spend.")

--- a/html/changelogs/RustingWithYou - banruins.yml
+++ b/html/changelogs/RustingWithYou - banruins.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Exoplanet ruins now have ban/force functionality."
+  - tweak: "Blacklists several away sites from Haneunim and Burzsia."

--- a/maps/away/away_site/abandoned_mining/cursed.dm
+++ b/maps/away/away_site/abandoned_mining/cursed.dm
@@ -3,6 +3,7 @@
 	description = "A lone asteroid with a hangar. Latest data from this sector shows it as a Hephaestus mining station, two years ago."
 	suffixes = list("away_site/abandoned_mining/cursed.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, ALL_COALITION_SECTORS)
+	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA)
 	spawn_weight = 1
 	spawn_cost = 1
 	id = "cursed"

--- a/maps/away/away_site/big_derelict/bigderelict.dm
+++ b/maps/away/away_site/big_derelict/bigderelict.dm
@@ -3,6 +3,7 @@
 	description = "A very large derelict station. According to the starmap, it shouldn't exist."
 	suffixes = list("away_site/big_derelict/bigderelict.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_NEW_ANKARA, SECTOR_BADLANDS, SECTOR_AEMAQ, ALL_COALITION_SECTORS)
+	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA)
 	spawn_weight = 1
 	spawn_cost = 2
 	id = "big_derelict"

--- a/maps/away/away_site/blueriver/blueriver.dm
+++ b/maps/away/away_site/blueriver/blueriver.dm
@@ -7,6 +7,7 @@
 	suffixes = list("away_site/blueriver/blueriver-1.dmm","away_site/blueriver/blueriver-2.dmm")
 	generate_mining_by_z = 2
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, ALL_COALITION_SECTORS)
+	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA)
 
 	unit_test_groups = list(1)
 

--- a/maps/away/away_site/goon_base/goon_base.dm
+++ b/maps/away/away_site/goon_base/goon_base.dm
@@ -3,6 +3,7 @@
 	description = "An asteroid with a occupied hangar carved into it."
 	suffixes = list("away_site/goon_base/goon_base.dmm")
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, ALL_COALITION_SECTORS)
+	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA)
 	spawn_weight = 1
 	ship_cost = 1
 	id = "goon"

--- a/maps/away/away_site/hivebot_hub/hivebot_hub.dm
+++ b/maps/away/away_site/hivebot_hub/hivebot_hub.dm
@@ -3,6 +3,7 @@
 	description = "An abandoned supply hub. This one's releasing the telltale signals of a potential hivebot infestation."
 	suffixes = list("away_site/hivebot_hub/hivebot_hub.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_NEW_ANKARA, SECTOR_BADLANDS, SECTOR_AEMAQ, ALL_COALITION_SECTORS)
+	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA)
 	spawn_weight = 1
 	spawn_cost = 1
 	id = "hivebot_hub"

--- a/maps/away/away_site/magshield/magshield.dm
+++ b/maps/away/away_site/magshield/magshield.dm
@@ -3,6 +3,7 @@
 	id = "magshield"
 	description = "It's an orbital shield station."
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_TAU_CETI, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_AEMAQ, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL, SECTOR_GAKAL, SECTOR_UUEOAESA, ALL_COALITION_SECTORS)
+	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA)
 	suffixes = list("away_site/magshield/magshield.dmm")
 	spawn_weight = 1
 	spawn_cost = 1

--- a/maps/away/away_site/racers/racers.dm
+++ b/maps/away/away_site/racers/racers.dm
@@ -3,6 +3,7 @@
 	description = "A station that doesn't appear to have been legally registered. It has four large hangar bays and a small habitation module - and the signals emittered by its dying equipment seem to identify it as belonging to an underground racing group."
 	suffixes = list("away_site/racers/racers.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_NEW_ANKARA, SECTOR_BADLANDS, SECTOR_AEMAQ, ALL_COALITION_SECTORS)
+	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA)
 	spawn_weight = 1
 	spawn_cost = 2
 	id = "racers"

--- a/maps/away/away_site/shady/shady.dm
+++ b/maps/away/away_site/shady/shady.dm
@@ -3,6 +3,7 @@
 	description = "An asteroid with a hangar carved out inside it. Scans detect an unregistered structure within, with multiple lifeforms present."
 	suffixes = list("away_site/shady/shady.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, ALL_COALITION_SECTORS)
+	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA)
 	spawn_weight = 1
 	spawn_cost = 1
 	id = "shady"

--- a/maps/away/away_site/wrecked_nt_ship/wrecked_nt_ship.dm
+++ b/maps/away/away_site/wrecked_nt_ship/wrecked_nt_ship.dm
@@ -3,6 +3,7 @@
 	description = "A wrecked ship once owned by NanoTrasen."
 	suffixes = list("away_site/wrecked_nt_ship/wrecked_nt_ship.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, ALL_COALITION_SECTORS)
+	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA)
 	spawn_weight = 1
 	spawn_cost = 2
 	id = "wrecked_nt_ship"

--- a/maps/random_ruins/exoplanets/konyang/pirate_moonshine.dm
+++ b/maps/random_ruins/exoplanets/konyang/pirate_moonshine.dm
@@ -6,6 +6,7 @@
 	template_flags = TEMPLATE_FLAG_NO_RUINS|TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED
 	sectors = list(SECTOR_HANEUNIM)
 	suffixes = list("konyang/pirate_moonshine.dmm")
+	ban_ruins = list(/datum/map_template/ruin/exoplanet/pirate_outpost)
 
 /area/konyang_pirate_moonshine
 	name = "Konyang Moonshiner Den"

--- a/maps/random_ruins/exoplanets/konyang/pirate_outpost.dm
+++ b/maps/random_ruins/exoplanets/konyang/pirate_outpost.dm
@@ -7,6 +7,7 @@
 	sectors = list(SECTOR_HANEUNIM)
 	suffixes = list("konyang/pirate_outpost.dmm")
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/konyang_pirate)
+	ban_ruins = list(/datum/map_template/ruin/exoplanet/pirate_moonshine)
 
 /area/konyang_pirate_outpost
 	name = "Konyang Pirate Outpost"


### PR DESCRIPTION
ban_ruins and force_ruins will now work for exoplanet ruins.

prevents several away sites from spawning in Haneunim and Burzsia which don't make sense to be in a settled system.