### PR TITLE
Fuel rod quantum physics nerf

### DIFF
--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -45,7 +45,7 @@
 		if(injecting)
 			to_chat(user, SPAN_WARNING("Shut \the [src] off before playing with the fuel rod!"))
 			return
-		if(!user.unEquip(W, src))
+		if(!user.unEquip(W, 0, src))
 			return
 		if(cur_assembly)
 			visible_message(SPAN_NOTICE("\The [user] swaps \the [src]'s [cur_assembly] for \a [W]."))

--- a/html/changelogs/Ramke - fuel injector fix.yml
+++ b/html/changelogs/Ramke - fuel injector fix.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ramke
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fuel rods no longer stay in both your hand and the fuel injector at the same time."
+  


### PR DESCRIPTION
Fuel rods no longer appear both on you and the fuel injector, saving space time from collapse.