### PR TITLE
More hammers in YouTool vendors

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -1136,7 +1136,7 @@
 		/obj/item/device/t_scanner = 5,
 		/obj/item/screwdriver = 5,
 		/obj/item/tape_roll = 3,
-		/obj/item/hammer = 3
+		/obj/item/hammer = 5
 	)
 	contraband = list(
 		/obj/item/weldingtool/hugetank = 2,

--- a/html/changelogs/ramke - hammertime.yml
+++ b/html/changelogs/ramke - hammertime.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ramke
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Increases number of hammers available in YouTool vendors."


### PR DESCRIPTION
Increases the number of hammers available in the YouTool vendor.

Should be enough for most engineers now instead of three only. Saves rebuilding the entire airlock just to fix minor damage to them.