### PR TITLE
Goon Base remap

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -3551,6 +3551,7 @@
 #include "maps\away\away_site\goon_base\goon_base.dm"
 #include "maps\away\away_site\goon_base\goon_base_areas.dm"
 #include "maps\away\away_site\goon_base\goon_base_ghostroles.dm"
+#include "maps\away\away_site\goon_base\goon_base_items.dm"
 #include "maps\away\away_site\hivebot_hub\hivebot_hub.dm"
 #include "maps\away\away_site\idris_wreck\idris_wreck.dm"
 #include "maps\away\away_site\konyang\point_verdant\point_verdant.dm"

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -130,6 +130,8 @@
 /obj/item/tank/hydrogen/shuttle/adjust_initial_gas()
 	air_contents.adjust_gas(GAS_HYDROGEN, 4*(3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C))
 
+/obj/item/tank/hydrogen/empty
+
 /*
  * Emergency Oxygen
  */

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -93,6 +93,9 @@
 	obj_flags = OBJ_FLAG_CONDUCTABLE
 	slot_flags = null	//they have no straps!
 
+/obj/item/tank/phoron/empty
+	volume = 0
+
 /obj/item/tank/phoron/adjust_initial_gas()
 	air_contents.adjust_gas(GAS_PHORON, (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C))
 

--- a/code/modules/overmap/overmap_shuttle.dm
+++ b/code/modules/overmap/overmap_shuttle.dm
@@ -176,4 +176,6 @@
 	. = ..()
 	new /obj/item/tank/hydrogen/shuttle(src)
 
+/obj/structure/fuel_port/hydrogen/empty
+
 #undef waypoint_sector

--- a/html/changelogs/DreamySkrell-goon-base-remap.yml
+++ b/html/changelogs/DreamySkrell-goon-base-remap.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Remaps the goon base to be nicer visually and in gameplay."

--- a/html/changelogs/DreamySkrell-goon-base-remap.yml
+++ b/html/changelogs/DreamySkrell-goon-base-remap.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - maptweak: "Remaps the goon base to be nicer visually and in gameplay."
+  - maptweak: "Goon base shuttle now has an empty fuel canister."

--- a/maps/away/away_site/goon_base/goon_base.dm
+++ b/maps/away/away_site/goon_base/goon_base.dm
@@ -7,8 +7,8 @@
 	ship_cost = 1
 	id = "goon"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/goon_ship)
-
 	unit_test_groups = list(2)
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 /singleton/submap_archetype/goon
 	map = "goon base"
@@ -93,8 +93,8 @@
 /datum/shuttle/autodock/overmap/goon_ship
 	name = "Wanted Vessel"
 	move_time = 20
-	shuttle_area = list(/area/shuttle/goon_ship/bridge, /area/shuttle/goon_ship/storage, /area/shuttle/goon_ship/med,
-						/area/shuttle/goon_ship/starboard, /area/shuttle/goon_ship/port, /area/shuttle/goon_ship/living)
+	shuttle_area = list(/area/shuttle/goon_shuttle/bridge, /area/shuttle/goon_shuttle/storage, /area/shuttle/goon_shuttle/med,
+						/area/shuttle/goon_shuttle/starboard, /area/shuttle/goon_shuttle/port, /area/shuttle/goon_shuttle/living)
 	dock_target = "goon_ship"
 	current_location = "nav_hangar_goon_ship"
 	landmark_transition = "nav_transit_goon_ship"

--- a/maps/away/away_site/goon_base/goon_base.dm
+++ b/maps/away/away_site/goon_base/goon_base.dm
@@ -55,9 +55,13 @@
 		~love, daryl <br>\
 		"
 
-/obj/item/paper/goon_base/notice
+/obj/item/paper/goon_base/notice_secret_base
 	name = "important notice"
-	info = "REMEMBER TO PUT THE BOOKSHELVES BACK IN PLACE WHEN YOU LEAVE! DON'T WANT ANY POTENTIAL TRESPASSING ASSHOLES STEALING OUR SHIT WHEN WE AREN'T HERE."
+	info = "there is secret entrance to gear equipment room with guns and stuff here in fake walls you can just move over. here in living room and in bathroom. do not let any visitors see it........"
+
+/obj/item/paper/goon_base/notice_secret_back_exit
+	name = "emergency secret back exit"
+	info = "this is for emergency time exit when everything is fucked and we are so over. take pickaxe or drill or whatever and dig straight directly forward north to get to space. remember eva suit............"
 
 //ship stuff
 /obj/effect/overmap/visitable/ship/landable/goon_ship

--- a/maps/away/away_site/goon_base/goon_base.dm
+++ b/maps/away/away_site/goon_base/goon_base.dm
@@ -31,38 +31,6 @@
 	base_turf = /turf/space
 	base_area = /area/space
 
-/obj/item/paper/goon_base
-	name = "/obj/item/paper/goon_base/ parent object"
-	desc = DESC_PARENT
-
-/obj/item/paper/goon_base/note
-	name = "dirty note"
-	info = "hey, boss <br>\
-			<br>\
-		<br>\
-		i had a bit of an acidnet when i was workig the smes <br>\
-		it fuckcng blew up <br>\
-		it wasnt my fault this time. i dident fuck up like u always say i do. it just blew op on its own <br>\
-		<br>\
-		only reason im teling you throgh this note insted of in person <br>\
-		(i fuckimg hate writing) is becaus i knew youd kill me <br>\
-		you threw jake, the olnly real enginer we ever had in this crew out of the airlock cause he short circiuted the booze vendor by accidnet <br>\
-		<br>\
-		so honestely if you guys are stuck here now and have to cannibelaize that dork we snatched last job to not starve then seriusly its ur fault not mine <br>\
-		i got a contact to pick me up, im far gon. u wont find me. dont try to find me if you dont end up starveng here <br>\
-		<br>\
-		<br>\
-		~love, daryl <br>\
-		"
-
-/obj/item/paper/goon_base/notice_secret_base
-	name = "important notice"
-	info = "there is secret entrance to gear equipment room with guns and stuff here in fake walls you can just move over. here in living room and in bathroom. do not let any visitors see it........"
-
-/obj/item/paper/goon_base/notice_secret_back_exit
-	name = "emergency secret back exit"
-	info = "this is for emergency time exit when everything is fucked and we are so over. take pickaxe or drill or whatever and dig straight directly forward north to get to space. remember eva suit............"
-
 //ship stuff
 /obj/effect/overmap/visitable/ship/landable/goon_ship
 	name = "Wanted Vessel"

--- a/maps/away/away_site/goon_base/goon_base.dmm
+++ b/maps/away/away_site/goon_base/goon_base.dmm
@@ -263,6 +263,11 @@
 "bZ" = (
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
+"ch" = (
+/obj/effect/floor_decal/corner/pink/diagonal,
+/obj/random/pottedplant,
+/turf/simulated/floor/tiled,
+/area/mine)
 "cm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -293,6 +298,13 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"cA" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "cF" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
@@ -420,15 +432,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
-"dN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/wall{
-	can_open = 1;
-	color = "#DDDDDD"
-	},
-/area/mine)
 "dQ" = (
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
@@ -545,6 +548,11 @@
 	pixel_x = -2
 	},
 /turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"ew" = (
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
 /area/mine)
 "eA" = (
 /obj/structure/table/reinforced/steel,
@@ -694,12 +702,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
-"fn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/mine)
 "fo" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -932,6 +934,15 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plating,
 /area/mine)
+"gH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall{
+	can_open = 1;
+	color = "#DDDDDD"
+	},
+/area/mine)
 "gI" = (
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
@@ -1008,6 +1019,12 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
+"ho" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 4
+	},
+/turf/unsimulated/floor/asteroid/ash/rocky,
+/area/mine)
 "hq" = (
 /obj/item/storage/bag/ore{
 	pixel_x = 7
@@ -1049,10 +1066,11 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "hL" = (
-/obj/structure/bed/stool/chair/office/light{
+/obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/random/dirt_75,
+/turf/unsimulated/floor/asteroid/ash,
 /area/mine)
 "hN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1556,6 +1574,11 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/mine)
+"kQ" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/space_heater,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "kR" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
@@ -1700,6 +1723,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
+"lw" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 10
+	},
+/obj/random/dirt_75,
+/turf/unsimulated/floor/asteroid/ash,
+/area/mine)
 "lz" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 9
@@ -1781,6 +1811,11 @@
 	pixel_x = 3
 	},
 /turf/simulated/floor/plating/asteroid,
+/area/mine)
+"mh" = (
+/obj/machinery/portable_atmospherics/canister/empty/hydrogen,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
 /area/mine)
 "mj" = (
 /obj/random/dirt_75,
@@ -1923,6 +1958,13 @@
 /area/mine)
 "ng" = (
 /obj/structure/closet,
+/turf/simulated/floor/tiled,
+/area/mine)
+"nj" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/random/pottedplant,
 /turf/simulated/floor/tiled,
 /area/mine)
 "nk" = (
@@ -2190,6 +2232,12 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
 /area/mine)
+"oL" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 2
+	},
+/turf/unsimulated/floor/asteroid/ash,
+/area/mine)
 "oM" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -2229,6 +2277,8 @@
 /area/mine)
 "oT" = (
 /obj/machinery/papershredder,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "oX" = (
@@ -2401,13 +2451,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/mine)
-"qa" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/mine)
 "qb" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -2455,6 +2498,12 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
+/area/mine)
+"qr" = (
+/obj/effect/floor_decal/industrial/loading/grey{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "qt" = (
 /obj/effect/floor_decal/corner/lime{
@@ -2516,14 +2565,6 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
-"qA" = (
-/obj/random/dirt_75,
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
 /area/mine)
 "qC" = (
 /obj/structure/table/wood,
@@ -2628,19 +2669,6 @@
 /area/mine)
 "qX" = (
 /turf/simulated/wall/r_wall,
-/area/mine)
-"qY" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/gun/projectile/automatic/c20r,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/north,
-/turf/simulated/floor/tiled/dark,
 /area/mine)
 "rc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2764,12 +2792,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
-"ss" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/mine)
 "sz" = (
 /obj/random/dirt_75,
 /obj/structure/reagent_dispensers/cookingoil,
@@ -2831,6 +2853,10 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
+/area/mine)
+"sS" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/plating/asteroid,
 /area/mine)
 "sT" = (
 /obj/structure/bed/stool/chair/office/dark,
@@ -2914,6 +2940,13 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"tw" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
+	},
+/obj/random/dirt_75,
+/turf/unsimulated/floor/asteroid/ash,
+/area/mine)
 "tA" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate,
@@ -2976,9 +3009,6 @@
 "ua" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
@@ -3069,12 +3099,28 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/mine)
+"uG" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/reagent_containers/weldpack{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "uJ" = (
 /obj/effect/floor_decal/industrial/loading/grey{
 	dir = 1
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
+/area/mine)
+"uN" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "uT" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
@@ -3083,6 +3129,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
 	},
+/obj/random/pottedplant,
 /turf/simulated/floor/wood,
 /area/mine)
 "uU" = (
@@ -3116,6 +3163,12 @@
 /obj/machinery/media/jukebox,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"vi" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 1
+	},
+/turf/unsimulated/floor/asteroid/ash/rocky,
+/area/mine)
 "vj" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/storage/toggle/leather_jacket/designer/black,
@@ -3235,6 +3288,9 @@
 	pixel_x = -9;
 	pixel_y = 3
 	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "vZ" = (
@@ -3309,12 +3365,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
-"wF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/mine)
 "wG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3350,6 +3400,10 @@
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
+/area/mine)
+"wU" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
 /area/mine)
 "wV" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -3569,6 +3623,12 @@
 /obj/machinery/power/apc/empty/north,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"yf" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/unsimulated/floor/asteroid/ash/rocky,
+/area/mine)
 "yl" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/structure/closet/crate,
@@ -3816,12 +3876,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
-"Al" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
 /area/mine)
 "Au" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -4078,6 +4132,20 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
+"Cj" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"Cm" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 8
+	},
+/turf/unsimulated/floor/asteroid/ash/rocky,
+/area/mine)
 "Cr" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
@@ -4169,6 +4237,12 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
+"DB" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
+	},
+/turf/unsimulated/floor/asteroid/ash/rocky,
+/area/mine)
 "DI" = (
 /obj/structure/table/steel,
 /obj/item/tank/air,
@@ -4226,6 +4300,10 @@
 	pixel_x = -7
 	},
 /turf/simulated/floor/plating,
+/area/mine)
+"Ek" = (
+/obj/effect/floor_decal/industrial/warning/dust,
+/turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "El" = (
 /obj/structure/table/steel,
@@ -4348,6 +4426,11 @@
 	dir = 9
 	},
 /obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
+"Fh" = (
+/obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/mine)
 "Fo" = (
@@ -4743,13 +4826,17 @@
 /obj/item/paper/goon_base/note,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
+"HH" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/turf/unsimulated/floor/asteroid/ash/rocky,
+/area/mine)
 "HJ" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
-/obj/structure/bed/stool/chair/padded/blue{
-	dir = 8
-	},
+/obj/random/pottedplant,
 /turf/simulated/floor/wood,
 /area/mine)
 "HK" = (
@@ -4955,6 +5042,7 @@
 	pixel_x = 6;
 	pixel_y = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "IW" = (
@@ -4983,6 +5071,13 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"Ja" = (
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/unsimulated/floor/asteroid/ash/rocky,
+/area/mine)
 "Jf" = (
 /obj/structure/table/steel,
 /obj/item/storage/firstaid/combat{
@@ -5004,10 +5099,7 @@
 "Jm" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/item/reagent_containers/weldpack{
-	pixel_x = 5;
-	pixel_y = -7
-	},
+/obj/machinery/chem_heater,
 /turf/simulated/floor/plating,
 /area/mine)
 "Jn" = (
@@ -5221,6 +5313,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine)
+"KF" = (
+/obj/structure/table/standard,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
+/area/mine)
 "KG" = (
 /obj/random/dirt_75,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -5246,6 +5345,15 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"KO" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/machinery/power/apc/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "KR" = (
 /obj/effect/floor_decal/corner/grey/full{
@@ -5321,12 +5429,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
-"LO" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable{
-	icon_state = "1-2"
+"LS" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "LY" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -5533,8 +5640,11 @@
 /area/mine)
 "Nh" = (
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/mineral/surface,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "Ni" = (
 /obj/effect/floor_decal/corner/grey{
@@ -5697,9 +5807,7 @@
 	pixel_x = 9;
 	pixel_y = -8
 	},
-/obj/item/tank/phoron{
-	pixel_y = 2
-	},
+/obj/item/tank/phoron/empty,
 /obj/item/clothing/glasses/welding{
 	pixel_x = -1;
 	pixel_y = 7
@@ -5768,6 +5876,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
+"OQ" = (
+/obj/machinery/portable_atmospherics/canister/empty/air,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/mine)
 "OW" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
@@ -5801,9 +5914,17 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
+"Pw" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/obj/random/dirt_75,
+/turf/unsimulated/floor/asteroid/ash,
+/area/mine)
 "PA" = (
 /obj/random/dirt_75,
-/turf/simulated/mineral/surface,
+/obj/random/dirt_75,
+/turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "PC" = (
 /obj/machinery/bodyscanner,
@@ -5847,6 +5968,13 @@
 	pixel_x = -6
 	},
 /turf/simulated/floor/tiled,
+/area/mine)
+"PO" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/random/dirt_75,
+/turf/unsimulated/floor/asteroid/ash,
 /area/mine)
 "PS" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -6022,6 +6150,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
+"QK" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating/asteroid,
+/area/mine)
 "QM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6058,7 +6190,9 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "QS" = (
-/obj/structure/reagent_dispensers/radioactive_waste,
+/obj/structure/reagent_dispensers/radioactive_waste{
+	pixel_y = -6
+	},
 /obj/effect/decal/cleanable/acid_remnants,
 /obj/effect/decal/cleanable/acid_remnants{
 	pixel_x = -8;
@@ -6610,6 +6744,8 @@
 	pixel_x = 6;
 	pixel_y = 9
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "UA" = (
@@ -6734,6 +6870,8 @@
 /obj/item/modular_computer/laptop/preset/civilian{
 	pixel_y = 9
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "VB" = (
@@ -7050,6 +7188,10 @@
 /obj/machinery/suit_cycler,
 /turf/simulated/floor/tiled,
 /area/mine)
+"XG" = (
+/obj/random/pottedplant,
+/turf/simulated/floor/tiled,
+/area/mine)
 "XI" = (
 /obj/structure/closet/cabinet,
 /obj/effect/floor_decal/corner/blue{
@@ -7176,6 +7318,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
+"Yu" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/turf/unsimulated/floor/asteroid/ash,
+/area/mine)
 "Yz" = (
 /obj/structure/trash_pile,
 /obj/random/dirt_75,
@@ -7334,6 +7482,7 @@
 /area/mine)
 "Zs" = (
 /obj/machinery/photocopier,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Zw" = (
@@ -7465,6 +7614,12 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
+/area/mine)
+"ZX" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 6
+	},
+/turf/unsimulated/floor/asteroid/ash,
 /area/mine)
 "ZY" = (
 /obj/machinery/door/airlock/external{
@@ -21810,9 +21965,9 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
+kz
+kz
+kz
 sB
 sB
 sB
@@ -22065,10 +22220,10 @@ sB
 sB
 sB
 sB
+kz
+kz
 sB
-sB
-sB
-sB
+kz
 sB
 sB
 sB
@@ -22319,9 +22474,9 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
+kz
+kz
+kz
 sB
 sB
 sB
@@ -26882,8 +27037,8 @@ bu
 sB
 sB
 sB
-sB
-sB
+kz
+kz
 sB
 sB
 sB
@@ -27137,9 +27292,9 @@ bu
 sB
 sB
 sB
+kz
 sB
-sB
-sB
+kz
 sB
 sB
 sB
@@ -27390,12 +27545,12 @@ bu
 bu
 bu
 sB
+kz
+kz
+kz
+kz
 sB
-sB
-sB
-sB
-sB
-sB
+kz
 sB
 sB
 sB
@@ -27647,11 +27802,11 @@ bu
 sB
 sB
 sB
+kz
 sB
 sB
-sB
-sB
-sB
+kz
+kz
 sB
 sB
 sB
@@ -27902,11 +28057,11 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 sB
@@ -28108,9 +28263,9 @@ bu
 bu
 sB
 sB
-sB
-sB
-sB
+kz
+kz
+kz
 sB
 sB
 sB
@@ -28363,12 +28518,12 @@ bu
 bu
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
+kz
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 mI
@@ -30049,7 +30204,7 @@ mI
 mI
 mI
 mI
-sB
+kz
 sB
 sB
 bu
@@ -30306,7 +30461,7 @@ mI
 mI
 mI
 mI
-sB
+kz
 sB
 sB
 sB
@@ -30563,7 +30718,7 @@ mI
 mI
 mI
 mI
-sB
+kz
 sB
 sB
 sB
@@ -30820,8 +30975,8 @@ mI
 mI
 mI
 mI
-sB
-sB
+kz
+kz
 sB
 sB
 bu
@@ -31077,8 +31232,8 @@ mI
 mI
 mI
 mI
-sB
-sB
+kz
+kz
 sB
 sB
 bu
@@ -31334,9 +31489,9 @@ mI
 mI
 mI
 mI
-sB
-sB
-sB
+kz
+kz
+kz
 sB
 bu
 bu
@@ -31591,7 +31746,7 @@ mI
 mI
 mI
 mI
-sB
+kz
 sB
 sB
 sB
@@ -37995,15 +38150,15 @@ mI
 mI
 sB
 sB
-sB
-sB
-sB
+Dr
+Dr
+Dr
+Dr
 mI
 mI
 mI
 mI
-mI
-sB
+kz
 mI
 mI
 mI
@@ -38236,8 +38391,8 @@ mI
 mI
 mI
 mI
-sB
-sB
+kz
+kz
 mI
 mI
 mI
@@ -38252,18 +38407,18 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
+Dr
+ew
+mh
+Dr
 mI
 mI
 sB
 mI
-sB
-sB
-sB
-sB
+kz
+kz
+kz
+kz
 mI
 mI
 sB
@@ -38493,6 +38648,12 @@ mI
 mI
 mI
 mI
+kz
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 sB
@@ -38503,27 +38664,21 @@ sB
 sB
 sB
 sB
+Dr
+Fh
+wU
+nB
+DB
+vi
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+kz
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 bu
@@ -38644,7 +38799,7 @@ mI
 mI
 qX
 Dr
-mE
+uG
 mE
 en
 Ic
@@ -38750,6 +38905,13 @@ mI
 mI
 mI
 mI
+kz
+PA
+PA
+PA
+kz
+kz
+kz
 sB
 sB
 sB
@@ -38759,27 +38921,20 @@ sB
 sB
 sB
 sB
+Dr
+wU
+OQ
+nB
+cA
+LS
+LS
+ho
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+kz
+kz
+kz
 sB
 sB
 sB
@@ -39006,6 +39161,11 @@ mI
 mI
 mI
 mI
+tw
+hL
+hL
+lw
+kz
 sB
 sB
 sB
@@ -39018,26 +39178,21 @@ sB
 sB
 sB
 sB
+Dr
+Dr
+nB
+nB
+Ja
+sS
+sS
+yf
 sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+kz
+kz
+kz
 sB
 sB
 sB
@@ -39263,6 +39418,10 @@ mI
 mI
 mI
 mI
+PO
+mV
+mV
+oL
 sB
 sB
 sB
@@ -39277,25 +39436,21 @@ sB
 sB
 sB
 sB
+Cm
+HH
+HH
+Ek
+QK
+QK
+yf
 sB
 sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+kz
+kz
+kz
 sB
 sB
 sB
@@ -39520,6 +39675,10 @@ mI
 mI
 mI
 mI
+PO
+mV
+nT
+oL
 sB
 sB
 sB
@@ -39537,14 +39696,10 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+Ek
+QK
+QK
+yf
 sB
 sB
 sB
@@ -39777,6 +39932,10 @@ mI
 mI
 mI
 mI
+Pw
+Yu
+Yu
+ZX
 sB
 sB
 sB
@@ -39794,14 +39953,10 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+Ek
+sS
+sS
+yf
 sB
 sB
 sB
@@ -39923,7 +40078,7 @@ Pp
 Dr
 mI
 sK
-gj
+Cj
 mI
 Dr
 Pp
@@ -40055,10 +40210,10 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
+Cm
+HH
+HH
+vi
 sB
 sB
 sB
@@ -40701,9 +40856,9 @@ Sj
 yS
 Yi
 Dr
-EI
-hL
-QX
+KF
+tF
+Li
 Dr
 Dr
 Dr
@@ -40837,9 +40992,9 @@ aE
 aE
 FF
 nA
-sB
-sB
-sB
+PA
+PA
+PA
 bu
 bu
 bu
@@ -40959,7 +41114,7 @@ Li
 Li
 Dr
 Zs
-Vw
+NH
 IV
 Dr
 xy
@@ -41094,8 +41249,8 @@ JW
 JW
 uB
 MV
-sB
-sB
+PA
+kz
 sB
 bu
 bu
@@ -41351,7 +41506,7 @@ pp
 QT
 bR
 nA
-sB
+PA
 sB
 sB
 bu
@@ -41580,7 +41735,7 @@ mI
 sB
 sB
 sB
-sB
+kz
 Ui
 nk
 Vu
@@ -41709,7 +41864,7 @@ Dr
 NH
 Qj
 Dr
-IG
+ch
 lW
 lW
 IG
@@ -41833,11 +41988,11 @@ mI
 mI
 mI
 mI
-sB
-sB
-sB
-sB
-sB
+kz
+kz
+kz
+kz
+PA
 Qv
 nX
 cP
@@ -41945,8 +42100,8 @@ mI
 mI
 mI
 mI
-mI
-mI
+qX
+qX
 qX
 qX
 qX
@@ -42092,9 +42247,9 @@ mI
 mI
 sB
 sB
-sB
-sB
-sB
+PA
+PA
+PA
 Qv
 nM
 eT
@@ -42202,7 +42357,7 @@ mI
 mI
 mI
 mI
-mI
+qX
 mI
 qX
 mI
@@ -42351,7 +42506,7 @@ sB
 sB
 sB
 sB
-sB
+kz
 Qv
 Lg
 cP
@@ -42608,7 +42763,7 @@ sB
 sB
 sB
 sB
-sB
+kz
 kr
 La
 eT
@@ -42719,7 +42874,7 @@ mI
 qX
 mI
 qX
-mI
+Dr
 Dr
 Dr
 Dr
@@ -42865,7 +43020,7 @@ sB
 sB
 sB
 sB
-sB
+kz
 Qv
 nM
 Qh
@@ -42976,12 +43131,12 @@ qX
 qX
 qX
 qX
-qX
 Dr
-Al
+KO
 qf
-dN
-qA
+qf
+gH
+Nh
 yS
 mQ
 Zl
@@ -43104,8 +43259,8 @@ sB
 sB
 sB
 sB
-sB
-sB
+nT
+nT
 sB
 sB
 sB
@@ -43235,7 +43390,7 @@ Dr
 Dr
 Dr
 Dr
-fn
+qr
 Dr
 Dr
 Dr
@@ -43361,8 +43516,8 @@ sB
 sB
 sB
 sB
-sB
-sB
+nT
+nT
 sB
 sB
 sB
@@ -43746,10 +43901,10 @@ qX
 mI
 qX
 Dr
-kW
+xs
 HK
 Uk
-ss
+eJ
 oP
 Dr
 FZ
@@ -43921,7 +44076,7 @@ iW
 ee
 rw
 Bo
-sB
+PA
 sB
 bu
 bu
@@ -44003,10 +44158,10 @@ qX
 qX
 qX
 Dr
-qY
-wF
-LO
-qa
+kW
+eJ
+Uk
+Uk
 VL
 Dr
 jV
@@ -44178,8 +44333,8 @@ bZ
 bZ
 Uq
 yx
-sB
-sB
+PA
+kz
 bu
 bu
 bu
@@ -44250,8 +44405,8 @@ bu
 bu
 bu
 mI
-Nh
-Nh
+mI
+mI
 mI
 mI
 qX
@@ -44435,8 +44590,8 @@ kp
 wp
 AA
 Bo
-sB
-sB
+PA
+PA
 bu
 bu
 bu
@@ -44547,7 +44702,7 @@ iK
 mn
 nB
 nB
-te
+kQ
 NP
 gm
 mI
@@ -44919,8 +45074,8 @@ mI
 mI
 sB
 sB
-sB
-sB
+kz
+kz
 sB
 sB
 sB
@@ -44951,7 +45106,7 @@ sB
 sB
 sB
 sB
-sB
+kz
 bu
 bu
 bu
@@ -45021,7 +45176,7 @@ bu
 bu
 bu
 mI
-Nh
+mI
 eu
 DR
 Ow
@@ -45176,6 +45331,8 @@ mI
 mI
 sB
 sB
+PA
+kz
 sB
 sB
 sB
@@ -45206,9 +45363,7 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
+PA
 bu
 bu
 bu
@@ -45278,9 +45433,9 @@ bu
 bu
 mI
 mI
-Nh
+mI
 ab
-Nh
+mI
 mI
 qX
 qX
@@ -45433,6 +45588,8 @@ mI
 mI
 sB
 sB
+PA
+kz
 sB
 sB
 sB
@@ -45450,6 +45607,9 @@ sB
 sB
 sB
 sB
+kz
+kz
+kz
 sB
 sB
 sB
@@ -45459,13 +45619,8 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+PA
+PA
 bu
 bu
 bu
@@ -45535,8 +45690,8 @@ bu
 bu
 mI
 mI
-PA
-PA
+mI
+mI
 mI
 mI
 qX
@@ -45690,6 +45845,11 @@ mI
 mI
 sB
 sB
+kz
+PA
+kz
+kz
+kz
 sB
 sB
 sB
@@ -45703,6 +45863,11 @@ sB
 sB
 sB
 sB
+kz
+kz
+PA
+kz
+kz
 sB
 sB
 sB
@@ -45711,18 +45876,8 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+kz
+PA
 bu
 bu
 bu
@@ -45817,7 +45972,7 @@ HU
 lW
 TJ
 TJ
-Vw
+XG
 Dr
 kI
 Dr
@@ -45948,6 +46103,12 @@ mI
 sB
 sB
 sB
+PA
+PA
+PA
+kz
+kz
+kz
 sB
 sB
 sB
@@ -45959,6 +46120,11 @@ sB
 sB
 sB
 sB
+PA
+PA
+PA
+kz
+kz
 sB
 sB
 sB
@@ -45966,20 +46132,9 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+kz
+kz
+PA
 bu
 bu
 bu
@@ -46207,6 +46362,9 @@ sB
 sB
 sB
 sB
+PA
+PA
+kz
 sB
 sB
 sB
@@ -46215,28 +46373,25 @@ sB
 sB
 sB
 sB
+kz
+kz
+kz
+kz
+PA
+kz
+kz
+kz
+kz
 sB
 sB
 sB
 sB
 sB
 sB
+kz
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+kz
 bu
 bu
 bu
@@ -46340,7 +46495,7 @@ FB
 NH
 sN
 Dr
-Tc
+nj
 lW
 Vw
 wY
@@ -46475,9 +46630,15 @@ mI
 mI
 mI
 mI
+kz
+kz
+kz
+kz
+mI
+mI
 sB
-sB
-sB
+kz
+kz
 sB
 mI
 mI
@@ -46485,15 +46646,9 @@ sB
 sB
 sB
 sB
-mI
-mI
 sB
 sB
-sB
-sB
-sB
-sB
-sB
+kz
 bu
 bu
 bu
@@ -46734,7 +46889,7 @@ mI
 mI
 mI
 mI
-sB
+kz
 mI
 mI
 mI
@@ -46750,7 +46905,7 @@ mI
 sB
 sB
 sB
-sB
+kz
 bu
 bu
 bu
@@ -54104,8 +54259,8 @@ bu
 bu
 sB
 sB
-sB
-sB
+kz
+kz
 sB
 sB
 mI
@@ -54361,11 +54516,11 @@ bu
 bu
 sB
 sB
-sB
-sB
-sB
-sB
-sB
+kz
+kz
+kz
+kz
+kz
 mI
 mI
 mI
@@ -54463,7 +54618,7 @@ mI
 mI
 mI
 mI
-sB
+kz
 sB
 bu
 bu
@@ -54619,17 +54774,17 @@ bu
 bu
 sB
 sB
+kz
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
 mI
 mI
 mI
@@ -54720,7 +54875,7 @@ mI
 mI
 mI
 mI
-sB
+kz
 sB
 sB
 bu
@@ -54877,14 +55032,14 @@ bu
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 sB
@@ -59534,8 +59689,8 @@ mI
 mI
 mI
 mI
-sB
-sB
+kz
+kz
 sB
 mI
 mI
@@ -59789,11 +59944,11 @@ sB
 mI
 mI
 mI
-sB
-sB
-sB
-sB
-sB
+kz
+kz
+kz
+kz
+kz
 sB
 mI
 mI
@@ -60046,9 +60201,9 @@ sB
 sB
 mI
 mI
-sB
-sB
-sB
+kz
+kz
+kz
 sB
 sB
 sB
@@ -60302,9 +60457,9 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
+kz
+kz
+kz
 sB
 sB
 sB
@@ -60635,7 +60790,7 @@ mI
 bu
 bu
 bu
-sB
+kz
 mI
 mI
 sB
@@ -60889,11 +61044,11 @@ mI
 mI
 mI
 mI
-sB
-sB
-sB
-sB
-sB
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 sB
@@ -61146,7 +61301,7 @@ mI
 mI
 mI
 mI
-sB
+kz
 bu
 bu
 bu
@@ -63691,8 +63846,8 @@ sB
 sB
 sB
 sB
-sB
-sB
+kz
+kz
 sB
 sB
 sB
@@ -63947,10 +64102,10 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
+kz
+kz
+kz
+kz
 sB
 sB
 sB
@@ -64199,16 +64354,16 @@ mI
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+PA
+kz
+kz
+kz
+kz
+kz
+uN
+PA
+kz
+kz
 sB
 sB
 sB
@@ -64457,16 +64612,16 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+kz
+PA
+PA
+PA
+PA
+PA
+kz
+PA
+kz
+kz
 sB
 sB
 sB
@@ -64716,20 +64871,20 @@ sB
 sB
 sB
 sB
+kz
 sB
+kz
+PA
+PA
+PA
+kz
+kz
+kz
+kz
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+kz
+kz
+kz
 sB
 sB
 sB
@@ -64980,15 +65135,15 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+kz
+PA
+PA
+PA
+kz
+PA
+PA
+kz
+kz
 sB
 sB
 bu
@@ -65240,12 +65395,12 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
+kz
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 bu

--- a/maps/away/away_site/goon_base/goon_base.dmm
+++ b/maps/away/away_site/goon_base/goon_base.dmm
@@ -1,4 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/structure/bed/padded,
+/obj/item/bedsheet/orange,
+/turf/simulated/floor/tiled,
+/area/mine)
 "ag" = (
 /obj/effect/map_effect/airlock/long/square,
 /turf/simulated/wall/shuttle/raider,
@@ -8,9 +13,18 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
 "aA" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/structure/table/steel,
+/obj/item/trash/cigbutt{
+	pixel_y = -4;
+	pixel_x = -9
+	},
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_y = 8;
+	pixel_x = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
 "aD" = (
 /obj/effect/map_effect/airlock/s_to_n,
 /turf/simulated/wall/shuttle/raider,
@@ -31,16 +45,10 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "aJ" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 13
-	},
-/obj/structure/mirror{
-	pixel_x = 27
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/item/trash/ramen,
+/turf/simulated/floor/plating,
+/area/mine)
 "aL" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -49,6 +57,10 @@
 /obj/machinery/power/apc/empty/north,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
+"aM" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/mine)
 "aP" = (
 /obj/structure/table/rack,
 /obj/item/clothing/shoes/magboots,
@@ -59,17 +71,35 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"aR" = (
+/obj/item/trash/proteinbar,
+/turf/simulated/floor/plating,
+/area/mine)
 "aT" = (
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
+/obj/structure/table/steel{
+	pixel_x = -2
 	},
+/obj/item/paper_bin,
+/obj/item/pen/black,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/device/gps,
 /turf/simulated/floor/wood,
-/area/goonbase)
+/area/mine)
+"bc" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/tiled,
+/area/mine)
 "bi" = (
 /obj/item/trash/cigbutt,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"bj" = (
+/obj/effect/floor_decal/corner_wide/grey/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "bk" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 1
@@ -99,29 +129,27 @@
 "bu" = (
 /turf/template_noop,
 /area/space)
+"bH" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
+/area/mine)
 "bL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/plating,
-/area/goonbase)
-"bN" = (
 /obj/structure/table/reinforced/steel,
-/obj/item/clothing/head/helmet/merc{
-	pixel_x = 6
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 1
 	},
-/obj/effect/floor_decal/spline/plain/black,
+/obj/item/clothing/suit/armor/cuirass,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
+"bN" = (
+/obj/item/trash/cigbutt,
+/turf/simulated/floor/wood,
+/area/mine)
 "bQ" = (
-/obj/machinery/door/airlock/maintenance{
-	dir = 4
-	},
+/obj/structure/trash_pile,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "bR" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -139,6 +167,18 @@
 	},
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
+"bY" = (
+/obj/structure/table/wood,
+/obj/item/deck/cards{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/storage/pill_bottle/dice/gaming{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/turf/simulated/floor/carpet/red,
+/area/mine)
 "bZ" = (
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
@@ -157,52 +197,57 @@
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "cu" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/gun/projectile/pistol{
-	layer = 2.99;
-	pixel_y = 6
-	},
-/obj/item/gun/projectile/pistol,
-/obj/effect/floor_decal/spline/plain{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/goonbase)
-"cH" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/plating,
-/area/goonbase)
-"cK" = (
-/obj/structure/bed/stool/chair{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"cN" = (
-/obj/item/material/ashtray/bronze,
+/obj/item/reagent_containers/food/drinks/bottle/rum,
 /obj/structure/table/wood,
 /turf/simulated/floor/carpet/red,
-/area/goonbase)
+/area/mine)
+"cx" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/mirror{
+	pixel_y = 31
+	},
+/obj/structure/sink{
+	pixel_y = 21
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"cH" = (
+/obj/structure/bed/stool/chair/sofa/right/black,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/wood,
+/area/mine)
+"cK" = (
+/obj/machinery/door/airlock{
+	dir = 8;
+	req_access = list(202)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"cN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/item/device/paicard,
+/obj/item/material/twohanded/fireaxe,
+/obj/item/weldingtool/hugetank,
+/obj/item/tank/jetpack/void,
+/obj/item/wirecutters/toolbelt,
+/turf/simulated/floor/plating,
+/area/mine)
 "cP" = (
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "cY" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/suit/armor/carrier/heavy,
-/obj/effect/floor_decal/spline/plain/black,
+/obj/structure/table/steel,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 12
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "dd" = (
 /obj/structure/bed/padded/bunk{
 	pixel_y = 0
@@ -217,16 +262,22 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/storage)
 "dh" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/paper/crumpled,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"dr" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
+/obj/structure/table/standard,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 10
 	},
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"dr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/mine)
 "dt" = (
 /obj/effect/shuttle_landmark/automatic/ghostrole_activation,
 /turf/template_noop,
@@ -240,6 +291,12 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"dz" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/mine)
 "dJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -250,28 +307,28 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "dK" = (
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"dT" = (
-/obj/structure/bed/padded/bunk{
-	pixel_y = 0
-	},
-/obj/item/bedsheet/black,
-/obj/item/toy/plushie/farwa{
-	pixel_y = -3;
-	pixel_x = 7
-	},
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
-	},
-/obj/effect/ghostspawpoint{
-	identifier = "goon"
-	},
+/obj/structure/closet/crate,
+/obj/item/clothing/head/beret,
+/obj/item/clothing/suit/storage/toggle/flannel/gray,
+/obj/item/clothing/suit/storage/vest,
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
+"dQ" = (
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"dT" = (
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/item/trash/cigbutt,
+/turf/simulated/floor/plating,
+/area/mine)
+"dV" = (
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 5
+	},
+/obj/machinery/computer/operating,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "eb" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -281,54 +338,60 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
 "eh" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
-"er" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/glasses/sunglasses/aviator{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 9
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/goonbase)
-"eA" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/fancy/tray,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
+/area/mine)
+"ei" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/corner_wide/grey{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/turf/simulated/floor/tiled,
+/area/mine)
+"eq" = (
+/obj/item/reagent_containers/glass/bucket/wood{
+	pixel_y = -3;
+	pixel_x = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
+"er" = (
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"eA" = (
+/obj/item/reagent_containers/glass/bucket/wood{
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
 "eB" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "eE" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/structure/table/steel,
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 6
+	},
+/obj/structure/table/steel{
+	pixel_x = -2
+	},
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "eH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/inhaler/space_drugs,
-/obj/item/reagent_containers/inhaler/space_drugs,
-/obj/item/reagent_containers/inhaler/space_drugs,
-/obj/item/reagent_containers/syringe/drugs,
-/obj/item/reagent_containers/syringe/drugs,
-/obj/item/reagent_containers/syringe/drugs,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/wood,
+/area/mine)
 "eI" = (
 /obj/structure/closet/walllocker/medical{
 	pixel_x = -32
@@ -346,12 +409,19 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "eJ" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"eK" = (
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "eO" = (
 /turf/simulated/floor/holofloor/tiled/ramp/bottom,
 /area/shuttle/goon_ship/bridge)
+"eP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/tray,
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
 "eS" = (
 /obj/item/trash/chips,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -382,17 +452,30 @@
 "fe" = (
 /obj/item/broken_bottle,
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
+"ff" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/tiled,
+/area/mine)
+"fh" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/structure/curtain/open{
+	color = "#854636"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "fj" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "fk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/machinery/door/airlock{
+	dir = 1;
+	req_access = list(202)
 	},
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
 "fm" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -406,10 +489,17 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "fr" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/trash/ramen,
+/obj/structure/closet/crate,
+/obj/item/clothing/accessory/medal/gold,
+/obj/item/clothing/accessory/crucifix/gold,
+/obj/item/clothing/wrists/watch/gold,
+/obj/item/coin/gold,
+/obj/item/flame/lighter/zippo/gold,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/material/phoron/full,
+/obj/random/highvalue/no_weapon,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "fs" = (
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /obj/structure/bed/roller,
@@ -428,79 +518,123 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "fz" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/red,
+/area/mine)
+"fA" = (
 /obj/structure/table/rack,
-/obj/item/device/flashlight/lantern,
-/obj/item/device/flashlight/lantern,
-/obj/item/device/flashlight/lantern,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"fG" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/trash/pistachios,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"fM" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/suit/armor/cuirass,
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 6
+/obj/item/clothing/suit/space/void/tcaf,
+/obj/item/clothing/head/helmet/space/void/tcaf,
+/obj/effect/floor_decal/corner_wide/grey{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"fC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
+"fG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"fI" = (
+/obj/structure/bed/stool/padded/orange{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/red,
+/area/mine)
+"fM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "fW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/stack/material/silver,
-/obj/item/stack/material/silver,
-/obj/item/stack/material/silver,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "fY" = (
 /turf/simulated/mineral/surface,
 /area/space)
 "gi" = (
-/obj/effect/floor_decal/corner_wide/lime{
-	dir = 5
+/obj/structure/table/wood,
+/obj/item/modular_computer/laptop/preset/civilian{
+	pixel_y = 9
+	},
+/turf/simulated/floor/wood,
+/area/mine)
+"gj" = (
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"gm" = (
+/obj/effect/floor_decal/spline/fancy{
+	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
+	dir = 8;
+	pixel_x = 0;
 	icon_state = "tube_empty"
 	},
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"gj" = (
-/obj/effect/floor_decal/corner_wide/lime{
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"gn" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/syndicate/black,
+/obj/item/clothing/head/helmet/space/syndicate/black,
+/obj/effect/floor_decal/corner_wide/grey{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"gm" = (
-/obj/structure/toilet{
-	dir = 8
+/turf/simulated/floor/tiled,
+/area/mine)
+"gp" = (
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/structure/table/steel,
+/obj/item/trash/gum{
+	pixel_y = 7;
+	pixel_x = -4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/goonbase)
+/area/mine)
 "gr" = (
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
-"gw" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 5
+"gs" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 8
 	},
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
-"gx" = (
-/obj/machinery/sleeper{
-	dir = 1
+/turf/simulated/floor/wood,
+/area/mine)
+"gw" = (
+/obj/structure/table/steel,
+/obj/item/storage/firstaid/o2{
+	pixel_x = -4
+	},
+/obj/item/storage/firstaid/radiation,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 4
 	},
 /obj/effect/floor_decal/corner_wide/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/goonbase)
+/area/mine)
+"gx" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/red,
+/area/mine)
 "gI" = (
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
@@ -508,11 +642,17 @@
 /obj/item/trash/raisins,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"gL" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/structure/bed/stool/chair/sofa/corner/concave/red,
+/turf/simulated/floor/wood,
+/area/mine)
 "gM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/cheesie,
+/obj/structure/lattice/catwalk/indoor/grate/old,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "gX" = (
 /obj/effect/decal/cleanable/floor_damage/random_broken,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -536,18 +676,46 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "he" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/head/headbando/random,
-/obj/item/clothing/suit/storage/toggle/track/red,
-/obj/item/clothing/suit/storage/vest,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 8
+	},
+/obj/structure/table/steel{
+	pixel_x = -2
+	},
+/obj/item/storage/toolbox{
+	pixel_y = 2;
+	pixel_x = 1
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"hr" = (
+/obj/item/paper/goon_base/notice{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/wrench{
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "hC" = (
 /obj/structure/sign/greencross{
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"hF" = (
+/obj/effect/floor_decal/corner/purple{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "hG" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 8
@@ -558,13 +726,18 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
-"hS" = (
-/obj/structure/table/steel{
-	pixel_x = -2
+"hN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/item/trash/waffles,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/turf/simulated/floor/plating,
+/area/mine)
+"hS" = (
+/obj/structure/table/rack,
+/obj/item/soap/syndie,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
 "hV" = (
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /obj/structure/bed/roller,
@@ -576,10 +749,10 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "hZ" = (
-/obj/item/trash/tray,
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "ia" = (
 /obj/item/deck/cards,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
@@ -603,19 +776,34 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "id" = (
-/obj/structure/bed/stool,
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
-"ie" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/bed/stool/chair/office/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
+"ie" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"ig" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/syndicate/black/engie,
+/obj/item/clothing/head/helmet/space/syndicate/black/engie,
+/turf/simulated/floor/tiled,
+/area/mine)
 "ip" = (
-/obj/item/deck/cards,
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
+/obj/item/trash/kokobar,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/wood,
+/area/mine)
+"is" = (
+/obj/machinery/atmospherics/pipe/tank/air,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/mine)
 "it" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/glass/rag,
@@ -647,31 +835,42 @@
 /obj/item/trash/chips,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"iK" = (
+/obj/effect/floor_decal/corner_wide/grey{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"iR" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "iV" = (
-/obj/item/trash/broken_electronics,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/item/rig/merc/ninja{
+	req_access = list(202)
+	},
+/obj/structure/table/rack,
+/turf/simulated/floor/wood,
+/area/mine)
 "iW" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
 "iX" = (
-/obj/structure/table/standard,
-/obj/item/device/breath_analyzer{
-	pixel_x = 7
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
 	},
-/obj/item/device/healthanalyzer{
-	pixel_x = -4
-	},
-/obj/effect/floor_decal/corner_wide/lime{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/turf/simulated/floor/carpet/red,
+/area/mine)
 "iY" = (
+/obj/structure/closet/crate,
+/obj/item/clothing/head/bearpelt,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/military/old,
+/obj/item/clothing/suit/storage/vest,
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
 "jg" = (
 /obj/machinery/body_scanconsole{
 	dir = 1;
@@ -682,6 +881,16 @@
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
+"jq" = (
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "js" = (
 /obj/structure/bed/stool,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -690,33 +899,41 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "jv" = (
-/obj/machinery/vending/boozeomat/merchant,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/spiderling_remains,
+/turf/simulated/floor/plating,
+/area/mine)
 "jz" = (
-/obj/item/rig/merc/ninja{
-	req_access = list(202)
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/item/trash/uselessplastic,
+/turf/simulated/floor/plating,
+/area/mine)
+"jV" = (
+/obj/item/reagent_containers/glass/bucket/wood{
+	pixel_y = 6;
+	pixel_x = -6
 	},
-/obj/structure/table/rack,
-/turf/simulated/floor/wood,
-/area/goonbase)
+/turf/simulated/floor/tiled,
+/area/mine)
+"jW" = (
+/obj/structure/dispenser/oxygen,
+/turf/simulated/floor/tiled,
+/area/mine)
 "jZ" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 6
-	},
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
+/obj/structure/janitorialcart/full,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
 "kg" = (
-/obj/machinery/vending/dinnerware,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
 "kj" = (
-/obj/machinery/door/airlock{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/obj/machinery/power/portgen/basic,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
 "kn" = (
 /obj/structure/closet,
 /obj/item/clothing/accessory/tshirt,
@@ -743,24 +960,34 @@
 /obj/structure/table/steel{
 	pixel_x = -2
 	},
-/obj/item/material/kitchen/rollingpin,
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
+/obj/item/trash/gum,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"kz" = (
+/obj/structure/table/reinforced/steel,
+/obj/item/clothing/accessory/holster/thigh/brown,
+/obj/item/clothing/accessory/holster/thigh/brown{
+	pixel_y = 9
+	},
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"kB" = (
+/obj/machinery/sleeper{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/goonbase)
-"kz" = (
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
-/obj/item/trash/coffee,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"kB" = (
-/obj/item/storage/pill_bottle/dice/gaming,
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
+/area/mine)
+"kE" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/mine)
 "kH" = (
 /obj/item/trash/gum,
 /turf/simulated/floor/tiled/yellow,
@@ -780,23 +1007,27 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "kL" = (
-/obj/structure/table/rack,
-/obj/item/towel/random,
-/obj/item/towel/random,
-/obj/item/towel/random,
-/obj/item/towel/random,
-/obj/item/towel/random,
-/obj/item/towel/random,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/goonbase)
+/area/mine)
 "kR" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 8
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/mc9mm,
+/obj/item/ammo_magazine/mc9mm,
+/obj/item/ammo_magazine/mc9mm,
+/obj/item/ammo_magazine/mc9mm,
+/obj/item/ammo_magazine/mc9mm,
+/obj/item/ammo_magazine/mc9mm,
+/obj/item/gun/projectile/pistol{
+	layer = 2.99;
+	pixel_y = 6
+	},
+/obj/item/gun/projectile/pistol,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "kS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -819,23 +1050,33 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "kV" = (
-/obj/machinery/chemical_dispenser/bar_alc/full{
-	dir = 8;
-	pixel_x = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
 "kW" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 7
+/obj/structure/table/steel{
+	pixel_x = -2
 	},
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
+/obj/item/trash/snack_bowl,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "kX" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
+"lb" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/obj/item/stack/material/platinum{
+	pixel_x = -6
+	},
+/obj/item/stack/material/platinum{
+	pixel_x = 6
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "le" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/effect/floor_decal/corner/black/diagonal{
@@ -846,48 +1087,77 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"lj" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/syndicate/black/green,
+/obj/item/clothing/head/helmet/space/syndicate/black/green,
+/turf/simulated/floor/tiled,
+/area/mine)
 "ln" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/can,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/turf/simulated/floor/wood,
+/area/mine)
 "lo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "lq" = (
 /obj/machinery/optable,
 /obj/item/storage/firstaid/surgery,
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
-"lz" = (
-/obj/machinery/vending/engineering{
-	req_access = null
+"lv" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/shower{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"lI" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/trash/match,
+/obj/item/bikehorn/rubberducky{
+	pixel_y = -5;
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"lz" = (
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 5
+	},
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
+	dir = 1;
 	icon_state = "tube_empty"
 	},
-/turf/simulated/floor/plating,
-/area/goonbase)
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"lI" = (
+/obj/structure/table/rack,
+/obj/item/device/flashlight/lantern,
+/obj/item/device/flashlight/lantern,
+/obj/item/device/flashlight/lantern,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"lK" = (
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "lQ" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "lU" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube_empty"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
+"lW" = (
+/turf/simulated/floor/tiled/full,
+/area/mine)
 "lY" = (
 /obj/item/trash/liquidfood,
 /obj/structure/cable{
@@ -903,16 +1173,20 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "mj" = (
-/obj/structure/table/reinforced/steel,
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 1
-	},
-/obj/item/clothing/suit/armor/cuirass,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cigbutt,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
+"mn" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/turf/simulated/floor/plating,
+/area/mine)
 "ms" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/goonbase)
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "mv" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/dark,
@@ -929,58 +1203,62 @@
 /area/shuttle/goon_ship/storage)
 "mE" = (
 /obj/structure/closet/crate,
-/obj/item/storage/box/freezer/organcooler,
-/obj/item/storage/box/freezer/organcooler,
-/obj/item/storage/box/freezer/organcooler,
-/obj/item/storage/box/freezer/organcooler,
-/obj/item/storage/box/freezer/organcooler,
-/obj/effect/floor_decal/corner_wide/lime{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/obj/item/clothing/head/bandana/pirate,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/flight,
+/obj/item/clothing/suit/storage/vest,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "mI" = (
 /turf/simulated/mineral/surface,
 /area/mine)
 "mJ" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/cryopod,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"mQ" = (
+/obj/structure/table/reinforced/steel,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest{
+	pixel_x = -8
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/door/window{
-	dir = 4
+/obj/item/clothing/accessory/storage/black_vest{
+	pixel_x = 8
 	},
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/spline/plain/black{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/goonbase)
-"mQ" = (
-/obj/structure/sink/kitchen{
-	name = "sink";
-	pixel_y = 26
-	},
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/area/mine)
 "mV" = (
-/obj/effect/decal/cleanable/molten_item,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 8;
+	dir = 4;
 	pixel_x = 0;
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
 "mW" = (
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
+/obj/machinery/portable_atmospherics/canister/phoron_scarce,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "nf" = (
-/obj/structure/bookcase,
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/structure/table/steel{
+	pixel_x = -2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"ng" = (
+/obj/structure/closet,
+/turf/simulated/floor/tiled,
+/area/mine)
 "nk" = (
 /obj/structure/table/steel,
 /obj/item/paper_bin{
@@ -993,36 +1271,46 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"nl" = (
+/obj/structure/table/wood,
+/obj/item/modular_computer/laptop/preset/civilian{
+	pixel_y = 9
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "no" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/ramen,
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
-"np" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
+/obj/structure/table/reinforced/steel,
+/obj/item/clothing/suit/armor/carrier/heavy,
+/obj/effect/floor_decal/spline/plain/black,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
+"np" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet/red,
+/area/mine)
 "nr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"nw" = (
+/obj/effect/floor_decal/corner_wide/red/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "nA" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/goon_ship/port)
+"nB" = (
+/turf/simulated/floor/plating/asteroid,
+/area/mine)
 "nC" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/shotgunammo,
-/obj/item/storage/box/shotgunammo,
-/obj/item/gun/projectile/shotgun/pump/combat,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/machinery/vending/boozeomat/merchant,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "nI" = (
 /obj/structure/bed/stool,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -1031,15 +1319,21 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "nJ" = (
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 5
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/c762,
+/obj/item/ammo_magazine/c762,
+/obj/item/ammo_magazine/c762,
+/obj/item/gun/projectile/automatic/rifle/sts35,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/obj/structure/table/steel{
-	pixel_x = -2
+/obj/machinery/light{
+	dir = 2;
+	pixel_y = 0;
+	icon_state = "tube_empty"
 	},
-/obj/item/wrench,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "nM" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
@@ -1048,9 +1342,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "nQ" = (
-/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/effect/floor_decal/spline/fancy{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
 "nR" = (
 /obj/structure/table/steel,
 /obj/item/trash/proteinbar{
@@ -1077,13 +1378,8 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "nT" = (
-/obj/structure/trash_pile,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/goonbase)
+/turf/unsimulated/floor/asteroid/ash,
+/area/mine)
 "nX" = (
 /obj/structure/table/steel,
 /obj/item/gun/projectile/revolver/lemat,
@@ -1102,31 +1398,34 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"od" = (
+/obj/machinery/cryopod,
+/turf/simulated/floor/tiled,
+/area/mine)
+"oe" = (
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 5
+	},
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "of" = (
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 8
-	},
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/item/storage/toolbox{
-	pixel_y = 2;
-	pixel_x = 1
-	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
+"op" = (
+/obj/machinery/media/jukebox,
+/turf/simulated/floor/tiled,
+/area/mine)
+"ov" = (
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
+	dir = 8;
+	pixel_y = 0;
 	icon_state = "tube_empty"
 	},
-/turf/simulated/floor/plating,
-/area/goonbase)
-"ov" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/head/beret,
-/obj/item/clothing/suit/storage/toggle/flannel/gray,
-/obj/item/clothing/suit/storage/vest,
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
 "ox" = (
 /obj/structure/table/steel,
 /obj/item/paper_bin{
@@ -1146,43 +1445,42 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "oH" = (
-/obj/effect/floor_decal/corner_wide/lime{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/item/trash/pistachios,
+/turf/simulated/floor/plating,
+/area/mine)
 "oI" = (
-/obj/machinery/gumballmachine,
-/turf/simulated/floor/wood,
-/area/goonbase)
-"oK" = (
-/obj/machinery/chemical_dispenser/bar_soft/full{
-	dir = 8;
-	pixel_x = 5
-	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"oM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/plating,
+/area/mine)
+"oK" = (
+/obj/machinery/bodyscanner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"oM" = (
+/obj/structure/table/rack,
+/obj/item/storage/box/shotgunammo,
+/obj/item/storage/box/shotgunammo,
+/obj/item/gun/projectile/shotgun/pump/combat,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "oP" = (
-/obj/structure/bed/stool/chair/sofa/right/black,
+/obj/structure/bookcase,
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/wood,
-/area/goonbase)
+/area/mine)
 "oX" = (
 /obj/structure/closet/walllocker/medical{
 	pixel_y = -32
@@ -1193,6 +1491,26 @@
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
+"pa" = (
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating,
+/area/mine)
+"pd" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"pn" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/toilet{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "pp" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
@@ -1203,24 +1521,45 @@
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/med)
-"px" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"pB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
+"pt" = (
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/structure/sink/kitchen{
+	name = "sink";
+	pixel_y = 26
 	},
-/obj/structure/closet/crate,
-/obj/item/stack/material/diamond,
-/obj/item/stack/material/diamond,
-/obj/item/stack/material/diamond,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"pw" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/random/soap{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"px" = (
+/obj/structure/closet/walllocker/medical{
+	pixel_y = 29
+	},
+/obj/item/tank/anesthetic,
+/obj/item/tank/anesthetic,
+/obj/item/tank/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"pz" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner_wide/grey/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"pB" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "pI" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -1232,16 +1571,24 @@
 /turf/simulated/floor/airless,
 /area/shuttle/goon_ship/bridge)
 "pJ" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/trash/liquidfood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/item/stack/material/platinum,
+/obj/item/stack/material/platinum,
+/obj/item/stack/material/platinum,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "pN" = (
 /obj/effect/landmark/entry_point/east{
 	name = "port, power"
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/living)
+"pQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/mine)
 "pT" = (
 /obj/item/storage/pill_bottle/dice/gaming,
 /obj/item/trash/cigbutt{
@@ -1264,13 +1611,86 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
-"qy" = (
-/obj/machinery/door/airlock{
-	dir = 1;
-	req_access = list(202)
+"pV" = (
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"qb" = (
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"qj" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/syndicate/black/med,
+/obj/item/clothing/head/helmet/space/syndicate/black/med,
+/obj/effect/floor_decal/corner_wide/grey{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"qt" = (
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 5
+	},
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/surgery{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"qv" = (
+/obj/structure/closet/crate,
+/obj/item/coin/diamond,
+/obj/item/clothing/wrists/goldbracer,
+/obj/item/clothing/wrists/armchain,
+/obj/item/clothing/wrists/goldbracer/emerald,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/clothing/wrists/watch/gold,
+/obj/item/flame/lighter/zippo/gold,
+/obj/item/stack/material/phoron/full,
+/obj/item/coin/gold,
+/obj/item/clothing/accessory/crucifix/gold,
+/obj/item/gun/projectile/automatic/rifle/dpra/gold,
+/obj/random/melee/highvalue,
+/turf/simulated/floor/plating,
+/area/mine)
+"qy" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/ammo_magazine/c45m,
+/obj/item/gun/projectile/automatic/lebman,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 2;
+	pixel_y = 0;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"qz" = (
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 5
+	},
+/obj/machinery/body_scanconsole{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"qC" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_y = 8;
+	pixel_x = 6
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "qD" = (
 /obj/item/clothing/head/collectable/paper{
 	pixel_y = -3;
@@ -1282,82 +1702,86 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "qJ" = (
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/item/trash/cigbutt,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"qN" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/item/trash/can,
+/turf/simulated/floor/wood,
+/area/mine)
+"qP" = (
+/obj/structure/table/steel{
+	pixel_x = -2
+	},
+/obj/item/trash/plate/steak,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"qW" = (
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/mine)
+"qX" = (
+/turf/simulated/wall/r_wall,
+/area/mine)
+"rc" = (
+/obj/structure/bed/padded/bunk{
+	pixel_y = 0
+	},
+/obj/item/bedsheet/black,
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube_empty"
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/goonbase)
-"qN" = (
-/obj/item/clothing/gloves/janitor,
-/obj/structure/table/rack,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"qP" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
+/obj/effect/ghostspawpoint{
+	identifier = "goon"
 	},
-/obj/machinery/portable_atmospherics/canister/phoron_scarce,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"qW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/cigbutt,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"qX" = (
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/item/trash/gum,
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"rc" = (
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 4
-	},
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/item/gun/custom_ka/frame05,
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = 0;
-	icon_state = "tube_empty"
+/area/mine)
+"ri" = (
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/plating,
+/area/mine)
+"rn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/cheesie,
+/turf/simulated/floor/plating,
+/area/mine)
+"rq" = (
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"ru" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/goonbase)
-"rn" = (
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/area/mine)
 "rw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/starboard)
+"rD" = (
+/obj/structure/bed/padded,
+/obj/item/bedsheet/black,
+/turf/simulated/floor/tiled,
+/area/mine)
 "rF" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/d762,
-/obj/item/ammo_magazine/d762,
-/obj/item/ammo_magazine/d762,
-/obj/item/gun/projectile/dragunov,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "rN" = (
-/obj/effect/decal/cleanable/spiderling_remains,
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/suit/space/syndicate/black,
+/obj/item/clothing/head/helmet/space/syndicate/black,
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
 "rU" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/light{
@@ -1368,20 +1792,28 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "rW" = (
-/obj/structure/table/rack,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
+/obj/structure/bed/padded/bunk{
+	pixel_y = 0
+	},
+/obj/item/bedsheet/black,
+/obj/effect/ghostspawpoint{
+	identifier = "goon"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
 "sa" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/storage)
+"sc" = (
+/obj/item/trash/tuna{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"se" = (
+/turf/simulated/floor/airless,
+/area/mine)
 "sg" = (
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /obj/structure/cable{
@@ -1389,69 +1821,63 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
+"sz" = (
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/item/handcuffs,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "sB" = (
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "sI" = (
-/obj/item/trash/kokobar,
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/structure/table/steel,
+/obj/item/clothing/glasses/welding,
+/obj/item/weldingtool,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
 "sK" = (
-/obj/machinery/shower{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plating,
+/area/mine)
+"sN" = (
+/obj/structure/bed/padded,
+/obj/item/bedsheet/purple,
+/turf/simulated/floor/tiled,
+/area/mine)
+"sO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/kidneys,
+/turf/simulated/floor/plating,
+/area/mine)
+"sP" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/red,
+/area/mine)
+"sX" = (
+/obj/structure/bookcase,
+/turf/simulated/floor/wood,
+/area/mine)
+"sZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/freezer,
-/area/goonbase)
-"sO" = (
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
-"sP" = (
-/obj/item/clothing/accessory/longsleeve_s,
-/obj/structure/closet{
-	icon_door = "blue";
-	name = "misc clothing"
-	},
-/obj/item/clothing/under/syndicate/tacticool,
-/obj/item/clothing/under/tactical,
-/obj/item/clothing/under/pants/black,
-/obj/item/clothing/under/color/brown,
-/obj/item/clothing/suit/storage/toggle/trench/grey,
-/obj/item/clothing/head/softcap/himeo,
-/obj/item/clothing/suit/storage/toggle/leather_vest,
-/obj/item/clothing/under/service_overalls,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"sX" = (
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 6
-	},
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plating,
-/area/goonbase)
-"sZ" = (
-/obj/structure/table/reinforced/steel,
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 10
-	},
-/obj/item/clothing/suit/armor/cuirass,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "te" = (
-/obj/structure/table/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/syndicate/black,
-/obj/item/clothing/head/helmet/space/syndicate/black,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
 "tp" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -1459,6 +1885,33 @@
 /obj/item/clothing/gloves/black,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"tr" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/mining,
+/obj/item/clothing/head/helmet/space/void/mining,
+/obj/effect/floor_decal/corner_wide/grey{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"tt" = (
+/obj/effect/floor_decal/corner/purple{
+	dir = 5
+	},
+/obj/structure/sink/kitchen{
+	name = "sink";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"tu" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/plating,
+/area/mine)
 "tv" = (
 /obj/structure/extinguisher_cabinet/north{
 	pixel_y = 30
@@ -1466,14 +1919,16 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "tz" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/machinery/appliance/cooker/oven,
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "tA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/can,
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/machinery/appliance/cooker/stove,
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/item/trash/stew,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "tI" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/starboard)
@@ -1482,26 +1937,66 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
 "tR" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"uy" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
+/obj/machinery/giga_drill{
+	name = "himean drill";
+	desc = "A giant, Himean drill - usually digging tunnels deep beneath the planet Himeo."
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 4;
+	dir = 8;
 	pixel_x = 0;
 	icon_state = "tube_empty"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/turf/simulated/floor/plating,
+/area/mine)
+"tS" = (
+/obj/structure/structural_support{
+	pixel_y = 8
+	},
+/turf/simulated/floor/plating/asteroid,
+/area/mine)
+"uu" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/grey,
+/turf/simulated/floor/plating,
+/area/mine)
+"uv" = (
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/machinery/appliance/cooker/stove,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"uy" = (
+/obj/structure/table/rack,
+/obj/item/stack/material/steel/full,
+/obj/item/stack/material/steel/full,
+/obj/item/stack/material/steel/full,
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "uB" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/port)
+"uT" = (
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
+	},
+/turf/simulated/floor/wood,
+/area/mine)
 "va" = (
 /obj/item/trash/cigbutt{
 	pixel_y = 7;
@@ -1511,9 +2006,10 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "vc" = (
-/obj/structure/bed/stool/chair,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/mine)
 "vh" = (
 /obj/structure/sign/emergency/meetingpoint{
 	pixel_y = 31
@@ -1527,21 +2023,28 @@
 /obj/item/clothing/accessory/tajaran/charm/stone,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"vq" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/item/towel/random{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "vt" = (
-/obj/item/reagent_containers/food/drinks/bottle/rum,
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
+/obj/machinery/door/airlock{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "vx" = (
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /obj/machinery/iv_drip,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "vz" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/unsimulated/floor/asteroid/ash/rocky,
+/turf/simulated/floor/airless/ceiling,
 /area/mine)
 "vB" = (
 /obj/structure/table/steel,
@@ -1573,27 +2076,52 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "vG" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/obj/item/handcuffs,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 5
+	},
+/obj/structure/table/steel{
+	pixel_x = -2
+	},
+/obj/item/wrench,
+/turf/simulated/floor/plating,
+/area/mine)
+"vH" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/plating,
+/area/mine)
+"vI" = (
+/obj/structure/table/wood,
+/obj/item/material/ashtray/bronze{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "vJ" = (
-/obj/structure/bed/padded/bunk{
-	pixel_y = 0
-	},
-/obj/item/bedsheet/black,
-/obj/effect/ghostspawpoint{
-	identifier = "goon"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"vM" = (
+/obj/structure/closet/cabinet,
+/turf/simulated/floor/tiled,
+/area/mine)
 "vR" = (
-/obj/machinery/door/airlock{
-	dir = 8;
-	req_access = list(202)
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/door/window{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"vZ" = (
+/obj/effect/floor_decal/corner_wide/grey,
+/turf/simulated/floor/tiled,
+/area/mine)
 "wh" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1601,25 +2129,23 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
 "wo" = (
-/obj/machinery/body_scanconsole{
-	pixel_x = -1
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
 	},
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/turf/simulated/floor/carpet/red,
+/area/mine)
 "wp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
 "wD" = (
-/obj/structure/trash_pile,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/iv_drip,
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/goonbase)
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "wG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1631,10 +2157,29 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/living)
 "wL" = (
-/obj/machinery/optable,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"wX" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/freezer/organcooler,
+/obj/item/storage/box/freezer/organcooler,
+/obj/item/storage/box/freezer/organcooler,
+/obj/item/storage/box/freezer/organcooler,
+/obj/item/storage/box/freezer/organcooler,
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
-/area/goonbase)
+/area/mine)
+"wY" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/plating,
+/area/mine)
 "wZ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1644,12 +2189,13 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "xf" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/head/bearpelt,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/military/old,
-/obj/item/clothing/suit/storage/vest,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/structure/trash_pile,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "xi" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/cheesiehonkers,
@@ -1674,35 +2220,67 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
+"xp" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/syndicate/black,
+/obj/item/clothing/head/helmet/space/syndicate/black,
+/obj/effect/floor_decal/corner_wide/grey{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "xr" = (
+/obj/structure/table/reinforced/glass,
+/obj/item/material/ashtray{
+	pixel_y = 2;
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/food/drinks/bottle/whitewine{
+	desc = "A mediocsre quality white wine, intended more for making spritzers than for drinking by itself. Produced on Visegrad by Idris.";
+	pixel_y = 7;
+	pixel_x = -7
+	},
+/turf/simulated/floor/wood,
+/area/mine)
+"xs" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"xH" = (
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"xJ" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/item/bikehorn/rubberducky{
+	pixel_y = -5;
+	pixel_x = 4
+	},
+/obj/item/towel/random{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"xK" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_ship/port)
+"xM" = (
 /obj/item/bedsheet/black,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/ghostspawpoint{
 	identifier = "goon_prisoner"
 	},
 /turf/simulated/floor/plating,
-/area/goonbase)
-"xH" = (
-/obj/machinery/door/airlock{
-	dir = 8;
-	req_access = list(202)
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"xK" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
-"xM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
 "xO" = (
 /obj/item/trash/cigbutt,
 /obj/effect/floor_decal/spline/plain/black{
@@ -1718,27 +2296,33 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "xQ" = (
+/obj/structure/table/reinforced/steel,
+/obj/item/clothing/suit/armor/cuirass,
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"xX" = (
 /obj/structure/table/steel,
 /obj/item/tank/air,
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"xX" = (
-/obj/structure/closet/walllocker/medical{
-	pixel_y = 29
-	},
-/obj/item/tank/anesthetic,
-/obj/item/tank/anesthetic,
-/obj/item/tank/anesthetic,
-/obj/item/clothing/mask/breath/medical,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/area/mine)
+"xY" = (
+/obj/structure/table/rack,
+/obj/item/clothing/gloves/boxing,
+/turf/simulated/floor/wood,
+/area/mine)
 "xZ" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 9
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/item/trash/match,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
 	},
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
+/turf/simulated/floor/plating,
+/area/mine)
 "ye" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -1748,22 +2332,16 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "yl" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/item/towel/random,
+/obj/item/towel/random,
+/obj/item/towel/random,
+/obj/item/towel/random,
+/obj/item/towel/random,
+/obj/item/towel/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "ym" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1777,11 +2355,18 @@
 /obj/item/trash/cheesie,
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
+"yq" = (
+/obj/structure/table/reinforced/steel,
+/turf/simulated/floor/tiled/dark/full,
+/area/mine)
 "yr" = (
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
-/obj/item/trash/cigbutt,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/wood,
+/area/mine)
 "yx" = (
 /obj/effect/landmark/entry_point/north{
 	name = "north, starboard engines"
@@ -1791,6 +2376,18 @@
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/goon_ship/starboard)
+"yD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"yH" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/mine)
 "yP" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -1804,10 +2401,10 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "yS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/spiderling_remains,
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/item/paper/crumpled,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "yW" = (
 /obj/structure/bed/padded/bunk{
 	pixel_y = 0
@@ -1821,20 +2418,18 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "yX" = (
-/obj/structure/closet/crate,
-/obj/item/coin/diamond,
-/obj/item/clothing/wrists/goldbracer,
-/obj/item/clothing/wrists/armchain,
-/obj/item/clothing/wrists/goldbracer/emerald,
-/obj/item/gun/projectile/automatic/rifle/dpra/gold,
-/obj/random/melee/highvalue,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"zb" = (
-/obj/item/trash/cigbutt,
+/obj/structure/bed/stool/chair/office/dark{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
-/area/goonbase)
+/area/mine)
+"zb" = (
+/obj/structure/table/steel{
+	pixel_x = -2
+	},
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "zd" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/bridge)
@@ -1845,12 +2440,11 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "zr" = (
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/item/trash/snack_bowl,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/structure/table/steel,
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/plating,
+/area/mine)
 "zs" = (
 /obj/structure/table/steel,
 /obj/item/device/healthanalyzer,
@@ -1858,18 +2452,17 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "zz" = (
-/obj/machinery/giga_drill{
-	name = "himean drill";
-	desc = "A giant, Himean drill - usually digging tunnels deep beneath the planet Himeo."
-	},
+/obj/structure/closet/toolcloset,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
+"zB" = (
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 10
+	},
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "zC" = (
 /obj/structure/bed/padded/bunk{
 	pixel_y = 0
@@ -1879,21 +2472,24 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Ag" = (
-/obj/structure/bookcase,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
+/obj/machinery/chemical_dispenser/bar_alc/full{
+	dir = 8;
+	pixel_x = 5
 	},
-/turf/simulated/floor/wood,
-/area/goonbase)
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "Ak" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/stack/material/platinum,
-/obj/item/stack/material/platinum,
-/obj/item/stack/material/platinum,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "Aw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1907,18 +2503,27 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "Ay" = (
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 9
+	},
 /obj/structure/table/steel{
 	pixel_x = -2
 	},
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/obj/item/tape_roll,
+/turf/simulated/floor/plating,
+/area/mine)
 "AA" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/starboard)
+"AI" = (
+/obj/structure/bed/stool/padded/orange{
+	dir = 2
+	},
+/turf/simulated/floor/carpet/red,
+/area/mine)
 "AR" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
@@ -1959,6 +2564,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
+"Bm" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/obj/item/stack/material/silver{
+	pixel_x = -6
+	},
+/obj/item/stack/material/silver{
+	pixel_x = 6
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "Bn" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/floor_decal/spline/plain/black{
@@ -1990,52 +2606,95 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Br" = (
-/obj/machinery/iv_drip,
-/obj/effect/floor_decal/corner_wide/lime{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/obj/structure/closet/crate,
+/obj/item/coin/diamond,
+/obj/item/clothing/wrists/goldbracer,
+/obj/item/clothing/wrists/armchain,
+/obj/item/clothing/wrists/goldbracer/emerald,
+/obj/item/gun/projectile/automatic/rifle/dpra/gold,
+/obj/random/melee/highvalue,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
 "Bt" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 4
+/obj/structure/toilet{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/trash/chips,
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "By" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "Bz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/chipbasket,
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "BE" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
+"BH" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner_wide/grey{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"BI" = (
+/obj/effect/floor_decal/corner_wide/grey{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "BK" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/accessory/holster/thigh/brown,
-/obj/item/clothing/accessory/holster/thigh/brown{
-	pixel_y = 9
+/obj/machinery/appliance/cooker/fryer,
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube_empty"
 	},
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 5
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"BW" = (
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
+/obj/item/trash/match,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"Cb" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/goonbase)
-"BW" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/wood,
-/area/goonbase)
+/area/mine)
 "Cf" = (
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = 0;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Ch" = (
+/obj/effect/floor_decal/corner_wide/red/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "Cr" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
@@ -2046,6 +2705,481 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "Cz" = (
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/item/trash/cigbutt,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"CR" = (
+/obj/item/storage/pill_bottle/dice/gaming,
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet/red,
+/area/mine)
+"CS" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_ship/living)
+"CY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"CZ" = (
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"Dj" = (
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/effect/floor_decal/corner/black/diagonal{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/goon_ship/living)
+"Dl" = (
+/obj/effect/landmark/entry_point/west{
+	name = "starboard, substation"
+	},
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/goon_ship/living)
+"Dm" = (
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/machinery/iff_beacon/name_change,
+/turf/simulated/floor/airless,
+/area/shuttle/goon_ship/bridge)
+"Do" = (
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"Dr" = (
+/turf/simulated/wall,
+/area/mine)
+"DI" = (
+/obj/structure/table/steel,
+/obj/item/tank/air,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_ship/living)
+"DN" = (
+/obj/effect/floor_decal/spline/plain/black,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/effect/floor_decal/corner/black/diagonal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/goon_ship/living)
+"DO" = (
+/obj/structure/closet,
+/obj/item/clothing/suit/storage/toggle/leather_jacket,
+/obj/item/clothing/glasses/sunglasses/fluff,
+/obj/item/storage/box/fancy/cigarettes,
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/goon_ship/living)
+"DT" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
+"DY" = (
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 5
+	},
+/obj/machinery/bodyscanner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"Ea" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/can,
+/turf/simulated/floor/plating,
+/area/mine)
+"El" = (
+/obj/machinery/computer/operating,
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"Em" = (
+/obj/structure/curtain/open/medical,
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/goon_ship/med)
+"Ex" = (
+/obj/structure/bed/stool/padded/orange{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/red,
+/area/mine)
+"EE" = (
+/obj/structure/table/steel,
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_ship/living)
+"EI" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled,
+/area/mine)
+"EP" = (
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 10
+	},
+/obj/structure/table/steel{
+	pixel_x = -2
+	},
+/obj/item/clothing/head/hardhat/dblue,
+/turf/simulated/floor/plating,
+/area/mine)
+"EQ" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/mine)
+"EV" = (
+/obj/item/trash/tray,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
+"Fc" = (
+/turf/simulated/floor/carpet/red,
+/area/mine)
+"Fe" = (
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/wood,
+/area/mine)
+"Fk" = (
+/obj/structure/bed/stool/chair/sofa/black,
+/turf/simulated/floor/wood,
+/area/mine)
+"Fo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Fp" = (
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/item/broken_bottle,
+/turf/simulated/floor/plating,
+/area/mine)
+"Ft" = (
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/effect/floor_decal/corner/black/diagonal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/goon_ship/living)
+"Fz" = (
+/obj/effect/floor_decal/corner_wide/red{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"FB" = (
+/obj/structure/bed/padded,
+/obj/item/bedsheet/yellow,
+/turf/simulated/floor/tiled,
+/area/mine)
+"FE" = (
+/obj/structure/table/reinforced/steel,
+/obj/item/clothing/head/helmet/material/makeshift,
+/obj/effect/floor_decal/spline/plain/black,
+/turf/simulated/floor/plating,
+/area/mine)
+"FF" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/goon_ship/port)
+"FO" = (
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/goon_ship/living)
+"FR" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/structure/bed/padded,
+/obj/item/bedsheet/blue,
+/turf/simulated/floor/wood,
+/area/mine)
+"FT" = (
+/obj/structure/closet/walllocker{
+	pixel_x = 30
+	},
+/obj/item/storage/bag/inflatable,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_ship/living)
+"FU" = (
+/obj/effect/floor_decal/corner_wide/grey/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"FZ" = (
+/obj/item/handcuffs/cable{
+	pixel_y = -11;
+	pixel_x = -5
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Ga" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/plating,
+/area/mine)
+"Gb" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/mc9mm,
+/obj/item/ammo_magazine/mc9mm,
+/obj/item/ammo_magazine/mc9mm,
+/obj/item/ammo_magazine/mc9mm,
+/obj/item/ammo_magazine/mc9mm,
+/obj/item/ammo_magazine/mc9mm,
+/obj/item/gun/projectile/pistol{
+	layer = 2.99;
+	pixel_y = 6
+	},
+/obj/item/gun/projectile/pistol,
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Gc" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/freezer/rations,
+/turf/simulated/floor/plating,
+/area/mine)
+"Gi" = (
+/obj/machinery/gumballmachine,
+/turf/simulated/floor/wood,
+/area/mine)
+"Gn" = (
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled,
+/area/mine)
+"Gp" = (
+/obj/effect/step_trigger/teleporter,
+/turf/template_noop,
+/area/space)
+"Gs" = (
+/obj/structure/closet/crate,
+/obj/item/clothing/head/turban,
+/obj/item/clothing/accessory/poncho,
+/obj/item/clothing/suit/storage/vest,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"Gw" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_ship/port)
+"Gy" = (
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/goon_ship/storage)
+"GB" = (
+/obj/structure/table/standard,
+/obj/item/device/breath_analyzer{
+	pixel_x = 7
+	},
+/obj/item/device/healthanalyzer{
+	pixel_x = -4
+	},
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"GF" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"GH" = (
+/obj/structure/table/reinforced/steel,
+/obj/item/clothing/head/helmet/merc{
+	pixel_x = 6
+	},
+/obj/effect/floor_decal/spline/plain/black,
+/turf/simulated/floor/plating,
+/area/mine)
+"GI" = (
+/obj/item/trash/maps,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"GL" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/structure/bed/stool/chair/sofa/right/red{
+	dir = 2
+	},
+/turf/simulated/floor/wood,
+/area/mine)
+"GP" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/mine)
+"GY" = (
+/obj/effect/overmap/visitable/ship/landable/goon_ship,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/goon_ship/bridge)
+"GZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/goon_ship/living)
+"Hd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Hp" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled,
+/area/mine)
+"Hr" = (
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/wood,
+/area/mine)
+"Hs" = (
+/obj/structure/table/steel,
+/obj/item/storage/firstaid/o2{
+	pixel_x = -4
+	},
+/obj/item/storage/firstaid/radiation,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 4
+	},
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/goon_ship/med)
+"Ht" = (
+/obj/effect/landmark/entry_point/north{
+	name = "aft, airlock"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/goon_ship/living)
+"Hx" = (
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating,
+/area/mine)
+"Hy" = (
+/obj/structure/table/steel,
+/obj/item/trash/snacktray{
+	pixel_y = 8
+	},
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/effect/floor_decal/corner/black/diagonal{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/goon_ship/living)
+"HB" = (
+/obj/structure/bed/stool/chair/sofa/left/black,
+/turf/simulated/floor/wood,
+/area/mine)
+"HC" = (
+/obj/machinery/smartfridge/foodheater,
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/goon_ship/living)
+"HD" = (
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/generic{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/item/paper/goon_base/note,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_ship/port)
+"HJ" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
+	},
+/obj/structure/bed/stool/chair/padded/blue{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/mine)
+"HW" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/syndicate/covert,
+/obj/item/clothing/head/helmet/space/syndicate/covert,
+/turf/simulated/floor/tiled,
+/area/mine)
+"HZ" = (
+/obj/machinery/optable,
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"Ia" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/d762,
+/obj/item/ammo_magazine/d762,
+/obj/item/ammo_magazine/d762,
+/obj/item/gun/projectile/dragunov,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Ib" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_ship/living)
+"Id" = (
+/obj/machinery/door/airlock/maintenance{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/goon_ship/port)
+"Ie" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/head/cowboy,
 /obj/item/clothing/shoes/cowboy,
@@ -2154,391 +3288,23 @@
 /obj/item/clothing/suit/storage/toggle/leather_jacket/designer/black,
 /obj/item/clothing/head/softcap,
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"CR" = (
-/obj/structure/bed/padded/bunk{
-	pixel_y = 0
-	},
-/obj/item/bedsheet/black,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
-	},
-/obj/effect/ghostspawpoint{
-	identifier = "goon"
-	},
+/area/mine)
+"Ig" = (
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"CS" = (
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
-"CY" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"CZ" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"Dj" = (
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/effect/floor_decal/corner/black/diagonal{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
-"Dl" = (
-/obj/effect/landmark/entry_point/west{
-	name = "starboard, substation"
-	},
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/living)
-"Dm" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/machinery/iff_beacon/name_change,
-/turf/simulated/floor/airless,
-/area/shuttle/goon_ship/bridge)
-"Dr" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/goonbase)
-"DI" = (
-/obj/structure/table/steel,
-/obj/item/tank/air,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
-"DN" = (
-/obj/effect/floor_decal/spline/plain/black,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/effect/floor_decal/corner/black/diagonal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
-"DO" = (
-/obj/structure/closet,
-/obj/item/clothing/suit/storage/toggle/leather_jacket,
-/obj/item/clothing/glasses/sunglasses/fluff,
-/obj/item/storage/box/fancy/cigarettes,
-/turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
-"DT" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"Ea" = (
+/area/mine)
+"Iz" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
 	},
 /turf/simulated/floor/carpet/red,
-/area/goonbase)
-"El" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/structure/dispenser/oxygen,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"Em" = (
-/obj/structure/curtain/open/medical,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
-"EE" = (
-/obj/structure/table/steel,
-/obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
-"EP" = (
-/obj/machinery/bodyscanner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_wide/lime{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"EV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/cryopod,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"Fc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/goonbase)
-"Fe" = (
-/obj/structure/table/wood,
-/obj/item/material/ashtray/bronze,
-/turf/simulated/floor/wood,
-/area/goonbase)
-"Fk" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"Fo" = (
-/obj/structure/bed/stool/chair/office/dark,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"Fp" = (
-/obj/structure/curtain/black,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"Ft" = (
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/effect/floor_decal/corner/black/diagonal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
-"FE" = (
-/obj/item/wrench,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"FF" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/port)
-"FO" = (
-/obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
-"FT" = (
-/obj/structure/closet/walllocker{
-	pixel_x = 30
-	},
-/obj/item/storage/bag/inflatable,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
-"Gb" = (
-/obj/structure/table/steel,
-/obj/item/storage/firstaid/combat{
-	pixel_x = -4
-	},
-/obj/item/storage/firstaid/trauma,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 4
-	},
-/obj/effect/floor_decal/corner_wide/lime{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"Gi" = (
-/obj/machinery/pipedispenser,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"Gp" = (
-/obj/effect/step_trigger/teleporter,
-/turf/template_noop,
-/area/space)
-"Gs" = (
-/obj/structure/bed/stool/chair/sofa/black,
-/turf/simulated/floor/wood,
-/area/goonbase)
-"Gw" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
-"Gy" = (
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
-"GB" = (
-/obj/structure/table/reinforced/glass,
-/obj/item/material/ashtray{
-	pixel_y = 2;
-	pixel_x = 3
-	},
-/obj/item/reagent_containers/food/drinks/bottle/whitewine{
-	desc = "A mediocsre quality white wine, intended more for making spritzers than for drinking by itself. Produced on Visegrad by Idris.";
-	pixel_y = 7;
-	pixel_x = -7
-	},
-/turf/simulated/floor/wood,
-/area/goonbase)
-"GH" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/wood,
-/area/goonbase)
-"GI" = (
-/obj/structure/table/rack,
-/obj/item/wrench,
-/obj/item/wrench,
-/obj/item/wrench,
-/obj/item/wrench,
-/obj/item/wrench,
-/obj/item/paper/goon_base/notice,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"GY" = (
-/obj/effect/overmap/visitable/ship/landable/goon_ship,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
-"GZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
-"Hr" = (
-/obj/machinery/computer/operating,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"Hs" = (
-/obj/structure/table/steel,
-/obj/item/storage/firstaid/o2{
-	pixel_x = -4
-	},
-/obj/item/storage/firstaid/radiation,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 4
-	},
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
-"Ht" = (
-/obj/effect/landmark/entry_point/north{
-	name = "aft, airlock"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
-"Hy" = (
-/obj/structure/table/steel,
-/obj/item/trash/snacktray{
-	pixel_y = 8
-	},
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/effect/floor_decal/corner/black/diagonal{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
-"HB" = (
-/obj/machinery/appliance/cooker/oven,
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"HC" = (
-/obj/machinery/smartfridge/foodheater,
-/turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
-"HD" = (
-/obj/random/dirt_75,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/generic{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/item/paper/goon_base/note,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
-"HZ" = (
-/obj/structure/curtain/medical,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"Ia" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"Ib" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
-"Id" = (
-/obj/machinery/door/airlock/maintenance{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
-"Ie" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"Ig" = (
-/obj/structure/table/steel,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 12
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"Iz" = (
-/obj/machinery/power/portgen/basic,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "IA" = (
-/obj/machinery/media/jukebox,
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/effect/floor_decal/spline/fancy{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "IL" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -2546,12 +3312,46 @@
 /obj/machinery/hologram/holopad/long_range,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
-"IS" = (
-/obj/structure/table/steel{
-	pixel_x = -2
+"IN" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/plating,
+/area/mine)
+"IQ" = (
+/obj/structure/bed/stool/chair/sofa/left/red{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/mine)
+"IS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"IU" = (
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
+"IW" = (
+/obj/effect/floor_decal/corner_wide/grey{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"IX" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/syndicate/black/red,
+/obj/item/clothing/head/helmet/space/syndicate/black/red,
+/obj/effect/floor_decal/corner_wide/grey{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "IZ" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 8
@@ -2577,16 +3377,18 @@
 "Jj" = (
 /obj/effect/map_effect/window_spawner/full/reinforced,
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
 "Jl" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
+/obj/structure/table/reinforced/steel,
+/obj/item/clothing/glasses/sunglasses/aviator{
+	pixel_x = -5;
+	pixel_y = 6
 	},
-/obj/item/trash/match,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "Jo" = (
 /obj/structure/bed/padded/bunk{
 	pixel_y = 0
@@ -2603,15 +3405,43 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"Jq" = (
+/obj/effect/floor_decal/corner_wide/lime/diagonal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "Jw" = (
-/obj/item/clothing/gloves/yellow,
+/obj/structure/bed/stool/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"Jx" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
+"JC" = (
+/obj/effect/floor_decal/corner/purple{
+	dir = 10
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "JD" = (
-/obj/item/trash/cheesie,
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/structure/sink/kitchen{
+	name = "sink";
+	pixel_y = 26
+	},
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "JW" = (
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
@@ -2629,10 +3459,9 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
 "Ke" = (
-/obj/structure/closet/toolcloset,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "Ki" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -2640,6 +3469,67 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
 "KB" = (
+/obj/structure/table/reinforced/steel,
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 10
+	},
+/obj/item/clothing/suit/armor/cuirass,
+/turf/simulated/floor/plating,
+/area/mine)
+"KD" = (
+/obj/structure/bed/stool/chair/office/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
+/area/mine)
+"KE" = (
+/obj/structure/table/steel{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/food/drinks/carton/milk{
+	pixel_y = 7
+	},
+/obj/item/storage/box/fancy/egg_box,
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"KG" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/red,
+/area/mine)
+"KK" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_ship/starboard)
+"KL" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"KR" = (
+/obj/structure/bed/padded/bunk{
+	pixel_y = 0
+	},
+/obj/item/bedsheet/black,
+/obj/item/toy/plushie/farwa{
+	pixel_y = -3;
+	pixel_x = 7
+	},
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube_empty"
+	},
+/obj/effect/ghostspawpoint{
+	identifier = "goon"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"KW" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/plasteel/full,
 /obj/item/stack/material/plasteel/full,
@@ -2648,33 +3538,11 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/goonbase)
-"KE" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/broken_bottle,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"KG" = (
-/obj/structure/table/rack,
-/obj/item/soap/syndie,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/freezer,
-/area/goonbase)
-"KK" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
-"KR" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/trash/cigbutt,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"KW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/trash_pile,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
+"KZ" = (
+/obj/structure/bookcase,
+/turf/simulated/floor/tiled,
+/area/mine)
 "La" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
@@ -2683,12 +3551,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "Ld" = (
-/obj/structure/noticeboard{
-	pixel_y = -30
+/obj/effect/floor_decal/spline/fancy{
+	dir = 1
 	},
-/obj/item/trash/candy,
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "Lg" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
@@ -2713,28 +3581,57 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
-"Mo" = (
-/obj/structure/table/standard,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
+"LM" = (
 /obj/effect/floor_decal/corner_wide/lime{
-	dir = 10
+	dir = 5
 	},
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/turf/simulated/floor/tiled,
+/area/mine)
+"Mh" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/loot,
+/turf/simulated/floor/plating,
+/area/mine)
+"Mk" = (
+/obj/effect/floor_decal/corner_wide/red{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"Mo" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/gun/projectile/automatic/c20r,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Mu" = (
+/obj/effect/floor_decal/corner_wide/grey/full,
+/turf/simulated/floor/tiled,
+/area/mine)
 "Mw" = (
 /turf/space,
 /area/space)
+"Mz" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/mine)
 "MB" = (
-/obj/item/storage/box/drinkingglasses,
-/obj/structure/table/steel{
-	pixel_x = -2
+/obj/machinery/door/airlock{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
+"ME" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/mine)
 "MJ" = (
 /obj/structure/table/steel,
 /obj/item/paper/crumpled,
@@ -2754,6 +3651,17 @@
 "MR" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/living)
+"MS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"MT" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/phoron_scarce,
+/turf/simulated/floor/plating,
+/area/mine)
 "MV" = (
 /obj/effect/landmark/entry_point/north{
 	name = "aft, port engines"
@@ -2779,20 +3687,56 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
-"Nk" = (
+"Ne" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
+"Nf" = (
+/obj/structure/bed/padded,
+/obj/item/bedsheet/rainbow,
+/turf/simulated/floor/tiled,
+/area/mine)
+"Ni" = (
+/obj/effect/floor_decal/corner_wide/grey{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"Nk" = (
+/obj/machinery/body_scanconsole{
+	pixel_x = -1
+	},
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"Np" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/wood,
+/area/mine)
+"Nq" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/empty/air,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "Nr" = (
-/obj/item/paper/crumpled,
+/obj/effect/decal/cleanable/molten_item,
 /obj/machinery/light{
 	dir = 8;
 	pixel_x = 0;
 	icon_state = "tube_empty"
 	},
-/turf/simulated/floor/wood,
-/area/goonbase)
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"NA" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"NB" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/plating,
+/area/mine)
 "NF" = (
 /obj/structure/noticeboard{
 	pixel_y = 32
@@ -2800,60 +3744,68 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "NH" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/effect/map_effect/airlock/long/square{
+	required_access = null
+	},
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/mine)
 "NP" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/gun/projectile/automatic/c20r,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
+/obj/machinery/portable_atmospherics/canister/phoron_scarce,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "NT" = (
-/obj/structure/table/steel,
-/obj/item/trash/cigbutt{
-	pixel_y = -4;
-	pixel_x = -9
+/obj/structure/table/rack,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube_empty"
 	},
-/obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_y = 8;
-	pixel_x = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "NX" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 7
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/red,
-/area/goonbase)
+/obj/item/trash/chipbasket,
+/turf/simulated/floor/plating,
+/area/mine)
 "NY" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
 "On" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/obj/item/trash/cigbutt,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/obj/item/clothing/gloves/janitor,
+/obj/structure/table/rack,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
+"Oo" = (
+/obj/structure/bed/stool/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"Or" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/structure/bed/stool/chair/sofa/red,
+/obj/item/handcuffs{
+	pixel_x = -10
+	},
+/turf/simulated/floor/wood,
+/area/mine)
 "Os" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/rations,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/item/trash/broken_electronics,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "Ow" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/item/deck/cards,
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet/red,
+/area/mine)
 "OA" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/mushroom{
@@ -2864,6 +3816,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"OI" = (
+/obj/structure/table/reinforced/steel,
+/obj/item/clothing/glasses/sunglasses/aviator,
+/obj/item/clothing/glasses/sunglasses/aviator{
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/sunglasses/aviator{
+	pixel_y = 10
+	},
+/obj/item/clothing/glasses/sunglasses/aviator{
+	pixel_y = 7
+	},
+/obj/item/clothing/glasses/sunglasses/aviator{
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/mine)
 "OL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fuel_port/hydrogen{
@@ -2889,81 +3858,83 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "Pc" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest{
-	pixel_x = -8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
 	},
-/obj/item/clothing/accessory/storage/black_vest{
-	pixel_x = 8
-	},
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/goonbase)
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "Pk" = (
 /obj/effect/overmap/visitable/sector/goon,
 /turf/simulated/mineral/surface,
 /area/mine)
 "Pp" = (
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "Pu" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "PC" = (
 /obj/machinery/bodyscanner,
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "PK" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"PL" = (
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 9
+/obj/machinery/light/small{
+	dir = 4
 	},
+/obj/structure/table/steel,
+/obj/item/device/flashlight/lantern,
+/obj/item/device/flashlight/lantern,
+/obj/item/device/flashlight/lantern,
+/obj/item/device/flashlight/lantern,
+/obj/item/device/flashlight/lantern,
+/obj/item/device/flashlight/lantern,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"PL" = (
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"PR" = (
+/obj/item/wrench,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
+"PS" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/mine)
+"PV" = (
+/obj/item/storage/box/drinkingglasses,
 /obj/structure/table/steel{
 	pixel_x = -2
 	},
-/obj/item/tape_roll,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"PR" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/goonbase)
-"PV" = (
-/obj/structure/bed/stool/chair/sofa/left/black,
-/turf/simulated/floor/wood,
-/area/goonbase)
-"PW" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"PY" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_y = 8;
-	pixel_x = 6
+/area/mine)
+"PW" = (
+/obj/structure/bed/padded/bunk{
+	pixel_y = 0
+	},
+/obj/item/bedsheet/black,
+/obj/effect/ghostspawpoint{
+	identifier = "goon_boss"
 	},
 /turf/simulated/floor/wood,
-/area/goonbase)
+/area/mine)
+"PY" = (
+/obj/item/material/ashtray/bronze,
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet/red,
+/area/mine)
 "PZ" = (
 /obj/structure/table/rack,
 /obj/item/clothing/gloves/latex,
@@ -2971,6 +3942,15 @@
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
+"Qc" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/empty/oxygen,
+/turf/simulated/floor/plating,
+/area/mine)
+"Qe" = (
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/mine)
 "Qf" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4;
@@ -2979,19 +3959,35 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
+"Qg" = (
+/obj/effect/floor_decal/corner_wide/grey/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "Qh" = (
 /obj/item/trash/coffee,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "Ql" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/portgen/basic,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"Qm" = (
-/obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/chemical_dispenser/bar_soft/full{
+	dir = 8;
+	pixel_x = 5
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
+"Qm" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
 "Qv" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /turf/simulated/floor/plating{
@@ -2999,9 +3995,10 @@
 	},
 /area/shuttle/goon_ship/bridge)
 "Qw" = (
-/obj/structure/punching_bag,
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/structure/dispenser/oxygen,
+/turf/simulated/floor/plating,
+/area/mine)
 "Qx" = (
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /obj/structure/cable{
@@ -3016,52 +4013,45 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/port)
 "QE" = (
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/item/trash/plate/steak,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/item/trash/liquidfood,
+/turf/simulated/floor/plating,
+/area/mine)
 "QM" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"QO" = (
-/obj/structure/closet{
-	icon_door = "blue";
-	name = "misc clothing"
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
 	},
-/obj/item/clothing/accessory/university/black,
-/obj/item/clothing/under/syndicate/ninja,
-/obj/item/clothing/under/pants/ripped,
-/obj/item/clothing/under/pants/tacticool,
-/obj/item/clothing/under/vysoka,
-/obj/item/clothing/suit/storage/toggle/varsity,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/midriff,
-/obj/item/clothing/under/suit_jacket/charcoal,
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"QP" = (
-/obj/item/reagent_containers/glass/bucket/wood{
-	pixel_y = -7
-	},
+/area/mine)
+"QO" = (
+/obj/structure/closet/crate/loot,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
+"QP" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/turf/simulated/floor/carpet/red,
+/area/mine)
+"QQ" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plating,
+/area/mine)
 "QT" = (
 /obj/machinery/atmospherics/binary/pump/high_power,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "QX" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "Rb" = (
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "Rc" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/med)
@@ -3091,21 +4081,30 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
-"Rv" = (
-/obj/effect/floor_decal/spline/plain/black{
+"Rl" = (
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
 	},
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/item/clothing/head/hardhat/dblue,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"RE" = (
-/obj/structure/table/rack,
-/obj/item/clothing/gloves/boxing,
 /turf/simulated/floor/wood,
-/area/goonbase)
+/area/mine)
+"Rt" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Rv" = (
+/obj/machinery/media/jukebox,
+/turf/simulated/floor/wood,
+/area/mine)
+"RE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "RQ" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector{
@@ -3115,10 +4114,23 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "RR" = (
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"Sd" = (
+/obj/machinery/door/airlock/glass,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/plating,
+/area/mine)
 "Sf" = (
 /obj/structure/table/steel,
 /obj/item/trash/proteinbar,
@@ -3128,59 +4140,74 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "Sj" = (
-/obj/structure/table/steel,
-/obj/item/clothing/glasses/welding,
-/obj/item/weldingtool,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/machinery/vending/dinnerware,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "Sk" = (
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
+/obj/structure/closet/crate,
+/obj/item/stack/material/diamond,
+/obj/item/stack/material/diamond,
+/obj/item/stack/material/diamond,
+/turf/simulated/floor/plating,
+/area/mine)
 "Sm" = (
 /obj/structure/table/rack,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/gun/projectile/pistol{
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"Su" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Sz" = (
+/obj/structure/trash_pile,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"SE" = (
+/obj/structure/table/reinforced/steel,
+/obj/item/clothing/mask/gas/syndicate{
 	layer = 2.99;
 	pixel_y = 6
 	},
-/obj/item/gun/projectile/pistol,
-/obj/effect/floor_decal/spline/plain{
+/obj/effect/floor_decal/spline/plain/black{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/goonbase)
-"Sz" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/trash/uselessplastic,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"SE" = (
-/obj/structure/table/steel,
-/obj/item/storage/firstaid/o2{
-	pixel_x = -4
-	},
-/obj/item/storage/firstaid/radiation,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 4
-	},
-/obj/effect/floor_decal/corner_wide/lime{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/area/mine)
 "SF" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 13
+	},
+/obj/structure/mirror{
+	pixel_x = 27
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
-/area/goonbase)
+/area/mine)
 "SG" = (
 /obj/structure/lattice/catwalk/indoor/grate/old,
 /obj/machinery/light{
@@ -3189,28 +4216,39 @@
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
+"SJ" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/plating,
+/area/mine)
 "SK" = (
 /obj/item/trash/cigbutt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "SU" = (
-/obj/structure/table/wood,
-/obj/item/modular_computer/laptop/preset/civilian{
-	pixel_y = 9
-	},
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/machinery/pipedispenser,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
 "SX" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/structure/closet/crate,
+/obj/item/clothing/head/headbando/random,
+/obj/item/clothing/suit/storage/toggle/track/red,
+/obj/item/clothing/suit/storage/vest,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "SZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"Tb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
 "Td" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -3221,10 +4259,20 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
 "To" = (
-/obj/structure/trash_pile,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/structure/closet{
+	icon_door = "blue";
+	name = "misc clothing"
+	},
+/obj/item/clothing/accessory/university/black,
+/obj/item/clothing/under/syndicate/ninja,
+/obj/item/clothing/under/pants/ripped,
+/obj/item/clothing/under/pants/tacticool,
+/obj/item/clothing/under/vysoka,
+/obj/item/clothing/suit/storage/toggle/varsity,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/midriff,
+/obj/item/clothing/under/suit_jacket/charcoal,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "Tr" = (
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /obj/structure/cable{
@@ -3235,71 +4283,128 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "Ts" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/accessory/medal/gold,
-/obj/item/clothing/accessory/crucifix/gold,
-/obj/item/clothing/wrists/watch/gold,
-/obj/item/coin/gold,
-/obj/item/flame/lighter/zippo/gold,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/material/phoron/full,
-/obj/random/highvalue/no_weapon,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "Tt" = (
 /obj/machinery/vending/dinnerware/plastic,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Tu" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/structure/bed/stool/chair,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "Ty" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "TA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube_empty"
+/obj/item/clothing/accessory/longsleeve_s,
+/obj/structure/closet{
+	icon_door = "blue";
+	name = "misc clothing"
 	},
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/item/clothing/under/syndicate/tacticool,
+/obj/item/clothing/under/tactical,
+/obj/item/clothing/under/pants/black,
+/obj/item/clothing/under/color/brown,
+/obj/item/clothing/suit/storage/toggle/trench/grey,
+/obj/item/clothing/head/softcap/himeo,
+/obj/item/clothing/suit/storage/toggle/leather_vest,
+/obj/item/clothing/under/service_overalls,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "TH" = (
-/obj/machinery/appliance/cooker/fryer,
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"TJ" = (
-/obj/structure/bed/roller,
-/obj/effect/floor_decal/industrial/outline/medical,
 /obj/effect/floor_decal/corner_wide/lime{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/goonbase)
-"TQ" = (
-/obj/structure/table/rack,
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/steel/full,
-/obj/effect/floor_decal/spline/plain/black{
+/area/mine)
+"TJ" = (
+/obj/structure/table/steel{
+	pixel_x = -2
+	},
+/obj/item/trash/waffles,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"TN" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/turf/simulated/floor/plating,
+/area/mine)
+"TO" = (
+/obj/effect/floor_decal/corner_wide/grey{
 	dir = 5
 	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
+/turf/simulated/floor/tiled,
+/area/mine)
+"TQ" = (
+/obj/structure/noticeboard{
+	pixel_y = -30
 	},
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/item/trash/candy,
+/turf/simulated/floor/wood,
+/area/mine)
+"TW" = (
+/obj/effect/floor_decal/corner_wide/red/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "TY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/trash_pile,
+/turf/simulated/floor/plating,
+/area/mine)
+"Uc" = (
+/obj/effect/decal/cleanable/spiderling_remains,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"Ud" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_ship/port)
+"Uf" = (
+/obj/structure/closet/secure_closet/cabinet{
+	req_access = list(20)
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"Ui" = (
+/obj/effect/landmark/entry_point/south{
+	name = "fore, bridge"
+	},
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/goon_ship/bridge)
+"Ul" = (
+/obj/effect/floor_decal/corner/beige{
+	dir = 5
+	},
+/obj/machinery/computer/ship/sensors,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/goon_ship/bridge)
+"Un" = (
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/structure/table/steel,
+/obj/item/trash/stew{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"Up" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/suit/pirate,
 /obj/item/storage/box/fancy/cigarettes/nicotine,
@@ -3314,48 +4419,7 @@
 /obj/random/spacecash,
 /obj/random/spacecash,
 /turf/simulated/floor/wood,
-/area/goonbase)
-"Uc" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/gun/projectile/automatic/lebman,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 2;
-	pixel_y = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/plating,
-/area/goonbase)
-"Ud" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
-"Ui" = (
-/obj/effect/landmark/entry_point/south{
-	name = "fore, bridge"
-	},
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/bridge)
-"Ul" = (
-/obj/effect/floor_decal/corner/beige{
-	dir = 5
-	},
-/obj/machinery/computer/ship/sensors,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
-"Up" = (
-/obj/structure/table/rack,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical/w,
-/obj/item/melee/baton/stunrod,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/area/mine)
 "Uq" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -3363,12 +4427,10 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/starboard)
 "Ur" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/head/bandana/pirate,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/flight,
-/obj/item/clothing/suit/storage/vest,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/ramen,
+/turf/simulated/floor/carpet/red,
+/area/mine)
 "UA" = (
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
@@ -3393,16 +4455,29 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "UX" = (
-/obj/machinery/portable_atmospherics/canister/phoron_scarce,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/goonbase)
-"Vc" = (
-/obj/machinery/appliance/cooker/stove,
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
-/obj/item/trash/stew,
+/obj/structure/table/standard,
+/obj/item/storage/box/fancy/tray,
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/white,
-/area/goonbase)
+/area/mine)
+"Vb" = (
+/obj/structure/bed/padded,
+/obj/item/bedsheet/brown,
+/obj/item/toy/plushie/farwa{
+	pixel_y = -3;
+	pixel_x = 7
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"Vc" = (
+/obj/structure/punching_bag,
+/turf/simulated/floor/wood,
+/area/mine)
 "Vo" = (
 /obj/structure/closet/walllocker/medical{
 	pixel_y = -32
@@ -3411,37 +4486,34 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Vp" = (
-/obj/structure/table/steel{
-	pixel_x = -2
+/obj/structure/lattice/catwalk/indoor/grate/old,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/paper_bin,
-/obj/item/pen/black,
-/obj/item/device/gps,
-/obj/item/device/gps,
-/obj/item/device/gps,
-/turf/simulated/floor/wood,
-/area/goonbase)
+/turf/simulated/floor/plating,
+/area/mine)
 "Vs" = (
-/obj/structure/table/steel{
-	pixel_x = -2
+/obj/item/paper/crumpled,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
 	},
-/obj/item/trash/tray,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/turf/simulated/floor/wood,
+/area/mine)
 "Vu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"Vw" = (
+/turf/simulated/floor/tiled,
+/area/mine)
 "Vx" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "VB" = (
 /obj/machinery/chemical_dispenser/bar_alc/full{
 	dir = 1;
@@ -3450,35 +4522,28 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "VD" = (
-/obj/structure/table/rack,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
+/obj/structure/table/steel{
+	pixel_x = -2
 	},
+/obj/item/trash/tray,
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
+"VK" = (
+/turf/simulated/floor/tiled/dark/full,
+/area/mine)
 "VL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/structure/table/wood,
+/obj/item/material/ashtray/bronze,
+/turf/simulated/floor/wood,
+/area/mine)
 "VY" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/table/steel,
-/obj/item/device/flashlight/lantern,
-/obj/item/device/flashlight/lantern,
-/obj/item/device/flashlight/lantern,
-/obj/item/device/flashlight/lantern,
-/obj/item/device/flashlight/lantern,
-/obj/item/device/flashlight/lantern,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/structure/table/rack,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical/w,
+/obj/item/melee/baton/stunrod,
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "Wb" = (
 /obj/item/trash/can,
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
@@ -3489,39 +4554,79 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
+"Wk" = (
+/obj/machinery/vending/dinnerware,
+/turf/simulated/floor/tiled,
+/area/mine)
+"Wn" = (
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled,
+/area/mine)
 "Wq" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
+/obj/structure/curtain/medical,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"Wt" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
+"Wu" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/plating,
+/area/mine)
 "Wv" = (
-/obj/structure/bed/padded/bunk{
-	pixel_y = 0
+/obj/structure/bed/roller,
+/obj/effect/floor_decal/industrial/outline/medical,
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 5
 	},
-/obj/item/bedsheet/black,
-/obj/effect/ghostspawpoint{
-	identifier = "goon_boss"
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"Ww" = (
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 10
 	},
-/turf/simulated/floor/wood,
-/area/goonbase)
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"WA" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/mine)
+"WD" = (
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/machinery/appliance/cooker/oven,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "WG" = (
-/obj/item/storage/box/handcuffs,
-/obj/item/melee/baton/stunrod,
-/obj/structure/table/steel,
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/item/trash/coffee,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"WI" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "WL" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
+"WM" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/mine)
 "WO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3536,16 +4641,14 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "WR" = (
-/obj/machinery/door/airlock{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/structure/bed/stool,
+/turf/simulated/floor/carpet/red,
+/area/mine)
 "WS" = (
-/obj/structure/closet/crate/loot,
+/obj/item/clothing/gloves/yellow,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "Xb" = (
 /obj/effect/shuttle_landmark/goon_ship/transit,
 /turf/space,
@@ -3589,26 +4692,27 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "Xx" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/mask/gas/syndicate{
-	layer = 2.99;
-	pixel_y = 6
-	},
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/goonbase)
-"Xz" = (
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"XP" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/chips,
 /turf/simulated/floor/carpet/red,
-/area/goonbase)
+/area/mine)
+"Xz" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 7
+	},
+/turf/simulated/floor/carpet/red,
+/area/mine)
+"XP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/item/stack/material/silver,
+/obj/item/stack/material/silver,
+/obj/item/stack/material/silver,
+/turf/simulated/floor/plating,
+/area/mine)
 "XS" = (
 /obj/machinery/computer/ship/engines{
 	dir = 8
@@ -3616,15 +4720,24 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "XY" = (
+/obj/machinery/vending/engineering{
+	req_access = null
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/device/paicard,
-/obj/item/material/twohanded/fireaxe,
-/obj/item/weldingtool/hugetank,
-/obj/item/tank/jetpack/void,
-/obj/item/wirecutters/toolbelt,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
+"Ya" = (
+/obj/structure/closet/crate,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"Yf" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/corner_wide/grey{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "Yh" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -3632,20 +4745,21 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "Yi" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/head/turban,
-/obj/item/clothing/accessory/poncho,
-/obj/item/clothing/suit/storage/vest,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
-"Yp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock{
-	dir = 8;
-	req_access = list(202)
+/obj/structure/table/steel{
+	pixel_x = -2
 	},
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/item/material/kitchen/rollingpin,
+/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"Yp" = (
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "Yt" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3653,16 +4767,11 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "Yz" = (
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/item/reagent_containers/food/drinks/carton/milk{
-	pixel_y = 7
-	},
-/obj/item/storage/box/fancy/egg_box,
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
+/obj/item/storage/box/handcuffs,
+/obj/item/melee/baton/stunrod,
+/obj/structure/table/steel,
+/turf/simulated/floor/wood,
+/area/mine)
 "YA" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -3679,15 +4788,23 @@
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
+"YU" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/standard,
+/obj/random/soap{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "YV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/kidneys,
+/obj/machinery/door/airlock{
+	dir = 8;
+	req_access = list(202)
+	},
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "YW" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -3706,18 +4823,28 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "YZ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_y = 8;
+	pixel_x = 6
+	},
+/turf/simulated/floor/wood,
+/area/mine)
+"Zc" = (
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 4
+	},
+/obj/structure/table/steel{
+	pixel_x = -2
+	},
+/obj/item/gun/custom_ka/frame05,
 /obj/machinery/light{
 	dir = 8;
-	pixel_x = 0;
+	pixel_y = 0;
 	icon_state = "tube_empty"
 	},
-/turf/simulated/floor/tiled/white,
-/area/goonbase)
-"Zc" = (
-/obj/item/trash/maps,
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/turf/simulated/floor/plating,
+/area/mine)
 "Ze" = (
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
@@ -3727,37 +4854,41 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Zi" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/c762,
-/obj/item/ammo_magazine/c762,
-/obj/item/ammo_magazine/c762,
-/obj/item/gun/projectile/automatic/rifle/sts35,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 2;
-	pixel_y = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/plating,
-/area/goonbase)
+/turf/simulated/floor/wood,
+/area/mine)
 "Zk" = (
-/obj/effect/map_effect/airlock/long/square{
-	required_access = null
+/obj/machinery/door/airlock{
+	dir = 8;
+	req_access = list(202)
 	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/goonbase)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "Zu" = (
-/obj/structure/janitorialcart/full,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/inhaler/space_drugs,
+/obj/item/reagent_containers/inhaler/space_drugs,
+/obj/item/reagent_containers/inhaler/space_drugs,
+/obj/item/reagent_containers/syringe/drugs,
+/obj/item/reagent_containers/syringe/drugs,
+/obj/item/reagent_containers/syringe/drugs,
 /turf/simulated/floor/plating,
-/area/goonbase)
+/area/mine)
 "Zw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/structure/table/steel,
+/obj/item/storage/firstaid/combat{
+	pixel_x = -4
+	},
+/obj/item/storage/firstaid/trauma,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 4
+	},
+/obj/effect/floor_decal/corner_wide/lime{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "Zx" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 10
@@ -3772,30 +4903,46 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "ZB" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/head/helmet/material/makeshift,
-/obj/effect/floor_decal/spline/plain/black,
-/turf/simulated/floor/plating,
-/area/goonbase)
+/obj/structure/table/rack,
+/obj/item/wrench,
+/obj/item/wrench,
+/obj/item/wrench,
+/obj/item/wrench,
+/obj/item/wrench,
+/obj/item/paper/goon_base/notice,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"ZH" = (
+/obj/structure/dispenser/oxygen,
+/obj/effect/floor_decal/corner_wide/grey{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "ZJ" = (
 /obj/structure/table/steel{
 	pixel_x = -2
 	},
 /obj/item/trash/plate,
 /turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/area/mine)
 "ZL" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = 0;
-	icon_state = "tube_empty"
+/obj/item/trash/cheesie,
+/turf/simulated/floor/wood,
+/area/mine)
+"ZT" = (
+/obj/effect/floor_decal/corner/purple{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
-/area/goonbase)
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/simulated/floor/tiled,
+/area/mine)
 "ZW" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/goonbase)
+/obj/machinery/power/portgen/basic,
+/turf/simulated/floor/plating,
+/area/mine)
 
 (1,1,1) = {"
 Mw
@@ -34452,15 +35599,15 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
 mI
 mI
 mI
@@ -34709,15 +35856,15 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+qX
 mI
 mI
 mI
@@ -34920,24 +36067,6 @@ mI
 mI
 mI
 mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
 mI
 mI
 mI
@@ -34975,6 +36104,24 @@ mI
 mI
 mI
 mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+Dr
+gn
+HW
+ig
+lj
+fA
+Dr
+qX
 mI
 mI
 mI
@@ -35177,24 +36324,6 @@ mI
 mI
 mI
 mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
 mI
 mI
 mI
@@ -35219,19 +36348,37 @@ mI
 mI
 mI
 mI
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+Dr
+TO
+bj
+lW
+Qg
+iK
+Dr
+qX
 mI
 mI
 mI
@@ -35429,29 +36576,6 @@ mI
 mI
 mI
 mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
 mI
 mI
 mI
@@ -35477,8 +36601,51 @@ mI
 mI
 mI
 mI
+qX
+qX
+qX
+qX
+qX
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+qX
 mI
 mI
+qX
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+qj
+lW
+lW
+lW
+xp
+Dr
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
 mI
 mI
 mI
@@ -35516,27 +36683,7 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+vz
 mI
 mI
 mI
@@ -35686,50 +36833,6 @@ mI
 mI
 mI
 mI
-OP
-OP
-OP
-OP
-OP
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
 mI
 mI
 mI
@@ -35755,8 +36858,51 @@ mI
 mI
 mI
 mI
+qX
+Dr
+Dr
+Dr
+Dr
+Dr
+QX
+QX
+QX
+QX
+QX
+QX
+QX
+QX
+Dr
+qX
 mI
 mI
+qX
+Dr
+QX
+QX
+QX
+QX
+QX
+QX
+QX
+Dr
+IX
+Mu
+lW
+FU
+tr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+qX
 mI
 mI
 mI
@@ -35794,7 +36940,8 @@ mI
 mI
 mI
 mI
-mI
+vz
+vz
 mI
 mI
 mI
@@ -35941,53 +37088,6 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-ms
-mW
-mW
-pB
-Ak
-fW
-YV
-zz
-mW
-px
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
 mI
 mI
 mI
@@ -36009,10 +37109,57 @@ mI
 mI
 mI
 mI
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+Dr
+QX
+QX
+QX
+wY
+QX
+QX
+QX
+QX
+QX
+QX
+QX
+QX
+Dr
 mI
 mI
 mI
 mI
+Dr
+QX
+QX
+QX
+QX
+QX
+QX
+QX
+wY
+Vw
+bj
+lW
+pz
+BH
+Dr
+QX
+QX
+QX
+Dr
+QX
+QX
+QX
+QX
+QX
+Dr
+qX
 mI
 mI
 mI
@@ -36049,11 +37196,11 @@ mI
 mI
 mI
 mI
+vz
+vz
+se
 mI
-mI
-mI
-mI
-mI
+Dr
 mI
 mI
 mI
@@ -36198,54 +37345,6 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-ms
-ms
-ms
-ms
-ms
-mW
-mW
-mW
-mW
-mW
-mW
-mW
-mW
-px
-ms
-QP
-mW
-bL
-mW
-xr
-ms
-OP
-ms
-ms
-ms
-ms
-ms
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
 mI
 mI
 mI
@@ -36267,9 +37366,57 @@ mI
 mI
 mI
 mI
+qX
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+QX
+QX
+QX
+Dr
+Dr
+Dr
+Rt
+Dr
+Dr
+Dr
+Dr
+QX
+Dr
 mI
+tS
 mI
 mI
+Dr
+QX
+QX
+Dr
+EQ
+QX
+QX
+Dr
+Dr
+TO
+lW
+lW
+lW
+BH
+Dr
+QX
+QX
+QX
+Dr
+QX
+QX
+QX
+QX
+QX
+Dr
+qX
 mI
 mI
 mI
@@ -36306,11 +37453,11 @@ mI
 mI
 mI
 mI
+se
+se
+se
 mI
-mI
-mI
-mI
-mI
+Dr
 mI
 mI
 mI
@@ -36455,54 +37602,6 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-ms
-Fe
-SU
-PY
-ms
-mW
-mW
-WS
-eH
-Os
-XY
-mW
-mW
-ie
-ms
-mW
-mW
-mW
-mW
-mW
-ms
-ms
-ms
-Ql
-Ig
-Iz
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-OP
-OP
 mI
 mI
 mI
@@ -36519,7 +37618,62 @@ mI
 mI
 mI
 mI
+qX
+qX
+qX
+qX
+qX
+qX
+Dr
+yH
+Hd
+ME
+ru
+tu
+Dr
+QX
+QX
+QX
+Dr
+kE
+QX
+QX
+QX
+QX
+kE
+Dr
+QX
+Dr
 mI
+Do
+Do
+tS
+Dr
+Rt
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+ZH
+Mu
+lW
+FU
+Vw
+wY
+QX
+QX
+QX
+wY
+QX
+QX
+QX
+QX
+QX
+Dr
+qX
 mI
 mI
 mI
@@ -36555,19 +37709,12 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+Dr
+se
+se
+se
+se
+Dr
 mI
 mI
 mI
@@ -36712,60 +37859,78 @@ bu
 bu
 mI
 mI
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+QX
+pa
+ru
+vH
+QX
+Dr
+QX
+QX
+QX
+Dr
+IN
+QX
+Bm
+IN
+QX
+IN
+Dr
+QX
+Dr
+Dr
+Do
+Do
+Do
+Dr
+QX
+QX
+QX
+Dr
+QX
+QX
+QX
+Dr
+Yf
+Vw
+Vw
+jW
+ei
+Dr
+Dr
+Dr
+Dr
+Dr
+QX
+QX
+Dr
 ms
-aT
-Pp
-Cf
-ms
-mW
-mW
-mW
-mW
-mW
-VL
-mW
-mW
-Tu
-ms
-mW
-mW
-mW
-hZ
-mW
-ms
-ms
-np
-mW
-gM
-Jw
-Ke
-ms
-nT
-mW
-mW
-mW
-To
-ms
-ms
-KW
-oM
-Nk
-lz
-mW
-mW
-To
-ms
-ms
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+Dr
+Dr
+qX
 mI
 mI
 mI
@@ -36801,30 +37966,12 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+Dr
+vz
+vz
+se
+se
+Dr
 mI
 mI
 mI
@@ -36969,65 +38116,6 @@ bu
 bu
 mI
 mI
-OP
-OP
-OP
-ms
-TY
-Cf
-Cf
-ms
-mW
-mW
-qP
-UX
-Ts
-yX
-TA
-mW
-Tu
-ms
-mW
-mW
-mW
-mW
-mW
-ms
-ms
-px
-mW
-mW
-mW
-mW
-BE
-mW
-mW
-mW
-mW
-mW
-BE
-mW
-qW
-mW
-mW
-mW
-mW
-mW
-mW
-ie
-ms
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-mI
-mI
-OP
 mI
 mI
 mI
@@ -37041,6 +38129,65 @@ mI
 mI
 mI
 mI
+mI
+mI
+mI
+qX
+Dr
+MT
+WM
+NB
+NB
+Dr
+is
+vH
+Hx
+yD
+tu
+Dr
+QX
+QX
+QX
+Dr
+Gc
+QX
+IN
+Mh
+QX
+lb
+Dr
+QX
+QX
+wY
+nB
+nB
+nB
+nB
+QX
+QX
+QX
+Dr
+QX
+QX
+QX
+Dr
+Dr
+Dr
+Cb
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+QX
+QX
+Dr
+QX
+QX
+Dr
+qX
 mI
 mI
 mI
@@ -37076,12 +38223,12 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
+Dr
+vz
+vz
+vz
+vz
+Dr
 mI
 mI
 mI
@@ -37226,78 +38373,78 @@ bu
 bu
 mI
 mI
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+Dr
+QQ
+QX
+QX
+Ga
+Dr
+QX
+pa
+MS
+QX
+Dr
+Dr
+QX
+QX
+QX
+Dr
+qv
+QX
+Mh
+Wu
+QX
+IN
+Dr
+QX
+QX
+Dr
+mI
+mI
+mI
+mI
+QX
+QX
+QX
+Dr
+QX
+QX
+QX
+Dr
+Vw
+Vw
+Vw
+Vw
+Vw
+QX
+Dr
+mI
+mI
+Dr
+mn
+mn
+Dr
 ms
-Wv
-Cf
-jz
-ms
-Yp
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-Jj
-Jj
-xH
-Jj
-Jj
-ms
-ms
-Sj
-mW
-mW
-mW
-Fc
-ms
-Bz
-To
-mW
-To
-Fc
-ms
-To
-mW
-mW
-mW
-mW
-mW
-Fc
-mW
-mW
-ms
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-mI
-mI
-OP
-mI
-mI
-mI
-mI
-mI
-sB
-sB
-sB
-mI
-mI
-mI
-mI
-mI
+Dr
+Dr
+qX
 mI
 mI
 mI
@@ -37306,11 +38453,11 @@ mI
 mI
 sB
 sB
-sB
-sB
-sB
-sB
-sB
+nT
+nT
+nT
+nT
+nT
 mI
 mI
 mI
@@ -37330,15 +38477,15 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-mI
-mI
-mI
-mI
-mI
-mI
+nT
+nT
+nT
+Dr
+Dr
+vz
+vz
+Dr
+Dr
 mI
 mI
 mI
@@ -37483,65 +38630,68 @@ bu
 bu
 mI
 mI
-OP
-OP
-OP
-ms
-ms
-vR
-ms
-ms
-iY
-TQ
-KB
-fz
-GI
-ms
-nf
-Cf
-Nr
-Vp
-Cf
-JD
-Cf
-GH
-WG
-ms
-ms
-ms
-ms
-bQ
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-bQ
-ms
-ms
-Ow
-ms
-ms
-bQ
-ms
-ms
-OP
-ms
-ms
-ms
-ms
-ms
-ms
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+Dr
+Nq
+QX
+QX
+QX
+QX
+QX
+uu
+uu
+QX
+Dr
+EQ
+QX
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Rt
+Dr
+Dr
+Dr
+Rt
+Dr
+Dr
+Do
+tS
+mI
+Dr
+Dr
+Rt
+Dr
+Dr
+Rt
+Dr
+Dr
+Vw
+Vw
+Vw
+Vw
+Vw
+QX
+Dr
 mI
 mI
 mI
@@ -37553,9 +38703,6 @@ sB
 sB
 sB
 sB
-sB
-sB
-mI
 mI
 mI
 sB
@@ -37565,10 +38712,10 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
+nT
+nT
+nT
+nT
 mI
 mI
 mI
@@ -37589,12 +38736,12 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
+nT
+nT
+nT
+nT
+nT
+nT
 sB
 mI
 mI
@@ -37740,65 +38887,75 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-ms
-xf
-iY
-Yi
-ms
-iY
-iY
-iY
-iY
-iY
-qy
-nf
-BW
-Cf
-Pp
-Cf
-Cf
-zb
-ZW
-Cf
-ms
-ms
-ZL
-iY
-eJ
-iY
-ZL
-ms
-ms
-nJ
-rc
-sX
-ms
-ms
-iY
-eJ
-ZL
-ms
-ms
-ms
-ZL
-eJ
-iY
-ms
-ms
-ms
-te
-te
-te
-te
-ms
-ms
-ms
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+Dr
+NB
+Qc
+Ga
+Wu
+Dr
+ME
+hN
+fC
+pQ
+WA
+pQ
+QX
+Dr
+Vw
+Vw
+Vw
+Vw
+Dr
+FU
+Vw
+IW
+IW
+ff
+Vw
+mn
+nB
+Do
+nB
+Do
+nB
+mn
+Vw
+ff
+IW
+Vw
+IW
+IW
+Vw
+Vw
+Vw
+Vw
+Vw
+Dr
+Dr
+mI
+sB
+sB
+sB
+sB
+nT
+nT
 sB
 sB
 sB
@@ -37814,6 +38971,8 @@ sB
 sB
 sB
 sB
+nT
+nT
 sB
 sB
 sB
@@ -37825,6 +38984,9 @@ sB
 sB
 sB
 sB
+nT
+nT
+nT
 sB
 sB
 sB
@@ -37832,24 +38994,9 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+nT
+nT
+nT
 sB
 sB
 sB
@@ -37997,65 +39144,77 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Vw
+Vw
+Vw
+Vw
+Dr
+Vw
+QX
+Dr
+Vw
+Vw
+Vw
+Vw
+wY
+Vw
+lW
+lW
+Vw
+ff
+Vw
+Sd
+Do
+Do
+Do
+Do
+Do
+ri
+Vw
+ff
+Vw
+Vw
+Vw
+Vw
+Vw
+Vw
+Dr
 ms
-dT
-iY
-vJ
-Fp
-tz
-iY
-DT
-iY
-cu
 ms
-Ag
-xZ
-eh
-eh
-eh
-eh
-eh
-Ea
-SX
-ms
-iY
-tz
-fG
-eJ
-eJ
-tz
-ms
-iV
-eJ
-kR
-eJ
-iY
-ms
-iY
-eJ
-tz
-Fk
-ms
-PK
-iY
-eJ
-iY
-iY
-ms
-VD
-eJ
-eJ
-eJ
-Zc
-lU
-mJ
-ms
-OP
-OP
-ms
+Dr
+vz
+vz
+vz
+sB
+sB
+sB
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -38081,22 +39240,10 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -38254,71 +39401,79 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-ms
-sP
-iY
-iY
-Fp
-iY
-er
-sZ
-iY
-Zi
-ms
-oI
-dr
-no
-sO
-id
-sO
-sO
-kW
-Ld
-ms
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-cH
-eJ
-eJ
-eJ
-eJ
-eJ
-cH
-eJ
-eJ
-eJ
-iY
-cH
-iY
-eJ
-KR
-eJ
-tz
-ms
-eJ
-eJ
-eJ
-eJ
-eJ
-iY
-fk
-ms
-ms
-ms
-Zk
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+Dr
+QX
+QX
+QX
+QX
+Dr
+Vw
+Vw
+Vw
+Vw
+Dr
+Vw
+QX
+Dr
+Vw
+Vw
+Vw
+Vw
+Dr
+TO
+lW
+vZ
+BI
+ff
+BI
+mn
+nB
+Do
+nB
+Do
+nB
+mn
+BI
+ff
+BI
+Vw
+Vw
+Vw
+Vw
+Vw
+Dr
+QX
+QX
+Dr
+Dr
+vz
 vz
 sB
 sB
 sB
 sB
 sB
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -38381,16 +39536,8 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+nT
+nT
 sB
 sB
 sB
@@ -38511,79 +39658,103 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-ms
-Ur
-iY
-iY
-Fp
-iY
-Pc
-ZB
-tz
-Zi
-ms
-tA
-dr
-sO
-eB
-eB
-eB
-sO
-kW
-Cf
-ms
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-pJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-ms
-eJ
-eJ
-El
-eJ
-eJ
-eJ
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
 Dr
+QX
+QX
+QX
+QX
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Vw
+QX
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+TO
+Vw
+iK
+Dr
+Dr
+Dr
+Dr
+Dr
+Do
+Do
+tS
+Dr
+Dr
+Dr
+Dr
+Dr
+Vw
+Vw
+Vw
+Vw
+Vw
+Dr
+QX
+QX
+QX
 Rb
-eJ
-eJ
-Rb
+vz
+vz
+nT
+vz
 sB
+vz
 sB
+vz
 sB
+vz
+nT
 sB
+vz
+nT
+nT
+nT
+vz
 sB
+vz
 sB
 sB
 sB
+vz
 sB
+vz
 sB
+nT
+nT
+nT
 sB
 sB
 sB
+vz
 sB
+vz
 sB
 sB
 sB
@@ -38598,6 +39769,10 @@ sB
 sB
 sB
 sB
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -38619,47 +39794,19 @@ sB
 sB
 sB
 sB
+nT
+nT
+nT
+nT
+nT
 sB
 sB
 sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+nT
+nT
 sB
 sB
 sB
@@ -38768,65 +39915,72 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-ms
-Cz
-iY
-iY
-Fp
-iY
-Xx
-bN
-tz
-NP
-ms
-Cf
-dr
-id
-kB
-ip
-vt
-id
-kW
-Cf
-WR
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-KR
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-NH
-eJ
-eJ
-eE
-eJ
-eJ
-eJ
-eJ
-Rb
-eJ
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+Dr
+QX
+QX
+QX
+QX
+Dr
+QX
+QX
+QX
+QX
+QX
+QX
+QX
+Dr
+dV
+dQ
+eK
+qb
+Dr
+WI
+WI
+WI
+Dr
+tt
+JC
+Dr
+tS
+Do
+mI
+mI
+mI
+mI
+mI
+mI
+Dr
+Vw
+Vw
+Vw
+Vw
+Vw
+Dr
+QX
+QX
 QX
 Rb
+vz
+vz
+nT
+nT
 sB
 sB
 sB
@@ -38836,6 +39990,10 @@ sB
 sB
 sB
 sB
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -38843,6 +40001,12 @@ sB
 sB
 sB
 sB
+nT
+nT
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -38864,59 +40028,42 @@ sB
 sB
 sB
 sB
+nT
+nT
+nT
+nT
+nT
+nT
+nT
+nT
+vz
 sB
+vz
 sB
+vz
 sB
+vz
 sB
 sB
+vz
 sB
 sB
 sB
+vz
 sB
 sB
+nT
+nT
+nT
+nT
+nT
 sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+nT
+nT
+nT
 sB
 sB
 sB
@@ -39025,71 +40172,84 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-ms
-QO
-iY
-iY
-Fp
-iY
-mj
-cY
-iY
-nC
-ms
-Cf
-dr
-sO
-cN
-eB
-kB
-sO
-kW
-Cf
-ms
-eJ
-eJ
-eJ
-KE
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-dh
-eJ
-eJ
-eJ
-ms
-fr
-eJ
-El
-eJ
-eJ
-iY
-iY
-ms
-ms
-ms
-ms
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+mI
+qX
+mI
+qX
+mI
+qX
+mI
+qX
+Dr
+QX
+QX
+QX
+QX
+wY
+QX
+QX
+QX
+QX
+QX
+Vw
+QX
+Dr
+oe
+kL
+kL
+Ww
+Dr
+TO
+Vw
+hF
+Dr
+ZT
+hF
+Dr
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+Dr
+Vw
+Vw
+Vw
+Vw
+Vw
+Dr
+QX
+QX
+Dr
+Dr
 vz
+vz
+nT
+nT
+nT
 sB
+nT
 sB
 sB
 sB
 sB
+nT
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -39097,6 +40257,12 @@ sB
 sB
 sB
 sB
+nT
+nT
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -39109,6 +40275,8 @@ sB
 sB
 sB
 sB
+nT
+nT
 sB
 sB
 sB
@@ -39119,6 +40287,10 @@ sB
 sB
 sB
 sB
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -39139,45 +40311,20 @@ sB
 sB
 sB
 sB
+nT
+nT
+nT
 sB
 sB
 sB
 sB
+nT
+nT
+nT
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+nT
 sB
 sB
 sB
@@ -39282,69 +40429,82 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+Dr
+QX
+QX
+QX
+QX
+Dr
+Dr
+Dr
+Dr
+Dr
+QX
+Vw
+Dr
+Dr
+qt
+lK
+kL
+Ww
+Dr
+TO
+lW
+Vw
+wY
+Vw
+hF
+Dr
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+Dr
+Dr
+Dr
+Dr
+Vw
+Vw
+Dr
 ms
-ov
-iY
-he
-Fp
-iY
-BK
-fM
-iY
-rF
 ms
-IA
-dr
-sO
-sO
-id
-sO
-sO
-NX
-Cf
-ms
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-SG
-eJ
-Sz
-eJ
-eJ
-eJ
-lI
-eJ
-eJ
-eJ
-iY
-SG
-DT
-eJ
-eJ
-eJ
-RR
-ms
-eJ
-eJ
-eJ
-eJ
-eJ
-VY
-xQ
-ms
-OP
-OP
-ms
+Dr
+vz
+vz
+vz
+nT
+nT
+nT
+nT
+nT
 sB
 sB
 sB
 sB
+nT
+nT
+nT
 sB
 sB
 sB
@@ -39352,6 +40512,12 @@ sB
 sB
 sB
 sB
+nT
+nT
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -39365,6 +40531,9 @@ sB
 sB
 sB
 sB
+nT
+nT
+nT
 sB
 sB
 sB
@@ -39388,6 +40557,10 @@ sB
 sB
 sB
 sB
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -39403,40 +40576,14 @@ sB
 sB
 sB
 sB
+nT
+nT
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+nT
+nT
+nT
 sB
 sB
 sB
@@ -39539,65 +40686,73 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-ms
-CR
-iY
-vJ
-Fp
-iY
-iY
-tz
-iY
-Uc
-ms
-oP
-gw
-Bt
-XP
-XP
-XP
-XP
-jZ
-Sk
-ms
-iY
-DT
-eJ
-eJ
-eJ
-iY
-ms
-rN
-eJ
-PR
-eJ
-iY
-ms
-tz
-eJ
-iY
-nQ
-ms
-iY
-tz
-eJ
-iY
-iY
-ms
-rW
-eJ
-eJ
-eJ
-iY
-ms
-ms
-ms
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+mI
+qX
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+aM
+Dr
+Dr
+Dr
+Dr
+AI
+bY
+fI
+Dr
+QX
+QX
+QX
+wY
+eK
+eK
+eK
+qb
+mn
+LM
+lW
+hF
+Dr
+Dr
+Dr
+Dr
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+qX
+qX
+Dr
+Vw
+Vw
+Vw
+Vw
+Vw
+Dr
+Dr
+nT
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -39614,6 +40769,13 @@ sB
 sB
 sB
 sB
+nT
+vz
+vz
+vz
+vz
+vz
+vz
 sB
 sB
 sB
@@ -39625,6 +40787,9 @@ sB
 sB
 sB
 sB
+nT
+nT
+nT
 sB
 sB
 sB
@@ -39647,6 +40812,12 @@ sB
 sB
 sB
 sB
+nT
+nT
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -39667,33 +40838,9 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+nT
+nT
+nT
 sB
 sB
 sB
@@ -39796,123 +40943,81 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-ms
-iY
-iY
-iY
-ms
-yl
-Jl
-iY
-iY
-Sm
-ms
-Gs
-GB
-Cf
-Cf
-Cf
-ZW
-Cf
-Cf
-Cf
-ms
-ms
-Ie
-iY
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+qX
+qX
+qX
+qX
+Dr
+xs
+xs
+xs
 eJ
-iY
-xM
-ms
-ms
-PL
-of
-Rv
-ms
-ms
-tR
-eJ
-Ie
-ms
-ms
-ms
-Ie
-eJ
-iY
-ms
-ms
-ms
-te
-te
-te
-te
-ms
-OP
-OP
-OP
-OP
-OP
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+Wt
+Dr
+aR
+QX
+wY
+Mz
+Rl
+Fc
+Ex
+Fc
+Dr
+QX
+Vw
+QX
+Dr
+TH
+Jq
+Jq
+eK
+Sd
+Vw
+lW
+iK
+Dr
 mI
 mI
 mI
 mI
-sB
-mI
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
 mI
 mI
 mI
 mI
+mI
+mI
+mI
+mI
+mI
+qX
+Dr
+Vw
+Vw
+Vw
+Vw
+Vw
+QX
+Dr
+nT
+nT
+nT
+sB
+sB
+sB
+sB
+sB
+nT
+nT
+nT
+mI
+sB
 mI
 sB
 sB
@@ -39922,16 +41027,25 @@ sB
 sB
 sB
 sB
+vz
+vz
+vz
+vz
+vz
+vz
 sB
 sB
 sB
 sB
+nT
+nT
+nT
 sB
 sB
 sB
 sB
-sB
-sB
+nT
+nT
 sB
 sB
 sB
@@ -39947,11 +41061,44 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
+sB
+sB
+sB
+nT
+nT
+nT
+nT
+nT
+nT
+nT
+nT
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
-sB
-sB
-sB
+mI
+mI
+mI
+mI
+mI
+nT
+nT
+nT
 sB
 sB
 sB
@@ -40053,75 +41200,48 @@ bu
 mI
 mI
 mI
-OP
-OP
-ms
-ms
-ms
-vR
-ms
-ms
-ms
-ms
-vR
-ms
-ms
-ms
-PV
-Cf
-Pu
-Cf
-Cf
-Cf
-sI
-RE
-Qw
-ms
-ms
-ms
-ms
-bQ
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-bQ
-ms
-ms
-Tu
-ms
-ms
-bQ
-ms
-ms
-OP
-ms
-ms
-ms
-ms
-ms
-ms
-OP
-OP
-mI
-mI
-OP
 mI
 mI
 mI
 mI
-sB
-sB
-sB
-sB
-sB
-sB
+mI
+mI
+qX
+mI
+qX
+mI
+qX
+Dr
+xs
+eJ
+eJ
+eJ
+Wt
+Dr
+FZ
+QX
+fh
+GL
+Np
+Fc
+Fc
+Fc
+Dr
+QX
+Vw
+QX
+Dr
+qz
+Jq
+Jq
+Ww
+mn
+LM
+Vw
+iK
+Dr
+tS
+Do
 mI
 mI
 mI
@@ -40131,41 +41251,28 @@ mI
 mI
 mI
 mI
+mI
+mI
+qX
+Dr
+QX
+QX
+QX
+QX
+QX
+QX
+Dr
+nT
+nT
 sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+nT
+nT
+nT
+nT
+mI
 mI
 mI
 mI
@@ -40177,6 +41284,24 @@ sB
 sB
 sB
 sB
+vz
+vz
+vz
+vz
+vz
+vz
+sB
+sB
+sB
+sB
+sB
+nT
+nT
+nT
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -40188,10 +41313,32 @@ sB
 sB
 sB
 sB
+mI
+mI
+mI
+mI
+mI
 sB
 sB
 sB
 sB
+sB
+sB
+nT
+nT
+nT
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+nT
 mI
 mI
 mI
@@ -40310,65 +41457,70 @@ bu
 mI
 mI
 mI
-OP
-OP
-ms
-sK
-HZ
-lo
-YZ
-kL
-ms
-TJ
-QM
-SF
-Gb
-ms
-ms
-ms
-ms
-ms
-vR
-ms
-ms
-ms
-ms
-ms
-OP
-ms
-NT
-yS
-FE
-Zu
-ms
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+qX
+qX
+qX
+qX
+Dr
+xs
+eJ
+eJ
+eJ
+Wt
+Dr
+jV
+sc
+fh
+Or
+gs
+GP
+GP
+uT
+Dr
+QX
+Vw
+QX
+Dr
+DY
+iR
+rq
+zB
+Dr
+WI
+WI
+WI
+Dr
+Do
+Do
+Do
+mI
+tS
+Do
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+Dr
+QX
+QX
+QX
+QX
+QX
+Dr
+Dr
 nT
-mW
-To
-mW
-mW
-ms
-mW
-mW
-oM
-mW
-mW
-mW
-mW
-mW
-mW
-ms
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-mI
-mI
-OP
+nT
 mI
 mI
 mI
@@ -40389,27 +41541,22 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
+vz
+vz
+vz
+vz
+vz
+vz
 sB
 sB
 sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+nT
+nT
+nT
+nT
 sB
 sB
 sB
@@ -40446,9 +41593,9 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
+nT
+nT
+nT
 mI
 mI
 mI
@@ -40567,62 +41714,69 @@ bu
 mI
 mI
 mI
-OP
-OP
-ms
-qJ
-HZ
-lo
-lo
-lo
-ms
-oH
-QM
-QM
-iX
-ms
-Ia
-rn
-Wq
-iY
-tz
-mV
-MB
-Qm
-ms
-OP
-OP
-ms
-Fo
-mW
-mW
-mW
-BE
-mW
-mW
-mW
-mW
-mW
-BE
-mW
-mW
-mW
-mW
-mW
-mW
-mW
-mW
-px
-ms
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+mI
+qX
+Dr
+Dr
+Dr
+xs
+eJ
+VK
+eJ
+pd
+Dr
+Wn
+Hp
+fh
+gL
+IQ
+PS
+PS
+dz
+Dr
+Dr
+Dr
+Rt
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+TO
+Vw
+iK
+Dr
+Do
+Do
+Do
+Do
+Do
+Do
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+qX
+nT
 mI
 mI
 mI
@@ -40644,19 +41798,12 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-sB
-sB
-sB
-sB
-sB
-sB
+vz
+vz
+vz
+vz
+vz
+vz
 mI
 mI
 mI
@@ -40824,60 +41971,68 @@ bu
 bu
 bu
 mI
-OP
-OP
-ms
-KG
-HZ
-EV
-gm
-aJ
-ms
-gi
-On
-QM
-SE
-ms
-CY
-Xz
-PW
-DT
-iY
-iY
-iY
-tz
-ms
-OP
-OP
-ms
-ln
-ie
-Vx
-qN
-ms
-Zw
-mW
-mW
-qW
-wD
-ms
-ms
-To
-mW
-To
-Gi
-dK
-Fc
-KW
-ms
-ms
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+qX
+qX
+Dr
+Ya
+Ya
+eJ
+eJ
+VK
+eJ
+Wt
+Dr
+Dr
+Dr
+Dr
+op
+Vw
+Vw
+Vw
+Fz
+Dr
+TW
+IW
+bH
+IW
+IW
+IW
+IW
+ff
+IW
+Ni
+lW
+iK
+mn
+nB
+nB
+Do
+Do
+Do
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
 mI
 mI
 mI
@@ -40901,17 +42056,9 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+nT
+nT
+nT
 mI
 mI
 mI
@@ -41081,54 +42228,51 @@ bu
 bu
 bu
 mI
-OP
-OP
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-gj
-QM
-vG
-Mo
-ms
-TH
-yr
-PW
-vc
-Vs
-ZJ
-cK
-aA
-ms
-OP
-OP
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+qX
+mI
+qX
+Dr
+eJ
+eJ
+eJ
+eJ
+VK
+eJ
+eJ
+QX
+QX
+wY
+KZ
+hr
+lW
+lW
+lW
+Vw
+SJ
+Vw
+Vw
+bH
+Vw
+lW
+lW
+Vw
+ff
+Vw
+lW
+lW
+Vw
+Sd
+nB
+nB
+Do
+Do
+Do
 mI
 mI
 mI
@@ -41168,6 +42312,9 @@ mI
 mI
 mI
 mI
+sB
+sB
+nT
 mI
 mI
 mI
@@ -41339,53 +42486,49 @@ bu
 bu
 mI
 mI
-OP
-OP
-OP
-OP
-ms
-eA
-Up
-ms
-mE
-QM
-QM
-Br
-ms
-Vc
-Xz
-CZ
-iY
-IS
+mI
+mI
+mI
+mI
+mI
 qX
-iY
-iY
-ms
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+qX
+Dr
+eJ
+eJ
+eJ
+eJ
+eJ
+eJ
+eJ
+QX
+QX
+Dr
+KZ
+Vw
+Mk
+Mk
+Vw
+Ch
+Dr
+nw
+BI
+bH
+BI
+BI
+BI
+BI
+ff
+BI
+BI
+Vw
+bj
+mn
+nB
+nB
+Do
+tS
 mI
 mI
 mI
@@ -41425,6 +42568,10 @@ mI
 mI
 mI
 mI
+mI
+sB
+sB
+sB
 mI
 mI
 mI
@@ -41596,52 +42743,48 @@ bu
 bu
 mI
 mI
-OP
-OP
-OP
-OP
-ms
-xX
-QM
-kj
-QM
-QM
-SF
-Br
-ms
-HB
-Xz
-PW
-vc
-hS
-QE
-cK
-iY
-ms
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+qX
+qX
+qX
+Dr
+Ya
+Ya
+eJ
+OI
+yq
+yq
+eJ
+QX
+QX
+Dr
+Dr
+Rt
+Dr
+Dr
+Su
+Dr
+Dr
+Dr
+Dr
+Rt
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Su
+Dr
+Dr
+Do
+Do
+Do
 mI
 mI
 mI
@@ -41682,6 +42825,10 @@ mI
 mI
 mI
 mI
+mI
+sB
+sB
+sB
 mI
 mI
 mI
@@ -41855,49 +43002,42 @@ mI
 mI
 mI
 mI
-OP
-OP
-ms
-wL
-QM
-Jj
-gj
-QM
-wo
-EP
-ms
-Yz
-kz
-PW
-iY
-IS
-IS
-tz
-fe
-ms
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+qX
+mI
+qX
+Dr
+Dr
+Dr
+eJ
+yq
+yq
+yq
+eJ
+QX
+QX
+Dr
+pn
+NA
+Dr
+EI
+Vw
+Vw
+EI
+EI
+Dr
+QX
+QX
+Dr
+ng
+Gn
+Gn
+Dr
+Vw
+Vw
+Dr
 mI
 mI
 mI
@@ -41939,6 +43079,13 @@ mI
 mI
 mI
 mI
+mI
+mI
+mI
+mI
+mI
+sB
+sB
 mI
 mI
 mI
@@ -42112,28 +43259,48 @@ mI
 mI
 mI
 mI
-OP
-OP
-ms
-Hr
-QM
-Jj
-oH
-QM
-QM
-gx
-ms
-ku
-Xz
-PW
-vc
-zr
-Vs
-cK
-aA
-ms
-OP
-OP
+mI
+mI
+mI
+qX
+qX
+qX
+qX
+qX
+Dr
+eJ
+eJ
+eJ
+eJ
+eJ
+QX
+QX
+Dr
+cx
+NA
+Dr
+EI
+Vw
+Vw
+Vw
+Vw
+Dr
+QX
+QX
+Dr
+Vw
+lW
+Gn
+Dr
+Vw
+Vw
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+qX
 mI
 mI
 mI
@@ -42174,27 +43341,7 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+sB
 mI
 mI
 mI
@@ -42369,48 +43516,48 @@ mI
 mI
 mI
 mI
-OP
-OP
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-Ay
-Xz
-PW
-tz
-iY
-DT
-iY
-iY
-ms
-OP
-OP
 mI
 mI
 mI
+qX
 mI
+qX
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+eJ
+VK
+VK
+VK
+GF
+Dr
+Dr
+Dr
+xJ
+YU
+Dr
+Wk
+Vw
+Oo
+Oo
+Oo
+Dr
+QX
+QX
+Dr
+Vw
+lW
+Vw
+wY
+Vw
+Vw
+Gn
+Dr
+cx
+vq
+lv
+Dr
+qX
 mI
 mI
 mI
@@ -42626,48 +43773,48 @@ mI
 mI
 mI
 mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-ms
-mQ
-Xz
-uy
-kg
-kV
-oK
-jv
-iY
-ms
-OP
-OP
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+qX
+qX
+qX
+qX
+Dr
+GF
+GF
+GF
+eJ
+GF
+Dr
+qX
+qX
+qX
+qX
+Dr
+pV
+vJ
+pV
+gp
+pV
+Dr
+QX
+QX
+Dr
+FB
+Vw
+sN
+Dr
+Vw
+lW
+Vw
+wY
+NA
+KL
+pw
+Dr
+qX
 mI
 mI
 mI
@@ -42883,48 +44030,48 @@ mI
 mI
 mI
 mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-ms
-OP
-OP
 mI
 mI
 mI
 mI
 mI
+qX
+mI
+qX
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+qX
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+pt
+vJ
+vJ
+vJ
+pV
+Dr
+QX
+QX
+Dr
+Dr
+Dr
+Dr
+Dr
+Vw
+lW
+ng
+Dr
+Dr
+Dr
+Dr
+Dr
+qX
 mI
 mI
 mI
@@ -43140,48 +44287,48 @@ mI
 mI
 mI
 mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
 mI
 mI
 mI
 mI
 mI
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+uv
+vJ
+vJ
+vJ
+vJ
+wY
+QX
+QX
+wY
+Vw
+Vw
+Vw
+Vw
+Vw
+Vw
+Wn
+Dr
+vM
+Vw
+Gn
+Dr
+qX
 mI
 mI
 mI
@@ -43402,43 +44549,43 @@ mI
 mI
 mI
 mI
+qX
+mI
+qX
+mI
+qX
+mI
+qX
+mI
+qX
+mI
+qX
 mI
 mI
-mI
-mI
-mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+WD
+vJ
+Un
+vJ
+vJ
+Dr
+QX
+QX
+Dr
+od
+Dr
+ng
+lW
+lW
+Vw
+Vw
+wY
+Vw
+lW
+Gn
+Dr
+qX
 mI
 mI
 mI
@@ -43659,43 +44806,43 @@ mI
 mI
 mI
 mI
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
 mI
 mI
-mI
-mI
-mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+Dr
+Dr
+Dr
+jq
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+vM
+lW
+lW
+Vw
+ng
+Dr
+Vw
+lW
+Vw
+Dr
+qX
 mI
 mI
 mI
@@ -43929,30 +45076,30 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+qX
+qX
+Dr
+IU
+IU
+Tb
+Dr
+Tb
+eP
+Tb
+Dr
+Dr
+Wn
+Vw
+Gn
+Vw
+ng
+Dr
+Nf
+bc
+rD
+Dr
+qX
 mI
 mI
 mI
@@ -44188,28 +45335,28 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+IU
+Tb
+Tb
+ri
+Ne
+Ne
+Ne
+Dr
+Dr
+Dr
+Rt
+Dr
+Rt
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+qX
 mI
 mI
 mI
@@ -44445,28 +45592,28 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+IU
+IU
+Tb
+TN
+Jx
+Jx
+Ne
+Dr
+Gn
+Gn
+Vw
+Dr
+Vw
+Vw
+Gn
+Gn
+Dr
+qX
+qX
+qX
 mI
 mI
 mI
@@ -44702,26 +45849,26 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+IU
+IU
+IU
+Dr
+eq
+Jx
+Ne
+Dr
+Vw
+lW
+Vw
+Dr
+Uf
+lW
+lW
+Vw
+Dr
+qX
 mI
 mI
 mI
@@ -44959,26 +46106,26 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+ng
+lW
+Vw
+Dr
+vI
+KD
+Mz
+Rl
+Dr
+qX
 mI
 mI
 mI
@@ -45216,26 +46363,26 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+Dr
+Vb
+Gn
+aa
+Dr
+nl
+qC
+FR
+HJ
+Dr
+qX
 mI
 mI
 mI
@@ -45481,18 +46628,18 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+Dr
+qX
 mI
 mI
 mI
@@ -45708,11 +46855,6 @@ bu
 mI
 mI
 mI
-bu
-mI
-mI
-mI
-bu
 mI
 mI
 mI
@@ -45743,13 +46885,18 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
+qX
 mI
 mI
 mI
@@ -45965,12 +47112,12 @@ bu
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-bu
-bu
+mI
+mI
+mI
+mI
+mI
+mI
 mI
 mI
 mI
@@ -46222,51 +47369,51 @@ bu
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
 mI
 mI
 mI
@@ -46478,53 +47625,53 @@ bu
 bu
 bu
 bu
-mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-mI
-mI
-bu
-bu
-bu
-mI
-mI
-bu
-bu
-bu
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+Ke
+Ke
+Sk
+pJ
+XP
+sO
+tR
+Ke
+kV
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
 mI
 mI
 mI
@@ -46735,54 +47882,54 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+kV
+OP
+eA
+Ke
+IS
+Ke
+xM
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
 mI
 mI
 mI
@@ -46992,54 +48139,54 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+OP
+OP
+OP
+OP
+VL
+gi
+YZ
+OP
+Ke
+Ke
+QO
+Zu
+BE
+cN
+Ke
+Ke
+DT
+OP
+Ke
+Ke
+Ke
+Ke
+Ke
+OP
+OP
+OP
+ZW
+cY
+kj
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
 mI
 mI
 mI
@@ -47249,60 +48396,60 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-mI
-mI
-mI
-mI
-mI
+OP
+OP
+OP
+OP
+Hr
+yX
+Zi
+OP
+Ke
+Ke
+Ke
+Ke
+Ke
+dr
+Ke
+Ke
+of
+OP
+Ke
+Ke
+Ke
+EV
+Ke
+OP
+OP
+fW
+Ke
+rn
+WS
+zz
+OP
+xf
+Ke
+Ke
+Ke
+bQ
+OP
+OP
+TY
+Fo
+Vx
+XY
+Ke
+Ke
+bQ
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
 mI
 mI
 mI
@@ -47506,65 +48653,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+OP
+Up
+Zi
+Zi
+OP
+Ke
+Ke
+mW
+NP
+fr
+Br
+CY
+Ke
+of
+OP
+Ke
+Ke
+Ke
+Ke
+Ke
+OP
+OP
+kV
+Ke
+Ke
+Ke
+Ke
+rF
+Ke
+Ke
+Ke
+Ke
+Ke
+rF
+Ke
+mj
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+DT
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
+OP
 mI
 mI
 mI
@@ -47763,65 +48910,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+OP
+PW
+Zi
+iV
+OP
+YV
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+Jj
+Jj
+Zk
+Jj
+Jj
+OP
+OP
+sI
+Ke
+Ke
+Ke
+sZ
+OP
+NX
+bQ
+Ke
+bQ
+sZ
+OP
+bQ
+Ke
+Ke
+Ke
+Ke
+Ke
+sZ
+Ke
+Ke
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
 mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+mI
+OP
 mI
 mI
 mI
@@ -48020,65 +49167,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+OP
+OP
+cK
+OP
+OP
+eJ
+uy
+KW
+lI
+ZB
+OP
+sX
+Zi
+Vs
+aT
+Zi
+ZL
+Zi
+yr
+Yz
+OP
+OP
+OP
+OP
+wL
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+wL
+OP
+OP
+oI
+OP
+OP
+wL
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
 bu
 bu
 bu
@@ -48277,65 +49424,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+OP
+iY
+eJ
+Gs
+OP
+eJ
+eJ
+eJ
+eJ
+eJ
+fk
+sX
+eH
+Zi
+yX
+Zi
+Zi
+bN
+ln
+Zi
+OP
+OP
+ov
+eJ
+gM
+eJ
+ov
+OP
+OP
+vG
+Zc
+eE
+OP
+OP
+eJ
+gM
+ov
+OP
+OP
+OP
+ov
+gM
+eJ
+OP
+OP
+OP
+rN
+rN
+rN
+rN
+OP
+OP
+OP
+OP
+OP
+OP
 bu
 bu
 bu
@@ -48534,65 +49681,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+OP
+KR
+eJ
+rW
+pB
+fM
+eJ
+Pp
+eJ
+Gb
+OP
+oP
+iX
+fz
+fz
+fz
+fz
+fz
+Iz
+Qe
+OP
+eJ
+fM
+oH
+gM
+gM
+fM
+OP
+Os
+gM
+xH
+gM
+eJ
+OP
+eJ
+gM
+fM
+Yp
+OP
+er
+eJ
+gM
+eJ
+eJ
+OP
+Sm
+gM
+gM
+gM
+GI
+te
+vR
+OP
+OP
+OP
+OP
 bu
 bu
 bu
@@ -48791,65 +49938,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+OP
+TA
+eJ
+eJ
+pB
+eJ
+Jl
+KB
+eJ
+nJ
+OP
+Gi
+sP
+Ur
+Fc
+WR
+Fc
+Fc
+Xz
+TQ
+OP
+gM
+gM
+gM
+gM
+gM
+gM
+Cf
+gM
+gM
+gM
+gM
+gM
+Cf
+gM
+gM
+gM
+eJ
+Cf
+eJ
+gM
+dT
+gM
+fM
+OP
+gM
+gM
+gM
+gM
+gM
+eJ
+fG
+OP
+OP
+OP
+NH
 bu
 bu
 bu
@@ -49048,65 +50195,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+OP
+mE
+eJ
+eJ
+pB
+eJ
+mQ
+FE
+fM
+nJ
+OP
+qN
+sP
+Fc
+np
+np
+np
+Fc
+Xz
+Zi
+OP
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+QE
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+OP
+gM
+gM
+Qw
+gM
+gM
+gM
+Bz
+QX
+gM
+gM
+QX
 bu
 bu
 bu
@@ -49305,65 +50452,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+OP
+Ie
+eJ
+eJ
+pB
+eJ
+SE
+GH
+fM
+Mo
+OP
+Zi
+sP
+WR
+CR
+Ow
+cu
+WR
+Xz
+Zi
+MB
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+dT
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+vc
+gM
+gM
+zr
+gM
+gM
+gM
+gM
+QX
+gM
+Vp
+QX
 bu
 bu
 bu
@@ -49562,65 +50709,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+OP
+To
+eJ
+eJ
+pB
+eJ
+bL
+no
+eJ
+oM
+OP
+Zi
+sP
+Fc
+PY
+np
+CR
+Fc
+Xz
+Zi
+OP
+gM
+gM
+gM
+Fp
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+gM
+yS
+gM
+gM
+gM
+OP
+aJ
+gM
+Qw
+gM
+gM
+eJ
+eJ
+OP
+OP
+OP
+OP
 bu
 bu
 bu
@@ -49819,65 +50966,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+OP
+dK
+eJ
+SX
+pB
+eJ
+kz
+xQ
+eJ
+Ia
+OP
+Rv
+sP
+Fc
+Fc
+WR
+Fc
+Fc
+gx
+Zi
+OP
+gM
+gM
+gM
+gM
+gM
+gM
+SG
+gM
+jz
+gM
+gM
+gM
+xZ
+gM
+gM
+gM
+eJ
+SG
+Pp
+gM
+gM
+gM
+Pu
+OP
+gM
+gM
+gM
+gM
+gM
+PK
+xX
+OP
+OP
+OP
+OP
 bu
 bu
 bu
@@ -50076,65 +51223,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+OP
+rc
+eJ
+rW
+pB
+eJ
+eJ
+fM
+eJ
+qy
+OP
+cH
+QP
+Xx
+KG
+KG
+KG
+KG
+wo
+qW
+OP
+eJ
+Pp
+gM
+gM
+gM
+eJ
+OP
+Uc
+gM
+lo
+gM
+eJ
+OP
+fM
+gM
+eJ
+gj
+OP
+eJ
+fM
+gM
+eJ
+eJ
+OP
+NT
+gM
+gM
+gM
+eJ
+OP
+OP
+OP
+OP
+OP
+OP
 bu
 bu
 bu
@@ -50333,65 +51480,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+OP
+eJ
+eJ
+eJ
+OP
+Ts
+BW
+eJ
+eJ
+kR
+OP
+Fk
+xr
+Zi
+Zi
+Zi
+ln
+Zi
+Zi
+Zi
+OP
+OP
+QM
+eJ
+gM
+eJ
+mV
+OP
+OP
+Ay
+he
+EP
+OP
+OP
+ie
+gM
+QM
+OP
+OP
+OP
+QM
+gM
+eJ
+OP
+OP
+OP
+rN
+rN
+rN
+rN
+OP
+OP
+OP
+OP
+OP
+OP
 bu
 bu
 bu
@@ -50590,65 +51737,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+OP
+OP
+cK
+OP
+OP
+OP
+OP
+cK
+OP
+OP
+OP
+HB
+Zi
+Fe
+Zi
+Zi
+Zi
+ip
+xY
+Vc
+OP
+OP
+OP
+OP
+wL
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+wL
+OP
+OP
+of
+OP
+OP
+wL
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+mI
+mI
+OP
 bu
 bu
 bu
@@ -50847,65 +51994,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+Qm
+Wq
+RE
+Pc
+yl
+OP
+Wv
+kL
+PL
+Zw
+OP
+OP
+OP
+OP
+OP
+cK
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+aA
+jv
+PR
+jZ
+OP
+xf
+Ke
+bQ
+Ke
+Ke
+OP
+Ke
+Ke
+Fo
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+mI
+mI
+OP
 bu
 bu
 bu
@@ -51104,65 +52251,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+lU
+Wq
+RE
+RE
+RE
+OP
+CZ
+kL
+kL
+GB
+OP
+Ak
+hZ
+gm
+eJ
+fM
+Nr
+PV
+Ig
+OP
+OP
+OP
+OP
+id
+Ke
+Ke
+Ke
+rF
+Ke
+Ke
+Ke
+Ke
+Ke
+rF
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+Ke
+kV
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+mI
+mI
+mI
 bu
 bu
 bu
@@ -51361,65 +52508,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+hS
+Wq
+mJ
+Bt
+SF
+OP
+lz
+Cz
+kL
+gw
+OP
+RR
+vJ
+IA
+Pp
+eJ
+eJ
+eJ
+fM
+OP
+OP
+OP
+OP
+Ea
+DT
+eh
+On
+OP
+sK
+Ke
+Ke
+mj
+Sz
+OP
+OP
+bQ
+Ke
+bQ
+SU
+kg
+sZ
+TY
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -51618,65 +52765,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+TH
+kL
+sz
+dh
+OP
+BK
+qJ
+IA
+Tu
+VD
+ZJ
+Jw
+eB
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -51875,65 +53022,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+mI
+OP
+OP
+OP
+OP
+OP
+UX
+VY
+OP
+wX
+kL
+kL
+wD
+OP
+tA
+vJ
+Ld
+eJ
+nf
+ku
+eJ
+eJ
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -52132,65 +53279,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+mI
+OP
+OP
+OP
+OP
+OP
+px
+kL
+vt
+kL
+kL
+PL
+wD
+OP
+tz
+vJ
+IA
+Tu
+TJ
+qP
+Jw
+eJ
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -52389,65 +53536,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+mI
+mI
+mI
+OP
+OP
+OP
+HZ
+kL
+Jj
+TH
+kL
+Nk
+oK
+OP
+KE
+WG
+IA
+eJ
+nf
+nf
+fM
+fe
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -52646,65 +53793,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+mI
+mI
+mI
+OP
+OP
+OP
+El
+kL
+Jj
+CZ
+kL
+kL
+kB
+OP
+Yi
+vJ
+IA
+Tu
+kW
+VD
+Jw
+eB
+OP
+OP
+OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -52903,65 +54050,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+mI
+mI
+mI
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+zb
+vJ
+IA
+fM
+eJ
+Pp
+eJ
+eJ
+OP
+OP
+OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -53160,65 +54307,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+mI
+mI
+mI
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+JD
+vJ
+nQ
+Sj
+Ag
+Ql
+nC
+eJ
+OP
+OP
+OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -53417,65 +54564,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+mI
+mI
+mI
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -53674,65 +54821,65 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+mI
+mI
+mI
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu

--- a/maps/away/away_site/goon_base/goon_base.dmm
+++ b/maps/away/away_site/goon_base/goon_base.dmm
@@ -31,6 +31,27 @@
 /obj/effect/map_effect/airlock/long/square,
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/living)
+"an" = (
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"as" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "ax" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -88,6 +109,12 @@
 /area/shuttle/goon_ship/starboard)
 "aM" = (
 /obj/structure/girder,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "aP" = (
@@ -138,6 +165,13 @@
 "bc" = (
 /obj/structure/table/wood,
 /obj/random/dirt_75,
+/obj/item/reagent_containers/bowl/plate{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/food/snacks/berrymuffin{
+	pixel_x = 3;
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "bi" = (
@@ -209,6 +243,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/mine)
 "bA" = (
@@ -226,6 +262,12 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "bN" = (
@@ -241,6 +283,18 @@
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/port)
+"bV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/mine)
 "bW" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -264,8 +318,8 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
 "ch" = (
-/obj/effect/floor_decal/corner/pink/diagonal,
 /obj/random/pottedplant,
+/obj/effect/floor_decal/corner/yellow/diagonal,
 /turf/simulated/floor/tiled,
 /area/mine)
 "cm" = (
@@ -300,15 +354,31 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "cA" = (
-/obj/effect/floor_decal/industrial/warning/dust/corner,
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
+/obj/structure/structural_support{
+	pixel_y = 8
 	},
-/turf/unsimulated/floor/asteroid/ash/rocky,
+/turf/simulated/floor/airless/ceiling,
 /area/mine)
 "cF" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
+"cG" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/mine)
@@ -319,7 +389,16 @@
 "cK" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/random/loot,
+/obj/random/loot{
+	pixel_y = 6;
+	pixel_x = -11
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "cN" = (
@@ -342,6 +421,19 @@
 "cP" = (
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"cT" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 11;
+	pixel_x = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "cV" = (
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
@@ -349,7 +441,27 @@
 /obj/random/junk,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/full,
+/area/mine)
+"cW" = (
+/obj/random/dirt_75,
+/obj/structure/barricade/metal{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/generic,
+/obj/item/ammo_casing/c45/practice{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/ammo_casing/c45/practice{
+	pixel_x = -10;
+	pixel_y = -1
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "cY" = (
 /obj/random/dirt_75,
@@ -410,6 +522,14 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/mine)
+"dE" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/mine)
 "dI" = (
 /obj/item/pickaxe/drill{
 	pixel_y = 7;
@@ -454,12 +574,24 @@
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/gun/energy/gun{
-	pixel_y = 3
+	pixel_y = 3;
+	pixel_x = -2
 	},
 /obj/item/gun/energy/rifle/ionrifle{
 	pixel_y = -2
 	},
 /turf/simulated/floor/tiled/dark,
+/area/mine)
+"dU" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/item/target,
+/obj/item/clothing/suit/storage/target_costume,
+/obj/structure/target_stake,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "dV" = (
 /obj/effect/floor_decal/corner/lime{
@@ -468,6 +600,15 @@
 /obj/machinery/computer/operating/terminal,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"dW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
 /area/mine)
 "dX" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
@@ -537,6 +678,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "eu" = (
@@ -545,7 +689,8 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/item/tank/oxygen/red{
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 1
 	},
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
@@ -579,6 +724,13 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
+"eC" = (
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "eE" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -593,6 +745,18 @@
 	pixel_y = -8
 	},
 /turf/simulated/floor/plating,
+/area/mine)
+"eF" = (
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 20;
+	pixel_y = 15
+	},
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 12;
+	pixel_y = 28
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "eH" = (
 /obj/effect/decal/cleanable/greenglow/radioactive{
@@ -638,6 +802,15 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
+"eN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
+/area/mine)
 "eO" = (
 /turf/simulated/floor/holofloor/tiled/ramp/bottom,
 /area/shuttle/goon_ship/bridge)
@@ -678,12 +851,25 @@
 	icon_state = "1-2"
 	},
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/mine)
 "ff" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
+/area/mine)
+"fg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "fh" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille,
@@ -784,6 +970,13 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/mine)
+"fL" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/structure/table/rack,
+/obj/item/gun/energy/disruptorpistol/practice,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "fM" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/random/dirt_75,
@@ -865,6 +1058,7 @@
 	pixel_x = -10;
 	pixel_y = -2
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "gn" = (
@@ -895,6 +1089,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/mine)
+"gq" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "gr" = (
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/mechanical,
@@ -904,7 +1107,20 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
+/area/mine)
+"gu" = (
+/obj/random/dirt_75,
+/obj/structure/structural_support{
+	pixel_y = 8
+	},
+/turf/simulated/floor/airless/ceiling,
 /area/mine)
 "gw" = (
 /obj/random/dirt_75,
@@ -959,11 +1175,14 @@
 /area/mine)
 "gM" = (
 /obj/random/dirt_75,
-/obj/structure/closet/crate/freezer,
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/heart,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/storage/box/produce,
+/obj/item/storage/box/produce,
+/obj/item/storage/box/produce,
+/obj/item/storage/box/produce,
+/obj/item/storage/box/produce,
+/obj/item/storage/box/produce,
+/obj/item/storage/box/produce,
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
 "gO" = (
@@ -992,6 +1211,19 @@
 /obj/item/reagent_containers/food/snacks/fish/fishfillet,
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
+"gV" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "gX" = (
 /obj/effect/decal/cleanable/floor_damage/random_broken,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1014,6 +1246,18 @@
 	},
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
+"hc" = (
+/obj/random/dirt_75,
+/obj/item/ammo_casing/c45/practice{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/ammo_casing/c45/practice{
+	pixel_x = 11;
+	pixel_y = -7
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "he" = (
 /obj/structure/reagent_dispensers/coolanttank,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1043,6 +1287,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
+"hu" = (
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 8
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"hv" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "hC" = (
 /obj/structure/sign/greencross{
 	pixel_x = -32
@@ -1065,6 +1324,15 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
+"hK" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/item/target,
+/obj/structure/target_stake,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "hL" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
@@ -1080,6 +1348,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "hS" = (
@@ -1090,6 +1361,9 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/mine)
@@ -1162,6 +1436,19 @@
 	},
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
+"if" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "ig" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/black/engie,
@@ -1169,6 +1456,33 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
+/area/mine)
+"ik" = (
+/obj/random/dirt_75,
+/obj/structure/table/reinforced/steel,
+/obj/item/ammo_magazine/c45m/practice{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/ammo_magazine/c45m/practice{
+	pixel_y = 3
+	},
+/obj/item/ammo_magazine/c45m/practice{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/obj/item/ammo_magazine/c45m/practice{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/ammo_magazine/c45m/practice{
+	pixel_y = 3
+	},
+/obj/item/ammo_magazine/c45m/practice{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "ip" = (
 /obj/structure/structural_support{
@@ -1365,6 +1679,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
+"jP" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/full,
+/area/mine)
 "jS" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/power/terminal{
@@ -1399,6 +1719,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/full,
 /area/mine)
 "kg" = (
@@ -1413,11 +1736,34 @@
 /obj/random/tech_supply{
 	pixel_y = -12
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "kj" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"km" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/mine)
 "kn" = (
@@ -1612,6 +1958,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "kW" = (
@@ -1628,16 +1977,22 @@
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
+"kZ" = (
+/obj/random/dirt_75,
+/obj/structure/table/rack,
+/obj/item/gun/energy/rifle/laser/practice,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "lb" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate,
-/obj/item/stack/material/platinum{
-	pixel_x = -6
-	},
-/obj/item/stack/material/platinum{
-	pixel_x = 6
-	},
 /obj/random/dirt_75,
+/obj/item/stack/material/plastic/full{
+	pixel_y = 3
+	},
+/obj/item/stack/material/plastic/full{
+	pixel_y = 3
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "le" = (
@@ -1828,6 +2183,12 @@
 "mn" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
+/area/mine)
+"mr" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "ms" = (
 /obj/machinery/door/airlock/external{
@@ -2067,12 +2428,11 @@
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/item/gun/energy/gun{
-	pixel_y = 8;
+	pixel_y = 3;
 	pixel_x = -2
 	},
-/obj/item/gun/energy/gun{
-	pixel_y = 2;
-	pixel_x = 2
+/obj/item/gun/energy/rifle/laser/noctiluca{
+	pixel_y = -2
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
@@ -2162,6 +2522,20 @@
 /obj/machinery/media/jukebox,
 /turf/simulated/floor/tiled,
 /area/mine)
+"os" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "ov" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
@@ -2225,6 +2599,9 @@
 /obj/random/tool{
 	pixel_y = -10
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "oK" = (
@@ -2281,6 +2658,11 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
+"oU" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "oX" = (
 /obj/structure/closet/walllocker/medical{
 	pixel_y = -32
@@ -2302,6 +2684,10 @@
 "pd" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 6;
+	pixel_y = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "pf" = (
@@ -2403,12 +2789,29 @@
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/living)
+"pO" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "pQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/dirt_75,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/mine)
@@ -2450,6 +2853,13 @@
 	pixel_x = -1
 	},
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"pZ" = (
+/obj/random/dirt_75,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "qb" = (
 /obj/effect/floor_decal/corner/lime{
@@ -2596,6 +3006,8 @@
 	icon_state = "1-2"
 	},
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/mine)
 "qJ" = (
@@ -2630,9 +3042,13 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "qN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
-/obj/structure/closet/toolcloset,
-/turf/simulated/floor/tiled,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
 /area/mine)
 "qO" = (
 /obj/structure/cable{
@@ -2644,6 +3060,12 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "qP" = (
@@ -2683,6 +3105,30 @@
 "ri" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/plating,
+/area/mine)
+"rl" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
+/area/mine)
+"rm" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 17;
+	pixel_y = -8
+	},
+/obj/effect/decal/cleanable/generic{
+	pixel_x = -2;
+	pixel_y = 16
+	},
+/obj/item/ammo_casing/c45/practice,
+/obj/item/ammo_casing/c45/practice{
+	pixel_x = -13;
+	pixel_y = 10
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "rn" = (
 /obj/random/dirt_75,
@@ -2734,6 +3180,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/full,
 /area/mine)
 "rU" = (
@@ -2791,6 +3238,27 @@
 /obj/item/reagent_containers/food/condiment/sugar,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
+/area/mine)
+"sl" = (
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"sp" = (
+/obj/random/dirt_75,
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "sz" = (
 /obj/random/dirt_75,
@@ -2879,10 +3347,6 @@
 "sY" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/item/pickaxe/drill{
-	pixel_y = 10;
-	pixel_x = 9
-	},
 /turf/simulated/floor/plating/asteroid,
 /area/mine)
 "sZ" = (
@@ -3099,6 +3563,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/mine)
+"uE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/mine)
 "uG" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -3106,6 +3575,10 @@
 /obj/item/reagent_containers/weldpack{
 	pixel_x = 5;
 	pixel_y = 5
+	},
+/obj/machinery/power/apc/north,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/mine)
@@ -3154,6 +3627,10 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
+/obj/item/melee/telebaton{
+	pixel_x = 5;
+	pixel_y = -2
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "vh" = (
@@ -3199,6 +3676,14 @@
 	pixel_x = 9;
 	pixel_y = 10
 	},
+/obj/item/melee/baton{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/melee/telebaton{
+	pixel_x = 5;
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/mine)
 "vv" = (
@@ -3209,6 +3694,23 @@
 	pixel_y = -10
 	},
 /obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"vw" = (
+/obj/random/dirt_75,
+/obj/structure/barricade/metal{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/item/ammo_casing/c45/practice{
+	pixel_y = -9
+	},
+/obj/item/ammo_casing/c45/practice{
+	pixel_x = -7;
+	pixel_y = 5
+	},
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "vx" = (
@@ -3331,18 +3833,30 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/mine)
-"wA" = (
-/obj/item/pickaxe{
-	pixel_y = -11;
-	pixel_x = 6
+"wu" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/wood,
+/area/mine)
+"wA" = (
 /obj/random/dirt_75,
-/obj/random/dirt_75,
+/obj/item/pickaxe/drill{
+	pixel_y = 10;
+	pixel_x = 9
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "wB" = (
@@ -3382,6 +3896,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/mine)
 "wJ" = (
@@ -3607,6 +4123,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "xZ" = (
@@ -3678,6 +4196,12 @@
 	icon_state = "1-8"
 	},
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "yx" = (
@@ -3762,6 +4286,9 @@
 	dir = 4
 	},
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "zb" = (
@@ -3779,6 +4306,19 @@
 "zd" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/bridge)
+"zk" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "zn" = (
 /obj/structure/closet,
 /obj/item/clothing/head/softcap,
@@ -3789,6 +4329,12 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/mine)
@@ -3803,6 +4349,12 @@
 	icon_state = "4-8"
 	},
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "zB" = (
@@ -3826,6 +4378,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"zD" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/structure/target_stake,
+/obj/item/target/syndicate,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"zM" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "zU" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -3845,6 +4415,12 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Ac" = (
@@ -3877,6 +4453,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
+"Al" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/random/dirt_75,
+/obj/item/trash/cigbutt{
+	pixel_x = -10;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/mine)
 "Au" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -3906,6 +4495,12 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "AA" = (
@@ -3932,6 +4527,14 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
+"AS" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "AU" = (
 /obj/structure/platform,
 /obj/effect/floor_decal/corner/grey{
@@ -3971,14 +4574,14 @@
 "Bm" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate,
-/obj/item/stack/material/silver{
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/stack/material/silver/full{
 	pixel_x = -6
 	},
-/obj/item/stack/material/silver{
+/obj/item/stack/material/silver/full{
 	pixel_x = 6
 	},
-/obj/random/dirt_75,
-/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Bn" = (
@@ -4018,6 +4621,9 @@
 /obj/random/dirt_75,
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/mine)
@@ -4078,6 +4684,8 @@
 	icon_state = "1-4"
 	},
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/mine)
 "BM" = (
@@ -4097,6 +4705,21 @@
 /obj/random/loot{
 	pixel_x = -11
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Ca" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/mine)
 "Cb" = (
@@ -4112,6 +4735,19 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Ce" = (
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/mine)
@@ -4162,6 +4798,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/mine)
 "CR" = (
@@ -4237,17 +4874,46 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
+"Dx" = (
+/obj/random/dirt_75,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "DB" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 9
 	},
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
+"DE" = (
+/obj/random/dirt_75,
+/obj/structure/closet/crate/freezer,
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/heart,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
 "DI" = (
 /obj/structure/table/steel,
 /obj/item/tank/air,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
+"DJ" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/mine)
 "DN" = (
 /obj/effect/floor_decal/spline/plain/black,
 /obj/effect/decal/cleanable/dirt,
@@ -4299,6 +4965,12 @@
 	pixel_y = 11;
 	pixel_x = -7
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Ek" = (
@@ -4315,6 +4987,7 @@
 	pixel_x = 2;
 	pixel_y = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Em" = (
@@ -4328,6 +5001,18 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
+"Eq" = (
+/obj/random/dirt_75,
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/mine)
 "Ew" = (
@@ -4381,6 +5066,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
+"EL" = (
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
+/area/mine)
 "EP" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
@@ -4400,6 +5092,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/mine)
 "EZ" = (
@@ -4499,6 +5192,14 @@
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/port)
+"FL" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/mine)
 "FO" = (
 /obj/item/trash/liquidfood,
 /turf/simulated/floor/tiled/yellow,
@@ -4602,6 +5303,16 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
+"Gh" = (
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "Gi" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
@@ -4612,6 +5323,10 @@
 /obj/random/tool{
 	pixel_x = -1;
 	pixel_y = -5
+	},
+/obj/item/clothing/ears/earmuffs/earphones/headphones{
+	pixel_y = 2;
+	pixel_x = 3
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -4735,6 +5450,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"Hb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "Hd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -4808,6 +5532,12 @@
 	icon_state = "2-4"
 	},
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "HC" = (
@@ -4826,6 +5556,13 @@
 /obj/item/paper/goon_base/note,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
+"HF" = (
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "HH" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
@@ -4893,6 +5630,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
+"HY" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/trash/cigbutt/cigarbutt/alt,
+/turf/simulated/floor/plating,
+/area/mine)
 "HZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4901,6 +5645,8 @@
 	icon_state = "1-8"
 	},
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/mine)
 "Ia" = (
@@ -4930,6 +5676,9 @@
 	pixel_x = -6
 	},
 /obj/random/tech_supply,
+/obj/item/grenade/chem_grenade{
+	pixel_x = 11
+	},
 /obj/item/grenade/chem_grenade{
 	pixel_x = 11
 	},
@@ -4973,6 +5722,8 @@
 	icon_state = "1-2"
 	},
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/mine)
 "IA" = (
@@ -4998,8 +5749,21 @@
 /turf/simulated/floor/tiled/full,
 /area/mine)
 "IG" = (
-/obj/effect/floor_decal/corner/pink/diagonal,
+/obj/effect/floor_decal/corner/yellow/diagonal,
 /turf/simulated/floor/tiled,
+/area/mine)
+"II" = (
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "IL" = (
 /obj/structure/cable{
@@ -5024,6 +5788,12 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -5072,11 +5842,12 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Ja" = (
-/obj/effect/floor_decal/industrial/warning/dust,
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
+/obj/random/dirt_75,
+/obj/item/weldingtool/emergency{
+	pixel_x = 11;
+	pixel_y = 15
 	},
-/turf/unsimulated/floor/asteroid/ash/rocky,
+/turf/unsimulated/floor/asteroid/ash,
 /area/mine)
 "Jf" = (
 /obj/structure/table/steel,
@@ -5170,9 +5941,6 @@
 "JD" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/clothing/wrists/goldbracer/ruby{
-	pixel_y = -6
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -5187,6 +5955,10 @@
 	pixel_y = 3;
 	pixel_x = -4
 	},
+/obj/item/clothing/under/goldendeep/vest,
+/obj/item/clothing/wrists/goldbracer/ruby{
+	pixel_y = -6
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "JF" = (
@@ -5195,6 +5967,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -5207,6 +5982,27 @@
 	pixel_y = -10
 	},
 /turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"JU" = (
+/obj/random/dirt_75,
+/obj/structure/barricade/metal{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/item/ammo_casing/c45/practice,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"JV" = (
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "JW" = (
 /turf/simulated/floor/plating,
@@ -5287,6 +6083,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/mine)
 "KD" = (
@@ -5310,6 +6107,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/mine)
@@ -5393,6 +6193,9 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "Lg" = (
@@ -5412,6 +6215,12 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
+"Lm" = (
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/mine)
 "Lq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5423,6 +6232,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
+"Lz" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "LM" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
@@ -5435,10 +6263,37 @@
 	},
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
+"LU" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/mine)
 "LY" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/structure/reagent_dispensers/coolanttank,
+/turf/simulated/floor/plating,
+/area/mine)
+"LZ" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Mf" = (
@@ -5486,6 +6341,9 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "Ml" = (
@@ -5525,10 +6383,23 @@
 "Mw" = (
 /turf/space,
 /area/space)
+"Mx" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/mine)
 "Mz" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/mine)
 "MA" = (
@@ -5658,6 +6529,12 @@
 	icon_state = "4-8"
 	},
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Np" = (
@@ -5665,6 +6542,12 @@
 /obj/item/trash/cigbutt{
 	pixel_y = -9;
 	pixel_x = -5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/mine)
@@ -5683,10 +6566,21 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/random/dirt_75,
 /obj/structure/table/steel,
+/obj/item/storage/belt/utility/alt{
+	pixel_y = 2
+	},
 /obj/random/tool{
 	pixel_y = 9
 	},
 /turf/simulated/floor/tiled,
+/area/mine)
+"Nz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
 /area/mine)
 "NA" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -5765,6 +6659,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/full,
 /area/mine)
 "Oo" = (
@@ -5789,6 +6686,12 @@
 /obj/item/trash/cigbutt{
 	pixel_y = -13;
 	pixel_x = 11
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/full,
 /area/mine)
@@ -5874,6 +6777,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "OQ" = (
@@ -5885,12 +6791,29 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
+"OX" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "Pc" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/item/storage/toolbox/emergency{
 	pixel_x = -11;
 	pixel_y = -8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/mine)
@@ -5906,11 +6829,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Pu" = (
-/obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
@@ -5937,6 +6863,20 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/north,
+/turf/simulated/floor/plating,
+/area/mine)
+"PG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/random/dirt_75,
+/obj/random/junk{
+	pixel_x = -9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/mine)
 "PK" = (
@@ -6073,6 +7013,12 @@
 	icon_state = "4-8"
 	},
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Qk" = (
@@ -6160,6 +7106,8 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/mine)
 "QO" = (
@@ -6181,12 +7129,23 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/asteroid,
 /area/mine)
 "QQ" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
+"QR" = (
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "QS" = (
@@ -6211,6 +7170,11 @@
 /obj/machinery/atmospherics/binary/pump/high_power,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
+"QV" = (
+/obj/random/dirt_75,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "QX" = (
 /turf/simulated/floor/plating,
 /area/mine)
@@ -6267,6 +7231,9 @@
 /area/shuttle/goon_ship/storage)
 "Rj" = (
 /obj/machinery/hologram/holopad/long_range,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/full,
 /area/mine)
 "Rl" = (
@@ -6294,6 +7261,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
+"Rx" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/stack/packageWrap{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Ry" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/structure/closet/crate,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "RD" = (
 /obj/structure/reagent_dispensers/radioactive_waste,
 /obj/effect/decal/cleanable/acid_remnants{
@@ -6315,7 +7302,14 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"RP" = (
+/obj/random/dirt_75,
+/turf/simulated/mineral/surface,
 /area/mine)
 "RQ" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
@@ -6332,6 +7326,17 @@
 /obj/random/junk,
 /obj/item/trash/can,
 /turf/simulated/floor/tiled,
+/area/mine)
+"RY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "Sd" = (
 /obj/machinery/door/airlock/glass,
@@ -6375,12 +7380,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "Sj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/random/dirt_75,
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/mine)
@@ -6470,6 +7478,10 @@
 	icon_state = "1-2"
 	},
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "SH" = (
@@ -6506,6 +7518,16 @@
 	},
 /obj/item/wrench{
 	pixel_y = -10
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"SW" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -6581,6 +7603,10 @@
 /obj/item/reagent_containers/food/drinks/waterbottle{
 	pixel_x = 1;
 	pixel_y = 19
+	},
+/obj/item/trash/cigbutt/cigarbutt/alt{
+	pixel_x = -1;
+	pixel_y = 4
 	},
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
@@ -6663,6 +7689,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "Ud" = (
@@ -6674,6 +7703,8 @@
 	req_access = list(20)
 	},
 /obj/random/dirt_75,
+/obj/item/melee/energy/sword/pirate/generic,
+/obj/item/clothing/head/bandana/red,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Uh" = (
@@ -6701,8 +7732,16 @@
 /obj/machinery/computer/ship/sensors,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"Um" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/ammo_casing/c45/practice{
+	pixel_x = 7;
+	pixel_y = -8
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "Un" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/steel,
 /obj/item/trash/stew{
 	pixel_x = 4;
@@ -6710,10 +7749,12 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "Up" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/steel,
 /obj/item/material/knife{
 	pixel_x = 5;
@@ -6723,7 +7764,10 @@
 	pixel_y = 5
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "Uq" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -6732,11 +7776,21 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/starboard)
 "Ur" = (
-/obj/item/reagent_containers/chem_disp_cartridge/clean_kois{
-	pixel_x = 7;
-	pixel_y = -4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/freezer,
+/obj/random/dirt_75,
+/obj/item/trash/cigbutt/roll{
+	pixel_x = 6;
+	pixel_y = -8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "Uz" = (
 /obj/structure/table/standard,
@@ -6829,7 +7883,31 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/item/pickaxe{
+	pixel_y = -16;
+	pixel_x = 6
+	},
 /turf/simulated/floor/plating/asteroid,
+/area/mine)
+"Vj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"Vk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/random/dirt_75,
+/obj/item/storage/belt/utility/alt{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "Vo" = (
 /obj/structure/closet/walllocker/medical{
@@ -6838,6 +7916,16 @@
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"Vq" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
+	},
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "Vs" = (
 /obj/random/junk,
 /obj/random/dirt_75,
@@ -6895,6 +7983,9 @@
 	pixel_x = 3;
 	pixel_y = -4
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "VK" = (
@@ -6927,6 +8018,12 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Wb" = (
@@ -6949,9 +8046,6 @@
 /area/mine)
 "Wn" = (
 /obj/structure/closet/crate,
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
 /obj/item/clothing/under/rank/security/zavod,
 /obj/item/clothing/under/pmc_modsuit,
 /obj/item/clothing/under/pmc_modsuit,
@@ -6969,7 +8063,8 @@
 /obj/item/clothing/suit/storage/hooded/wintercoat/hoodie/random,
 /obj/item/clothing/head/bandana/colorable/random,
 /obj/item/clothing/head/beanie/random,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "Wq" = (
 /obj/random/dirt_75,
@@ -6983,6 +8078,30 @@
 "Wt" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/device/radio/off{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/device/radio/off{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/device/radio/off{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/device/radio/off{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/device/radio/off{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/device/radio/off{
+	pixel_x = 6;
+	pixel_y = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "Wu" = (
@@ -7010,6 +8129,10 @@
 	pixel_x = 4
 	},
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"Wy" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner,
+/turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "WA" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -7172,6 +8295,11 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
+/obj/random/junk{
+	pixel_x = -9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/mine)
 "Xz" = (
@@ -7191,6 +8319,12 @@
 "XG" = (
 /obj/random/pottedplant,
 /turf/simulated/floor/tiled,
+/area/mine)
+"XH" = (
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 8
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "XI" = (
 /obj/structure/closet/cabinet,
@@ -7262,10 +8396,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
+"XT" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/structure/closet/crate,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/ears/earmuffs,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "XY" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "Ya" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -7310,6 +8455,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Yt" = (
@@ -7323,6 +8469,16 @@
 	dir = 4
 	},
 /turf/unsimulated/floor/asteroid/ash,
+/area/mine)
+"Yx" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Yz" = (
 /obj/structure/trash_pile,
@@ -7346,6 +8502,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "YI" = (
@@ -7425,9 +8584,6 @@
 /area/shuttle/goon_ship/living)
 "Zi" = (
 /obj/structure/closet,
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
 /obj/item/clothing/under/suit_jacket/charcoal,
 /obj/item/clothing/suit/storage/toggle/leather_jacket/midriff,
 /obj/item/clothing/suit/storage/toggle/varsity,
@@ -7440,13 +8596,22 @@
 /obj/item/clothing/head/headbando/random,
 /obj/item/clothing/under/vysoka,
 /obj/item/clothing/suit/storage/toggle/leather_jacket/military/tan,
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "Zk" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Zl" = (
@@ -7525,11 +8690,21 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
+"ZI" = (
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "ZJ" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
@@ -7544,53 +8719,63 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "ZR" = (
 /obj/structure/closet/crate/freezer{
 	name = "emergency rations (vaurca)"
 	},
+/obj/item/reagent_containers/chem_disp_cartridge/clean_kois,
 /obj/item/reagent_containers/food/snacks/koisbar{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/food/snacks/koisbar_clean{
-	pixel_x = 4
+	pixel_x = -5
 	},
 /obj/item/reagent_containers/food/snacks/koisbar{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/food/snacks/koisbar_clean{
-	pixel_x = 4
+	pixel_x = -5
 	},
 /obj/item/reagent_containers/food/snacks/koisbar{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/food/snacks/koisbar_clean{
-	pixel_x = 4
+	pixel_x = -5
 	},
 /obj/item/reagent_containers/food/snacks/koisbar{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/food/snacks/koisbar_clean{
-	pixel_x = 4
+	pixel_x = -5
 	},
 /obj/item/reagent_containers/food/snacks/koisbar{
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/food/snacks/koisbar_clean{
-	pixel_x = 4
+	pixel_x = -5
 	},
 /obj/item/reagent_containers/food/snacks/koisbar{
-	pixel_x = -4
+	pixel_x = -5
 	},
 /obj/item/reagent_containers/food/snacks/koisbar_clean{
-	pixel_x = 4
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/snacks/koisbar_clean{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/snacks/koisbar_clean{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/snacks/koisbar_clean{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/snacks/koisbar_clean{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/snacks/koisbar_clean{
+	pixel_x = 8
 	},
 /obj/item/reagent_containers/food/snacks/koisbar{
-	pixel_x = -4
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/food/snacks/koisbar{
+	pixel_x = -5
 	},
 /obj/item/reagent_containers/food/snacks/koisbar_clean{
-	pixel_x = 4
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/snacks/koisbar_clean{
+	pixel_x = 8
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
@@ -38800,7 +39985,7 @@ mI
 qX
 Dr
 uG
-mE
+cT
 en
 Ic
 Dr
@@ -38925,12 +40110,12 @@ Dr
 wU
 OQ
 nB
-cA
+yf
+sB
+Wy
 LS
 LS
 ho
-sB
-sB
 sB
 kz
 kz
@@ -39057,7 +40242,7 @@ qX
 qX
 Dr
 Qk
-Yi
+hv
 Jm
 ME
 Dr
@@ -39182,12 +40367,12 @@ Dr
 Dr
 nB
 nB
-Ja
+yf
+sB
+Ek
 sS
 sS
 yf
-sB
-sB
 sB
 sB
 kz
@@ -39314,7 +40499,7 @@ Dr
 Dr
 Dr
 Dr
-Rt
+kI
 Dr
 Dr
 Dr
@@ -39419,7 +40604,7 @@ mI
 mI
 mI
 PO
-mV
+Ja
 mV
 oL
 sB
@@ -39439,12 +40624,12 @@ sB
 Cm
 HH
 HH
+sB
+sB
 Ek
 QK
 QK
 yf
-sB
-sB
 sB
 sB
 sB
@@ -39556,8 +40741,8 @@ Dr
 wL
 Zl
 Li
-Li
-Li
+an
+ZI
 sI
 Li
 Jl
@@ -39571,7 +40756,7 @@ wL
 Li
 Yi
 Li
-Li
+eC
 Li
 QX
 Dr
@@ -39696,12 +40881,12 @@ sB
 sB
 sB
 sB
+sB
+sB
 Ek
 QK
 QK
 yf
-sB
-sB
 sB
 sB
 sB
@@ -39809,14 +40994,14 @@ Dr
 Li
 AL
 zW
-wH
-sZ
-sZ
-pJ
+LU
+Ca
+Ca
+II
+Dx
+RY
 EV
-pJ
-EV
-pJ
+qN
 hS
 Dr
 mI
@@ -39825,13 +41010,13 @@ vR
 mI
 Dr
 Br
-pJ
+qN
 Cz
-pJ
-pJ
-pJ
-pJ
-iV
+qN
+bV
+qN
+qN
+Mx
 KB
 Yp
 rN
@@ -39953,12 +41138,12 @@ sB
 sB
 sB
 sB
+sB
+sB
 Ek
 sS
 sS
 yf
-sB
-sB
 sB
 sB
 sB
@@ -40065,11 +41250,11 @@ Dr
 Dr
 UN
 NH
-Qj
+if
 Dr
 Dr
 Dr
-Rt
+LZ
 Dr
 Dr
 Dr
@@ -40210,12 +41395,12 @@ sB
 sB
 sB
 sB
+sB
+sB
 Cm
 HH
 HH
 vi
-sB
-sB
 sB
 sB
 sB
@@ -40317,18 +41502,18 @@ Dr
 yH
 Hd
 ME
-ru
+Vk
 tu
 Dr
 un
 NH
-Qj
+if
 Dr
 kE
 Li
-Li
-Li
-Li
+JV
+Lm
+QR
 tA
 Dr
 Pp
@@ -40579,7 +41764,7 @@ NX
 Dr
 qO
 Xx
-ys
+pO
 Dr
 IN
 mE
@@ -40596,7 +41781,7 @@ gj
 no
 Dr
 Pp
-Li
+an
 mQ
 Dr
 Vz
@@ -40834,27 +42019,27 @@ Hx
 yD
 tu
 Dr
-Ep
+as
 NH
 gw
 Dr
 dK
-mE
+Rx
 dh
 Mh
-Li
+Ce
 lb
 Dr
 hN
-pJ
-iV
+qN
+Mx
 QP
 QP
 QP
 QP
 Sj
-yS
-Yi
+Eq
+AS
 Dr
 KF
 tF
@@ -40874,7 +42059,7 @@ uU
 Fe
 Dr
 cF
-QX
+Li
 Dr
 qX
 mI
@@ -41099,7 +42284,7 @@ qv
 Li
 kB
 Wu
-Li
+Ce
 Gi
 Dr
 sI
@@ -41345,10 +42530,10 @@ Li
 Li
 uu
 uu
-Li
+ZI
 Dr
 EQ
-Nk
+OX
 Dr
 Dr
 Dr
@@ -41356,7 +42541,7 @@ Dr
 Dr
 Dr
 Dr
-Rt
+cG
 Dr
 Dr
 Dr
@@ -41387,8 +42572,8 @@ mI
 sB
 sB
 sB
-sB
-sB
+kz
+kz
 sB
 sB
 sB
@@ -41613,8 +42798,8 @@ IG
 OH
 Dr
 Ld
-NH
-gx
+Gh
+Vq
 IW
 ff
 Vw
@@ -41632,7 +42817,7 @@ Vw
 IW
 IW
 ZJ
-Zw
+uE
 kV
 Vw
 mt
@@ -41859,19 +43044,19 @@ Dr
 Ie
 sM
 TJ
-NH
+sl
 Dr
 NH
-Qj
+if
 Dr
 ch
 lW
 lW
 IG
-wY
-NH
+Sd
+HF
 lW
-lW
+mr
 Vw
 ff
 Vw
@@ -42116,18 +43301,18 @@ Dr
 SU
 Fo
 Ag
-qN
+ZL
 Dr
 NH
-Qj
+if
 Dr
 Zo
 IG
 IG
 JD
 Dr
-TO
-lW
+gq
+jP
 vZ
 BI
 ff
@@ -42143,8 +43328,8 @@ aA
 Cf
 aA
 aA
-aA
-BI
+SW
+DJ
 ws
 Vw
 Dr
@@ -42366,7 +43551,7 @@ mI
 qX
 Dr
 Vs
-mE
+HY
 mE
 iY
 Dr
@@ -42376,7 +43561,7 @@ Dr
 Dr
 Dr
 Sz
-Qj
+if
 Dr
 Dr
 Dr
@@ -42628,8 +43813,8 @@ oI
 Li
 Dr
 wL
-Li
-Li
+an
+ZI
 Zl
 HB
 Iz
@@ -42659,7 +43844,7 @@ Dr
 Ig
 sP
 cV
-yX
+km
 lW
 Dr
 Sv
@@ -42880,14 +44065,14 @@ Dr
 Dr
 Dr
 Sm
-sZ
+Ur
 SG
-sZ
+Al
 wH
-qf
-sZ
-sZ
-sZ
+Nz
+PG
+fg
+dW
 HZ
 NH
 yS
@@ -43137,7 +44322,7 @@ qf
 qf
 gH
 Nh
-yS
+sp
 mQ
 Zl
 Dr
@@ -43459,12 +44644,12 @@ sB
 sB
 kz
 mV
+gu
 cN
-cN
 vz
 vz
 vz
-vz
+cA
 sB
 sB
 sB
@@ -43652,9 +44837,9 @@ dT
 Dr
 aR
 Ea
-wY
+dE
 Mz
-Rl
+wu
 AI
 id
 fI
@@ -44175,7 +45360,7 @@ uT
 Dr
 Jl
 NH
-Ep
+os
 Dr
 DY
 iR
@@ -44432,7 +45617,7 @@ dz
 Dr
 Dr
 Dr
-kI
+Lz
 Dr
 Dr
 Dr
@@ -44487,12 +45672,12 @@ mI
 mI
 mI
 mI
+cA
 vz
 vz
 vz
 vz
-vz
-vz
+cA
 mI
 mI
 mI
@@ -44682,7 +45867,7 @@ Dr
 Dr
 Dr
 op
-Vw
+Hb
 Vw
 Vw
 Fz
@@ -44707,8 +45892,8 @@ NP
 gm
 mI
 mI
-mI
-mI
+fL
+kZ
 mI
 mI
 mI
@@ -44924,8 +46109,8 @@ gj
 Ow
 mg
 qX
+Yi
 wA
-Li
 Dr
 Uk
 Uk
@@ -44948,8 +46133,8 @@ Vw
 NH
 Nk
 NH
-TJ
-lW
+EL
+rl
 Vw
 ff
 Vw
@@ -44962,11 +46147,11 @@ nB
 te
 cH
 Pu
-mI
-mI
-mI
-mI
-mI
+Ow
+Ow
+sY
+ZC
+XT
 mI
 mI
 mI
@@ -45203,10 +46388,10 @@ Ch
 Dr
 nw
 BI
-zr
-BI
-BI
-BI
+gV
+FL
+Yx
+zM
 BI
 ff
 BI
@@ -45220,10 +46405,10 @@ Gs
 tS
 mI
 mI
-mI
-mI
-mI
-mI
+Ow
+no
+gj
+Ry
 mI
 mI
 mI
@@ -45471,16 +46656,16 @@ Dr
 Su
 Dr
 Dr
-te
+oU
 he
 he
 mI
 mI
-mI
-mI
-mI
-mI
-mI
+ik
+hc
+rm
+Um
+no
 mI
 mI
 mI
@@ -45734,9 +46919,9 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
+cW
+vw
+JU
 mI
 mI
 mI
@@ -45974,7 +47159,7 @@ TJ
 TJ
 XG
 Dr
-kI
+Lz
 Dr
 Dr
 Vw
@@ -45991,10 +47176,10 @@ Dr
 Dr
 qX
 mI
-mI
-mI
-mI
-mI
+pZ
+pZ
+Cj
+RP
 mI
 mI
 mI
@@ -46248,10 +47433,10 @@ lv
 Dr
 qX
 mI
-mI
-mI
-mI
-mI
+hu
+no
+no
+no
 mI
 mI
 mI
@@ -46505,10 +47690,10 @@ pw
 Dr
 qX
 mI
-mI
-mI
-mI
-mI
+hK
+no
+no
+no
 mI
 mI
 mI
@@ -46741,8 +47926,8 @@ Dr
 pt
 wo
 UX
-fM
-fM
+QV
+QV
 np
 Dr
 VY
@@ -46763,9 +47948,9 @@ Dr
 qX
 mI
 mI
-mI
-mI
-mI
+no
+eF
+no
 mI
 mI
 mI
@@ -46998,7 +48183,7 @@ Dr
 uv
 oH
 RE
-RE
+zk
 xY
 xY
 wH
@@ -47020,8 +48205,8 @@ Dr
 qX
 mI
 mI
-mI
-mI
+dU
+no
 mI
 mI
 mI
@@ -47265,7 +48450,7 @@ Dr
 od
 Dr
 YI
-lW
+eN
 lW
 Vw
 Vw
@@ -47278,7 +48463,7 @@ qX
 mI
 mI
 mI
-mI
+XH
 mI
 mI
 mI
@@ -47522,7 +48707,7 @@ Dr
 Dr
 Dr
 XI
-lW
+eN
 xE
 Vw
 sO
@@ -47535,7 +48720,7 @@ qX
 mI
 mI
 mI
-mI
+zD
 mI
 mI
 mI
@@ -47775,13 +48960,13 @@ gM
 Dr
 sz
 eP
-Ne
+DE
 Dr
 Dr
 Wn
-Vw
+Vj
 El
-Vw
+Zw
 Zi
 Dr
 Nf
@@ -48541,7 +49726,7 @@ mI
 qX
 Dr
 Se
-Ur
+IU
 sh
 Dr
 eq
@@ -63815,7 +65000,7 @@ bu
 bu
 bu
 bu
-mI
+bu
 mI
 mI
 mI
@@ -64331,9 +65516,9 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
+mI
+mI
+mI
 mI
 mI
 mI
@@ -64848,7 +66033,7 @@ bu
 bu
 bu
 bu
-mI
+bu
 mI
 mI
 mI
@@ -65105,8 +66290,8 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
 mI
 mI
 mI
@@ -66662,9 +67847,9 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
+mI
+mI
+mI
 bu
 bu
 bu
@@ -66918,9 +68103,9 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
+mI
+mI
+mI
 bu
 bu
 bu

--- a/maps/away/away_site/goon_base/goon_base.dmm
+++ b/maps/away/away_site/goon_base/goon_base.dmm
@@ -29,17 +29,11 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
 "aA" = (
-/obj/structure/table/steel,
-/obj/item/trash/cigbutt{
-	pixel_y = -4;
-	pixel_x = -9
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
 	},
-/obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_y = 8;
-	pixel_x = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "aD" = (
 /obj/effect/map_effect/airlock/s_to_n,
@@ -61,9 +55,10 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "aJ" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/trash/ramen,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/warning,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "aL" = (
 /obj/structure/cable{
@@ -103,12 +98,11 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "aT" = (
-/obj/random/dirt_75,
-/obj/item/pipewrench{
-	pixel_x = -6;
-	pixel_y = 6
+/obj/effect/floor_decal/corner/grey/full{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
 /area/mine)
 "aY" = (
 /obj/structure/closet/crate/bin{
@@ -173,35 +167,6 @@
 "bu" = (
 /turf/template_noop,
 /area/space)
-"bx" = (
-/obj/structure/table/rack,
-/obj/item/clothing/accessory/holster/thigh/brown{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/clothing/accessory/holster/thigh/brown{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/clothing/accessory/holster/thigh/brown{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/clothing/accessory/holster/hip/brown{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/clothing/accessory/holster/hip/brown{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/clothing/accessory/holster/hip/brown{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
-/area/mine)
 "bA" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -219,29 +184,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine)
-"bL" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/tech_supply{
-	pixel_y = -12
-	},
-/turf/simulated/floor/plating,
-/area/mine)
 "bN" = (
-/obj/structure/trash_pile,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/turf/simulated/floor/plating,
-/area/mine)
-"bQ" = (
-/obj/structure/trash_pile,
-/obj/effect/decal/cleanable/dirt,
+/obj/random/dirt_75,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/mine)
 "bR" = (
@@ -272,13 +219,6 @@
 "bZ" = (
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
-"cl" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 10
-	},
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled,
-/area/mine)
 "cm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -294,9 +234,9 @@
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "cu" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/white,
+/obj/structure/table/rack,
+/turf/simulated/floor/plating,
 /area/mine)
 "cx" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -317,22 +257,18 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "cH" = (
-/obj/random/dirt_75,
-/obj/item/clothing/shoes/magboots{
-	pixel_x = 12;
-	pixel_y = -12
-	},
-/turf/simulated/floor/tiled/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "cK" = (
 /obj/random/dirt_75,
-/obj/structure/trash_pile,
+/obj/random/dirt_75,
+/obj/random/loot,
 /turf/simulated/floor/plating,
 /area/mine)
 "cN" = (
-/obj/random/junk,
 /obj/random/dirt_75,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless/ceiling,
 /area/mine)
 "cP" = (
 /turf/simulated/floor/tiled/dark,
@@ -342,14 +278,16 @@
 	name = "trashbin"
 	},
 /obj/random/junk,
-/obj/item/trash/can,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "cY" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/reagent_dispensers/fueltank,
 /obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/barren,
+/obj/item/tank/air{
+	pixel_x = -9
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "dd" = (
 /obj/structure/bed/padded/bunk{
@@ -366,29 +304,17 @@
 /area/shuttle/goon_ship/storage)
 "dh" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
 /obj/random/dirt_75,
-/obj/item/material/twohanded/fireaxe,
-/obj/item/wirecutters/clippers,
-/obj/item/wirecutters,
-/obj/item/tank/jetpack/void,
-/obj/item/weldingtool/hugetank,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "dr" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 1
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/mine)
-"ds" = (
-/obj/structure/table/steel,
-/obj/random/dirt_75,
-/obj/random/tech_supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "dt" = (
 /obj/effect/shuttle_landmark/automatic/ghostrole_activation,
@@ -432,7 +358,8 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "dK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
@@ -455,9 +382,15 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "dT" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/trash/cigbutt,
-/turf/simulated/floor/plating,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/gun/energy/gun{
+	pixel_y = 3
+	},
+/obj/item/gun/energy/rifle/ionrifle{
+	pixel_y = -2
+	},
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "dV" = (
 /obj/effect/floor_decal/corner/lime{
@@ -490,12 +423,10 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
 "eh" = (
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/mine)
 "ei" = (
@@ -504,14 +435,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
-"ek" = (
-/obj/random/dirt_75,
-/obj/effect/decal/cleanable/generic{
-	pixel_x = 17;
-	pixel_y = -8
-	},
-/turf/simulated/floor/plating/asteroid,
 /area/mine)
 "eq" = (
 /obj/item/reagent_containers/glass/bucket/wood{
@@ -522,52 +445,67 @@
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
 "er" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled/dark,
-/area/mine)
-"et" = (
-/obj/random/dirt_75,
-/obj/item/clothing/head/cone{
-	pixel_x = 12;
-	pixel_y = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/exoplanet/barren,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "eA" = (
-/obj/item/stack/material/plasteel/full{
-	pixel_y = 4
-	},
-/obj/item/stack/material/plasteel/full{
-	pixel_y = 4
-	},
-/obj/item/stack/material/plasteel/full{
-	pixel_y = 4
-	},
 /obj/structure/table/reinforced/steel,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/plating,
+/obj/item/storage/toolbox/lunchbox/filled{
+	pixel_x = 1;
+	pixel_y = 13
+	},
+/obj/item/storage/toolbox/lunchbox/heart{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/storage/toolbox/lunchbox/cat/filled{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/mine)
 "eB" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/white,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = -9;
+	pixel_y = 14
+	},
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "eE" = (
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 6
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/structure/table/steel{
-	pixel_x = -2
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/storage/toolbox/mechanical,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 17;
+	pixel_y = -8
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "eH" = (
-/obj/item/reagent_containers/chem_disp_cartridge/clean_kois{
-	pixel_x = 7;
-	pixel_y = -4
+/obj/effect/decal/cleanable/greenglow/radioactive{
+	pixel_x = -10;
+	pixel_y = 9
 	},
-/turf/simulated/floor/tiled/freezer,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "eI" = (
 /obj/structure/closet/walllocker/medical{
@@ -633,9 +571,11 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "fe" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/mine)
 "ff" = (
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -653,15 +593,6 @@
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
-"fk" = (
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/effect/decal/cleanable/generic{
-	pixel_x = -9;
-	pixel_y = 14
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/mine)
 "fm" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -675,11 +606,11 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "fr" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/clothing/shoes/slippers/carp{
+	pixel_y = -4;
+	pixel_x = -5
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/mine)
 "fs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -698,12 +629,6 @@
 /obj/machinery/power/portgen/basic,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
-"fz" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/dirt_75,
-/obj/structure/closet/crate,
-/turf/simulated/floor/plating,
-/area/mine)
 "fA" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/void/tcaf,
@@ -724,10 +649,15 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "fG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/mirror{
+	pixel_y = 31
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/sink{
+	pixel_y = 21
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "fI" = (
 /obj/structure/bed/stool/padded/orange{
@@ -736,8 +666,9 @@
 /turf/simulated/floor/carpet/red,
 /area/mine)
 "fM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "fR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
@@ -747,12 +678,35 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "fW" = (
-/obj/effect/floor_decal/corner/purple{
-	dir = 10
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/mc9mm{
+	pixel_x = -6
 	},
-/obj/random/dirt_75,
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/tiled,
+/obj/item/ammo_magazine/mc9mm{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/mc9mm{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/mc9mm{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/mc9mm{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/mc9mm{
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/pistol{
+	pixel_y = 6;
+	pixel_x = -4
+	},
+/obj/item/gun/projectile/pistol{
+	pixel_y = -3;
+	pixel_x = 2
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "fY" = (
 /turf/simulated/mineral/surface,
@@ -769,22 +723,30 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "gi" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 9
+/obj/structure/table/steel,
+/obj/random/desktoy{
+	pixel_x = -4;
+	pixel_y = 8
 	},
-/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "gj" = (
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "gm" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/full,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = -10;
+	pixel_y = -2
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "gn" = (
 /obj/structure/table/rack,
@@ -826,20 +788,19 @@
 /turf/simulated/floor/wood,
 /area/mine)
 "gw" = (
-/obj/structure/table/steel,
-/obj/item/device/hand_labeler{
-	pixel_x = -1;
-	pixel_y = 3
+/obj/random/dirt_75,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 4;
+	pixel_y = 19
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/mine)
 "gx" = (
-/obj/machinery/door/airlock/external{
-	dir = 4
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
 	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warning/full,
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "gE" = (
 /obj/structure/bed/stool{
@@ -863,8 +824,13 @@
 /turf/simulated/floor/wood,
 /area/mine)
 "gM" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/obj/structure/closet/crate/freezer,
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/heart,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "gO" = (
 /obj/structure/closet/crate/freezer,
@@ -915,22 +881,9 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "he" = (
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 8
-	},
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/item/storage/toolbox{
-	pixel_y = 2;
-	pixel_x = 1
-	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/plating,
+/obj/structure/reagent_dispensers/coolanttank,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "hq" = (
 /obj/item/storage/bag/ore{
@@ -980,16 +933,12 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "hS" = (
-/obj/structure/table/steel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /obj/random/dirt_75,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 11
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 3;
-	pixel_x = 2
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
 /area/mine)
 "hV" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -1003,9 +952,8 @@
 /area/shuttle/goon_ship/med)
 "hZ" = (
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "ia" = (
 /obj/item/deck/cards,
@@ -1030,13 +978,36 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "id" = (
-/obj/structure/bed/stool/chair/office/dark,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/structure/table/wood,
+/obj/item/deck/cards{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/material/ashtray/bronze{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/one{
+	pixel_x = -20
+	},
+/turf/simulated/floor/carpet/red,
 /area/mine)
 "ie" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = -7;
+	pixel_y = -15
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 1;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "ig" = (
 /obj/structure/table/rack,
@@ -1047,11 +1018,12 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "ip" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/structural_support{
+	pixel_y = 8
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
 /area/mine)
 "is" = (
 /obj/machinery/atmospherics/pipe/tank/air,
@@ -1090,19 +1062,6 @@
 /obj/item/trash/chips,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
-"iF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
-/area/mine)
-"iH" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
-/area/mine)
 "iK" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
@@ -1124,29 +1083,43 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "iV" = (
-/obj/structure/structural_support{
-	pixel_y = 8
-	},
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating/asteroid,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
 /area/mine)
 "iW" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
 "iX" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/trash_pile,
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/white,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "iY" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled,
+/obj/random/dirt_75,
+/obj/structure/table/steel,
+/obj/random/tool{
+	pixel_y = 2
+	},
+/obj/item/tank/emergency_oxygen/double{
+	pixel_y = 5
+	},
+/obj/item/tank/emergency_oxygen/double{
+	pixel_y = 5
+	},
+/obj/item/tank/emergency_oxygen/double{
+	pixel_y = 5
+	},
+/obj/item/tank/emergency_oxygen/double{
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "jg" = (
 /obj/machinery/body_scanconsole{
@@ -1176,9 +1149,12 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "jv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/spiderling_remains,
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/obj/random/tool{
+	pixel_y = 6;
+	pixel_x = 8
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "jw" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1191,9 +1167,23 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "jz" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/trash/uselessplastic,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/clothing/suit/armor/carrier/heavy{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/clothing/suit/armor/carrier/heavy{
+	pixel_x = -6;
+	pixel_y = 0
+	},
+/obj/item/clothing/head/helmet/merc{
+	pixel_x = 4
+	},
+/obj/item/clothing/head/helmet/merc{
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "jS" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -1226,22 +1216,28 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "jZ" = (
-/obj/structure/janitorialcart/full,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine)
-"kg" = (
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine)
-"kj" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/turf/simulated/floor/tiled/full,
+/area/mine)
+"kg" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/tech_supply{
+	pixel_y = -12
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"kj" = (
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "kn" = (
@@ -1267,25 +1263,19 @@
 	},
 /area/shuttle/goon_ship/bridge)
 "ku" = (
-/obj/effect/floor_decal/corner/grey/full{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "kz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/full,
+/obj/random/dirt_75,
+/turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "kB" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/loot,
 /obj/random/dirt_75,
-/obj/item/trash/cigbutt{
-	pixel_x = 7;
-	pixel_y = -10
-	},
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/plating,
 /area/mine)
 "kE" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1405,13 +1395,12 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "kR" = (
-/obj/random/dirt_75,
-/obj/random/loot,
-/obj/random/tech_supply{
-	pixel_x = -9;
-	pixel_y = 5
+/obj/effect/floor_decal/corner/purple{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/tiled,
 /area/mine)
 "kS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1435,18 +1424,19 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "kV" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine)
-"kW" = (
-/obj/effect/floor_decal/corner/grey{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/west,
-/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
+/area/mine)
+"kW" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/ammo_magazine/c762,
+/obj/item/ammo_magazine/c762,
+/obj/item/ammo_magazine/c762,
+/obj/item/gun/projectile/automatic/rifle/sts35,
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "kX" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -1502,33 +1492,31 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
-"ln" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
-/area/mine)
 "lo" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 4
+/obj/structure/table/reinforced/steel,
+/obj/item/stack/material/glass/reinforced/full{
+	pixel_x = -16;
+	pixel_y = 4
 	},
+/obj/item/stack/material/glass/reinforced/full{
+	pixel_x = -16;
+	pixel_y = 4
+	},
+/obj/item/stack/material/glass/reinforced/full{
+	pixel_x = -16;
+	pixel_y = 4
+	},
+/obj/item/stack/material/steel/full{
+	pixel_y = 4
+	},
+/obj/item/stack/material/steel/full{
+	pixel_y = 4
+	},
+/obj/item/stack/material/steel/full{
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
-/area/mine)
-"lp" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/gun/energy/gun{
-	pixel_y = 3
-	},
-/obj/item/gun/energy/rifle/ionrifle{
-	pixel_y = -2
-	},
-/turf/simulated/floor/tiled/dark,
 /area/mine)
 "lq" = (
 /obj/machinery/optable,
@@ -1551,48 +1539,20 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "lz" = (
-/obj/effect/floor_decal/corner/grey/full,
-/obj/random/dirt_75,
-/obj/random/tech_supply{
-	pixel_x = -9;
-	pixel_y = 5
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/west,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
-"lB" = (
-/obj/random/tech_supply{
-	pixel_x = -9;
-	pixel_y = 5
-	},
-/turf/simulated/floor/tiled/full,
-/area/mine)
 "lI" = (
-/obj/structure/table/rack,
-/obj/item/clothing/shoes/magboots{
-	pixel_x = -4;
-	pixel_y = 5
+/obj/item/storage/toolbox/emergency{
+	pixel_x = -11;
+	pixel_y = -8
 	},
-/obj/item/clothing/shoes/magboots{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/clothing/shoes/magboots{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/clothing/shoes/magboots{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/clothing/shoes/magboots{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/clothing/shoes/magboots{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/turf/simulated/floor/tiled/full,
+/turf/unsimulated/floor/asteroid/ash,
 /area/mine)
 "lJ" = (
 /obj/item/crowbar,
@@ -1628,9 +1588,10 @@
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "lU" = (
-/obj/structure/trash_pile,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
@@ -1652,9 +1613,12 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "mj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/cigbutt,
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/obj/item/clothing/head/cone{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "mn" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
@@ -1665,9 +1629,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 1
-	},
+/obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/plating,
 /area/mine)
 "mt" = (
@@ -1692,26 +1654,13 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
 "mE" = (
-/obj/structure/table/steel,
 /obj/random/dirt_75,
-/obj/item/gun/custom_ka/frame05{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/wrench{
-	pixel_y = -10
-	},
-/turf/simulated/floor/tiled,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "mI" = (
 /turf/simulated/mineral/surface,
-/area/mine)
-"mJ" = (
-/obj/effect/floor_decal/corner/purple{
-	dir = 10
-	},
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled,
 /area/mine)
 "mO" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -1730,26 +1679,21 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "mQ" = (
-/obj/random/junk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
+/obj/random/loot,
 /turf/simulated/floor/plating,
 /area/mine)
 "mV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/turf/unsimulated/floor/asteroid/ash,
 /area/mine)
 "mW" = (
-/obj/item/storage/toolbox/emergency{
-	pixel_x = -11;
-	pixel_y = -8
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 1
 	},
-/turf/unsimulated/floor/asteroid/ash,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "mX" = (
 /obj/structure/closet/crate,
@@ -1780,8 +1724,15 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "nf" = (
-/obj/random/dirt_75,
-/turf/simulated/floor/plating/asteroid,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/snacks/pbjsandwich{
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/food/snacks/reubensandwich{
+	pixel_y = 10
+	},
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "ng" = (
 /obj/structure/closet,
@@ -1807,47 +1758,31 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
-"nm" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/effect/decal/cleanable/generic{
-	pixel_x = 17;
-	pixel_y = -8
-	},
-/turf/simulated/floor/plating,
-/area/mine)
 "no" = (
 /obj/random/dirt_75,
-/obj/random/tech_supply{
-	pixel_x = -9;
-	pixel_y = 5
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "np" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/c45m/lebman,
-/obj/item/ammo_magazine/c45m/lebman,
-/obj/item/ammo_magazine/c45m/lebman,
-/obj/item/gun/projectile/automatic/lebman{
-	pixel_y = 0
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/steel,
+/obj/item/reagent_containers/food/drinks/carton/milk{
+	pixel_y = 10;
+	pixel_x = -4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/obj/item/reagent_containers/food/drinks/carton/milk{
+	pixel_y = 12;
+	pixel_x = 7
+	},
+/obj/item/storage/box/fancy/egg_box{
+	pixel_y = 6;
+	pixel_x = -2
+	},
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "nr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
-"nu" = (
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/item/trash/match,
-/turf/simulated/floor/tiled/freezer,
-/area/mine)
 "nw" = (
 /obj/effect/floor_decal/corner/red/full{
 	dir = 1
@@ -1864,9 +1799,33 @@
 /turf/simulated/floor/plating/asteroid,
 /area/mine)
 "nC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating/asteroid,
+/obj/structure/table/rack,
+/obj/item/clothing/accessory/storage/pouches/brown{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/storage/pouches/brown{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/storage/pouches/brown{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/storage/brown_vest{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/storage/brown_vest{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/storage/brown_vest{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "nI" = (
 /obj/structure/bed/stool,
@@ -1876,12 +1835,17 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "nJ" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/gun/energy/gun{
+	pixel_y = 8;
+	pixel_x = -2
 	},
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
+/obj/item/gun/energy/gun{
+	pixel_y = 2;
+	pixel_x = 2
+	},
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "nM" = (
 /obj/effect/floor_decal/corner/beige{
@@ -1891,11 +1855,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "nQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/storage/box/shotgunammo,
+/obj/item/storage/box/shotgunshells,
+/obj/item/gun/projectile/shotgun/pump/combat,
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "nR" = (
 /obj/structure/table/steel,
@@ -1956,23 +1921,34 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "of" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine)
-"oi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "op" = (
 /obj/machinery/media/jukebox,
 /turf/simulated/floor/tiled,
 /area/mine)
 "ov" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = 0;
-	icon_state = "tube_empty"
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/clothing/suit/armor/carrier/generic{
+	pixel_x = -6
+	},
+/obj/item/clothing/suit/armor/carrier/generic{
+	pixel_x = -6
+	},
+/obj/item/clothing/suit/armor/carrier/generic{
+	pixel_x = -6
+	},
+/obj/item/clothing/head/helmet/merc{
+	pixel_x = 4
+	},
+/obj/item/clothing/head/helmet/merc{
+	pixel_x = 4
+	},
+/obj/item/clothing/head/helmet/merc{
+	pixel_x = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
@@ -2003,42 +1979,62 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "oH" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/trash/pistachios,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "oI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/random/dirt_75,
+/obj/random/tool{
+	pixel_y = -10
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "oK" = (
-/obj/structure/reagent_dispensers/radioactive_waste,
-/obj/effect/decal/cleanable/acid_remnants{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/acid_remnants{
-	pixel_y = -7;
-	pixel_x = 2
-	},
-/obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/turf/simulated/floor/tiled/full,
+/area/mine)
+"oM" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
-"oM" = (
-/obj/random/dirt_75,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/plating,
-/area/mine)
 "oP" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/ammo_magazine/c45m{
+	pixel_x = -6
 	},
-/turf/simulated/floor/tiled/white,
+/obj/item/ammo_magazine/c45m{
+	pixel_x = 7
+	},
+/obj/item/ammo_magazine/c45m{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/c45m{
+	pixel_x = 7
+	},
+/obj/item/ammo_magazine/c45m{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/c45m{
+	pixel_x = 7
+	},
+/obj/item/gun/projectile/sec/lethal{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/gun/projectile/sec/lethal{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "oX" = (
 /obj/structure/closet/walllocker/medical{
@@ -2071,12 +2067,6 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
-"pj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/full,
 /area/mine)
 "pn" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -2120,15 +2110,11 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "px" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/structure/mirror{
-	pixel_y = 31
-	},
-/obj/structure/sink{
-	pixel_y = 21
-	},
+/obj/structure/table/steel,
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/white,
+/obj/random/dirt_75,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled,
 /area/mine)
 "pz" = (
 /obj/structure/table/steel,
@@ -2143,15 +2129,10 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "pB" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/snacks/pbjsandwich{
-	pixel_y = -4
+/obj/structure/reagent_dispensers/water_cooler{
+	pixel_x = -9
 	},
-/obj/item/reagent_containers/food/snacks/reubensandwich{
-	pixel_y = 10
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled,
 /area/mine)
 "pI" = (
 /obj/structure/railing/mapped{
@@ -2164,8 +2145,9 @@
 /turf/simulated/floor/airless,
 /area/shuttle/goon_ship/bridge)
 "pJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/plating,
 /area/mine)
 "pN" = (
 /obj/effect/landmark/entry_point/east{
@@ -2176,7 +2158,6 @@
 "pQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
@@ -2205,17 +2186,17 @@
 "pV" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/steel,
-/obj/item/reagent_containers/food/drinks/carton/milk{
-	pixel_y = 10;
-	pixel_x = -4
+/obj/item/trash/waffles{
+	pixel_y = 5;
+	pixel_x = -1
 	},
-/obj/item/reagent_containers/food/drinks/carton/milk{
-	pixel_y = 12;
-	pixel_x = 7
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/storage/box/fancy/egg_box{
-	pixel_y = 6;
-	pixel_x = -2
+/obj/random/dirt_75,
+/obj/item/reagent_containers/food/snacks/jellystew{
+	pixel_y = 8;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled/white,
 /area/mine)
@@ -2302,16 +2283,11 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "qy" = (
-/obj/structure/closet/crate,
-/obj/random/spacecash,
-/obj/random/spacecash,
-/obj/random/spacecash,
-/obj/random/spacecash,
-/obj/item/spacecash/c1000,
-/obj/item/spacecash/c500,
-/obj/item/spacecash/c200,
-/obj/random/spacecash,
-/obj/random/spacecash,
+/obj/effect/floor_decal/corner/purple{
+	dir = 10
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "qz" = (
@@ -2362,7 +2338,9 @@
 /area/mine)
 "qJ" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/exoplanet/barren,
+/obj/random/dirt_75,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/plating,
 /area/mine)
 "qL" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2390,12 +2368,9 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "qN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/random/dirt_75,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/structure/closet/toolcloset,
+/turf/simulated/floor/tiled,
 /area/mine)
 "qO" = (
 /obj/structure/cable{
@@ -2407,27 +2382,32 @@
 /area/mine)
 "qP" = (
 /obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/gun/projectile/automatic/c20r,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/plating,
 /area/mine)
 "qW" = (
-/obj/random/dirt_75,
-/obj/random/loot{
-	pixel_x = -11
+/obj/structure/reagent_dispensers/radioactive_waste,
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_x = -8;
+	pixel_y = 6
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_y = -7;
+	pixel_x = 2
+	},
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "qX" = (
 /turf/simulated/wall/r_wall,
 /area/mine)
 "rc" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
@@ -2438,8 +2418,7 @@
 "rn" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/structure/closet/toolcloset,
 /turf/simulated/floor/plating,
 /area/mine)
 "rq" = (
@@ -2475,16 +2454,15 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "rF" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/decal/cleanable/dirt,
+/obj/random/dirt_75,
+/obj/machinery/pipedispenser,
 /turf/simulated/floor/plating,
 /area/mine)
 "rN" = (
-/obj/structure/table/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/syndicate/black,
-/obj/item/clothing/head/helmet/space/syndicate/black,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "rU" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -2496,24 +2474,13 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "rW" = (
+/obj/structure/reagent_dispensers/radioactive_waste,
+/obj/effect/decal/cleanable/acid_remnants,
+/obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/random/dirt_75,
-/obj/random/tool{
-	pixel_y = 6;
-	pixel_x = 8
-	},
-/turf/simulated/floor/plating,
-/area/mine)
-"rX" = (
 /obj/random/dirt_75,
-/obj/item/trash/cigbutt{
-	pixel_y = -9;
-	pixel_x = 1
-	},
-/obj/item/trash/match{
-	pixel_y = 11;
-	pixel_x = -7
-	},
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "sa" = (
 /turf/simulated/wall/shuttle/raider,
@@ -2553,21 +2520,10 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
-"sp" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/smg10mm,
-/obj/item/ammo_magazine/smg10mm,
-/obj/item/ammo_magazine/smg10mm,
-/obj/item/gun/projectile/automatic/konyang_pirate{
-	pixel_y = 5
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/mine)
 "sz" = (
-/obj/machinery/iv_drip,
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/white,
+/obj/structure/reagent_dispensers/cookingoil,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "sB" = (
 /turf/unsimulated/floor/asteroid/ash/rocky,
@@ -2577,22 +2533,16 @@
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
 "sI" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/item/gun/energy/gun{
-	pixel_y = 8;
-	pixel_x = -2
-	},
-/obj/item/gun/energy/gun{
-	pixel_y = 2;
-	pixel_x = 2
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/obj/structure/trash_pile,
+/turf/simulated/floor/plating,
 /area/mine)
 "sK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plating,
+/obj/structure/structural_support{
+	pixel_y = 8
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
 /area/mine)
 "sM" = (
 /obj/structure/bed/stool/chair/office/light{
@@ -2608,71 +2558,53 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "sO" = (
-/obj/structure/table/steel,
-/obj/random/dirt_75,
-/obj/item/storage/backpack/messenger/syndie{
-	pixel_x = -2;
-	pixel_y = 9
+/obj/structure/closet,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
 	},
+/obj/item/clothing/head/softcap,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/designer/black,
+/obj/item/clothing/suit/storage/legion,
+/obj/item/clothing/head/beret/legion/field,
+/obj/item/clothing/head/softcap/tcfl,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/flight/white,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/flight/green,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/designer/red,
+/obj/item/clothing/suit/storage/leathercoat,
+/obj/item/clothing/gloves/fingerless,
+/obj/item/clothing/head/ushanka/dominia,
+/obj/item/clothing/suit/storage/toggle/bomber,
 /turf/simulated/floor/tiled,
 /area/mine)
 "sP" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/storage/belt/utility/alt{
-	pixel_x = -1;
-	pixel_y = 13
-	},
-/obj/item/storage/belt/utility/alt{
-	pixel_x = -1;
-	pixel_y = 13
-	},
-/obj/item/storage/belt/utility/alt{
-	pixel_x = -1;
-	pixel_y = 13
-	},
-/obj/item/storage/wallet/lanyard,
-/obj/item/clothing/mask/balaclava/grey{
-	pixel_x = -5;
-	pixel_y = -9
-	},
-/obj/item/clothing/mask/balaclava/grey{
-	pixel_x = -5;
-	pixel_y = -9
-	},
-/obj/item/clothing/mask/balaclava/grey{
-	pixel_x = -5;
-	pixel_y = -9
-	},
-/obj/item/clothing/mask/balaclava/grey{
-	pixel_x = -5;
-	pixel_y = -9
-	},
-/obj/item/clothing/mask/balaclava/grey{
-	pixel_x = -5;
-	pixel_y = -9
-	},
-/obj/item/clothing/mask/balaclava/grey{
-	pixel_x = -5;
-	pixel_y = -9
-	},
-/turf/simulated/floor/tiled/dark/full,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "sX" = (
-/obj/effect/floor_decal/industrial/loading/grey,
-/turf/simulated/floor/plating,
+/obj/structure/closet/crate,
+/obj/random/spacecash,
+/obj/random/spacecash,
+/obj/random/spacecash,
+/obj/random/spacecash,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c500,
+/obj/item/spacecash/c200,
+/obj/random/spacecash,
+/obj/random/spacecash,
+/turf/simulated/floor/tiled,
 /area/mine)
 "sZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "te" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "tp" = (
 /obj/structure/closet,
@@ -2718,44 +2650,15 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
-"tz" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 5
-	},
-/obj/structure/table/rack,
-/obj/item/device/gps{
-	pixel_x = 5
-	},
-/obj/item/device/gps{
-	pixel_x = -6
-	},
-/obj/item/device/gps{
-	pixel_x = 5
-	},
-/obj/item/device/gps{
-	pixel_x = -6
-	},
-/obj/item/device/gps{
-	pixel_x = 5
-	},
-/obj/item/device/gps{
-	pixel_x = -6
-	},
-/turf/simulated/floor/tiled,
-/area/mine)
 "tA" = (
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/item/storage/toolbox/emergency{
-	pixel_x = -11;
-	pixel_y = -8
-	},
-/turf/simulated/floor/plating,
-/area/mine)
-"tC" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/reagent_dispensers/coolanttank,
+/obj/structure/closet/crate,
 /obj/random/dirt_75,
+/obj/item/material/twohanded/fireaxe,
+/obj/item/wirecutters/clippers,
+/obj/item/wirecutters,
+/obj/item/tank/jetpack/void,
+/obj/item/weldingtool/hugetank,
 /turf/simulated/floor/plating,
 /area/mine)
 "tF" = (
@@ -2775,8 +2678,8 @@
 /area/shuttle/goon_ship/starboard)
 "tR" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/loot,
 /obj/random/dirt_75,
+/obj/structure/closet/toolcloset,
 /turf/simulated/floor/plating,
 /area/mine)
 "tS" = (
@@ -2821,8 +2724,10 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "uy" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/reagent_dispensers/coolanttank,
 /obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/floor/plating,
 /area/mine)
 "uB" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -2843,14 +2748,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/mine)
-"uS" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 1
-	},
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
-/area/mine)
 "uT" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
@@ -2862,6 +2759,9 @@
 /area/mine)
 "uU" = (
 /obj/structure/trash_pile,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
+	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
@@ -2874,9 +2774,12 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "vc" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/plating,
+/obj/structure/table/steel,
+/obj/item/clothing/head/cowboy{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "vh" = (
 /obj/structure/sign/emergency/meetingpoint{
@@ -2902,15 +2805,13 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "vt" = (
-/obj/machinery/door/airlock/external{
-	dir = 4
+/obj/structure/table/reinforced/steel,
+/obj/item/storage/box/zipties{
+	layer = 2.99;
+	pixel_x = 9;
+	pixel_y = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warning/cee,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark/full,
 /area/mine)
 "vx" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -2950,12 +2851,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "vG" = (
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 5
-	},
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/structure/closet/crate,
 /turf/simulated/floor/plating,
 /area/mine)
 "vH" = (
@@ -2986,17 +2884,13 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "vR" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = -9;
+	pixel_y = 3
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/door/window{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "vZ" = (
 /obj/effect/floor_decal/corner/grey,
@@ -3019,11 +2913,13 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
 "wo" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "wp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3039,21 +2935,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
-"wz" = (
-/obj/random/junk,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
-/area/mine)
-"wA" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
-/area/mine)
 "wD" = (
+/obj/structure/closet/firecloset,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -3084,9 +2969,8 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "wL" = (
-/obj/machinery/door/airlock/maintenance{
-	dir = 4
-	},
+/obj/structure/trash_pile,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "wS" = (
@@ -3105,12 +2989,12 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "wX" = (
-/obj/structure/table/steel,
-/obj/item/clothing/head/cowboy{
-	pixel_x = -4;
-	pixel_y = 4
+/obj/random/dirt_75,
+/obj/item/trash/cigbutt{
+	pixel_x = 7;
+	pixel_y = -10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "wY" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -3127,12 +3011,12 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "xf" = (
-/obj/structure/trash_pile,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table/steel,
+/obj/item/storage/box/yarn{
+	pixel_x = -3;
+	pixel_y = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/mine)
 "xi" = (
 /obj/structure/closet/crate,
@@ -3168,20 +3052,19 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "xr" = (
-/obj/structure/table/steel,
-/obj/item/device/versebook/trinary{
-	pixel_x = 4;
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
 /area/mine)
 "xs" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/red,
-/obj/item/ammo_magazine/c762,
-/obj/item/ammo_magazine/c762,
-/obj/item/ammo_magazine/c762,
-/obj/item/gun/projectile/automatic/rifle/sts35,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/gun/projectile/automatic/c20r,
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "xz" = (
@@ -3200,11 +3083,13 @@
 /turf/simulated/floor/tiled/full,
 /area/mine)
 "xH" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 8
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/item/storage/backpack/messenger/syndie{
+	pixel_x = -2;
+	pixel_y = 9
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/mine)
 "xJ" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -3229,87 +3114,6 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "xM" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled/white,
-/area/mine)
-"xO" = (
-/obj/item/trash/cigbutt,
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/effect/floor_decal/corner/black/diagonal{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
-"xQ" = (
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled,
-/area/mine)
-"xX" = (
-/obj/structure/table/steel,
-/obj/item/tank/air,
-/turf/simulated/floor/tiled/dark,
-/area/mine)
-"xY" = (
-/obj/random/dirt_75,
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/plating,
-/area/mine)
-"xZ" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/trash/match,
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/plating,
-/area/mine)
-"ye" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/empty/north,
-/turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
-"yl" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
-/area/mine)
-"ym" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
-"yp" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 6
-	},
-/obj/item/trash/cheesie,
-/turf/simulated/floor/carpet,
-/area/shuttle/goon_ship/living)
-"yq" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/storage/pill_bottle/mortaphenyl{
 	pixel_x = -13;
@@ -3328,9 +3132,103 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/mine)
-"yr" = (
+"xO" = (
+/obj/item/trash/cigbutt,
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/effect/floor_decal/corner/black/diagonal{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/goon_ship/living)
+"xQ" = (
+/obj/structure/table/steel,
+/obj/item/device/versebook/trinary{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"xX" = (
 /obj/random/dirt_75,
-/turf/unsimulated/floor/asteroid/ash/rocky,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/turf/simulated/floor/plating,
+/area/mine)
+"xY" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"xZ" = (
+/obj/structure/reagent_dispensers/keg/beerkeg/rice,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
+"ye" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/empty/north,
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/goon_ship/living)
+"yl" = (
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/structure/closet/crate,
+/obj/item/clothing/head/sol/marine,
+/obj/item/clothing/head/sol/marine/grey,
+/obj/item/clothing/head/sol/garrison,
+/obj/item/clothing/head/sol/army/service/officer,
+/obj/item/clothing/head/sol/garrison,
+/obj/item/clothing/under/rank/sol/marine,
+/obj/item/clothing/under/rank/sol/marine,
+/obj/item/clothing/under/rank/sol/marine/grey,
+/obj/item/clothing/under/rank/sol/service/marine,
+/obj/item/clothing/under/rank/sol/army/grey,
+/obj/item/clothing/under/rank/sol/army/service,
+/obj/item/clothing/under/rank/sol/army/service/officer,
+/turf/simulated/floor/tiled,
+/area/mine)
+"ym" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/goon_ship/living)
+"yp" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
+	},
+/obj/item/trash/cheesie,
+/turf/simulated/floor/carpet,
+/area/shuttle/goon_ship/living)
+"yq" = (
+/obj/structure/table/reinforced/steel,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 12
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/tiled/dark/full,
+/area/mine)
+"yr" = (
+/obj/random/junk,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "ys" = (
 /obj/structure/cable{
@@ -3376,8 +3274,11 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "yS" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/paper/crumpled,
+/obj/random/dirt_75,
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "yW" = (
@@ -3393,23 +3294,26 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "yX" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/machinery/door/firedoor/noid,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/mine)
-"yY" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/random/dirt_75,
-/obj/machinery/pipedispenser,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/mine)
 "zb" = (
-/obj/item/clothing/shoes/slippers/carp{
-	pixel_y = -4;
-	pixel_x = -5
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/tank/emergency_oxygen/engi{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "zd" = (
 /turf/simulated/wall/shuttle/raider,
@@ -3421,9 +3325,10 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "zr" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/structure/table/steel,
-/obj/item/storage/toolbox/mechanical,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "zs" = (
@@ -3433,11 +3338,8 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "zz" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
@@ -3493,26 +3395,26 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "Ag" = (
+/obj/structure/table/steel,
 /obj/random/dirt_75,
-/turf/simulated/floor/airless/ceiling,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 4;
+	pixel_y = 19
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 11
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "Ah" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
-"Ak" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/random/dirt_75,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/mine)
-"Am" = (
-/obj/machinery/atmospherics/binary/pump/aux/on,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
 /area/mine)
 "Au" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -3537,22 +3439,12 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
-"Ax" = (
-/obj/random/dirt_75,
-/obj/random/tool{
-	pixel_y = 6;
-	pixel_x = 8
-	},
-/turf/simulated/floor/tiled,
-/area/mine)
 "Ay" = (
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/item/tape_roll,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "AA" = (
@@ -3590,11 +3482,6 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
-"AW" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/exoplanet/barren,
-/area/mine)
 "Ba" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -3664,46 +3551,49 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Br" = (
-/obj/structure/reagent_dispensers/keg/beerkeg/rice,
-/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Bt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/grey{
+	dir = 10
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/mine)
 "By" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "Bz" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/structure/table/steel,
+/obj/item/gamehelm/pink{
+	icon_state = "closed_pink";
+	pixel_y = 2;
+	pixel_x = 3
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/mine)
 "BE" = (
-/obj/random/dirt_75,
-/obj/structure/closet/crate/freezer,
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/heart,
-/turf/simulated/floor/tiled/freezer,
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "BH" = (
+/obj/structure/table/steel,
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
-/obj/structure/table/rack,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/emergency_oxygen/double{
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "BI" = (
@@ -3719,24 +3609,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "BK" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/effect/floor_decal/corner/blue/diagonal,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled,
 /area/mine)
 "BW" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/barren,
-/area/mine)
-"BX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/obj/random/loot{
+	pixel_x = -11
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Cb" = (
@@ -3752,31 +3639,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine)
-"Cd" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/structure/closet/crate,
-/obj/item/clothing/head/sol/marine,
-/obj/item/clothing/head/sol/marine/grey,
-/obj/item/clothing/head/sol/garrison,
-/obj/item/clothing/head/sol/army/service/officer,
-/obj/item/clothing/head/sol/garrison,
-/obj/item/clothing/under/rank/sol/marine,
-/obj/item/clothing/under/rank/sol/marine,
-/obj/item/clothing/under/rank/sol/marine/grey,
-/obj/item/clothing/under/rank/sol/service/marine,
-/obj/item/clothing/under/rank/sol/army/grey,
-/obj/item/clothing/under/rank/sol/army/service,
-/obj/item/clothing/under/rank/sol/army/service/officer,
-/turf/simulated/floor/tiled,
-/area/mine)
 "Cf" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Ch" = (
 /obj/effect/floor_decal/corner/red/full{
@@ -3798,39 +3665,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
-"Ct" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/dirt_75,
-/obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_x = -7;
-	pixel_y = -15
-	},
-/obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_x = 1;
-	pixel_y = 0
-	},
-/obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_x = -9;
-	pixel_y = 5
-	},
-/turf/simulated/floor/exoplanet/barren,
-/area/mine)
 "Cz" = (
+/obj/random/junk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/structure/closet/toolcloset,
 /turf/simulated/floor/plating,
 /area/mine)
 "CR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/item/tank/emergency_oxygen/engi{
-	pixel_x = -6;
-	pixel_y = 5
-	},
 /turf/simulated/floor/plating,
 /area/mine)
 "CS" = (
@@ -3838,22 +3683,25 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "CY" = (
-/obj/machinery/atmospherics/portables_connector/aux{
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "CZ" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled,
+/obj/item/melee/baton/stunrod{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "Df" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Dj" = (
@@ -3893,20 +3741,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
-"Dv" = (
-/obj/structure/reagent_dispensers/water_cooler{
-	pixel_x = -9
-	},
-/turf/simulated/floor/tiled,
-/area/mine)
-"Dy" = (
-/obj/structure/table/steel,
-/obj/random/dirt_75,
-/obj/item/clothing/gloves/yellow{
-	pixel_y = 9
-	},
-/turf/simulated/floor/tiled,
-/area/mine)
 "DI" = (
 /obj/structure/table/steel,
 /obj/item/tank/air,
@@ -3931,11 +3765,6 @@
 /obj/item/storage/box/fancy/cigarettes,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
-"DT" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine)
 "DY" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
@@ -3947,22 +3776,26 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "Ea" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/can,
+/obj/random/dirt_75,
+/obj/item/trash/cigbutt{
+	pixel_y = -9;
+	pixel_x = 1
+	},
+/obj/item/trash/match{
+	pixel_y = 11;
+	pixel_x = -7
+	},
 /turf/simulated/floor/plating,
 /area/mine)
-"Ek" = (
-/obj/structure/table/steel,
-/obj/random/dirt_75,
-/obj/random/hardhat,
-/turf/simulated/floor/tiled,
-/area/mine)
 "El" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 9
+/obj/structure/table/steel,
+/obj/item/paper_bin{
+	pixel_y = 4;
+	pixel_x = 3
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/pen/fountain/black{
+	pixel_x = 2;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -4031,14 +3864,11 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "EP" = (
-/obj/effect/floor_decal/spline/plain/black{
+/obj/effect/floor_decal/corner/purple{
 	dir = 10
 	},
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/item/clothing/head/hardhat/dblue,
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "EQ" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -4046,12 +3876,10 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "EV" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/item/storage/box/shotgunammo,
-/obj/item/storage/box/shotgunshells,
-/obj/item/gun/projectile/shotgun/pump/combat,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random/dirt_75,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
 /area/mine)
 "EZ" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -4062,10 +3890,6 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/generic{
-	pixel_x = 17;
-	pixel_y = -8
-	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Fb" = (
@@ -4077,38 +3901,24 @@
 /turf/simulated/floor/carpet/red,
 /area/mine)
 "Fe" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 6
-	},
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled,
-/area/mine)
-"Fj" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_x = 4;
-	pixel_y = 12
-	},
-/turf/simulated/floor/exoplanet/barren,
-/area/mine)
-"Fk" = (
-/obj/effect/floor_decal/spline/fancy/wood{
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plating,
 /area/mine)
 "Fo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Fp" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/broken_bottle,
-/turf/simulated/floor/plating,
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Ft" = (
 /obj/effect/floor_decal/spline/plain/black{
@@ -4123,13 +3933,6 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
-"Fv" = (
-/obj/random/dirt_75,
-/obj/random/tool{
-	pixel_y = -10
-	},
-/turf/simulated/floor/plating,
-/area/mine)
 "Fz" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -4150,12 +3953,9 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "FE" = (
-/obj/structure/table/steel,
-/obj/item/towel/random{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/turf/simulated/floor/tiled,
+/obj/random/dirt_75,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/plating,
 /area/mine)
 "FF" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -4177,14 +3977,6 @@
 	identifier = "goon_boss"
 	},
 /turf/simulated/floor/wood,
-/area/mine)
-"FS" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 12
-	},
-/obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor/tiled/dark/full,
 /area/mine)
 "FT" = (
 /obj/structure/closet/walllocker{
@@ -4219,10 +4011,32 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "Gb" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots{
+	pixel_x = -4;
+	pixel_y = 5
 	},
-/turf/simulated/floor/plating,
+/obj/item/clothing/shoes/magboots{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "Gc" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -4242,22 +4056,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
 "Gi" = (
-/obj/structure/reagent_dispensers/radioactive_waste,
-/obj/effect/decal/cleanable/acid_remnants,
-/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/barren,
-/area/mine)
-"Gk" = (
-/obj/structure/table/steel,
-/obj/item/gamehelm/pink{
-	icon_state = "closed_pink";
-	pixel_y = 2;
-	pixel_x = 3
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/mine)
 "Gn" = (
 /obj/structure/table/steel,
@@ -4272,11 +4073,12 @@
 /turf/template_noop,
 /area/space)
 "Gs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 6
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 10;
+	pixel_y = 2
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Gw" = (
 /obj/machinery/light{
@@ -4293,13 +4095,10 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
 "GB" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/dirt_75,
-/obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_x = -7;
-	pixel_y = -15
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
 	},
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/floor/plating,
 /area/mine)
 "GF" = (
 /obj/structure/table/rack,
@@ -4337,15 +4136,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "GH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/random/dirt_75,
+/obj/machinery/vending/engineering{
+	req_access = null
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "GI" = (
-/obj/item/trash/maps,
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/obj/item/clothing/gloves/yellow{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "GL" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -4398,10 +4201,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
-"Hr" = (
-/obj/random/dirt_75,
-/turf/unsimulated/floor/asteroid/ash,
-/area/mine)
 "Hs" = (
 /obj/structure/table/steel,
 /obj/item/storage/firstaid/o2{
@@ -4445,29 +4244,12 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
-"HA" = (
-/obj/random/dirt_75,
-/obj/structure/reagent_dispensers/cookingoil,
-/turf/simulated/floor/tiled/freezer,
-/area/mine)
 "HB" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack,
-/obj/item/clothing/suit/armor/carrier/heavy{
-	pixel_x = -6;
-	pixel_y = 1
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/item/clothing/suit/armor/carrier/heavy{
-	pixel_x = -6;
-	pixel_y = 0
-	},
-/obj/item/clothing/head/helmet/merc{
-	pixel_x = 4
-	},
-/obj/item/clothing/head/helmet/merc{
-	pixel_x = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "HC" = (
 /obj/machinery/smartfridge/foodheater,
@@ -4549,16 +4331,25 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "HZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/plating,
 /area/mine)
 "Ia" = (
-/obj/item/melee/baton/stunrod{
-	pixel_x = 9;
-	pixel_y = -4
+/obj/machinery/door/airlock/external{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/cee,
+/turf/simulated/floor/plating,
 /area/mine)
 "Ib" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -4574,31 +4365,20 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "Ie" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/random/hardhat,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Ig" = (
-/obj/structure/table/wood,
-/obj/item/deck/cards{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/material/ashtray/bronze{
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/one{
-	pixel_x = -20
-	},
-/turf/simulated/floor/carpet/red,
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Iz" = (
-/obj/item/trash/chips/dirtberry{
-	pixel_x = 10;
-	pixel_y = -4
-	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4606,10 +4386,8 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "IA" = (
-/obj/machinery/atmospherics/binary/pump/aux/on{
-	dir = 8
-	},
-/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/mine)
 "IB" = (
@@ -4639,6 +4417,12 @@
 "IN" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 17;
+	pixel_y = -8
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "IQ" = (
@@ -4651,10 +4435,10 @@
 /turf/simulated/floor/wood,
 /area/mine)
 "IS" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/barren,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/plating,
 /area/mine)
 "IU" = (
 /turf/simulated/floor/tiled/freezer,
@@ -4697,19 +4481,11 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
-"Jj" = (
-/obj/structure/table/steel,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/item/clothing/gloves/boxing,
-/turf/simulated/floor/tiled,
-/area/mine)
 "Jl" = (
-/obj/effect/floor_decal/corner/grey/full{
-	dir = 8
-	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled,
+/obj/random/loot,
+/obj/structure/table/rack,
+/turf/simulated/floor/plating,
 /area/mine)
 "Jo" = (
 /obj/structure/bed/padded/bunk{
@@ -4734,26 +4510,19 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "Jw" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/portables_connector/aux{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/random/dirt_75,
-/obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_x = 10;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_x = -10;
-	pixel_y = -2
-	},
-/turf/simulated/floor/exoplanet/barren,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "Jx" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/item/broken_bottle{
-	pixel_x = -6;
-	pixel_y = 9
-	},
+/obj/item/trash/match,
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
 "Jz" = (
@@ -4776,19 +4545,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
-"JD" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/table/steel,
-/obj/item/trash/waffles{
-	pixel_y = 5;
-	pixel_x = -1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled/white,
-/area/mine)
 "JW" = (
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
@@ -4805,17 +4561,34 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
-"Kb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
-/area/mine)
 "Ke" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/storage/belt/military{
+	pixel_y = -3;
+	pixel_x = -3
+	},
+/obj/item/storage/belt/military{
+	pixel_y = -3;
+	pixel_x = -3
+	},
+/obj/item/storage/belt/military{
+	pixel_y = -3;
+	pixel_x = -3
+	},
+/obj/item/storage/belt/military{
+	pixel_y = 5;
+	pixel_x = 2
+	},
+/obj/item/storage/belt/military{
+	pixel_y = 5;
+	pixel_x = 2
+	},
+/obj/item/storage/belt/military{
+	pixel_y = 5;
+	pixel_x = 2
+	},
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "Ki" = (
 /obj/structure/cable{
@@ -4836,12 +4609,8 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "KB" = (
-/obj/structure/table/steel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
-/obj/item/clothing/glasses/welding,
-/obj/item/weldingtool{
-	pixel_y = 4
-	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "KD" = (
@@ -4853,21 +4622,21 @@
 /turf/simulated/floor/tiled/full,
 /area/mine)
 "KE" = (
-/obj/random/dirt_75,
-/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "KG" = (
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/freezer,
-/area/mine)
-"KI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/random/dirt_75,
-/obj/random/dirt_75,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/mine)
 "KJ" = (
@@ -4892,12 +4661,12 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "KR" = (
-/obj/random/dirt_75,
-/obj/item/storage/toolbox/emergency{
-	pixel_x = 4;
-	pixel_y = 19
+/obj/effect/floor_decal/corner/grey/full{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "KS" = (
 /obj/structure/bed/stool/chair/folding{
@@ -4906,20 +4675,10 @@
 /turf/simulated/floor/tiled/full,
 /area/mine)
 "KW" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/storage/toolbox/lunchbox/filled{
-	pixel_x = 1;
-	pixel_y = 13
-	},
-/obj/item/storage/toolbox/lunchbox/heart{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/item/storage/toolbox/lunchbox/cat/filled{
-	pixel_x = 4;
-	pixel_y = 1
-	},
-/turf/simulated/floor/tiled/dark/full,
+/obj/machinery/atmospherics/binary/pump/aux/on,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "KZ" = (
 /turf/simulated/wall{
@@ -4935,7 +4694,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "Ld" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/grey/full{
+	dir = 8
+	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -4967,54 +4728,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
-"Ls" = (
-/obj/structure/table/steel,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/tech_supply,
-/turf/simulated/floor/tiled,
-/area/mine)
 "LM" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
-"LR" = (
-/obj/structure/closet/crate/bin{
-	name = "trashbin"
-	},
-/obj/random/junk,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled,
-/area/mine)
-"LS" = (
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/machinery/door/firedoor/noid{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/mine)
 "LY" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/power/portgen/basic,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
-"Mg" = (
-/obj/effect/floor_decal/corner/grey/full{
-	dir = 4
-	},
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled,
 /area/mine)
 "Mh" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -5063,16 +4787,19 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "Mo" = (
-/obj/random/dirt_75,
-/obj/item/tank/oxygen/brown{
-	pixel_x = -10;
-	pixel_y = -5
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "Mu" = (
 /obj/effect/floor_decal/corner/grey/full,
 /obj/random/dirt_75,
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "Mw" = (
@@ -5086,24 +4813,11 @@
 /area/mine)
 "MB" = (
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/structure/table/steel,
-/obj/random/tool{
-	pixel_y = 2
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 17;
+	pixel_y = -8
 	},
-/obj/item/tank/emergency_oxygen/double{
-	pixel_y = 5
-	},
-/obj/item/tank/emergency_oxygen/double{
-	pixel_y = 5
-	},
-/obj/item/tank/emergency_oxygen/double{
-	pixel_y = 5
-	},
-/obj/item/tank/emergency_oxygen/double{
-	pixel_y = 5
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/asteroid,
 /area/mine)
 "ME" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -5164,25 +4878,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/goon_ship/port)
-"MY" = (
-/obj/structure/closet,
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
-	},
-/obj/item/clothing/under/suit_jacket/charcoal,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/midriff,
-/obj/item/clothing/suit/storage/toggle/varsity,
-/obj/item/clothing/under/pants/tacticool,
-/obj/item/clothing/under/pants/ripped,
-/obj/item/clothing/accessory/university/black,
-/obj/item/clothing/suit/storage/toggle/track/red,
-/obj/item/clothing/suit/storage/toggle/flannel/gray,
-/obj/item/clothing/head/beret,
-/obj/item/clothing/head/headbando/random,
-/obj/item/clothing/under/vysoka,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/military/tan,
-/turf/simulated/floor/tiled,
-/area/mine)
 "MZ" = (
 /obj/item/paper/crumpled{
 	pixel_y = 13;
@@ -5220,10 +4915,9 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "Nk" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 4
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
@@ -5243,9 +4937,7 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "Nr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
@@ -5256,7 +4948,6 @@
 /area/mine)
 "NA" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
-/obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
@@ -5273,28 +4964,21 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "NH" = (
-/obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/mine)
 "NP" = (
-/obj/random/dirt_75,
-/obj/random/loot,
-/obj/structure/table/rack,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "NT" = (
-/obj/structure/table/rack,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 4;
+	pixel_y = 12
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "NU" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -5304,16 +4988,12 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "NX" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/rack,
-/obj/item/storage/box/smokebombs{
-	pixel_x = 6;
+/obj/random/dirt_75,
+/obj/item/pipewrench{
+	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/item/storage/box/flashbangs{
-	pixel_x = -3
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/mine)
 "NY" = (
 /obj/effect/decal/cleanable/generic,
@@ -5324,10 +5004,11 @@
 /turf/simulated/floor/airless/ceiling,
 /area/mine)
 "On" = (
-/obj/item/clothing/gloves/janitor,
-/obj/structure/table/rack,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "Oo" = (
 /obj/structure/bed/stool/chair{
@@ -5347,23 +5028,16 @@
 /turf/simulated/floor/wood,
 /area/mine)
 "Os" = (
-/obj/item/trash/broken_electronics,
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/obj/item/trash/cigbutt{
+	pixel_y = -13;
+	pixel_x = 11
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "Ow" = (
-/obj/random/tech_supply{
-	pixel_x = -9;
-	pixel_y = 5
-	},
-/turf/simulated/floor/exoplanet/barren,
-/area/mine)
-"Oy" = (
-/obj/structure/table/steel,
-/obj/item/storage/box/yarn{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
 /area/mine)
 "OA" = (
 /obj/structure/table/steel,
@@ -5410,15 +5084,22 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "OP" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "OW" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "Pc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = -11;
+	pixel_y = -8
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Pk" = (
@@ -5426,49 +5107,52 @@
 /turf/simulated/mineral/surface,
 /area/mine)
 "Pp" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "Pu" = (
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "PC" = (
 /obj/machinery/bodyscanner,
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
-"PI" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled,
-/area/mine)
 "PK" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/table/steel,
-/obj/item/device/flashlight/lantern,
-/obj/item/device/flashlight/lantern,
-/obj/item/device/flashlight/lantern,
-/obj/item/device/flashlight/lantern,
-/obj/item/device/flashlight/lantern,
-/obj/item/device/flashlight/lantern,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/iv_drip,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "PL" = (
-/obj/effect/decal/cleanable/generic{
-	pixel_x = 8
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/structure/table/rack,
+/obj/item/device/gps{
+	pixel_x = 5
+	},
+/obj/item/device/gps{
+	pixel_x = -6
+	},
+/obj/item/device/gps{
+	pixel_x = 5
+	},
+/obj/item/device/gps{
+	pixel_x = -6
+	},
+/obj/item/device/gps{
+	pixel_x = 5
+	},
+/obj/item/device/gps{
+	pixel_x = -6
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
-"PR" = (
-/obj/item/wrench,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
 /area/mine)
 "PS" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -5477,23 +5161,52 @@
 /turf/simulated/floor/wood,
 /area/mine)
 "PV" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/barren,
-/area/mine)
-"PW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 9
+/obj/structure/table/reinforced/steel,
+/obj/item/storage/belt/utility/alt{
+	pixel_x = -1;
+	pixel_y = 13
 	},
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
+/obj/item/storage/belt/utility/alt{
+	pixel_x = -1;
+	pixel_y = 13
+	},
+/obj/item/storage/belt/utility/alt{
+	pixel_x = -1;
+	pixel_y = 13
+	},
+/obj/item/storage/wallet/lanyard,
+/obj/item/clothing/mask/balaclava/grey{
+	pixel_x = -5;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/balaclava/grey{
+	pixel_x = -5;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/balaclava/grey{
+	pixel_x = -5;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/balaclava/grey{
+	pixel_x = -5;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/balaclava/grey{
+	pixel_x = -5;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/balaclava/grey{
+	pixel_x = -5;
+	pixel_y = -9
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/mine)
 "PY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/dirt_75,
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "PZ" = (
 /obj/structure/table/rack,
@@ -5502,19 +5215,6 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
-"Qb" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/dirt_75,
-/obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_x = 10;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_x = 1;
-	pixel_y = 19
-	},
-/turf/simulated/floor/exoplanet/barren,
-/area/mine)
 "Qc" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/oxygen,
@@ -5522,9 +5222,9 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "Qe" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 8
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "Qf" = (
@@ -5553,23 +5253,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
-"Ql" = (
-/obj/random/dirt_75,
-/obj/item/tank/air{
-	pixel_x = -9
-	},
-/turf/simulated/floor/tiled/full,
-/area/mine)
 "Qm" = (
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/structure/table/rack,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/floor/plating,
+/obj/item/clothing/shoes/magboots{
+	pixel_x = 12;
+	pixel_y = -12
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "Qv" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
@@ -5578,9 +5268,13 @@
 	},
 /area/shuttle/goon_ship/bridge)
 "Qw" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/structure/dispenser/oxygen,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = -7;
+	pixel_y = -15
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Qx" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -5611,38 +5305,42 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/port)
 "QE" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/item/trash/liquidfood,
-/turf/simulated/floor/plating,
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 11
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "QM" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/mine)
-"QO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
-"QP" = (
+"QO" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/item/trash/cigbutt{
-	pixel_x = -10;
-	pixel_y = -3
-	},
 /obj/effect/decal/cleanable/generic{
-	pixel_x = -9;
-	pixel_y = 14
+	pixel_x = 8
 	},
-/turf/simulated/floor/tiled/freezer,
+/obj/item/reagent_containers/food/snacks/koisbar{
+	pixel_x = -5;
+	pixel_y = -12
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"QP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
 /area/mine)
 "QQ" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -5661,7 +5359,7 @@
 /obj/machinery/door/airlock/external,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/cee{
-	dir = 8
+	dir = 4
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
@@ -5716,42 +5414,22 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "Rv" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/storage/box/zipties{
-	layer = 2.99;
-	pixel_x = 9;
-	pixel_y = 10
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/item/clothing/glasses/welding,
+/obj/item/weldingtool{
+	pixel_y = 4
 	},
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/floor/tiled,
 /area/mine)
 "RE" = (
-/obj/structure/table/rack,
-/obj/item/clothing/accessory/storage/pouches/brown{
-	pixel_x = 5;
-	pixel_y = 5
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/clothing/accessory/storage/pouches/brown{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/clothing/accessory/storage/pouches/brown{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/clothing/accessory/storage/brown_vest{
-	pixel_x = -5;
-	pixel_y = -4
-	},
-/obj/item/clothing/accessory/storage/brown_vest{
-	pixel_x = -5;
-	pixel_y = -4
-	},
-/obj/item/clothing/accessory/storage/brown_vest{
-	pixel_x = -5;
-	pixel_y = -4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "RQ" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
@@ -5762,35 +5440,12 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "RR" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/mc9mm{
-	pixel_x = -6
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
 	},
-/obj/item/ammo_magazine/mc9mm{
-	pixel_x = 6
-	},
-/obj/item/ammo_magazine/mc9mm{
-	pixel_x = -6
-	},
-/obj/item/ammo_magazine/mc9mm{
-	pixel_x = 6
-	},
-/obj/item/ammo_magazine/mc9mm{
-	pixel_x = -6
-	},
-/obj/item/ammo_magazine/mc9mm{
-	pixel_x = 6
-	},
-/obj/item/gun/projectile/pistol{
-	pixel_y = 6;
-	pixel_x = -4
-	},
-/obj/item/gun/projectile/pistol{
-	pixel_y = -3;
-	pixel_x = 2
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/obj/random/junk,
+/obj/item/trash/can,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Sd" = (
 /obj/machinery/door/airlock/glass,
@@ -5834,31 +5489,33 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "Sj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
+"Sk" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/trash/cigbutt{
+	pixel_x = -10;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/generic{
+	pixel_x = -9;
+	pixel_y = 14
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
+"Sm" = (
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/random/dirt_75,
 /obj/machinery/power/apc/north,
 /turf/simulated/floor/plating,
-/area/mine)
-"Sk" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled,
-/area/mine)
-"Sm" = (
-/obj/structure/table/rack,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/oxygen,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/dark,
 /area/mine)
 "Su" = (
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -5875,57 +5532,52 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
-"Sw" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/dirt_75,
-/obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_x = 10;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_x = -6;
-	pixel_y = -5
-	},
-/turf/simulated/floor/exoplanet/barren,
-/area/mine)
 "Sx" = (
-/obj/structure/table/rack,
+/obj/item/stack/material/plasteel/full{
+	pixel_y = 4
+	},
+/obj/item/stack/material/plasteel/full{
+	pixel_y = 4
+	},
+/obj/item/stack/material/plasteel/full{
+	pixel_y = 4
+	},
+/obj/structure/table/reinforced/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
 /area/mine)
 "Sz" = (
-/obj/structure/trash_pile,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/random/dirt_75,
+/obj/random/loot{
+	pixel_x = -11
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/mine)
 "SE" = (
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/effect/decal/cleanable/generic{
-	pixel_x = 8
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
 	},
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/floor/tiled,
 /area/mine)
 "SF" = (
+/obj/structure/table/steel,
 /obj/random/dirt_75,
-/obj/random/loot,
-/turf/simulated/floor/plating,
+/obj/item/clothing/gloves/yellow{
+	pixel_y = 9
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "SG" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
+/obj/item/trash/chips/dirtberry{
+	pixel_x = 10;
+	pixel_y = -4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "SH" = (
@@ -5951,21 +5603,21 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "SU" = (
-/obj/machinery/pipedispenser,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/mine)
-"SX" = (
 /obj/structure/table/steel,
-/obj/item/paper_bin{
-	pixel_y = 4;
-	pixel_x = 3
-	},
-/obj/item/pen/fountain/black{
-	pixel_x = 2;
+/obj/random/dirt_75,
+/obj/item/gun/custom_ka/frame05{
+	pixel_x = -8;
 	pixel_y = 5
 	},
+/obj/item/wrench{
+	pixel_y = -10
+	},
 /turf/simulated/floor/tiled,
+/area/mine)
+"SX" = (
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "SZ" = (
 /obj/structure/cable{
@@ -5998,13 +5650,14 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "To" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/item/trash/cigbutt{
-	pixel_x = -10;
-	pixel_y = -3
+/obj/effect/floor_decal/corner/grey{
+	dir = 10
 	},
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled/white,
+/obj/structure/table/rack,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/oxygen,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Tr" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -6016,29 +5669,7 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "Ts" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/stack/material/glass/reinforced/full{
-	pixel_x = -16;
-	pixel_y = 4
-	},
-/obj/item/stack/material/glass/reinforced/full{
-	pixel_x = -16;
-	pixel_y = 4
-	},
-/obj/item/stack/material/glass/reinforced/full{
-	pixel_x = -16;
-	pixel_y = 4
-	},
-/obj/item/stack/material/steel/full{
-	pixel_y = 4
-	},
-/obj/item/stack/material/steel/full{
-	pixel_y = 4
-	},
-/obj/item/stack/material/steel/full{
-	pixel_y = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/industrial/loading/grey,
 /turf/simulated/floor/plating,
 /area/mine)
 "Tt" = (
@@ -6046,86 +5677,44 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Tu" = (
-/obj/structure/structural_support{
-	pixel_y = 8
-	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
-/turf/simulated/floor/plating/asteroid,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 1;
+	pixel_y = 19
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Ty" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "TA" = (
-/obj/structure/trash_pile,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 10
+/obj/machinery/door/airlock/external,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 8
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "TH" = (
-/obj/structure/table/steel,
 /obj/random/dirt_75,
-/obj/item/storage/toolbox/emergency{
-	pixel_x = 4;
-	pixel_y = 19
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 11
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 3;
-	pixel_x = 2
-	},
-/turf/simulated/floor/tiled,
-/area/mine)
-"TJ" = (
-/obj/effect/decal/cleanable/greenglow/radioactive{
-	pixel_x = -10;
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/broken_bottle{
+	pixel_x = -6;
 	pixel_y = 9
 	},
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/effect/decal/cleanable/generic{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
-"TM" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/ammo_magazine/c45m{
-	pixel_x = -6
-	},
-/obj/item/ammo_magazine/c45m{
-	pixel_x = 7
-	},
-/obj/item/ammo_magazine/c45m{
-	pixel_x = -6
-	},
-/obj/item/ammo_magazine/c45m{
-	pixel_x = 7
-	},
-/obj/item/ammo_magazine/c45m{
-	pixel_x = -6
-	},
-/obj/item/ammo_magazine/c45m{
-	pixel_x = 7
-	},
-/obj/item/gun/projectile/sec/lethal{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/gun/projectile/sec/lethal{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/turf/simulated/floor/tiled/dark,
+"TJ" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "TN" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille,
@@ -6138,12 +5727,33 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "TQ" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table/rack,
+/obj/item/clothing/accessory/holster/thigh/brown{
+	pixel_x = -2;
+	pixel_y = -2
 	},
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
+/obj/item/clothing/accessory/holster/thigh/brown{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/holster/thigh/brown{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/holster/hip/brown{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/clothing/accessory/holster/hip/brown{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/clothing/accessory/holster/hip/brown{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "TW" = (
 /obj/effect/floor_decal/corner/red/full{
@@ -6151,14 +5761,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
-"TY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/trash_pile,
-/turf/simulated/floor/plating,
-/area/mine)
 "Uc" = (
-/obj/effect/decal/cleanable/spiderling_remains,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "Ud" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -6208,10 +5818,17 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "Up" = (
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/steel,
+/obj/item/material/knife{
+	pixel_x = 5;
+	pixel_y = 12
+	},
+/obj/item/material/kitchen/rollingpin{
+	pixel_y = 5
+	},
 /obj/random/dirt_75,
-/obj/structure/closet/toolcloset,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "Uq" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -6220,20 +5837,11 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/starboard)
 "Ur" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/dirt_75,
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/plating,
-/area/mine)
-"Uu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/reagent_containers/chem_disp_cartridge/clean_kois{
+	pixel_x = 7;
+	pixel_y = -4
 	},
-/obj/random/dirt_75,
-/obj/random/loot{
-	pixel_x = -11
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "UA" = (
 /obj/random/dirt_75,
@@ -6265,11 +5873,13 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "UX" = (
-/obj/effect/floor_decal/corner/grey/full{
-	dir = 8
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/trash/cigbutt{
+	pixel_x = -10;
+	pixel_y = -3
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "Vb" = (
 /obj/structure/bed/padded,
@@ -6284,44 +5894,10 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "Vc" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/storage/belt/military{
-	pixel_y = -3;
-	pixel_x = -3
+/obj/machinery/atmospherics/binary/pump/aux/on{
+	dir = 8
 	},
-/obj/item/storage/belt/military{
-	pixel_y = -3;
-	pixel_x = -3
-	},
-/obj/item/storage/belt/military{
-	pixel_y = -3;
-	pixel_x = -3
-	},
-/obj/item/storage/belt/military{
-	pixel_y = 5;
-	pixel_x = 2
-	},
-/obj/item/storage/belt/military{
-	pixel_y = 5;
-	pixel_x = 2
-	},
-/obj/item/storage/belt/military{
-	pixel_y = 5;
-	pixel_x = 2
-	},
-/turf/simulated/floor/tiled/dark,
-/area/mine)
-"Vd" = (
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/tech_supply,
-/turf/simulated/floor/tiled/freezer,
-/area/mine)
-"Vi" = (
-/obj/random/dirt_75,
-/obj/structure/closet/toolcloset,
 /turf/simulated/floor/plating,
 /area/mine)
 "Vo" = (
@@ -6331,17 +5907,11 @@
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
-"Vp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 10
-	},
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
-/area/mine)
 "Vs" = (
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/junk,
 /obj/random/dirt_75,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/mine)
 "Vu" = (
@@ -6353,9 +5923,12 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "Vx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/plating,
+/obj/structure/table/steel,
+/obj/item/towel/random{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "VB" = (
 /obj/machinery/chemical_dispenser/bar_alc/full{
@@ -6365,31 +5938,34 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "VD" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/structure/table/steel,
 /obj/random/dirt_75,
-/obj/structure/closet/toolcloset,
+/obj/item/storage/box/fancy/cigarettes/nicotine{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = 3;
+	pixel_y = -4
+	},
 /turf/simulated/floor/tiled,
-/area/mine)
-"VH" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "VK" = (
 /turf/simulated/floor/tiled/dark/full,
 /area/mine)
 "VL" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
-/area/mine)
-"VN" = (
-/obj/random/dirt_75,
-/obj/random/tech_supply{
-	pixel_x = -9;
-	pixel_y = 5
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/c45m/lebman,
+/obj/item/ammo_magazine/c45m/lebman,
+/obj/item/ammo_magazine/c45m/lebman,
+/obj/item/gun/projectile/automatic/lebman{
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "VR" = (
 /obj/effect/floor_decal/corner/lime{
@@ -6402,23 +5978,12 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "VY" = (
-/obj/structure/closet,
-/obj/effect/floor_decal/corner/blue{
-	dir = 10
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/clothing/head/softcap,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/designer/black,
-/obj/item/clothing/suit/storage/legion,
-/obj/item/clothing/head/beret/legion/field,
-/obj/item/clothing/head/softcap/tcfl,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/flight/white,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/flight/green,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/designer/red,
-/obj/item/clothing/suit/storage/leathercoat,
-/obj/item/clothing/gloves/fingerless,
-/obj/item/clothing/head/ushanka/dominia,
-/obj/item/clothing/suit/storage/toggle/bomber,
-/turf/simulated/floor/tiled,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "Wb" = (
 /obj/item/trash/can,
@@ -6463,10 +6028,12 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "Wq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/random/dirt_75,
+/obj/random/loot,
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Wt" = (
@@ -6481,12 +6048,10 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "Wv" = (
-/obj/structure/table/steel,
-/obj/random/desktoy{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Ww" = (
 /obj/effect/floor_decal/corner/lime{
@@ -6523,9 +6088,11 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "WG" = (
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/machinery/door/firedoor/noid,
-/obj/random/dirt_75,
+/obj/structure/table/steel,
+/obj/item/device/hand_labeler{
+	pixel_x = -1;
+	pixel_y = 3
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "WI" = (
@@ -6561,25 +6128,29 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "WR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
+/obj/random/tool{
+	pixel_y = 6;
+	pixel_x = 8
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "WS" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/structure/table/steel,
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
-/obj/item/storage/box/fancy/cigarettes/nicotine{
-	pixel_x = -5;
-	pixel_y = 6
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 10;
+	pixel_y = 2
 	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = 3;
-	pixel_y = -4
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 1;
+	pixel_y = 5
 	},
-/turf/simulated/floor/tiled,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = -6;
+	pixel_y = -5
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Xb" = (
 /obj/effect/shuttle_landmark/goon_ship/transit,
@@ -6624,27 +6195,19 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "Xx" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner/grey{
-	dir = 10
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/tank/emergency_oxygen/double{
-	pixel_y = 5
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "Xz" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/steel,
-/obj/item/material/knife{
-	pixel_x = 5;
-	pixel_y = 12
-	},
-/obj/item/material/kitchen/rollingpin{
-	pixel_y = 5
-	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/white,
+/obj/random/dirt_75,
+/obj/item/clothing/gloves/boxing,
+/turf/simulated/floor/tiled,
 /area/mine)
 "XF" = (
 /obj/effect/floor_decal/corner/grey{
@@ -6677,13 +6240,45 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "XP" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/table/rack,
+/obj/item/device/flashlight/lantern{
+	pixel_x = -6;
+	pixel_y = 3
 	},
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled/white,
+/obj/item/device/flashlight/lantern{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/device/flashlight/lantern{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/device/flashlight/heavy,
+/obj/item/device/flashlight{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight/flare/glowstick/random,
+/obj/item/device/flashlight/flare/glowstick/random,
+/obj/item/device/flashlight/flare/glowstick/random,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/plating,
 /area/mine)
 "XS" = (
 /obj/machinery/computer/ship/engines{
@@ -6692,32 +6287,19 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "XY" = (
-/obj/machinery/vending/engineering{
-	req_access = null
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Ya" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
-/obj/item/clothing/suit/armor/carrier/generic{
-	pixel_x = -6
+/obj/item/storage/box/smokebombs{
+	pixel_x = 6;
+	pixel_y = 6
 	},
-/obj/item/clothing/suit/armor/carrier/generic{
-	pixel_x = -6
-	},
-/obj/item/clothing/suit/armor/carrier/generic{
-	pixel_x = -6
-	},
-/obj/item/clothing/head/helmet/merc{
-	pixel_x = 4
-	},
-/obj/item/clothing/head/helmet/merc{
-	pixel_x = 4
-	},
-/obj/item/clothing/head/helmet/merc{
-	pixel_x = 4
+/obj/item/storage/box/flashbangs{
+	pixel_x = -3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
@@ -6737,15 +6319,15 @@
 /area/shuttle/goon_ship/living)
 "Yi" = (
 /obj/random/dirt_75,
-/obj/item/trash/cigbutt{
-	pixel_y = -13;
-	pixel_x = 11
-	},
-/turf/simulated/floor/tiled/full,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "Yp" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/grey/full{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Yt" = (
 /obj/machinery/light/small{
@@ -6754,11 +6336,9 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "Yz" = (
+/obj/structure/trash_pile,
 /obj/random/dirt_75,
-/obj/item/clothing/gloves/yellow{
-	pixel_x = -9;
-	pixel_y = 7
-	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "YA" = (
@@ -6805,12 +6385,11 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "YV" = (
-/obj/effect/floor_decal/corner/purple{
-	dir = 10
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
 	},
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/wood,
 /area/mine)
 "YW" = (
 /obj/structure/cable{
@@ -6830,23 +6409,15 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "YZ" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "Zc" = (
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 4
-	},
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/grey/full,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Ze" = (
 /turf/simulated/floor/tiled/yellow,
@@ -6857,39 +6428,39 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Zi" = (
-/obj/structure/closet/firecloset,
-/obj/effect/floor_decal/industrial/outline/firefighting_closet,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
+/obj/structure/closet,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/item/clothing/under/suit_jacket/charcoal,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/midriff,
+/obj/item/clothing/suit/storage/toggle/varsity,
+/obj/item/clothing/under/pants/tacticool,
+/obj/item/clothing/under/pants/ripped,
+/obj/item/clothing/accessory/university/black,
+/obj/item/clothing/suit/storage/toggle/track/red,
+/obj/item/clothing/suit/storage/toggle/flannel/gray,
+/obj/item/clothing/head/beret,
+/obj/item/clothing/head/headbando/random,
+/obj/item/clothing/under/vysoka,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/military/tan,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Zk" = (
-/obj/structure/reagent_dispensers/coolanttank,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/exoplanet/barren,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "Zl" = (
 /obj/random/junk,
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
-/area/mine)
-"Zu" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_x = 10;
-	pixel_y = 2
-	},
-/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Zw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Zx" = (
 /obj/effect/floor_decal/spline/plain/black{
@@ -6906,18 +6477,11 @@
 /area/shuttle/goon_ship/living)
 "ZB" = (
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/effect/decal/cleanable/generic{
-	pixel_x = -9;
-	pixel_y = 3
+/obj/item/tank/oxygen/brown{
+	pixel_x = -10;
+	pixel_y = -5
 	},
-/turf/simulated/floor/exoplanet/barren,
-/area/mine)
-"ZG" = (
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/loot,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/mine)
 "ZH" = (
 /obj/structure/dispenser/oxygen,
@@ -6929,50 +6493,17 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "ZJ" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "ZL" = (
-/obj/structure/table/rack,
-/obj/item/device/flashlight/lantern{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/device/flashlight/lantern{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/device/flashlight/lantern{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/device/flashlight/heavy,
-/obj/item/device/flashlight{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/device/flashlight{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/device/flashlight{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/device/flashlight{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/device/flashlight{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/device/flashlight/flare/glowstick/random,
-/obj/item/device/flashlight/flare/glowstick/random,
-/obj/item/device/flashlight/flare/glowstick/random,
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/structure/closet/toolcloset,
 /turf/simulated/floor/plating,
 /area/mine)
 "ZR" = (
@@ -7034,9 +6565,15 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "ZW" = (
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/barren,
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/smg10mm,
+/obj/item/ammo_magazine/smg10mm,
+/obj/item/ammo_magazine/smg10mm,
+/obj/item/gun/projectile/automatic/konyang_pirate{
+	pixel_y = 5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "ZY" = (
 /obj/machinery/door/airlock/external{
@@ -37934,13 +37471,13 @@ mI
 mI
 qX
 Dr
-Ls
-hS
+px
+QE
 Nt
 jS
-yl
+EZ
 lh
-Bt
+sZ
 gc
 jw
 NU
@@ -38191,11 +37728,11 @@ mI
 mI
 qX
 Dr
-Dy
+SF
 tF
-Qe
+aJ
 IB
-EZ
+eE
 Jz
 Li
 MH
@@ -38448,13 +37985,13 @@ mI
 mI
 qX
 Dr
-KB
-HZ
+Rv
+oK
 Au
 FD
 SM
 Ep
-Vi
+ZL
 zU
 dY
 bA
@@ -38479,8 +38016,8 @@ qX
 qX
 Dr
 wb
-Mg
-HZ
+KR
+oK
 Qg
 bm
 Dr
@@ -38705,9 +38242,9 @@ mI
 mI
 qX
 Dr
-tC
+uy
 Li
-IN
+Gi
 Dr
 Dr
 kI
@@ -38723,8 +38260,8 @@ Dr
 Dr
 Dr
 mI
-SE
-Gi
+QO
+rW
 mI
 Dr
 Dr
@@ -38736,9 +38273,9 @@ Dr
 Dr
 Dr
 qj
-pJ
-Ax
-cH
+TJ
+jv
+Qm
 xp
 Dr
 qX
@@ -38789,7 +38326,7 @@ mI
 mI
 mI
 mI
-Ag
+cN
 mI
 mI
 mI
@@ -38964,37 +38501,37 @@ qX
 Dr
 LY
 Li
-Vs
+IS
 Dr
-NP
+Jl
 Ep
 Li
 Dr
-uU
-cN
+wL
+Zl
 Li
 Li
 Li
-cK
+sI
 Li
-NP
+Jl
 Dr
 mI
-oK
-TJ
+qW
+eH
 mI
 Dr
-uU
+wL
 Li
-fe
+Yi
 Li
 Li
 Li
 QX
 Dr
 IX
-lz
-pJ
+Mu
+TJ
 FU
 tr
 Dr
@@ -39046,8 +38583,8 @@ mI
 mI
 mI
 mI
-Ag
-Ag
+cN
+cN
 mI
 mI
 mI
@@ -39220,44 +38757,44 @@ qX
 qX
 Dr
 eL
-Ur
-Up
+qJ
+tR
 Dr
 Li
 AL
 zW
 wH
-Bt
-Bt
-WR
-Ak
-WR
-Ak
-WR
-qN
+sZ
+sZ
+pJ
+EV
+pJ
+EV
+pJ
+hS
 Dr
 mI
 mI
-ZB
+vR
 mI
 Dr
-GH
-WR
-mQ
-WR
-WR
-WR
-WR
-yX
-Ld
-ku
-pj
+Br
+pJ
+Cz
+pJ
+pJ
+pJ
+pJ
+iV
+KB
+Yp
+rN
 pz
-Xx
+BH
 Dr
-cK
+sI
 Li
-KE
+cu
 Dr
 Fb
 pf
@@ -39302,8 +38839,8 @@ mI
 mI
 mI
 mI
-Ag
-Ag
+cN
+cN
 se
 mI
 Dr
@@ -39481,7 +39018,7 @@ Dr
 Dr
 Dr
 UN
-wD
+NH
 Qj
 Dr
 Dr
@@ -39491,35 +39028,35 @@ Dr
 Dr
 Dr
 Dr
-Wq
+Pp
 Dr
 mI
-Tu
-ZW
+sK
+gj
 mI
 Dr
-Wq
+Pp
 Li
 Dr
 EQ
-NP
-uU
+Jl
+wL
 Dr
 Dr
 XF
 lW
-Ie
-lI
-BH
+OP
+Gb
+To
 Dr
 Li
-no
+yS
 Li
 Dr
 Li
 Mm
-wz
-uS
+yr
+mW
 Uh
 Dr
 qX
@@ -39738,7 +39275,7 @@ ru
 tu
 Dr
 un
-wD
+NH
 Qj
 Dr
 kE
@@ -39746,16 +39283,16 @@ Li
 Li
 Li
 Li
-dh
+tA
 Dr
-Wq
+Pp
 Dr
 mI
-ZW
-ZW
-Tu
+gj
+gj
+sK
 Dr
-LS
+KE
 Dr
 Dr
 Dr
@@ -39764,20 +39301,20 @@ Dr
 Dr
 Dr
 ZH
-Mu
-gm
-UX
-oi
-yX
-WR
-WR
-WR
-yX
-Nr
+Zc
+On
+aT
+Zw
+iV
+pJ
+pJ
+pJ
+iV
 CR
-Pc
+zb
+Nr
 Ew
-kR
+Wq
 Dr
 qX
 mI
@@ -39988,50 +39525,50 @@ Dr
 Dr
 Dr
 Dr
-yY
+rF
 pa
 ru
 vH
-aT
+NX
 Dr
 qO
-Zw
+Xx
 ys
 Dr
-nm
-hZ
+IN
+mE
 Bm
-NH
-ZG
-fz
+dK
+cK
+vG
 Dr
-Wq
+Pp
 Dr
 Dr
-uy
-ZW
-uy
+no
+gj
+no
 Dr
-Wq
+Pp
 Li
-SF
+mQ
 Dr
 QX
 QX
 QX
 Dr
 Yf
-wD
-nQ
+NH
+er
 jW
 ei
 Dr
-NP
-cK
+Jl
+sI
 Li
 Dr
 lJ
-IA
+Vc
 Dr
 ZY
 Dr
@@ -40073,8 +39610,8 @@ mI
 mI
 mI
 Dr
-Ag
-Ag
+cN
+cN
 se
 se
 Dr
@@ -40242,7 +39779,7 @@ qX
 Dr
 MT
 WM
-Ur
+qJ
 NB
 Dr
 is
@@ -40252,26 +39789,26 @@ yD
 tu
 Dr
 Ep
-wD
-KR
-Dr
 NH
-hZ
-VL
+gw
+Dr
+dK
+mE
+dh
 Mh
 Li
 lb
 Dr
 hN
-WR
-yX
-nC
-nC
-nC
-nC
-QO
-no
-fe
+pJ
+iV
+QP
+QP
+QP
+QP
+Sj
+yS
+Yi
 Dr
 QX
 QX
@@ -40287,8 +39824,8 @@ Dr
 Dr
 Dr
 Dr
-TA
-PW
+uU
+Fe
 Dr
 cF
 QX
@@ -40330,10 +39867,10 @@ mI
 mI
 mI
 Dr
-Ag
-Ag
-Ag
-Ag
+cN
+cN
+cN
+cN
 Dr
 mI
 mI
@@ -40498,35 +40035,35 @@ mI
 qX
 Dr
 QQ
-Yz
+GI
 Li
 Ga
 Dr
-oM
+KG
 pa
 MS
-xY
+FE
 Dr
 Dr
-Sk
-wD
-uU
+zz
+NH
+wL
 Dr
 qv
 Li
-tR
+kB
 Wu
 Li
-IN
+Gi
 Dr
-cK
+sI
 Li
 Dr
 mI
 mI
 mI
 mI
-uU
+wL
 Li
 Li
 Dr
@@ -40536,10 +40073,10 @@ QX
 Dr
 FU
 IW
-Ie
+OP
 IW
-Gs
-CY
+xr
+Jw
 Dr
 mI
 mI
@@ -40547,7 +40084,7 @@ Dr
 mn
 mn
 Dr
-gx
+ms
 Dr
 Dr
 qX
@@ -40588,8 +40125,8 @@ nT
 nT
 Dr
 Dr
-Ag
-Ag
+cN
+cN
 Dr
 Dr
 mI
@@ -40756,7 +40293,7 @@ qX
 Dr
 Nq
 Li
-rW
+WR
 Li
 Li
 Li
@@ -40765,7 +40302,7 @@ uu
 Li
 Dr
 EQ
-nJ
+Nk
 Dr
 Dr
 Dr
@@ -40780,8 +40317,8 @@ Dr
 Rt
 Dr
 Dr
-uy
-Tu
+no
+sK
 mI
 Dr
 Dr
@@ -40793,10 +40330,10 @@ Dr
 Dr
 TO
 lW
-kz
+jZ
 Vw
 fR
-CY
+Jw
 Dr
 mI
 mI
@@ -40861,11 +40398,11 @@ mI
 mI
 mI
 mI
-yr
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
+kz
 mI
 mI
 mI
@@ -40990,7 +40527,7 @@ bu
 bu
 bu
 bu
-mI
+bu
 mI
 mI
 mI
@@ -41016,30 +40553,30 @@ Qc
 Ga
 Wu
 Dr
-xY
+GH
 hN
 fC
-PY
-WA
 pQ
-nJ
+WA
+rc
+Nk
 Dr
 Vw
 Vw
 Vw
 Vw
 Dr
-Jl
-wD
-gi
+Ld
+NH
+gx
 IW
 ff
 Vw
 mn
 nB
+Fp
 Ow
-nf
-uy
+no
 nB
 mn
 Vw
@@ -41048,9 +40585,9 @@ IW
 Vw
 IW
 IW
-dr
-oi
 ZJ
+Zw
+kV
 Vw
 mt
 Dr
@@ -41060,13 +40597,13 @@ sB
 sB
 sB
 sB
-Hr
-Hr
-yr
-yr
-yr
-yr
-yr
+mV
+mV
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 sB
@@ -41096,10 +40633,10 @@ nT
 sB
 sB
 sB
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
 nT
 nT
 nT
@@ -41117,12 +40654,12 @@ mI
 mI
 mI
 mI
-yr
-yr
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
+kz
+kz
 mI
 mI
 sB
@@ -41247,8 +40784,8 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
 mI
 mI
 mI
@@ -41273,12 +40810,12 @@ Dr
 Dr
 Dr
 Dr
-Ek
+Ie
 sM
-pJ
-wD
+TJ
+NH
 Dr
-wD
+NH
 Qj
 Dr
 Vw
@@ -41286,7 +40823,7 @@ lW
 lW
 Vw
 wY
-wD
+NH
 lW
 lW
 Vw
@@ -41299,32 +40836,32 @@ Do
 Do
 Do
 ri
-wD
+NH
 ff
 Vw
 lW
-pJ
-wD
-Ie
+TJ
+NH
+OP
 lW
 Dr
-ms
-vt
+CY
+Ia
 Dr
+cN
+cN
 vz
-vz
-vz
 sB
 sB
 sB
-Hr
-Hr
-Hr
-Hr
-yr
-yr
-yr
-yr
+mV
+mV
+mV
+mV
+kz
+kz
+kz
+kz
 sB
 sB
 sB
@@ -41353,12 +40890,12 @@ nT
 sB
 sB
 sB
-yr
-yr
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 sB
@@ -41376,13 +40913,13 @@ sB
 sB
 sB
 sB
-yr
-yr
-yr
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 sB
@@ -41504,8 +41041,8 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
 mI
 mI
 mI
@@ -41525,17 +41062,17 @@ qX
 qX
 qX
 Dr
-Qm
-Qm
-lU
-rn
+xX
+xX
+iX
+bN
 Dr
-mE
-ds
-TH
-VD
+SU
+Fo
+Ag
+qN
 Dr
-wD
+NH
 Qj
 Dr
 Vw
@@ -41550,17 +41087,17 @@ BI
 ff
 BI
 mn
-nf
-uy
-ek
+Ow
+no
+MB
 Do
 nB
 mn
-Fe
-WG
-Fe
-Fe
-Fe
+aA
+Cf
+aA
+aA
+aA
 BI
 ws
 Vw
@@ -41569,15 +41106,15 @@ Sv
 Ew
 Dr
 Dr
-vz
-vz
+cN
+cN
 sB
 sB
-yr
-yr
-yr
-Hr
-Hr
+kz
+kz
+kz
+mV
+mV
 nT
 nT
 sB
@@ -41596,9 +41133,9 @@ sB
 sB
 sB
 sB
-yr
-yr
-yr
+kz
+kz
+kz
 sB
 sB
 sB
@@ -41613,11 +41150,11 @@ sB
 sB
 sB
 sB
-yr
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 sB
@@ -41632,12 +41169,12 @@ sB
 sB
 sB
 sB
-yr
-yr
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 sB
@@ -41648,11 +41185,11 @@ sB
 sB
 sB
 sB
-yr
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
+kz
 mI
 mI
 mI
@@ -41761,8 +41298,8 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
 mI
 mI
 mI
@@ -41782,17 +41319,17 @@ qX
 mI
 qX
 Dr
-Zl
-hZ
-hZ
-MB
+Vs
+mE
+mE
+iY
 Dr
 Dr
 Dr
 Dr
 Dr
 Dr
-qW
+Sz
 Qj
 Dr
 Dr
@@ -41808,62 +41345,59 @@ Dr
 Dr
 Dr
 Dr
-et
-uy
-Tu
+mj
+no
+sK
 Dr
 Dr
 Dr
 Dr
 Dr
 Dr
-YZ
-VN
-kj
+XY
+SE
+Uc
 lW
 Dr
 Sv
 SH
 dX
-Rb
-vz
-vz
-nT
-Ag
-yr
-Ag
-sB
-vz
-sB
+TA
+cN
 vz
 nT
+cN
+kz
+cN
+sB
+vz
 sB
 vz
 nT
+sB
+vz
 nT
 nT
-vz
-sB
-vz
-sB
-sB
-sB
-vz
-sB
-vz
-yr
-Hr
-Hr
-Hr
-yr
-yr
-sB
+nT
 vz
 sB
 vz
 sB
 sB
 sB
+vz
+sB
+vz
+kz
+mV
+mV
+mV
+kz
+kz
+sB
+vz
+sB
+vz
 sB
 sB
 sB
@@ -41871,11 +41405,14 @@ sB
 sB
 sB
 sB
-yr
-yr
-yr
-yr
-Hr
+sB
+sB
+sB
+kz
+kz
+kz
+kz
+mV
 nT
 nT
 nT
@@ -41887,12 +41424,12 @@ sB
 sB
 sB
 sB
-yr
-yr
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 sB
@@ -41904,13 +41441,13 @@ nT
 nT
 nT
 nT
-mW
-yr
-yr
-yr
-yr
-yr
-yr
+lI
+kz
+kz
+kz
+kz
+kz
+kz
 nT
 nT
 sB
@@ -42018,8 +41555,8 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
 mI
 mI
 mI
@@ -42039,22 +41576,22 @@ qX
 qX
 qX
 Dr
-lU
-tA
-Fv
+iX
+Pc
+oI
 Li
 Dr
-uU
+wL
 Li
 Li
-cN
-rc
-TQ
+Zl
+HB
+Iz
 ys
 Dr
 dV
 dQ
-sz
+PK
 Qy
 Dr
 WI
@@ -42064,8 +41601,8 @@ Dr
 tt
 JC
 Dr
-iV
-ZW
+ip
+gj
 mI
 mI
 mI
@@ -42073,16 +41610,16 @@ qX
 qX
 qX
 Dr
-PI
-xQ
-LR
-zz
+Ig
+sP
+cV
+yX
 lW
 Dr
 Sv
 SH
 dX
-Nk
+Rb
 vz
 vz
 nT
@@ -42107,13 +41644,13 @@ sB
 sB
 sB
 sB
-Hr
-Hr
-Hr
-Hr
-Hr
-Hr
-yr
+mV
+mV
+mV
+mV
+mV
+mV
+kz
 sB
 sB
 sB
@@ -42164,15 +41701,15 @@ nT
 nT
 nT
 sB
-yr
-yr
-yr
+kz
+kz
+kz
 nT
 nT
 nT
-yr
-yr
-yr
+kz
+kz
+kz
 sB
 sB
 sB
@@ -42275,9 +41812,9 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
+bu
+bu
+bu
 mI
 mI
 mI
@@ -42296,21 +41833,21 @@ qX
 mI
 qX
 Dr
-Sj
-Bt
-Iz
-Bt
+Sm
+sZ
+SG
+sZ
 wH
 qf
-Bt
-Bt
-Bt
-ln
-wD
-no
+sZ
+sZ
+sZ
+HZ
+NH
+yS
 Dr
 oe
-cu
+SX
 kL
 Ww
 Dr
@@ -42319,7 +41856,7 @@ Vw
 hF
 Dr
 ZT
-YV
+qy
 Dr
 mI
 mI
@@ -42331,17 +41868,17 @@ mI
 qX
 Dr
 Dr
-Zi
+wD
 Dr
-kj
+Uc
 Vw
 Dr
 Sv
-dK
+Df
 Dr
 Dr
-Ag
-Ag
+cN
+cN
 nT
 nT
 nT
@@ -42363,12 +41900,12 @@ sB
 sB
 sB
 sB
-Hr
-Hr
-Hr
-Hr
-Hr
-Hr
+mV
+mV
+mV
+mV
+mV
+mV
 sB
 sB
 sB
@@ -42423,15 +41960,15 @@ nT
 sB
 sB
 sB
-yr
+kz
 nT
 nT
 nT
 sB
-yr
-yr
-Hr
-yr
+kz
+kz
+mV
+kz
 sB
 sB
 sB
@@ -42532,9 +42069,9 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
+bu
+bu
+bu
 mI
 mI
 mI
@@ -42553,17 +42090,17 @@ qX
 qX
 qX
 Dr
-xY
-no
-SF
-cN
+FE
+yS
+mQ
+Zl
 Dr
 Dr
 Dr
 Dr
 Dr
 Qj
-wD
+NH
 Dr
 Dr
 qt
@@ -42573,10 +42110,10 @@ Ml
 Dr
 TO
 lW
-wD
+NH
 wY
-wD
-fW
+NH
+kR
 Dr
 mI
 mI
@@ -42590,20 +42127,20 @@ Dr
 Dr
 Dr
 Dr
-kj
+Uc
 lW
 Dr
-ms
-vt
+CY
+Ia
 Dr
 vz
-Ag
-Ag
-Hr
-Hr
-Hr
-Hr
-Hr
+cN
+cN
+mV
+mV
+mV
+mV
+mV
 sB
 sB
 sB
@@ -42618,13 +42155,13 @@ sB
 sB
 sB
 sB
-Hr
-Hr
-Hr
-Hr
-Hr
-Hr
-yr
+mV
+mV
+mV
+mV
+mV
+mV
+kz
 sB
 sB
 sB
@@ -42657,9 +42194,9 @@ sB
 sB
 sB
 sB
-yr
-yr
-yr
+kz
+kz
+kz
 sB
 sB
 sB
@@ -42686,10 +42223,10 @@ nT
 nT
 sB
 sB
-yr
-Hr
-Hr
-Hr
+kz
+mV
+mV
+mV
 sB
 sB
 sB
@@ -42789,9 +42326,9 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
+bu
+bu
+bu
 mI
 mI
 mI
@@ -42819,9 +42356,9 @@ AI
 bY
 fI
 Dr
-wo
-TQ
-wA
+Zk
+Iz
+Ay
 wY
 eK
 eK
@@ -42830,7 +42367,7 @@ qb
 mn
 LM
 lW
-mJ
+EP
 Dr
 Dr
 Dr
@@ -42847,19 +42384,19 @@ qX
 qX
 qX
 Dr
-kj
+Uc
 Vw
 Vw
-wD
+NH
 mt
 Dr
 Dr
 nT
 nT
-Hr
-Hr
-Hr
-yr
+mV
+mV
+mV
+kz
 sB
 sB
 sB
@@ -42874,10 +42411,10 @@ sB
 sB
 sB
 sB
-yr
-Hr
-Ag
-Ag
+kz
+mV
+cN
+cN
 vz
 vz
 vz
@@ -42907,15 +42444,15 @@ sB
 sB
 sB
 sB
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
 sB
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
 sB
 sB
 nT
@@ -42943,10 +42480,10 @@ sB
 sB
 sB
 sB
-yr
-Hr
-Hr
-Hr
+kz
+mV
+mV
+mV
 sB
 sB
 sB
@@ -43046,10 +42583,10 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
 mI
 mI
 mI
@@ -43062,22 +42599,22 @@ qX
 qX
 Dr
 Dr
-EV
-sI
+nQ
+nJ
 ua
-lp
+dT
 Dr
 aR
-rX
+Ea
 wY
 Mz
 Rl
 AI
-Ig
+id
 fI
 Dr
 Li
-wD
+NH
 Qj
 Dr
 wJ
@@ -43086,8 +42623,8 @@ Jq
 eK
 Sd
 Vw
-Ql
-cl
+cY
+Bt
 Dr
 mI
 mI
@@ -43104,10 +42641,10 @@ mI
 mI
 qX
 Dr
-zz
-pJ
-pJ
-Mo
+yX
+TJ
+TJ
+ZB
 mt
 Li
 Dr
@@ -43167,12 +42704,12 @@ mI
 mI
 mI
 mI
-yr
-yr
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
+kz
+kz
 nT
 nT
 nT
@@ -43202,10 +42739,10 @@ mI
 mI
 mI
 mI
-Hr
-Hr
-Hr
-yr
+mV
+mV
+mV
+kz
 sB
 sB
 sB
@@ -43303,10 +42840,10 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
 mI
 mI
 mI
@@ -43318,11 +42855,11 @@ qX
 mI
 qX
 Dr
-xs
+kW
 HK
 Uk
 eJ
-TM
+oP
 Dr
 FZ
 aS
@@ -43333,8 +42870,8 @@ Fc
 Ex
 Fc
 Dr
-uU
-wD
+wL
+NH
 Qj
 Dr
 qz
@@ -43343,11 +42880,11 @@ Jq
 VR
 mn
 LM
-wD
-cl
+NH
+Bt
 Dr
-Tu
-PV
+sK
+oM
 mI
 mI
 mI
@@ -43361,11 +42898,11 @@ mI
 mI
 qX
 Dr
-Gb
-iH
-Kb
-BX
-Df
+GB
+ku
+lU
+eh
+IA
 Li
 Dr
 nT
@@ -43408,10 +42945,10 @@ nT
 nT
 nT
 nT
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
 sB
 sB
 sB
@@ -43424,15 +42961,15 @@ mI
 mI
 mI
 mI
-yr
-yr
-yr
-yr
-yr
-yr
-Hr
-Hr
-Hr
+kz
+kz
+kz
+kz
+kz
+kz
+mV
+mV
+mV
 sB
 sB
 sB
@@ -43560,10 +43097,10 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
 mI
 mI
 mI
@@ -43575,11 +43112,11 @@ qX
 qX
 qX
 Dr
-qP
+xs
 eJ
 Uk
 Uk
-np
+VL
 Dr
 jV
 sc
@@ -43590,8 +43127,8 @@ GP
 GP
 uT
 Dr
-NP
-wD
+Jl
+NH
 Ep
 Dr
 DY
@@ -43603,12 +43140,12 @@ WI
 WI
 WI
 Dr
-Ct
-GB
-Sw
+ie
+Qw
+WS
 mI
+sK
 Tu
-Qb
 mI
 mI
 mI
@@ -43618,9 +43155,9 @@ mI
 mI
 qX
 Dr
-Vp
-Am
-PW
+Mo
+KW
+Fe
 Ac
 Ac
 Dr
@@ -43663,13 +43200,13 @@ nT
 nT
 nT
 nT
-yr
-yr
-yr
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
+kz
+kz
+kz
 sB
 sB
 sB
@@ -43682,16 +43219,16 @@ mI
 mI
 mI
 mI
-yr
-yr
-yr
-yr
-yr
-yr
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
 mI
 mI
 mI
@@ -43817,10 +43354,10 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
 mI
 mI
 mI
@@ -43832,11 +43369,11 @@ qX
 Dr
 Dr
 Dr
-qP
+xs
 eJ
 VK
 Ah
-sp
+ZW
 Dr
 Ez
 Hp
@@ -43860,12 +43397,12 @@ TO
 Vw
 iK
 Dr
-Fj
-qJ
-BW
-BW
-PV
-cY
+NT
+te
+of
+of
+oM
+Wv
 mI
 mI
 mI
@@ -43916,16 +43453,16 @@ mI
 sB
 sB
 sB
-yr
-yr
-yr
-yr
-yr
-yr
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
+kz
 mI
 mI
 mI
@@ -43942,7 +43479,7 @@ mI
 mI
 mI
 mI
-yr
+kz
 mI
 mI
 mI
@@ -44076,8 +43613,8 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
 mI
 mI
 mI
@@ -44087,13 +43624,13 @@ qX
 qX
 qX
 Dr
-Ya
-HB
+ov
+jz
 HV
 eJ
 VK
 eJ
-RR
+fW
 Dr
 Dr
 Dr
@@ -44107,10 +43644,10 @@ Dr
 TW
 IW
 bH
-El
-kW
-gi
-gi
+BE
+lz
+gx
+gx
 ff
 IW
 Ni
@@ -44119,9 +43656,9 @@ iK
 mn
 nB
 nB
-qJ
-AW
-Jw
+te
+NP
+gm
 mI
 mI
 mI
@@ -44170,13 +43707,13 @@ mI
 mI
 mI
 mI
-yr
-yr
-yr
-yr
-yr
-yr
-yr
+kz
+kz
+kz
+kz
+kz
+kz
+kz
 mI
 mI
 mI
@@ -44333,8 +43870,8 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
 mI
 mI
 mI
@@ -44353,32 +43890,32 @@ eJ
 BJ
 QX
 QX
-sX
+Ts
 KZ
 hr
-Yi
+Os
 Rj
-lB
+dr
 Vw
 SJ
 Vw
-wD
-nJ
-wD
-pJ
+NH
+Nk
+NH
+TJ
 lW
 Vw
 ff
 Vw
 lW
 lW
-wD
+NH
 Sd
 nB
 nB
-qJ
-VH
-IS
+te
+cH
+Pu
 mI
 mI
 mI
@@ -44590,8 +44127,8 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
 mI
 mI
 mI
@@ -44612,15 +44149,15 @@ QX
 QX
 QX
 Dr
-wD
-WS
+NH
+VD
 Mk
-wD
+NH
 Ch
 Dr
 nw
 BI
-fr
+zr
 BI
 BI
 BI
@@ -44628,12 +44165,12 @@ BI
 ff
 BI
 EJ
-wD
+NH
 bj
 mn
 nB
 nB
-Zu
+Gs
 tS
 mI
 mI
@@ -44847,7 +44384,7 @@ bu
 bu
 bu
 bu
-mI
+bu
 mI
 mI
 mI
@@ -44858,12 +44395,12 @@ qX
 qX
 qX
 Dr
-NX
+Ya
 pd
 HV
 OI
-sP
-Rv
+PV
+vt
 BJ
 QX
 iO
@@ -44877,7 +44414,7 @@ Dr
 Dr
 Dr
 Dr
-fr
+zr
 wS
 Dr
 Dr
@@ -44888,9 +44425,9 @@ Dr
 Su
 Dr
 Dr
-qJ
-Zk
-Zk
+te
+he
+he
 mI
 mI
 mI
@@ -45104,7 +44641,7 @@ bu
 bu
 bu
 bu
-mI
+bu
 mI
 mI
 mI
@@ -45118,28 +44655,28 @@ Dr
 Dr
 Dr
 HV
+xM
 yq
-FS
-KW
+eA
 BJ
 QX
-eA
+Sx
 Dr
 pn
-iX
+NA
 Dr
 Ks
 Vw
-cV
-Dv
+RR
+pB
 EI
 Dr
-fr
+zr
 Tj
 Dr
 ng
-Oy
-FE
+xf
+Vx
 Dr
 aY
 Vw
@@ -45380,15 +44917,15 @@ Uk
 Ah
 BJ
 QX
-Ts
+lo
 Dr
 cx
-NA
+YZ
 Dr
 HU
 lW
-pJ
-pJ
+TJ
+TJ
 Vw
 Dr
 kI
@@ -45396,7 +44933,7 @@ Dr
 Dr
 Vw
 KS
-xr
+xQ
 Dr
 Tc
 Vw
@@ -45637,29 +45174,29 @@ VK
 eJ
 Wt
 QX
-sX
+Ts
 KZ
 xJ
 YU
 Dr
 Wk
-wD
+NH
 Oo
 Oo
 Oo
 Dr
 Qj
-uU
+wL
 Dr
-wD
-pJ
+NH
+TJ
 Vw
 wY
 Vw
 Vw
 qq
 Dr
-px
+fG
 vq
 lv
 Dr
@@ -45889,34 +45426,34 @@ qX
 qX
 Dr
 GF
-bx
-RE
+TQ
+nC
 WB
-Vc
-ZL
-Sx
+Ke
+XP
+qP
 Dr
 Dr
 Dr
 Dr
-JD
-eB
+pV
+fM
 mO
 gp
 uD
 Dr
-Uu
-cN
+BW
+Zl
 Dr
 FB
-wD
+NH
 sN
 Dr
 Tc
 lW
 Vw
 wY
-iX
+NA
 KL
 pw
 Dr
@@ -46156,20 +45693,20 @@ Dr
 Dr
 Dr
 pt
-xM
-To
-eB
-eB
-pV
+wo
+UX
+fM
+fM
+np
 Dr
-KI
-Cz
-Dr
-Dr
+VY
+rn
 Dr
 Dr
 Dr
-tz
+Dr
+Dr
+PL
 lW
 GM
 Dr
@@ -46413,26 +45950,26 @@ qX
 qX
 Dr
 uv
-XP
-BK
-BK
-oP
-oP
+oH
+RE
+RE
+xY
+xY
 wH
-bL
-iF
+kg
+QM
 wH
-ip
+fe
 qF
-iY
-CZ
-Cd
+BK
+kj
+yl
 yy
 mX
 Dr
 vM
 Vw
-gw
+WG
 Dr
 qX
 mI
@@ -46670,14 +46207,14 @@ mI
 qX
 Dr
 WD
-eB
+fM
 Un
-Xz
+Up
 vJ
-pB
+nf
 Dr
-bN
-Br
+Yz
+xZ
 Dr
 od
 Dr
@@ -46689,7 +46226,7 @@ Vw
 wY
 Vw
 IF
-Jj
+Xz
 Dr
 qX
 mI
@@ -46942,11 +46479,11 @@ XI
 lW
 xE
 Vw
-VY
+sO
 Dr
-wD
-HZ
-zb
+NH
+oK
+fr
 Dr
 qX
 mI
@@ -47188,18 +46725,18 @@ qX
 Dr
 sC
 IU
-BE
+gM
 Dr
-HA
+sz
 eP
 Ne
 Dr
 Dr
 Wn
 Vw
-SX
+El
 Vw
-MY
+Zi
 Dr
 Nf
 bc
@@ -47444,12 +46981,12 @@ mI
 qX
 Dr
 ZR
-Ia
+CZ
 Ne
 ri
-kB
-fk
-Jx
+wX
+eB
+TH
 Dr
 Dr
 Dr
@@ -47704,18 +47241,18 @@ gO
 Tb
 Gc
 TN
-KG
-nu
+hZ
+Jx
 oz
 Dr
 Gn
-sO
+xH
 Vw
 Dr
 Vw
 Vw
-wX
-Wv
+vc
+gi
 Dr
 qX
 qX
@@ -47958,21 +47495,21 @@ mI
 qX
 Dr
 Se
-eH
+Ur
 sh
 Dr
 eq
-Vd
-QP
+PY
+Sk
 Dr
-wD
-pJ
-wD
+NH
+TJ
+NH
 Dr
 Uf
 lW
-pJ
-qy
+TJ
+sX
 Dr
 qX
 mI
@@ -48224,11 +47761,11 @@ Dr
 Dr
 ng
 lW
-PL
+Qe
 Dr
 vI
 KD
-Fk
+YV
 Rl
 Dr
 qX
@@ -48443,8 +47980,8 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
 mI
 mI
 mI
@@ -48480,7 +48017,7 @@ qX
 qX
 Dr
 Vb
-Gk
+Bz
 aa
 Dr
 nl
@@ -48700,8 +48237,8 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
 mI
 mI
 mI
@@ -48958,8 +48495,8 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
 mI
 mI
 mI
@@ -49215,8 +48752,8 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
 mI
 mI
 mI
@@ -49472,9 +49009,9 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
+bu
+bu
+bu
 mI
 mI
 mI
@@ -49731,8 +49268,8 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
 mI
 mI
 mI
@@ -49988,9 +49525,9 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
+bu
+bu
+bu
 mI
 mI
 mI
@@ -50245,6 +49782,10 @@ bu
 bu
 bu
 bu
+bu
+bu
+bu
+bu
 mI
 mI
 mI
@@ -50285,13 +49826,9 @@ mI
 mI
 mI
 mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
 mI
 mI
 mI
@@ -50502,6 +50039,13 @@ bu
 bu
 bu
 bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 mI
 mI
 mI
@@ -50542,13 +50086,6 @@ mI
 mI
 mI
 mI
-Vx
-XY
-Ke
-Ke
-bQ
-OP
-OP
 mI
 mI
 mI
@@ -50759,6 +50296,18 @@ bu
 bu
 bu
 bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 mI
 mI
 mI
@@ -50794,18 +50343,6 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-Ke
-Ke
-Ke
-Ke
-Ke
-DT
-OP
 mI
 mI
 mI
@@ -51016,6 +50553,20 @@ bu
 bu
 bu
 bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 mI
 mI
 mI
@@ -51056,28 +50607,14 @@ mI
 mI
 mI
 mI
-Ke
-Ke
-Ke
-sZ
-Ke
-Ke
-OP
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -51273,65 +50810,6 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-OP
-OP
-OP
-OP
-wL
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-wL
-OP
-OP
-oI
-OP
-OP
-wL
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-mI
-mI
-mI
 bu
 bu
 bu
@@ -51339,6 +50817,65 @@ bu
 bu
 bu
 bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -51530,65 +51067,17 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-OP
-OP
-ov
-eJ
-gM
-eJ
-ov
-OP
-OP
-vG
-Zc
-eE
-OP
-OP
-eJ
-gM
-ov
-OP
-OP
-OP
-ov
-gM
-eJ
-OP
-OP
-OP
-rN
-rN
-rN
-rN
-OP
-OP
-OP
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -51597,6 +51086,54 @@ bu
 bu
 bu
 mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+sB
+sB
+sB
+sB
+sB
+sB
+bu
+bu
+bu
+bu
+bu
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -51787,65 +51324,19 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-OP
-eJ
-fM
-oH
-gM
-gM
-fM
-OP
-Os
-gM
-xH
-gM
-eJ
-OP
-eJ
-gM
-fM
-Yp
-OP
-er
-eJ
-gM
-eJ
-eJ
-OP
-Sm
-gM
-gM
-gM
-GI
-te
-vR
-OP
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -51854,6 +51345,52 @@ bu
 bu
 bu
 mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+sB
+sB
+sB
+sB
+sB
+sB
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+sB
+sB
+sB
 mI
 mI
 mI
@@ -52044,65 +51581,20 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-OP
-gM
-gM
-gM
-gM
-gM
-gM
-Cf
-gM
-gM
-gM
-gM
-gM
-Cf
-gM
-gM
-gM
-eJ
-Cf
-eJ
-gM
-dT
-gM
-fM
-OP
-gM
-gM
-gM
-gM
-gM
-eJ
-fG
-OP
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -52111,6 +51603,51 @@ bu
 bu
 bu
 mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+sB
+sB
+sB
+sB
+sB
+sB
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+sB
+sB
 mI
 mI
 mI
@@ -52301,6 +51838,28 @@ bu
 bu
 bu
 bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 mI
 mI
 mI
@@ -52322,41 +51881,6 @@ mI
 mI
 mI
 mI
-mI
-mI
-OP
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-QE
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-OP
-gM
-gM
-Qw
-gM
-gM
-gM
-Bz
-QX
 mI
 mI
 mI
@@ -52367,8 +51891,21 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 mI
 mI
 mI
@@ -52558,6 +52095,29 @@ bu
 bu
 bu
 bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 mI
 mI
 mI
@@ -52577,43 +52137,6 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-OP
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-dT
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-vc
-gM
-gM
-zr
-gM
-gM
-gM
-gM
-QX
 mI
 mI
 mI
@@ -52626,8 +52149,22 @@ bu
 bu
 bu
 bu
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 mI
 mI
 bu
@@ -52815,6 +52352,31 @@ bu
 bu
 bu
 bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 mI
 mI
 mI
@@ -52833,47 +52395,22 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-OP
-gM
-gM
-gM
-Fp
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-gM
-yS
-gM
-gM
-gM
-OP
-aJ
-gM
-Qw
-gM
-gM
-eJ
-eJ
-OP
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -53072,6 +52609,35 @@ bu
 bu
 bu
 bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+mI
+bu
+bu
 mI
 mI
 mI
@@ -53085,52 +52651,23 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-OP
-gM
-gM
-gM
-gM
-gM
-gM
-SG
-gM
-jz
-gM
-gM
-gM
-xZ
-gM
-gM
-gM
-eJ
-SG
-Pp
-gM
-gM
-gM
-Pu
-OP
-gM
-gM
-gM
-gM
-gM
-PK
-xX
-OP
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -53329,6 +52866,36 @@ bu
 bu
 bu
 bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 mI
 mI
 mI
@@ -53338,56 +52905,26 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-OP
-eJ
-Pp
-gM
-gM
-gM
-eJ
-OP
-Uc
-gM
-lo
-gM
-eJ
-OP
-fM
-gM
-eJ
-gj
-OP
-eJ
-fM
-gM
-eJ
-eJ
-OP
-NT
-gM
-gM
-gM
-eJ
-OP
-OP
-OP
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -53586,65 +53123,65 @@ bu
 bu
 bu
 bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-OP
-OP
-QM
-eJ
-gM
-eJ
-mV
-OP
-OP
-Ay
-he
-EP
-OP
-OP
-ie
-gM
-QM
-OP
-OP
-OP
-QM
-gM
-eJ
-OP
-OP
-OP
-rN
-rN
-rN
-rN
-OP
-OP
-OP
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -53679,7 +53216,7 @@ sB
 sB
 sB
 sB
-mI
+sB
 mI
 mI
 mI
@@ -53843,65 +53380,65 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-OP
-OP
-OP
-OP
-wL
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-wL
-OP
-OP
-of
-OP
-OP
-wL
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -54100,65 +53637,65 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-OP
-OP
-OP
-aA
-jv
-PR
-jZ
-OP
-xf
-Ke
-bQ
-Ke
-Ke
-OP
-Ke
-Ke
-Fo
-Ke
-Ke
-Ke
-Ke
-Ke
-Ke
-OP
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -54357,65 +53894,65 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-OP
-id
-Ke
-Ke
-Ke
-rF
-Ke
-Ke
-Ke
-Ke
-Ke
-rF
-Ke
-Ke
-Ke
-Ke
-Ke
-Ke
-Ke
-Ke
-kV
-OP
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -54614,65 +54151,65 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-OP
-Ea
-DT
-eh
-On
-OP
-sK
-Ke
-Ke
-mj
-Sz
-OP
-OP
-bQ
-Ke
-bQ
-SU
-kg
-sZ
-TY
-OP
-OP
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -54871,65 +54408,65 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -55128,65 +54665,65 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -55385,65 +54922,65 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -55642,65 +55179,65 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -55899,65 +55436,65 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -56156,65 +55693,65 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -56413,65 +55950,65 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -56670,65 +56207,65 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -56927,65 +56464,65 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu

--- a/maps/away/away_site/goon_base/goon_base.dmm
+++ b/maps/away/away_site/goon_base/goon_base.dmm
@@ -53,6 +53,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/alarm/north,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_north)
 "av" = (
@@ -324,6 +325,7 @@
 	pixel_x = -5;
 	pixel_y = 2
 	},
+/obj/machinery/alarm/west,
 /turf/simulated/floor/carpet/red,
 /area/goonbase/living)
 "cb" = (
@@ -340,6 +342,7 @@
 "ch" = (
 /obj/random/pottedplant,
 /obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/machinery/alarm/north,
 /turf/simulated/floor/tiled,
 /area/goonbase/hallway_north)
 "cm" = (
@@ -859,6 +862,7 @@
 "eP" = (
 /obj/item/trash/tray,
 /obj/random/dirt_75,
+/obj/machinery/alarm/west,
 /turf/simulated/floor/tiled/freezer,
 /area/goonbase/kitchen)
 "eS" = (
@@ -1311,6 +1315,11 @@
 	},
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/hallway_north)
+"hd" = (
+/obj/random/dirt_75,
+/obj/machinery/alarm/west,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_airlock)
 "he" = (
 /obj/structure/reagent_dispensers/coolanttank,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1499,6 +1508,7 @@
 	pixel_x = -9;
 	pixel_y = 5
 	},
+/obj/machinery/alarm/north,
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/hallway_north)
 "if" = (
@@ -1779,6 +1789,7 @@
 	pixel_y = -13;
 	pixel_x = 11
 	},
+/obj/machinery/alarm/north,
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
 "jW" = (
@@ -2051,6 +2062,7 @@
 /obj/item/ammo_magazine/c762,
 /obj/item/ammo_magazine/c762,
 /obj/item/gun/projectile/automatic/rifle/sts35,
+/obj/machinery/alarm/north,
 /turf/simulated/floor/tiled/dark,
 /area/goonbase/equipment)
 "kZ" = (
@@ -2186,6 +2198,7 @@
 	dir = 4
 	},
 /obj/random/dirt_75,
+/obj/machinery/alarm/north,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_airlock)
 "lK" = (
@@ -2837,6 +2850,13 @@
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_shuttle/med)
+"ps" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/machinery/alarm/east,
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "pt" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/sink/kitchen{
@@ -3096,6 +3116,7 @@
 	pixel_x = -12
 	},
 /obj/random/dirt_75,
+/obj/machinery/alarm/north,
 /turf/simulated/floor/tiled/white,
 /area/goonbase/medbay)
 "qC" = (
@@ -3481,6 +3502,7 @@
 "sT" = (
 /obj/structure/bed/stool/chair/office/dark,
 /obj/random/dirt_75,
+/obj/machinery/alarm/north,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_south)
 "sX" = (
@@ -3636,6 +3658,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/maint_south)
+"uj" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
+	},
+/obj/machinery/alarm/west,
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "um" = (
 /obj/structure/reagent_dispensers/radioactive_waste{
 	pixel_x = 12;
@@ -3747,6 +3776,14 @@
 /obj/random/dirt_75,
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
+"uQ" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/random/dirt_75,
+/obj/machinery/alarm/east,
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_south)
 "uT" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
@@ -4189,6 +4226,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/alarm/west,
 /turf/simulated/floor/tiled,
 /area/goonbase/hallway_south)
 "xz" = (
@@ -4310,6 +4348,7 @@
 /obj/structure/reagent_dispensers/keg/beerkeg/rice,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/alarm/east,
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_north)
 "yb" = (
@@ -4854,6 +4893,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/machinery/alarm/north,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_south)
 "Bt" = (
@@ -5210,6 +5250,14 @@
 /obj/item/storage/box/fancy/cigarettes,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_shuttle/living)
+"DP" = (
+/obj/structure/trash_pile,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/machinery/alarm/north,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_north)
 "DR" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -5481,6 +5529,11 @@
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_shuttle/port)
+"FG" = (
+/obj/random/dirt_75,
+/obj/machinery/alarm/north,
+/turf/simulated/floor/tiled,
+/area/goonbase/living)
 "FL" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 6
@@ -5936,6 +5989,7 @@
 	pixel_x = 5
 	},
 /obj/item/reagent_containers/food/drinks/bottle/small/beer/light,
+/obj/machinery/alarm/north,
 /turf/simulated/floor/tiled,
 /area/goonbase/kitchen)
 "HV" = (
@@ -6015,6 +6069,7 @@
 /obj/structure/table/steel,
 /obj/random/dirt_75,
 /obj/random/hardhat,
+/obj/machinery/alarm/north,
 /turf/simulated/floor/tiled,
 /area/goonbase/atmos)
 "Ig" = (
@@ -6136,6 +6191,11 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/goonbase/power)
+"IT" = (
+/obj/random/dirt_75,
+/obj/machinery/alarm/south,
+/turf/simulated/floor/tiled,
+/area/goonbase/living)
 "IU" = (
 /turf/simulated/floor/tiled/freezer,
 /area/goonbase/kitchen)
@@ -6181,6 +6241,10 @@
 	},
 /turf/unsimulated/floor/asteroid/ash,
 /area/mine)
+"Jd" = (
+/obj/machinery/alarm/north,
+/turf/simulated/floor/tiled,
+/area/goonbase/living)
 "Jf" = (
 /obj/structure/table/steel,
 /obj/item/storage/firstaid/combat{
@@ -6495,6 +6559,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/alarm/north,
 /turf/simulated/floor/tiled,
 /area/goonbase/hallway_south)
 "KG" = (
@@ -7617,6 +7682,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/machinery/alarm/west,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_north)
 "QS" = (
@@ -7649,6 +7715,14 @@
 "QX" = (
 /turf/simulated/floor/plating,
 /area/goonbase/equipment)
+"QY" = (
+/obj/structure/structural_support{
+	pixel_y = 8
+	},
+/obj/random/dirt_75,
+/obj/machinery/alarm/south,
+/turf/simulated/floor/plating/asteroid,
+/area/goonbase/maint_south)
 "Rb" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -7736,6 +7810,7 @@
 /obj/item/weldingtool{
 	pixel_y = 4
 	},
+/obj/machinery/alarm/north,
 /turf/simulated/floor/tiled,
 /area/goonbase/power)
 "Rx" = (
@@ -7784,6 +7859,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/goonbase/kitchen)
+"RK" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/alarm/north,
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "RL" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid{
@@ -7827,6 +7909,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/alarm/east,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_north)
 "RZ" = (
@@ -8218,6 +8301,7 @@
 /obj/random/dirt_75,
 /obj/item/melee/energy/sword/pirate/generic,
 /obj/item/clothing/head/bandana/red,
+/obj/machinery/alarm/north,
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
 "Uh" = (
@@ -8590,6 +8674,7 @@
 /obj/item/clothing/head/bandana/colorable/random,
 /obj/item/clothing/head/beanie/random,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm/north,
 /turf/simulated/floor/tiled/full,
 /area/goonbase/living)
 "Wq" = (
@@ -8950,6 +9035,14 @@
 /obj/item/clothing/ears/earmuffs,
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/hallway_north)
+"XX" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
+	},
+/obj/random/dirt_75,
+/obj/machinery/alarm/west,
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "XY" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -8980,6 +9073,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/alarm/east,
 /turf/simulated/floor/tiled,
 /area/goonbase/eva)
 "Yh" = (
@@ -9354,6 +9448,7 @@
 /obj/item/reagent_containers/food/snacks/koisbar_clean{
 	pixel_x = 8
 	},
+/obj/machinery/alarm/north,
 /turf/simulated/floor/tiled/freezer,
 /area/goonbase/kitchen)
 "ZS" = (
@@ -41608,7 +41703,7 @@ pz
 BH
 kk
 UG
-GV
+hd
 cu
 kk
 Fb
@@ -42105,7 +42200,7 @@ yC
 mI
 Xa
 gj
-sK
+QY
 Gv
 KE
 Gv
@@ -43384,7 +43479,7 @@ Ql
 Ld
 Gh
 Vq
-BC
+uj
 ff
 Vw
 mn
@@ -43900,7 +43995,7 @@ jP
 vZ
 BI
 ff
-BI
+ps
 mn
 Ow
 rY
@@ -43908,7 +44003,7 @@ MB
 OS
 hE
 Rn
-aA
+uQ
 Cf
 aA
 aA
@@ -44391,7 +44486,7 @@ qX
 qX
 qX
 SL
-iX
+DP
 Pc
 oI
 jY
@@ -44923,7 +45018,7 @@ lK
 kL
 Ml
 fl
-dH
+RK
 vk
 vd
 Tn
@@ -46461,7 +46556,7 @@ BC
 bH
 nt
 lz
-gx
+XX
 gx
 ff
 BC
@@ -47746,7 +47841,7 @@ WH
 MI
 Ql
 jH
-yk
+Jd
 KS
 xQ
 jH
@@ -49296,7 +49391,7 @@ xE
 yk
 sO
 jH
-NH
+FG
 xL
 fr
 jH
@@ -50319,7 +50414,7 @@ Sk
 jH
 NH
 Lw
-NH
+IT
 jH
 Uf
 lA

--- a/maps/away/away_site/goon_base/goon_base.dmm
+++ b/maps/away/away_site/goon_base/goon_base.dmm
@@ -50,6 +50,24 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
+"aF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"aG" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "aI" = (
 /obj/item/reagent_containers/glass/bucket/wood{
 	pixel_y = -7
@@ -65,6 +83,9 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/random/tech_supply{
+	pixel_x = 15
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "aL" = (
@@ -109,6 +130,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "aY" = (
@@ -316,6 +340,16 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
+"di" = (
+/obj/effect/floor_decal/corner/grey/full{
+	dir = 8
+	},
+/obj/machinery/power/apc/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "dr" = (
 /obj/random/tech_supply{
 	pixel_x = -9;
@@ -456,6 +490,12 @@
 	dir = 4
 	},
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "eu" = (
@@ -463,6 +503,9 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/item/tank/oxygen/red{
+	pixel_x = -2
+	},
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "eA" = (
@@ -660,6 +703,9 @@
 	dir = 10
 	},
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "fG" = (
@@ -950,7 +996,18 @@
 	dir = 10
 	},
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
+/area/mine)
+"hO" = (
+/obj/random/dirt_75,
+/obj/item/tank/emergency_oxygen/double{
+	pixel_y = -2;
+	pixel_x = 3
+	},
+/turf/simulated/floor/plating/asteroid,
 /area/mine)
 "hS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -958,6 +1015,9 @@
 	},
 /obj/random/dirt_75,
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "hV" = (
@@ -1037,6 +1097,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
+"im" = (
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
+/area/mine)
 "ip" = (
 /obj/structure/structural_support{
 	pixel_y = 8
@@ -1082,6 +1149,10 @@
 /obj/item/trash/chips,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"iC" = (
+/obj/machinery/photocopier,
+/turf/simulated/floor/tiled,
+/area/mine)
 "iK" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
@@ -1107,6 +1178,9 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "iW" = (
@@ -1567,6 +1641,12 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
+"lB" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/machinery/power/portgen/basic,
+/turf/simulated/floor/plating,
+/area/mine)
 "lI" = (
 /obj/item/storage/toolbox/emergency{
 	pixel_x = -11;
@@ -1625,6 +1705,10 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"mc" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/full,
+/area/mine)
 "mf" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/storage/toggle/brown_jacket/sleeveless,
@@ -1635,11 +1719,7 @@
 "mg" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/item/tank/emergency_oxygen/double{
-	pixel_y = -2;
-	pixel_x = 3
-	},
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/mineral/surface,
 /area/mine)
 "mj" = (
 /obj/random/dirt_75,
@@ -1651,6 +1731,17 @@
 /area/mine)
 "mn" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/turf/simulated/floor/plating,
+/area/mine)
+"mo" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "ms" = (
@@ -1682,6 +1773,12 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
+"mC" = (
+/obj/structure/bed/stool/chair/office/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "mE" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -2176,6 +2273,9 @@
 "pJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "pN" = (
@@ -2188,6 +2288,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "pT" = (
@@ -2295,29 +2398,19 @@
 "qv" = (
 /obj/structure/closet/crate,
 /obj/item/coin/diamond,
-/obj/item/clothing/wrists/goldbracer,
-/obj/item/clothing/wrists/armchain,
-/obj/item/clothing/wrists/goldbracer/emerald,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/clothing/wrists/watch/gold,
 /obj/item/flame/lighter/zippo/gold,
-/obj/item/stack/material/phoron/full,
 /obj/item/coin/gold,
-/obj/item/gun/projectile/automatic/rifle/dpra/gold,
 /obj/random/dirt_75,
 /obj/random/highvalue/no_weapon,
 /obj/item/clothing/accessory/crucifix/gold,
 /obj/random/melee/highvalue,
-/obj/item/clothing/wrists/armchain,
 /turf/simulated/floor/plating,
 /area/mine)
 "qw" = (
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/item/tank/oxygen/red{
-	pixel_x = -2
-	},
-/turf/simulated/floor/exoplanet/barren,
+/obj/effect/floor_decal/corner/pink/diagonal,
+/turf/simulated/floor/tiled,
 /area/mine)
 "qy" = (
 /obj/effect/floor_decal/corner/purple{
@@ -2415,6 +2508,10 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/north,
 /turf/simulated/floor/plating,
 /area/mine)
 "qP" = (
@@ -2446,6 +2543,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "ri" = (
@@ -2499,7 +2599,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/full,
+/area/mine)
+"rP" = (
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/north,
+/turf/simulated/floor/plating,
 /area/mine)
 "rU" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -2619,6 +2730,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
+"sR" = (
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "sX" = (
 /obj/structure/closet/crate,
 /obj/random/spacecash,
@@ -2635,6 +2753,10 @@
 "sY" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/item/pickaxe/drill{
+	pixel_y = 10;
+	pixel_x = 9
+	},
 /turf/simulated/floor/plating/asteroid,
 /area/mine)
 "sZ" = (
@@ -2730,6 +2852,15 @@
 	},
 /turf/simulated/floor/plating/asteroid,
 /area/mine)
+"tV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "ua" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -2767,8 +2898,11 @@
 /area/mine)
 "uy" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/reagent_dispensers/coolanttank,
 /obj/random/dirt_75,
+/obj/machinery/power/apc/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "uB" = (
@@ -2796,6 +2930,13 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
+/area/mine)
+"uN" = (
+/obj/structure/table/standard,
+/obj/item/modular_computer/laptop/preset/civilian{
+	pixel_y = 9
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "uT" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
@@ -3402,6 +3543,14 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
+"zA" = (
+/obj/structure/table/standard,
+/obj/item/modular_computer/handheld/pda/civilian{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "zB" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -3480,8 +3629,8 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/random/tech_supply{
-	pixel_x = 15
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -3613,6 +3762,9 @@
 	dir = 6
 	},
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Bt" = (
@@ -3704,6 +3856,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Cf" = (
@@ -3736,6 +3891,9 @@
 /obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "CR" = (
@@ -3743,6 +3901,9 @@
 	dir = 5
 	},
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "CS" = (
@@ -3914,6 +4075,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
+"EB" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	layer = 5;
+	name = "adjusted reinforced window";
+	pixel_y = -6
+	},
+/obj/item/clothing/accessory/crucifix/gold{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/clothing/wrists/watch/gold{
+	pixel_x = 5
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "EE" = (
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/mechanical,
@@ -3946,6 +4127,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "EZ" = (
@@ -4017,6 +4201,9 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "FE" = (
@@ -4207,6 +4394,10 @@
 /obj/machinery/vending/engineering{
 	req_access = null
 	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/north,
 /turf/simulated/floor/plating,
 /area/mine)
 "GI" = (
@@ -4242,6 +4433,24 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood,
+/area/mine)
+"GT" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/window/reinforced{
+	layer = 5;
+	name = "adjusted reinforced window";
+	pixel_y = -6
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/stack/material/phoron/full,
+/obj/item/stack/material/phoron{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "GY" = (
 /obj/effect/overmap/visitable/ship/landable/goon_ship,
@@ -4349,6 +4558,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
+"HP" = (
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "HU" = (
 /obj/structure/closet/cabinet{
 	pixel_y = 0
@@ -4443,6 +4659,14 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
+/area/mine)
+"It" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "Iz" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -4678,6 +4902,9 @@
 "KB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "KD" = (
@@ -4698,6 +4925,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/mine)
@@ -4801,10 +5031,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
+"LN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/mine)
 "LY" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/power/portgen/basic,
 /obj/random/dirt_75,
+/obj/structure/reagent_dispensers/coolanttank,
 /turf/simulated/floor/plating,
 /area/mine)
 "Mh" = (
@@ -4976,13 +5213,16 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "Nh" = (
-/obj/item/pickaxe/drill{
-	pixel_y = 10;
-	pixel_x = 9
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/floor/plating/asteroid,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/gun/projectile/automatic/rifle/dpra/gold,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Ni" = (
 /obj/effect/floor_decal/corner/grey{
@@ -5020,6 +5260,10 @@
 "Nt" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/random/dirt_75,
+/obj/structure/table/steel,
+/obj/random/tool{
+	pixel_y = 9
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "NA" = (
@@ -5084,6 +5328,12 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/full,
 /area/mine)
 "Oo" = (
@@ -5169,6 +5419,13 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
+"OY" = (
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "Pc" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -5177,6 +5434,10 @@
 	pixel_y = -8
 	},
 /turf/simulated/floor/plating,
+/area/mine)
+"Pe" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "Pk" = (
 /obj/effect/overmap/visitable/sector/goon,
@@ -5187,6 +5448,9 @@
 	dir = 4
 	},
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Pu" = (
@@ -5195,11 +5459,16 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
+"Pw" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/mine)
 "PA" = (
 /obj/random/dirt_75,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/mineral/surface,
 /area/mine)
 "PC" = (
 /obj/machinery/bodyscanner,
@@ -5422,6 +5691,9 @@
 "QP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating/asteroid,
 /area/mine)
 "QQ" = (
@@ -5529,6 +5801,28 @@
 /obj/item/trash/can,
 /turf/simulated/floor/tiled,
 /area/mine)
+"RS" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/wrists/goldbracer/ruby{
+	pixel_y = -6
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/clothing/wrists/armchain/emerald{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/clothing/wrists/armchain{
+	pixel_y = 3;
+	pixel_x = -4
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "Sd" = (
 /obj/machinery/door/airlock/glass,
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -5575,6 +5869,9 @@
 	dir = 9
 	},
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Sk" = (
@@ -5682,6 +5979,9 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "SU" = (
@@ -5782,6 +6082,10 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
+"TC" = (
+/obj/machinery/papershredder,
 /turf/simulated/floor/plating,
 /area/mine)
 "TH" = (
@@ -6012,9 +6316,13 @@
 /area/mine)
 "Vx" = (
 /obj/structure/table/steel,
-/obj/item/towel/random{
-	pixel_x = 6;
-	pixel_y = 2
+/obj/item/storage/box/fancy/chocolate_box{
+	pixel_x = -2;
+	pixel_y = 14
+	},
+/obj/item/storage/box/fancy/chips/variety{
+	pixel_x = 17;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -6161,6 +6469,9 @@
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "WB" = (
@@ -6177,9 +6488,13 @@
 /area/mine)
 "WG" = (
 /obj/structure/table/steel,
+/obj/item/towel/random{
+	pixel_x = 12;
+	pixel_y = 10
+	},
 /obj/item/device/hand_labeler{
-	pixel_x = -1;
-	pixel_y = 3
+	pixel_x = -5;
+	pixel_y = 1
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -6290,6 +6605,16 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
+"Xy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "Xz" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
@@ -6397,6 +6722,10 @@
 	dir = 5
 	},
 /obj/random/dirt_75,
+/obj/machinery/power/apc/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "Yh" = (
@@ -6415,6 +6744,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "Yt" = (
@@ -6575,6 +6907,8 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "ZH" = (
@@ -27718,7 +28052,7 @@ mI
 mI
 mI
 mI
-bu
+sB
 bu
 bu
 bu
@@ -27975,7 +28309,7 @@ mI
 mI
 mI
 mI
-bu
+sB
 bu
 bu
 bu
@@ -28232,14 +28566,14 @@ mI
 mI
 mI
 mI
+sB
+sB
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
 bu
 bu
 bu
@@ -28489,14 +28823,14 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
 mI
 mI
 bu
@@ -28746,12 +29080,12 @@ bu
 mI
 mI
 bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 mI
 mI
@@ -29004,10 +29338,10 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
 bu
 bu
 mI
@@ -29263,8 +29597,8 @@ bu
 bu
 bu
 bu
-bu
-bu
+sB
+sB
 bu
 mI
 mI
@@ -38080,11 +38414,11 @@ mI
 qX
 Dr
 Rv
-oK
+It
 Au
 FD
 SM
-Ep
+mo
 ZL
 zU
 dY
@@ -38337,8 +38671,8 @@ mI
 qX
 Dr
 uy
-Li
-Gi
+HP
+tR
 Dr
 Dr
 kI
@@ -38625,7 +38959,7 @@ QX
 Dr
 IX
 Mu
-TJ
+im
 FU
 tr
 Dr
@@ -38852,7 +39186,7 @@ qX
 Dr
 eL
 qJ
-tR
+lB
 Dr
 Li
 AL
@@ -39138,8 +39472,8 @@ wL
 Dr
 Dr
 XF
-lW
-OP
+Pe
+LN
 Gb
 To
 Dr
@@ -39147,7 +39481,7 @@ Li
 yS
 Li
 Dr
-Li
+rP
 Mm
 yr
 mW
@@ -39398,7 +39732,7 @@ ZH
 Zc
 On
 aT
-Zw
+aF
 iV
 pJ
 pJ
@@ -39647,12 +39981,12 @@ Pp
 Li
 mQ
 Dr
-QX
-QX
-QX
+uN
+zA
+TC
 Dr
 Yf
-NH
+OY
 er
 jW
 ei
@@ -39904,8 +40238,8 @@ Sj
 yS
 Yi
 Dr
-QX
-QX
+EI
+mC
 QX
 Dr
 Dr
@@ -40161,13 +40495,13 @@ wL
 Li
 Li
 Dr
-QX
-QX
-QX
+iC
+Vw
+sR
 Dr
-FU
-IW
-OP
+di
+BE
+tV
 IW
 xr
 Jw
@@ -40648,17 +40982,17 @@ Ga
 Wu
 Dr
 GH
-hN
+Xy
 fC
 pQ
 WA
 rc
-Nk
+aG
 Dr
-Vw
-Vw
-Vw
-Vw
+EB
+qw
+qw
+Nh
 Dr
 Ld
 NH
@@ -40912,10 +41246,10 @@ Dr
 NH
 Qj
 Dr
-Vw
+qw
 lW
 lW
-Vw
+qw
 wY
 NH
 lW
@@ -41169,10 +41503,10 @@ Dr
 NH
 Qj
 Dr
-Vw
-Vw
-Vw
-Vw
+GT
+qw
+qw
+RS
 Dr
 TO
 lW
@@ -42476,9 +42810,9 @@ mI
 qX
 qX
 qX
-qX
 Dr
-Uc
+Pe
+Pw
 Vw
 Vw
 NH
@@ -42732,9 +43066,9 @@ mI
 mI
 mI
 mI
-mI
 qX
 Dr
+mc
 yX
 TJ
 TJ
@@ -42989,8 +43323,8 @@ mI
 mI
 mI
 mI
-mI
 qX
+Dr
 Dr
 GB
 ku
@@ -43246,7 +43580,7 @@ mI
 mI
 mI
 mI
-mI
+qX
 qX
 Dr
 Mo
@@ -43453,8 +43787,8 @@ bu
 bu
 bu
 mI
-sY
-Nh
+mg
+mg
 mI
 mI
 qX
@@ -43970,7 +44304,7 @@ mI
 mI
 gj
 Ow
-Ow
+hO
 qX
 wA
 Li
@@ -44224,7 +44558,7 @@ bu
 bu
 bu
 mI
-qw
+mg
 eu
 ZC
 Ow
@@ -44481,8 +44815,8 @@ bu
 bu
 mI
 mI
+mg
 ab
-gj
 mg
 mI
 qX
@@ -44738,7 +45072,7 @@ bu
 bu
 mI
 mI
-no
+PA
 PA
 mI
 mI

--- a/maps/away/away_site/goon_base/goon_base.dmm
+++ b/maps/away/away_site/goon_base/goon_base.dmm
@@ -17,6 +17,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "ag" = (
@@ -89,23 +90,25 @@
 "aR" = (
 /obj/item/trash/proteinbar,
 /obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/mine)
 "aS" = (
 /obj/random/dirt_75,
 /obj/random/junk,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = -9;
+	pixel_y = 14
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "aT" = (
-/obj/structure/table/steel{
-	pixel_x = -2
+/obj/random/dirt_75,
+/obj/item/pipewrench{
+	pixel_x = -6;
+	pixel_y = 6
 	},
-/obj/item/paper_bin,
-/obj/item/pen/black,
-/obj/item/device/gps,
-/obj/item/device/gps,
-/obj/item/device/gps,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plating,
 /area/mine)
 "aY" = (
 /obj/structure/closet/crate/bin{
@@ -119,6 +122,7 @@
 /area/mine)
 "bc" = (
 /obj/structure/table/wood,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "bi" = (
@@ -158,6 +162,7 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "bp" = (
@@ -168,27 +173,71 @@
 "bu" = (
 /turf/template_noop,
 /area/space)
+"bx" = (
+/obj/structure/table/rack,
+/obj/item/clothing/accessory/holster/thigh/brown{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/holster/thigh/brown{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/holster/thigh/brown{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/holster/hip/brown{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/clothing/accessory/holster/hip/brown{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/clothing/accessory/holster/hip/brown{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "bA" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "bH" = (
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "bL" = (
-/obj/structure/table/reinforced/steel,
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/item/clothing/suit/armor/cuirass,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/tech_supply{
+	pixel_y = -12
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "bN" = (
-/obj/item/trash/cigbutt,
-/turf/simulated/floor/wood,
+/obj/structure/trash_pile,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "bQ" = (
 /obj/structure/trash_pile,
@@ -214,10 +263,6 @@
 /area/shuttle/goon_ship/living)
 "bY" = (
 /obj/structure/table/wood,
-/obj/item/deck/cards{
-	pixel_x = 7;
-	pixel_y = 6
-	},
 /obj/item/storage/pill_bottle/dice/gaming{
 	pixel_x = -5;
 	pixel_y = 2
@@ -227,6 +272,13 @@
 "bZ" = (
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
+"cl" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
+/area/mine)
 "cm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -242,9 +294,9 @@
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "cu" = (
-/obj/item/reagent_containers/food/drinks/bottle/rum,
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet/red,
+/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "cx" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -254,6 +306,8 @@
 /obj/structure/sink{
 	pixel_y = 21
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "cF" = (
@@ -263,28 +317,21 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "cH" = (
-/obj/structure/bed/stool/chair/sofa/right/black,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
+/obj/random/dirt_75,
+/obj/item/clothing/shoes/magboots{
+	pixel_x = 12;
+	pixel_y = -12
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "cK" = (
-/obj/machinery/door/airlock{
-	dir = 8;
-	req_access = list(202)
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/obj/structure/trash_pile,
+/turf/simulated/floor/plating,
 /area/mine)
 "cN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/device/paicard,
-/obj/item/material/twohanded/fireaxe,
-/obj/item/weldingtool/hugetank,
-/obj/item/tank/jetpack/void,
-/obj/item/wirecutters/toolbelt,
+/obj/random/junk,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "cP" = (
@@ -295,16 +342,14 @@
 	name = "trashbin"
 	},
 /obj/random/junk,
+/obj/item/trash/can,
 /turf/simulated/floor/tiled,
 /area/mine)
 "cY" = (
-/obj/structure/table/steel,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 12
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "dd" = (
 /obj/structure/bed/padded/bunk{
@@ -320,21 +365,30 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/storage)
 "dh" = (
-/obj/structure/table/standard,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/reagent_containers/blood/OMinus,
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/obj/random/dirt_75,
+/obj/item/material/twohanded/fireaxe,
+/obj/item/wirecutters/clippers,
+/obj/item/wirecutters,
+/obj/item/tank/jetpack/void,
+/obj/item/weldingtool/hugetank,
+/turf/simulated/floor/plating,
 /area/mine)
 "dr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/grey{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"ds" = (
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled,
 /area/mine)
 "dt" = (
 /obj/effect/shuttle_landmark/automatic/ghostrole_activation,
@@ -342,6 +396,7 @@
 /area/space)
 "dv" = (
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "dx" = (
@@ -357,6 +412,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
+/obj/structure/table/wood,
 /turf/simulated/floor/wood,
 /area/mine)
 "dI" = (
@@ -376,11 +432,9 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "dK" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/head/beret,
-/obj/item/clothing/suit/storage/toggle/flannel/gray,
-/obj/item/clothing/suit/storage/vest,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "dQ" = (
 /obj/item/reagent_containers/blood/OMinus,
@@ -391,6 +445,13 @@
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
 /obj/structure/closet/crate/freezer,
+/obj/item/tank/anesthetic,
+/obj/item/tank/anesthetic,
+/obj/item/tank/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "dT" = (
@@ -402,19 +463,22 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
-/obj/machinery/computer/operating,
+/obj/machinery/computer/operating/terminal,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "dX" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "dY" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "eb" = (
@@ -441,6 +505,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
+"ek" = (
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 17;
+	pixel_y = -8
+	},
+/turf/simulated/floor/plating/asteroid,
+/area/mine)
 "eq" = (
 /obj/item/reagent_containers/glass/bucket/wood{
 	pixel_y = -3;
@@ -453,16 +525,32 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled/dark,
 /area/mine)
-"eA" = (
-/obj/item/reagent_containers/glass/bucket/wood{
-	pixel_y = -7
+"et" = (
+/obj/random/dirt_75,
+/obj/item/clothing/head/cone{
+	pixel_x = 12;
+	pixel_y = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"eA" = (
+/obj/item/stack/material/plasteel/full{
+	pixel_y = 4
+	},
+/obj/item/stack/material/plasteel/full{
+	pixel_y = 4
+	},
+/obj/item/stack/material/plasteel/full{
+	pixel_y = 4
+	},
+/obj/structure/table/reinforced/steel,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
 /area/mine)
 "eB" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "eE" = (
 /obj/effect/floor_decal/spline/plain/black{
@@ -475,8 +563,11 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "eH" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/wood,
+/obj/item/reagent_containers/chem_disp_cartridge/clean_kois{
+	pixel_x = 7;
+	pixel_y = -4
+	},
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "eI" = (
 /obj/structure/closet/walllocker/medical{
@@ -503,6 +594,7 @@
 "eL" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/power/portgen/basic/advanced,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "eO" = (
@@ -541,8 +633,9 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "fe" = (
-/obj/item/broken_bottle,
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "ff" = (
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -561,11 +654,13 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "fk" = (
-/obj/machinery/door/airlock{
-	dir = 1;
-	req_access = list(202)
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = -9;
+	pixel_y = 14
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "fm" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -580,15 +675,10 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "fr" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/accessory/medal/gold,
-/obj/item/clothing/accessory/crucifix/gold,
-/obj/item/clothing/wrists/watch/gold,
-/obj/item/coin/gold,
-/obj/item/flame/lighter/zippo/gold,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/material/phoron/full,
-/obj/random/highvalue/no_weapon,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "fs" = (
@@ -609,10 +699,10 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "fz" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/red,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
 /area/mine)
 "fA" = (
 /obj/structure/table/rack,
@@ -621,6 +711,8 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "fC" = (
@@ -628,6 +720,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "fG" = (
@@ -650,12 +743,16 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/mine)
 "fW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/purple{
+	dir = 10
+	},
+/obj/random/dirt_75,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/tiled,
 /area/mine)
 "fY" = (
 /turf/simulated/mineral/surface,
@@ -668,29 +765,26 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "gi" = (
-/obj/structure/table/wood,
-/obj/item/modular_computer/laptop/preset/civilian{
-	pixel_y = 9
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
 	},
-/turf/simulated/floor/wood,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "gj" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "gm" = (
-/obj/effect/floor_decal/spline/fancy{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "gn" = (
 /obj/structure/table/rack,
@@ -699,6 +793,8 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "gp" = (
@@ -731,29 +827,25 @@
 /area/mine)
 "gw" = (
 /obj/structure/table/steel,
-/obj/item/storage/firstaid/o2{
-	pixel_x = -4
+/obj/item/device/hand_labeler{
+	pixel_x = -1;
+	pixel_y = 3
 	},
-/obj/item/storage/firstaid/radiation,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 4
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled,
 /area/mine)
 "gx" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 7
+/obj/machinery/door/airlock/external{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/red,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/simulated/floor/plating,
 /area/mine)
 "gE" = (
 /obj/structure/bed/stool{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "gI" = (
@@ -855,6 +947,7 @@
 	pixel_x = 10;
 	pixel_y = 3
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "hC" = (
@@ -883,13 +976,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "hS" = (
-/obj/structure/table/rack,
-/obj/item/soap/syndie,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/freezer,
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 11
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "hV" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -902,9 +1002,10 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "hZ" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "ia" = (
 /obj/item/deck/cards,
@@ -941,20 +1042,21 @@
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/black/engie,
 /obj/item/clothing/head/helmet/space/syndicate/black/engie,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "ip" = (
-/obj/item/trash/kokobar,
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "is" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "it" = (
@@ -988,6 +1090,19 @@
 /obj/item/trash/chips,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"iF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
+"iH" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
 "iK" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
@@ -1005,31 +1120,33 @@
 /obj/machinery/sleeper{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "iV" = (
-/obj/item/rig/merc/ninja{
-	req_access = list(202)
+/obj/structure/structural_support{
+	pixel_y = 8
 	},
-/obj/structure/table/rack,
-/turf/simulated/floor/wood,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
 /area/mine)
 "iW" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
 "iX" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 9
-	},
-/turf/simulated/floor/carpet/red,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "iY" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/head/bearpelt,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/military/old,
-/obj/item/clothing/suit/storage/vest,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "jg" = (
 /obj/machinery/body_scanconsole{
@@ -1070,6 +1187,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "jz" = (
@@ -1085,6 +1203,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "jV" = (
@@ -1095,10 +1214,15 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/item/trash/cigbutt{
+	pixel_y = -13;
+	pixel_x = 11
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "jW" = (
 /obj/structure/dispenser/oxygen,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "jZ" = (
@@ -1112,9 +1236,13 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "kj" = (
-/obj/machinery/power/portgen/basic,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "kn" = (
 /obj/structure/closet,
@@ -1139,35 +1267,106 @@
 	},
 /area/shuttle/goon_ship/bridge)
 "ku" = (
-/obj/structure/table/steel{
-	pixel_x = -2
+/obj/effect/floor_decal/corner/grey/full{
+	dir = 4
 	},
-/obj/item/trash/gum,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
 /area/mine)
 "kz" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/accessory/holster/thigh/brown,
-/obj/item/clothing/accessory/holster/thigh/brown{
-	pixel_y = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "kB" = (
-/obj/machinery/sleeper{
-	dir = 1
+/obj/random/dirt_75,
+/obj/item/trash/cigbutt{
+	pixel_x = 7;
+	pixel_y = -10
 	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "kE" = (
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /obj/structure/closet/crate,
+/obj/item/reagent_containers/syringe/drugs,
+/obj/item/reagent_containers/syringe/drugs,
+/obj/item/reagent_containers/syringe/drugs,
+/obj/item/reagent_containers/inhaler/space_drugs{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/inhaler/space_drugs{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/inhaler/space_drugs{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/inhaler/space_drugs{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/inhaler/xuxigas{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/inhaler/xuxigas{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/inhaler/xuxigas{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/inhaler/xuxigas{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/inhaler/soporific{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/inhaler/soporific{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/pill/tox{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/pill/nerospectan{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/pill/happy{
+	pixel_x = 2;
+	pixel_y = -5
+	},
+/obj/item/reagent_containers/pill/bio_vitamin{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/pill/heroin{
+	pixel_x = 7;
+	pixel_y = -6
+	},
+/obj/item/reagent_containers/pill/cocaine{
+	pixel_x = -8;
+	pixel_y = -7
+	},
+/obj/item/reagent_containers/inhaler/raskara_dust{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/pill/happy{
+	pixel_x = 2;
+	pixel_y = -5
+	},
+/obj/item/reagent_containers/syringe/drugs,
 /turf/simulated/floor/plating,
 /area/mine)
 "kH" = (
@@ -1206,20 +1405,11 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "kR" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/gun/projectile/pistol{
-	layer = 2.99;
-	pixel_y = 6
-	},
-/obj/item/gun/projectile/pistol,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/random/dirt_75,
+/obj/random/loot,
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
 	},
 /turf/simulated/floor/plating,
 /area/mine)
@@ -1250,11 +1440,13 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "kW" = (
-/obj/structure/table/steel{
-	pixel_x = -2
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
 	},
-/obj/item/trash/snack_bowl,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable,
+/obj/machinery/power/apc/west,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "kX" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -1270,6 +1462,7 @@
 /obj/item/stack/material/platinum{
 	pixel_x = 6
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "le" = (
@@ -1289,23 +1482,35 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "lj" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/black/green,
 /obj/item/clothing/head/helmet/space/syndicate/black/green,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "ll" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "ln" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "lo" = (
 /obj/structure/lattice/catwalk/indoor/grate/old,
@@ -1313,6 +1518,17 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
+/area/mine)
+"lp" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/gun/energy/gun{
+	pixel_y = 3
+	},
+/obj/item/gun/energy/rifle/ionrifle{
+	pixel_y = -2
+	},
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "lq" = (
 /obj/machinery/optable,
@@ -1329,27 +1545,61 @@
 	pixel_y = -5;
 	pixel_x = 4
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "lz" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 5
+/obj/effect/floor_decal/corner/grey/full,
+/obj/random/dirt_75,
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
 	},
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
+/turf/simulated/floor/tiled,
+/area/mine)
+"lB" = (
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "lI" = (
 /obj/structure/table/rack,
-/obj/item/device/flashlight/lantern,
-/obj/item/device/flashlight/lantern,
-/obj/item/device/flashlight/lantern,
-/turf/simulated/floor/tiled/dark,
+/obj/item/clothing/shoes/magboots{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "lJ" = (
 /obj/item/crowbar,
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "lK" = (
@@ -1378,12 +1628,11 @@
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "lU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/freezer,
+/obj/structure/trash_pile,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "lW" = (
 /turf/simulated/floor/tiled/full,
@@ -1415,12 +1664,17 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "mt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/mine)
 "mv" = (
@@ -1438,19 +1692,26 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
 "mE" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/head/bandana/pirate,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/flight,
-/obj/item/clothing/suit/storage/vest,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/item/gun/custom_ka/frame05{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/wrench{
+	pixel_y = -10
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "mI" = (
 /turf/simulated/mineral/surface,
 /area/mine)
 "mJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/cryopod,
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/purple{
+	dir = 10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "mO" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -1469,17 +1730,9 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "mQ" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest{
-	pixel_x = -8
-	},
-/obj/item/clothing/accessory/storage/black_vest{
-	pixel_x = 8
-	},
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 1
-	},
+/obj/random/junk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "mV" = (
@@ -1492,14 +1745,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "mW" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
+/obj/item/storage/toolbox/emergency{
+	pixel_x = -11;
+	pixel_y = -8
 	},
-/obj/machinery/portable_atmospherics/canister/phoron_scarce,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/unsimulated/floor/asteroid/ash,
 /area/mine)
 "mX" = (
 /obj/structure/closet/crate,
@@ -1509,13 +1759,29 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
 	},
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/shoes/laceup/brown,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots/cavalry,
+/obj/item/clothing/shoes/jackboots/toeless,
+/obj/item/clothing/shoes/cowboy,
+/obj/item/clothing/shoes/cowboy/classic,
+/obj/item/clothing/shoes/cowboy/lizard,
+/obj/item/clothing/shoes/winter,
+/obj/item/clothing/shoes/winter/toeless,
+/obj/item/clothing/shoes/workboots,
+/obj/item/clothing/shoes/workboots/brown,
+/obj/item/clothing/shoes/workboots/toeless,
+/obj/item/clothing/shoes/konyang,
+/obj/item/clothing/shoes/sneakers/rainbow,
+/obj/item/clothing/shoes/sneakers/blue,
+/obj/item/clothing/shoes/sandals/caligae,
+/obj/item/clothing/shoes/workboots/toeless,
 /turf/simulated/floor/tiled,
 /area/mine)
 "nf" = (
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
 /area/mine)
 "ng" = (
 /obj/structure/closet,
@@ -1538,22 +1804,50 @@
 /obj/item/modular_computer/laptop/preset/civilian{
 	pixel_y = 9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
+"nm" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 17;
+	pixel_y = -8
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "no" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/suit/armor/carrier/heavy,
-/obj/effect/floor_decal/spline/plain/black,
+/obj/random/dirt_75,
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "np" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet/red,
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/c45m/lebman,
+/obj/item/ammo_magazine/c45m/lebman,
+/obj/item/ammo_magazine/c45m/lebman,
+/obj/item/gun/projectile/automatic/lebman{
+	pixel_y = 0
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "nr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"nu" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/trash/match,
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
 "nw" = (
 /obj/effect/floor_decal/corner/red/full{
 	dir = 1
@@ -1570,8 +1864,9 @@
 /turf/simulated/floor/plating/asteroid,
 /area/mine)
 "nC" = (
-/obj/machinery/vending/boozeomat/merchant,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
 /area/mine)
 "nI" = (
 /obj/structure/bed/stool,
@@ -1581,19 +1876,11 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "nJ" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/c762,
-/obj/item/ammo_magazine/c762,
-/obj/item/ammo_magazine/c762,
-/obj/item/gun/projectile/automatic/rifle/sts35,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 2;
-	pixel_y = 0;
-	icon_state = "tube_empty"
-	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "nM" = (
@@ -1604,15 +1891,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "nQ" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "nR" = (
 /obj/structure/table/steel,
@@ -1669,12 +1952,17 @@
 	dir = 5
 	},
 /obj/machinery/optable,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "of" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
+/area/mine)
+"oi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
 /area/mine)
 "op" = (
 /obj/machinery/media/jukebox,
@@ -1705,6 +1993,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/effect/decal/cleanable/fruit_smudge,
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
 "oE" = (
@@ -1724,31 +2013,32 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "oK" = (
-/obj/machinery/bodyscanner{
-	dir = 1
+/obj/structure/reagent_dispensers/radioactive_waste,
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_x = -8;
+	pixel_y = 6
 	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_y = -7;
+	pixel_x = 2
 	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "oM" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/shotgunammo,
-/obj/item/storage/box/shotgunammo,
-/obj/item/gun/projectile/shotgun/pump/combat,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
+/obj/random/dirt_75,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/mine)
 "oP" = (
-/obj/structure/bookcase,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "oX" = (
 /obj/structure/closet/walllocker/medical{
@@ -1765,6 +2055,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "pd" = (
@@ -1778,7 +2069,14 @@
 	pixel_x = 7;
 	pixel_y = 6
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
+/area/mine)
+"pj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "pn" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -1786,6 +2084,7 @@
 	dir = 4;
 	pixel_y = 0
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "pp" = (
@@ -1804,6 +2103,8 @@
 	name = "sink";
 	pixel_y = 26
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "pw" = (
@@ -1813,17 +2114,20 @@
 	pixel_y = 3
 	},
 /obj/structure/table/standard,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "px" = (
-/obj/structure/closet/walllocker/medical{
-	pixel_y = 29
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/mirror{
+	pixel_y = 31
 	},
-/obj/item/tank/anesthetic,
-/obj/item/tank/anesthetic,
-/obj/item/tank/anesthetic,
-/obj/item/clothing/mask/breath/medical,
-/obj/effect/floor_decal/corner/lime/diagonal,
+/obj/structure/sink{
+	pixel_y = 21
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "pz" = (
@@ -1831,11 +2135,23 @@
 /obj/effect/floor_decal/corner/grey/full{
 	dir = 1
 	},
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
 /turf/simulated/floor/tiled,
 /area/mine)
 "pB" = (
-/obj/structure/curtain/black,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/snacks/pbjsandwich{
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/food/snacks/reubensandwich{
+	pixel_y = 10
+	},
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "pI" = (
 /obj/structure/railing/mapped{
@@ -1848,12 +2164,8 @@
 /turf/simulated/floor/airless,
 /area/shuttle/goon_ship/bridge)
 "pJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/stack/material/platinum,
-/obj/item/stack/material/platinum,
-/obj/item/stack/material/platinum,
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "pN" = (
 /obj/effect/landmark/entry_point/east{
@@ -1864,6 +2176,8 @@
 "pQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "pT" = (
@@ -1891,6 +2205,18 @@
 "pV" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/steel,
+/obj/item/reagent_containers/food/drinks/carton/milk{
+	pixel_y = 10;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/drinks/carton/milk{
+	pixel_y = 12;
+	pixel_x = 7
+	},
+/obj/item/storage/box/fancy/egg_box{
+	pixel_y = 6;
+	pixel_x = -2
+	},
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "qb" = (
@@ -1927,12 +2253,17 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "qq" = (
 /obj/structure/table/steel,
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
+	},
+/obj/item/device/paicard{
+	pixel_x = -4;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -1948,6 +2279,7 @@
 	pixel_x = -3;
 	pixel_y = -7
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "qv" = (
@@ -1961,26 +2293,26 @@
 /obj/item/flame/lighter/zippo/gold,
 /obj/item/stack/material/phoron/full,
 /obj/item/coin/gold,
-/obj/item/clothing/accessory/crucifix/gold,
 /obj/item/gun/projectile/automatic/rifle/dpra/gold,
+/obj/random/dirt_75,
+/obj/random/highvalue/no_weapon,
+/obj/item/clothing/accessory/crucifix/gold,
 /obj/random/melee/highvalue,
+/obj/item/clothing/wrists/armchain,
 /turf/simulated/floor/plating,
 /area/mine)
 "qy" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/ammo_magazine/c45m,
-/obj/item/gun/projectile/automatic/lebman,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 2;
-	pixel_y = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/plating,
+/obj/structure/closet/crate,
+/obj/random/spacecash,
+/obj/random/spacecash,
+/obj/random/spacecash,
+/obj/random/spacecash,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c500,
+/obj/item/spacecash/c200,
+/obj/random/spacecash,
+/obj/random/spacecash,
+/turf/simulated/floor/tiled,
 /area/mine)
 "qz" = (
 /obj/effect/floor_decal/corner/lime{
@@ -1989,13 +2321,24 @@
 /obj/machinery/body_scanconsole{
 	dir = 4
 	},
+/obj/item/storage/box/freezer/organcooler{
+	pixel_y = -9;
+	pixel_x = -12
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "qC" = (
 /obj/structure/table/wood,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_y = 8;
+	pixel_y = 14;
 	pixel_x = 6
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/rocks{
+	pixel_x = -1;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -2011,12 +2354,15 @@
 /area/shuttle/goon_ship/living)
 "qF" = (
 /obj/effect/floor_decal/corner/blue,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "qJ" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/item/trash/cigbutt,
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "qL" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2025,58 +2371,75 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
+/obj/random/dirt_75,
+/obj/random/tech_supply{
+	pixel_y = 6;
+	pixel_x = 7
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "qM" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/random/dirt_75,
+/obj/random/tool{
+	pixel_y = 6;
+	pixel_x = 8
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "qN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/can,
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/random/dirt_75,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
 /area/mine)
 "qO" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "qP" = (
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/item/trash/plate/steak,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/gun/projectile/automatic/c20r,
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "qW" = (
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/light,
-/turf/simulated/floor/wood,
+/obj/random/dirt_75,
+/obj/random/loot{
+	pixel_x = -11
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "qX" = (
 /turf/simulated/wall/r_wall,
 /area/mine)
 "rc" = (
-/obj/structure/bed/padded/bunk{
-	pixel_y = 0
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/item/bedsheet/black,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "ri" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/plating,
 /area/mine)
 "rn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/cheesie,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/mine)
 "rq" = (
@@ -2087,12 +2450,14 @@
 /obj/random/medical,
 /obj/random/medical,
 /obj/random/medical,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "ru" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "rw" = (
@@ -2131,11 +2496,24 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "rW" = (
-/obj/structure/bed/padded/bunk{
-	pixel_y = 0
+/obj/random/dirt_75,
+/obj/random/tool{
+	pixel_y = 6;
+	pixel_x = 8
 	},
-/obj/item/bedsheet/black,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
+/area/mine)
+"rX" = (
+/obj/random/dirt_75,
+/obj/item/trash/cigbutt{
+	pixel_y = -9;
+	pixel_x = 1
+	},
+/obj/item/trash/match{
+	pixel_y = 11;
+	pixel_x = -7
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "sa" = (
 /turf/simulated/wall/shuttle/raider,
@@ -2147,9 +2525,11 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/mine)
 "se" = (
+/obj/random/dirt_75,
 /turf/simulated/floor/airless,
 /area/mine)
 "sg" = (
@@ -2173,9 +2553,20 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
+"sp" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/smg10mm,
+/obj/item/ammo_magazine/smg10mm,
+/obj/item/ammo_magazine/smg10mm,
+/obj/item/gun/projectile/automatic/konyang_pirate{
+	pixel_y = 5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "sz" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/item/handcuffs,
+/obj/machinery/iv_drip,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "sB" = (
@@ -2186,11 +2577,17 @@
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
 "sI" = (
-/obj/structure/table/steel,
-/obj/item/clothing/glasses/welding,
-/obj/item/weldingtool,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/gun/energy/gun{
+	pixel_y = 8;
+	pixel_x = -2
+	},
+/obj/item/gun/energy/gun{
+	pixel_y = 2;
+	pixel_x = 2
+	},
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "sK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2201,31 +2598,68 @@
 /obj/structure/bed/stool/chair/office/light{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "sN" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/purple,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "sO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/kidneys,
-/turf/simulated/floor/plating,
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/item/storage/backpack/messenger/syndie{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "sP" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
+/obj/structure/table/reinforced/steel,
+/obj/item/storage/belt/utility/alt{
+	pixel_x = -1;
+	pixel_y = 13
 	},
-/turf/simulated/floor/carpet/red,
+/obj/item/storage/belt/utility/alt{
+	pixel_x = -1;
+	pixel_y = 13
+	},
+/obj/item/storage/belt/utility/alt{
+	pixel_x = -1;
+	pixel_y = 13
+	},
+/obj/item/storage/wallet/lanyard,
+/obj/item/clothing/mask/balaclava/grey{
+	pixel_x = -5;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/balaclava/grey{
+	pixel_x = -5;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/balaclava/grey{
+	pixel_x = -5;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/balaclava/grey{
+	pixel_x = -5;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/balaclava/grey{
+	pixel_x = -5;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/balaclava/grey{
+	pixel_x = -5;
+	pixel_y = -9
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/mine)
 "sX" = (
-/obj/structure/bookcase,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/industrial/loading/grey,
+/turf/simulated/floor/plating,
 /area/mine)
 "sZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2264,6 +2698,9 @@
 	name = "sink";
 	pixel_y = 26
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "tu" = (
@@ -2272,6 +2709,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/empty,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "tv" = (
@@ -2281,20 +2719,51 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "tz" = (
-/obj/machinery/appliance/cooker/oven,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/obj/structure/table/rack,
+/obj/item/device/gps{
+	pixel_x = 5
+	},
+/obj/item/device/gps{
+	pixel_x = -6
+	},
+/obj/item/device/gps{
+	pixel_x = 5
+	},
+/obj/item/device/gps{
+	pixel_x = -6
+	},
+/obj/item/device/gps{
+	pixel_x = 5
+	},
+/obj/item/device/gps{
+	pixel_x = -6
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "tA" = (
-/obj/machinery/appliance/cooker/stove,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/item/trash/stew,
-/turf/simulated/floor/tiled/white,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = -11;
+	pixel_y = -8
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"tC" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/reagent_dispensers/coolanttank,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "tF" = (
 /obj/structure/bed/stool/chair/office/light{
 	dir = 8
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "tI" = (
@@ -2305,16 +2774,9 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
 "tR" = (
-/obj/machinery/giga_drill{
-	name = "himean drill";
-	desc = "A giant, Himean drill - usually digging tunnels deep beneath the planet Himeo."
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/loot,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "tS" = (
@@ -2332,6 +2794,7 @@
 "un" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "uq" = (
@@ -2340,6 +2803,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "uu" = (
@@ -2347,27 +2811,18 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "uv" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/appliance/cooker/stove,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "uy" = (
-/obj/structure/table/rack,
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/steel/full,
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 5
-	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "uB" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -2379,10 +2834,22 @@
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/steel,
 /obj/item/trash/coffee{
-	pixel_x = 11;
-	pixel_y = 3
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/shot{
+	pixel_y = 2;
+	pixel_x = -4
 	},
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"uS" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 1
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "uT" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
@@ -2395,6 +2862,7 @@
 /area/mine)
 "uU" = (
 /obj/structure/trash_pile,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "va" = (
@@ -2429,14 +2897,20 @@
 	pixel_x = -5;
 	pixel_y = 8
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "vt" = (
-/obj/machinery/door/airlock{
-	dir = 1
+/obj/machinery/door/airlock/external{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/cee,
+/turf/simulated/floor/plating,
 /area/mine)
 "vx" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -2482,18 +2956,24 @@
 /obj/structure/table/steel{
 	pixel_x = -2
 	},
-/obj/item/wrench,
 /turf/simulated/floor/plating,
 /area/mine)
 "vH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "vI" = (
 /obj/structure/table/wood,
 /obj/item/material/ashtray/bronze{
-	pixel_x = -6;
-	pixel_y = -3
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/clothing/mask/smokable/cigarette/cigar/oracle{
+	pixel_x = 6;
+	pixel_y = 1
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -2528,6 +3008,8 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "wh" = (
@@ -2537,10 +3019,11 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
 "wo" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/carpet/red,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "wp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2551,14 +3034,28 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
-"wD" = (
-/obj/machinery/iv_drip,
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
+"wz" = (
+/obj/random/junk,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
+"wA" = (
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
+"wD" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "wG" = (
 /obj/structure/cable{
@@ -2604,19 +3101,16 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "wX" = (
-/obj/structure/closet/crate,
-/obj/item/storage/box/freezer/organcooler,
-/obj/item/storage/box/freezer/organcooler,
-/obj/item/storage/box/freezer/organcooler,
-/obj/item/storage/box/freezer/organcooler,
-/obj/item/storage/box/freezer/organcooler,
-/obj/effect/floor_decal/corner/lime{
-	dir = 5
+/obj/structure/table/steel,
+/obj/item/clothing/head/cowboy{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled,
 /area/mine)
 "wY" = (
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -2674,20 +3168,20 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "xr" = (
-/obj/structure/table/reinforced/glass,
-/obj/item/material/ashtray{
-	pixel_y = 2;
-	pixel_x = 3
+/obj/structure/table/steel,
+/obj/item/device/versebook/trinary{
+	pixel_x = 4;
+	pixel_y = 3
 	},
-/obj/item/reagent_containers/food/drinks/bottle/whitewine{
-	pixel_y = 7;
-	pixel_x = -7
-	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled,
 /area/mine)
 "xs" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/item/ammo_magazine/c762,
+/obj/item/ammo_magazine/c762,
+/obj/item/ammo_magazine/c762,
+/obj/item/gun/projectile/automatic/rifle/sts35,
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "xz" = (
@@ -2696,6 +3190,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "xE" = (
@@ -2724,6 +3219,9 @@
 	pixel_x = -5;
 	pixel_y = 8
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "xK" = (
@@ -2731,9 +3229,13 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "xM" = (
-/obj/item/bedsheet/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "xO" = (
 /obj/item/trash/cigbutt,
@@ -2750,12 +3252,10 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "xQ" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/suit/armor/cuirass,
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "xX" = (
 /obj/structure/table/steel,
@@ -2763,9 +3263,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "xY" = (
-/obj/structure/table/rack,
-/obj/item/clothing/gloves/boxing,
-/turf/simulated/floor/wood,
+/obj/random/dirt_75,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/plating,
 /area/mine)
 "xZ" = (
 /obj/structure/lattice/catwalk/indoor/grate/old,
@@ -2786,15 +3286,15 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "yl" = (
-/obj/structure/table/rack,
-/obj/item/towel/random,
-/obj/item/towel/random,
-/obj/item/towel/random,
-/obj/item/towel/random,
-/obj/item/towel/random,
-/obj/item/towel/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "ym" = (
 /obj/structure/cable{
@@ -2811,20 +3311,32 @@
 /area/shuttle/goon_ship/living)
 "yq" = (
 /obj/structure/table/reinforced/steel,
+/obj/item/storage/pill_bottle/mortaphenyl{
+	pixel_x = -13;
+	pixel_y = 4
+	},
+/obj/item/storage/pill_bottle/inaprovaline{
+	pixel_y = 5
+	},
+/obj/item/storage/pill_bottle/perconol{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/obj/item/storage/pill_bottle/inaprovaline{
+	pixel_x = 7;
+	pixel_y = 2
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/mine)
 "yr" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/wood,
+/obj/random/dirt_75,
+/turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "ys" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "yx" = (
@@ -2844,12 +3356,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "yH" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "yP" = (
@@ -2879,17 +3393,23 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "yX" = (
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/mine)
+"yY" = (
+/obj/random/dirt_75,
+/obj/machinery/pipedispenser,
+/turf/simulated/floor/plating,
 /area/mine)
 "zb" = (
-/obj/structure/table/steel{
-	pixel_x = -2
+/obj/item/clothing/shoes/slippers/carp{
+	pixel_y = -4;
+	pixel_x = -5
 	},
-/obj/effect/floor_decal/corner/grey/diagonal,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled,
 /area/mine)
 "zd" = (
 /turf/simulated/wall/shuttle/raider,
@@ -2913,9 +3433,14 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "zz" = (
-/obj/structure/closet/toolcloset,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "zB" = (
 /obj/effect/floor_decal/corner/lime{
@@ -2945,6 +3470,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "zW" = (
@@ -2954,6 +3480,8 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Ac" = (
@@ -2961,14 +3489,12 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Ag" = (
-/obj/machinery/chemical_dispenser/bar_alc/full{
-	dir = 8;
-	pixel_x = 5
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/turf/simulated/floor/airless/ceiling,
 /area/mine)
 "Ah" = (
 /obj/effect/floor_decal/corner/red{
@@ -2977,20 +3503,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "Ak" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/item/reagent_containers/food/snacks/meat,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random/dirt_75,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
+/area/mine)
+"Am" = (
+/obj/machinery/atmospherics/binary/pump/aux/on,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "Au" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/tech_supply{
+	pixel_x = 15
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -3006,6 +3537,14 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
+"Ax" = (
+/obj/random/dirt_75,
+/obj/random/tool{
+	pixel_y = 6;
+	pixel_x = 8
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "Ay" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 9
@@ -3032,6 +3571,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "AR" = (
@@ -3049,6 +3590,11 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
+"AW" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "Ba" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -3083,6 +3629,8 @@
 /obj/item/stack/material/silver{
 	pixel_x = 6
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Bn" = (
@@ -3116,22 +3664,17 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Br" = (
-/obj/structure/closet/crate,
-/obj/item/coin/diamond,
-/obj/item/clothing/wrists/goldbracer,
-/obj/item/clothing/wrists/armchain,
-/obj/item/clothing/wrists/goldbracer/emerald,
-/obj/item/gun/projectile/automatic/rifle/dpra/gold,
-/obj/random/melee/highvalue,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/keg/beerkeg/rice,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Bt" = (
-/obj/structure/toilet{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "By" = (
 /obj/structure/table/steel,
@@ -3145,15 +3688,22 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "BE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/freezer/rations,
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/obj/structure/closet/crate/freezer,
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/heart,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "BH" = (
-/obj/structure/table/steel,
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
+/obj/structure/table/rack,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/oxygen,
 /turf/simulated/floor/tiled,
 /area/mine)
 "BI" = (
@@ -3169,22 +3719,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "BK" = (
-/obj/machinery/appliance/cooker/fryer,
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "BW" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"BX" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 8
 	},
-/obj/item/trash/match,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
 /area/mine)
 "Cb" = (
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -3194,7 +3747,27 @@
 /obj/machinery/door/airlock/maintenance{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
+/area/mine)
+"Cd" = (
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/structure/closet/crate,
+/obj/item/clothing/head/sol/marine,
+/obj/item/clothing/head/sol/marine/grey,
+/obj/item/clothing/head/sol/garrison,
+/obj/item/clothing/head/sol/army/service/officer,
+/obj/item/clothing/head/sol/garrison,
+/obj/item/clothing/under/rank/sol/marine,
+/obj/item/clothing/under/rank/sol/marine,
+/obj/item/clothing/under/rank/sol/marine/grey,
+/obj/item/clothing/under/rank/sol/service/marine,
+/obj/item/clothing/under/rank/sol/army/grey,
+/obj/item/clothing/under/rank/sol/army/service,
+/obj/item/clothing/under/rank/sol/army/service/officer,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Cf" = (
 /obj/structure/lattice/catwalk/indoor/grate/old,
@@ -3213,6 +3786,7 @@
 	name = "trashbin"
 	},
 /obj/random/junk,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Cr" = (
@@ -3224,37 +3798,62 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"Ct" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = -7;
+	pixel_y = -15
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 1;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "Cz" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/item/trash/cigbutt,
-/turf/simulated/floor/tiled/white,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/structure/closet/toolcloset,
+/turf/simulated/floor/plating,
 /area/mine)
 "CR" = (
-/obj/item/storage/pill_bottle/dice/gaming,
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/tank/emergency_oxygen/engi{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "CS" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "CY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube_empty"
+/obj/machinery/atmospherics/portables_connector/aux{
+	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "CZ" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Df" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/mine)
 "Dj" = (
@@ -3291,7 +3890,22 @@
 /area/mine)
 "Du" = (
 /obj/effect/floor_decal/industrial/warning,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
+/area/mine)
+"Dv" = (
+/obj/structure/reagent_dispensers/water_cooler{
+	pixel_x = -9
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"Dy" = (
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/item/clothing/gloves/yellow{
+	pixel_y = 9
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "DI" = (
 /obj/structure/table/steel,
@@ -3329,6 +3943,7 @@
 /obj/machinery/bodyscanner{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "Ea" = (
@@ -3336,10 +3951,20 @@
 /obj/item/trash/can,
 /turf/simulated/floor/plating,
 /area/mine)
+"Ek" = (
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/random/hardhat,
+/turf/simulated/floor/tiled,
+/area/mine)
 "El" = (
-/obj/machinery/computer/operating,
-/obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "Em" = (
 /obj/structure/curtain/open/medical,
@@ -3351,12 +3976,14 @@
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Ew" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 2
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Ex" = (
@@ -3377,6 +4004,14 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
+/obj/item/trash/cigbutt{
+	pixel_y = -9;
+	pixel_x = 1
+	},
+/obj/item/trash/match{
+	pixel_y = 11;
+	pixel_x = -11
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "EE" = (
@@ -3392,6 +4027,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "EP" = (
@@ -3406,12 +4042,16 @@
 /area/mine)
 "EQ" = (
 /obj/structure/reagent_dispensers/watertank,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "EV" = (
-/obj/item/trash/tray,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/storage/box/shotgunammo,
+/obj/item/storage/box/shotgunshells,
+/obj/item/gun/projectile/shotgun/pump/combat,
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "EZ" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -3420,25 +4060,42 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 17;
+	pixel_y = -8
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Fb" = (
 /obj/structure/bed/stool,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Fc" = (
 /turf/simulated/floor/carpet/red,
 /area/mine)
 "Fe" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
 	},
-/turf/simulated/floor/wood,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
+/area/mine)
+"Fj" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 4;
+	pixel_y = 12
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Fk" = (
-/obj/structure/bed/stool/chair/sofa/black,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/wood,
 /area/mine)
 "Fo" = (
@@ -3466,6 +4123,13 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"Fv" = (
+/obj/random/dirt_75,
+/obj/random/tool{
+	pixel_y = -10
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "Fz" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -3475,19 +4139,23 @@
 "FB" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "FD" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "FE" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/head/helmet/material/makeshift,
-/obj/effect/floor_decal/spline/plain/black,
-/turf/simulated/floor/plating,
+/obj/structure/table/steel,
+/obj/item/towel/random{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "FF" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -3510,6 +4178,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/mine)
+"FS" = (
+/obj/structure/table/reinforced/steel,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 12
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/simulated/floor/tiled/dark/full,
+/area/mine)
 "FT" = (
 /obj/structure/closet/walllocker{
 	pixel_x = 30
@@ -3530,28 +4206,21 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/item/trash/cigbutt/roll{
+	pixel_x = -9;
+	pixel_y = 5
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Ga" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Gb" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/ammo_magazine/mc9mm,
-/obj/item/gun/projectile/pistol{
-	layer = 2.99;
-	pixel_y = 6
-	},
-/obj/item/gun/projectile/pistol,
-/obj/effect/floor_decal/spline/plain{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/mine)
@@ -3573,11 +4242,29 @@
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
 "Gi" = (
-/obj/machinery/gumballmachine,
-/turf/simulated/floor/wood,
+/obj/structure/reagent_dispensers/radioactive_waste,
+/obj/effect/decal/cleanable/acid_remnants,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"Gk" = (
+/obj/structure/table/steel,
+/obj/item/gamehelm/pink{
+	icon_state = "closed_pink";
+	pixel_y = 2;
+	pixel_x = 3
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "Gn" = (
 /obj/structure/table/steel,
+/obj/random/tool{
+	pixel_x = -1;
+	pixel_y = -5
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "Gp" = (
@@ -3585,11 +4272,11 @@
 /turf/template_noop,
 /area/space)
 "Gs" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/head/turban,
-/obj/item/clothing/accessory/poncho,
-/obj/item/clothing/suit/storage/vest,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
 /area/mine)
 "Gw" = (
 /obj/machinery/light{
@@ -3606,30 +4293,54 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
 "GB" = (
-/obj/structure/table/standard,
-/obj/item/device/breath_analyzer{
-	pixel_x = 7
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = -7;
+	pixel_y = -15
 	},
-/obj/item/device/healthanalyzer{
-	pixel_x = -4
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "GF" = (
 /obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/mask/gas/syndicate{
+	pixel_x = -5
+	},
+/obj/item/clothing/mask/gas/syndicate{
+	pixel_x = -5
+	},
+/obj/item/clothing/mask/gas/alt{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/clothing/mask/gas/alt{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/clothing/mask/gas/alt{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/clothing/mask/gas/tactical{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/obj/item/clothing/mask/gas/tactical{
+	pixel_x = 4;
+	pixel_y = -6
+	},
+/obj/item/clothing/mask/gas/tactical{
+	pixel_x = 4;
+	pixel_y = -6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "GH" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/head/helmet/merc{
-	pixel_x = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/effect/floor_decal/spline/plain/black,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "GI" = (
@@ -3650,6 +4361,10 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/military,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/military/old/alt,
+/obj/item/storage/belt/fannypack/recolorable/random,
 /turf/simulated/floor/tiled,
 /area/mine)
 "GP" = (
@@ -3670,6 +4385,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
+/obj/random/dirt_75,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/mine)
 "Hp" = (
@@ -3682,11 +4399,8 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "Hr" = (
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/wood,
+/obj/random/dirt_75,
+/turf/unsimulated/floor/asteroid/ash,
 /area/mine)
 "Hs" = (
 /obj/structure/table/steel,
@@ -3717,6 +4431,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Hy" = (
@@ -3730,9 +4445,29 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"HA" = (
+/obj/random/dirt_75,
+/obj/structure/reagent_dispensers/cookingoil,
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
 "HB" = (
-/obj/structure/bed/stool/chair/sofa/left/black,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/clothing/suit/armor/carrier/heavy{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/clothing/suit/armor/carrier/heavy{
+	pixel_x = -6;
+	pixel_y = 0
+	},
+/obj/item/clothing/head/helmet/merc{
+	pixel_x = 4
+	},
+/obj/item/clothing/head/helmet/merc{
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "HC" = (
 /obj/machinery/smartfridge/foodheater,
@@ -3809,23 +4544,21 @@
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/covert,
 /obj/item/clothing/head/helmet/space/syndicate/covert,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "HZ" = (
-/obj/machinery/optable,
-/obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "Ia" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/d762,
-/obj/item/ammo_magazine/d762,
-/obj/item/ammo_magazine/d762,
-/obj/item/gun/projectile/dragunov,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/item/melee/baton/stunrod{
+	pixel_x = 9;
+	pixel_y = -4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "Ib" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -3841,130 +4574,43 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "Ie" = (
-/obj/structure/closet/cabinet,
-/obj/item/clothing/head/cowboy,
-/obj/item/clothing/shoes/cowboy,
-/obj/item/clothing/under/pants/camo,
-/obj/item/clothing/under/pants/camo,
-/obj/item/clothing/under/syndicate/tacticool,
-/obj/item/clothing/under/pants/tacticool,
-/obj/item/clothing/under/rank/sol/marine,
-/obj/item/clothing/head/sol/marine,
-/obj/item/clothing/under/rank/sol,
-/obj/item/clothing/under/rank/elyran_fatigues,
-/obj/item/clothing/under/dominia/fleet,
-/obj/item/clothing/under/dominia/fleet/armsman,
-/obj/item/clothing/head/dominia/fleet,
-/obj/item/clothing/head/dominia/fleet/armsman,
-/obj/item/clothing/under/pants/jeans,
-/obj/item/clothing/under/pants/jeansblack,
-/obj/item/clothing/head/beanie/random,
-/obj/item/clothing/head/beanie/random,
-/obj/item/clothing/head/headbando/random,
-/obj/item/clothing/head/headbando/random,
-/obj/item/clothing/head/beret/colorable/random,
-/obj/item/clothing/head/bandana/colorable/random,
-/obj/item/clothing/head/bandana/colorable/random,
-/obj/item/clothing/head/softcap/colorable/random,
-/obj/item/clothing/head/softcap/colorable/random,
-/obj/item/clothing/suit/storage/hooded/wintercoat/hoodie/random,
-/obj/item/clothing/suit/storage/hooded/wintercoat/hoodie/random,
-/obj/item/clothing/suit/storage/toggle/trench/colorable/random,
-/obj/item/clothing/suit/storage/toggle/trench/colorable/random,
-/obj/random/bandana,
-/obj/random/belt,
-/obj/random/colored_jumpsuit,
-/obj/random/colored_jumpsuit,
-/obj/random/colored_jumpsuit,
-/obj/random/hoodie,
-/obj/random/hoodie,
-/obj/random/suit,
-/obj/random/suit,
-/obj/random/softcap,
-/obj/random/gloves,
-/obj/random/gloves,
-/obj/item/clothing/suit/storage/toggle/trench/colorable/random,
-/obj/item/clothing/suit/storage/toggle/trench,
-/obj/item/clothing/under/uniform/gadpathur,
-/obj/item/clothing/head/gadpathur,
-/obj/item/clothing/head/sidecap/pmcg,
-/obj/item/clothing/head/sidecap/zavod,
-/obj/item/clothing/under/pmc_modsuit,
-/obj/item/clothing/under/rank/security/zavod,
-/obj/item/clothing/shoes/sneakers/hitops/red,
-/obj/item/clothing/shoes/sneakers/hitops/black,
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/under/syndicate/combat,
-/obj/item/clothing/under/syndicate,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/military,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/military,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/military/old,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/military/old,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/military/old/alt,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/military/old/alt,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/military/tan,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/military/tan,
-/obj/item/clothing/suit/storage/toggle/dominia/bomber,
-/obj/item/clothing/suit/storage/toggle/bomber,
-/obj/item/clothing/head/ushanka/dominia,
-/obj/item/clothing/gloves/black_leather,
-/obj/item/clothing/gloves/black_leather,
-/obj/item/clothing/gloves/fingerless,
-/obj/item/clothing/gloves/fingerless,
-/obj/item/clothing/suit/storage/leathercoat,
-/obj/item/clothing/suit/storage/toggle/leather_jacket,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/designer,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/designer/black,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/designer/red,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/flight,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/flight/green,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/flight/white,
-/obj/item/clothing/head/softcap/tcfl,
-/obj/item/clothing/head/softcap/tcfl,
-/obj/item/clothing/head/beret/legion,
-/obj/item/clothing/head/beret/legion/field,
-/obj/item/clothing/suit/storage/legion,
-/obj/item/clothing/suit/storage/legion,
-/obj/item/clothing/under/legion,
-/obj/item/clothing/under/legion,
-/obj/item/clothing/suit/storage/vest/legion,
-/obj/item/clothing/accessory/storage/brown_vest,
-/obj/item/clothing/accessory/storage/brown_vest,
-/obj/item/clothing/accessory/storage/white_vest,
-/obj/item/clothing/accessory/storage/white_vest,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/black_vest,
-/obj/item/clothing/accessory/storage/pouches/black,
-/obj/item/clothing/accessory/storage/pouches/black,
-/obj/item/clothing/accessory/storage/pouches/brown,
-/obj/item/clothing/accessory/storage/pouches/brown,
-/obj/item/clothing/accessory/storage/pouches/white,
-/obj/item/clothing/accessory/storage/pouches/white,
-/obj/item/clothing/accessory/holster/armpit/brown,
-/obj/item/clothing/accessory/holster/hip/brown,
-/obj/item/clothing/accessory/holster/thigh/brown,
-/obj/item/clothing/accessory/holster/thigh,
-/obj/item/clothing/accessory/holster/hip,
-/obj/item/clothing/accessory/holster/armpit,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/designer/black,
-/obj/item/clothing/head/softcap,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "Ig" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/tiled/dark,
-/area/mine)
-"Iz" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 10
+/obj/structure/table/wood,
+/obj/item/deck/cards{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/material/ashtray/bronze{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/one{
+	pixel_x = -20
 	},
 /turf/simulated/floor/carpet/red,
 /area/mine)
-"IA" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
+"Iz" = (
+/obj/item/trash/chips/dirtberry{
+	pixel_x = 10;
+	pixel_y = -4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
+"IA" = (
+/obj/machinery/atmospherics/binary/pump/aux/on{
+	dir = 8
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "IB" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -3972,12 +4618,15 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "IF" = (
 /obj/random/junk{
 	pixel_x = -9
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
 /area/mine)
 "IL" = (
@@ -3989,6 +4638,7 @@
 /area/shuttle/goon_ship/bridge)
 "IN" = (
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "IQ" = (
@@ -4001,13 +4651,10 @@
 /turf/simulated/floor/wood,
 /area/mine)
 "IS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/plating,
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "IU" = (
 /turf/simulated/floor/tiled/freezer,
@@ -4025,6 +4672,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "IZ" = (
@@ -4050,19 +4698,18 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "Jj" = (
-/obj/effect/map_effect/window_spawner/full/reinforced,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/clothing/gloves/boxing,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Jl" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/glasses/sunglasses/aviator{
-	pixel_x = -5;
-	pixel_y = 6
+/obj/effect/floor_decal/corner/grey/full{
+	dir = 8
 	},
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Jo" = (
 /obj/structure/bed/padded/bunk{
@@ -4087,21 +4734,33 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "Jw" = (
-/obj/structure/bed/stool/chair{
-	dir = 1
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/random/dirt_75,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 10;
+	pixel_y = 9
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = -10;
+	pixel_y = -2
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Jx" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/item/broken_bottle{
+	pixel_x = -6;
+	pixel_y = 9
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
 "Jz" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "JC" = (
@@ -4112,15 +4771,22 @@
 	pixel_x = -8;
 	pixel_y = -2
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "JD" = (
-/obj/structure/sink/kitchen{
-	name = "sink";
-	pixel_y = 26
-	},
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/steel,
+/obj/item/trash/waffles{
+	pixel_y = 5;
+	pixel_x = -1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "JW" = (
@@ -4139,6 +4805,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
+"Kb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
 "Ke" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -4152,45 +4826,55 @@
 "Ks" = (
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/coffee/full{
-	pixel_y = 16
+	pixel_y = 16;
+	pixel_x = -3
+	},
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = 5;
+	pixel_y = 2
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "KB" = (
-/obj/structure/table/reinforced/steel,
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 10
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/item/clothing/glasses/welding,
+/obj/item/weldingtool{
+	pixel_y = 4
 	},
-/obj/item/clothing/suit/armor/cuirass,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/mine)
 "KD" = (
 /obj/structure/bed/stool/chair/office/light{
 	dir = 4
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
 /area/mine)
 "KE" = (
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/item/reagent_containers/food/drinks/carton/milk{
-	pixel_y = 7
-	},
-/obj/item/storage/box/fancy/egg_box,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/random/dirt_75,
+/obj/structure/table/rack,
+/turf/simulated/floor/plating,
 /area/mine)
 "KG" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 4
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
+"KI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/red,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "KJ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "KK" = (
@@ -4203,22 +4887,17 @@
 /obj/structure/toilet{
 	dir = 8
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "KR" = (
-/obj/structure/bed/padded/bunk{
-	pixel_y = 0
+/obj/random/dirt_75,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 4;
+	pixel_y = 19
 	},
-/obj/item/bedsheet/black,
-/obj/item/toy/plushie/farwa{
-	pixel_y = -3;
-	pixel_x = 7
-	},
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/mine)
 "KS" = (
 /obj/structure/bed/stool/chair/folding{
@@ -4227,18 +4906,26 @@
 /turf/simulated/floor/tiled/full,
 /area/mine)
 "KW" = (
-/obj/structure/table/rack,
-/obj/item/stack/material/plasteel/full,
-/obj/item/stack/material/plasteel/full,
-/obj/item/stack/material/plasteel/full,
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 6
+/obj/structure/table/reinforced/steel,
+/obj/item/storage/toolbox/lunchbox/filled{
+	pixel_x = 1;
+	pixel_y = 13
 	},
-/turf/simulated/floor/plating,
+/obj/item/storage/toolbox/lunchbox/heart{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/storage/toolbox/lunchbox/cat/filled{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/mine)
 "KZ" = (
-/obj/structure/bookcase,
-/turf/simulated/floor/tiled,
+/turf/simulated/wall{
+	can_open = 1;
+	color = "#DDDDDD"
+	},
 /area/mine)
 "La" = (
 /obj/effect/floor_decal/corner/beige{
@@ -4248,11 +4935,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "Ld" = (
-/obj/effect/floor_decal/spline/fancy{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Lg" = (
 /obj/effect/floor_decal/corner/beige{
@@ -4282,25 +4967,80 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
+"Ls" = (
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled,
+/area/mine)
 "LM" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
+"LR" = (
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
+/obj/random/junk,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
+/area/mine)
+"LS" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "LY" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/power/portgen/basic,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
+/area/mine)
+"Mg" = (
+/obj/effect/floor_decal/corner/grey/full{
+	dir = 4
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Mh" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate/loot,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Mk" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
+	},
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/item/paper_bin{
+	pixel_y = 5;
+	pixel_x = 4
+	},
+/obj/item/pen/black{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/melee/baton/stunrod{
+	pixel_x = -2;
+	pixel_y = 4
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -4318,21 +5058,21 @@
 /obj/structure/bed/stool/chair/folding{
 	dir = 8
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Mo" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/ammo_magazine/a10mm,
-/obj/item/gun/projectile/automatic/c20r,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/random/dirt_75,
+/obj/item/tank/oxygen/brown{
+	pixel_x = -10;
+	pixel_y = -5
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Mu" = (
 /obj/effect/floor_decal/corner/grey/full,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Mw" = (
@@ -4345,13 +5085,29 @@
 /turf/simulated/floor/wood,
 /area/mine)
 "MB" = (
-/obj/machinery/door/airlock{
-	dir = 1
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/structure/table/steel,
+/obj/random/tool{
+	pixel_y = 2
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/item/tank/emergency_oxygen/double{
+	pixel_y = 5
+	},
+/obj/item/tank/emergency_oxygen/double{
+	pixel_y = 5
+	},
+/obj/item/tank/emergency_oxygen/double{
+	pixel_y = 5
+	},
+/obj/item/tank/emergency_oxygen/double{
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "ME" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "MH" = (
@@ -4359,6 +5115,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "MJ" = (
@@ -4384,11 +5141,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/random/dirt_75,
+/obj/item/tank/emergency_oxygen/double{
+	pixel_y = -9;
+	pixel_x = -6
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "MT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/phoron,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/mine)
 "MV" = (
@@ -4400,6 +5164,25 @@
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/goon_ship/port)
+"MY" = (
+/obj/structure/closet,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/item/clothing/under/suit_jacket/charcoal,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/midriff,
+/obj/item/clothing/suit/storage/toggle/varsity,
+/obj/item/clothing/under/pants/tacticool,
+/obj/item/clothing/under/pants/ripped,
+/obj/item/clothing/accessory/university/black,
+/obj/item/clothing/suit/storage/toggle/track/red,
+/obj/item/clothing/suit/storage/toggle/flannel/gray,
+/obj/item/clothing/head/beret,
+/obj/item/clothing/head/headbando/random,
+/obj/item/clothing/under/vysoka,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/military/tan,
+/turf/simulated/floor/tiled,
+/area/mine)
 "MZ" = (
 /obj/item/paper/crumpled{
 	pixel_y = 13;
@@ -4427,6 +5210,7 @@
 /obj/effect/ghostspawpoint{
 	identifier = "goon"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Ni" = (
@@ -4436,41 +5220,50 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "Nk" = (
-/obj/machinery/body_scanconsole{
-	pixel_x = -1
+/obj/machinery/door/airlock/external,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "Np" = (
 /obj/effect/floor_decal/spline/fancy/wood,
+/obj/item/trash/cigbutt{
+	pixel_y = -9;
+	pixel_x = -5
+	},
 /turf/simulated/floor/wood,
 /area/mine)
 "Nq" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/air,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Nr" = (
-/obj/effect/decal/cleanable/molten_item,
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "Nt" = (
 /obj/effect/floor_decal/industrial/warning,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "NA" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "NB" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "NF" = (
@@ -4480,14 +5273,15 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "NH" = (
-/obj/effect/map_effect/airlock/long/square{
-	required_access = null
-	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "NP" = (
-/obj/machinery/portable_atmospherics/canister/phoron_scarce,
-/obj/effect/decal/cleanable/dirt,
+/obj/random/dirt_75,
+/obj/random/loot,
+/obj/structure/table/rack,
 /turf/simulated/floor/plating,
 /area/mine)
 "NT" = (
@@ -4506,12 +5300,20 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "NX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/chipbasket,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/storage/box/smokebombs{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/box/flashbangs{
+	pixel_x = -3
+	},
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "NY" = (
 /obj/effect/decal/cleanable/generic,
@@ -4531,6 +5333,7 @@
 /obj/structure/bed/stool/chair{
 	dir = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Or" = (
@@ -4548,9 +5351,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "Ow" = (
-/obj/item/deck/cards,
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet/red,
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"Oy" = (
+/obj/structure/table/steel,
+/obj/item/storage/box/yarn{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "OA" = (
 /obj/structure/table/steel,
@@ -4604,13 +5417,9 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "Pc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "Pk" = (
 /obj/effect/overmap/visitable/sector/goon,
@@ -4630,6 +5439,13 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
+"PI" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
+/area/mine)
 "PK" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4644,9 +5460,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "PL" = (
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 8
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "PR" = (
 /obj/item/wrench,
@@ -4660,23 +5477,23 @@
 /turf/simulated/floor/wood,
 /area/mine)
 "PV" = (
-/obj/item/storage/box/drinkingglasses,
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "PW" = (
-/obj/structure/bed/padded/bunk{
-	pixel_y = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 9
 	},
-/obj/item/bedsheet/black,
-/turf/simulated/floor/wood,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "PY" = (
-/obj/item/material/ashtray/bronze,
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "PZ" = (
 /obj/structure/table/rack,
@@ -4685,14 +5502,30 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
+"Qb" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 1;
+	pixel_y = 19
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "Qc" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/oxygen,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Qe" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/industrial/warning,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Qf" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -4706,6 +5539,7 @@
 /obj/effect/floor_decal/corner/grey/full{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Qh" = (
@@ -4716,26 +5550,26 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Ql" = (
-/obj/machinery/chemical_dispenser/bar_soft/full{
-	dir = 8;
-	pixel_x = 5
+/obj/random/dirt_75,
+/obj/item/tank/air{
+	pixel_x = -9
 	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "Qm" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/freezer,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/turf/simulated/floor/plating,
 /area/mine)
 "Qv" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
@@ -4767,6 +5601,7 @@
 /obj/item/storage/firstaid/fire{
 	pixel_x = 4
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "Qz" = (
@@ -4789,19 +5624,30 @@
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "QO" = (
-/obj/structure/closet/crate/loot,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "QP" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 5
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/trash/cigbutt{
+	pixel_x = -10;
+	pixel_y = -3
 	},
-/turf/simulated/floor/carpet/red,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = -9;
+	pixel_y = 14
+	},
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "QQ" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "QT" = (
@@ -4813,6 +5659,11 @@
 /area/mine)
 "Rb" = (
 /obj/machinery/door/airlock/external,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 8
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Rc" = (
@@ -4865,12 +5716,42 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "Rv" = (
-/obj/machinery/media/jukebox,
-/turf/simulated/floor/wood,
+/obj/structure/table/reinforced/steel,
+/obj/item/storage/box/zipties{
+	layer = 2.99;
+	pixel_x = 9;
+	pixel_y = 10
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/mine)
 "RE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/obj/structure/table/rack,
+/obj/item/clothing/accessory/storage/pouches/brown{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/storage/pouches/brown{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/storage/pouches/brown{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/accessory/storage/brown_vest{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/storage/brown_vest{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/item/clothing/accessory/storage/brown_vest{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "RQ" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
@@ -4881,16 +5762,35 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "RR" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/mc9mm{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/mc9mm{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/mc9mm{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/mc9mm{
+	pixel_x = 6
+	},
+/obj/item/ammo_magazine/mc9mm{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/mc9mm{
+	pixel_x = 6
+	},
+/obj/item/gun/projectile/pistol{
+	pixel_y = 6;
+	pixel_x = -4
+	},
+/obj/item/gun/projectile/pistol{
+	pixel_y = -3;
+	pixel_x = 2
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "Sd" = (
 /obj/machinery/door/airlock/glass,
@@ -4934,21 +5834,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "Sj" = (
-/obj/machinery/vending/dinnerware,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/random/dirt_75,
+/obj/machinery/power/apc/north,
+/turf/simulated/floor/plating,
 /area/mine)
 "Sk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/closet/crate,
-/obj/item/stack/material/diamond,
-/obj/item/stack/material/diamond,
-/obj/item/stack/material/diamond,
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Sm" = (
 /obj/structure/table/rack,
@@ -4974,10 +5872,29 @@
 /area/mine)
 "Sv" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
+/area/mine)
+"Sw" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = -6;
+	pixel_y = -5
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Sx" = (
 /obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
 /area/mine)
 "Sz" = (
@@ -4989,26 +5906,18 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "SE" = (
-/obj/structure/table/reinforced/steel,
-/obj/item/clothing/mask/gas/syndicate{
-	layer = 2.99;
-	pixel_y = 6
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 8
 	},
-/obj/effect/floor_decal/spline/plain/black{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "SF" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 13
-	},
-/obj/structure/mirror{
-	pixel_x = 27
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/obj/random/dirt_75,
+/obj/random/loot,
+/turf/simulated/floor/plating,
 /area/mine)
 "SG" = (
 /obj/structure/lattice/catwalk/indoor/grate/old,
@@ -5021,6 +5930,7 @@
 /area/mine)
 "SH" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/aux,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "SJ" = (
@@ -5037,6 +5947,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "SU" = (
@@ -5045,11 +5956,16 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "SX" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/head/headbando/random,
-/obj/item/clothing/suit/storage/toggle/track/red,
-/obj/item/clothing/suit/storage/vest,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/table/steel,
+/obj/item/paper_bin{
+	pixel_y = 4;
+	pixel_x = 3
+	},
+/obj/item/pen/fountain/black{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "SZ" = (
 /obj/structure/cable{
@@ -5082,19 +5998,13 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "To" = (
-/obj/structure/closet{
-	icon_door = "blue";
-	name = "misc clothing"
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/trash/cigbutt{
+	pixel_x = -10;
+	pixel_y = -3
 	},
-/obj/item/clothing/accessory/university/black,
-/obj/item/clothing/under/syndicate/ninja,
-/obj/item/clothing/under/pants/ripped,
-/obj/item/clothing/under/pants/tacticool,
-/obj/item/clothing/under/vysoka,
-/obj/item/clothing/suit/storage/toggle/varsity,
-/obj/item/clothing/suit/storage/toggle/leather_jacket/midriff,
-/obj/item/clothing/under/suit_jacket/charcoal,
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "Tr" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -5106,61 +6016,115 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "Ts" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/rack,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/table/reinforced/steel,
+/obj/item/stack/material/glass/reinforced/full{
+	pixel_x = -16;
+	pixel_y = 4
+	},
+/obj/item/stack/material/glass/reinforced/full{
+	pixel_x = -16;
+	pixel_y = 4
+	},
+/obj/item/stack/material/glass/reinforced/full{
+	pixel_x = -16;
+	pixel_y = 4
+	},
+/obj/item/stack/material/steel/full{
+	pixel_y = 4
+	},
+/obj/item/stack/material/steel/full{
+	pixel_y = 4
+	},
+/obj/item/stack/material/steel/full{
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/plating,
 /area/mine)
 "Tt" = (
 /obj/machinery/vending/dinnerware/plastic,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Tu" = (
-/obj/structure/bed/stool/chair,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/structural_support{
+	pixel_y = 8
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
 /area/mine)
 "Ty" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "TA" = (
-/obj/item/clothing/accessory/longsleeve_s,
-/obj/structure/closet{
-	icon_door = "blue";
-	name = "misc clothing"
+/obj/structure/trash_pile,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
 	},
-/obj/item/clothing/under/syndicate/tacticool,
-/obj/item/clothing/under/tactical,
-/obj/item/clothing/under/pants/black,
-/obj/item/clothing/under/color/brown,
-/obj/item/clothing/suit/storage/toggle/trench/grey,
-/obj/item/clothing/head/softcap/himeo,
-/obj/item/clothing/suit/storage/toggle/leather_vest,
-/obj/item/clothing/under/service_overalls,
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "TH" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 5
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 4;
+	pixel_y = 19
 	},
-/turf/simulated/floor/tiled/white,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 11
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "TJ" = (
-/obj/structure/table/steel{
-	pixel_x = -2
+/obj/effect/decal/cleanable/greenglow/radioactive{
+	pixel_x = -10;
+	pixel_y = 9
 	},
-/obj/item/trash/waffles,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"TM" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/ammo_magazine/c45m{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/c45m{
+	pixel_x = 7
+	},
+/obj/item/ammo_magazine/c45m{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/c45m{
+	pixel_x = 7
+	},
+/obj/item/ammo_magazine/c45m{
+	pixel_x = -6
+	},
+/obj/item/ammo_magazine/c45m{
+	pixel_x = 7
+	},
+/obj/item/gun/projectile/sec/lethal{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/gun/projectile/sec/lethal{
+	pixel_x = 5;
+	pixel_y = -1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "TN" = (
@@ -5174,11 +6138,12 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "TQ" = (
-/obj/structure/noticeboard{
-	pixel_y = -30
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/trash/candy,
-/turf/simulated/floor/wood,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "TW" = (
 /obj/effect/floor_decal/corner/red/full{
@@ -5203,6 +6168,7 @@
 /obj/structure/closet/secure_closet/cabinet{
 	req_access = list(20)
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Uh" = (
@@ -5210,6 +6176,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Ui" = (
@@ -5236,23 +6203,15 @@
 	pixel_x = 4;
 	pixel_y = 8
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "Up" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/suit/pirate,
-/obj/item/storage/box/fancy/cigarettes/nicotine,
-/obj/item/storage/box/fancy/cigarettes/nicotine,
-/obj/item/storage/box/fancy/cigarettes/nicotine,
-/obj/item/reagent_containers/food/drinks/bottle/vintage_wine,
-/obj/item/reagent_containers/food/drinks/bottle/goldschlager,
-/obj/item/reagent_containers/food/drinks/bottle/melonliquor,
-/obj/random/spacecash,
-/obj/random/spacecash,
-/obj/random/spacecash,
-/obj/random/spacecash,
-/obj/random/spacecash,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/structure/closet/toolcloset,
+/turf/simulated/floor/plating,
 /area/mine)
 "Uq" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -5261,9 +6220,20 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/starboard)
 "Ur" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/ramen,
-/turf/simulated/floor/carpet/red,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/plating,
+/area/mine)
+"Uu" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/random/dirt_75,
+/obj/random/loot{
+	pixel_x = -11
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "UA" = (
 /obj/random/dirt_75,
@@ -5291,18 +6261,15 @@
 "UN" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "UX" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/fancy/tray,
-/obj/effect/floor_decal/corner/lime/diagonal,
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
+/obj/effect/floor_decal/corner/grey/full{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Vb" = (
 /obj/structure/bed/padded,
@@ -5317,8 +6284,45 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "Vc" = (
-/obj/structure/punching_bag,
-/turf/simulated/floor/wood,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/storage/belt/military{
+	pixel_y = -3;
+	pixel_x = -3
+	},
+/obj/item/storage/belt/military{
+	pixel_y = -3;
+	pixel_x = -3
+	},
+/obj/item/storage/belt/military{
+	pixel_y = -3;
+	pixel_x = -3
+	},
+/obj/item/storage/belt/military{
+	pixel_y = 5;
+	pixel_x = 2
+	},
+/obj/item/storage/belt/military{
+	pixel_y = 5;
+	pixel_x = 2
+	},
+/obj/item/storage/belt/military{
+	pixel_y = 5;
+	pixel_x = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"Vd" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
+"Vi" = (
+/obj/random/dirt_75,
+/obj/structure/closet/toolcloset,
+/turf/simulated/floor/plating,
 /area/mine)
 "Vo" = (
 /obj/structure/closet/walllocker/medical{
@@ -5328,20 +6332,17 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Vp" = (
-/obj/structure/lattice/catwalk/indoor/grate/old,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Vs" = (
-/obj/item/paper/crumpled,
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/plating,
 /area/mine)
 "Vu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5364,19 +6365,31 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "VD" = (
-/obj/structure/table/steel{
-	pixel_x = -2
-	},
-/obj/item/trash/tray,
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/obj/structure/closet/toolcloset,
+/turf/simulated/floor/tiled,
+/area/mine)
+"VH" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "VK" = (
 /turf/simulated/floor/tiled/dark/full,
 /area/mine)
 "VL" = (
-/obj/structure/table/wood,
-/obj/item/material/ashtray/bronze,
-/turf/simulated/floor/wood,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
+"VN" = (
+/obj/random/dirt_75,
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "VR" = (
 /obj/effect/floor_decal/corner/lime{
@@ -5389,12 +6402,23 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "VY" = (
-/obj/structure/table/rack,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical/w,
-/obj/item/melee/baton/stunrod,
-/obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/white,
+/obj/structure/closet,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/item/clothing/head/softcap,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/designer/black,
+/obj/item/clothing/suit/storage/legion,
+/obj/item/clothing/head/beret/legion/field,
+/obj/item/clothing/head/softcap/tcfl,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/flight/white,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/flight/green,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/designer/red,
+/obj/item/clothing/suit/storage/leathercoat,
+/obj/item/clothing/gloves/fingerless,
+/obj/item/clothing/head/ushanka/dominia,
+/obj/item/clothing/suit/storage/toggle/bomber,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Wb" = (
 /obj/item/trash/can,
@@ -5408,6 +6432,10 @@
 /area/shuttle/goon_ship/med)
 "Wk" = (
 /obj/machinery/vending/dinnerware,
+/obj/machinery/power/apc/north,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "Wn" = (
@@ -5415,12 +6443,31 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
+/obj/item/clothing/under/rank/security/zavod,
+/obj/item/clothing/under/pmc_modsuit,
+/obj/item/clothing/under/pmc_modsuit,
+/obj/item/clothing/head/sidecap/zavod,
+/obj/item/clothing/head/sidecap/pmcg,
+/obj/item/clothing/head/gadpathur,
+/obj/item/clothing/under/uniform/gadpathur,
+/obj/item/clothing/suit/storage/toggle/trench,
+/obj/random/gloves,
+/obj/random/softcap,
+/obj/random/suit,
+/obj/random/hoodie,
+/obj/random/colored_jumpsuit,
+/obj/random/bandana,
+/obj/item/clothing/suit/storage/hooded/wintercoat/hoodie/random,
+/obj/item/clothing/head/bandana/colorable/random,
+/obj/item/clothing/head/beanie/random,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Wq" = (
-/obj/structure/curtain/medical,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "Wt" = (
 /obj/structure/table/rack,
@@ -5430,15 +6477,16 @@
 "Wu" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Wv" = (
-/obj/structure/bed/roller,
-/obj/effect/floor_decal/industrial/outline/medical,
-/obj/effect/floor_decal/corner/lime{
-	dir = 5
+/obj/structure/table/steel,
+/obj/random/desktoy{
+	pixel_x = -4;
+	pixel_y = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Ww" = (
 /obj/effect/floor_decal/corner/lime{
@@ -5471,12 +6519,14 @@
 "WD" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/appliance/cooker/oven,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "WG" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/item/trash/coffee,
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "WI" = (
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -5494,6 +6544,7 @@
 "WM" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "WO" = (
@@ -5510,13 +6561,25 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "WR" = (
-/obj/structure/bed/stool,
-/turf/simulated/floor/carpet/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "WS" = (
-/obj/item/clothing/gloves/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/item/storage/box/fancy/cigarettes/nicotine{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = 3;
+	pixel_y = -4
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "Xb" = (
 /obj/effect/shuttle_landmark/goon_ship/transit,
@@ -5561,18 +6624,27 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "Xx" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 4
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner/grey{
+	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/chips,
-/turf/simulated/floor/carpet/red,
+/obj/item/tank/emergency_oxygen/double{
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "Xz" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 7
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/steel,
+/obj/item/material/knife{
+	pixel_x = 5;
+	pixel_y = 12
 	},
-/turf/simulated/floor/carpet/red,
+/obj/item/material/kitchen/rollingpin{
+	pixel_y = 5
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "XF" = (
 /obj/effect/floor_decal/corner/grey{
@@ -5586,15 +6658,32 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
+/obj/machinery/power/apc/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/item/clothing/head/bearpelt,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/military/old,
+/obj/item/clothing/under/service_overalls,
+/obj/item/clothing/suit/storage/toggle/leather_vest,
+/obj/item/clothing/head/softcap/himeo,
+/obj/item/clothing/suit/storage/toggle/trench/grey,
+/obj/item/clothing/under/color/brown,
+/obj/item/clothing/under/pants/black,
+/obj/item/clothing/under/tactical,
+/obj/item/clothing/under/syndicate/tacticool,
+/obj/item/clothing/accessory/longsleeve_s,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/flight,
 /turf/simulated/floor/tiled,
 /area/mine)
 "XP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/stack/material/silver,
-/obj/item/stack/material/silver,
-/obj/item/stack/material/silver,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/white,
 /area/mine)
 "XS" = (
 /obj/machinery/computer/ship/engines{
@@ -5610,8 +6699,26 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "Ya" = (
-/obj/structure/closet/crate,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack,
+/obj/item/clothing/suit/armor/carrier/generic{
+	pixel_x = -6
+	},
+/obj/item/clothing/suit/armor/carrier/generic{
+	pixel_x = -6
+	},
+/obj/item/clothing/suit/armor/carrier/generic{
+	pixel_x = -6
+	},
+/obj/item/clothing/head/helmet/merc{
+	pixel_x = 4
+	},
+/obj/item/clothing/head/helmet/merc{
+	pixel_x = 4
+	},
+/obj/item/clothing/head/helmet/merc{
+	pixel_x = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "Yf" = (
@@ -5619,6 +6726,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Yh" = (
@@ -5628,16 +6736,12 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/goon_ship/living)
 "Yi" = (
-/obj/structure/table/steel{
-	pixel_x = -2
+/obj/random/dirt_75,
+/obj/item/trash/cigbutt{
+	pixel_y = -13;
+	pixel_x = 11
 	},
-/obj/item/material/kitchen/rollingpin,
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "Yp" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
@@ -5650,10 +6754,12 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "Yz" = (
-/obj/item/storage/box/handcuffs,
-/obj/item/melee/baton/stunrod,
-/obj/structure/table/steel,
-/turf/simulated/floor/wood,
+/obj/random/dirt_75,
+/obj/item/clothing/gloves/yellow{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "YA" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -5671,6 +6777,14 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/random/dirt_75,
+/obj/item/clothing/accessory/poncho,
+/obj/item/clothing/head/turban,
+/obj/item/clothing/head/turban/gadpathur,
+/obj/item/clothing/head/turban/brown,
 /turf/simulated/floor/tiled,
 /area/mine)
 "YK" = (
@@ -5685,15 +6799,18 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "YV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock{
-	dir = 8;
-	req_access = list(202)
+/obj/effect/floor_decal/corner/purple{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "YW" = (
 /obj/structure/cable{
@@ -5713,12 +6830,9 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "YZ" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey{
-	pixel_y = 8;
-	pixel_x = 6
-	},
-/turf/simulated/floor/wood,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Zc" = (
 /obj/effect/floor_decal/spline/plain/black{
@@ -5727,7 +6841,6 @@
 /obj/structure/table/steel{
 	pixel_x = -2
 	},
-/obj/item/gun/custom_ka/frame05,
 /obj/machinery/light{
 	dir = 8;
 	pixel_y = 0;
@@ -5744,44 +6857,39 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Zi" = (
-/turf/simulated/floor/wood,
+/obj/structure/closet/firecloset,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
 /area/mine)
 "Zk" = (
-/obj/machinery/door/airlock{
-	dir = 8;
-	req_access = list(202)
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/reagent_dispensers/coolanttank,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Zl" = (
 /obj/random/junk,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/mine)
 "Zu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/inhaler/space_drugs,
-/obj/item/reagent_containers/inhaler/space_drugs,
-/obj/item/reagent_containers/inhaler/space_drugs,
-/obj/item/reagent_containers/syringe/drugs,
-/obj/item/reagent_containers/syringe/drugs,
-/obj/item/reagent_containers/syringe/drugs,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Zw" = (
-/obj/structure/table/steel,
-/obj/item/storage/firstaid/combat{
-	pixel_x = -4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/storage/firstaid/trauma,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 4
-	},
-/obj/effect/floor_decal/corner/lime{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "Zx" = (
 /obj/effect/floor_decal/spline/plain/black{
@@ -5797,32 +6905,75 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "ZB" = (
-/obj/structure/table/rack,
-/obj/item/wrench,
-/obj/item/wrench,
-/obj/item/wrench,
-/obj/item/wrench,
-/obj/item/wrench,
-/obj/item/paper/goon_base/notice,
-/turf/simulated/floor/tiled/dark,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = -9;
+	pixel_y = 3
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"ZG" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/loot,
+/turf/simulated/floor/plating,
 /area/mine)
 "ZH" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "ZJ" = (
-/obj/structure/table/steel{
-	pixel_x = -2
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/item/trash/plate,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled,
 /area/mine)
 "ZL" = (
-/obj/item/trash/cheesie,
-/turf/simulated/floor/wood,
+/obj/structure/table/rack,
+/obj/item/device/flashlight/lantern{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/device/flashlight/lantern{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/device/flashlight/lantern{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/device/flashlight/heavy,
+/obj/item/device/flashlight{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight/flare/glowstick/random,
+/obj/item/device/flashlight/flare/glowstick/random,
+/obj/item/device/flashlight/flare/glowstick/random,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/plating,
 /area/mine)
 "ZR" = (
 /obj/structure/closet/crate/freezer{
@@ -5878,12 +7029,14 @@
 	},
 /obj/structure/mopbucket,
 /obj/item/mop,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "ZW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/portgen/basic,
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "ZY" = (
 /obj/machinery/door/airlock/external{
@@ -5892,6 +7045,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/plating,
 /area/mine)
 
@@ -18667,6 +19822,8 @@ bu
 bu
 bu
 bu
+mI
+mI
 bu
 bu
 bu
@@ -18686,11 +19843,9 @@ bu
 bu
 bu
 bu
-bu
-bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -18921,6 +20076,10 @@ bu
 bu
 bu
 bu
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -18940,15 +20099,11 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -19179,6 +20334,8 @@ bu
 bu
 bu
 bu
+mI
+mI
 bu
 bu
 bu
@@ -19199,13 +20356,11 @@ bu
 bu
 bu
 bu
-bu
-bu
-fY
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -19457,11 +20612,11 @@ bu
 bu
 bu
 bu
-bu
-bu
-fY
-fY
-fY
+sB
+sB
+mI
+mI
+mI
 bu
 bu
 bu
@@ -19712,12 +20867,12 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -19968,6 +21123,13 @@ bu
 bu
 bu
 bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -19975,20 +21137,13 @@ bu
 bu
 bu
 bu
+mI
+mI
+sB
+sB
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-fY
-fY
-bu
-bu
-bu
-bu
-bu
+sB
 bu
 bu
 bu
@@ -20223,29 +21378,29 @@ bu
 bu
 bu
 bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
-bu
-bu
-bu
-bu
+mI
+mI
+mI
+mI
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -20478,30 +21633,30 @@ bu
 bu
 bu
 bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
-fY
-bu
-bu
+mI
+mI
+mI
+mI
+mI
+sB
+sB
 bu
 bu
 bu
@@ -20731,34 +21886,34 @@ bu
 bu
 bu
 bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
-bu
-bu
+sB
+mI
+mI
+mI
+mI
+sB
+sB
 bu
 bu
 bu
@@ -21003,17 +22158,17 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+mI
+mI
+mI
+sB
 bu
 bu
 bu
@@ -21262,15 +22417,15 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -21494,7 +22649,6 @@ bu
 bu
 bu
 bu
-bu
 mI
 mI
 mI
@@ -21520,15 +22674,14 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+mI
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -21539,7 +22692,9 @@ bu
 bu
 bu
 bu
-fY
+bu
+bu
+mI
 bu
 bu
 bu
@@ -21751,7 +22906,6 @@ bu
 bu
 bu
 bu
-bu
 mI
 mI
 mI
@@ -21779,12 +22933,11 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-bu
-bu
+mI
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -21794,10 +22947,12 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
+bu
+bu
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -22036,6 +23191,10 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -22047,14 +23206,10 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -22293,6 +23448,10 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -22304,14 +23463,10 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -22552,6 +23707,8 @@ mI
 mI
 mI
 mI
+sB
+sB
 bu
 bu
 bu
@@ -22564,10 +23721,8 @@ bu
 bu
 bu
 bu
-bu
-bu
-fY
-fY
+mI
+mI
 bu
 bu
 bu
@@ -22809,8 +23964,8 @@ mI
 mI
 mI
 mI
-bu
-bu
+sB
+sB
 bu
 bu
 bu
@@ -23033,7 +24188,7 @@ bu
 bu
 bu
 bu
-bu
+fY
 mI
 mI
 mI
@@ -23066,7 +24221,7 @@ mI
 mI
 mI
 mI
-bu
+sB
 bu
 bu
 bu
@@ -23328,9 +24483,9 @@ mI
 bu
 bu
 bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -23585,9 +24740,9 @@ mI
 mI
 bu
 bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -23843,7 +24998,7 @@ mI
 bu
 bu
 bu
-fY
+mI
 bu
 bu
 bu
@@ -24277,8 +25432,8 @@ bu
 bu
 bu
 bu
-bu
-bu
+sB
+sB
 bu
 bu
 bu
@@ -24530,13 +25685,13 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -24785,16 +25940,16 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -25041,12 +26196,12 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -25125,6 +26280,7 @@ mI
 mI
 mI
 mI
+sB
 bu
 bu
 bu
@@ -25141,9 +26297,8 @@ bu
 bu
 bu
 bu
-bu
-fY
-fY
+mI
+mI
 bu
 bu
 bu
@@ -25296,14 +26451,14 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -25382,6 +26537,7 @@ mI
 mI
 mI
 mI
+sB
 bu
 bu
 bu
@@ -25398,11 +26554,10 @@ bu
 bu
 bu
 bu
-bu
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -25551,16 +26706,16 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -25639,6 +26794,7 @@ mI
 mI
 mI
 mI
+sB
 bu
 bu
 bu
@@ -25655,11 +26811,10 @@ bu
 bu
 bu
 bu
-bu
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -25806,6 +26961,97 @@ bu
 bu
 bu
 bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+sB
 bu
 bu
 bu
@@ -25818,105 +27064,14 @@ bu
 bu
 bu
 bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
 bu
 bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -26035,6 +27190,7 @@ mI
 mI
 mI
 mI
+sB
 bu
 bu
 bu
@@ -26060,20 +27216,19 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -26153,8 +27308,8 @@ mI
 mI
 mI
 mI
-bu
-bu
+sB
+sB
 bu
 bu
 bu
@@ -26292,6 +27447,7 @@ mI
 mI
 mI
 mI
+sB
 bu
 bu
 bu
@@ -26314,21 +27470,20 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -26410,12 +27565,12 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-bu
-fY
+sB
+sB
+sB
+sB
+sB
+mI
 bu
 bu
 bu
@@ -26549,6 +27704,8 @@ mI
 mI
 mI
 mI
+sB
+sB
 bu
 bu
 bu
@@ -26560,32 +27717,30 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -26667,14 +27822,14 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
+sB
+sB
+sB
+sB
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -26806,42 +27961,42 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -26924,14 +28079,14 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
+sB
+sB
+sB
+sB
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -27068,30 +28223,30 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -27181,14 +28336,14 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
+sB
+sB
+sB
+sB
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -27325,127 +28480,127 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+sB
+sB
+sB
 bu
-bu
-bu
-bu
-bu
-bu
-bu
 mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
 bu
 bu
 bu
@@ -27695,24 +28850,24 @@ mI
 mI
 mI
 mI
+sB
+sB
+bu
+bu
+mI
+mI
+mI
+mI
 bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
 bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-fY
-fY
+mI
+mI
 bu
 bu
 bu
@@ -27952,26 +29107,26 @@ mI
 mI
 mI
 mI
+sB
+sB
+bu
+bu
+bu
+mI
+mI
 bu
 bu
 bu
 bu
 bu
-fY
-fY
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -28209,6 +29364,8 @@ mI
 mI
 mI
 mI
+sB
+sB
 bu
 bu
 bu
@@ -28222,13 +29379,11 @@ bu
 bu
 bu
 bu
-bu
-bu
-fY
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -28466,6 +29621,9 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
 bu
 bu
 bu
@@ -28477,15 +29635,12 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -28723,6 +29878,10 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -28733,16 +29892,12 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -28980,6 +30135,10 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -28990,16 +30149,12 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -29237,6 +30392,10 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -29250,11 +30409,7 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-fY
+mI
 bu
 bu
 bu
@@ -29494,10 +30649,10 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -29751,10 +30906,10 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -30008,10 +31163,10 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -30265,15 +31420,15 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
+sB
 bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -30522,15 +31677,15 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
+sB
 bu
 bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -30779,9 +31934,9 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
+sB
+sB
+sB
 bu
 bu
 bu
@@ -31036,9 +32191,9 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
+sB
+sB
+sB
 bu
 bu
 bu
@@ -31292,8 +32447,8 @@ mI
 mI
 mI
 mI
-bu
-bu
+sB
+sB
 bu
 bu
 bu
@@ -31549,7 +32704,7 @@ mI
 mI
 mI
 mI
-bu
+sB
 bu
 bu
 bu
@@ -31806,6 +32961,7 @@ mI
 mI
 mI
 mI
+sB
 bu
 bu
 bu
@@ -31821,9 +32977,8 @@ bu
 bu
 bu
 bu
-bu
-fY
-fY
+mI
+mI
 bu
 bu
 bu
@@ -32079,8 +33234,8 @@ bu
 bu
 bu
 bu
-fY
-fY
+mI
+mI
 bu
 bu
 bu
@@ -32325,7 +33480,7 @@ bu
 bu
 bu
 bu
-fY
+mI
 bu
 bu
 bu
@@ -32336,7 +33491,7 @@ bu
 bu
 bu
 bu
-fY
+mI
 bu
 bu
 bu
@@ -32581,9 +33736,9 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -32838,9 +33993,9 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -33095,9 +34250,9 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -33353,7 +34508,7 @@ bu
 bu
 bu
 bu
-fY
+mI
 bu
 bu
 bu
@@ -33366,7 +34521,7 @@ bu
 bu
 bu
 bu
-fY
+mI
 bu
 bu
 bu
@@ -33621,10 +34776,10 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -33878,10 +35033,10 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -34135,10 +35290,10 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -34393,8 +35548,8 @@ bu
 bu
 bu
 bu
-fY
-fY
+mI
+mI
 bu
 bu
 bu
@@ -35404,9 +36559,9 @@ mI
 bu
 bu
 bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -35661,9 +36816,9 @@ mI
 bu
 bu
 bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -36779,13 +37934,13 @@ mI
 mI
 qX
 Dr
-Gn
-Gn
+Ls
+hS
 Nt
 jS
-EZ
+yl
 lh
-qf
+Bt
 gc
 jw
 NU
@@ -37036,13 +38191,13 @@ mI
 mI
 qX
 Dr
-Gn
+Dy
 tF
-Nt
+Qe
 IB
 EZ
 Jz
-QX
+Li
 MH
 xz
 KJ
@@ -37200,7 +38355,7 @@ sB
 sB
 sB
 sB
-bu
+sB
 bu
 bu
 bu
@@ -37293,13 +38448,13 @@ mI
 mI
 qX
 Dr
-Gn
-Vw
+KB
+HZ
 Au
 FD
 SM
 Ep
-QX
+Vi
 zU
 dY
 bA
@@ -37310,10 +38465,10 @@ qX
 qX
 qX
 qX
-qX
 mI
 mI
-qX
+mI
+mI
 qX
 qX
 qX
@@ -37324,8 +38479,8 @@ qX
 qX
 Dr
 wb
-bj
-lW
+Mg
+HZ
 Qg
 bm
 Dr
@@ -37457,7 +38612,7 @@ sB
 sB
 sB
 sB
-bu
+sB
 bu
 bu
 bu
@@ -37550,8 +38705,8 @@ mI
 mI
 qX
 Dr
-IN
-QX
+tC
+Li
 IN
 Dr
 Dr
@@ -37567,10 +38722,10 @@ Dr
 Dr
 Dr
 Dr
-qX
 mI
+SE
+Gi
 mI
-qX
 Dr
 Dr
 Dr
@@ -37581,9 +38736,9 @@ Dr
 Dr
 Dr
 qj
-lW
-lW
-lW
+pJ
+Ax
+cH
 xp
 Dr
 qX
@@ -37634,7 +38789,7 @@ mI
 mI
 mI
 mI
-vz
+Ag
 mI
 mI
 mI
@@ -37714,9 +38869,9 @@ sB
 sB
 sB
 sB
-bu
-bu
-bu
+sB
+sB
+sB
 bu
 bu
 bu
@@ -37808,38 +38963,38 @@ mI
 qX
 Dr
 LY
-QX
-IN
+Li
+Vs
 Dr
-QX
-Qj
-QX
-Dr
-uU
-Zl
-QX
-QX
-QX
-QX
-QX
-QX
-Dr
-qX
-mI
-mI
-qX
+NP
+Ep
+Li
 Dr
 uU
-QX
-QX
-QX
-QX
-QX
+cN
+Li
+Li
+Li
+cK
+Li
+NP
+Dr
+mI
+oK
+TJ
+mI
+Dr
+uU
+Li
+fe
+Li
+Li
+Li
 QX
 Dr
 IX
-Mu
-lW
+lz
+pJ
 FU
 tr
 Dr
@@ -37891,8 +39046,8 @@ mI
 mI
 mI
 mI
-vz
-vz
+Ag
+Ag
 mI
 mI
 mI
@@ -37971,10 +39126,10 @@ sB
 sB
 sB
 sB
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -38065,44 +39220,44 @@ qX
 qX
 Dr
 eL
-IN
-IN
+Ur
+Up
 Dr
-QX
+Li
 AL
 zW
 wH
-qf
-qf
-QX
-QX
-QX
-uU
-QX
-QX
+Bt
+Bt
+WR
+Ak
+WR
+Ak
+WR
+qN
 Dr
 mI
 mI
-mI
+ZB
 mI
 Dr
-QX
-QX
-Zl
-QX
-QX
-QX
-QX
-wY
-Vw
-bj
-lW
+GH
+WR
+mQ
+WR
+WR
+WR
+WR
+yX
+Ld
+ku
+pj
 pz
-BH
+Xx
 Dr
-QX
-QX
-QX
+cK
+Li
+KE
 Dr
 Fb
 pf
@@ -38147,8 +39302,8 @@ mI
 mI
 mI
 mI
-vz
-vz
+Ag
+Ag
 se
 mI
 Dr
@@ -38228,10 +39383,10 @@ sB
 sB
 sB
 sB
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -38326,7 +39481,7 @@ Dr
 Dr
 Dr
 UN
-Vw
+wD
 Qj
 Dr
 Dr
@@ -38336,35 +39491,35 @@ Dr
 Dr
 Dr
 Dr
-QX
+Wq
 Dr
 mI
-tS
-mI
+Tu
+ZW
 mI
 Dr
-QX
-QX
+Wq
+Li
 Dr
 EQ
-QX
+NP
 uU
 Dr
 Dr
 XF
 lW
-lW
-lW
+Ie
+lI
 BH
 Dr
-QX
-QX
-QX
+Li
+no
+Li
 Dr
-QX
+Li
 Mm
-QX
-fR
+wz
+uS
 Uh
 Dr
 qX
@@ -38485,9 +39640,9 @@ sB
 sB
 sB
 sB
-bu
-bu
-bu
+sB
+sB
+sB
 bu
 bu
 bu
@@ -38583,24 +39738,24 @@ ru
 tu
 Dr
 un
-Vw
+wD
 Qj
 Dr
 kE
-QX
-QX
-QX
-QX
-kE
+Li
+Li
+Li
+Li
+dh
 Dr
-QX
+Wq
 Dr
 mI
-Do
-Do
-tS
+ZW
+ZW
+Tu
 Dr
-Rt
+LS
 Dr
 Dr
 Dr
@@ -38610,19 +39765,19 @@ Dr
 Dr
 ZH
 Mu
-lW
-FU
-Vw
-wY
-QX
-QX
-QX
-wY
-QX
-QX
-QX
-mt
-QX
+gm
+UX
+oi
+yX
+WR
+WR
+WR
+yX
+Nr
+CR
+Pc
+Ew
+kR
 Dr
 qX
 mI
@@ -38742,8 +39897,8 @@ sB
 sB
 sB
 sB
-bu
-bu
+sB
+sB
 bu
 bu
 bu
@@ -38833,50 +39988,50 @@ Dr
 Dr
 Dr
 Dr
-QX
+yY
 pa
 ru
 vH
-QX
+aT
 Dr
 qO
-qf
+Zw
 ys
 Dr
-IN
-QX
+nm
+hZ
 Bm
-IN
-QX
-IN
+NH
+ZG
+fz
 Dr
-QX
+Wq
 Dr
 Dr
-Do
-Do
-Do
+uy
+ZW
+uy
 Dr
-QX
-QX
-QX
+Wq
+Li
+SF
 Dr
 QX
 QX
 QX
 Dr
 Yf
-Vw
-Vw
+wD
+nQ
 jW
 ei
 Dr
-QX
-QX
-QX
+NP
+cK
+Li
 Dr
 lJ
-Zl
+IA
 Dr
 ZY
 Dr
@@ -38918,8 +40073,8 @@ mI
 mI
 mI
 Dr
-vz
-vz
+Ag
+Ag
 se
 se
 Dr
@@ -38999,7 +40154,7 @@ QC
 QC
 sB
 sB
-bu
+sB
 bu
 bu
 bu
@@ -39087,7 +40242,7 @@ qX
 Dr
 MT
 WM
-NB
+Ur
 NB
 Dr
 is
@@ -39096,27 +40251,27 @@ Hx
 yD
 tu
 Dr
-Qj
-Vw
-QX
+Ep
+wD
+KR
 Dr
-IN
-QX
-IN
+NH
+hZ
+VL
 Mh
-QX
+Li
 lb
 Dr
-QX
-QX
-wY
-nB
-nB
-nB
-nB
-QX
-QX
-QX
+hN
+WR
+yX
+nC
+nC
+nC
+nC
+QO
+no
+fe
 Dr
 QX
 QX
@@ -39132,8 +40287,8 @@ Dr
 Dr
 Dr
 Dr
-uU
-QX
+TA
+PW
 Dr
 cF
 QX
@@ -39175,10 +40330,10 @@ mI
 mI
 mI
 Dr
-vz
-vz
-vz
-vz
+Ag
+Ag
+Ag
+Ag
 Dr
 mI
 mI
@@ -39256,7 +40411,7 @@ FF
 nA
 sB
 sB
-bu
+sB
 bu
 bu
 bu
@@ -39343,37 +40498,37 @@ mI
 qX
 Dr
 QQ
-QX
-QX
+Yz
+Li
 Ga
 Dr
-QX
+oM
 pa
 MS
-QX
+xY
 Dr
 Dr
-QX
-Vw
+Sk
+wD
 uU
 Dr
 qv
-QX
-Mh
+Li
+tR
 Wu
-QX
+Li
 IN
 Dr
-QX
-QX
+cK
+Li
 Dr
 mI
 mI
 mI
 mI
 uU
-QX
-QX
+Li
+Li
 Dr
 QX
 QX
@@ -39381,10 +40536,10 @@ QX
 Dr
 FU
 IW
-Vw
+Ie
 IW
-ll
-Uh
+Gs
+CY
 Dr
 mI
 mI
@@ -39392,7 +40547,7 @@ Dr
 mn
 mn
 Dr
-ms
+gx
 Dr
 Dr
 qX
@@ -39433,8 +40588,8 @@ nT
 nT
 Dr
 Dr
-vz
-vz
+Ag
+Ag
 Dr
 Dr
 mI
@@ -39513,7 +40668,7 @@ uB
 MV
 sB
 sB
-bu
+sB
 bu
 bu
 bu
@@ -39600,17 +40755,17 @@ mI
 qX
 Dr
 Nq
-QX
-QX
-QX
-QX
-QX
+Li
+rW
+Li
+Li
+Li
 uu
 uu
-QX
+Li
 Dr
 EQ
-QX
+nJ
 Dr
 Dr
 Dr
@@ -39625,8 +40780,8 @@ Dr
 Rt
 Dr
 Dr
-Do
-tS
+uy
+Tu
 mI
 Dr
 Dr
@@ -39637,11 +40792,11 @@ Rt
 Dr
 Dr
 TO
-Vw
-Vw
+lW
+kz
 Vw
 fR
-Uh
+CY
 Dr
 mI
 mI
@@ -39706,11 +40861,11 @@ mI
 mI
 mI
 mI
-sB
-sB
-sB
-sB
-sB
+yr
+yr
+yr
+yr
+yr
 mI
 mI
 mI
@@ -39770,7 +40925,7 @@ bR
 nA
 sB
 sB
-bu
+sB
 bu
 bu
 bu
@@ -39861,30 +41016,30 @@ Qc
 Ga
 Wu
 Dr
-ME
+xY
 hN
 fC
-pQ
+PY
 WA
 pQ
-QX
+nJ
 Dr
 Vw
 Vw
 Vw
 Vw
 Dr
-FU
-Vw
-IW
+Jl
+wD
+gi
 IW
 ff
 Vw
 mn
 nB
-Do
-nB
-Do
+Ow
+nf
+uy
 nB
 mn
 Vw
@@ -39893,9 +41048,9 @@ IW
 Vw
 IW
 IW
-Ni
-Vw
-Vw
+dr
+oi
+ZJ
 Vw
 mt
 Dr
@@ -39905,26 +41060,13 @@ sB
 sB
 sB
 sB
-nT
-nT
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-nT
-nT
-sB
+Hr
+Hr
+yr
+yr
+yr
+yr
+yr
 sB
 sB
 sB
@@ -39937,7 +41079,10 @@ sB
 sB
 nT
 nT
-nT
+sB
+sB
+sB
+sB
 sB
 sB
 sB
@@ -39951,23 +41096,33 @@ nT
 sB
 sB
 sB
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+yr
+yr
+yr
+yr
+nT
+nT
+nT
 sB
 sB
 sB
-sB
-sB
-sB
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+yr
+yr
+yr
+yr
+yr
+yr
 mI
 mI
 sB
@@ -40118,20 +41273,20 @@ Dr
 Dr
 Dr
 Dr
-Gn
+Ek
 sM
-Vw
-Vw
+pJ
+wD
+Dr
+wD
+Qj
 Dr
 Vw
-QX
-Dr
-Vw
-Vw
-Vw
+lW
+lW
 Vw
 wY
-Vw
+wD
 lW
 lW
 Vw
@@ -40144,17 +41299,17 @@ Do
 Do
 Do
 ri
-Vw
+wD
 ff
 Vw
-Vw
-Vw
-Vw
-Vw
-Vw
+lW
+pJ
+wD
+Ie
+lW
 Dr
 ms
-ZY
+vt
 Dr
 vz
 vz
@@ -40162,6 +41317,35 @@ vz
 sB
 sB
 sB
+Hr
+Hr
+Hr
+Hr
+yr
+yr
+yr
+yr
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 nT
 nT
 nT
@@ -40169,41 +41353,12 @@ nT
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-nT
-nT
-nT
-nT
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+yr
+yr
+yr
+yr
+yr
+yr
 sB
 sB
 sB
@@ -40221,13 +41376,13 @@ sB
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+yr
+yr
+yr
+yr
+yr
+yr
+yr
 sB
 sB
 sB
@@ -40370,18 +41525,18 @@ qX
 qX
 qX
 Dr
-QX
-uU
-QX
-QX
+Qm
+Qm
+lU
+rn
 Dr
-Gn
-Gn
-Gn
-Vw
+mE
+ds
+TH
+VD
 Dr
-Vw
-QX
+wD
+Qj
 Dr
 Vw
 Vw
@@ -40395,17 +41550,17 @@ BI
 ff
 BI
 mn
-nB
-Do
-nB
+nf
+uy
+ek
 Do
 nB
 mn
-BI
-ff
-BI
-BI
-BI
+Fe
+WG
+Fe
+Fe
+Fe
 BI
 ws
 Vw
@@ -40418,75 +41573,11 @@ vz
 vz
 sB
 sB
-sB
-sB
-sB
-nT
-nT
-nT
-nT
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+yr
+yr
+yr
+Hr
+Hr
 nT
 nT
 sB
@@ -40498,6 +41589,70 @@ sB
 sB
 sB
 sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+yr
+yr
+yr
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+yr
+yr
+yr
+yr
+yr
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+yr
+yr
+yr
+yr
+yr
+yr
+sB
+sB
+sB
+sB
+nT
+nT
+sB
+sB
+sB
+sB
+yr
+yr
+yr
+yr
+yr
 mI
 mI
 mI
@@ -40628,17 +41783,17 @@ mI
 qX
 Dr
 Zl
-QX
-QX
-QX
+hZ
+hZ
+MB
 Dr
 Dr
 Dr
 Dr
 Dr
 Dr
-Vw
-QX
+qW
+Qj
 Dr
 Dr
 Dr
@@ -40653,19 +41808,19 @@ Dr
 Dr
 Dr
 Dr
-Do
-Do
-tS
+et
+uy
+Tu
 Dr
 Dr
 Dr
 Dr
 Dr
 Dr
-Vw
-Vw
-TO
-Vw
+YZ
+VN
+kj
+lW
 Dr
 Sv
 SH
@@ -40674,9 +41829,9 @@ Rb
 vz
 vz
 nT
-vz
-sB
-vz
+Ag
+yr
+Ag
 sB
 vz
 sB
@@ -40687,32 +41842,57 @@ vz
 nT
 nT
 nT
-vz
-sB
-vz
-sB
-sB
-sB
-vz
-sB
-vz
-sB
-nT
-nT
-nT
-sB
-sB
-sB
 vz
 sB
 vz
 sB
 sB
 sB
+vz
+sB
+vz
+yr
+Hr
+Hr
+Hr
+yr
+yr
+sB
+vz
+sB
+vz
 sB
 sB
 sB
 sB
+sB
+sB
+sB
+sB
+sB
+sB
+yr
+yr
+yr
+yr
+Hr
+nT
+nT
+nT
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+yr
+yr
+yr
+yr
+yr
+yr
 sB
 sB
 sB
@@ -40724,38 +41904,13 @@ nT
 nT
 nT
 nT
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-nT
-nT
-nT
-nT
-nT
-sB
-sB
-sB
-sB
-sB
-sB
+mW
+yr
+yr
+yr
+yr
+yr
+yr
 nT
 nT
 sB
@@ -40884,22 +42039,22 @@ qX
 qX
 qX
 Dr
-QX
-QX
-QX
-QX
+lU
+tA
+Fv
+Li
 Dr
 uU
-QX
-QX
-Zl
-QX
-QX
-QX
+Li
+Li
+cN
+rc
+TQ
+ys
 Dr
 dV
 dQ
-eK
+sz
 Qy
 Dr
 WI
@@ -40909,8 +42064,8 @@ Dr
 tt
 JC
 Dr
-tS
-Do
+iV
+ZW
 mI
 mI
 mI
@@ -40918,16 +42073,16 @@ qX
 qX
 qX
 Dr
-wS
-Vw
-cV
-TO
-Vw
+PI
+xQ
+LR
+zz
+lW
 Dr
 Sv
 SH
 dX
-Rb
+Nk
 vz
 vz
 nT
@@ -40952,13 +42107,13 @@ sB
 sB
 sB
 sB
-nT
-nT
-nT
-nT
-nT
-nT
-sB
+Hr
+Hr
+Hr
+Hr
+Hr
+Hr
+yr
 sB
 sB
 sB
@@ -41009,15 +42164,15 @@ nT
 nT
 nT
 sB
-sB
-sB
-sB
+yr
+yr
+yr
 nT
 nT
 nT
-sB
-sB
-sB
+yr
+yr
+yr
 sB
 sB
 sB
@@ -41141,21 +42296,21 @@ qX
 mI
 qX
 Dr
-uU
-QX
-QX
-QX
-wY
-QX
-QX
-QX
-QX
-QX
-Vw
-QX
+Sj
+Bt
+Iz
+Bt
+wH
+qf
+Bt
+Bt
+Bt
+ln
+wD
+no
 Dr
 oe
-kL
+cu
 kL
 Ww
 Dr
@@ -41164,7 +42319,7 @@ Vw
 hF
 Dr
 ZT
-hF
+YV
 Dr
 mI
 mI
@@ -41176,17 +42331,17 @@ mI
 qX
 Dr
 Dr
-Tj
+Zi
 Dr
-TO
+kj
 Vw
 Dr
 Sv
-Df
+dK
 Dr
 Dr
-vz
-vz
+Ag
+Ag
 nT
 nT
 nT
@@ -41208,12 +42363,12 @@ sB
 sB
 sB
 sB
-nT
-nT
-nT
-nT
-nT
-nT
+Hr
+Hr
+Hr
+Hr
+Hr
+Hr
 sB
 sB
 sB
@@ -41268,15 +42423,15 @@ nT
 sB
 sB
 sB
-sB
+yr
 nT
 nT
 nT
 sB
-sB
-sB
-nT
-sB
+yr
+yr
+Hr
+yr
 sB
 sB
 sB
@@ -41398,17 +42553,17 @@ qX
 qX
 qX
 Dr
-QX
-QX
-QX
-Zl
+xY
+no
+SF
+cN
 Dr
 Dr
 Dr
 Dr
 Dr
-QX
-Vw
+Qj
+wD
 Dr
 Dr
 qt
@@ -41418,37 +42573,37 @@ Ml
 Dr
 TO
 lW
-Vw
+wD
 wY
-Vw
-hF
+wD
+fW
 Dr
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 qX
-mI
-mI
-mI
-mI
-mI
-mI
-qX
 Dr
 Dr
 Dr
 Dr
-TO
-Vw
+kj
+lW
 Dr
 ms
-ZY
+vt
 Dr
 vz
-vz
-vz
-nT
-nT
-nT
-nT
-nT
+Ag
+Ag
+Hr
+Hr
+Hr
+Hr
+Hr
 sB
 sB
 sB
@@ -41463,12 +42618,13 @@ sB
 sB
 sB
 sB
-nT
-nT
-nT
-nT
-nT
-nT
+Hr
+Hr
+Hr
+Hr
+Hr
+Hr
+yr
 sB
 sB
 sB
@@ -41481,34 +42637,6 @@ sB
 sB
 sB
 sB
-sB
-nT
-nT
-nT
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-nT
 nT
 nT
 nT
@@ -41527,14 +42655,41 @@ sB
 sB
 sB
 sB
-nT
-nT
+sB
+sB
+yr
+yr
+yr
 sB
 sB
 sB
 nT
 nT
 nT
+nT
+nT
+mI
+mI
+mI
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+nT
+nT
+sB
+sB
+yr
+Hr
+Hr
+Hr
 sB
 sB
 sB
@@ -41664,9 +42819,9 @@ AI
 bY
 fI
 Dr
-QX
-QX
-QX
+wo
+TQ
+wA
 wY
 eK
 eK
@@ -41675,12 +42830,12 @@ qb
 mn
 LM
 lW
-hF
+mJ
 Dr
 Dr
 Dr
 Dr
-qX
+mI
 mI
 mI
 mI
@@ -41692,18 +42847,19 @@ qX
 qX
 qX
 Dr
-TO
+kj
 Vw
 Vw
-Vw
+wD
 mt
 Dr
 Dr
 nT
 nT
-nT
-nT
-nT
+Hr
+Hr
+Hr
+yr
 sB
 sB
 sB
@@ -41718,15 +42874,14 @@ sB
 sB
 sB
 sB
-sB
-sB
-nT
+yr
+Hr
+Ag
+Ag
 vz
 vz
 vz
 vz
-vz
-vz
 sB
 sB
 sB
@@ -41752,46 +42907,46 @@ sB
 sB
 sB
 sB
+yr
+yr
+yr
+yr
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-nT
-nT
-nT
-nT
-nT
-nT
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+yr
+yr
+yr
+yr
 sB
 sB
 nT
 nT
 nT
+nT
+nT
+mI
+mI
+mI
+mI
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+yr
+Hr
+Hr
+Hr
 sB
 sB
 sB
@@ -41906,24 +43061,24 @@ qX
 qX
 qX
 Dr
-xs
-xs
-xs
+Dr
+EV
+sI
 ua
-Wt
+lp
 Dr
 aR
-Li
+rX
 wY
 Mz
 Rl
-Fc
-Ex
-Fc
+AI
+Ig
+fI
 Dr
-QX
-Vw
-uU
+Li
+wD
+Qj
 Dr
 wJ
 Jq
@@ -41931,8 +43086,8 @@ Jq
 eK
 Sd
 Vw
-lW
-iK
+Ql
+cl
 Dr
 mI
 mI
@@ -41949,12 +43104,12 @@ mI
 mI
 qX
 Dr
-TO
-Vw
-Vw
-Vw
+zz
+pJ
+pJ
+Mo
 mt
-QX
+Li
 Dr
 nT
 nT
@@ -42012,12 +43167,12 @@ mI
 mI
 mI
 mI
-sB
-sB
-sB
-sB
-sB
-sB
+yr
+yr
+yr
+yr
+yr
+yr
 nT
 nT
 nT
@@ -42047,10 +43202,10 @@ mI
 mI
 mI
 mI
-nT
-nT
-nT
-sB
+Hr
+Hr
+Hr
+yr
 sB
 sB
 sB
@@ -42167,7 +43322,7 @@ xs
 HK
 Uk
 eJ
-Wt
+TM
 Dr
 FZ
 aS
@@ -42175,12 +43330,12 @@ fh
 GL
 Np
 Fc
-Fc
+Ex
 Fc
 Dr
-QX
-Vw
-QX
+uU
+wD
+Qj
 Dr
 qz
 Jq
@@ -42188,11 +43343,11 @@ Jq
 VR
 mn
 LM
-Vw
-iK
+wD
+cl
 Dr
-tS
-Do
+Tu
+PV
 mI
 mI
 mI
@@ -42206,12 +43361,12 @@ mI
 mI
 qX
 Dr
-QX
-QX
-QX
-ll
+Gb
+iH
+Kb
+BX
 Df
-QX
+Li
 Dr
 nT
 nT
@@ -42253,10 +43408,10 @@ nT
 nT
 nT
 nT
-sB
-sB
-sB
-sB
+yr
+yr
+yr
+yr
 sB
 sB
 sB
@@ -42269,15 +43424,15 @@ mI
 mI
 mI
 mI
-sB
-sB
-sB
-sB
-sB
-sB
-nT
-nT
-nT
+yr
+yr
+yr
+yr
+yr
+yr
+Hr
+Hr
+Hr
 sB
 sB
 sB
@@ -42420,11 +43575,11 @@ qX
 qX
 qX
 Dr
-xs
+qP
 eJ
 Uk
-Ah
-Wt
+Uk
+np
 Dr
 jV
 sc
@@ -42435,9 +43590,9 @@ GP
 GP
 uT
 Dr
-QX
-Vw
-QX
+NP
+wD
+Ep
 Dr
 DY
 iR
@@ -42448,12 +43603,12 @@ WI
 WI
 WI
 Dr
-Do
-Do
-Do
+Ct
+GB
+Sw
 mI
-tS
-Do
+Tu
+Qb
 mI
 mI
 mI
@@ -42463,9 +43618,9 @@ mI
 mI
 qX
 Dr
-QX
-QX
-QX
+Vp
+Am
+PW
 Ac
 Ac
 Dr
@@ -42508,13 +43663,13 @@ nT
 nT
 nT
 nT
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+yr
+yr
+yr
+yr
+yr
+yr
+yr
 sB
 sB
 sB
@@ -42527,16 +43682,16 @@ mI
 mI
 mI
 mI
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+yr
+yr
+yr
+yr
+yr
+yr
+yr
+yr
+yr
+yr
 mI
 mI
 mI
@@ -42677,11 +43832,11 @@ qX
 Dr
 Dr
 Dr
-xs
+qP
 eJ
 VK
-eJ
-pd
+Ah
+sp
 Dr
 Ez
 Hp
@@ -42694,7 +43849,7 @@ dz
 Dr
 Dr
 Dr
-Rt
+kI
 Dr
 Dr
 Dr
@@ -42705,12 +43860,12 @@ TO
 Vw
 iK
 Dr
-Do
-Do
-Do
-Do
-Do
-Do
+Fj
+qJ
+BW
+BW
+PV
+cY
 mI
 mI
 mI
@@ -42761,16 +43916,16 @@ mI
 sB
 sB
 sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+yr
+yr
+yr
+yr
+yr
+yr
+yr
+yr
+yr
+yr
 mI
 mI
 mI
@@ -42787,7 +43942,7 @@ mI
 mI
 mI
 mI
-sB
+yr
 mI
 mI
 mI
@@ -42933,12 +44088,12 @@ qX
 qX
 Dr
 Ya
-Ya
+HB
 HV
 eJ
 VK
 eJ
-Wt
+RR
 Dr
 Dr
 Dr
@@ -42952,10 +44107,10 @@ Dr
 TW
 IW
 bH
-IW
-IW
-IW
-IW
+El
+kW
+gi
+gi
 ff
 IW
 Ni
@@ -42964,9 +44119,9 @@ iK
 mn
 nB
 nB
-Do
-Do
-Do
+qJ
+AW
+Jw
 mI
 mI
 mI
@@ -43015,13 +44170,13 @@ mI
 mI
 mI
 mI
-sB
-sB
-sB
-sB
-sB
-sB
-sB
+yr
+yr
+yr
+yr
+yr
+yr
+yr
 mI
 mI
 mI
@@ -43198,32 +44353,32 @@ eJ
 BJ
 QX
 QX
-wY
+sX
 KZ
 hr
-lW
+Yi
 Rj
-lW
+lB
 Vw
 SJ
 Vw
-Vw
-bH
-Vw
-lW
+wD
+nJ
+wD
+pJ
 lW
 Vw
 ff
 Vw
 lW
 lW
-Vw
+wD
 Sd
 nB
 nB
-Do
-Do
-Do
+qJ
+VH
+IS
 mI
 mI
 mI
@@ -43368,7 +44523,7 @@ sB
 sB
 sB
 sB
-bu
+sB
 bu
 bu
 bu
@@ -43455,17 +44610,17 @@ eJ
 BJ
 QX
 QX
+QX
 Dr
-KZ
-Vw
+wD
+WS
 Mk
-Mk
-Vw
+wD
 Ch
 Dr
 nw
 BI
-bH
+fr
 BI
 BI
 BI
@@ -43473,12 +44628,12 @@ BI
 ff
 BI
 EJ
-Vw
+wD
 bj
 mn
 nB
 nB
-Do
+Zu
 tS
 mI
 mI
@@ -43625,7 +44780,7 @@ sB
 sB
 sB
 sB
-bu
+sB
 bu
 bu
 bu
@@ -43703,12 +44858,12 @@ qX
 qX
 qX
 Dr
-Ya
-Ya
+NX
+pd
 HV
 OI
-yq
-yq
+sP
+Rv
 BJ
 QX
 iO
@@ -43722,7 +44877,7 @@ Dr
 Dr
 Dr
 Dr
-bH
+fr
 wS
 Dr
 Dr
@@ -43733,9 +44888,9 @@ Dr
 Su
 Dr
 Dr
-Do
-Do
-Do
+qJ
+Zk
+Zk
 mI
 mI
 mI
@@ -43882,7 +45037,7 @@ sB
 sB
 sB
 sB
-bu
+sB
 bu
 bu
 bu
@@ -43964,27 +45119,27 @@ Dr
 Dr
 HV
 yq
-yq
-yq
+FS
+KW
 BJ
 QX
-Sx
+eA
 Dr
 pn
-NA
+iX
 Dr
 Ks
 Vw
 cV
-EI
+Dv
 EI
 Dr
-bH
+fr
 Tj
 Dr
 ng
-Gn
-Gn
+Oy
+FE
 Dr
 aY
 Vw
@@ -44139,7 +45294,7 @@ sB
 sB
 sB
 sB
-bu
+sB
 bu
 bu
 bu
@@ -44225,23 +45380,23 @@ Uk
 Ah
 BJ
 QX
-Sx
+Ts
 Dr
 cx
 NA
 Dr
 HU
-Vw
-Vw
-Vw
+lW
+pJ
+pJ
 Vw
 Dr
-Rt
+kI
 Dr
 Dr
 Vw
 KS
-Gn
+xr
 Dr
 Tc
 Vw
@@ -44396,7 +45551,7 @@ sB
 sB
 sB
 sB
-bu
+sB
 bu
 bu
 bu
@@ -44477,34 +45632,34 @@ mI
 qX
 Dr
 HV
+eJ
 VK
-VK
-VK
-GF
+eJ
+Wt
 QX
-QX
-Dr
+sX
+KZ
 xJ
 YU
 Dr
 Wk
-Vw
+wD
 Oo
 Oo
 Oo
 Dr
-QX
+Qj
 uU
 Dr
-Vw
-lW
+wD
+pJ
 Vw
 wY
 Vw
 Vw
 qq
 Dr
-cx
+px
 vq
 lv
 Dr
@@ -44653,7 +45808,7 @@ sB
 sB
 sB
 sB
-bu
+sB
 bu
 bu
 bu
@@ -44734,34 +45889,34 @@ qX
 qX
 Dr
 GF
-GF
-GF
+bx
+RE
 WB
-GF
+Vc
+ZL
 Sx
-Sx
 Dr
 Dr
 Dr
 Dr
-pV
-vJ
+JD
+eB
 mO
 gp
 uD
 Dr
-QX
-Zl
+Uu
+cN
 Dr
 FB
-Vw
+wD
 sN
 Dr
 Tc
 lW
 Vw
 wY
-NA
+iX
 KL
 pw
 Dr
@@ -44910,7 +46065,7 @@ sB
 sB
 sB
 sB
-bu
+sB
 bu
 bu
 bu
@@ -45001,20 +46156,20 @@ Dr
 Dr
 Dr
 pt
-vJ
-vJ
-vJ
-vJ
+xM
+To
+eB
+eB
 pV
 Dr
-QX
-QX
+KI
+Cz
 Dr
 Dr
 Dr
 Dr
 Dr
-Tc
+tz
 lW
 GM
 Dr
@@ -45167,7 +46322,7 @@ mI
 sB
 sB
 sB
-bu
+sB
 bu
 bu
 bu
@@ -45258,26 +46413,26 @@ qX
 qX
 Dr
 uv
-vJ
-vJ
-vJ
-vJ
-vJ
-wY
-QX
-QX
-wY
-Vw
+XP
+BK
+BK
+oP
+oP
+wH
+bL
+iF
+wH
+ip
 qF
-yy
-yy
-yy
+iY
+CZ
+Cd
 yy
 mX
 Dr
 vM
 Vw
-Gn
+gw
 Dr
 qX
 mI
@@ -45515,14 +46670,14 @@ mI
 qX
 Dr
 WD
-vJ
+eB
 Un
-pV
+Xz
 vJ
-vJ
+pB
 Dr
-uU
-QX
+bN
+Br
 Dr
 od
 Dr
@@ -45534,7 +46689,7 @@ Vw
 wY
 Vw
 IF
-Gn
+Jj
 Dr
 qX
 mI
@@ -45787,11 +46942,11 @@ XI
 lW
 xE
 Vw
-GM
+VY
 Dr
-Vw
-lW
-Vw
+wD
+HZ
+zb
 Dr
 qX
 mI
@@ -46033,18 +47188,18 @@ qX
 Dr
 sC
 IU
-Tb
+BE
 Dr
-Tb
+HA
 eP
 Ne
 Dr
 Dr
 Wn
 Vw
-Gn
+SX
 Vw
-GM
+MY
 Dr
 Nf
 bc
@@ -46289,11 +47444,11 @@ mI
 qX
 Dr
 ZR
-IU
+Ia
 Ne
 ri
-Tb
-Ne
+kB
+fk
 Jx
 Dr
 Dr
@@ -46549,18 +47704,18 @@ gO
 Tb
 Gc
 TN
-Tb
-Jx
+KG
+nu
 oz
 Dr
 Gn
-Gn
+sO
 Vw
 Dr
 Vw
 Vw
-Gn
-Gn
+wX
+Wv
 Dr
 qX
 qX
@@ -46803,21 +47958,21 @@ mI
 qX
 Dr
 Se
-IU
+eH
 sh
 Dr
 eq
-Jx
-Jx
+Vd
+QP
 Dr
-Vw
-lW
-Vw
+wD
+pJ
+wD
 Dr
 Uf
 lW
-lW
-Vw
+pJ
+qy
 Dr
 qX
 mI
@@ -47069,11 +48224,11 @@ Dr
 Dr
 ng
 lW
-Vw
+PL
 Dr
 vI
 KD
-Mz
+Fk
 Rl
 Dr
 qX
@@ -47237,9 +48392,9 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -47325,7 +48480,7 @@ qX
 qX
 Dr
 Vb
-Gn
+Gk
 aa
 Dr
 nl
@@ -47493,11 +48648,11 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -47750,11 +48905,11 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -48007,11 +49162,11 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -48265,10 +49420,10 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -48321,50 +49476,50 @@ mI
 mI
 mI
 mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 mI
 mI
 mI
@@ -48522,9 +49677,9 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -48576,53 +49731,53 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-Ke
-Ke
-Sk
-pJ
-XP
-sO
-tR
-Ke
-kV
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 mI
 mI
 mI
@@ -48833,54 +49988,54 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-Ke
-Ke
-Ke
-Ke
-Ke
-Ke
-Ke
-Ke
-kV
-OP
-eA
-Ke
-IS
-Ke
-xM
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 mI
 mI
 mI
@@ -49090,54 +50245,54 @@ bu
 bu
 bu
 bu
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 OP
 OP
 OP
-VL
-gi
-YZ
-OP
-Ke
-Ke
-QO
-Zu
-BE
-cN
-Ke
-Ke
-DT
-OP
-Ke
-Ke
-Ke
-Ke
-Ke
 OP
 OP
 OP
-ZW
-cY
-kj
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
 mI
 mI
 mI
@@ -49347,46 +50502,46 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-Hr
-yX
-Zi
-OP
-Ke
-Ke
-Ke
-Ke
-Ke
-dr
-Ke
-Ke
-of
-OP
-Ke
-Ke
-Ke
-EV
-Ke
-OP
-OP
-fW
-Ke
-rn
-WS
-zz
-OP
-xf
-Ke
-Ke
-Ke
-bQ
-OP
-OP
-TY
-Fo
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 Vx
 XY
 Ke
@@ -49394,13 +50549,13 @@ Ke
 bQ
 OP
 OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 mI
 mI
 mI
@@ -49604,46 +50759,46 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-Up
-Zi
-Zi
-OP
-Ke
-Ke
-mW
-NP
-fr
-Br
-CY
-Ke
-of
-OP
-Ke
-Ke
-Ke
-Ke
-Ke
-OP
-OP
-kV
-Ke
-Ke
-Ke
-Ke
-rF
-Ke
-Ke
-Ke
-Ke
-Ke
-rF
-Ke
-mj
-Ke
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 Ke
 Ke
 Ke
@@ -49651,18 +50806,18 @@ Ke
 Ke
 DT
 OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
 mI
 mI
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 mI
 mI
 mI
@@ -49801,9 +50956,9 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -49861,65 +51016,65 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-PW
-Zi
-iV
-OP
-YV
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-Jj
-Jj
-Zk
-Jj
-Jj
-OP
-OP
-sI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 Ke
 Ke
 Ke
 sZ
-OP
-NX
-bQ
-Ke
-bQ
-sZ
-OP
-bQ
 Ke
 Ke
-Ke
-Ke
-Ke
-sZ
-Ke
-Ke
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
 OP
 mI
 mI
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 mI
 mI
 mI
@@ -50058,8 +51213,8 @@ bu
 bu
 bu
 bu
-fY
-fY
+mI
+mI
 bu
 bu
 bu
@@ -50118,29 +51273,29 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-OP
-cK
-OP
-OP
-eJ
-uy
-KW
-lI
-ZB
-OP
-sX
-Zi
-Vs
-aT
-Zi
-ZL
-Zi
-yr
-Yz
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 OP
 OP
@@ -50174,9 +51329,9 @@ OP
 OP
 OP
 OP
-OP
-OP
-OP
+mI
+mI
+mI
 bu
 bu
 bu
@@ -50375,29 +51530,29 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-iY
-eJ
-Gs
-OP
-eJ
-eJ
-eJ
-eJ
-eJ
-fk
-sX
-eH
-Zi
-yX
-Zi
-Zi
-bN
-ln
-Zi
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 OP
 ov
@@ -50431,9 +51586,9 @@ rN
 OP
 OP
 OP
-OP
-OP
-OP
+mI
+mI
+mI
 bu
 bu
 bu
@@ -50632,29 +51787,29 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-KR
-eJ
-rW
-pB
-fM
-eJ
-Pp
-eJ
-Gb
-OP
-oP
-iX
-fz
-fz
-fz
-fz
-fz
-Iz
-Qe
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 eJ
 fM
@@ -50688,9 +51843,9 @@ GI
 te
 vR
 OP
-OP
-OP
-OP
+mI
+mI
+mI
 bu
 bu
 bu
@@ -50889,29 +52044,29 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-TA
-eJ
-eJ
-pB
-eJ
-Jl
-KB
-eJ
-nJ
-OP
-Gi
-sP
-Ur
-Fc
-WR
-Fc
-Fc
-Xz
-TQ
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 gM
 gM
@@ -50945,9 +52100,9 @@ gM
 eJ
 fG
 OP
-OP
-OP
-NH
+mI
+mI
+mI
 bu
 bu
 bu
@@ -51146,29 +52301,29 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-mE
-eJ
-eJ
-pB
-eJ
-mQ
-FE
-fM
-nJ
-OP
-qN
-sP
-Fc
-np
-np
-np
-Fc
-Xz
-Zi
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 gM
 gM
@@ -51202,9 +52357,9 @@ gM
 gM
 Bz
 QX
-gM
-gM
-QX
+mI
+mI
+mI
 bu
 bu
 bu
@@ -51338,6 +52493,7 @@ mI
 mI
 mI
 mI
+sB
 bu
 bu
 bu
@@ -51357,10 +52513,9 @@ bu
 bu
 bu
 bu
-bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -51403,30 +52558,30 @@ bu
 bu
 bu
 bu
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
-OP
-OP
-OP
-Ie
-eJ
-eJ
-pB
-eJ
-SE
-GH
-fM
-Mo
-OP
-Zi
-sP
-WR
-CR
-Ow
-cu
-WR
-Xz
-Zi
-MB
 gM
 gM
 gM
@@ -51459,9 +52614,152 @@ gM
 gM
 gM
 QX
-gM
-Vp
-QX
+mI
+mI
+mI
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+mI
+mI
+mI
+mI
+bu
+bu
+bu
+bu
+bu
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+sB
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -51475,149 +52773,6 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
 bu
 bu
 bu
@@ -51660,29 +52815,29 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-To
-eJ
-eJ
-pB
-eJ
-bL
-no
-eJ
-oM
-OP
-Zi
-sP
-Fc
-PY
-np
-CR
-Fc
-Xz
-Zi
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 gM
 gM
@@ -51716,9 +52871,10 @@ gM
 eJ
 eJ
 OP
-OP
-OP
-OP
+mI
+mI
+mI
+bu
 bu
 bu
 bu
@@ -51743,11 +52899,10 @@ bu
 bu
 bu
 bu
-bu
 mI
 mI
 mI
-bu
+sB
 mI
 mI
 mI
@@ -51852,8 +53007,7 @@ mI
 mI
 mI
 mI
-bu
-bu
+sB
 bu
 bu
 bu
@@ -51872,8 +53026,9 @@ bu
 bu
 bu
 bu
-fY
-fY
+bu
+mI
+mI
 bu
 bu
 bu
@@ -51917,29 +53072,29 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-dK
-eJ
-SX
-pB
-eJ
-kz
-xQ
-eJ
-Ia
-OP
-Rv
-sP
-Fc
-Fc
-WR
-Fc
-Fc
-gx
-Zi
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 gM
 gM
@@ -51973,9 +53128,9 @@ gM
 PK
 xX
 OP
-OP
-OP
-OP
+mI
+mI
+mI
 bu
 bu
 bu
@@ -52004,12 +53159,12 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -52109,7 +53264,7 @@ mI
 mI
 mI
 mI
-bu
+sB
 bu
 bu
 bu
@@ -52174,29 +53329,29 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-rc
-eJ
-rW
-pB
-eJ
-eJ
-fM
-eJ
-qy
-OP
-cH
-QP
-Xx
-KG
-KG
-KG
-KG
-wo
-qW
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 eJ
 Pp
@@ -52230,9 +53385,9 @@ eJ
 OP
 OP
 OP
-OP
-OP
-OP
+mI
+mI
+mI
 bu
 bu
 bu
@@ -52261,12 +53416,12 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -52366,8 +53521,8 @@ mI
 mI
 mI
 mI
-bu
-bu
+sB
+sB
 bu
 bu
 bu
@@ -52431,29 +53586,29 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-eJ
-eJ
-eJ
-OP
-Ts
-BW
-eJ
-eJ
-kR
-OP
-Fk
-xr
-Zi
-Zi
-Zi
-ln
-Zi
-Zi
-Zi
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 OP
 QM
@@ -52487,9 +53642,13 @@ rN
 OP
 OP
 OP
-OP
-OP
-OP
+mI
+mI
+mI
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -52515,24 +53674,20 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -52623,8 +53778,8 @@ mI
 mI
 mI
 mI
-bu
-bu
+sB
+sB
 bu
 bu
 bu
@@ -52688,29 +53843,29 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-OP
-cK
-OP
-OP
-OP
-OP
-cK
-OP
-OP
-OP
-HB
-Zi
-Fe
-Zi
-Zi
-Zi
-ip
-xY
-Vc
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 OP
 OP
@@ -52746,7 +53901,11 @@ OP
 OP
 mI
 mI
-OP
+mI
+bu
+bu
+bu
+bu
 bu
 bu
 bu
@@ -52772,24 +53931,20 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -52880,8 +54035,8 @@ mI
 mI
 mI
 mI
-bu
-bu
+sB
+sB
 bu
 bu
 bu
@@ -52945,29 +54100,29 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-Qm
-Wq
-RE
-Pc
-yl
-OP
-Wv
-kL
-PL
-Zw
-OP
-OP
-OP
-OP
-OP
-cK
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 OP
 OP
@@ -52992,18 +54147,18 @@ Ke
 Ke
 Ke
 OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
 mI
 mI
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -53034,19 +54189,19 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -53137,9 +54292,9 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
+sB
+sB
+sB
 bu
 bu
 bu
@@ -53202,31 +54357,31 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-lU
-Wq
-RE
-RE
-RE
-OP
-CZ
-kL
-kL
-GB
-OP
-Ak
-hZ
-gm
-eJ
-fM
-Nr
-PV
-Ig
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 id
 Ke
@@ -53249,15 +54404,15 @@ Ke
 Ke
 kV
 OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 mI
 mI
 mI
@@ -53291,20 +54446,20 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -53395,8 +54550,8 @@ mI
 mI
 mI
 mI
-bu
-bu
+sB
+sB
 bu
 bu
 bu
@@ -53459,31 +54614,31 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-hS
-Wq
-mJ
-Bt
-SF
-OP
-lz
-Cz
-kL
-gw
-OP
-RR
-vJ
-IA
-Pp
-eJ
-eJ
-eJ
-fM
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 Ea
 DT
@@ -53506,13 +54661,13 @@ sZ
 TY
 OP
 OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 mI
 mI
 mI
@@ -53550,18 +54705,18 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -53652,8 +54807,8 @@ mI
 mI
 mI
 mI
-bu
-bu
+sB
+sB
 bu
 bu
 bu
@@ -53716,41 +54871,31 @@ bu
 bu
 bu
 bu
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-TH
-kL
-sz
-dh
-OP
-BK
-qJ
-IA
-Tu
-VD
-ZJ
-Jw
-eB
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 OP
 OP
 OP
@@ -53764,6 +54909,16 @@ OP
 OP
 OP
 OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+mI
 mI
 mI
 mI
@@ -53815,10 +54970,10 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -53909,13 +55064,8 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
 bu
 bu
 bu
@@ -53923,10 +55073,15 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
+bu
+bu
+bu
+bu
+bu
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -53974,140 +55129,6 @@ bu
 bu
 bu
 mI
-OP
-OP
-OP
-OP
-OP
-UX
-VY
-OP
-wX
-kL
-kL
-wD
-OP
-tA
-vJ
-Ld
-eJ
-nf
-ku
-eJ
-eJ
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
 mI
 mI
 mI
@@ -54180,10 +55201,144 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+sB
+sB
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+sB
+sB
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -54231,140 +55386,6 @@ bu
 bu
 bu
 mI
-OP
-OP
-OP
-OP
-OP
-px
-kL
-vt
-kL
-kL
-PL
-wD
-OP
-tz
-vJ
-IA
-Tu
-TJ
-qP
-Jw
-eJ
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
 mI
 mI
 mI
@@ -54437,10 +55458,144 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+sB
+sB
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+sB
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -54490,140 +55645,6 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-HZ
-kL
-Jj
-TH
-kL
-Nk
-oK
-OP
-KE
-WG
-IA
-eJ
-nf
-nf
-fM
-fe
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
 mI
 mI
 mI
@@ -54687,7 +55708,141 @@ bu
 bu
 bu
 bu
-fY
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+sB
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+sB
+bu
+bu
+bu
+bu
+bu
+bu
+mI
 bu
 bu
 bu
@@ -54747,28 +55902,28 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-El
-kL
-Jj
-CZ
-kL
-kL
-kB
-OP
-Yi
-vJ
-IA
-Tu
-kW
-VD
-Jw
-eB
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 mI
 mI
 mI
@@ -54846,106 +56001,106 @@ bu
 bu
 bu
 bu
+sB
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+sB
+bu
+bu
+bu
 bu
 mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
 bu
 bu
 bu
@@ -55004,28 +56159,28 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-zb
-vJ
-IA
-fM
-eJ
-Pp
-eJ
-eJ
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 mI
 mI
 mI
@@ -55103,7 +56258,7 @@ bu
 bu
 bu
 bu
-bu
+sB
 mI
 mI
 mI
@@ -55199,10 +56354,10 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -55261,140 +56416,6 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-JD
-vJ
-nQ
-Sj
-Ag
-Ql
-nC
-eJ
-OP
-OP
-OP
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-mI
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
 mI
 mI
 mI
@@ -55456,9 +56477,143 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+bu
+mI
+mI
+mI
+mI
+bu
+bu
+bu
+bu
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+bu
+bu
+bu
+bu
+bu
+mI
+mI
+mI
 bu
 bu
 bu
@@ -55518,28 +56673,28 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 mI
 mI
 mI
@@ -55775,28 +56930,28 @@ bu
 mI
 mI
 mI
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
-OP
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 mI
 mI
 mI
@@ -56399,7 +57554,7 @@ bu
 bu
 bu
 bu
-bu
+sB
 mI
 mI
 mI
@@ -56656,7 +57811,7 @@ bu
 bu
 bu
 bu
-bu
+sB
 mI
 mI
 mI
@@ -56913,7 +58068,7 @@ bu
 bu
 bu
 bu
-bu
+sB
 mI
 mI
 mI
@@ -57169,8 +58324,8 @@ bu
 bu
 bu
 bu
-bu
-bu
+sB
+sB
 mI
 mI
 mI
@@ -57181,7 +58336,7 @@ mI
 mI
 mI
 mI
-mI
+sB
 mI
 mI
 mI
@@ -57426,8 +58581,8 @@ bu
 bu
 bu
 bu
-bu
-bu
+sB
+sB
 mI
 mI
 mI
@@ -57438,7 +58593,7 @@ mI
 mI
 mI
 mI
-mI
+sB
 mI
 mI
 mI
@@ -57683,8 +58838,8 @@ bu
 bu
 bu
 bu
-bu
-bu
+sB
+sB
 mI
 mI
 mI
@@ -57694,8 +58849,8 @@ mI
 mI
 mI
 mI
-mI
-mI
+sB
+sB
 mI
 mI
 mI
@@ -57940,8 +59095,8 @@ bu
 bu
 bu
 bu
-bu
-bu
+sB
+sB
 mI
 mI
 mI
@@ -57951,9 +59106,9 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
+sB
+sB
+sB
 mI
 mI
 mI
@@ -58197,93 +59352,93 @@ bu
 bu
 bu
 bu
+sB
+sB
+sB
+sB
+mI
+sB
+mI
+mI
+mI
+sB
+sB
+sB
+sB
+sB
+sB
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+bu
 bu
 bu
 bu
 bu
 mI
-bu
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-bu
-bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-bu
-bu
 bu
 bu
 bu
@@ -58454,94 +59609,94 @@ bu
 bu
 bu
 bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+mI
+mI
+sB
+sB
+sB
+sB
+sB
+sB
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
 bu
-bu
-bu
 mI
 mI
-mI
-bu
-bu
-bu
-bu
-bu
-bu
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-fY
-fY
-bu
+sB
 bu
 bu
 bu
@@ -58713,24 +59868,24 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -58796,9 +59951,9 @@ bu
 bu
 bu
 bu
-fY
-fY
-bu
+mI
+mI
+sB
 bu
 bu
 bu
@@ -58973,21 +60128,21 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -59052,16 +60207,16 @@ mI
 bu
 bu
 bu
+sB
+mI
+mI
+sB
+sB
+sB
 bu
-fY
-fY
 bu
 bu
-bu
-bu
-bu
-bu
-fY
+mI
 bu
 bu
 bu
@@ -59230,6 +60385,12 @@ bu
 bu
 bu
 bu
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -59237,88 +60398,82 @@ bu
 bu
 bu
 bu
+sB
+sB
+sB
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-fY
-fY
 bu
 bu
 bu
@@ -59488,6 +60643,10 @@ bu
 bu
 bu
 bu
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -59497,6 +60656,69 @@ bu
 bu
 bu
 bu
+sB
+sB
+sB
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+mI
+sB
 bu
 bu
 bu
@@ -59504,80 +60726,13 @@ bu
 bu
 bu
 bu
+sB
+sB
+sB
 mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
 bu
 bu
 bu
@@ -59746,6 +60901,8 @@ bu
 bu
 bu
 bu
+sB
+sB
 bu
 bu
 bu
@@ -59757,10 +60914,8 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
+sB
+sB
 mI
 mI
 mI
@@ -59829,12 +60984,12 @@ bu
 bu
 bu
 bu
-bu
-bu
-fY
-fY
-fY
-fY
+sB
+sB
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -60017,8 +61172,8 @@ bu
 bu
 bu
 bu
-bu
-bu
+sB
+sB
 mI
 mI
 mI
@@ -60088,10 +61243,10 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -60345,10 +61500,10 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -60603,8 +61758,8 @@ bu
 bu
 bu
 bu
-fY
-fY
+mI
+mI
 bu
 bu
 bu
@@ -61863,9 +63018,9 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
+sB
+sB
+sB
 bu
 bu
 bu
@@ -62102,6 +63257,26 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -62111,27 +63286,7 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-fY
+mI
 bu
 bu
 bu
@@ -62356,6 +63511,28 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -62364,32 +63541,10 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -62613,6 +63768,27 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -62623,30 +63799,9 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
+mI
+mI
+mI
 bu
 bu
 bu
@@ -62864,6 +64019,34 @@ mI
 mI
 mI
 mI
+sB
+sB
+sB
+sB
+bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -62873,36 +64056,8 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-fY
-fY
+mI
+mI
 bu
 bu
 bu
@@ -63128,28 +64283,28 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -63387,27 +64542,27 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -63645,26 +64800,26 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 bu
 bu
 bu
@@ -63904,24 +65059,24 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-fY
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+mI
+sB
 bu
 bu
 bu
@@ -64169,17 +65324,17 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+mI
+mI
+mI
+sB
+mI
 bu
 bu
 bu
@@ -64428,16 +65583,16 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-fY
-fY
-fY
-fY
-fY
-fY
+sB
+sB
+sB
+sB
+mI
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -64690,11 +65845,11 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -64947,11 +66102,11 @@ bu
 bu
 bu
 bu
-fY
-fY
-fY
-fY
-fY
+mI
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -65206,8 +66361,8 @@ bu
 bu
 bu
 bu
-bu
-bu
+mI
+mI
 bu
 bu
 bu
@@ -65679,9 +66834,9 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
+mI
+mI
+mI
 bu
 bu
 bu
@@ -65935,10 +67090,10 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
+mI
+mI
+mI
+mI
 bu
 bu
 bu
@@ -66194,7 +67349,7 @@ bu
 bu
 bu
 bu
-bu
+mI
 bu
 bu
 bu

--- a/maps/away/away_site/goon_base/goon_base.dmm
+++ b/maps/away/away_site/goon_base/goon_base.dmm
@@ -2,7 +2,22 @@
 "aa" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/orange,
+/obj/effect/ghostspawpoint{
+	identifier = "goon"
+	},
 /turf/simulated/floor/tiled,
+/area/mine)
+"ad" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "ag" = (
 /obj/effect/map_effect/airlock/long/square,
@@ -73,6 +88,12 @@
 /area/shuttle/goon_ship/living)
 "aR" = (
 /obj/item/trash/proteinbar,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
+"aS" = (
+/obj/random/dirt_75,
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/mine)
 "aT" = (
@@ -86,6 +107,16 @@
 /obj/item/device/gps,
 /turf/simulated/floor/wood,
 /area/mine)
+"aY" = (
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
+/obj/random/junk,
+/obj/effect/floor_decal/corner/blue/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "bc" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/tiled,
@@ -95,7 +126,7 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "bj" = (
-/obj/effect/floor_decal/corner_wide/grey/full{
+/obj/effect/floor_decal/corner/grey/full{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -121,6 +152,14 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"bm" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 10
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/turf/simulated/floor/tiled,
+/area/mine)
 "bp" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate,
@@ -129,6 +168,12 @@
 "bu" = (
 /turf/template_noop,
 /area/space)
+"bA" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "bH" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
@@ -184,7 +229,7 @@
 /area/shuttle/goon_ship/starboard)
 "cm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -210,6 +255,12 @@
 	pixel_y = 21
 	},
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"cF" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "cH" = (
 /obj/structure/bed/stool/chair/sofa/right/black,
@@ -239,6 +290,13 @@
 "cP" = (
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"cV" = (
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
+/obj/random/junk,
+/turf/simulated/floor/tiled,
+/area/mine)
 "cY" = (
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/electrical{
@@ -268,7 +326,7 @@
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -282,6 +340,10 @@
 /obj/effect/shuttle_landmark/automatic/ghostrole_activation,
 /turf/template_noop,
 /area/space)
+"dv" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/plating,
+/area/mine)
 "dx" = (
 /obj/structure/table/steel,
 /obj/item/device/binoculars,
@@ -296,6 +358,13 @@
 	dir = 6
 	},
 /turf/simulated/floor/wood,
+/area/mine)
+"dI" = (
+/obj/item/pickaxe/drill{
+	pixel_y = 7;
+	pixel_x = -10
+	},
+/turf/simulated/floor/airless/ceiling,
 /area/mine)
 "dJ" = (
 /obj/structure/cable{
@@ -314,7 +383,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "dQ" = (
-/obj/structure/table/rack,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "dT" = (
@@ -323,11 +399,23 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "dV" = (
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /obj/machinery/computer/operating,
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"dX" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"dY" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "eb" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -348,7 +436,7 @@
 /area/mine)
 "ei" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
@@ -358,9 +446,7 @@
 	pixel_y = -3;
 	pixel_x = 5
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
 "er" = (
@@ -400,7 +486,7 @@
 /obj/item/tank/anesthetic,
 /obj/item/tank/anesthetic,
 /obj/item/tank/anesthetic,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/light{
 	dir = 8;
 	pixel_x = 0;
@@ -414,12 +500,17 @@
 "eK" = (
 /turf/simulated/floor/tiled/white,
 /area/mine)
+"eL" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/power/portgen/basic/advanced,
+/turf/simulated/floor/plating,
+/area/mine)
 "eO" = (
 /turf/simulated/floor/holofloor/tiled/ramp/bottom,
 /area/shuttle/goon_ship/bridge)
 "eP" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/item/trash/tray,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
 "eS" = (
@@ -501,7 +592,7 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "fs" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/bed/roller,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
@@ -527,7 +618,7 @@
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/void/tcaf,
 /obj/item/clothing/head/helmet/space/void/tcaf,
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
@@ -555,6 +646,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/mine)
+"fR" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "fW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -563,6 +660,16 @@
 "fY" = (
 /turf/simulated/mineral/surface,
 /area/space)
+"gc" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "gi" = (
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop/preset/civilian{
@@ -589,17 +696,25 @@
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/black,
 /obj/item/clothing/head/helmet/space/syndicate/black,
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "gp" = (
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/steel,
 /obj/item/trash/gum{
 	pixel_y = 7;
 	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/heart{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup{
+	pixel_x = -5;
+	pixel_y = -8
 	},
 /turf/simulated/floor/tiled/white,
 /area/mine)
@@ -623,7 +738,7 @@
 /obj/item/storage/firstaid/toxin{
 	pixel_x = 4
 	},
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -634,6 +749,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/red,
+/area/mine)
+"gE" = (
+/obj/structure/bed/stool{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "gI" = (
 /turf/simulated/floor/plating,
@@ -652,6 +773,32 @@
 "gM" = (
 /obj/structure/lattice/catwalk/indoor/grate/old,
 /turf/simulated/floor/plating,
+/area/mine)
+"gO" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/food/drinks/carton/milk,
+/obj/item/reagent_containers/food/drinks/carton/milk,
+/obj/item/reagent_containers/food/drinks/carton/milk,
+/obj/item/reagent_containers/food/drinks/carton/milk,
+/obj/item/reagent_containers/food/drinks/carton/milk,
+/obj/item/storage/box/fancy/egg_box,
+/obj/item/storage/box/fancy/egg_box,
+/obj/item/storage/box/fancy/egg_box,
+/obj/item/storage/box/fancy/egg_box,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/fish/fishfillet,
+/obj/item/reagent_containers/food/snacks/fish/fishfillet,
+/obj/item/reagent_containers/food/snacks/fish/fishfillet,
+/obj/item/reagent_containers/food/snacks/fish/fishfillet,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "gX" = (
 /obj/effect/decal/cleanable/floor_damage/random_broken,
@@ -692,6 +839,12 @@
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/plating,
+/area/mine)
+"hq" = (
+/obj/item/storage/bag/ore{
+	pixel_x = 7
+	},
+/turf/simulated/floor/airless/ceiling,
 /area/mine)
 "hr" = (
 /obj/item/paper/goon_base/notice{
@@ -739,7 +892,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
 "hV" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/bed/roller,
 /obj/machinery/light{
 	dir = 8;
@@ -749,7 +902,7 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "hZ" = (
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/mine)
@@ -836,10 +989,17 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "iK" = (
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
+/area/mine)
+"iO" = (
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
+/obj/random/junk,
+/turf/simulated/floor/plating,
 /area/mine)
 "iR" = (
 /obj/machinery/sleeper{
@@ -878,7 +1038,7 @@
 	pixel_y = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "jq" = (
@@ -903,9 +1063,28 @@
 /obj/effect/decal/cleanable/spiderling_remains,
 /turf/simulated/floor/plating,
 /area/mine)
+"jw" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "jz" = (
 /obj/structure/lattice/catwalk/indoor/grate/old,
 /obj/item/trash/uselessplastic,
+/turf/simulated/floor/plating,
+/area/mine)
+"jS" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "jV" = (
@@ -913,6 +1092,9 @@
 	pixel_y = 6;
 	pixel_x = -6
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
 "jW" = (
@@ -978,7 +1160,7 @@
 /obj/machinery/sleeper{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -992,9 +1174,22 @@
 /obj/item/trash/gum,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"kI" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "kJ" = (
 /obj/machinery/sleeper,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "kK" = (
@@ -1007,7 +1202,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "kL" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "kR" = (
@@ -1087,11 +1282,26 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"lh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "lj" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/black/green,
 /obj/item/clothing/head/helmet/space/syndicate/black/green,
 /turf/simulated/floor/tiled,
+/area/mine)
+"ll" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "ln" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1107,7 +1317,7 @@
 "lq" = (
 /obj/machinery/optable,
 /obj/item/storage/firstaid/surgery,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "lv" = (
@@ -1122,7 +1332,7 @@
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "lz" = (
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /obj/machinery/light{
@@ -1138,15 +1348,35 @@
 /obj/item/device/flashlight/lantern,
 /turf/simulated/floor/tiled/dark,
 /area/mine)
+"lJ" = (
+/obj/item/crowbar,
+/turf/simulated/floor/plating,
+/area/mine)
 "lK" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/table/standard,
+/obj/item/storage/box/masks{
+	pixel_y = 8;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -11;
+	pixel_y = 12
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = -1;
+	pixel_y = 2
+	},
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "lQ" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"lR" = (
+/obj/structure/closet/crate/miningcart,
+/turf/unsimulated/floor/asteroid/ash/rocky,
+/area/mine)
 "lU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -1187,6 +1417,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine)
+"mt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "mv" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/dark,
@@ -1214,6 +1450,22 @@
 "mJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/cryopod,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"mO" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/steel,
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/shot{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/shot{
+	pixel_y = 4;
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/shot{
+	pixel_y = -3
+	},
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "mQ" = (
@@ -1248,6 +1500,16 @@
 /obj/machinery/portable_atmospherics/canister/phoron_scarce,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
+/area/mine)
+"mX" = (
+/obj/structure/closet/crate,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "nf" = (
 /obj/structure/table/steel{
@@ -1293,7 +1555,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "nw" = (
-/obj/effect/floor_decal/corner_wide/red/full{
+/obj/effect/floor_decal/corner/red/full{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -1403,7 +1665,7 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "oe" = (
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /obj/machinery/optable,
@@ -1438,6 +1700,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"oz" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
 "oE" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
@@ -1458,7 +1727,7 @@
 /obj/machinery/bodyscanner{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -1488,7 +1757,7 @@
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "pa" = (
@@ -1502,6 +1771,14 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark,
+/area/mine)
+"pf" = (
+/obj/structure/table/steel,
+/obj/item/deck/cards{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "pn" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -1522,7 +1799,7 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/med)
 "pt" = (
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/sink/kitchen{
 	name = "sink";
 	pixel_y = 26
@@ -1546,12 +1823,12 @@
 /obj/item/tank/anesthetic,
 /obj/item/tank/anesthetic,
 /obj/item/clothing/mask/breath/medical,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "pz" = (
 /obj/structure/table/steel,
-/obj/effect/floor_decal/corner_wide/grey/full{
+/obj/effect/floor_decal/corner/grey/full{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -1612,33 +1889,64 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "pV" = (
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "qb" = (
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /obj/structure/table/standard,
+/obj/item/device/healthanalyzer{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/device/breath_analyzer{
+	pixel_x = 7
+	},
+/obj/item/bodybag/cryobag{
+	pixel_x = -4
+	},
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
+/obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"qf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "qj" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/black/med,
 /obj/item/clothing/head/helmet/space/syndicate/black/med,
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
+"qq" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "qt" = (
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/surgery{
 	pixel_y = 8
+	},
+/obj/item/storage/firstaid{
+	pixel_x = -3;
+	pixel_y = -7
 	},
 /turf/simulated/floor/tiled/white,
 /area/mine)
@@ -1675,7 +1983,7 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "qz" = (
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /obj/machinery/body_scanconsole{
@@ -1701,15 +2009,40 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"qF" = (
+/obj/effect/floor_decal/corner/blue,
+/turf/simulated/floor/tiled,
+/area/mine)
 "qJ" = (
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/item/trash/cigbutt,
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"qL" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"qM" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "qN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/can,
 /turf/simulated/floor/wood,
+/area/mine)
+"qO" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "qP" = (
 /obj/structure/table/steel{
@@ -1735,9 +2068,6 @@
 	dir = 1;
 	icon_state = "tube_empty"
 	},
-/obj/effect/ghostspawpoint{
-	identifier = "goon"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "ri" = (
@@ -1750,7 +2080,13 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "rq" = (
-/obj/structure/closet/crate/freezer,
+/obj/structure/closet/crate/medical,
+/obj/item/roller,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "ru" = (
@@ -1768,6 +2104,9 @@
 "rD" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/black,
+/obj/effect/ghostspawpoint{
+	identifier = "goon"
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "rF" = (
@@ -1796,9 +2135,6 @@
 	pixel_y = 0
 	},
 /obj/item/bedsheet/black,
-/obj/effect/ghostspawpoint{
-	identifier = "goon"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "sa" = (
@@ -1809,25 +2145,45 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "se" = (
 /turf/simulated/floor/airless,
 /area/mine)
 "sg" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
+"sh" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
 "sz" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/item/handcuffs,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "sB" = (
 /turf/unsimulated/floor/asteroid/ash/rocky,
+/area/mine)
+"sC" = (
+/obj/structure/closet/crate/freezer/rations,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "sI" = (
 /obj/structure/table/steel,
@@ -1840,6 +2196,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
+/area/mine)
+"sM" = (
+/obj/structure/bed/stool/chair/office/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "sN" = (
 /obj/structure/bed/padded,
@@ -1889,7 +2251,7 @@
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/void/mining,
 /obj/item/clothing/head/helmet/space/void/mining,
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
@@ -1920,20 +2282,26 @@
 /area/shuttle/goon_ship/living)
 "tz" = (
 /obj/machinery/appliance/cooker/oven,
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "tA" = (
 /obj/machinery/appliance/cooker/stove,
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/item/trash/stew,
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"tF" = (
+/obj/structure/bed/stool/chair/office/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "tI" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/starboard)
 "tL" = (
-/obj/machinery/portable_atmospherics/canister/hydrogen,
+/obj/machinery/portable_atmospherics/canister/empty/hydrogen,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
 "tR" = (
@@ -1955,6 +2323,25 @@
 	},
 /turf/simulated/floor/plating/asteroid,
 /area/mine)
+"ua" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"un" = (
+/obj/structure/closet/firecloset,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/turf/simulated/floor/plating,
+/area/mine)
+"uq" = (
+/obj/machinery/power/rtg,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "uu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -1963,7 +2350,7 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "uv" = (
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/appliance/cooker/stove,
 /turf/simulated/floor/tiled/white,
 /area/mine)
@@ -1988,6 +2375,15 @@
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/port)
+"uD" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/steel,
+/obj/item/trash/coffee{
+	pixel_x = 11;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "uT" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
@@ -1996,6 +2392,10 @@
 	dir = 10
 	},
 /turf/simulated/floor/wood,
+/area/mine)
+"uU" = (
+/obj/structure/trash_pile,
+/turf/simulated/floor/plating,
 /area/mine)
 "va" = (
 /obj/item/trash/cigbutt{
@@ -2035,11 +2435,11 @@
 /obj/machinery/door/airlock{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "vx" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/iv_drip,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
@@ -2098,7 +2498,7 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "vJ" = (
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "vM" = (
@@ -2119,7 +2519,15 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "vZ" = (
-/obj/effect/floor_decal/corner_wide/grey,
+/obj/effect/floor_decal/corner/grey,
+/turf/simulated/floor/tiled,
+/area/mine)
+"wb" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
 /area/mine)
 "wh" = (
@@ -2139,9 +2547,15 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
+"ws" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "wD" = (
 /obj/machinery/iv_drip,
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -2150,15 +2564,45 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/door/airlock/maintenance{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/living)
+"wH" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"wJ" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 5
+	},
+/obj/structure/bed/stool/chair/folding,
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "wL" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"wS" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/turf/simulated/floor/tiled,
+/area/mine)
+"wV" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/mine)
@@ -2169,7 +2613,7 @@
 /obj/item/storage/box/freezer/organcooler,
 /obj/item/storage/box/freezer/organcooler,
 /obj/item/storage/box/freezer/organcooler,
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
@@ -2224,7 +2668,7 @@
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/black,
 /obj/item/clothing/head/helmet/space/syndicate/black,
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
@@ -2236,7 +2680,6 @@
 	pixel_x = 3
 	},
 /obj/item/reagent_containers/food/drinks/bottle/whitewine{
-	desc = "A mediocsre quality white wine, intended more for making spritzers than for drinking by itself. Produced on Visegrad by Idris.";
 	pixel_y = 7;
 	pixel_x = -7
 	},
@@ -2246,6 +2689,20 @@
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/dark,
+/area/mine)
+"xz" = (
+/obj/machinery/power/rtg,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"xE" = (
+/obj/structure/bed/stool/chair/folding{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "xH" = (
 /obj/structure/lattice/catwalk/indoor/grate/old,
@@ -2276,9 +2733,6 @@
 "xM" = (
 /obj/item/bedsheet/black,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/ghostspawpoint{
-	identifier = "goon_prisoner"
-	},
 /turf/simulated/floor/plating,
 /area/mine)
 "xO" = (
@@ -2367,6 +2821,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/mine)
+"ys" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "yx" = (
 /obj/effect/landmark/entry_point/north{
 	name = "north, starboard engines"
@@ -2376,6 +2836,10 @@
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/goon_ship/starboard)
+"yy" = (
+/obj/effect/floor_decal/corner/blue/diagonal,
+/turf/simulated/floor/tiled,
+/area/mine)
 "yD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -2393,11 +2857,8 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/item/frame/apc{
-	pixel_y = -6;
-	pixel_x = -9
-	},
 /obj/random/dirt_75,
+/obj/machinery/power/apc/empty/north,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
 "yS" = (
@@ -2427,7 +2888,7 @@
 /obj/structure/table/steel{
 	pixel_x = -2
 	},
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "zd" = (
@@ -2448,7 +2909,7 @@
 "zs" = (
 /obj/structure/table/steel,
 /obj/item/device/healthanalyzer,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "zz" = (
@@ -2457,10 +2918,16 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "zB" = (
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
-/obj/structure/closet/crate/freezer,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/structure/closet/crate,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "zC" = (
@@ -2471,10 +2938,41 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"zU" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"zW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Ac" = (
+/obj/machinery/atmospherics/portables_connector/aux{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/plating,
+/area/mine)
 "Ag" = (
 /obj/machinery/chemical_dispenser/bar_alc/full{
 	dir = 8;
 	pixel_x = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"Ah" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
@@ -2487,8 +2985,14 @@
 /obj/item/reagent_containers/food/snacks/meat,
 /obj/item/reagent_containers/food/snacks/meat,
 /obj/item/reagent_containers/food/snacks/meat,
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"Au" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "Aw" = (
 /obj/structure/cable{
@@ -2524,6 +3028,12 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/mine)
+"AL" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "AR" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
@@ -2536,7 +3046,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "AV" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "Ba" = (
@@ -2641,20 +3151,26 @@
 /area/mine)
 "BH" = (
 /obj/structure/table/steel,
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "BI" = (
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
+"BJ" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "BK" = (
 /obj/machinery/appliance/cooker/fryer,
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube_empty"
@@ -2690,9 +3206,13 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "Ch" = (
-/obj/effect/floor_decal/corner_wide/red/full{
+/obj/effect/floor_decal/corner/red/full{
 	dir = 4
 	},
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
+/obj/random/junk,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Cr" = (
@@ -2705,7 +3225,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "Cz" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/item/trash/cigbutt,
 /turf/simulated/floor/tiled/white,
 /area/mine)
@@ -2727,11 +3247,15 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "CZ" = (
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"Df" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/turf/simulated/floor/plating,
 /area/mine)
 "Dj" = (
 /obj/effect/floor_decal/spline/plain/black{
@@ -2765,6 +3289,10 @@
 "Dr" = (
 /turf/simulated/wall,
 /area/mine)
+"Du" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
+/area/mine)
 "DI" = (
 /obj/structure/table/steel,
 /obj/item/tank/air,
@@ -2795,7 +3323,7 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "DY" = (
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /obj/machinery/bodyscanner{
@@ -2810,19 +3338,46 @@
 /area/mine)
 "El" = (
 /obj/machinery/computer/operating,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "Em" = (
 /obj/structure/curtain/open/medical,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
+"Ep" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
+/area/mine)
+"Ew" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 2
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "Ex" = (
 /obj/structure/bed/stool/padded/orange{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/red,
+/area/mine)
+"Ez" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/drinks/waterbottle{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "EE" = (
 /obj/structure/table/steel,
@@ -2831,6 +3386,12 @@
 /area/shuttle/goon_ship/living)
 "EI" = (
 /obj/structure/table/standard,
+/turf/simulated/floor/tiled,
+/area/mine)
+"EJ" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "EP" = (
@@ -2850,6 +3411,19 @@
 "EV" = (
 /obj/item/trash/tray,
 /obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/mine)
+"EZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Fb" = (
+/obj/structure/bed/stool,
 /turf/simulated/floor/plating,
 /area/mine)
 "Fc" = (
@@ -2893,7 +3467,7 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Fz" = (
-/obj/effect/floor_decal/corner_wide/red{
+/obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
@@ -2901,6 +3475,12 @@
 "FB" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/yellow,
+/turf/simulated/floor/tiled,
+/area/mine)
+"FD" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "FE" = (
@@ -2925,6 +3505,9 @@
 	},
 /obj/structure/bed/padded,
 /obj/item/bedsheet/blue,
+/obj/effect/ghostspawpoint{
+	identifier = "goon_boss"
+	},
 /turf/simulated/floor/wood,
 /area/mine)
 "FT" = (
@@ -2935,7 +3518,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "FU" = (
-/obj/effect/floor_decal/corner_wide/grey/full{
+/obj/effect/floor_decal/corner/grey/full{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -2945,6 +3528,8 @@
 	pixel_y = -11;
 	pixel_x = -5
 	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
 "Ga" = (
@@ -2971,9 +3556,21 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "Gc" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/freezer/rations,
-/turf/simulated/floor/plating,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/snacks/chocolatebar,
+/obj/item/reagent_containers/food/snacks/chocolatebar,
+/obj/item/reagent_containers/food/snacks/chocolatebar,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "Gi" = (
 /obj/machinery/gumballmachine,
@@ -3016,7 +3613,7 @@
 /obj/item/device/healthanalyzer{
 	pixel_x = -4
 	},
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3048,6 +3645,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/mine)
+"GM" = (
+/obj/structure/closet,
+/obj/effect/floor_decal/corner/blue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "GP" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -3070,6 +3674,11 @@
 /area/mine)
 "Hp" = (
 /obj/structure/bed,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/ghostspawpoint{
+	identifier = "goon_prisoner"
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "Hr" = (
@@ -3088,7 +3697,7 @@
 /obj/item/storage/firstaid/toxin{
 	pixel_x = 4
 	},
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "Ht" = (
@@ -3097,6 +3706,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
+"Hw" = (
+/obj/item/pickaxe{
+	pixel_y = -9
+	},
+/turf/unsimulated/floor/asteroid/ash,
+/area/mine)
 "Hx" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 8
@@ -3144,6 +3759,52 @@
 	},
 /turf/simulated/floor/wood,
 /area/mine)
+"HK" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
+"HU" = (
+/obj/structure/closet/cabinet{
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/food/drinks/bottle/whitewine{
+	pixel_y = 0;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/rum{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/bottle/sake,
+/obj/item/reagent_containers/food/drinks/bottle/algae_wine{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/drinks/bottle/absinthe{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/drinks/bottle/champagne,
+/obj/item/reagent_containers/food/drinks/bottle/small/beer{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/drinks/bottle/small/beer{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/bottle/small/beer{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/drinks/bottle/small/beer{
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/bottle/small/beer/light,
+/turf/simulated/floor/tiled,
+/area/mine)
+"HV" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "HW" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/covert,
@@ -3152,7 +3813,7 @@
 /area/mine)
 "HZ" = (
 /obj/machinery/optable,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "Ia" = (
@@ -3305,6 +3966,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
+"IB" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/power/smes/buildable/horizon_shuttle,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"IF" = (
+/obj/random/junk{
+	pixel_x = -9
+	},
+/turf/simulated/floor/tiled/full,
+/area/mine)
 "IL" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -3338,7 +4013,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
 "IW" = (
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
@@ -3347,7 +4022,7 @@
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/black/red,
 /obj/item/clothing/head/helmet/space/syndicate/black/red,
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
@@ -3371,7 +4046,7 @@
 /obj/item/storage/firstaid/fire{
 	pixel_x = 4
 	},
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "Jj" = (
@@ -3406,7 +4081,7 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Jq" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal{
+/obj/effect/floor_decal/corner/lime/diagonal{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -3418,10 +4093,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "Jx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
+/area/mine)
+"Jz" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "JC" = (
 /obj/effect/floor_decal/corner/purple{
@@ -3438,7 +4119,7 @@
 	name = "sink";
 	pixel_y = 26
 	},
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/mine)
@@ -3468,6 +4149,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
+"Ks" = (
+/obj/structure/table/standard,
+/obj/machinery/chemical_dispenser/coffee/full{
+	pixel_y = 16
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "KB" = (
 /obj/structure/table/reinforced/steel,
 /obj/effect/floor_decal/spline/plain/black{
@@ -3490,7 +4178,7 @@
 	pixel_y = 7
 	},
 /obj/item/storage/box/fancy/egg_box,
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "KG" = (
@@ -3498,6 +4186,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/red,
+/area/mine)
+"KJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "KK" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -3524,10 +4218,13 @@
 	dir = 1;
 	icon_state = "tube_empty"
 	},
-/obj/effect/ghostspawpoint{
-	identifier = "goon"
-	},
 /turf/simulated/floor/tiled/dark,
+/area/mine)
+"KS" = (
+/obj/structure/bed/stool/chair/folding{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "KW" = (
 /obj/structure/table/rack,
@@ -3570,6 +4267,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
+"Li" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/mine)
 "Lq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3582,10 +4283,15 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
 "LM" = (
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
+/area/mine)
+"LY" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/power/portgen/basic,
+/turf/simulated/floor/plating,
 /area/mine)
 "Mh" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -3593,10 +4299,26 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "Mk" = (
-/obj/effect/floor_decal/corner_wide/red{
+/obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
+/area/mine)
+"Ml" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
+/obj/item/reagent_containers/syringe,
+/turf/simulated/floor/tiled/white,
+/area/mine)
+"Mm" = (
+/obj/structure/bed/stool/chair/folding{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "Mo" = (
 /obj/structure/table/rack,
@@ -3610,7 +4332,7 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "Mu" = (
-/obj/effect/floor_decal/corner_wide/grey/full,
+/obj/effect/floor_decal/corner/grey/full,
 /turf/simulated/floor/tiled,
 /area/mine)
 "Mw" = (
@@ -3630,6 +4352,13 @@
 /area/mine)
 "ME" = (
 /obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/mine)
+"MH" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "MJ" = (
@@ -3659,7 +4388,7 @@
 /area/mine)
 "MT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/canister/phoron_scarce,
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
 /turf/simulated/floor/plating,
 /area/mine)
 "MV" = (
@@ -3688,17 +4417,20 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
 "Ne" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
 "Nf" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/rainbow,
+/obj/effect/ghostspawpoint{
+	identifier = "goon"
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "Ni" = (
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -3707,7 +4439,7 @@
 /obj/machinery/body_scanconsole{
 	pixel_x = -1
 	},
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "Np" = (
@@ -3727,6 +4459,10 @@
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
+/area/mine)
+"Nt" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled,
 /area/mine)
 "NA" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
@@ -3766,6 +4502,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
+"NU" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "NX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/trash/chipbasket,
@@ -3775,6 +4517,10 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
+"Og" = (
+/obj/structure/closet/crate/miningcart/ore,
+/turf/simulated/floor/airless/ceiling,
+/area/mine)
 "On" = (
 /obj/item/clothing/gloves/janitor,
 /obj/structure/table/rack,
@@ -3835,10 +4581,10 @@
 /area/mine)
 "OL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/fuel_port/hydrogen{
+/obj/structure/fuel_port/hydrogen/empty{
 	pixel_y = 32
 	},
-/obj/machinery/portable_atmospherics/canister/hydrogen,
+/obj/machinery/portable_atmospherics/canister/empty/hydrogen,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
 "OM" = (
@@ -3881,7 +4627,7 @@
 /area/mine)
 "PC" = (
 /obj/machinery/bodyscanner,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "PK" = (
@@ -3898,7 +4644,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "PL" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/mine)
@@ -3925,9 +4671,6 @@
 	pixel_y = 0
 	},
 /obj/item/bedsheet/black,
-/obj/effect/ghostspawpoint{
-	identifier = "goon_boss"
-	},
 /turf/simulated/floor/wood,
 /area/mine)
 "PY" = (
@@ -3939,7 +4682,7 @@
 /obj/structure/table/rack,
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/mask/surgical/w,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "Qc" = (
@@ -3960,7 +4703,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
 "Qg" = (
-/obj/effect/floor_decal/corner_wide/grey/full{
+/obj/effect/floor_decal/corner/grey/full{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -3969,6 +4712,12 @@
 /obj/item/trash/coffee,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"Qj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "Ql" = (
 /obj/machinery/chemical_dispenser/bar_soft/full{
 	dir = 8;
@@ -4000,12 +4749,26 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "Qx" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
+"Qy" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/combat{
+	pixel_x = -4
+	},
+/obj/item/storage/firstaid/trauma,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "Qz" = (
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
@@ -4081,6 +4844,10 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
+"Rj" = (
+/obj/machinery/hologram/holopad/long_range,
+/turf/simulated/floor/tiled/full,
+/area/mine)
 "Rl" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -4122,7 +4889,7 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "Sd" = (
@@ -4130,6 +4897,33 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
+/area/mine)
+"Se" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/storage/box/produce{
+	layer = 2.99;
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/item/storage/box/fancy/egg_box,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/storage/box/fancy/egg_box,
+/obj/item/reagent_containers/food/drinks/carton/milk,
+/obj/item/reagent_containers/food/drinks/carton/milk,
+/obj/item/reagent_containers/food/drinks/carton/milk,
+/obj/item/reagent_containers/food/drinks/carton/milk,
+/obj/item/reagent_containers/food/drinks/carton/soymilk,
+/obj/item/reagent_containers/food/drinks/carton/soymilk,
+/obj/item/reagent_containers/food/drinks/carton/milk,
+/turf/simulated/floor/tiled/freezer,
 /area/mine)
 "Sf" = (
 /obj/structure/table/steel,
@@ -4178,6 +4972,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine)
+"Sv" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
+/turf/simulated/floor/plating,
+/area/mine)
+"Sx" = (
+/obj/structure/table/rack,
+/turf/simulated/floor/plating,
+/area/mine)
 "Sz" = (
 /obj/structure/trash_pile,
 /obj/effect/decal/cleanable/dirt,
@@ -4217,6 +5019,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/mine)
+"SH" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/aux,
+/turf/simulated/floor/plating,
+/area/mine)
 "SJ" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid,
@@ -4227,6 +5033,12 @@
 /obj/item/trash/cigbutt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"SM" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "SU" = (
 /obj/machinery/pipedispenser,
 /obj/effect/decal/cleanable/dirt,
@@ -4246,8 +5058,14 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
 "Tb" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
+/area/mine)
+"Tc" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "Td" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4258,6 +5076,11 @@
 /obj/machinery/power/apc/empty/west,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
+"Tj" = (
+/obj/structure/closet/firecloset,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/turf/simulated/floor/tiled,
+/area/mine)
 "To" = (
 /obj/structure/closet{
 	icon_door = "blue";
@@ -4274,7 +5097,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "Tr" = (
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -4328,7 +5151,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/mine)
 "TH" = (
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
@@ -4345,7 +5168,7 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "TO" = (
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
@@ -4358,7 +5181,7 @@
 /turf/simulated/floor/wood,
 /area/mine)
 "TW" = (
-/obj/effect/floor_decal/corner_wide/red/full{
+/obj/effect/floor_decal/corner/red/full{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -4382,12 +5205,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
+"Uh" = (
+/obj/machinery/atmospherics/portables_connector/aux{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/plating,
+/area/mine)
 "Ui" = (
 /obj/effect/landmark/entry_point/south{
 	name = "fore, bridge"
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/bridge)
+"Uk" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "Ul" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
@@ -4396,7 +5230,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
 "Un" = (
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/steel,
 /obj/item/trash/stew{
 	pixel_x = 4;
@@ -4454,10 +5288,15 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"UN" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/turf/simulated/floor/plating,
+/area/mine)
 "UX" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/fancy/tray,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/light{
 	dir = 8;
 	pixel_x = 0;
@@ -4471,6 +5310,9 @@
 /obj/item/toy/plushie/farwa{
 	pixel_y = -3;
 	pixel_x = 7
+	},
+/obj/effect/ghostspawpoint{
+	identifier = "goon"
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -4536,17 +5378,27 @@
 /obj/item/material/ashtray/bronze,
 /turf/simulated/floor/wood,
 /area/mine)
+"VR" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 10
+	},
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip{
+	pixel_x = 7
+	},
+/turf/simulated/floor/tiled/white,
+/area/mine)
 "VY" = (
 /obj/structure/table/rack,
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/mask/surgical/w,
 /obj/item/melee/baton/stunrod,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "Wb" = (
 /obj/item/trash/can,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -4560,6 +5412,9 @@
 /area/mine)
 "Wn" = (
 /obj/structure/closet/crate,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "Wq" = (
@@ -4580,14 +5435,22 @@
 "Wv" = (
 /obj/structure/bed/roller,
 /obj/effect/floor_decal/industrial/outline/medical,
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "Ww" = (
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 10
+	},
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/o2{
+	pixel_x = -4
+	},
+/obj/item/storage/firstaid/radiation,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/mine)
@@ -4599,13 +5462,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/mine)
+"WB" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "WD" = (
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/appliance/cooker/oven,
 /turf/simulated/floor/tiled/white,
 /area/mine)
 "WG" = (
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/item/trash/coffee,
 /turf/simulated/floor/tiled/white,
 /area/mine)
@@ -4705,6 +5574,20 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/mine)
+"XF" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/suit_cycler,
+/turf/simulated/floor/tiled,
+/area/mine)
+"XI" = (
+/obj/structure/closet/cabinet,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "XP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -4733,7 +5616,7 @@
 /area/mine)
 "Yf" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
@@ -4749,7 +5632,7 @@
 	pixel_x = -2
 	},
 /obj/item/material/kitchen/rollingpin,
-/obj/effect/floor_decal/corner_wide/grey/diagonal,
+/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube_empty"
@@ -4783,9 +5666,16 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"YI" = (
+/obj/structure/closet,
+/obj/effect/floor_decal/corner/blue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "YK" = (
 /obj/machinery/computer/operating,
-/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
 "YU" = (
@@ -4864,6 +5754,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/mine)
+"Zl" = (
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/mine)
 "Zu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -4884,7 +5778,7 @@
 /obj/item/storage/firstaid/fire{
 	pixel_x = 4
 	},
-/obj/effect/floor_decal/corner_wide/lime{
+/obj/effect/floor_decal/corner/lime{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -4914,7 +5808,7 @@
 /area/mine)
 "ZH" = (
 /obj/structure/dispenser/oxygen,
-/obj/effect/floor_decal/corner_wide/grey{
+/obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
@@ -4930,6 +5824,54 @@
 /obj/item/trash/cheesie,
 /turf/simulated/floor/wood,
 /area/mine)
+"ZR" = (
+/obj/structure/closet/crate/freezer{
+	name = "emergency rations (vaurca)"
+	},
+/obj/item/reagent_containers/food/snacks/koisbar{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/snacks/koisbar_clean{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/snacks/koisbar{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/snacks/koisbar_clean{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/snacks/koisbar{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/snacks/koisbar_clean{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/snacks/koisbar{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/snacks/koisbar_clean{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/snacks/koisbar{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/snacks/koisbar_clean{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/snacks/koisbar{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/snacks/koisbar_clean{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/snacks/koisbar{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/food/snacks/koisbar_clean{
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/mine)
 "ZT" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
@@ -4941,6 +5883,15 @@
 "ZW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/portgen/basic,
+/turf/simulated/floor/plating,
+/area/mine)
+"ZY" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 
@@ -34545,13 +35496,13 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+qX
+qX
+qX
+qX
+qX
+qX
 mI
 mI
 mI
@@ -34802,13 +35753,13 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+Dr
+Dr
+Dr
+Dr
+qX
 mI
 mI
 mI
@@ -35059,13 +36010,13 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+dv
+qM
+NU
+Dr
+qX
 mI
 mI
 mI
@@ -35312,20 +36263,20 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+qX
+qX
+qX
+qX
+Dr
+Du
+uq
+KJ
+Dr
+qX
+qX
+qX
+qX
 mI
 mI
 mI
@@ -35569,20 +36520,20 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+Dr
+Dr
+Dr
+Dr
+wV
+ad
+qL
+Dr
+Dr
+Dr
+Dr
+qX
 mI
 mI
 mI
@@ -35826,20 +36777,20 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+Gn
+Gn
+Nt
+jS
+EZ
+lh
+qf
+gc
+jw
+NU
+Dr
+qX
 mI
 mI
 mI
@@ -36083,20 +37034,20 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+Gn
+tF
+Nt
+IB
+EZ
+Jz
+QX
+MH
+xz
+KJ
+Dr
+qX
 mI
 mI
 mI
@@ -36340,19 +37291,19 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
 qX
-qX
-qX
-qX
-qX
+Dr
+Gn
+Vw
+Au
+FD
+SM
+Ep
+QX
+zU
+dY
+bA
+Dr
 qX
 qX
 qX
@@ -36372,11 +37323,11 @@ qX
 qX
 qX
 Dr
-TO
+wb
 bj
 lW
 Qg
-iK
+bm
 Dr
 qX
 mI
@@ -36597,15 +37548,15 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
 qX
-qX
-qX
-qX
-qX
+Dr
+IN
+QX
+IN
+Dr
+Dr
+kI
+Dr
 Dr
 Dr
 Dr
@@ -36854,31 +37805,31 @@ mI
 mI
 mI
 mI
-mI
-mI
+qX
+Dr
+LY
+QX
+IN
+Dr
+QX
+Qj
+QX
+Dr
+uU
+Zl
+QX
+QX
+QX
+QX
+QX
+QX
+Dr
+qX
 mI
 mI
 qX
 Dr
-Dr
-Dr
-Dr
-Dr
-QX
-QX
-QX
-QX
-QX
-QX
-QX
-QX
-Dr
-qX
-mI
-mI
-qX
-Dr
-QX
+uU
 QX
 QX
 QX
@@ -37112,32 +38063,32 @@ mI
 qX
 qX
 qX
-qX
-qX
-qX
-qX
+Dr
+eL
+IN
+IN
+Dr
+QX
+AL
+zW
+wH
+qf
+qf
+QX
+QX
+QX
+uU
+QX
+QX
+Dr
+mI
+mI
+mI
+mI
 Dr
 QX
 QX
-QX
-wY
-QX
-QX
-QX
-QX
-QX
-QX
-QX
-QX
-Dr
-mI
-mI
-mI
-mI
-Dr
-QX
-QX
-QX
+Zl
 QX
 QX
 QX
@@ -37153,11 +38104,11 @@ QX
 QX
 QX
 Dr
-QX
-QX
-QX
-QX
-QX
+Fb
+pf
+gE
+ll
+Uh
 Dr
 qX
 mI
@@ -37374,9 +38325,9 @@ Dr
 Dr
 Dr
 Dr
-QX
-QX
-QX
+UN
+Vw
+Qj
 Dr
 Dr
 Dr
@@ -37397,10 +38348,10 @@ QX
 Dr
 EQ
 QX
-QX
+uU
 Dr
 Dr
-TO
+XF
 lW
 lW
 lW
@@ -37411,10 +38362,10 @@ QX
 QX
 Dr
 QX
+Mm
 QX
-QX
-QX
-QX
+fR
+Uh
 Dr
 qX
 mI
@@ -37452,7 +38403,7 @@ mI
 mI
 mI
 mI
-mI
+Dr
 se
 se
 se
@@ -37631,9 +38582,9 @@ ME
 ru
 tu
 Dr
-QX
-QX
-QX
+un
+Vw
+Qj
 Dr
 kE
 QX
@@ -37670,7 +38621,7 @@ wY
 QX
 QX
 QX
-QX
+mt
 QX
 Dr
 qX
@@ -37888,9 +38839,9 @@ ru
 vH
 QX
 Dr
-QX
-QX
-QX
+qO
+qf
+ys
 Dr
 IN
 QX
@@ -37920,14 +38871,14 @@ Vw
 jW
 ei
 Dr
-Dr
-Dr
-Dr
-Dr
+QX
 QX
 QX
 Dr
-ms
+lJ
+Zl
+Dr
+ZY
 Dr
 Dr
 qX
@@ -38145,11 +39096,11 @@ Hx
 yD
 tu
 Dr
-QX
-QX
+Qj
+Vw
 QX
 Dr
-Gc
+IN
 QX
 IN
 Mh
@@ -38181,10 +39132,10 @@ Dr
 Dr
 Dr
 Dr
-QX
+uU
 QX
 Dr
-QX
+cF
 QX
 Dr
 qX
@@ -38403,8 +39354,8 @@ QX
 Dr
 Dr
 QX
-QX
-QX
+Vw
+uU
 Dr
 qv
 QX
@@ -38420,20 +39371,20 @@ mI
 mI
 mI
 mI
+uU
+QX
+QX
+Dr
 QX
 QX
 QX
 Dr
-QX
-QX
-QX
-Dr
+FU
+IW
 Vw
-Vw
-Vw
-Vw
-Vw
-QX
+IW
+ll
+Uh
 Dr
 mI
 mI
@@ -38685,12 +39636,12 @@ Dr
 Rt
 Dr
 Dr
+TO
 Vw
 Vw
 Vw
-Vw
-Vw
-QX
+fR
+Uh
 Dr
 mI
 mI
@@ -38942,11 +39893,11 @@ IW
 Vw
 IW
 IW
+Ni
 Vw
 Vw
 Vw
-Vw
-Vw
+mt
 Dr
 Dr
 mI
@@ -39167,8 +40118,8 @@ Dr
 Dr
 Dr
 Dr
-Vw
-Vw
+Gn
+sM
 Vw
 Vw
 Dr
@@ -39203,7 +40154,7 @@ Vw
 Vw
 Dr
 ms
-ms
+ZY
 Dr
 vz
 vz
@@ -39415,18 +40366,18 @@ mI
 mI
 mI
 mI
-mI
-mI
+qX
+qX
 qX
 Dr
 QX
-QX
+uU
 QX
 QX
 Dr
-Vw
-Vw
-Vw
+Gn
+Gn
+Gn
 Vw
 Dr
 Vw
@@ -39453,14 +40404,14 @@ mn
 BI
 ff
 BI
-Vw
-Vw
-Vw
-Vw
+BI
+BI
+BI
+ws
 Vw
 Dr
-QX
-QX
+Sv
+Ew
 Dr
 Dr
 vz
@@ -39672,11 +40623,11 @@ mI
 mI
 mI
 mI
-mI
+qX
 mI
 qX
 Dr
-QX
+Zl
 QX
 QX
 QX
@@ -39710,15 +40661,15 @@ Dr
 Dr
 Dr
 Dr
+Dr
 Vw
 Vw
-Vw
-Vw
+TO
 Vw
 Dr
-QX
-QX
-QX
+Sv
+SH
+dX
 Rb
 vz
 vz
@@ -39938,10 +40889,10 @@ QX
 QX
 QX
 Dr
+uU
 QX
 QX
-QX
-QX
+Zl
 QX
 QX
 QX
@@ -39949,7 +40900,7 @@ Dr
 dV
 dQ
 eK
-qb
+Qy
 Dr
 WI
 WI
@@ -39963,19 +40914,19 @@ Do
 mI
 mI
 mI
-mI
-mI
-mI
+qX
+qX
+qX
 Dr
+wS
 Vw
-Vw
-Vw
-Vw
+cV
+TO
 Vw
 Dr
-QX
-QX
-QX
+Sv
+SH
+dX
 Rb
 vz
 vz
@@ -40190,7 +41141,7 @@ qX
 mI
 qX
 Dr
-QX
+uU
 QX
 QX
 QX
@@ -40222,16 +41173,16 @@ mI
 mI
 mI
 mI
-mI
+qX
 Dr
-Vw
-Vw
-Vw
-Vw
+Dr
+Tj
+Dr
+TO
 Vw
 Dr
-QX
-QX
+Sv
+Df
 Dr
 Dr
 vz
@@ -40450,7 +41401,7 @@ Dr
 QX
 QX
 QX
-QX
+Zl
 Dr
 Dr
 Dr
@@ -40463,7 +41414,7 @@ Dr
 qt
 lK
 kL
-Ww
+Ml
 Dr
 TO
 lW
@@ -40472,23 +41423,23 @@ wY
 Vw
 hF
 Dr
+qX
 mI
 mI
 mI
 mI
 mI
 mI
-mI
-mI
+qX
 Dr
 Dr
 Dr
 Dr
-Vw
+TO
 Vw
 Dr
 ms
-ms
+ZY
 Dr
 vz
 vz
@@ -40704,8 +41655,8 @@ Dr
 Dr
 Dr
 Dr
-aM
 Dr
+aM
 Dr
 Dr
 Dr
@@ -40729,23 +41680,23 @@ Dr
 Dr
 Dr
 Dr
+qX
 mI
 mI
 mI
 mI
 mI
 mI
-mI
-mI
+qX
 qX
 qX
 qX
 Dr
+TO
 Vw
 Vw
 Vw
-Vw
-Vw
+mt
 Dr
 Dr
 nT
@@ -40958,11 +41909,11 @@ Dr
 xs
 xs
 xs
-eJ
+ua
 Wt
 Dr
 aR
-QX
+Li
 wY
 Mz
 Rl
@@ -40972,9 +41923,9 @@ Fc
 Dr
 QX
 Vw
-QX
+uU
 Dr
-TH
+wJ
 Jq
 Jq
 eK
@@ -40998,11 +41949,11 @@ mI
 mI
 qX
 Dr
+TO
 Vw
 Vw
 Vw
-Vw
-Vw
+mt
 QX
 Dr
 nT
@@ -41028,7 +41979,7 @@ sB
 sB
 sB
 vz
-vz
+Og
 vz
 vz
 vz
@@ -41213,13 +42164,13 @@ mI
 qX
 Dr
 xs
-eJ
-eJ
+HK
+Uk
 eJ
 Wt
 Dr
 FZ
-QX
+aS
 fh
 GL
 Np
@@ -41234,7 +42185,7 @@ Dr
 qz
 Jq
 Jq
-Ww
+VR
 mn
 LM
 Vw
@@ -41258,8 +42209,8 @@ Dr
 QX
 QX
 QX
-QX
-QX
+ll
+Df
 QX
 Dr
 nT
@@ -41288,7 +42239,7 @@ vz
 vz
 vz
 vz
-vz
+dI
 vz
 sB
 sB
@@ -41471,8 +42422,8 @@ qX
 Dr
 xs
 eJ
-eJ
-eJ
+Uk
+Ah
 Wt
 Dr
 jV
@@ -41515,8 +42466,8 @@ Dr
 QX
 QX
 QX
-QX
-QX
+Ac
+Ac
 Dr
 Dr
 nT
@@ -41541,7 +42492,7 @@ mI
 mI
 mI
 mI
-vz
+hq
 vz
 vz
 vz
@@ -41732,7 +42683,7 @@ VK
 eJ
 pd
 Dr
-Wn
+Ez
 Hp
 fh
 gL
@@ -41983,7 +42934,7 @@ qX
 Dr
 Ya
 Ya
-eJ
+HV
 eJ
 VK
 eJ
@@ -42057,7 +43008,7 @@ mI
 mI
 mI
 nT
-nT
+Hw
 nT
 mI
 mI
@@ -42238,20 +43189,20 @@ qX
 mI
 qX
 Dr
-eJ
-eJ
-eJ
+Uk
+Uk
+Ah
 eJ
 VK
 eJ
-eJ
+BJ
 QX
 QX
 wY
 KZ
 hr
 lW
-lW
+Rj
 lW
 Vw
 SJ
@@ -42495,13 +43446,13 @@ qX
 mI
 qX
 Dr
+Uk
+Uk
+Ah
+HK
+Uk
 eJ
-eJ
-eJ
-eJ
-eJ
-eJ
-eJ
+BJ
 QX
 QX
 Dr
@@ -42521,7 +43472,7 @@ BI
 BI
 ff
 BI
-BI
+EJ
 Vw
 bj
 mn
@@ -42569,7 +43520,7 @@ mI
 mI
 mI
 mI
-sB
+lR
 sB
 sB
 mI
@@ -42754,13 +43705,13 @@ qX
 Dr
 Ya
 Ya
-eJ
+HV
 OI
 yq
 yq
-eJ
+BJ
 QX
-QX
+iO
 Dr
 Dr
 Rt
@@ -42771,8 +43722,8 @@ Dr
 Dr
 Dr
 Dr
-Rt
-Dr
+bH
+wS
 Dr
 Dr
 Dr
@@ -43011,31 +43962,31 @@ qX
 Dr
 Dr
 Dr
-eJ
+HV
 yq
 yq
 yq
-eJ
+BJ
 QX
-QX
+Sx
 Dr
 pn
 NA
 Dr
-EI
+Ks
 Vw
-Vw
+cV
 EI
 EI
 Dr
-QX
-QX
+bH
+Tj
 Dr
 ng
 Gn
 Gn
 Dr
-Vw
+aY
 Vw
 Dr
 mI
@@ -43268,31 +44219,31 @@ qX
 qX
 qX
 Dr
+HV
 eJ
-eJ
-eJ
-eJ
-eJ
+Uk
+Ah
+BJ
 QX
-QX
+Sx
 Dr
 cx
 NA
 Dr
-EI
+HU
 Vw
 Vw
 Vw
 Vw
 Dr
-QX
-QX
+Rt
+Dr
 Dr
 Vw
-lW
+KS
 Gn
 Dr
-Vw
+Tc
 Vw
 Dr
 Dr
@@ -43525,13 +44476,13 @@ qX
 mI
 qX
 Dr
-eJ
+HV
 VK
 VK
 VK
 GF
-Dr
-Dr
+QX
+QX
 Dr
 xJ
 YU
@@ -43543,7 +44494,7 @@ Oo
 Oo
 Dr
 QX
-QX
+uU
 Dr
 Vw
 lW
@@ -43551,7 +44502,7 @@ Vw
 wY
 Vw
 Vw
-Gn
+qq
 Dr
 cx
 vq
@@ -43785,28 +44736,28 @@ Dr
 GF
 GF
 GF
-eJ
+WB
 GF
+Sx
+Sx
 Dr
-qX
-qX
-qX
-qX
+Dr
+Dr
 Dr
 pV
 vJ
-pV
+mO
 gp
-pV
+uD
 Dr
 QX
-QX
+Zl
 Dr
 FB
 Vw
 sN
 Dr
-Vw
+Tc
 lW
 Vw
 wY
@@ -44045,12 +44996,12 @@ Dr
 Dr
 Dr
 Dr
-qX
-mI
-mI
-qX
+Dr
+Dr
+Dr
 Dr
 pt
+vJ
 vJ
 vJ
 vJ
@@ -44063,9 +45014,9 @@ Dr
 Dr
 Dr
 Dr
-Vw
+Tc
 lW
-ng
+GM
 Dr
 Dr
 Dr
@@ -44303,8 +45254,7 @@ qX
 qX
 qX
 qX
-mI
-mI
+qX
 qX
 Dr
 uv
@@ -44312,17 +45262,18 @@ vJ
 vJ
 vJ
 vJ
+vJ
 wY
 QX
 QX
 wY
 Vw
-Vw
-Vw
-Vw
-Vw
-Vw
-Wn
+qF
+yy
+yy
+yy
+yy
+mX
 Dr
 vM
 Vw
@@ -44561,28 +45512,28 @@ qX
 mI
 qX
 mI
-mI
 qX
 Dr
 WD
 vJ
 Un
+pV
 vJ
 vJ
 Dr
-QX
+uU
 QX
 Dr
 od
 Dr
-ng
+YI
 lW
 lW
 Vw
 Vw
 wY
 Vw
-lW
+IF
 Gn
 Dr
 qX
@@ -44817,9 +45768,9 @@ qX
 qX
 qX
 qX
-mI
-mI
 qX
+qX
+Dr
 Dr
 Dr
 Dr
@@ -44832,11 +45783,11 @@ Dr
 Dr
 Dr
 Dr
-vM
+XI
 lW
-lW
+xE
 Vw
-ng
+GM
 Dr
 Vw
 lW
@@ -45075,25 +46026,25 @@ mI
 mI
 mI
 mI
-mI
+qX
 qX
 qX
 qX
 Dr
-IU
+sC
 IU
 Tb
 Dr
 Tb
 eP
-Tb
+Ne
 Dr
 Dr
 Wn
 Vw
 Gn
 Vw
-ng
+GM
 Dr
 Nf
 bc
@@ -45337,13 +46288,13 @@ mI
 mI
 qX
 Dr
+ZR
 IU
-Tb
-Tb
+Ne
 ri
+Tb
 Ne
-Ne
-Ne
+Jx
 Dr
 Dr
 Dr
@@ -45594,13 +46545,13 @@ mI
 mI
 qX
 Dr
-IU
-IU
+gO
 Tb
+Gc
 TN
+Tb
 Jx
-Jx
-Ne
+oz
 Dr
 Gn
 Gn
@@ -45851,13 +46802,13 @@ mI
 mI
 qX
 Dr
+Se
 IU
-IU
-IU
+sh
 Dr
 eq
 Jx
-Ne
+Jx
 Dr
 Vw
 lW

--- a/maps/away/away_site/goon_base/goon_base.dmm
+++ b/maps/away/away_site/goon_base/goon_base.dmm
@@ -50,24 +50,6 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
-"aF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/mine)
-"aG" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/random/dirt_75,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/mine)
 "aI" = (
 /obj/item/reagent_containers/glass/bucket/wood{
 	pixel_y = -7
@@ -87,6 +69,14 @@
 	pixel_x = 15
 	},
 /turf/simulated/floor/tiled,
+/area/mine)
+"aK" = (
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_y = 8;
+	pixel_x = 20
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "aL" = (
 /obj/structure/cable{
@@ -195,9 +185,32 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
+"bt" = (
+/obj/structure/reagent_dispensers/radioactive_waste{
+	pixel_x = 7
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/greenglow/radioactive{
+	pixel_x = 12;
+	pixel_y = -5
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "bu" = (
 /turf/template_noop,
 /area/space)
+"bz" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "bA" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -301,6 +314,19 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/airless/ceiling,
 /area/mine)
+"cO" = (
+/obj/structure/table/steel,
+/obj/random/bomb_supply{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/random/dirt_75,
+/obj/item/device/transfer_valve{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "cP" = (
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
@@ -339,16 +365,6 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
-"di" = (
-/obj/effect/floor_decal/corner/grey/full{
-	dir = 8
-	},
-/obj/machinery/power/apc/north,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/tiled,
 /area/mine)
 "dr" = (
 /obj/random/tech_supply{
@@ -403,6 +419,15 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
+/area/mine)
+"dN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/wall{
+	can_open = 1;
+	color = "#DDDDDD"
+	},
 /area/mine)
 "dQ" = (
 /obj/item/reagent_containers/blood/OMinus,
@@ -476,6 +501,19 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
+/area/mine)
+"en" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/computer_hardware/network_card/signaler{
+	pixel_x = -1;
+	pixel_y = -10
+	},
+/obj/item/weldingtool/emergency{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "eq" = (
 /obj/item/reagent_containers/glass/bucket/wood{
@@ -656,6 +694,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
+"fn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "fo" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -696,6 +740,19 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
+/area/mine)
+"fB" = (
+/obj/structure/reagent_dispensers/radioactive_waste{
+	pixel_x = -8
+	},
+/obj/effect/decal/cleanable/acid_remnants,
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_y = -7;
+	pixel_x = 2
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "fC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -991,6 +1048,12 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
+"hL" = (
+/obj/structure/bed/stool/chair/office/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "hN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -1000,14 +1063,6 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
-"hO" = (
-/obj/random/dirt_75,
-/obj/item/tank/emergency_oxygen/double{
-	pixel_y = -2;
-	pixel_x = 3
-	},
-/turf/simulated/floor/plating/asteroid,
 /area/mine)
 "hS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1097,13 +1152,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
-"im" = (
-/obj/random/dirt_75,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/full,
-/area/mine)
 "ip" = (
 /obj/structure/structural_support{
 	pixel_y = 8
@@ -1141,6 +1189,22 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"iy" = (
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/greenglow/radioactive{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 2;
+	pixel_y = -10
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "iA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet/north{
@@ -1149,9 +1213,13 @@
 /obj/item/trash/chips,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
-"iC" = (
-/obj/machinery/photocopier,
-/turf/simulated/floor/tiled,
+"iD" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/full,
 /area/mine)
 "iK" = (
 /obj/effect/floor_decal/corner/grey{
@@ -1641,12 +1709,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
-"lB" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/dirt_75,
-/obj/machinery/power/portgen/basic,
-/turf/simulated/floor/plating,
-/area/mine)
 "lI" = (
 /obj/item/storage/toolbox/emergency{
 	pixel_x = -11;
@@ -1705,10 +1767,6 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
-"mc" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/full,
-/area/mine)
 "mf" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/storage/toggle/brown_jacket/sleeveless,
@@ -1718,8 +1776,11 @@
 /area/shuttle/goon_ship/living)
 "mg" = (
 /obj/random/dirt_75,
-/obj/random/dirt_75,
-/turf/simulated/mineral/surface,
+/obj/item/tank/emergency_oxygen/double{
+	pixel_y = -2;
+	pixel_x = 3
+	},
+/turf/simulated/floor/plating/asteroid,
 /area/mine)
 "mj" = (
 /obj/random/dirt_75,
@@ -1731,17 +1792,6 @@
 /area/mine)
 "mn" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/plating,
-/area/mine)
-"mo" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/random/dirt_75,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating,
 /area/mine)
 "ms" = (
@@ -1773,12 +1823,6 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/storage)
-"mC" = (
-/obj/structure/bed/stool/chair/office/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/mine)
 "mE" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -1787,6 +1831,23 @@
 /area/mine)
 "mI" = (
 /turf/simulated/mineral/surface,
+/area/mine)
+"mN" = (
+/obj/effect/decal/cleanable/acid_remnants,
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_y = -7;
+	pixel_x = 2
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "mO" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -2024,6 +2085,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"nY" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/full,
+/area/mine)
 "oc" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 4
@@ -2161,6 +2226,10 @@
 	pixel_y = -1
 	},
 /turf/simulated/floor/tiled/dark,
+/area/mine)
+"oT" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/plating,
 /area/mine)
 "oX" = (
 /obj/structure/closet/walllocker/medical{
@@ -2332,6 +2401,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/mine)
+"qa" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "qb" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -2409,8 +2485,15 @@
 /turf/simulated/floor/plating,
 /area/mine)
 "qw" = (
-/obj/effect/floor_decal/corner/pink/diagonal,
-/turf/simulated/floor/tiled,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "qy" = (
 /obj/effect/floor_decal/corner/purple{
@@ -2433,6 +2516,14 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"qA" = (
+/obj/random/dirt_75,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "qC" = (
 /obj/structure/table/wood,
@@ -2538,6 +2629,19 @@
 "qX" = (
 /turf/simulated/wall/r_wall,
 /area/mine)
+"qY" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/gun/projectile/automatic/c20r,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/north,
+/turf/simulated/floor/tiled/dark,
+/area/mine)
 "rc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2604,14 +2708,6 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/mine)
-"rP" = (
-/obj/random/dirt_75,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/north,
-/turf/simulated/floor/plating,
-/area/mine)
 "rU" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/light{
@@ -2667,6 +2763,12 @@
 /obj/item/reagent_containers/food/condiment/sugar,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
+/area/mine)
+"ss" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "sz" = (
 /obj/random/dirt_75,
@@ -2730,12 +2832,10 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
-"sR" = (
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/turf/simulated/floor/tiled,
+"sT" = (
+/obj/structure/bed/stool/chair/office/dark,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "sX" = (
 /obj/structure/closet/crate,
@@ -2840,6 +2940,27 @@
 /obj/machinery/portable_atmospherics/canister/empty/hydrogen,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
+"tN" = (
+/obj/structure/reagent_dispensers/radioactive_waste{
+	pixel_y = -8
+	},
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_y = -7;
+	pixel_x = 2
+	},
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/greenglow/radioactive{
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "tR" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
@@ -2852,20 +2973,44 @@
 	},
 /turf/simulated/floor/plating/asteroid,
 /area/mine)
-"tV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled,
-/area/mine)
 "ua" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
+/area/mine)
+"ui" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = -9;
+	pixel_y = 3
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"um" = (
+/obj/structure/reagent_dispensers/radioactive_waste{
+	pixel_x = 12;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/acid_remnants,
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_y = -7;
+	pixel_x = 2
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "un" = (
 /obj/structure/closet/firecloset,
@@ -2931,13 +3076,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
-"uN" = (
-/obj/structure/table/standard,
-/obj/item/modular_computer/laptop/preset/civilian{
-	pixel_y = 9
-	},
-/turf/simulated/floor/tiled,
-/area/mine)
 "uT" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
@@ -2994,6 +3132,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/mine)
+"vs" = (
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
+/area/mine)
 "vt" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/storage/box/zipties{
@@ -3002,6 +3147,16 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor/tiled/dark/full,
+/area/mine)
+"vv" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 2;
+	pixel_y = -10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "vx" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -3134,12 +3289,31 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
+"wB" = (
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/item/device/assembly/signaler{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "wD" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
+/area/mine)
+"wF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "wG" = (
 /obj/structure/cable{
@@ -3265,6 +3439,16 @@
 /obj/item/ammo_magazine/a10mm,
 /obj/item/gun/projectile/automatic/c20r,
 /turf/simulated/floor/tiled/dark,
+/area/mine)
+"xy" = (
+/obj/effect/floor_decal/corner/grey/full{
+	dir = 8
+	},
+/obj/machinery/power/apc/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "xz" = (
 /obj/machinery/power/rtg,
@@ -3463,6 +3647,17 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
+"yJ" = (
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_y = -7;
+	pixel_x = 2
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "yP" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -3472,6 +3667,13 @@
 /obj/machinery/power/apc/empty/north,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
+"yR" = (
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "yS" = (
 /obj/random/dirt_75,
 /obj/random/tech_supply{
@@ -3542,14 +3744,6 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
-"zA" = (
-/obj/structure/table/standard,
-/obj/item/modular_computer/handheld/pda/civilian{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/turf/simulated/floor/plating,
 /area/mine)
 "zB" = (
 /obj/effect/floor_decal/corner/lime{
@@ -3622,6 +3816,12 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
+/area/mine)
+"Al" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
 /area/mine)
 "Au" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -3993,6 +4193,18 @@
 /obj/item/storage/box/fancy/cigarettes,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"DR" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"DV" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/full,
+/area/mine)
 "DY" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
@@ -4072,26 +4284,6 @@
 /obj/item/trash/match{
 	pixel_y = 11;
 	pixel_x = -11
-	},
-/turf/simulated/floor/tiled,
-/area/mine)
-"EB" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	layer = 5;
-	name = "adjusted reinforced window";
-	pixel_y = -6
-	},
-/obj/item/clothing/accessory/crucifix/gold{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/clothing/wrists/watch/gold{
-	pixel_x = 5
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -4184,6 +4376,13 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"Fv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "Fz" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -4221,6 +4420,17 @@
 /obj/item/trash/liquidfood,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"FP" = (
+/obj/structure/reagent_dispensers/radioactive_waste{
+	pixel_x = 6
+	},
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/greenglow/radioactive{
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "FR" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
@@ -4434,24 +4644,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/mine)
-"GT" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/window/reinforced{
-	layer = 5;
-	name = "adjusted reinforced window";
-	pixel_y = -6
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/stack/material/phoron/full,
-/obj/item/stack/material/phoron{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/turf/simulated/floor/tiled,
-/area/mine)
 "GY" = (
 /obj/effect/overmap/visitable/ship/landable/goon_ship,
 /turf/simulated/floor/tiled/dark,
@@ -4467,6 +4659,14 @@
 /obj/random/dirt_75,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
+/area/mine)
+"Hf" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Hp" = (
 /obj/structure/bed,
@@ -4558,13 +4758,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/mine)
-"HP" = (
-/obj/random/dirt_75,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/mine)
 "HU" = (
 /obj/structure/closet/cabinet{
 	pixel_y = 0
@@ -4638,6 +4831,23 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
+"Ic" = (
+/obj/structure/closet/crate,
+/obj/random/dirt_75,
+/obj/random/bomb_supply,
+/obj/random/bomb_supply,
+/obj/random/bomb_supply,
+/obj/random/bomb_supply,
+/obj/random/bomb_supply,
+/obj/random/bomb_supply{
+	pixel_x = -6
+	},
+/obj/random/tech_supply,
+/obj/item/grenade/chem_grenade{
+	pixel_x = 11
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "Id" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 8
@@ -4660,13 +4870,15 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
-"It" = (
+"Iy" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/greenglow/radioactive{
+	pixel_x = -13;
+	pixel_y = 9
 	},
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Iz" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -4697,6 +4909,10 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
+/area/mine)
+"IG" = (
+/obj/effect/floor_decal/corner/pink/diagonal,
+/turf/simulated/floor/tiled,
 /area/mine)
 "IL" = (
 /obj/structure/cable{
@@ -4733,6 +4949,13 @@
 /area/mine)
 "IU" = (
 /turf/simulated/floor/tiled/freezer,
+/area/mine)
+"IV" = (
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/turf/simulated/floor/tiled,
 /area/mine)
 "IW" = (
 /obj/effect/floor_decal/corner/grey{
@@ -4776,6 +4999,22 @@
 /obj/random/dirt_75,
 /obj/random/loot,
 /obj/structure/table/rack,
+/turf/simulated/floor/plating,
+/area/mine)
+"Jm" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/reagent_containers/weldpack{
+	pixel_x = 5;
+	pixel_y = -7
+	},
+/turf/simulated/floor/plating,
+/area/mine)
+"Jn" = (
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Jo" = (
@@ -4836,6 +5075,47 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
+"JD" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/wrists/goldbracer/ruby{
+	pixel_y = -6
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/clothing/wrists/armchain/emerald{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/clothing/wrists/armchain{
+	pixel_y = 3;
+	pixel_x = -4
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"JF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"JJ" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 2;
+	pixel_y = -10
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "JW" = (
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
@@ -4887,6 +5167,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/starboard)
+"Kj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "Ks" = (
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/coffee/full{
@@ -5031,18 +5321,37 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
-"LN" = (
+"LO" = (
+/obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/mine)
 "LY" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/structure/reagent_dispensers/coolanttank,
 /turf/simulated/floor/plating,
+/area/mine)
+"Mf" = (
+/obj/structure/reagent_dispensers/radioactive_waste,
+/obj/effect/decal/cleanable/acid_remnants,
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_y = 16;
+	pixel_x = 2
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/greenglow/radioactive{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "Mh" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -5114,6 +5423,16 @@
 	dir = 9
 	},
 /turf/simulated/floor/wood,
+/area/mine)
+"MA" = (
+/obj/structure/reagent_dispensers/radioactive_waste,
+/obj/effect/decal/cleanable/acid_remnants,
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 2;
+	pixel_y = -10
+	},
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "MB" = (
 /obj/random/dirt_75,
@@ -5213,16 +5532,9 @@
 /turf/simulated/floor/tiled,
 /area/mine)
 "Nh" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/gun/projectile/automatic/rifle/dpra/gold,
-/turf/simulated/floor/tiled,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/mineral/surface,
 /area/mine)
 "Ni" = (
 /obj/effect/floor_decal/corner/grey{
@@ -5286,6 +5598,15 @@
 "NH" = (
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
+/area/mine)
+"NO" = (
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/generic{
+	pixel_x = 2;
+	pixel_y = -10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "NP" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -5365,6 +5686,26 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating/asteroid,
 /area/mine)
+"Ox" = (
+/obj/structure/table/steel,
+/obj/random/dirt_75,
+/obj/item/device/assembly/timer{
+	pixel_y = -21;
+	pixel_x = -4
+	},
+/obj/item/integrated_circuit/input/signaler{
+	pixel_x = 9;
+	pixel_y = -8
+	},
+/obj/item/tank/phoron{
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/welding{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "OA" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/mushroom{
@@ -5375,6 +5716,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_ship/bridge)
+"OH" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/gun/projectile/automatic/rifle/dpra/gold,
+/turf/simulated/floor/tiled,
+/area/mine)
 "OI" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/clothing/glasses/sunglasses/aviator,
@@ -5419,13 +5772,6 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
-"OY" = (
-/obj/random/dirt_75,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/mine)
 "Pc" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -5434,10 +5780,6 @@
 	pixel_y = -8
 	},
 /turf/simulated/floor/plating,
-/area/mine)
-"Pe" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/full,
 /area/mine)
 "Pk" = (
 /obj/effect/overmap/visitable/sector/goon,
@@ -5459,13 +5801,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
-"Pw" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/mine)
 "PA" = (
 /obj/random/dirt_75,
 /turf/simulated/mineral/surface,
@@ -5475,6 +5810,14 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/goon_ship/med)
+"PD" = (
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/north,
+/turf/simulated/floor/plating,
+/area/mine)
 "PK" = (
 /obj/machinery/iv_drip,
 /obj/random/dirt_75,
@@ -5604,6 +5947,18 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
+"Qk" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/clothing/suit/bomb_suit{
+	pixel_y = -3
+	},
+/obj/item/clothing/head/bomb_hood{
+	pixel_y = 9
+	},
+/obj/structure/table/rack,
+/turf/simulated/floor/plating,
+/area/mine)
 "Qm" = (
 /obj/random/dirt_75,
 /obj/item/clothing/shoes/magboots{
@@ -5702,6 +6057,22 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
+"QS" = (
+/obj/structure/reagent_dispensers/radioactive_waste,
+/obj/effect/decal/cleanable/acid_remnants,
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_y = -7;
+	pixel_x = 2
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "QT" = (
 /obj/machinery/atmospherics/binary/pump/high_power,
 /turf/simulated/floor/plating,
@@ -5721,6 +6092,19 @@
 "Rc" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_ship/med)
+"Rd" = (
+/obj/structure/reagent_dispensers/radioactive_waste{
+	pixel_y = 6;
+	pixel_x = 5
+	},
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_y = -7;
+	pixel_x = 2
+	},
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "Rg" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 7
@@ -5776,6 +6160,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
+"RD" = (
+/obj/structure/reagent_dispensers/radioactive_waste,
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/acid_remnants{
+	pixel_y = -7;
+	pixel_x = 2
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "RE" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/cable{
@@ -5799,28 +6197,6 @@
 	},
 /obj/random/junk,
 /obj/item/trash/can,
-/turf/simulated/floor/tiled,
-/area/mine)
-"RS" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/clothing/wrists/goldbracer/ruby{
-	pixel_y = -6
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/clothing/wrists/armchain/emerald{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/item/clothing/wrists/armchain{
-	pixel_y = 3;
-	pixel_x = -4
-	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "Sd" = (
@@ -5894,6 +6270,9 @@
 	},
 /obj/random/dirt_75,
 /obj/machinery/power/apc/north,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Su" = (
@@ -6084,10 +6463,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
-"TC" = (
-/obj/machinery/papershredder,
-/turf/simulated/floor/plating,
-/area/mine)
 "TH" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -6229,10 +6604,38 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/mine)
+"Uz" = (
+/obj/structure/table/standard,
+/obj/item/modular_computer/handheld/pda/civilian{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/simulated/floor/plating,
+/area/mine)
 "UA" = (
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/port)
+"UB" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	layer = 5;
+	name = "adjusted reinforced window";
+	pixel_y = -6
+	},
+/obj/item/clothing/accessory/crucifix/gold{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/clothing/wrists/watch/gold{
+	pixel_x = 5
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
 "UD" = (
 /obj/structure/table/rack,
 /obj/item/clothing/shoes/magboots,
@@ -6323,6 +6726,13 @@
 /obj/item/storage/box/fancy/chips/variety{
 	pixel_x = 17;
 	pixel_y = 5
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"Vz" = (
+/obj/structure/table/standard,
+/obj/item/modular_computer/laptop/preset/civilian{
+	pixel_y = 9
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
@@ -6555,6 +6965,21 @@
 	},
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
+"Xa" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/structure/table/rack,
+/obj/item/clothing/suit/hazmat/general,
+/obj/item/clothing/head/hazmat/general{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/pill/hyronalin,
+/obj/item/reagent_containers/hypospray/autoinjector/hyronalin{
+	pixel_x = 3
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "Xb" = (
 /obj/effect/shuttle_landmark/goon_ship/transit,
 /turf/space,
@@ -6569,6 +6994,12 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"Xl" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/machinery/power/portgen/basic,
+/turf/simulated/floor/plating,
+/area/mine)
 "Xn" = (
 /obj/effect/floor_decal/spline/plain/black,
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -6603,16 +7034,6 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
-/turf/simulated/floor/plating,
-/area/mine)
-"Xy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/random/dirt_75,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/mine)
 "Xz" = (
@@ -6772,6 +7193,13 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"YG" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/mine)
 "YI" = (
 /obj/structure/closet,
 /obj/effect/floor_decal/corner/blue{
@@ -6878,6 +7306,36 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
+"Zo" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/window/reinforced{
+	layer = 5;
+	name = "adjusted reinforced window";
+	pixel_y = -6
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/stack/material/phoron/full,
+/obj/item/stack/material/phoron{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/turf/simulated/floor/tiled,
+/area/mine)
+"Zq" = (
+/obj/structure/reagent_dispensers/radioactive_waste{
+	pixel_x = -9
+	},
+/obj/random/dirt_75,
+/obj/effect/decal/cleanable/greenglow/radioactive,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"Zs" = (
+/obj/machinery/photocopier,
+/turf/simulated/floor/tiled,
+/area/mine)
 "Zw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -6907,8 +7365,6 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "ZH" = (
@@ -6933,6 +7389,13 @@
 /obj/random/dirt_75,
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/plating,
+/area/mine)
+"ZO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
 /area/mine)
 "ZR" = (
 /obj/structure/closet/crate/freezer{
@@ -36890,8 +37353,8 @@ mI
 mI
 mI
 mI
-mI
-mI
+MA
+Rd
 mI
 mI
 mI
@@ -37146,17 +37609,17 @@ mI
 mI
 mI
 mI
+bt
+fB
+RD
+aK
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+qX
+qX
+qX
+qX
+qX
 mI
 mI
 mI
@@ -37401,19 +37864,19 @@ mI
 mI
 mI
 mI
+no
+NO
+QS
+mN
+vv
+FP
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+Dr
+Dr
+Dr
+qX
 mI
 mI
 mI
@@ -37657,19 +38120,19 @@ qX
 mI
 mI
 mI
+Zq
+iy
+tN
+yJ
+ui
+gj
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+qX
+Dr
+Ox
+wB
+Dr
 qX
 qX
 qX
@@ -37917,17 +38380,17 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+um
+Hf
 mI
 mI
 mI
 qX
+Dr
+sT
+cO
+Dr
+Dr
 Dr
 Dr
 Dr
@@ -38174,17 +38637,17 @@ mI
 mI
 mI
 mI
-mI
-mI
-mI
-mI
-mI
-mI
-mI
+ZC
+Mf
 mI
 mI
 mI
 qX
+Dr
+mE
+mE
+en
+Ic
 Dr
 gn
 HW
@@ -38414,11 +38877,11 @@ mI
 qX
 Dr
 Rv
-It
+iD
 Au
 FD
 SM
-mo
+qw
 ZL
 zU
 dY
@@ -38431,17 +38894,17 @@ qX
 qX
 qX
 mI
+JJ
+Iy
 mI
-mI
-mI
 qX
 qX
 qX
-qX
-qX
-qX
-qX
-qX
+Dr
+Qk
+Yi
+Jm
+ME
 Dr
 wb
 KR
@@ -38671,7 +39134,7 @@ mI
 qX
 Dr
 uy
-HP
+Jn
 tR
 Dr
 Dr
@@ -38696,7 +39159,7 @@ Dr
 Dr
 Dr
 Dr
-Dr
+Rt
 Dr
 Dr
 Dr
@@ -38959,7 +39422,7 @@ QX
 Dr
 IX
 Mu
-im
+vs
 FU
 tr
 Dr
@@ -39186,7 +39649,7 @@ qX
 Dr
 eL
 qJ
-lB
+Xl
 Dr
 Li
 AL
@@ -39472,8 +39935,8 @@ wL
 Dr
 Dr
 XF
-Pe
-LN
+nY
+ZO
 Gb
 To
 Dr
@@ -39481,7 +39944,7 @@ Li
 yS
 Li
 Dr
-rP
+PD
 Mm
 yr
 mW
@@ -39716,7 +40179,7 @@ Dr
 Pp
 Dr
 mI
-gj
+Xa
 gj
 sK
 Dr
@@ -39732,7 +40195,7 @@ ZH
 Zc
 On
 aT
-aF
+Fv
 iV
 pJ
 pJ
@@ -39981,12 +40444,12 @@ Pp
 Li
 mQ
 Dr
-uN
-zA
-TC
+Vz
+Uz
+oT
 Dr
 Yf
-OY
+yR
 er
 jW
 ei
@@ -40239,7 +40702,7 @@ yS
 Yi
 Dr
 EI
-mC
+hL
 QX
 Dr
 Dr
@@ -40495,13 +40958,13 @@ wL
 Li
 Li
 Dr
-iC
+Zs
 Vw
-sR
+IV
 Dr
-di
+xy
 BE
-tV
+JF
 IW
 xr
 Jw
@@ -40982,17 +41445,17 @@ Ga
 Wu
 Dr
 GH
-Xy
+Kj
 fC
 pQ
 WA
 rc
-aG
+bz
 Dr
-EB
-qw
-qw
-Nh
+UB
+IG
+IG
+OH
 Dr
 Ld
 NH
@@ -41246,10 +41709,10 @@ Dr
 NH
 Qj
 Dr
-qw
+IG
 lW
 lW
-qw
+IG
 wY
 NH
 lW
@@ -41484,8 +41947,8 @@ mI
 mI
 mI
 mI
-mI
-mI
+qX
+qX
 qX
 qX
 qX
@@ -41503,10 +41966,10 @@ Dr
 NH
 Qj
 Dr
-GT
-qw
-qw
-RS
+Zo
+IG
+IG
+JD
 Dr
 TO
 lW
@@ -41741,7 +42204,7 @@ mI
 mI
 mI
 mI
-mI
+qX
 mI
 qX
 mI
@@ -42257,9 +42720,9 @@ qX
 mI
 qX
 mI
-qX
-mI
-qX
+Dr
+Dr
+Dr
 Dr
 Sm
 sZ
@@ -42514,11 +42977,11 @@ qX
 qX
 qX
 qX
-qX
-qX
-qX
 Dr
-FE
+Al
+qf
+dN
+qA
 yS
 mQ
 Zl
@@ -42772,7 +43235,7 @@ Dr
 Dr
 Dr
 Dr
-Dr
+fn
 Dr
 Dr
 Dr
@@ -42811,8 +43274,8 @@ qX
 qX
 qX
 Dr
-Pe
-Pw
+nY
+YG
 Vw
 Vw
 NH
@@ -43068,7 +43531,7 @@ mI
 mI
 qX
 Dr
-mc
+DV
 yX
 TJ
 TJ
@@ -43286,7 +43749,7 @@ Dr
 kW
 HK
 Uk
-eJ
+ss
 oP
 Dr
 FZ
@@ -43540,10 +44003,10 @@ qX
 qX
 qX
 Dr
-xs
-eJ
-Uk
-Uk
+qY
+wF
+LO
+qa
 VL
 Dr
 jV
@@ -43787,8 +44250,8 @@ bu
 bu
 bu
 mI
-mg
-mg
+Nh
+Nh
 mI
 mI
 qX
@@ -44304,7 +44767,7 @@ mI
 mI
 gj
 Ow
-hO
+mg
 qX
 wA
 Li
@@ -44558,9 +45021,9 @@ bu
 bu
 bu
 mI
-mg
+Nh
 eu
-ZC
+DR
 Ow
 gF
 BM
@@ -44815,9 +45278,9 @@ bu
 bu
 mI
 mI
-mg
+Nh
 ab
-mg
+Nh
 mI
 qX
 qX

--- a/maps/away/away_site/goon_base/goon_base.dmm
+++ b/maps/away/away_site/goon_base/goon_base.dmm
@@ -14,6 +14,13 @@
 /obj/item/clothing/head/helmet/space/emergency,
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/equipment)
+"ac" = (
+/obj/random/dirt_75,
+/obj/machinery/light/colored/decayed{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/goonbase/living)
 "ad" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -105,6 +112,13 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/empty/north,
+/obj/item/tank/hydrogen/empty{
+	pixel_x = 8;
+	pixel_y = -7
+	},
+/obj/item/paper/goon_base/shuttle_fuel_note{
+	pixel_x = -10
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_shuttle/starboard)
 "aM" = (
@@ -134,6 +148,9 @@
 /obj/item/trash/proteinbar,
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/living)
 "aS" = (
@@ -158,6 +175,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/goonbase/eva)
+"aV" = (
+/obj/item/device/flashlight/flare/glowstick/random{
+	pixel_y = -10;
+	pixel_x = -5
+	},
+/turf/unsimulated/floor/asteroid/ash/rocky,
+/area/mine)
 "aY" = (
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
@@ -184,6 +208,9 @@
 /obj/item/reagent_containers/food/snacks/berrymuffin{
 	pixel_x = 3;
 	pixel_y = 4
+	},
+/obj/machinery/light/colored/decayed{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
@@ -242,7 +269,7 @@
 	pixel_x = 12;
 	pixel_y = -5
 	},
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/floor/plating/asteroid,
 /area/goonbase/maint_south)
 "bu" = (
 /turf/template_noop,
@@ -288,6 +315,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
+"bF" = (
+/obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/maint_south)
 "bH" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -327,6 +361,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_south)
 "bW" = (
@@ -371,6 +406,17 @@
 /obj/machinery/alarm/north,
 /turf/simulated/floor/tiled,
 /area/goonbase/hallway_north)
+"ci" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_south)
 "cm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -393,6 +439,13 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_airlock)
+"cw" = (
+/obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/maint_north)
 "cx" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/mirror{
@@ -545,6 +598,18 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/goonbase/power)
+"dc" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/ammo_magazine/a10mm,
+/obj/item/gun/projectile/automatic/c20r,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/goonbase/equipment)
 "dd" = (
 /obj/structure/bed/padded/bunk{
 	pixel_y = 0
@@ -595,10 +660,14 @@
 	dir = 6
 	},
 /obj/structure/table/wood,
+/obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/goonbase/living)
 "dE" = (
-/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/airlock/maintenance_hatch{
+	id_tag = "goon_base_prison_door";
+	locked = 1
+	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -680,6 +749,11 @@
 	},
 /obj/machinery/computer/operating/terminal,
 /obj/random/dirt_75,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/white,
 /area/goonbase/medbay)
 "dW" = (
@@ -818,6 +892,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_south)
 "eE" = (
@@ -928,6 +1003,9 @@
 	dir = 9
 	},
 /obj/random/dirt_75,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
 "fa" = (
@@ -977,9 +1055,11 @@
 /turf/simulated/floor/plating,
 /area/goonbase/maint_north)
 "fh" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/structure/curtain/open{
 	color = "#854636"
+	},
+/obj/effect/map_effect/window_spawner/full/reinforced/polarized/grille{
+	id = "goon_base_prison_window"
 	},
 /turf/simulated/floor/plating,
 /area/goonbase/living)
@@ -1002,6 +1082,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_shuttle/storage)
+"fp" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/floodlight/randomcharge{
+	dir = 2
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/goonbase/hallway_north)
 "fr" = (
 /obj/item/clothing/shoes/slippers/carp{
 	pixel_y = -4;
@@ -1026,6 +1116,12 @@
 /obj/machinery/power/portgen/basic,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_shuttle/port)
+"fz" = (
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/equipment)
 "fA" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/void/tcaf,
@@ -1048,7 +1144,7 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/floor/plating/asteroid,
 /area/goonbase/maint_south)
 "fC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1128,6 +1224,13 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/goonbase/equipment)
+"fX" = (
+/obj/random/dirt_75,
+/obj/random/junk{
+	pixel_x = -9
+	},
+/turf/simulated/floor/airless/ceiling,
+/area/mine)
 "fY" = (
 /turf/simulated/mineral/surface,
 /area/space)
@@ -1203,6 +1306,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/goonbase/hallway_north)
@@ -1292,6 +1398,12 @@
 /obj/item/storage/box/produce,
 /obj/item/storage/box/produce,
 /obj/item/storage/box/produce,
+/obj/machinery/button/remote/airlock{
+	dir = 2;
+	id = "goon_base_freezer_door";
+	specialfunctions = 4;
+	pixel_y = -19
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/goonbase/kitchen)
 "gO" = (
@@ -1378,6 +1490,12 @@
 	},
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
+"hp" = (
+/obj/machinery/floodlight/randomcharge{
+	dir = 2
+	},
+/turf/simulated/floor/airless/ceiling,
+/area/mine)
 "hq" = (
 /obj/item/storage/bag/ore{
 	pixel_x = 7
@@ -1390,9 +1508,9 @@
 	pixel_y = 3
 	},
 /obj/random/dirt_75,
-/obj/item/paper/goon_base/notice_secret_base{
-	pixel_x = -1;
-	pixel_y = -4
+/obj/item/paper/goon_base/secret_base_note{
+	pixel_x = -3;
+	pixel_y = -3
 	},
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
@@ -1426,6 +1544,9 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_shuttle/living)
 "hE" = (
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
 /turf/simulated/floor/plating/asteroid,
 /area/goonbase/hallway_south)
 "hF" = (
@@ -1466,6 +1587,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_north)
@@ -1697,7 +1821,10 @@
 /turf/simulated/floor/plating,
 /area/goonbase/equipment)
 "iQ" = (
-/obj/machinery/door/airlock/glass,
+/obj/machinery/door/airlock/glass{
+	locked = 1;
+	id_tag = "goon_base_freezer_door"
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/kitchen)
 "iR" = (
@@ -1722,6 +1849,9 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_north)
 "iY" = (
@@ -1745,6 +1875,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_north)
+"je" = (
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/plating/asteroid,
+/area/goonbase/hallway_north)
 "jg" = (
 /obj/machinery/body_scanconsole{
 	dir = 1;
@@ -1816,6 +1952,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/goonbase/equipment)
+"jB" = (
+/obj/machinery/floodlight/randomcharge{
+	dir = 1
+	},
+/turf/simulated/floor/airless/ceiling,
+/area/mine)
 "jH" = (
 /turf/simulated/wall,
 /area/goonbase/living)
@@ -1825,6 +1967,7 @@
 	master_tag = "airlock_goon_base_maint";
 	name = "airlock_goon_base_maint"
 	},
+/obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_airlock)
 "jP" = (
@@ -1865,6 +2008,9 @@
 "jW" = (
 /obj/structure/dispenser/oxygen,
 /obj/random/dirt_75,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/eva)
 "jY" = (
@@ -1932,6 +2078,7 @@
 /obj/structure/closet,
 /obj/item/clothing/accessory/tshirt,
 /obj/item/clothing/accessory/holster/utility/machete,
+/obj/item/material/hatchet/machete/steel,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_shuttle/living)
 "kp" = (
@@ -2180,6 +2327,11 @@
 /obj/item/clothing/head/helmet/space/syndicate/black/green,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/eva)
 "ll" = (
@@ -2188,6 +2340,9 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_airlock)
 "lo" = (
@@ -2327,6 +2482,7 @@
 	pixel_y = -2;
 	pixel_x = 3
 	},
+/obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating/asteroid,
 /area/goonbase/equipment)
 "mh" = (
@@ -2418,7 +2574,7 @@
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/floor/plating/asteroid,
 /area/goonbase/maint_south)
 "mO" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -2484,16 +2640,35 @@
 "nf" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/snacks/sliceable/bread,
+/obj/item/reagent_containers/food/snacks/sliceable/bread{
+	pixel_y = -4;
+	pixel_x = 3
+	},
 /obj/item/reagent_containers/food/snacks/pbjsandwich{
 	pixel_y = -4
 	},
 /obj/item/reagent_containers/food/snacks/reubensandwich{
 	pixel_y = 10
 	},
+/obj/item/reagent_containers/food/snacks/NTellabread{
+	pixel_y = 11
+	},
 /turf/simulated/floor/tiled/white,
 /area/goonbase/kitchen)
 "ng" = (
 /obj/structure/closet,
+/obj/random/suit,
+/obj/random/suit,
+/obj/random/suit,
+/obj/item/clothing/shoes/laceup{
+	pixel_y = -8
+	},
+/obj/item/clothing/under/pj/red,
+/obj/item/clothing/under/pants/jeans{
+	pixel_y = -5
+	},
+/obj/item/clothing/suit/storage/hooded/wintercoat/mars,
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
 "nj" = (
@@ -2501,6 +2676,9 @@
 	dir = 5
 	},
 /obj/random/pottedplant,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
 "nk" = (
@@ -2545,6 +2723,7 @@
 	pixel_y = 6;
 	pixel_x = -2
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/goonbase/kitchen)
 "nq" = (
@@ -2608,6 +2787,14 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/goonbase/equipment)
+"nE" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/random/dirt_75,
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor/plating,
+/area/goonbase/power)
 "nI" = (
 /obj/structure/bed/stool,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -2640,6 +2827,9 @@
 /obj/item/storage/box/shotgunammo,
 /obj/item/storage/box/shotgunshells,
 /obj/item/gun/projectile/shotgun/pump/combat,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/goonbase/equipment)
 "nR" = (
@@ -2726,6 +2916,9 @@
 /area/goonbase/hallway_north)
 "op" = (
 /obj/machinery/media/jukebox,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
 "os" = (
@@ -2762,6 +2955,9 @@
 	},
 /obj/item/clothing/head/helmet/merc{
 	pixel_x = 4
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/goonbase/equipment)
@@ -2859,6 +3055,7 @@
 	pixel_x = 5;
 	pixel_y = -1
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/goonbase/equipment)
 "oT" = (
@@ -2870,6 +3067,9 @@
 "oU" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/reagent_dispensers/watertank,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/hallway_north)
 "oX" = (
@@ -2890,12 +3090,26 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/goonbase/atmos)
+"pb" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/random/dirt_75,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/tiled/white,
+/area/goonbase/kitchen)
 "pd" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
 /obj/item/storage/box/donkpockets{
 	pixel_x = 6;
 	pixel_y = 6
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = -3;
+	pixel_y = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/goonbase/equipment)
@@ -2906,8 +3120,18 @@
 	pixel_y = 6
 	},
 /obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_airlock)
+"ph" = (
+/obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/maint_north)
 "pn" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/toilet{
@@ -2978,6 +3202,9 @@
 /obj/structure/reagent_dispensers/water_cooler{
 	pixel_x = -9
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/kitchen)
 "pI" = (
@@ -3003,7 +3230,7 @@
 	name = "port, power"
 	},
 /turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_shuttle/port)
+/area/shuttle/goon_shuttle/storage)
 "pO" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3015,6 +3242,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_north)
 "pQ" = (
@@ -3104,6 +3332,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/equipment)
 "qj" = (
@@ -3125,14 +3356,17 @@
 	pixel_x = -4;
 	pixel_y = 5
 	},
+/obj/item/clothing/head/ushanka/dominia{
+	pixel_x = 5;
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
 "qr" = (
-/obj/effect/floor_decal/industrial/loading/grey{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/goonbase/equipment)
+/obj/random/dirt_75,
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor/exoplanet/barren,
+/area/goonbase/maint_south)
 "qt" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
@@ -3156,6 +3390,9 @@
 /obj/item/flame/lighter/zippo/gold,
 /obj/item/coin/gold,
 /obj/random/dirt_75,
+/obj/item/stack/material/gold/full{
+	pixel_y = 4
+	},
 /obj/random/highvalue/no_weapon,
 /obj/item/clothing/accessory/crucifix/gold,
 /obj/random/melee/highvalue,
@@ -3178,6 +3415,7 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/light/small/emergency,
 /turf/simulated/floor/tiled,
 /area/goonbase/hallway_north)
 "qz" = (
@@ -3206,6 +3444,11 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/rocks{
 	pixel_x = -1;
 	pixel_y = 5
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
@@ -3257,6 +3500,9 @@
 /obj/random/tool{
 	pixel_y = 6;
 	pixel_x = 8
+	},
+/obj/machinery/light/small/emergency{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/goonbase/power)
@@ -3596,16 +3842,10 @@
 /turf/simulated/floor/plating,
 /area/goonbase/maint_south)
 "sX" = (
-/obj/structure/closet/crate,
-/obj/random/spacecash,
-/obj/random/spacecash,
-/obj/random/spacecash,
-/obj/random/spacecash,
-/obj/item/spacecash/c1000,
-/obj/item/spacecash/c500,
-/obj/item/spacecash/c200,
-/obj/random/spacecash,
-/obj/random/spacecash,
+/obj/item/clothing/shoes/workboots/toeless{
+	pixel_x = 6;
+	pixel_y = -5
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
 "sY" = (
@@ -3695,9 +3935,12 @@
 /turf/simulated/floor/tiled,
 /area/goonbase/power)
 "tL" = (
-/obj/machinery/portable_atmospherics/canister/empty/hydrogen,
+/obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_shuttle/starboard)
+/area/goonbase/maint_north)
 "tN" = (
 /obj/structure/reagent_dispensers/radioactive_waste{
 	pixel_y = -8
@@ -3723,6 +3966,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/structure/closet/toolcloset,
+/obj/item/stack/material/graphite/full,
 /turf/simulated/floor/plating,
 /area/goonbase/power)
 "tS" = (
@@ -3746,7 +3990,7 @@
 	pixel_y = 3
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/floor/plating/asteroid,
 /area/goonbase/maint_south)
 "um" = (
 /obj/structure/reagent_dispensers/radioactive_waste{
@@ -3773,6 +4017,15 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_north)
+"up" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "uq" = (
 /obj/machinery/power/rtg,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -3931,6 +4184,9 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/goonbase/living)
 "vr" = (
@@ -3968,7 +4224,7 @@
 	pixel_y = -10
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/floor/plating/asteroid,
 /area/goonbase/maint_south)
 "vw" = (
 /obj/random/dirt_75,
@@ -4038,14 +4294,17 @@
 "vI" = (
 /obj/structure/table/wood,
 /obj/item/material/ashtray/bronze{
-	pixel_x = -5;
-	pixel_y = 2
+	pixel_x = -7;
+	pixel_y = -1
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/item/clothing/mask/smokable/cigarette/cigar/oracle{
 	pixel_x = 6;
 	pixel_y = 1
+	},
+/obj/item/device/flashlight/lamp/green{
+	pixel_y = 14
 	},
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
@@ -4055,6 +4314,13 @@
 /area/goonbase/kitchen)
 "vM" = (
 /obj/structure/closet/cabinet,
+/obj/item/clothing/suit/storage/hooded/wintercoat/iac,
+/obj/item/clothing/suit/storage/toggle/labcoat/accent,
+/obj/item/clothing/shoes/sneakers/hitops/brown{
+	pixel_y = -7
+	},
+/obj/item/clothing/under/pants/tacticool,
+/obj/item/clothing/under/syndicate/tracksuit,
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
 "vR" = (
@@ -4126,6 +4392,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/goonbase/living)
+"wv" = (
+/obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/turf/simulated/floor/plating/asteroid,
+/area/goonbase/hallway_north)
 "wA" = (
 /obj/random/dirt_75,
 /obj/item/pickaxe/drill{
@@ -4506,6 +4779,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/machinery/light/small/emergency,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_north)
 "yx" = (
@@ -4547,7 +4821,7 @@
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/floor/plating/asteroid,
 /area/goonbase/maint_south)
 "yP" = (
 /obj/structure/cable{
@@ -4565,6 +4839,9 @@
 /obj/random/dirt_75,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/goonbase/eva)
@@ -4684,6 +4961,11 @@
 /obj/random/medical,
 /obj/random/medical,
 /obj/structure/closet/crate,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/white,
 /area/goonbase/medbay)
 "zC" = (
@@ -4719,6 +5001,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_airlock)
+"zR" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "zU" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -4792,6 +5081,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_north)
+"An" = (
+/obj/random/dirt_75,
+/obj/structure/trash_pile,
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/maint_airlock)
 "Ap" = (
 /obj/structure/structural_support{
 	pixel_y = 8
@@ -4892,6 +5189,10 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/item/paper/goon_base/shuttle_power_note{
+	pixel_x = 6;
+	pixel_y = 4
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_shuttle/port)
@@ -5009,6 +5310,9 @@
 	pixel_y = 2;
 	pixel_x = 3
 	},
+/obj/machinery/light/colored/decayed{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
 "BC" = (
@@ -5024,6 +5328,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/hallway_south)
 "BH" = (
@@ -5034,6 +5343,7 @@
 /obj/item/tank/emergency_oxygen/double{
 	pixel_y = 5
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/goonbase/eva)
 "BI" = (
@@ -5056,15 +5366,23 @@
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
 "BM" = (
-/obj/item/paper/goon_base/notice_secret_back_exit{
-	pixel_x = 4;
-	pixel_y = 2
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 4
 	},
-/obj/random/dirt_75,
-/obj/random/dirt_75,
+/obj/item/paper/goon_base/secret_back_exit_note{
+	pixel_x = -10;
+	pixel_y = -3
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/equipment)
 "BO" = (
@@ -5085,6 +5403,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_north)
@@ -5160,6 +5481,9 @@
 "Co" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/equipment)
 "Cr" = (
@@ -5171,6 +5495,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_shuttle/bridge)
+"Cs" = (
+/obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/goonbase/maint_north)
 "Cz" = (
 /obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5181,10 +5512,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_south)
+"CC" = (
+/obj/machinery/atmospherics/portables_connector/aux{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/machinery/light,
+/turf/simulated/floor/plating,
+/area/goonbase/hallway_south)
 "CL" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_shuttle/starboard)
+"CQ" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
+/area/goonbase/maint_south)
 "CR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -5259,6 +5605,13 @@
 "Do" = (
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/hallway_north)
+"Dp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/loading/grey,
+/turf/simulated/floor/plating,
+/area/goonbase/equipment)
 "Dr" = (
 /turf/simulated/wall,
 /area/mine)
@@ -5358,6 +5711,11 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/white,
 /area/goonbase/medbay)
 "Ea" = (
@@ -5386,6 +5744,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_north)
+"Ei" = (
+/obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/maint_south)
 "Ek" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /turf/unsimulated/floor/asteroid/ash/rocky,
@@ -5401,6 +5766,11 @@
 	pixel_y = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
 "Em" = (
@@ -5464,6 +5834,9 @@
 /obj/item/trash/match{
 	pixel_y = 11;
 	pixel_x = -11
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
@@ -5551,6 +5924,9 @@
 /obj/structure/table/steel,
 /obj/random/dirt_75,
 /obj/random/tech_supply,
+/obj/machinery/light/colored/decayed{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/atmos)
 "Fp" = (
@@ -5914,6 +6290,9 @@
 	},
 /obj/random/dirt_75,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/atmos)
 "Hf" = (
@@ -5927,6 +6306,9 @@
 "Ho" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_south)
 "Hp" = (
@@ -5956,6 +6338,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/goon_shuttle/storage)
+"Hu" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/random/dirt_75,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_south)
 "Hw" = (
 /obj/item/pickaxe{
 	pixel_y = -9
@@ -6007,7 +6399,6 @@
 	pixel_x = -2;
 	pixel_y = 3
 	},
-/obj/item/paper/goon_base/note,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_shuttle/port)
 "HF" = (
@@ -6088,6 +6479,9 @@
 /obj/item/clothing/head/helmet/space/syndicate/covert,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/light/colored/decayed{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/eva)
 "HY" = (
@@ -6386,6 +6780,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/goonbase/medbay)
+"Ju" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/goonbase/living)
 "Jw" = (
 /obj/machinery/atmospherics/portables_connector/aux{
 	dir = 1
@@ -6400,6 +6798,10 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/item/trash/match,
+/obj/random/junk{
+	pixel_x = -11;
+	pixel_y = 10
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/goonbase/kitchen)
 "Jz" = (
@@ -6409,6 +6811,11 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/goonbase/power)
+"JA" = (
+/obj/random/dirt_75,
+/obj/machinery/light,
+/turf/simulated/floor/plating,
+/area/goonbase/hallway_south)
 "JC" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
@@ -6463,6 +6870,9 @@
 /obj/effect/map_effect/marker/airlock{
 	master_tag = "airlock_goon_base_main";
 	name = "airlock_goon_base_main"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
@@ -6654,6 +7064,10 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/machinery/alarm/north,
+/obj/item/modular_computer/laptop/preset/civilian{
+	pixel_y = 9;
+	pixel_x = -7
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/hallway_south)
 "KG" = (
@@ -6718,6 +7132,13 @@
 /obj/machinery/alarm/east,
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
+"KX" = (
+/obj/item/device/flashlight/flare{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/turf/unsimulated/floor/asteroid/ash,
+/area/mine)
 "KZ" = (
 /turf/simulated/wall{
 	can_open = 1;
@@ -6867,6 +7288,9 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/structure/reagent_dispensers/coolanttank,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/power)
 "LZ" = (
@@ -6933,6 +7357,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
 "Ml" = (
@@ -6994,6 +7423,19 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/button/switch/windowtint{
+	dir = 8;
+	id = "goon_base_prison_window";
+	pixel_x = -22;
+	pixel_y = -4
+	},
+/obj/machinery/button/remote/airlock{
+	dir = 8;
+	id = "goon_base_prison_door";
+	specialfunctions = 4;
+	pixel_x = -22;
+	pixel_y = 10
+	},
 /turf/simulated/floor/wood,
 /area/goonbase/living)
 "MA" = (
@@ -7062,6 +7504,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/goon_shuttle/bridge)
+"MM" = (
+/obj/random/junk,
+/obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/maint_north)
+"MR" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/junk{
+	pixel_x = -9
+	},
+/turf/unsimulated/floor/asteroid/ash/rocky,
+/area/mine)
 "MS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -7237,6 +7695,13 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/hallway_north)
+"NQ" = (
+/obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/goonbase/maint_south)
 "NT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/reagent_containers/food/drinks/waterbottle{
@@ -7272,6 +7737,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_airlock)
+"Of" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "Og" = (
 /obj/structure/closet/crate/miningcart/ore,
 /turf/simulated/floor/airless/ceiling,
@@ -7343,6 +7819,9 @@
 	pixel_x = -1;
 	pixel_y = 7
 	},
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_south)
 "Oy" = (
@@ -7384,19 +7863,16 @@
 /area/goonbase/hallway_north)
 "OI" = (
 /obj/structure/table/reinforced/steel,
-/obj/item/clothing/glasses/sunglasses/aviator,
 /obj/item/clothing/glasses/sunglasses/aviator{
-	pixel_y = 5
+	pixel_y = 9
 	},
 /obj/item/clothing/glasses/sunglasses/aviator{
-	pixel_y = 10
-	},
-/obj/item/clothing/glasses/sunglasses/aviator{
-	pixel_y = 7
+	pixel_y = 6
 	},
 /obj/item/clothing/glasses/sunglasses/aviator{
 	pixel_y = 3
 	},
+/obj/item/clothing/glasses/sunglasses/aviator,
 /turf/simulated/floor/tiled/dark/full,
 /area/goonbase/equipment)
 "OL" = (
@@ -7463,6 +7939,15 @@
 /obj/effect/overmap/visitable/sector/goon,
 /turf/simulated/mineral/surface,
 /area/mine)
+"Po" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "Pp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7558,6 +8043,20 @@
 /obj/random/dirt_75,
 /turf/unsimulated/floor/asteroid/ash,
 /area/mine)
+"PP" = (
+/obj/machinery/light/colored/decayed{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/goonbase/kitchen)
+"PQ" = (
+/obj/random/dirt_75,
+/obj/random/glowstick{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/turf/simulated/floor/plating/asteroid,
+/area/goonbase/hallway_north)
 "PS" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -7605,11 +8104,22 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/goonbase/equipment)
+"PX" = (
+/obj/random/dirt_75,
+/obj/item/device/flashlight/marshallingwand{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/turf/simulated/floor/airless/ceiling,
+/area/mine)
 "PY" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/tech_supply,
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/goonbase/kitchen)
 "PZ" = (
@@ -7623,6 +8133,9 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/oxygen,
 /obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/atmos)
 "Qe" = (
@@ -7673,6 +8186,9 @@
 	pixel_y = 9
 	},
 /obj/structure/table/rack,
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_south)
 "Ql" = (
@@ -7727,6 +8243,11 @@
 	pixel_x = 4
 	},
 /obj/random/dirt_75,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/white,
 /area/goonbase/medbay)
 "Qz" = (
@@ -7747,6 +8268,9 @@
 /obj/item/storage/toolbox/mechanical{
 	pixel_y = 3;
 	pixel_x = 2
+	},
+/obj/machinery/light/colored/decayed{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/goonbase/power)
@@ -7819,7 +8343,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/floor/plating/asteroid,
 /area/goonbase/maint_south)
 "QT" = (
 /obj/machinery/atmospherics/binary/pump/high_power,
@@ -7964,7 +8488,7 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/floor/plating/asteroid,
 /area/goonbase/maint_south)
 "RE" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -8100,6 +8624,9 @@
 	icon_state = "2-4"
 	},
 /obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_north)
 "Su" = (
@@ -8167,6 +8694,13 @@
 /obj/item/clothing/gloves/yellow{
 	pixel_y = 9
 	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/obj/item/device/flashlight{
+	pixel_x = 2;
+	pixel_y = -1
+	},
 /turf/simulated/floor/tiled,
 /area/goonbase/power)
 "SG" = (
@@ -8227,6 +8761,11 @@
 /obj/machinery/alarm/west,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_airlock)
+"SS" = (
+/obj/random/dirt_75,
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled,
+/area/goonbase/living)
 "SU" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
@@ -8286,6 +8825,10 @@
 /obj/machinery/power/apc/empty/west,
 /turf/simulated/floor/plating,
 /area/shuttle/goon_shuttle/living)
+"Tg" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_south)
 "Tj" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
@@ -8420,6 +8963,9 @@
 	pixel_y = 3
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/goonbase/equipment)
 "TW" = (
@@ -8441,13 +8987,19 @@
 /turf/simulated/floor/tiled,
 /area/goonbase/hallway_south)
 "Uf" = (
-/obj/structure/closet/secure_closet/cabinet{
-	req_access = list(20)
-	},
 /obj/random/dirt_75,
 /obj/item/melee/energy/sword/pirate/generic,
 /obj/item/clothing/head/bandana/red,
 /obj/machinery/alarm/north,
+/obj/structure/closet/cabinet,
+/obj/item/spacecash/c1000,
+/obj/item/spacecash/c500,
+/obj/random/spacecash,
+/obj/random/spacecash,
+/obj/random/spacecash,
+/obj/item/spacecash/c200,
+/obj/random/spacecash,
+/obj/random/spacecash,
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
 "Uh" = (
@@ -8544,6 +9096,15 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
+	},
+/obj/item/pen/fountain/silver{
+	pixel_x = -5;
+	pixel_y = -1
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
 "UA" = (
@@ -8660,6 +9221,9 @@
 	pixel_x = -4;
 	pixel_y = 6
 	},
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/atmos)
 "Vo" = (
@@ -8676,6 +9240,11 @@
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0;
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled,
 /area/goonbase/hallway_north)
@@ -8708,11 +9277,12 @@
 /area/goonbase/living)
 "Vz" = (
 /obj/structure/table/standard,
-/obj/item/modular_computer/laptop/preset/civilian{
-	pixel_y = 9
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/device/flashlight/lamp/off{
+	pixel_x = -6;
+	pixel_y = 11
 	},
-/obj/random/dirt_75,
-/obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/goonbase/hallway_south)
 "VB" = (
@@ -8832,6 +9402,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_airlock)
+"Ws" = (
+/obj/random/junk{
+	pixel_x = -9
+	},
+/turf/unsimulated/floor/asteroid/ash,
+/area/mine)
 "Wt" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -8859,6 +9435,12 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
 /turf/simulated/floor/tiled/dark,
 /area/goonbase/equipment)
 "Wu" = (
@@ -8906,6 +9488,9 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/goonbase/equipment)
 "WD" = (
@@ -8946,6 +9531,9 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/random/dirt_75,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/atmos)
 "WO" = (
@@ -9095,6 +9683,7 @@
 /area/goonbase/eva)
 "XG" = (
 /obj/random/pottedplant,
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/goonbase/kitchen)
 "XH" = (
@@ -9165,6 +9754,9 @@
 /obj/item/device/flashlight/flare/glowstick/random,
 /obj/item/device/flashlight/flare/glowstick/random,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/equipment)
 "XS" = (
@@ -9181,6 +9773,12 @@
 /obj/item/clothing/ears/earmuffs,
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/hallway_north)
+"XU" = (
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/plating/asteroid,
+/area/goonbase/hallway_south)
 "XY" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -9198,6 +9796,11 @@
 	},
 /obj/item/storage/box/flashbangs{
 	pixel_x = -3
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0;
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/goonbase/equipment)
@@ -9225,6 +9828,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_south)
+"Yo" = (
+/obj/random/dirt_75,
+/obj/machinery/floodlight/randomcharge{
+	dir = 1
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/goonbase/hallway_north)
 "Yp" = (
 /obj/effect/floor_decal/corner/grey/full{
 	dir = 4
@@ -9361,6 +9971,7 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/goonbase/living)
 "Zc" = (
@@ -9459,6 +10070,10 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/goonbase/hallway_south)
+"Zv" = (
+/obj/machinery/light,
+/turf/simulated/floor/carpet/red,
+/area/goonbase/living)
 "Zw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -9615,6 +10230,7 @@
 	pixel_y = 5
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/goonbase/equipment)
 "ZX" = (
@@ -40292,7 +40908,7 @@ iy
 tN
 yJ
 ui
-gj
+CQ
 mI
 mI
 vr
@@ -40795,7 +41411,7 @@ Jz
 da
 MH
 xz
-KJ
+nE
 ba
 Af
 mI
@@ -41566,12 +42182,12 @@ Ep
 jY
 yC
 JX
-Oz
+MM
 jY
 an
 ZI
 sI
-jY
+cw
 Jl
 yC
 mI
@@ -41580,11 +42196,11 @@ eH
 mI
 Gv
 wL
-JK
+bF
 Yi
 JK
 eC
-JK
+bF
 xB
 QB
 IX
@@ -41689,7 +42305,7 @@ mI
 mI
 PO
 mV
-nT
+Ws
 oL
 sB
 sB
@@ -41818,7 +42434,7 @@ eL
 qJ
 Xl
 ba
-jY
+tL
 AL
 zW
 LU
@@ -42337,7 +42953,7 @@ GX
 if
 yC
 kE
-jY
+cw
 JV
 Lm
 QR
@@ -42603,9 +43219,9 @@ yC
 Bw
 yC
 yC
-no
+NQ
 gj
-no
+qr
 Gv
 Pp
 ZS
@@ -42622,7 +43238,7 @@ jW
 ei
 kk
 Oy
-UG
+An
 GV
 kk
 lJ
@@ -42669,7 +43285,7 @@ mI
 mI
 Dr
 cN
-cN
+PX
 se
 se
 Dr
@@ -42927,7 +43543,7 @@ mI
 Dr
 cN
 cN
-cN
+fX
 cN
 Dr
 mI
@@ -43108,7 +43724,7 @@ GX
 JX
 yC
 qv
-jY
+ph
 kB
 Wu
 Ce
@@ -43122,7 +43738,7 @@ nn
 nn
 nn
 wL
-JK
+Ei
 JK
 GG
 Zs
@@ -43391,7 +44007,7 @@ lW
 jZ
 Ji
 fR
-Jw
+CC
 GG
 mI
 mI
@@ -43620,7 +44236,7 @@ rc
 bz
 Ql
 UB
-IG
+up
 IG
 OH
 Ql
@@ -43631,15 +44247,15 @@ LR
 ff
 Vw
 mn
-ka
+je
 Fp
 Ow
 rV
-hE
+XU
 Rn
 Ji
 Rh
-IW
+ci
 Ji
 IW
 IW
@@ -43873,7 +44489,7 @@ sM
 RO
 sl
 pW
-GX
+Cs
 if
 Ql
 ch
@@ -44134,7 +44750,7 @@ GX
 if
 Ql
 Zo
-IG
+zR
 IG
 JD
 Ql
@@ -44145,7 +44761,7 @@ BI
 ff
 jy
 mn
-Ow
+wv
 rY
 MB
 OS
@@ -44153,12 +44769,12 @@ hE
 Rn
 LF
 Cf
-aA
+Hu
 aA
 SW
 DJ
 ws
-Ji
+Tg
 GG
 JH
 Ew
@@ -44642,7 +45258,7 @@ yC
 JX
 an
 ZI
-Oz
+MM
 HB
 Iz
 ys
@@ -44909,7 +45525,7 @@ SX
 kL
 Ww
 fl
-dH
+Po
 Vw
 hF
 Ql
@@ -44929,7 +45545,7 @@ GG
 wD
 GG
 Uc
-Ji
+Tg
 GG
 JH
 Df
@@ -45146,7 +45762,7 @@ qX
 SL
 KO
 qf
-qf
+Dp
 gH
 Nh
 sp
@@ -45191,7 +45807,7 @@ GG
 CY
 Ia
 GG
-vz
+hp
 cN
 cN
 mV
@@ -45402,7 +46018,7 @@ SL
 SL
 SL
 SL
-qr
+QX
 SL
 SL
 jH
@@ -45514,7 +46130,7 @@ kz
 sB
 sB
 nT
-nT
+KX
 nT
 nT
 nT
@@ -45671,7 +46287,7 @@ AI
 id
 fI
 jH
-jY
+tL
 GX
 Qj
 fl
@@ -45704,14 +46320,14 @@ TJ
 TJ
 ZB
 mt
-Li
+JA
 GG
 nT
 nT
 nT
 sB
 sB
-sB
+aV
 sB
 sB
 nT
@@ -45913,7 +46529,7 @@ qX
 YT
 qX
 SL
-xs
+dc
 HK
 Uk
 eJ
@@ -45926,7 +46542,7 @@ GL
 Np
 Fc
 Ex
-Fc
+Zv
 jH
 JX
 GX
@@ -46078,7 +46694,7 @@ UD
 RZ
 gr
 VZ
-tL
+JY
 Lh
 JY
 JY
@@ -46245,7 +46861,7 @@ mI
 hq
 vz
 vz
-vz
+jB
 vz
 vz
 sB
@@ -46455,8 +47071,8 @@ dH
 Vw
 iK
 Ql
+fp
 NT
-te
 of
 of
 oM
@@ -46947,7 +47563,7 @@ VK
 eJ
 BJ
 QX
-QX
+fz
 Ts
 KZ
 hr
@@ -47214,14 +47830,14 @@ NH
 Ch
 jH
 nw
-BI
+Of
 gV
 FL
 Yx
 zM
-BI
+Of
 ff
-BI
+Of
 EJ
 vd
 bj
@@ -47232,7 +47848,7 @@ Gs
 tS
 mI
 mI
-Ow
+PQ
 rY
 xc
 Ry
@@ -47492,7 +48108,7 @@ ik
 hc
 rm
 Um
-rY
+Yo
 mI
 mI
 mI
@@ -47732,7 +48348,7 @@ WH
 zr
 Tj
 jH
-ng
+sX
 xf
 Vx
 jH
@@ -47994,7 +48610,7 @@ KS
 xQ
 jH
 Tc
-yk
+Ju
 jH
 jH
 jH
@@ -48133,7 +48749,7 @@ sB
 sB
 sB
 PA
-PA
+MR
 PA
 kz
 kz
@@ -48504,7 +49120,7 @@ BW
 Zl
 jH
 FB
-NH
+ac
 sN
 jH
 nj
@@ -49265,7 +49881,7 @@ YT
 ao
 WH
 WD
-fM
+pb
 Un
 Up
 vJ
@@ -50553,21 +51169,21 @@ mI
 ao
 WH
 Se
-IU
+PP
 sh
 WH
 eq
 PY
 Sk
 jH
-NH
+SS
 Lw
 cg
 jH
 Uf
 lA
 Lw
-sX
+yk
 jH
 oB
 mI

--- a/maps/away/away_site/goon_base/goon_base.dmm
+++ b/maps/away/away_site/goon_base/goon_base.dmm
@@ -7,6 +7,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/mine)
+"ab" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "ad" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -451,6 +458,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
+"eu" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "eA" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/storage/toolbox/lunchbox/filled{
@@ -809,6 +823,12 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
+"gF" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/machinery/door/airlock/maintenance_hatch,
+/turf/simulated/floor/plating,
+/area/mine)
 "gI" = (
 /turf/simulated/floor/plating,
 /area/shuttle/goon_ship/living)
@@ -892,15 +912,15 @@
 /turf/simulated/floor/airless/ceiling,
 /area/mine)
 "hr" = (
-/obj/item/paper/goon_base/notice{
-	pixel_x = -3;
-	pixel_y = -2
-	},
 /obj/item/wrench{
 	pixel_x = 10;
 	pixel_y = 3
 	},
 /obj/random/dirt_75,
+/obj/item/paper/goon_base/notice_secret_base{
+	pixel_x = -1;
+	pixel_y = -4
+	},
 /turf/simulated/floor/tiled,
 /area/mine)
 "hC" = (
@@ -1612,6 +1632,15 @@
 /obj/item/gun/projectile/sec/wood,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_ship/living)
+"mg" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/tank/emergency_oxygen/double{
+	pixel_y = -2;
+	pixel_x = 3
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "mj" = (
 /obj/random/dirt_75,
 /obj/item/clothing/head/cone{
@@ -2282,6 +2311,14 @@
 /obj/item/clothing/wrists/armchain,
 /turf/simulated/floor/plating,
 /area/mine)
+"qw" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/item/tank/oxygen/red{
+	pixel_x = -2
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
 "qy" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
@@ -2595,6 +2632,11 @@
 /obj/random/spacecash,
 /turf/simulated/floor/tiled,
 /area/mine)
+"sY" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
+/area/mine)
 "sZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2747,6 +2789,13 @@
 	pixel_x = -4
 	},
 /turf/simulated/floor/tiled/white,
+/area/mine)
+"uJ" = (
+/obj/effect/floor_decal/industrial/loading/grey{
+	dir = 1
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "uT" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
@@ -2934,6 +2983,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
+/area/mine)
+"wA" = (
+/obj/item/pickaxe{
+	pixel_y = -11;
+	pixel_x = 6
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "wD" = (
 /obj/structure/closet/firecloset,
@@ -3615,6 +3673,15 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
+/area/mine)
+"BM" = (
+/obj/item/paper/goon_base/notice_secret_back_exit{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
 /area/mine)
 "BW" = (
 /obj/structure/cable{
@@ -4908,6 +4975,15 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/mine)
+"Nh" = (
+/obj/item/pickaxe/drill{
+	pixel_y = 10;
+	pixel_x = 9
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
+/area/mine)
 "Ni" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 1
@@ -5117,6 +5193,12 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/mine)
+"PA" = (
+/obj/random/dirt_75,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
 /turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "PC" = (
@@ -5900,6 +5982,12 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/mine)
+"Vi" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
+/area/mine)
 "Vo" = (
 /obj/structure/closet/walllocker/medical{
 	pixel_y = -32
@@ -6482,6 +6570,12 @@
 	pixel_y = -5
 	},
 /turf/simulated/floor/tiled,
+/area/mine)
+"ZC" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
 /area/mine)
 "ZH" = (
 /obj/structure/dispenser/oxygen,
@@ -26710,10 +26804,10 @@ bu
 bu
 bu
 bu
+sB
+sB
 bu
-bu
-bu
-bu
+sB
 mI
 mI
 mI
@@ -26966,11 +27060,11 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -27215,15 +27309,15 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
 mI
 mI
 mI
@@ -27470,17 +27564,17 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+mI
 mI
 mI
 mI
@@ -27721,23 +27815,23 @@ bu
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+sB
+mI
+mI
+mI
+sB
+sB
+sB
+sB
+mI
 mI
 mI
 mI
@@ -27983,16 +28077,16 @@ mI
 mI
 mI
 mI
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
-bu
+sB
+sB
+sB
+mI
+mI
+mI
+mI
+mI
+mI
+sB
 mI
 mI
 mI
@@ -28981,7 +29075,7 @@ bu
 bu
 bu
 bu
-bu
+mI
 mI
 mI
 mI
@@ -29236,9 +29330,9 @@ bu
 bu
 bu
 bu
-bu
-bu
-bu
+mI
+mI
+mI
 mI
 mI
 mI
@@ -43359,8 +43453,8 @@ bu
 bu
 bu
 mI
-mI
-mI
+sY
+Nh
 mI
 mI
 qX
@@ -43617,8 +43711,8 @@ bu
 bu
 mI
 mI
-mI
-mI
+Vi
+sY
 mI
 qX
 qX
@@ -43874,12 +43968,12 @@ bu
 bu
 mI
 mI
-mI
-mI
-mI
+gj
+Ow
+Ow
 qX
-mI
-qX
+wA
+Li
 Dr
 Uk
 Uk
@@ -44130,14 +44224,14 @@ bu
 bu
 bu
 mI
-mI
-mI
-mI
-mI
-qX
-mI
-qX
-Dr
+qw
+eu
+ZC
+Ow
+gF
+BM
+mE
+uJ
 Uk
 Uk
 Ah
@@ -44387,9 +44481,9 @@ bu
 bu
 mI
 mI
-mI
-mI
-mI
+ab
+gj
+mg
 mI
 qX
 qX
@@ -44644,8 +44738,8 @@ bu
 bu
 mI
 mI
-mI
-mI
+no
+PA
 mI
 mI
 qX

--- a/maps/away/away_site/goon_base/goon_base.dmm
+++ b/maps/away/away_site/goon_base/goon_base.dmm
@@ -267,6 +267,27 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/goonbase/power)
+"bC" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/cee,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_main";
+	name = "airlock_goon_base_main"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = -19;
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/hallway_south)
 "bH" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -339,6 +360,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/goonbase/maint_north)
+"cg" = (
+/obj/random/dirt_75,
+/obj/machinery/alarm/south,
+/turf/simulated/floor/tiled,
+/area/goonbase/living)
 "ch" = (
 /obj/random/pottedplant,
 /obj/effect/floor_decal/corner/yellow/diagonal,
@@ -390,6 +416,20 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_maint";
+	name = "airlock_goon_base_maint"
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = -6
+	},
+/obj/machinery/airlock_sensor{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_airlock)
 "cG" = (
@@ -656,6 +696,10 @@
 	dir = 1
 	},
 /obj/random/dirt_75,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_main";
+	name = "airlock_goon_base_main"
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
 "dY" = (
@@ -886,6 +930,14 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
+"fa" = (
+/obj/structure/trash_pile,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/machinery/alarm/north,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_north)
 "fb" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/bed/stool,
@@ -1315,11 +1367,6 @@
 	},
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/hallway_north)
-"hd" = (
-/obj/random/dirt_75,
-/obj/machinery/alarm/west,
-/turf/simulated/floor/plating,
-/area/goonbase/maint_airlock)
 "he" = (
 /obj/structure/reagent_dispensers/coolanttank,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1364,6 +1411,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_south)
+"hA" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
+	},
+/obj/random/dirt_75,
+/obj/machinery/alarm/west,
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "hC" = (
 /obj/structure/sign/greencross{
 	pixel_x = -32
@@ -1735,6 +1790,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/goonbase/power)
+"jy" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/machinery/alarm/east,
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "jz" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
@@ -1757,6 +1819,14 @@
 "jH" = (
 /turf/simulated/wall,
 /area/goonbase/living)
+"jK" = (
+/obj/random/dirt_75,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_maint";
+	name = "airlock_goon_base_maint"
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/maint_airlock)
 "jP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -2288,6 +2358,16 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/full,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_maint";
+	name = "airlock_goon_base_maint"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button{
+	pixel_x = 12;
+	pixel_y = -28;
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_airlock)
 "mt" = (
@@ -2443,6 +2523,9 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/goonbase/living)
+"nn" = (
+/turf/simulated/mineral/surface,
+/area/goonbase/maint_south)
 "no" = (
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
@@ -2850,13 +2933,6 @@
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_shuttle/med)
-"ps" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 6
-	},
-/obj/machinery/alarm/east,
-/turf/simulated/floor/tiled,
-/area/goonbase/hallway_north)
 "pt" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/sink/kitchen{
@@ -3371,6 +3447,20 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/hallway_north)
+"rZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
+/obj/random/dirt_75,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_main";
+	name = "airlock_goon_base_main"
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = -6
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/hallway_south)
 "sc" = (
 /obj/item/trash/tuna{
 	pixel_x = 6;
@@ -3658,13 +3748,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/maint_south)
-"uj" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 9
-	},
-/obj/machinery/alarm/west,
-/turf/simulated/floor/tiled,
-/area/goonbase/hallway_north)
 "um" = (
 /obj/structure/reagent_dispensers/radioactive_waste{
 	pixel_x = 12;
@@ -3776,14 +3859,6 @@
 /obj/random/dirt_75,
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
-"uQ" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 6
-	},
-/obj/random/dirt_75,
-/obj/machinery/alarm/east,
-/turf/simulated/floor/tiled,
-/area/goonbase/hallway_south)
 "uT" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
@@ -4011,6 +4086,10 @@
 "wc" = (
 /turf/simulated/wall/r_wall,
 /area/goonbase/atmos)
+"wg" = (
+/obj/machinery/alarm/north,
+/turf/simulated/floor/tiled,
+/area/goonbase/living)
 "wo" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/cable{
@@ -5128,6 +5207,11 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_main";
+	name = "airlock_goon_base_main"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
 "CZ" = (
@@ -5140,6 +5224,10 @@
 "Df" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux,
 /obj/random/dirt_75,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_main";
+	name = "airlock_goon_base_main"
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
 "Dj" = (
@@ -5250,14 +5338,6 @@
 /obj/item/storage/box/fancy/cigarettes,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/goon_shuttle/living)
-"DP" = (
-/obj/structure/trash_pile,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/random/dirt_75,
-/obj/machinery/alarm/north,
-/turf/simulated/floor/plating,
-/area/goonbase/maint_north)
 "DR" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -5353,6 +5433,10 @@
 	dir = 2
 	},
 /obj/random/dirt_75,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_main";
+	name = "airlock_goon_base_main"
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
 "Ex" = (
@@ -5529,11 +5613,6 @@
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/goon_shuttle/port)
-"FG" = (
-/obj/random/dirt_75,
-/obj/machinery/alarm/north,
-/turf/simulated/floor/tiled,
-/area/goonbase/living)
 "FL" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 6
@@ -5957,6 +6036,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/goonbase/equipment)
+"HO" = (
+/obj/random/dirt_75,
+/obj/machinery/alarm/north,
+/turf/simulated/floor/tiled,
+/area/goonbase/living)
 "HU" = (
 /obj/structure/closet/cabinet{
 	pixel_y = 0
@@ -6034,6 +6118,16 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/cee,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_main";
+	name = "airlock_goon_base_main"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/access_button{
+	pixel_x = 28;
+	pixel_y = -20;
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
 "Ic" = (
@@ -6191,11 +6285,6 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/goonbase/power)
-"IT" = (
-/obj/random/dirt_75,
-/obj/machinery/alarm/south,
-/turf/simulated/floor/tiled,
-/area/goonbase/living)
 "IU" = (
 /turf/simulated/floor/tiled/freezer,
 /area/goonbase/kitchen)
@@ -6241,10 +6330,6 @@
 	},
 /turf/unsimulated/floor/asteroid/ash,
 /area/mine)
-"Jd" = (
-/obj/machinery/alarm/north,
-/turf/simulated/floor/tiled,
-/area/goonbase/living)
 "Jf" = (
 /obj/structure/table/steel,
 /obj/item/storage/firstaid/combat{
@@ -6371,6 +6456,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
+/area/goonbase/hallway_south)
+"JH" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
+/obj/random/dirt_75,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_main";
+	name = "airlock_goon_base_main"
+	},
+/turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
 "JJ" = (
 /obj/random/dirt_75,
@@ -6621,6 +6715,7 @@
 /obj/machinery/atmospherics/binary/pump/aux/on,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/alarm/east,
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
 "KZ" = (
@@ -6663,6 +6758,14 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
+"Ll" = (
+/obj/structure/structural_support{
+	pixel_y = 8
+	},
+/obj/random/dirt_75,
+/obj/machinery/alarm/south,
+/turf/simulated/floor/plating/asteroid,
+/area/goonbase/maint_south)
 "Lm" = (
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6722,10 +6825,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_north)
+"LF" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/random/dirt_75,
+/obj/machinery/alarm/east,
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_south)
 "LM" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
+"LR" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
+	},
+/obj/machinery/alarm/west,
 /turf/simulated/floor/tiled,
 /area/goonbase/hallway_north)
 "LS" = (
@@ -7715,14 +7833,6 @@
 "QX" = (
 /turf/simulated/floor/plating,
 /area/goonbase/equipment)
-"QY" = (
-/obj/structure/structural_support{
-	pixel_y = 8
-	},
-/obj/random/dirt_75,
-/obj/machinery/alarm/south,
-/turf/simulated/floor/plating/asteroid,
-/area/goonbase/maint_south)
 "Rb" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -7730,6 +7840,15 @@
 	dir = 4
 	},
 /obj/random/dirt_75,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_main";
+	name = "airlock_goon_base_main"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button{
+	pixel_x = 28;
+	dir = 2
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
 "Rd" = (
@@ -7859,13 +7978,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/goonbase/kitchen)
-"RK" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 5
-	},
-/obj/machinery/alarm/north,
-/turf/simulated/floor/tiled,
-/area/goonbase/hallway_north)
 "RL" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid{
@@ -8003,6 +8115,15 @@
 "Sv" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/random/dirt_75,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_main";
+	name = "airlock_goon_base_main"
+	},
+/obj/machinery/airlock_sensor{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
 "Sw" = (
@@ -8066,6 +8187,10 @@
 "SH" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/aux,
 /obj/random/dirt_75,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_main";
+	name = "airlock_goon_base_main"
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
 "SI" = (
@@ -8097,6 +8222,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/goonbase/power)
+"SQ" = (
+/obj/random/dirt_75,
+/obj/machinery/alarm/west,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_airlock)
 "SU" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
@@ -8124,6 +8254,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
 /area/goonbase/medbay)
+"SY" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/obj/machinery/alarm/north,
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "SZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8215,6 +8352,15 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_main";
+	name = "airlock_goon_base_main"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	dir = 2
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/hallway_south)
 "TG" = (
@@ -9035,14 +9181,6 @@
 /obj/item/clothing/ears/earmuffs,
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/hallway_north)
-"XX" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 9
-	},
-/obj/random/dirt_75,
-/obj/machinery/alarm/west,
-/turf/simulated/floor/tiled,
-/area/goonbase/hallway_north)
 "XY" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -9494,6 +9632,16 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/full,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_goon_base_maint";
+	name = "airlock_goon_base_maint"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/access_button{
+	pixel_x = -12;
+	pixel_y = 28;
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/goonbase/maint_airlock)
 
@@ -41703,7 +41851,7 @@ pz
 BH
 kk
 UG
-hd
+SQ
 cu
 kk
 Fb
@@ -42200,7 +42348,7 @@ yC
 mI
 Xa
 gj
-QY
+Ll
 Gv
 KE
 Gv
@@ -42738,7 +42886,7 @@ uU
 Fe
 kk
 cF
-GV
+jK
 kk
 cn
 mI
@@ -42969,10 +43117,10 @@ yC
 sI
 jY
 yC
-mI
-mI
-mI
-mI
+nn
+nn
+nn
+nn
 wL
 JK
 JK
@@ -43229,7 +43377,7 @@ yC
 Ql
 rY
 Ap
-mI
+nn
 Gv
 Gv
 RL
@@ -43479,7 +43627,7 @@ Ql
 Ld
 Gh
 Vq
-uj
+LR
 ff
 Vw
 mn
@@ -43756,7 +43904,7 @@ OP
 lW
 GG
 CY
-Ia
+bC
 GG
 cN
 cN
@@ -43995,7 +44143,7 @@ jP
 vZ
 BI
 ff
-ps
+jy
 mn
 Ow
 rY
@@ -44003,7 +44151,7 @@ MB
 OS
 hE
 Rn
-uQ
+LF
 Cf
 aA
 aA
@@ -44012,7 +44160,7 @@ DJ
 ws
 Ji
 GG
-Sv
+JH
 Ew
 GG
 GG
@@ -44486,7 +44634,7 @@ qX
 qX
 qX
 SL
-DP
+fa
 Pc
 oI
 jY
@@ -44526,7 +44674,7 @@ cV
 km
 lW
 GG
-Sv
+rZ
 SH
 dX
 Rb
@@ -44783,7 +44931,7 @@ GG
 Uc
 Ji
 GG
-Sv
+JH
 Df
 GG
 GG
@@ -45018,7 +45166,7 @@ lK
 kL
 Ml
 fl
-RK
+SY
 vk
 vd
 Tn
@@ -46556,7 +46704,7 @@ BC
 bH
 nt
 lz
-XX
+hA
 gx
 ff
 BC
@@ -47841,7 +47989,7 @@ WH
 MI
 Ql
 jH
-Jd
+wg
 KS
 xQ
 jH
@@ -49391,7 +49539,7 @@ xE
 yk
 sO
 jH
-FG
+HO
 xL
 fr
 jH
@@ -50414,7 +50562,7 @@ Sk
 jH
 NH
 Lw
-IT
+cg
 jH
 Uf
 lA

--- a/maps/away/away_site/goon_base/goon_base.dmm
+++ b/maps/away/away_site/goon_base/goon_base.dmm
@@ -6,14 +6,14 @@
 	identifier = "goon"
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "ab" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/item/clothing/suit/space/emergency,
 /obj/item/clothing/head/helmet/space/emergency,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/equipment)
 "ad" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -26,18 +26,21 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "ag" = (
 /obj/effect/map_effect/airlock/long/square,
 /turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "an" = (
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
+"ao" = (
+/turf/simulated/wall/r_wall,
+/area/goonbase/kitchen)
 "as" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51,26 +54,22 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
-"ax" = (
-/obj/effect/decal/cleanable/dirt,
+/area/goonbase/maint_north)
+"av" = (
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
+/area/shuttle/goon_shuttle/port)
 "aA" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 6
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "aD" = (
 /obj/effect/map_effect/airlock/s_to_n,
 /turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/storage)
-"aE" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/living)
 "aI" = (
 /obj/item/reagent_containers/glass/bucket/wood{
 	pixel_y = -7
@@ -81,7 +80,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "aJ" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/random/dirt_75,
@@ -90,7 +89,7 @@
 	pixel_x = 15
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/power)
 "aK" = (
 /obj/effect/decal/cleanable/acid_remnants{
 	pixel_y = 8;
@@ -98,7 +97,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "aL" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -106,7 +105,7 @@
 	},
 /obj/machinery/power/apc/empty/north,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
 "aM" = (
 /obj/structure/girder,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -115,8 +114,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/living)
 "aP" = (
 /obj/structure/table/rack,
 /obj/item/clothing/shoes/magboots,
@@ -126,13 +128,13 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "aR" = (
 /obj/item/trash/proteinbar,
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/living)
 "aS" = (
 /obj/random/dirt_75,
 /obj/random/junk,
@@ -140,8 +142,11 @@
 	pixel_x = -9;
 	pixel_y = 14
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/living)
 "aT" = (
 /obj/effect/floor_decal/corner/grey/full{
 	dir = 8
@@ -151,7 +156,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "aY" = (
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
@@ -161,7 +166,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
+"ba" = (
+/turf/simulated/wall,
+/area/goonbase/power)
+"bb" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/atmos)
 "bc" = (
 /obj/structure/table/wood,
 /obj/random/dirt_75,
@@ -173,17 +185,17 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "bi" = (
 /obj/item/trash/cigbutt,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "bj" = (
 /obj/effect/floor_decal/corner/grey/full{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "bk" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 1
@@ -204,7 +216,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "bm" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
@@ -213,12 +225,12 @@
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "bp" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
+/area/shuttle/goon_shuttle/living)
 "bt" = (
 /obj/structure/reagent_dispensers/radioactive_waste{
 	pixel_x = 7
@@ -230,7 +242,7 @@
 	pixel_y = -5
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "bu" = (
 /turf/template_noop,
 /area/space)
@@ -246,14 +258,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "bA" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "bH" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -269,20 +281,20 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_north)
 "bN" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "bR" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
 /turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "bV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
@@ -294,7 +306,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "bW" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -305,7 +317,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "bY" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice/gaming{
@@ -313,15 +325,23 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/carpet/red,
-/area/mine)
-"bZ" = (
+/area/goonbase/living)
+"cb" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/goonbase/maint_north)
 "ch" = (
 /obj/random/pottedplant,
 /obj/effect/floor_decal/corner/yellow/diagonal,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "cm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -331,7 +351,10 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
+"cn" = (
+/turf/simulated/wall/r_wall,
+/area/goonbase/maint_airlock)
 "ct" = (
 /obj/effect/shuttle_landmark/goon_ship/hangar,
 /turf/unsimulated/floor/asteroid/ash/rocky,
@@ -340,7 +363,7 @@
 /obj/random/dirt_75,
 /obj/structure/table/rack,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "cx" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/mirror{
@@ -352,7 +375,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/living)
 "cA" = (
 /obj/structure/structural_support{
 	pixel_y = 8
@@ -365,7 +388,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "cG" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid{
@@ -381,11 +404,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "cH" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "cK" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -400,7 +423,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "cN" = (
 /obj/random/dirt_75,
 /turf/simulated/floor/airless/ceiling,
@@ -417,10 +440,10 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "cP" = (
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "cT" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -433,7 +456,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "cV" = (
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
@@ -443,7 +466,7 @@
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/hallway_south)
 "cW" = (
 /obj/random/dirt_75,
 /obj/structure/barricade/metal{
@@ -462,41 +485,50 @@
 	pixel_y = -1
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "cY" = (
 /obj/random/dirt_75,
 /obj/item/tank/air{
 	pixel_x = -9
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/hallway_north)
+"cZ" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/goonbase/equipment)
+"da" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/power)
 "dd" = (
 /obj/structure/bed/padded/bunk{
 	pixel_y = 0
 	},
 /obj/item/bedsheet/black,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "dg" = (
 /obj/effect/landmark/entry_point/west{
 	name = "starboard, storage"
 	},
 /turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/storage)
+/area/shuttle/goon_shuttle/living)
 "dh" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "dr" = (
 /obj/random/tech_supply{
 	pixel_x = -9;
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/living)
 "dt" = (
 /obj/effect/shuttle_landmark/automatic/ghostrole_activation,
 /turf/template_noop,
@@ -505,7 +537,7 @@
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "dx" = (
 /obj/structure/table/steel,
 /obj/item/device/binoculars,
@@ -514,14 +546,14 @@
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "dz" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
 /obj/structure/table/wood,
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
 "dE" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -529,7 +561,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/living)
+"dH" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "dI" = (
 /obj/item/pickaxe/drill{
 	pixel_y = 7;
@@ -545,13 +583,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "dK" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "dQ" = (
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
@@ -569,7 +607,7 @@
 /obj/item/clothing/mask/breath/medical,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "dT" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -581,7 +619,7 @@
 	pixel_y = -2
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "dU" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
@@ -592,7 +630,7 @@
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "dV" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
@@ -600,7 +638,7 @@
 /obj/machinery/computer/operating/terminal,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "dW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -609,43 +647,47 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "dX" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "dY" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
-"eb" = (
-/obj/structure/reagent_dispensers/watertank,
+/area/goonbase/power)
+"ed" = (
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
-"ee" = (
-/obj/machinery/atmospherics/binary/pump/high_power,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/port)
+"ef" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/goonbase/maint_south)
 "eh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "ei" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "en" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -658,7 +700,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "eq" = (
 /obj/item/reagent_containers/glass/bucket/wood{
 	pixel_y = -3;
@@ -666,7 +708,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "er" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -682,7 +724,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "eu" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -693,7 +735,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/equipment)
 "ew" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -714,7 +756,7 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/mine)
+/area/goonbase/equipment)
 "eB" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -723,14 +765,14 @@
 	pixel_y = 14
 	},
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "eC" = (
 /obj/random/dirt_75,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "eE" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -745,7 +787,7 @@
 	pixel_y = -8
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "eF" = (
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/generic{
@@ -757,7 +799,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "eH" = (
 /obj/effect/decal/cleanable/greenglow/radioactive{
 	pixel_x = -10;
@@ -773,7 +815,7 @@
 	pixel_y = -1
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "eI" = (
 /obj/structure/closet/walllocker/medical{
 	pixel_x = -32
@@ -789,19 +831,19 @@
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "eJ" = (
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "eK" = (
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "eL" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/power/portgen/basic/advanced,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "eN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -810,29 +852,36 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/living)
 "eO" = (
 /turf/simulated/floor/holofloor/tiled/ramp/bottom,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "eP" = (
 /obj/item/trash/tray,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "eS" = (
 /obj/item/trash/chips,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
 	},
 /turf/simulated/floor/carpet,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "eT" = (
 /obj/structure/bed/stool/chair/office/bridge/generic{
 	dir = 1;
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
+"eW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 9
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/hallway_south)
 "fb" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/bed/stool,
@@ -845,7 +894,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "fe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -854,12 +903,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "ff" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "fg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -870,42 +919,45 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "fh" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/structure/curtain/open{
 	color = "#854636"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/living)
 "fj" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
+"fl" = (
+/turf/simulated/wall,
+/area/goonbase/medbay)
 "fm" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
+/area/shuttle/goon_shuttle/living)
 "fo" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "fr" = (
 /obj/item/clothing/shoes/slippers/carp{
 	pixel_y = -4;
 	pixel_x = -5
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "fs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/bed/roller,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "ft" = (
 /obj/structure/closet/crate/bin{
 	name = "trashbin";
@@ -913,11 +965,11 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "fv" = (
 /obj/machinery/power/portgen/basic,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "fA" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/void/tcaf,
@@ -928,7 +980,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "fB" = (
 /obj/structure/reagent_dispensers/radioactive_waste{
 	pixel_x = -8
@@ -941,7 +993,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "fC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -952,7 +1004,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "fG" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/mirror{
@@ -963,32 +1015,32 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/living)
 "fI" = (
 /obj/structure/bed/stool/padded/orange{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/red,
-/area/mine)
+/area/goonbase/living)
 "fL" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/structure/table/rack,
 /obj/item/gun/energy/disruptorpistol/practice,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "fM" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "fR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "fW" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/mc9mm{
@@ -1019,7 +1071,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "fY" = (
 /turf/simulated/mineral/surface,
 /area/space)
@@ -1033,7 +1085,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "gi" = (
 /obj/structure/table/steel,
 /obj/random/desktoy{
@@ -1041,12 +1093,12 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "gj" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "gm" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
@@ -1060,7 +1112,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "gn" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/black,
@@ -1071,7 +1123,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "gp" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/steel,
@@ -1088,7 +1140,7 @@
 	pixel_y = -8
 	},
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "gq" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
@@ -1097,12 +1149,12 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "gr" = (
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "gs" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 8
@@ -1114,7 +1166,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
 "gu" = (
 /obj/random/dirt_75,
 /obj/structure/structural_support{
@@ -1129,27 +1181,31 @@
 	pixel_y = 19
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "gx" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 9
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "gE" = (
 /obj/structure/bed/stool{
 	dir = 1
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "gF" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/equipment)
+"gG" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
+/area/goonbase/equipment)
 "gH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1158,21 +1214,18 @@
 	can_open = 1;
 	color = "#DDDDDD"
 	},
-/area/mine)
-"gI" = (
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/goonbase/equipment)
 "gJ" = (
 /obj/item/trash/raisins,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "gL" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
 	},
 /obj/structure/bed/stool/chair/sofa/corner/concave/red,
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
 "gM" = (
 /obj/random/dirt_75,
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -1184,7 +1237,7 @@
 /obj/item/storage/box/produce,
 /obj/item/storage/box/produce,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "gO" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/food/drinks/carton/milk,
@@ -1210,7 +1263,7 @@
 /obj/item/reagent_containers/food/snacks/fish/fishfillet,
 /obj/item/reagent_containers/food/snacks/fish/fishfillet,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "gV" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -1223,7 +1276,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_north)
 "gX" = (
 /obj/effect/decal/cleanable/floor_damage/random_broken,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1238,14 +1291,14 @@
 /obj/item/broken_device,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "gZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
 	},
 /turf/simulated/floor/carpet,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "hc" = (
 /obj/random/dirt_75,
 /obj/item/ammo_casing/c45/practice{
@@ -1257,12 +1310,12 @@
 	pixel_y = -7
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "he" = (
 /obj/structure/reagent_dispensers/coolanttank,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "ho" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 4
@@ -1286,14 +1339,14 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "hu" = (
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/generic{
 	pixel_x = 8
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "hv" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -1301,29 +1354,28 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "hC" = (
 /obj/structure/sign/greencross{
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
+"hE" = (
+/turf/simulated/floor/plating/asteroid,
+/area/goonbase/hallway_south)
 "hF" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "hG" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
-"hI" = (
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/storage)
 "hK" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
@@ -1332,7 +1384,7 @@
 /obj/structure/target_stake,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "hL" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
@@ -1352,7 +1404,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "hS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -1366,7 +1418,12 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
+"hT" = (
+/obj/random/dirt_75,
+/obj/structure/closet/toolcloset,
+/turf/simulated/floor/plating,
+/area/goonbase/power)
 "hV" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/bed/roller,
@@ -1376,12 +1433,12 @@
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "hZ" = (
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "ia" = (
 /obj/item/deck/cards,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
@@ -1403,7 +1460,15 @@
 	},
 /obj/structure/table/wood,
 /turf/simulated/floor/carpet,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
+"ib" = (
+/obj/structure/bed/stool/chair/office/light{
+	dir = 8
+	},
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_south)
 "id" = (
 /obj/structure/table/wood,
 /obj/item/deck/cards{
@@ -1418,7 +1483,7 @@
 	pixel_x = -20
 	},
 /turf/simulated/floor/carpet/red,
-/area/mine)
+/area/goonbase/living)
 "ie" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
@@ -1435,7 +1500,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "if" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1448,7 +1513,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "ig" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/black/engie,
@@ -1456,7 +1521,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "ik" = (
 /obj/random/dirt_75,
 /obj/structure/table/reinforced/steel,
@@ -1483,7 +1548,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "ip" = (
 /obj/structure/structural_support{
 	pixel_y = 8
@@ -1491,13 +1556,13 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating/asteroid,
-/area/mine)
+/area/goonbase/hallway_north)
 "is" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "it" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/glass/rag,
@@ -1510,7 +1575,7 @@
 	pixel_x = -6
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "iu" = (
 /obj/item/broken_bottle,
 /obj/effect/decal/cleanable/dirt,
@@ -1520,7 +1585,7 @@
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "iy" = (
 /obj/effect/decal/cleanable/acid_remnants{
 	pixel_x = -8;
@@ -1536,7 +1601,7 @@
 	pixel_y = -10
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "iA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet/north{
@@ -1544,7 +1609,7 @@
 	},
 /obj/item/trash/chips,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "iD" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -1552,27 +1617,31 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/power)
 "iK" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "iO" = (
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/equipment)
+"iQ" = (
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/plating,
+/area/goonbase/kitchen)
 "iR" = (
 /obj/machinery/sleeper{
 	dir = 8
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "iV" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -1582,18 +1651,14 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
-"iW" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/goonbase/maint_airlock)
 "iX" = (
 /obj/structure/trash_pile,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "iY" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -1614,7 +1679,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "jg" = (
 /obj/machinery/body_scanconsole{
 	dir = 1;
@@ -1624,7 +1689,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "jq" = (
 /obj/machinery/door/airlock/glass{
 	dir = 4
@@ -1634,14 +1699,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/kitchen)
 "js" = (
 /obj/structure/bed/stool,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
 /turf/simulated/floor/carpet,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "jv" = (
 /obj/random/dirt_75,
 /obj/random/tool{
@@ -1649,7 +1714,7 @@
 	pixel_x = 8
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "jw" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -1659,7 +1724,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "jz" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
@@ -1678,13 +1743,16 @@
 	pixel_x = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
+"jH" = (
+/turf/simulated/wall,
+/area/goonbase/living)
 "jP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/hallway_north)
 "jS" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/power/terminal{
@@ -1695,7 +1763,10 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
+"jU" = (
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/goon_shuttle/starboard)
 "jV" = (
 /obj/item/reagent_containers/glass/bucket/wood{
 	pixel_y = 6;
@@ -1709,12 +1780,16 @@
 	pixel_x = 11
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "jW" = (
 /obj/structure/dispenser/oxygen,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
+"jY" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_north)
 "jZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1723,7 +1798,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/hallway_south)
+"ka" = (
+/turf/simulated/floor/plating/asteroid,
+/area/goonbase/hallway_north)
 "kg" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1743,7 +1821,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_north)
 "kj" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/random/dirt_75,
@@ -1754,7 +1832,10 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
+"kk" = (
+/turf/simulated/wall,
+/area/goonbase/maint_airlock)
 "km" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
@@ -1765,17 +1846,17 @@
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "kn" = (
 /obj/structure/closet,
 /obj/item/clothing/accessory/tshirt,
 /obj/item/clothing/accessory/holster/utility/machete,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "kp" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/port)
 "kr" = (
 /obj/effect/landmark/entry_point/south{
 	name = "fore, bridge"
@@ -1787,12 +1868,12 @@
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "ku" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "kz" = (
 /obj/random/dirt_75,
 /turf/unsimulated/floor/asteroid/ash/rocky,
@@ -1802,7 +1883,7 @@
 /obj/structure/closet/crate/loot,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "kE" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
@@ -1884,11 +1965,11 @@
 	},
 /obj/item/reagent_containers/syringe/drugs,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "kH" = (
 /obj/item/trash/gum,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "kI" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid{
@@ -1901,12 +1982,12 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "kJ" = (
 /obj/machinery/sleeper,
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "kK" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -1915,16 +1996,16 @@
 	pixel_y = -31
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "kL" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "kQ" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/space_heater,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "kR" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
@@ -1932,11 +2013,11 @@
 /obj/random/dirt_75,
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "kS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
 "kU" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/food/condiment/shaker/peppermill{
@@ -1953,7 +2034,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "kV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -1962,7 +2043,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "kW" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -1971,18 +2052,13 @@
 /obj/item/ammo_magazine/c762,
 /obj/item/gun/projectile/automatic/rifle/sts35,
 /turf/simulated/floor/tiled/dark,
-/area/mine)
-"kX" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/goonbase/equipment)
 "kZ" = (
 /obj/random/dirt_75,
 /obj/structure/table/rack,
 /obj/item/gun/energy/rifle/laser/practice,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "lb" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate,
@@ -1994,7 +2070,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "le" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/effect/floor_decal/corner/black/diagonal{
@@ -2004,7 +2080,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "lh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2015,7 +2091,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "lj" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/black/green,
@@ -2023,7 +2099,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "ll" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
@@ -2031,7 +2107,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "lo" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/stack/material/glass/reinforced/full{
@@ -2057,13 +2133,13 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/equipment)
 "lq" = (
 /obj/machinery/optable,
 /obj/item/storage/firstaid/surgery,
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "lv" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/shower{
@@ -2077,7 +2153,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/living)
 "lw" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 10
@@ -2093,7 +2169,10 @@
 /obj/machinery/power/apc/west,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
+"lA" = (
+/turf/simulated/floor/tiled/full,
+/area/goonbase/living)
 "lI" = (
 /obj/item/storage/toolbox/emergency{
 	pixel_x = -11;
@@ -2108,7 +2187,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "lK" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/table/standard,
@@ -2125,11 +2204,11 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "lQ" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "lR" = (
 /obj/structure/closet/crate/miningcart,
 /turf/unsimulated/floor/asteroid/ash/rocky,
@@ -2141,24 +2220,24 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "lW" = (
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/hallway_south)
 "lY" = (
 /obj/item/trash/liquidfood,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "mf" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/storage/toggle/brown_jacket/sleeveless,
 /obj/item/ammo_magazine/c45m,
 /obj/item/gun/projectile/sec/wood,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "mg" = (
 /obj/random/dirt_75,
 /obj/item/tank/emergency_oxygen/double{
@@ -2166,7 +2245,7 @@
 	pixel_x = 3
 	},
 /turf/simulated/floor/plating/asteroid,
-/area/mine)
+/area/goonbase/equipment)
 "mh" = (
 /obj/machinery/portable_atmospherics/canister/empty/hydrogen,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2179,17 +2258,17 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "mn" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_north)
 "mr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/hallway_north)
 "ms" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
@@ -2197,18 +2276,21 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "mt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "mv" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
+"my" = (
+/turf/simulated/floor/plating,
+/area/shuttle/goon_shuttle/living)
 "mz" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
@@ -2218,13 +2300,13 @@
 	},
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
+/area/shuttle/goon_shuttle/living)
 "mE" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "mI" = (
 /turf/simulated/mineral/surface,
 /area/mine)
@@ -2244,7 +2326,7 @@
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "mO" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/steel,
@@ -2260,12 +2342,12 @@
 	pixel_y = -3
 	},
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "mQ" = (
 /obj/random/dirt_75,
 /obj/random/loot,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "mV" = (
 /obj/random/dirt_75,
 /turf/unsimulated/floor/asteroid/ash,
@@ -2277,7 +2359,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "mX" = (
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/corner/blue{
@@ -2305,7 +2387,7 @@
 /obj/item/clothing/shoes/sandals/caligae,
 /obj/item/clothing/shoes/workboots/toeless,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "nf" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -2316,18 +2398,18 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "ng" = (
 /obj/structure/closet,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "nj" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
 /obj/random/pottedplant,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "nk" = (
 /obj/structure/table/steel,
 /obj/item/paper_bin{
@@ -2339,7 +2421,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "nl" = (
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop/preset/civilian{
@@ -2347,11 +2429,11 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "no" = (
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "np" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/steel,
@@ -2368,23 +2450,36 @@
 	pixel_x = -2
 	},
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
+"nq" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_south)
 "nr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
+"nt" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "nw" = (
 /obj/effect/floor_decal/corner/red/full{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "nA" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
 /turf/simulated/floor/airless,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/starboard)
 "nB" = (
 /turf/simulated/floor/plating/asteroid,
 /area/mine)
@@ -2416,14 +2511,14 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "nI" = (
 /obj/structure/bed/stool,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "nJ" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -2435,14 +2530,14 @@
 	pixel_y = -2
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "nM" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
 /obj/machinery/computer/ship/engines,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "nQ" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -2450,7 +2545,7 @@
 /obj/item/storage/box/shotgunshells,
 /obj/item/gun/projectile/shotgun/pump/combat,
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "nR" = (
 /obj/structure/table/steel,
 /obj/item/trash/proteinbar{
@@ -2465,7 +2560,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "nS" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 1
@@ -2475,10 +2570,21 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "nT" = (
 /turf/unsimulated/floor/asteroid/ash,
 /area/mine)
+"nV" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_north)
 "nX" = (
 /obj/structure/table/steel,
 /obj/item/gun/projectile/revolver/lemat,
@@ -2486,11 +2592,15 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "nY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/hallway_south)
+"oa" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/full,
+/area/goonbase/eva)
 "oc" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 4
@@ -2500,11 +2610,11 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "od" = (
 /obj/machinery/cryopod,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "oe" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
@@ -2512,16 +2622,16 @@
 /obj/machinery/optable,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "of" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "op" = (
 /obj/machinery/media/jukebox,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "os" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2535,7 +2645,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "ov" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
@@ -2558,7 +2668,7 @@
 	pixel_x = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "ox" = (
 /obj/structure/table/steel,
 /obj/item/paper_bin{
@@ -2570,7 +2680,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "oz" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -2578,13 +2688,16 @@
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/fruit_smudge,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
+"oB" = (
+/turf/simulated/wall/r_wall,
+/area/goonbase/living)
 "oE" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "oH" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/cable{
@@ -2593,7 +2706,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "oI" = (
 /obj/random/dirt_75,
 /obj/random/tool{
@@ -2603,12 +2716,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "oK" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/eva)
 "oL" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 2
@@ -2620,7 +2733,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "oP" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2651,18 +2764,18 @@
 	pixel_y = -1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "oT" = (
 /obj/machinery/papershredder,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "oU" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "oX" = (
 /obj/structure/closet/walllocker/medical{
 	pixel_y = -32
@@ -2672,7 +2785,7 @@
 /obj/item/reagent_containers/blood/OMinus,
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "pa" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 4
@@ -2680,7 +2793,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "pd" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
@@ -2689,7 +2802,7 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "pf" = (
 /obj/structure/table/steel,
 /obj/item/deck/cards{
@@ -2698,7 +2811,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "pn" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/toilet{
@@ -2707,17 +2820,23 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/living)
 "pp" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/starboard)
+"pq" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/atmos)
 "pr" = (
 /obj/effect/landmark/entry_point/east{
 	name = "port, medbay"
 	},
 /turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "pt" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/sink/kitchen{
@@ -2727,7 +2846,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "pw" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/random/soap{
@@ -2739,14 +2858,14 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/living)
 "px" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/tech_supply,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/power)
 "pz" = (
 /obj/structure/table/steel,
 /obj/effect/floor_decal/corner/grey/full{
@@ -2758,13 +2877,13 @@
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "pB" = (
 /obj/structure/reagent_dispensers/water_cooler{
 	pixel_x = -9
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/kitchen)
 "pI" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -2774,7 +2893,7 @@
 	},
 /obj/machinery/shipsensors,
 /turf/simulated/floor/airless,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "pJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
@@ -2782,13 +2901,13 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "pN" = (
 /obj/effect/landmark/entry_point/east{
 	name = "port, power"
 	},
 /turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/port)
 "pO" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -2801,7 +2920,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "pQ" = (
 /obj/random/dirt_75,
 /obj/structure/cable{
@@ -2814,7 +2933,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "pT" = (
 /obj/item/storage/pill_bottle/dice/gaming,
 /obj/item/trash/cigbutt{
@@ -2828,7 +2947,7 @@
 	},
 /obj/structure/table/wood,
 /turf/simulated/floor/carpet,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "pU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2836,7 +2955,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "pV" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/steel,
@@ -2853,14 +2972,17 @@
 	pixel_x = -1
 	},
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
+"pW" = (
+/turf/simulated/wall,
+/area/goonbase/atmos)
 "pZ" = (
 /obj/random/dirt_75,
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "qb" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -2881,13 +3003,13 @@
 	},
 /obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "qf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/equipment)
 "qj" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/black/med,
@@ -2897,7 +3019,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "qq" = (
 /obj/structure/table/steel,
 /obj/effect/floor_decal/corner/blue{
@@ -2908,13 +3030,13 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "qr" = (
 /obj/effect/floor_decal/industrial/loading/grey{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/equipment)
 "qt" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
@@ -2929,7 +3051,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "qv" = (
 /obj/structure/closet/crate,
 /obj/item/coin/diamond,
@@ -2942,7 +3064,7 @@
 /obj/item/clothing/accessory/crucifix/gold,
 /obj/random/melee/highvalue,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "qw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2953,7 +3075,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "qy" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
@@ -2961,7 +3083,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "qz" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
@@ -2975,7 +3097,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "qC" = (
 /obj/structure/table/wood,
 /obj/random/dirt_75,
@@ -2989,7 +3111,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "qD" = (
 /obj/item/clothing/head/collectable/paper{
 	pixel_y = -3;
@@ -2999,7 +3121,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "qF" = (
 /obj/effect/floor_decal/corner/blue,
 /obj/structure/cable{
@@ -3009,13 +3131,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "qJ" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "qL" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -3029,7 +3151,7 @@
 	pixel_x = 7
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "qM" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -3040,7 +3162,7 @@
 	pixel_x = 8
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "qN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
@@ -3049,7 +3171,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "qO" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -3067,12 +3189,22 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "qP" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/stack/liquidbags/half_full{
+	pixel_x = -3
+	},
+/obj/item/stack/barbed_wire/half_full{
+	pixel_x = 3;
+	pixel_y = 2
+	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/equipment)
+"qR" = (
+/turf/simulated/floor/plating,
+/area/shuttle/goon_shuttle/port)
 "qW" = (
 /obj/structure/reagent_dispensers/radioactive_waste,
 /obj/effect/decal/cleanable/acid_remnants{
@@ -3088,10 +3220,10 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "qX" = (
 /turf/simulated/wall/r_wall,
-/area/mine)
+/area/goonbase/equipment)
 "rc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3101,17 +3233,22 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "ri" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
+"rj" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_shuttle/starboard)
 "rl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/hallway_north)
 "rm" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -3129,13 +3266,17 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "rn" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_north)
+"ro" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/turf/simulated/floor/plating,
+/area/goonbase/medbay)
 "rq" = (
 /obj/structure/closet/crate/medical,
 /obj/item/roller,
@@ -3146,20 +3287,20 @@
 /obj/random/medical,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "ru" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "rw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
 /turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
 "rD" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/black,
@@ -3167,12 +3308,12 @@
 	identifier = "goon"
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "rF" = (
 /obj/random/dirt_75,
 /obj/machinery/pipedispenser,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "rN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -3182,7 +3323,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/eva)
 "rU" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/light{
@@ -3191,7 +3332,11 @@
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
+"rV" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/goonbase/hallway_south)
 "rW" = (
 /obj/structure/reagent_dispensers/radioactive_waste,
 /obj/effect/decal/cleanable/acid_remnants,
@@ -3200,10 +3345,11 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
-"sa" = (
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/storage)
+/area/goonbase/maint_south)
+"rY" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/goonbase/hallway_north)
 "sc" = (
 /obj/item/trash/tuna{
 	pixel_x = 6;
@@ -3213,7 +3359,7 @@
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/living)
 "se" = (
 /obj/random/dirt_75,
 /turf/simulated/floor/airless,
@@ -3224,7 +3370,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "sh" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/condiment/flour,
@@ -3238,14 +3384,14 @@
 /obj/item/reagent_containers/food/condiment/sugar,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "sl" = (
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "sp" = (
 /obj/random/dirt_75,
 /obj/random/tech_supply{
@@ -3258,45 +3404,51 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
+"sx" = (
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/goon_shuttle/med)
 "sz" = (
 /obj/random/dirt_75,
 /obj/structure/reagent_dispensers/cookingoil,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "sB" = (
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
 "sC" = (
 /obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "sI" = (
 /obj/random/dirt_75,
 /obj/structure/trash_pile,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "sK" = (
 /obj/structure/structural_support{
 	pixel_y = 8
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating/asteroid,
-/area/mine)
+/area/goonbase/maint_south)
 "sM" = (
 /obj/structure/bed/stool/chair/office/light{
 	dir = 4
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/atmos)
 "sN" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/purple,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "sO" = (
 /obj/structure/closet,
 /obj/effect/floor_decal/corner/blue{
@@ -3315,13 +3467,13 @@
 /obj/item/clothing/head/ushanka/dominia,
 /obj/item/clothing/suit/storage/toggle/bomber,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "sP" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "sS" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating/asteroid,
@@ -3330,7 +3482,7 @@
 /obj/structure/bed/stool/chair/office/dark,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "sX" = (
 /obj/structure/closet/crate,
 /obj/random/spacecash,
@@ -3343,30 +3495,30 @@
 /obj/random/spacecash,
 /obj/random/spacecash,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "sY" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating/asteroid,
-/area/mine)
+/area/goonbase/equipment)
 "sZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "te" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "tp" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/suit/storage/toggle/leather_jacket/flight,
 /obj/item/clothing/gloves/black,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "tr" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/void/mining,
@@ -3375,7 +3527,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "tt" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
@@ -3388,7 +3540,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "tu" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -3397,13 +3549,13 @@
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "tv" = (
 /obj/structure/extinguisher_cabinet/north{
 	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "tw" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 9
@@ -3421,7 +3573,7 @@
 /obj/item/tank/jetpack/void,
 /obj/item/weldingtool/hugetank,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "tF" = (
 /obj/structure/bed/stool/chair/office/light{
 	dir = 8
@@ -3429,14 +3581,11 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
-"tI" = (
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/starboard)
+/area/goonbase/power)
 "tL" = (
 /obj/machinery/portable_atmospherics/canister/empty/hydrogen,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
 "tN" = (
 /obj/structure/reagent_dispensers/radioactive_waste{
 	pixel_y = -8
@@ -3457,25 +3606,25 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "tR" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "tS" = (
 /obj/structure/structural_support{
 	pixel_y = 8
 	},
 /turf/simulated/floor/plating/asteroid,
-/area/mine)
+/area/goonbase/hallway_north)
 "ua" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "ui" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -3486,7 +3635,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "um" = (
 /obj/structure/reagent_dispensers/radioactive_waste{
 	pixel_x = 12;
@@ -3505,13 +3654,13 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "un" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "uq" = (
 /obj/machinery/power/rtg,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -3520,7 +3669,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "uu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -3528,13 +3677,13 @@
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "uv" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/appliance/cooker/stove,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "uy" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
@@ -3543,13 +3692,16 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
+"uz" = (
+/turf/simulated/floor/tiled,
+/area/goonbase/kitchen)
 "uB" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
 /turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/starboard)
 "uD" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/steel,
@@ -3562,12 +3714,12 @@
 	pixel_x = -4
 	},
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "uE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "uG" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -3581,14 +3733,14 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "uJ" = (
 /obj/effect/floor_decal/industrial/loading/grey{
 	dir = 1
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/equipment)
 "uN" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -3604,7 +3756,7 @@
 	},
 /obj/random/pottedplant,
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
 "uU" = (
 /obj/structure/trash_pile,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
@@ -3612,7 +3764,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "va" = (
 /obj/item/trash/cigbutt{
 	pixel_y = 7;
@@ -3620,7 +3772,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "vc" = (
 /obj/structure/table/steel,
 /obj/item/clothing/head/cowboy{
@@ -3632,14 +3784,18 @@
 	pixel_y = -2
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
+"vd" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "vh" = (
 /obj/structure/sign/emergency/meetingpoint{
 	pixel_y = 31
 	},
 /obj/machinery/media/jukebox,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "vi" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 1
@@ -3651,7 +3807,10 @@
 /obj/item/clothing/suit/storage/toggle/leather_jacket/designer/black,
 /obj/item/clothing/accessory/tajaran/charm/stone,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
+"vk" = (
+/turf/simulated/floor/tiled/full,
+/area/goonbase/hallway_north)
 "vq" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/item/towel/random{
@@ -3661,14 +3820,17 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/living)
+"vr" = (
+/turf/simulated/wall/r_wall,
+/area/goonbase/maint_south)
 "vs" = (
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/eva)
 "vt" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/storage/box/zipties{
@@ -3685,7 +3847,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/mine)
+/area/goonbase/equipment)
 "vv" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -3695,7 +3857,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "vw" = (
 /obj/random/dirt_75,
 /obj/structure/barricade/metal{
@@ -3712,12 +3874,12 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "vx" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/iv_drip,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "vz" = (
 /turf/simulated/floor/airless/ceiling,
 /area/mine)
@@ -3725,7 +3887,7 @@
 /obj/structure/table/steel,
 /obj/item/tank/air,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "vC" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 1
@@ -3740,7 +3902,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "vD" = (
 /obj/structure/table/steel,
 /obj/item/trash/raisins,
@@ -3749,18 +3911,18 @@
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "vG" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "vH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "vI" = (
 /obj/structure/table/wood,
 /obj/item/material/ashtray/bronze{
@@ -3774,15 +3936,15 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "vJ" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "vM" = (
 /obj/structure/closet/cabinet,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "vR" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -3794,11 +3956,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "vZ" = (
 /obj/effect/floor_decal/corner/grey,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "wb" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
@@ -3808,13 +3970,10 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
-"wh" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
+/area/goonbase/eva)
+"wc" = (
+/turf/simulated/wall/r_wall,
+/area/goonbase/atmos)
 "wo" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/cable{
@@ -3823,12 +3982,12 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "wp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
 "ws" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 4
@@ -3838,7 +3997,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "wu" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -3850,7 +4009,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
 "wA" = (
 /obj/random/dirt_75,
 /obj/item/pickaxe/drill{
@@ -3858,7 +4017,7 @@
 	pixel_x = 9
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/equipment)
 "wB" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
@@ -3871,14 +4030,14 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "wD" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "wG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3888,7 +4047,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/med)
 "wH" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -3899,24 +4058,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/living)
 "wJ" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /obj/structure/bed/stool/chair/folding,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/north,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "wL" = (
 /obj/structure/trash_pile,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "wS" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "wU" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
@@ -3930,7 +4093,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "wX" = (
 /obj/random/dirt_75,
 /obj/item/trash/cigbutt{
@@ -3938,13 +4101,13 @@
 	pixel_y = -10
 	},
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "wY" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/living)
 "wZ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3952,7 +4115,12 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
+"xc" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/goonbase/hallway_north)
 "xf" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/yarn{
@@ -3960,7 +4128,7 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "xi" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/cheesiehonkers,
@@ -3974,7 +4142,7 @@
 /obj/item/reagent_containers/food/snacks/no_raisin,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
+/area/shuttle/goon_shuttle/living)
 "xn" = (
 /obj/effect/decal/cleanable/spiderling_remains,
 /obj/machinery/light{
@@ -3984,7 +4152,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
 "xp" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/black,
@@ -3993,14 +4161,14 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "xr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "xs" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -4009,7 +4177,10 @@
 /obj/item/ammo_magazine/a10mm,
 /obj/item/gun/projectile/automatic/c20r,
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
+"xu" = (
+/turf/simulated/wall/r_wall,
+/area/goonbase/hallway_south)
 "xy" = (
 /obj/effect/floor_decal/corner/grey/full{
 	dir = 8
@@ -4019,7 +4190,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "xz" = (
 /obj/machinery/power/rtg,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -4028,13 +4199,16 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
+"xB" = (
+/turf/simulated/floor/plating,
+/area/goonbase/maint_south)
 "xE" = (
 /obj/structure/bed/stool/chair/folding{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/living)
 "xH" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
@@ -4043,7 +4217,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "xJ" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/shower{
@@ -4061,11 +4235,16 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/living)
 "xK" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
+"xL" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full,
+/area/goonbase/living)
 "xM" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/storage/pill_bottle/mortaphenyl{
@@ -4084,7 +4263,7 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/mine)
+/area/goonbase/equipment)
 "xO" = (
 /obj/item/trash/cigbutt,
 /obj/effect/floor_decal/spline/plain/black{
@@ -4098,7 +4277,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "xQ" = (
 /obj/structure/table/steel,
 /obj/item/device/versebook/trinary{
@@ -4106,7 +4285,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "xX" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -4117,7 +4296,7 @@
 /obj/item/clothing/head/helmet/space/emergency,
 /obj/item/clothing/head/helmet/space/emergency,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "xY" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/cable{
@@ -4126,13 +4305,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "xZ" = (
 /obj/structure/reagent_dispensers/keg/beerkeg/rice,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_north)
+"yb" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_shuttle/port)
 "ye" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -4140,13 +4323,16 @@
 	},
 /obj/machinery/power/apc/empty/north,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "yf" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
 	},
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
+"yk" = (
+/turf/simulated/floor/tiled,
+/area/goonbase/living)
 "yl" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/structure/closet/crate,
@@ -4163,20 +4349,20 @@
 /obj/item/clothing/under/rank/sol/army/service,
 /obj/item/clothing/under/rank/sol/army/service/officer,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "ym" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "yp" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
 /obj/item/trash/cheesie,
 /turf/simulated/floor/carpet,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "yq" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/storage/toolbox/electrical{
@@ -4184,13 +4370,13 @@
 	},
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled/dark/full,
-/area/mine)
+/area/goonbase/equipment)
 "yr" = (
 /obj/random/junk,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "ys" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -4203,7 +4389,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "yx" = (
 /obj/effect/landmark/entry_point/north{
 	name = "north, starboard engines"
@@ -4212,25 +4398,28 @@
 	dir = 1
 	},
 /turf/simulated/floor/airless,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
 "yy" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
+"yC" = (
+/turf/simulated/wall,
+/area/goonbase/maint_north)
 "yD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "yH" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "yJ" = (
 /obj/effect/decal/cleanable/acid_remnants{
 	pixel_y = -7;
@@ -4241,7 +4430,7 @@
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "yP" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -4250,14 +4439,17 @@
 /obj/random/dirt_75,
 /obj/machinery/power/apc/empty/north,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
+"yQ" = (
+/turf/simulated/floor/tiled/full,
+/area/goonbase/kitchen)
 "yR" = (
 /obj/random/dirt_75,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "yS" = (
 /obj/random/dirt_75,
 /obj/random/tech_supply{
@@ -4265,7 +4457,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "yW" = (
 /obj/structure/bed/padded/bunk{
 	pixel_y = 0
@@ -4277,7 +4469,7 @@
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "yX" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
@@ -4290,7 +4482,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "zb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
@@ -4302,10 +4494,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plating,
-/area/mine)
-"zd" = (
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/bridge)
+/area/goonbase/maint_airlock)
 "zk" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/cable{
@@ -4318,13 +4507,22 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "zn" = (
 /obj/structure/closet,
 /obj/item/clothing/head/softcap,
 /obj/item/clothing/accessory/holster/waist,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
+"zp" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_shuttle/storage)
+"zq" = (
+/obj/random/dirt_75,
+/obj/random/loot,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_south)
 "zr" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -4337,13 +4535,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_north)
 "zs" = (
 /obj/structure/table/steel,
 /obj/item/device/healthanalyzer,
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "zz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4356,7 +4554,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/maint_north)
 "zB" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -4369,7 +4567,7 @@
 /obj/random/medical,
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "zC" = (
 /obj/structure/bed/padded/bunk{
 	pixel_y = 0
@@ -4377,7 +4575,7 @@
 /obj/item/bedsheet/black,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "zD" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
@@ -4386,7 +4584,7 @@
 /obj/item/target/syndicate,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "zM" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 6
@@ -4395,7 +4593,14 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
+"zQ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 2
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_airlock)
 "zU" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -4405,7 +4610,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "zW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4422,7 +4627,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Ac" = (
 /obj/machinery/atmospherics/portables_connector/aux{
 	dir = 8
@@ -4430,7 +4635,10 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
+"Af" = (
+/turf/simulated/wall/r_wall,
+/area/goonbase/power)
 "Ag" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
@@ -4446,13 +4654,13 @@
 	pixel_x = 2
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/atmos)
 "Ah" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "Al" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4465,7 +4673,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
+"Ap" = (
+/obj/structure/structural_support{
+	pixel_y = 8
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
+/area/goonbase/hallway_north)
 "Au" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -4476,7 +4691,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/power)
 "Aw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4488,7 +4703,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "Ay" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -4501,20 +4716,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "AA" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
 /turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
 "AI" = (
 /obj/structure/bed/stool/padded/orange{
 	dir = 2
 	},
 /turf/simulated/floor/carpet/red,
-/area/mine)
+/area/goonbase/living)
 "AL" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -4522,11 +4740,11 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "AR" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
 "AS" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -4534,18 +4752,22 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "AU" = (
 /obj/structure/platform,
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "AV" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
+"AW" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_shuttle/port)
 "Ba" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -4554,7 +4776,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "Be" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/food/snacks/liquidfood,
@@ -4570,7 +4792,20 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
+/area/shuttle/goon_shuttle/living)
+"Bf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/hallway_north)
 "Bm" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate,
@@ -4583,7 +4818,7 @@
 	pixel_x = 6
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Bn" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/floor_decal/spline/plain/black{
@@ -4594,13 +4829,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
-"Bo" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/storage)
 "Bq" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/glass/rag,
@@ -4613,7 +4842,7 @@
 	pixel_x = -6
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "Br" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -4626,18 +4855,34 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "Bt" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
+"Bu" = (
+/turf/simulated/wall/r_wall,
+/area/goonbase/maint_north)
+"Bw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/maint_north)
 "By" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "Bz" = (
 /obj/structure/table/steel,
 /obj/item/gamehelm/pink{
@@ -4646,7 +4891,13 @@
 	pixel_x = 3
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
+"BC" = (
+/obj/effect/floor_decal/corner/grey{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_north)
 "BE" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 9
@@ -4655,7 +4906,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "BH" = (
 /obj/structure/table/steel,
 /obj/effect/floor_decal/corner/grey{
@@ -4665,19 +4916,19 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "BI" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "BJ" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "BK" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/structure/cable{
@@ -4687,7 +4938,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "BM" = (
 /obj/item/paper/goon_base/notice_secret_back_exit{
 	pixel_x = 4;
@@ -4696,7 +4947,12 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/equipment)
+"BO" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_south)
 "BW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4712,7 +4968,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_north)
 "Ca" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4721,7 +4977,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Cb" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid{
@@ -4740,7 +4996,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/eva)
 "Ce" = (
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4750,13 +5006,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Cf" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "Ch" = (
 /obj/effect/floor_decal/corner/red/full{
 	dir = 4
@@ -4767,7 +5023,7 @@
 /obj/random/junk,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "Cj" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -4775,13 +5031,18 @@
 	dir = 8
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "Cm" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 8
 	},
 /turf/unsimulated/floor/asteroid/ash/rocky,
 /area/mine)
+"Co" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/equipment)
 "Cr" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
@@ -4790,7 +5051,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "Cz" = (
 /obj/random/junk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4800,7 +5061,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
+"CL" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_shuttle/starboard)
 "CR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -4810,11 +5075,11 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "CS" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "CY" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
@@ -4824,19 +5089,19 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "CZ" = (
 /obj/item/melee/baton/stunrod{
 	pixel_x = 9;
 	pixel_y = -4
 	},
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "Df" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "Dj" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 5
@@ -4846,13 +5111,13 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "Dl" = (
 /obj/effect/landmark/entry_point/west{
 	name = "starboard, substation"
 	},
 /turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "Dm" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -4862,10 +5127,10 @@
 	},
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/airless,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "Do" = (
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "Dr" = (
 /turf/simulated/wall,
 /area/mine)
@@ -4873,7 +5138,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "Dx" = (
 /obj/random/dirt_75,
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -4885,7 +5150,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "DB" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 9
@@ -4901,19 +5166,31 @@
 /obj/item/organ/internal/heart,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
+"DF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/goon_shuttle/living)
 "DI" = (
 /obj/structure/table/steel,
 /obj/item/tank/air,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "DJ" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
+"DL" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/goon_shuttle/living)
 "DN" = (
 /obj/effect/floor_decal/spline/plain/black,
 /obj/effect/decal/cleanable/dirt,
@@ -4925,14 +5202,14 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "DO" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/storage/toggle/leather_jacket,
 /obj/item/clothing/glasses/sunglasses/fluff,
 /obj/item/storage/box/fancy/cigarettes,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "DR" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -4940,11 +5217,11 @@
 /obj/item/clothing/suit/space/emergency,
 /obj/item/clothing/head/helmet/space/emergency,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/equipment)
 "DV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/hallway_south)
 "DY" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
@@ -4954,7 +5231,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "Ea" = (
 /obj/random/dirt_75,
 /obj/item/trash/cigbutt{
@@ -4971,8 +5248,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/living)
+"Ee" = (
+/obj/structure/trash_pile,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/hallway_north)
 "Ek" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /turf/unsimulated/floor/asteroid/ash/rocky,
@@ -4989,12 +5274,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "Em" = (
 /obj/structure/curtain/open/medical,
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "Ep" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5002,7 +5287,7 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Eq" = (
 /obj/random/dirt_75,
 /obj/random/tech_supply{
@@ -5014,20 +5299,20 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "Ew" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 2
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "Ex" = (
 /obj/structure/bed/stool/padded/orange{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/red,
-/area/mine)
+/area/goonbase/living)
 "Ez" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -5049,42 +5334,42 @@
 	pixel_x = -11
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "EE" = (
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "EI" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/kitchen)
 "EJ" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "EL" = (
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/hallway_north)
 "EP" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "EQ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "EV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
@@ -5094,7 +5379,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "EZ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -5105,22 +5390,26 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
+"Fa" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_airlock)
 "Fb" = (
 /obj/structure/bed/stool,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "Fc" = (
 /turf/simulated/floor/carpet/red,
-/area/mine)
+/area/goonbase/living)
 "Fe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "Fh" = (
 /obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -5131,14 +5420,14 @@
 /obj/random/dirt_75,
 /obj/random/tech_supply,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/atmos)
 "Fp" = (
 /obj/random/tech_supply{
 	pixel_x = -9;
 	pixel_y = 5
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "Ft" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 6
@@ -5151,26 +5440,26 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "Fv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "Fz" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "FB" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/yellow,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "FD" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -5180,18 +5469,18 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/power)
 "FE" = (
 /obj/random/dirt_75,
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "FF" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
 /turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "FL" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 6
@@ -5199,11 +5488,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "FO" = (
 /obj/item/trash/liquidfood,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "FP" = (
 /obj/structure/reagent_dispensers/radioactive_waste{
 	pixel_x = 6
@@ -5214,7 +5503,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "FR" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
@@ -5225,24 +5514,24 @@
 	identifier = "goon_boss"
 	},
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
 "FT" = (
 /obj/structure/closet/walllocker{
 	pixel_x = 30
 	},
 /obj/item/storage/bag/inflatable,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "FU" = (
 /obj/effect/floor_decal/corner/grey/full{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "FZ" = (
 /obj/item/handcuffs/cable{
 	pixel_y = -11;
-	pixel_x = -5
+	pixel_x = -13
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -5250,14 +5539,18 @@
 	pixel_x = -9;
 	pixel_y = 5
 	},
+/obj/machinery/power/apc/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/living)
 "Ga" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "Gb" = (
 /obj/structure/table/rack,
 /obj/item/clothing/shoes/magboots{
@@ -5285,7 +5578,7 @@
 	pixel_y = -1
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/eva)
 "Gc" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/condiment/flour,
@@ -5302,7 +5595,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "Gh" = (
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5312,12 +5605,12 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "Gi" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Gn" = (
 /obj/structure/table/steel,
 /obj/random/tool{
@@ -5329,7 +5622,7 @@
 	pixel_x = 3
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "Gp" = (
 /obj/effect/step_trigger/teleporter,
 /turf/template_noop,
@@ -5341,27 +5634,40 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
+"Gv" = (
+/turf/simulated/wall,
+/area/goonbase/maint_south)
 "Gw" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "Gy" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
+/area/shuttle/goon_shuttle/living)
+"Gz" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/living)
 "GB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "GF" = (
 /obj/structure/table/rack,
 /obj/item/clothing/mask/gas/syndicate{
@@ -5396,7 +5702,10 @@
 	pixel_y = -6
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
+"GG" = (
+/turf/simulated/wall,
+/area/goonbase/hallway_south)
 "GH" = (
 /obj/random/dirt_75,
 /obj/machinery/vending/engineering{
@@ -5407,7 +5716,7 @@
 	},
 /obj/machinery/power/apc/north,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "GI" = (
 /obj/random/dirt_75,
 /obj/item/clothing/gloves/yellow{
@@ -5415,7 +5724,7 @@
 	pixel_y = 7
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "GL" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -5424,7 +5733,7 @@
 	dir = 2
 	},
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
 "GM" = (
 /obj/structure/closet,
 /obj/effect/floor_decal/corner/blue{
@@ -5435,21 +5744,29 @@
 /obj/item/clothing/suit/storage/toggle/leather_jacket/military/old/alt,
 /obj/item/storage/belt/fannypack/recolorable/random,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "GP" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
+"GV" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_airlock)
+"GX" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
+/area/goonbase/maint_north)
 "GY" = (
 /obj/effect/overmap/visitable/ship/landable/goon_ship,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "GZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "Hb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5458,7 +5775,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "Hd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -5466,7 +5783,7 @@
 /obj/random/dirt_75,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "Hf" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -5474,7 +5791,12 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
+"Ho" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_south)
 "Hp" = (
 /obj/structure/bed,
 /obj/random/dirt_75,
@@ -5483,7 +5805,7 @@
 	identifier = "goon_prisoner"
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "Hs" = (
 /obj/structure/table/steel,
 /obj/item/storage/firstaid/o2{
@@ -5495,13 +5817,13 @@
 	},
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "Ht" = (
 /obj/effect/landmark/entry_point/north{
 	name = "aft, airlock"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "Hw" = (
 /obj/item/pickaxe{
 	pixel_y = -9
@@ -5515,7 +5837,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "Hy" = (
 /obj/structure/table/steel,
 /obj/item/trash/snacktray{
@@ -5526,7 +5848,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "HB" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -5539,11 +5861,11 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "HC" = (
 /obj/machinery/smartfridge/foodheater,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "HD" = (
 /obj/random/dirt_75,
 /obj/structure/cable{
@@ -5555,14 +5877,14 @@
 	},
 /obj/item/paper/goon_base/note,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "HF" = (
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "HH" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
@@ -5575,13 +5897,13 @@
 	},
 /obj/random/pottedplant,
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
 "HK" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 2
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "HU" = (
 /obj/structure/closet/cabinet{
 	pixel_y = 0
@@ -5615,13 +5937,13 @@
 	},
 /obj/item/reagent_containers/food/drinks/bottle/small/beer/light,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/kitchen)
 "HV" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "HW" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/covert,
@@ -5629,14 +5951,14 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "HY" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/item/trash/cigbutt/cigarbutt/alt,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "HZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5648,7 +5970,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Ia" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
@@ -5659,11 +5981,7 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/cee,
 /turf/simulated/floor/plating,
-/area/mine)
-"Ib" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/goonbase/hallway_south)
 "Ic" = (
 /obj/structure/closet/crate,
 /obj/random/dirt_75,
@@ -5683,7 +6001,7 @@
 	pixel_x = 11
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "Id" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 8
@@ -5692,20 +6010,31 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "Ie" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
 /obj/random/hardhat,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/atmos)
 "Ig" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
+"Io" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/goonbase/kitchen)
 "Iy" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -5715,7 +6044,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "Iz" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -5725,12 +6054,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "IA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux,
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "IB" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/power/smes/buildable/horizon_shuttle,
@@ -5740,18 +6069,18 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "IF" = (
 /obj/random/junk{
 	pixel_x = -9
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/living)
 "IG" = (
 /obj/effect/floor_decal/corner/yellow/diagonal,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "II" = (
 /obj/random/dirt_75,
 /obj/structure/cable{
@@ -5764,14 +6093,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "IL" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/machinery/hologram/holopad/long_range,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "IN" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
@@ -5782,7 +6111,10 @@
 	pixel_y = -8
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
+"IP" = (
+/turf/simulated/wall/r_wall,
+/area/goonbase/eva)
 "IQ" = (
 /obj/structure/bed/stool/chair/sofa/left/red{
 	dir = 8
@@ -5797,16 +6129,16 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
 "IS" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "IU" = (
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "IV" = (
 /obj/structure/filingcabinet/chestdrawer{
 	pixel_x = 6;
@@ -5814,13 +6146,13 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "IW" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "IX" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/space/syndicate/black/red,
@@ -5830,7 +6162,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "IZ" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 8
@@ -5840,7 +6172,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "Ja" = (
 /obj/random/dirt_75,
 /obj/item/weldingtool/emergency{
@@ -5860,26 +6192,29 @@
 	},
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
+"Ji" = (
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_south)
 "Jl" = (
 /obj/random/dirt_75,
 /obj/random/loot,
 /obj/structure/table/rack,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Jm" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/machinery/chem_heater,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "Jn" = (
 /obj/random/dirt_75,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "Jo" = (
 /obj/structure/bed/padded/bunk{
 	pixel_y = 0
@@ -5891,17 +6226,17 @@
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "Jp" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "Jq" = (
 /obj/effect/floor_decal/corner/lime/diagonal{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "Jw" = (
 /obj/machinery/atmospherics/portables_connector/aux{
 	dir = 1
@@ -5910,21 +6245,21 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "Jx" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/item/trash/match,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "Jz" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "JC" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
@@ -5937,7 +6272,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "JD" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -5960,7 +6295,7 @@
 	pixel_y = -6
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "JF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5972,7 +6307,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "JJ" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -5982,7 +6317,11 @@
 	pixel_y = -10
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
+"JK" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_south)
 "JU" = (
 /obj/random/dirt_75,
 /obj/structure/barricade/metal{
@@ -5993,7 +6332,7 @@
 	},
 /obj/item/ammo_casing/c45/practice,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "JV" = (
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6003,14 +6342,26 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "JW" = (
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/goonbase/atmos)
+"JX" = (
+/obj/structure/trash_pile,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_north)
+"JY" = (
+/turf/simulated/floor/plating,
+/area/shuttle/goon_shuttle/starboard)
 "JZ" = (
 /obj/machinery/power/portgen/basic/advanced,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "Ka" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6019,7 +6370,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
+"Kb" = (
+/obj/structure/structural_support{
+	pixel_y = 8
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
+/area/goonbase/hallway_south)
 "Ke" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -6048,13 +6406,17 @@
 	pixel_x = 2
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
+"Kg" = (
+/obj/machinery/atmospherics/binary/pump/high_power,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_shuttle/starboard)
 "Ki" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
 "Kj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -6064,7 +6426,13 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
+"Kp" = (
+/obj/machinery/door/airlock/glass,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/plating,
+/area/goonbase/hallway_north)
 "Ks" = (
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/coffee/full{
@@ -6076,7 +6444,16 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/kitchen)
+"Kw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random/dirt_75,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_south)
 "KB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
@@ -6085,7 +6462,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "KD" = (
 /obj/structure/bed/stool/chair/office/light{
 	dir = 4
@@ -6093,7 +6470,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/living)
 "KE" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid{
@@ -6112,31 +6489,31 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "KF" = (
 /obj/structure/table/standard,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "KG" = (
 /obj/random/dirt_75,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "KJ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "KK" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/port)
 "KL" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/toilet{
@@ -6145,7 +6522,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/living)
 "KO" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
@@ -6154,7 +6531,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/equipment)
 "KR" = (
 /obj/effect/floor_decal/corner/grey/full{
 	dir = 4
@@ -6162,32 +6539,38 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "KS" = (
 /obj/structure/bed/stool/chair/folding{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/living)
+"KV" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/goon_shuttle/port)
 "KW" = (
 /obj/machinery/atmospherics/binary/pump/aux/on,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "KZ" = (
 /turf/simulated/wall{
 	can_open = 1;
 	color = "#DDDDDD"
 	},
-/area/mine)
+/area/goonbase/equipment)
 "La" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
 /obj/machinery/computer/ship/helm,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "Ld" = (
 /obj/effect/floor_decal/corner/grey/full{
 	dir = 8
@@ -6197,30 +6580,30 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "Lg" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
 /obj/machinery/computer/shuttle_control/explore/goon_ship,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "Lh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
 "Li" = (
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "Lm" = (
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Lq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6231,7 +6614,30 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
+"Lu" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/plating,
+/area/goonbase/atmos)
+"Lv" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/maint_south)
+"Lw" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full,
+/area/goonbase/living)
 "Lz" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid{
@@ -6250,13 +6656,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "LM" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "LS" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
@@ -6273,13 +6679,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "LY" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/structure/reagent_dispensers/coolanttank,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "LZ" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid{
@@ -6295,7 +6701,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Mf" = (
 /obj/structure/reagent_dispensers/radioactive_waste,
 /obj/effect/decal/cleanable/acid_remnants,
@@ -6314,7 +6720,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "Mh" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate/loot,
@@ -6322,7 +6728,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Mk" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -6345,7 +6751,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "Ml" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -6355,7 +6761,7 @@
 	},
 /obj/item/reagent_containers/syringe,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "Mm" = (
 /obj/structure/bed/stool/chair/folding{
 	dir = 8
@@ -6363,14 +6769,14 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "Mo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 10
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "Mu" = (
 /obj/effect/floor_decal/corner/grey/full,
 /obj/random/dirt_75,
@@ -6379,7 +6785,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "Mw" = (
 /turf/space,
 /area/space)
@@ -6393,7 +6799,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/eva)
+"My" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating/asteroid,
+/area/goonbase/hallway_north)
 "Mz" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
@@ -6401,7 +6812,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
 "MA" = (
 /obj/structure/reagent_dispensers/radioactive_waste,
 /obj/effect/decal/cleanable/acid_remnants,
@@ -6411,7 +6822,7 @@
 	pixel_y = -10
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "MB" = (
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/generic{
@@ -6419,12 +6830,12 @@
 	pixel_y = -8
 	},
 /turf/simulated/floor/plating/asteroid,
-/area/mine)
+/area/goonbase/hallway_south)
 "ME" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "MH" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
@@ -6432,7 +6843,26 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
+"MI" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/hallway_north)
 "MJ" = (
 /obj/structure/table/steel,
 /obj/item/paper/crumpled,
@@ -6448,10 +6878,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
-"MR" = (
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/bridge)
 "MS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -6462,14 +6889,14 @@
 	pixel_x = -6
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "MT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/phoron,
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "MV" = (
 /obj/effect/landmark/entry_point/north{
 	name = "aft, port engines"
@@ -6478,7 +6905,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/airless,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "MZ" = (
 /obj/item/paper/crumpled{
 	pixel_y = 13;
@@ -6490,16 +6917,16 @@
 	},
 /obj/machinery/power/apc/empty/south,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "Nc" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
 "Ne" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "Nf" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/rainbow,
@@ -6508,7 +6935,11 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
+"Ng" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
+/area/goonbase/kitchen)
 "Nh" = (
 /obj/random/dirt_75,
 /obj/machinery/portable_atmospherics/powered/scrubber,
@@ -6516,13 +6947,13 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Ni" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "Nk" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -6536,7 +6967,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_north)
+"Nl" = (
+/obj/random/dirt_75,
+/obj/random/loot,
+/obj/structure/table/rack,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_south)
 "Np" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/item/trash/cigbutt{
@@ -6550,18 +6987,18 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
 "Nq" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/air,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "Nr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "Nt" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/random/dirt_75,
@@ -6573,7 +7010,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/power)
 "Nz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6581,28 +7018,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "NA" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/living)
 "NB" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "NF" = (
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "NH" = (
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "NO" = (
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/generic{
@@ -6611,12 +7048,12 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "NP" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "NT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/reagent_containers/food/drinks/waterbottle{
@@ -6624,14 +7061,14 @@
 	pixel_y = 12
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "NU" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
 "NX" = (
 /obj/random/dirt_75,
 /obj/item/pipewrench{
@@ -6639,11 +7076,19 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "NY" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
+/area/shuttle/goon_shuttle/living)
+"Od" = (
+/obj/random/dirt_75,
+/obj/random/tech_supply{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/maint_airlock)
 "Og" = (
 /obj/structure/closet/crate/miningcart/ore,
 /turf/simulated/floor/airless/ceiling,
@@ -6663,14 +7108,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/eva)
 "Oo" = (
 /obj/structure/bed/stool/chair{
 	dir = 4
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/kitchen)
 "Or" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -6680,7 +7125,7 @@
 	pixel_x = -10
 	},
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
 "Os" = (
 /obj/random/dirt_75,
 /obj/item/trash/cigbutt{
@@ -6694,11 +7139,11 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/living)
 "Ow" = (
 /obj/random/dirt_75,
 /turf/simulated/floor/plating/asteroid,
-/area/mine)
+/area/goonbase/hallway_north)
 "Ox" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
@@ -6716,7 +7161,18 @@
 	pixel_y = 7
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
+"Oy" = (
+/obj/random/dirt_75,
+/obj/random/loot,
+/obj/structure/table/rack,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_airlock)
+"Oz" = (
+/obj/random/junk,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_north)
 "OA" = (
 /obj/structure/table/steel,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/mushroom{
@@ -6726,7 +7182,11 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
+"OF" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full,
+/area/goonbase/eva)
 "OH" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -6738,7 +7198,7 @@
 	},
 /obj/item/gun/projectile/automatic/rifle/dpra/gold,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "OI" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/clothing/glasses/sunglasses/aviator,
@@ -6755,7 +7215,7 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/mine)
+/area/goonbase/equipment)
 "OL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fuel_port/hydrogen/empty{
@@ -6763,7 +7223,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/empty/hydrogen,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
 "OM" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -6772,7 +7232,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "OP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6781,16 +7241,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "OQ" = (
 /obj/machinery/portable_atmospherics/canister/empty/air,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/mine)
-"OW" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+"OS" = (
+/turf/simulated/floor/exoplanet/barren,
+/area/goonbase/hallway_south)
 "OX" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -6804,7 +7263,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Pc" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -6816,7 +7275,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Pk" = (
 /obj/effect/overmap/visitable/sector/goon,
 /turf/simulated/mineral/surface,
@@ -6833,13 +7292,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "Pu" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "Pw" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 5
@@ -6856,7 +7315,7 @@
 /obj/machinery/bodyscanner,
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "PD" = (
 /obj/random/dirt_75,
 /obj/structure/cable{
@@ -6864,7 +7323,7 @@
 	},
 /obj/machinery/power/apc/north,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "PG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6878,12 +7337,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "PK" = (
 /obj/machinery/iv_drip,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "PL" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
@@ -6908,7 +7367,7 @@
 	pixel_x = -6
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "PO" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
@@ -6921,7 +7380,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
 "PV" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/storage/belt/utility/alt{
@@ -6962,33 +7421,33 @@
 	pixel_y = -9
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/mine)
+/area/goonbase/equipment)
 "PY" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/tech_supply,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "PZ" = (
 /obj/structure/table/rack,
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/mask/surgical/w,
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "Qc" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/oxygen,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "Qe" = (
 /obj/effect/decal/cleanable/generic{
 	pixel_x = 8
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "Qf" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4;
@@ -6996,18 +7455,18 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
+/area/shuttle/goon_shuttle/living)
 "Qg" = (
 /obj/effect/floor_decal/corner/grey/full{
 	dir = 1
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "Qh" = (
 /obj/item/trash/coffee,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "Qj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7020,7 +7479,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Qk" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -7032,7 +7491,10 @@
 	},
 /obj/structure/table/rack,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
+"Ql" = (
+/turf/simulated/wall,
+/area/goonbase/hallway_north)
 "Qm" = (
 /obj/random/dirt_75,
 /obj/item/clothing/shoes/magboots{
@@ -7040,13 +7502,19 @@
 	pixel_y = -12
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/eva)
+"Qu" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/goonbase/equipment)
 "Qv" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "Qw" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
@@ -7055,14 +7523,14 @@
 	pixel_y = -15
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "Qx" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "Qy" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -7077,13 +7545,16 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "Qz" = (
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
+/area/shuttle/goon_shuttle/storage)
+"QB" = (
+/turf/simulated/wall,
+/area/goonbase/eva)
 "QC" = (
 /turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/bridge)
 "QE" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
@@ -7095,7 +7566,7 @@
 	pixel_x = 2
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/power)
 "QK" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating/asteroid,
@@ -7109,7 +7580,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_north)
 "QO" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -7122,7 +7593,7 @@
 	pixel_y = -12
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "QP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
@@ -7131,13 +7602,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/asteroid,
-/area/mine)
+/area/goonbase/maint_south)
 "QQ" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "QR" = (
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7147,7 +7618,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "QS" = (
 /obj/structure/reagent_dispensers/radioactive_waste{
 	pixel_y = -6
@@ -7165,19 +7636,19 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "QT" = (
 /obj/machinery/atmospherics/binary/pump/high_power,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "QV" = (
 /obj/random/dirt_75,
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "QX" = (
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/equipment)
 "Rb" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -7186,10 +7657,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
-"Rc" = (
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/med)
+/area/goonbase/hallway_south)
 "Rd" = (
 /obj/structure/reagent_dispensers/radioactive_waste{
 	pixel_y = 6;
@@ -7202,7 +7670,7 @@
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "Rg" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 7
@@ -7211,7 +7679,12 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
+"Rh" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/tiled,
+/area/goonbase/hallway_south)
 "Ri" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/storage/box/freezer/organcooler{
@@ -7228,20 +7701,24 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
+/area/shuttle/goon_shuttle/living)
 "Rj" = (
 /obj/machinery/hologram/holopad/long_range,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/living)
 "Rl" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
 	},
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
+"Rn" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/turf/simulated/floor/plating,
+/area/goonbase/hallway_south)
 "Rt" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid{
@@ -7251,7 +7728,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/living)
 "Rv" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
@@ -7260,7 +7737,7 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/power)
 "Rx" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -7270,7 +7747,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Ry" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -7280,7 +7757,7 @@
 /obj/item/target,
 /obj/item/target,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "RD" = (
 /obj/structure/reagent_dispensers/radioactive_waste,
 /obj/effect/decal/cleanable/acid_remnants{
@@ -7294,7 +7771,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "RE" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/cable{
@@ -7306,7 +7783,21 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
+"RL" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/maint_south)
+"RO" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full,
+/area/goonbase/atmos)
 "RP" = (
 /obj/random/dirt_75,
 /turf/simulated/mineral/surface,
@@ -7318,7 +7809,7 @@
 	layer = 2.8
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "RR" = (
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
@@ -7326,7 +7817,7 @@
 /obj/random/junk,
 /obj/item/trash/can,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/kitchen)
 "RY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/dirt_75,
@@ -7337,13 +7828,16 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
+"RZ" = (
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/goon_shuttle/storage)
 "Sd" = (
 /obj/machinery/door/airlock/glass,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/medbay)
 "Se" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/food/snacks/meat,
@@ -7370,7 +7864,7 @@
 /obj/item/reagent_containers/food/drinks/carton/soymilk,
 /obj/item/reagent_containers/food/drinks/carton/milk,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "Sf" = (
 /obj/structure/table/steel,
 /obj/item/trash/proteinbar,
@@ -7378,7 +7872,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "Sj" = (
 /obj/random/dirt_75,
 /obj/structure/cable{
@@ -7391,7 +7885,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "Sk" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -7405,18 +7899,14 @@
 	pixel_y = 14
 	},
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "Sm" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/random/dirt_75,
-/obj/machinery/power/apc/north,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Su" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid{
@@ -7426,12 +7916,18 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/kitchen)
 "Sv" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
+"Sw" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/goon_shuttle/port)
 "Sx" = (
 /obj/item/stack/material/plasteel/full{
 	pixel_y = 4
@@ -7445,14 +7941,14 @@
 /obj/structure/table/reinforced/steel,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/equipment)
 "Sz" = (
 /obj/random/dirt_75,
 /obj/random/loot{
 	pixel_x = -11
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/maint_north)
 "SE" = (
 /obj/random/dirt_75,
 /obj/random/tech_supply{
@@ -7460,7 +7956,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "SF" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
@@ -7468,7 +7964,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/power)
 "SG" = (
 /obj/item/trash/chips/dirtberry{
 	pixel_x = 10;
@@ -7483,22 +7979,31 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "SH" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/aux,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
+"SI" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/goonbase/medbay)
 "SJ" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/living)
 "SK" = (
 /obj/item/trash/cigbutt,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
+"SL" = (
+/turf/simulated/wall,
+/area/goonbase/equipment)
 "SM" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -7508,7 +8013,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/power)
 "SU" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
@@ -7520,7 +8025,7 @@
 	pixel_y = -10
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/atmos)
 "SW" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 6
@@ -7530,28 +8035,28 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "SX" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "SZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "Tb" = (
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "Tc" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "Td" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -7560,12 +8065,18 @@
 	},
 /obj/machinery/power/apc/empty/west,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
+/area/shuttle/goon_shuttle/living)
 "Tj" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
+"Tn" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/plating,
+/area/goonbase/hallway_north)
 "To" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
@@ -7575,7 +8086,7 @@
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/oxygen,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "Tr" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/cable{
@@ -7584,15 +8095,15 @@
 	},
 /obj/machinery/power/apc/empty/west,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "Ts" = (
 /obj/effect/floor_decal/industrial/loading/grey,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/equipment)
 "Tt" = (
 /obj/machinery/vending/dinnerware/plastic,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "Tu" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
@@ -7609,11 +8120,11 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "Ty" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "TA" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -7622,7 +8133,13 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
+"TG" = (
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/obj/random/dirt_75,
+/turf/simulated/floor/exoplanet/barren,
+/area/goonbase/maint_south)
 "TH" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -7632,21 +8149,21 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
 "TJ" = (
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/hallway_south)
 "TN" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/kitchen)
 "TO" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "TQ" = (
 /obj/structure/table/rack,
 /obj/item/clothing/accessory/holster/thigh/brown{
@@ -7675,13 +8192,13 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "TW" = (
 /obj/effect/floor_decal/corner/red/full{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "Uc" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
@@ -7693,11 +8210,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
-"Ud" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/goonbase/hallway_south)
 "Uf" = (
 /obj/structure/closet/secure_closet/cabinet{
 	req_access = list(20)
@@ -7706,7 +8219,7 @@
 /obj/item/melee/energy/sword/pirate/generic,
 /obj/item/clothing/head/bandana/red,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "Uh" = (
 /obj/machinery/atmospherics/portables_connector/aux{
 	dir = 1
@@ -7714,24 +8227,24 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "Ui" = (
 /obj/effect/landmark/entry_point/south{
 	name = "fore, bridge"
 	},
 /turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "Uk" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "Ul" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
 	},
 /obj/machinery/computer/ship/sensors,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "Um" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -7740,7 +8253,7 @@
 	pixel_y = -8
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "Un" = (
 /obj/structure/table/steel,
 /obj/item/trash/stew{
@@ -7753,7 +8266,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/kitchen)
 "Up" = (
 /obj/structure/table/steel,
 /obj/item/material/knife{
@@ -7768,13 +8281,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
-"Uq" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/goon_ship/starboard)
+/area/goonbase/kitchen)
 "Ur" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7790,8 +8297,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
+"Uv" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full,
+/area/goonbase/kitchen)
 "Uz" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/handheld/pda/civilian{
@@ -7801,11 +8315,11 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_south)
 "UA" = (
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "UB" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -7825,32 +8339,41 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "UD" = (
 /obj/structure/table/rack,
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/syndicate/black,
 /obj/item/clothing/head/helmet/space/syndicate/black,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "UE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/storage)
+/area/shuttle/goon_shuttle/living)
+"UG" = (
+/obj/random/dirt_75,
+/obj/structure/trash_pile,
+/turf/simulated/floor/plating,
+/area/goonbase/maint_airlock)
 "UH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "UN" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
+"UP" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_shuttle/starboard)
 "UX" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/item/trash/cigbutt{
@@ -7859,7 +8382,7 @@
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "Vb" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/brown,
@@ -7871,14 +8394,14 @@
 	identifier = "goon"
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "Vc" = (
 /obj/machinery/atmospherics/binary/pump/aux/on{
 	dir = 8
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "Vi" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -7888,7 +8411,7 @@
 	pixel_x = 6
 	},
 /turf/simulated/floor/plating/asteroid,
-/area/mine)
+/area/goonbase/equipment)
 "Vj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -7897,7 +8420,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "Vk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -7908,14 +8431,14 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "Vo" = (
 /obj/structure/closet/walllocker/medical{
 	pixel_y = -32
 	},
 /obj/item/storage/firstaid/regular,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "Vq" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 9
@@ -7925,22 +8448,22 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "Vs" = (
 /obj/random/junk,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Vu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/goon_ship/bridge)
+/area/shuttle/goon_shuttle/bridge)
 "Vw" = (
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "Vx" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/fancy/chocolate_box{
@@ -7952,7 +8475,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "Vz" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop/preset/civilian{
@@ -7961,14 +8484,14 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "VB" = (
 /obj/machinery/chemical_dispenser/bar_alc/full{
 	dir = 1;
 	pixel_y = -2
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "VD" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -7987,10 +8510,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "VK" = (
 /turf/simulated/floor/tiled/dark/full,
-/area/mine)
+/area/goonbase/equipment)
 "VL" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/c45m/lebman,
@@ -8001,7 +8524,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "VR" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -8011,7 +8534,7 @@
 	pixel_x = 7
 	},
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "VY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8025,7 +8548,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_north)
+"VZ" = (
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/goon_shuttle/storage)
 "Wb" = (
 /obj/item/trash/can,
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -8035,7 +8561,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
 "Wk" = (
 /obj/machinery/vending/dinnerware,
 /obj/machinery/power/apc/north,
@@ -8043,7 +8569,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/kitchen)
 "Wn" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/under/rank/security/zavod,
@@ -8065,7 +8591,7 @@
 /obj/item/clothing/head/beanie/random,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/living)
 "Wq" = (
 /obj/random/dirt_75,
 /obj/random/loot,
@@ -8074,7 +8600,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 "Wt" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -8103,19 +8629,19 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "Wu" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Wv" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/reagent_dispensers/fueltank,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "Ww" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 10
@@ -8129,7 +8655,7 @@
 	pixel_x = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/medbay)
 "Wy" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner,
 /turf/unsimulated/floor/asteroid/ash/rocky,
@@ -8144,19 +8670,19 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "WB" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "WD" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/appliance/cooker/oven,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/kitchen)
 "WG" = (
 /obj/structure/table/steel,
 /obj/item/towel/random{
@@ -8168,39 +8694,42 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
+"WH" = (
+/turf/simulated/wall,
+/area/goonbase/kitchen)
 "WI" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "WL" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "WM" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "WO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "WQ" = (
 /obj/machinery/chemical_dispenser/bar_soft/full{
 	pixel_y = -2;
 	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "WR" = (
 /obj/random/dirt_75,
 /obj/random/tool{
@@ -8208,7 +8737,7 @@
 	pixel_x = 8
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "WS" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
@@ -8225,7 +8754,7 @@
 	pixel_y = -5
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "Xa" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -8240,7 +8769,7 @@
 	pixel_x = 3
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "Xb" = (
 /obj/effect/shuttle_landmark/goon_ship/transit,
 /turf/space,
@@ -8254,13 +8783,20 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
+"Xf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/shuttle/goon_shuttle/living)
 "Xl" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/random/dirt_75,
 /obj/machinery/power/portgen/basic,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/power)
+"Xm" = (
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/goon_shuttle/living)
 "Xn" = (
 /obj/effect/floor_decal/spline/plain/black,
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -8271,14 +8807,14 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "Xt" = (
 /obj/structure/dispenser/oxygen,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "Xw" = (
 /obj/structure/bed/stool,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -8288,7 +8824,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "Xx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8301,31 +8837,41 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
+"Xy" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/hallway_south)
 "Xz" = (
 /obj/structure/table/steel,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/item/clothing/gloves/boxing,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "XF" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
 /obj/machinery/suit_cycler,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "XG" = (
 /obj/random/pottedplant,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/kitchen)
 "XH" = (
 /obj/effect/decal/cleanable/generic{
 	pixel_x = 8
 	},
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "XI" = (
 /obj/structure/closet/cabinet,
 /obj/effect/floor_decal/corner/blue{
@@ -8348,7 +8894,7 @@
 /obj/item/clothing/accessory/longsleeve_s,
 /obj/item/clothing/suit/storage/toggle/leather_jacket/flight,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "XP" = (
 /obj/structure/table/rack,
 /obj/item/device/flashlight/lantern{
@@ -8389,13 +8935,13 @@
 /obj/item/device/flashlight/flare/glowstick/random,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/equipment)
 "XS" = (
 /obj/machinery/computer/ship/engines{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "XT" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -8403,7 +8949,7 @@
 /obj/item/clothing/suit/storage/hazardvest,
 /obj/item/clothing/ears/earmuffs,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "XY" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -8411,7 +8957,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/hallway_south)
 "Ya" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
@@ -8423,7 +8969,7 @@
 	pixel_x = -3
 	},
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "Yf" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/corner/grey{
@@ -8435,18 +8981,18 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "Yh" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
 	},
 /turf/simulated/floor/carpet,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "Yi" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_south)
 "Yp" = (
 /obj/effect/floor_decal/corner/grey/full{
 	dir = 4
@@ -8457,13 +9003,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
+"Yq" = (
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/goon_shuttle/port)
 "Yt" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "Yu" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 4
@@ -8479,24 +9028,24 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "Yz" = (
 /obj/structure/trash_pile,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_north)
 "YA" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/starboard)
+/area/shuttle/goon_shuttle/starboard)
 "YD" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "YG" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
@@ -8506,7 +9055,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "YI" = (
 /obj/structure/closet,
 /obj/effect/floor_decal/corner/blue{
@@ -8521,12 +9070,25 @@
 /obj/item/clothing/head/turban/gadpathur,
 /obj/item/clothing/head/turban/brown,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "YK" = (
 /obj/machinery/computer/operating,
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/shuttle/goon_ship/med)
+/area/shuttle/goon_shuttle/med)
+"YP" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/maint_north)
+"YT" = (
+/turf/simulated/mineral/surface,
+/area/goonbase/equipment)
 "YU" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/standard,
@@ -8538,14 +9100,14 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/living)
 "YV" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
 	},
 /obj/random/dirt_75,
 /turf/simulated/floor/wood,
-/area/mine)
+/area/goonbase/living)
 "YW" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -8554,7 +9116,7 @@
 /obj/random/dirt_75,
 /obj/item/trash/broken_electronics,
 /turf/simulated/floor/plating,
-/area/shuttle/goon_ship/port)
+/area/shuttle/goon_shuttle/port)
 "YX" = (
 /obj/item/trash/cigbutt{
 	pixel_y = -14;
@@ -8562,26 +9124,41 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "YZ" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/white,
-/area/mine)
+/area/goonbase/living)
 "Zc" = (
 /obj/effect/floor_decal/corner/grey/full,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
+"Zd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/shuttle/goon_shuttle/storage)
 "Ze" = (
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/living)
 "Zf" = (
 /obj/structure/table/steel,
 /obj/item/wrench,
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
+"Zg" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/noid,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/medbay)
 "Zi" = (
 /obj/structure/closet,
 /obj/item/clothing/under/suit_jacket/charcoal,
@@ -8600,7 +9177,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/full,
-/area/mine)
+/area/goonbase/living)
 "Zk" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -8613,12 +9190,12 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "Zl" = (
 /obj/random/junk,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/hallway_north)
 "Zo" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -8636,7 +9213,7 @@
 	pixel_y = 7
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "Zq" = (
 /obj/structure/reagent_dispensers/radioactive_waste{
 	pixel_x = -9
@@ -8644,16 +9221,16 @@
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/greenglow/radioactive,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/maint_south)
 "Zs" = (
 /obj/machinery/photocopier,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "Zw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/living)
 "Zx" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 10
@@ -8666,7 +9243,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/shuttle/goon_ship/living)
+/area/shuttle/goon_shuttle/storage)
 "ZB" = (
 /obj/random/dirt_75,
 /obj/item/tank/oxygen/brown{
@@ -8674,13 +9251,13 @@
 	pixel_y = -5
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "ZC" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/exoplanet/barren,
-/area/mine)
+/area/goonbase/hallway_north)
 "ZH" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/corner/grey{
@@ -8689,14 +9266,14 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "ZI" = (
 /obj/random/dirt_75,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_north)
 "ZJ" = (
 /obj/effect/floor_decal/corner/grey{
 	dir = 1
@@ -8708,12 +9285,12 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_south)
 "ZL" = (
 /obj/random/dirt_75,
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/atmos)
 "ZO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8723,7 +9300,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/eva)
 "ZR" = (
 /obj/structure/closet/crate/freezer{
 	name = "emergency rations (vaurca)"
@@ -8778,7 +9355,14 @@
 	pixel_x = 8
 	},
 /turf/simulated/floor/tiled/freezer,
-/area/mine)
+/area/goonbase/kitchen)
+"ZS" = (
+/obj/random/dirt_75,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/goonbase/maint_south)
 "ZT" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
@@ -8788,7 +9372,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
-/area/mine)
+/area/goonbase/hallway_north)
 "ZW" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/smg10mm,
@@ -8799,7 +9383,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
-/area/mine)
+/area/goonbase/equipment)
 "ZX" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 6
@@ -8816,7 +9400,7 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/plating,
-/area/mine)
+/area/goonbase/maint_airlock)
 
 (1,1,1) = {"
 Mw
@@ -38419,13 +39003,13 @@ mI
 mI
 mI
 mI
-qX
-qX
-qX
-qX
-qX
-qX
-qX
+Af
+Af
+Af
+Af
+Af
+Af
+Af
 mI
 mI
 mI
@@ -38676,13 +39260,13 @@ mI
 mI
 mI
 mI
-qX
-Dr
-Dr
-Dr
-Dr
-Dr
-qX
+Af
+ba
+ba
+ba
+ba
+ba
+Af
 mI
 mI
 mI
@@ -38933,13 +39517,13 @@ mI
 mI
 mI
 mI
-qX
-Dr
+Af
+ba
 dv
 qM
 NU
-Dr
-qX
+ba
+Af
 mI
 mI
 mI
@@ -38954,12 +39538,12 @@ fB
 RD
 aK
 mI
-qX
-qX
-qX
-qX
-qX
-qX
+vr
+vr
+vr
+vr
+vr
+vr
 mI
 mI
 mI
@@ -39186,20 +39770,20 @@ mI
 mI
 mI
 mI
-qX
-qX
-qX
-qX
-qX
-Dr
+Af
+Af
+Af
+Af
+Af
+ba
 Du
 uq
 KJ
-Dr
-qX
-qX
-qX
-qX
+ba
+Af
+Af
+Af
+Af
 mI
 mI
 mI
@@ -39211,12 +39795,12 @@ mN
 vv
 FP
 mI
-qX
-Dr
-Dr
-Dr
-Dr
-qX
+vr
+Gv
+Gv
+Gv
+Gv
+vr
 mI
 mI
 mI
@@ -39443,20 +40027,20 @@ mI
 mI
 mI
 mI
-qX
-Dr
-Dr
-Dr
-Dr
-Dr
+Af
+ba
+ba
+ba
+ba
+ba
 wV
 ad
 qL
-Dr
-Dr
-Dr
-Dr
-qX
+ba
+ba
+ba
+ba
+Af
 mI
 mI
 mI
@@ -39468,20 +40052,20 @@ ui
 gj
 mI
 mI
-qX
-Dr
+vr
+Gv
 Ox
 wB
-Dr
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
+Gv
+vr
+IP
+IP
+IP
+IP
+IP
+IP
+cn
+cn
 mI
 mI
 mI
@@ -39700,8 +40284,8 @@ mI
 mI
 mI
 mI
-qX
-Dr
+Af
+ba
 px
 QE
 Nt
@@ -39712,8 +40296,8 @@ sZ
 gc
 jw
 NU
-Dr
-qX
+ba
+Af
 mI
 mI
 mI
@@ -39725,20 +40309,20 @@ Hf
 mI
 mI
 mI
-qX
-Dr
+vr
+Gv
 sT
 cO
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-qX
+Gv
+Gv
+QB
+QB
+QB
+QB
+QB
+QB
+kk
+cn
 mI
 mI
 mI
@@ -39957,45 +40541,45 @@ mI
 mI
 mI
 mI
-qX
-Dr
+Af
+ba
 SF
 tF
 aJ
 IB
 eE
 Jz
-Li
+da
 MH
 xz
 KJ
-Dr
-qX
+ba
+Af
 mI
 mI
 mI
 mI
 mI
 mI
-ZC
+TG
 Mf
 mI
 mI
 mI
-qX
-Dr
+vr
+Gv
 uG
 cT
 en
 Ic
-Dr
+QB
 gn
 HW
 ig
 lj
 fA
-Dr
-qX
+kk
+cn
 mI
 mI
 mI
@@ -40214,45 +40798,45 @@ mI
 mI
 mI
 mI
-qX
-Dr
+Af
+ba
 Rv
 iD
 Au
 FD
 SM
 qw
-ZL
+hT
 zU
 dY
 bA
-Dr
-qX
-qX
-qX
-qX
-qX
-qX
+ba
+Af
+Bu
+Bu
+Bu
+Bu
+Bu
 mI
 JJ
 Iy
 mI
-qX
-qX
-qX
-Dr
+vr
+vr
+vr
+Gv
 Qk
 hv
 Jm
-ME
-Dr
+Ho
+QB
 wb
 KR
 oK
 Qg
 bm
-Dr
-qX
+kk
+cn
 mI
 mI
 mI
@@ -40471,55 +41055,55 @@ mI
 mI
 mI
 mI
-qX
-Dr
+Af
+ba
 uy
 Jn
 tR
-Dr
-Dr
+ba
+ba
 kI
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
+ba
+ba
+ba
+ba
+ba
+ba
+yC
+yC
+yC
+yC
+yC
 mI
 QO
 rW
 mI
-Dr
-Dr
-Dr
-Dr
-Dr
-kI
-Dr
-Dr
-Dr
+Gv
+Gv
+Gv
+Gv
+Gv
+Lv
+Gv
+Gv
+QB
 qj
-TJ
+OF
 jv
 Qm
 xp
-Dr
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
+kk
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
+cn
 mI
 mI
 mI
@@ -40728,55 +41312,55 @@ mI
 mI
 mI
 mI
-qX
-Dr
+Af
+ba
 LY
-Li
+da
 IS
-Dr
+ba
 Jl
 Ep
-Li
-Dr
-wL
-Zl
-Li
+jY
+yC
+JX
+Oz
+jY
 an
 ZI
 sI
-Li
+jY
 Jl
-Dr
+yC
 mI
 qW
 eH
 mI
-Dr
+Gv
 wL
-Li
+JK
 Yi
-Li
+JK
 eC
-Li
-QX
-Dr
+JK
+xB
+QB
 IX
 Mu
 vs
 FU
 tr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-qX
+kk
+kk
+kk
+kk
+kk
+kk
+kk
+kk
+kk
+kk
+kk
+cn
 mI
 mI
 mI
@@ -40983,15 +41567,15 @@ mI
 mI
 mI
 mI
-qX
-qX
-qX
-Dr
+wc
+wc
+wc
+ba
 eL
 qJ
 Xl
-Dr
-Li
+ba
+jY
 AL
 zW
 LU
@@ -41003,37 +41587,37 @@ RY
 EV
 qN
 hS
-Dr
+yC
 mI
 mI
 vR
 mI
-Dr
+Gv
 Br
-qN
+Kw
 Cz
-qN
+Kw
 bV
-qN
-qN
+Kw
+Kw
 Mx
 KB
 Yp
 rN
 pz
 BH
-Dr
-sI
-Li
+kk
+UG
+GV
 cu
-Dr
+kk
 Fb
 pf
 gE
 ll
 Uh
-Dr
-qX
+kk
+cn
 mI
 mI
 mI
@@ -41240,57 +41824,57 @@ mI
 mI
 mI
 mI
-qX
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
+wc
+pW
+pW
+pW
+pW
+pW
+pW
+pW
 UN
-NH
+GX
 if
-Dr
-Dr
-Dr
+yC
+yC
+yC
 LZ
-Dr
-Dr
-Dr
-Dr
-Pp
-Dr
+yC
+yC
+yC
+yC
+Bw
+yC
 mI
 sK
-Cj
+ef
 mI
-Dr
+Gv
 Pp
-Li
-Dr
-EQ
-Jl
+JK
+Gv
+BO
+Nl
 wL
-Dr
-Dr
+Gv
+QB
 XF
-nY
+oa
 ZO
 Gb
 To
-Dr
-Li
-yS
-Li
-Dr
+kk
+GV
+Od
+GV
+kk
 PD
 Mm
 yr
 mW
 Uh
-Dr
-qX
+kk
+cn
 mI
 mI
 mI
@@ -41492,45 +42076,45 @@ mI
 mI
 mI
 mI
-qX
-qX
-qX
-qX
-qX
-qX
-Dr
+wc
+wc
+wc
+wc
+wc
+wc
+pW
 yH
 Hd
 ME
 Vk
 tu
-Dr
+pW
 un
-NH
+GX
 if
-Dr
+yC
 kE
-Li
+jY
 JV
 Lm
 QR
 tA
-Dr
-Pp
-Dr
+yC
+Bw
+yC
 mI
 Xa
 gj
 sK
-Dr
+Gv
 KE
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
+Gv
+Gv
+GG
+GG
+GG
+GG
+QB
 ZH
 Zc
 On
@@ -41544,10 +42128,10 @@ iV
 CR
 zb
 Nr
-Ew
+zQ
 Wq
-Dr
-qX
+kk
+cn
 mI
 mI
 mI
@@ -41639,25 +42223,25 @@ sB
 sB
 sB
 sB
-Rc
-Rc
-Rc
-Rc
+sx
+sx
+sx
+sx
 pr
-Rc
-Rc
-Rc
-Rc
-MR
+sx
+sx
+sx
+sx
+sx
 sB
 sB
 sB
 pN
-QC
-QC
-QC
-QC
-QC
+Yq
+Yq
+Yq
+Yq
+Yq
 sB
 sB
 sB
@@ -41749,62 +42333,62 @@ mI
 mI
 mI
 mI
-qX
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
+wc
+pW
+pW
+pW
+pW
+pW
+pW
 rF
 pa
 ru
 vH
 NX
-Dr
+pW
 qO
 Xx
 pO
-Dr
+yC
 IN
 mE
 Bm
 dK
 cK
 vG
-Dr
-Pp
-Dr
-Dr
+yC
+Bw
+yC
+yC
 no
 gj
 no
-Dr
+Gv
 Pp
-an
-mQ
-Dr
+ZS
+zq
+GG
 Vz
 Uz
 oT
-Dr
+QB
 Yf
 yR
 er
 jW
 ei
-Dr
-Jl
-sI
-Li
-Dr
+kk
+Oy
+UG
+GV
+kk
 lJ
 Vc
-Dr
+kk
 ZY
-Dr
-Dr
-qX
+kk
+kk
+cn
 mI
 mI
 mI
@@ -41896,7 +42480,7 @@ sB
 sB
 sB
 sB
-Rc
+sx
 lq
 eI
 Em
@@ -41905,21 +42489,21 @@ hV
 fs
 vx
 oX
-MR
-MR
-MR
-MR
-MR
-hI
-OW
-Ud
+sx
+VZ
+VZ
+VZ
+VZ
+av
+ed
+yb
 xK
-QC
-QC
-QC
-QC
-QC
-QC
+Yq
+Yq
+Yq
+Yq
+Yq
+Yq
 sB
 sB
 sB
@@ -42006,33 +42590,33 @@ mI
 mI
 mI
 mI
-qX
-Dr
+wc
+pW
 MT
 WM
-qJ
+Lu
 NB
-Dr
+pW
 is
 vH
 Hx
 yD
 tu
-Dr
+pW
 as
-NH
+GX
 gw
-Dr
+yC
 dK
 Rx
 dh
 Mh
 Ce
 lb
-Dr
+yC
 hN
 qN
-Mx
+nV
 QP
 QP
 QP
@@ -42040,28 +42624,28 @@ QP
 Sj
 Eq
 AS
-Dr
+GG
 KF
-tF
+ib
 Li
-Dr
-Dr
-Dr
+QB
+QB
+QB
 Cb
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
+QB
+QB
+kk
+kk
+kk
+kk
+kk
 uU
 Fe
-Dr
+kk
 cF
-Li
-Dr
-qX
+GV
+kk
+cn
 mI
 mI
 mI
@@ -42153,7 +42737,7 @@ sB
 sB
 sB
 pI
-Rc
+sx
 YK
 AV
 Em
@@ -42162,21 +42746,21 @@ Qx
 cm
 AV
 Jf
-MR
+sx
 UD
-Ze
+RZ
 Bq
-MR
+VZ
 yP
 Ba
-JW
-JW
+qR
+qR
 Gw
-aE
-aE
-aE
+kp
+kp
+kp
 FF
-nA
+Sw
 PA
 PA
 PA
@@ -42263,62 +42847,62 @@ mI
 mI
 mI
 mI
-qX
-Dr
+wc
+pW
 QQ
 GI
-Li
+bb
 Ga
-Dr
+pW
 KG
 pa
 MS
 FE
-Dr
-Dr
+pW
+pW
 zz
-NH
-wL
-Dr
+GX
+JX
+yC
 qv
-Li
+jY
 kB
 Wu
 Ce
 Gi
-Dr
+yC
 sI
-Li
-Dr
+jY
+yC
 mI
 mI
 mI
 mI
 wL
-Li
-Li
-Dr
+JK
+JK
+GG
 Zs
-NH
+nq
 IV
-Dr
+GG
 xy
 BE
 JF
 IW
 xr
 Jw
-Dr
+GG
 mI
 mI
-Dr
-mn
-mn
-Dr
+kk
+Fa
+Fa
+kk
 ms
-Dr
-Dr
-qX
+kk
+kk
+cn
 mI
 mI
 mI
@@ -42407,32 +42991,32 @@ sB
 sB
 sB
 sB
-zd
-zd
-zd
-zd
-zd
-zd
+QC
+QC
+QC
+QC
+QC
+QC
 PC
 jg
 AV
 sg
 AV
 zs
-MR
+sx
 aP
 Jp
 fj
-MR
+VZ
 gX
 HD
 UA
-JW
-JW
-JW
-JW
-JW
-uB
+qR
+qR
+qR
+qR
+qR
+KV
 MV
 PA
 kz
@@ -42520,52 +43104,52 @@ mI
 mI
 mI
 mI
-qX
-Dr
+wc
+pW
 Nq
-Li
+bb
 WR
-Li
-Li
-Li
+bb
+bb
+bb
 uu
 uu
-ZI
-Dr
+JW
+pW
 EQ
 OX
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
+yC
+yC
+yC
+yC
+yC
+yC
+yC
 cG
-Dr
-Dr
-Dr
-Rt
-Dr
-Dr
-no
-sK
+yC
+yC
+yC
+YP
+yC
+Ql
+rY
+Ap
 mI
-Dr
-Dr
-Rt
-Dr
-Dr
-Rt
-Dr
-Dr
+Gv
+Gv
+RL
+GG
+GG
+Xy
+GG
+GG
 TO
 lW
 jZ
-Vw
+Ji
 fR
 Jw
-Dr
+GG
 mI
 mI
 mI
@@ -42664,33 +43248,33 @@ sB
 sB
 sB
 sB
-zd
+QC
 MJ
 vD
 AU
 cP
-zd
+QC
 kJ
 AV
 PZ
 sg
 AV
 Hs
-MR
+sx
 UD
-Ze
+RZ
 Zf
-MR
+VZ
 YW
 Aw
 fv
 JZ
 XS
-kX
-pp
+KK
+AW
 QT
 bR
-nA
+Sw
 PA
 sB
 sB
@@ -42777,13 +43361,13 @@ mI
 mI
 mI
 mI
-qX
-Dr
+wc
+pW
 NB
 Qc
 Ga
-Wu
-Dr
+pq
+pW
 GH
 Kj
 fC
@@ -42791,38 +43375,38 @@ pQ
 WA
 rc
 bz
-Dr
+Ql
 UB
 IG
 IG
 OH
-Dr
+Ql
 Ld
 Gh
 Vq
-IW
+BC
 ff
 Vw
 mn
-nB
+ka
 Fp
 Ow
-no
-nB
-mn
-Vw
-ff
+rV
+hE
+Rn
+Ji
+Rh
 IW
-Vw
+Ji
 IW
 IW
 ZJ
 uE
 kV
-Vw
+Ji
 mt
-Dr
-Dr
+GG
+GG
 mI
 sB
 sB
@@ -42926,28 +43510,28 @@ nk
 Vu
 AU
 Ty
-zd
-MR
-MR
-MR
+QC
+sx
+sx
+sx
 wG
-MR
-MR
-MR
-MR
+sx
+sx
+sx
+VZ
 hG
-MR
-MR
-QC
+VZ
+VZ
+Yq
 Id
-QC
-QC
-QC
-QC
-QC
-QC
-QC
-QC
+Yq
+Yq
+Yq
+Yq
+Yq
+Yq
+Yq
+Yq
 sB
 sB
 bu
@@ -43034,51 +43618,51 @@ mI
 mI
 mI
 mI
-qX
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
+wc
+pW
+pW
+pW
+pW
+pW
+pW
 Ie
 sM
-TJ
+RO
 sl
-Dr
-NH
+pW
+GX
 if
-Dr
+Ql
 ch
-lW
-lW
+vk
+vk
 IG
-Sd
+Kp
 HF
-lW
+vk
 mr
 Vw
 ff
 Vw
-Sd
+Kp
 Do
 Do
-Do
-Do
-Do
+OS
+OS
+OS
 ri
-NH
-ff
-Vw
+nq
+Rh
+Ji
 lW
 TJ
-NH
+nq
 OP
 lW
-Dr
+GG
 CY
 Ia
-Dr
+GG
 cN
 cN
 vz
@@ -43183,14 +43767,14 @@ nX
 cP
 eO
 SK
-zd
+QC
 dd
 zC
 yW
 SZ
 hC
 vj
-MR
+Xm
 lQ
 ym
 lY
@@ -43198,13 +43782,13 @@ dJ
 WO
 OM
 iA
-MR
+VZ
 By
 DI
 Xt
 EE
 it
-MR
+VZ
 sB
 sB
 bu
@@ -43292,25 +43876,25 @@ qX
 qX
 qX
 qX
-Dr
+SL
 xX
 xX
 iX
 bN
-Dr
+pW
 SU
 Fo
 Ag
 ZL
-Dr
-NH
+pW
+GX
 if
-Dr
+Ql
 Zo
 IG
 IG
 JD
-Dr
+Ql
 gq
 jP
 vZ
@@ -43319,11 +43903,11 @@ ff
 BI
 mn
 Ow
-no
+rY
 MB
-Do
-nB
-mn
+OS
+hE
+Rn
 aA
 Cf
 aA
@@ -43331,12 +43915,12 @@ aA
 SW
 DJ
 ws
-Vw
-Dr
+Ji
+GG
 Sv
 Ew
-Dr
-Dr
+GG
+GG
 cN
 cN
 sB
@@ -43440,14 +44024,14 @@ nM
 eT
 AU
 nr
-zd
+QC
 NF
 Ze
 FO
 SZ
 va
 kn
-MR
+Xm
 vh
 xO
 IZ
@@ -43455,13 +44039,13 @@ Bn
 IZ
 Zx
 HC
-MR
-gI
-gI
-gI
-gI
+VZ
+Qz
+Qz
+Qz
+Qz
 aI
-MR
+VZ
 sB
 sB
 bu
@@ -43543,53 +44127,53 @@ mI
 mI
 mI
 qX
-mI
+YT
 qX
-mI
+YT
 qX
-mI
+YT
 qX
-Dr
+SL
 Vs
 HY
 mE
 iY
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
+pW
+pW
+pW
+pW
+pW
+pW
 Sz
 if
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-TO
+fl
+fl
+fl
+fl
+fl
+fl
+dH
 Vw
 iK
-Dr
-Dr
-Dr
-Dr
-Dr
+Ql
+Ql
+Ql
+Ql
+Ql
 mj
-no
-sK
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
+rV
+Kb
+GG
+GG
+GG
+GG
+GG
+GG
 XY
 SE
 Uc
 lW
-Dr
+GG
 Sv
 SH
 dX
@@ -43697,14 +44281,14 @@ Lg
 cP
 AU
 GY
-zd
+QC
 YX
 eS
 nI
 Xw
 Yh
 DO
-MR
+Xm
 ye
 bk
 Xd
@@ -43712,12 +44296,12 @@ Xd
 Xd
 Xn
 VB
-MR
-gI
-gI
-MR
-MR
-MR
+VZ
+Qz
+Qz
+VZ
+VZ
+VZ
 ag
 sB
 sB
@@ -43806,47 +44390,47 @@ qX
 qX
 qX
 qX
-Dr
+SL
 iX
 Pc
 oI
-Li
-Dr
-wL
+jY
+yC
+JX
 an
 ZI
-Zl
+Oz
 HB
 Iz
 ys
-Dr
+fl
 dV
 dQ
 PK
 Qy
-Dr
+fl
 WI
 WI
 WI
-Dr
+Ql
 tt
 JC
-Dr
+Ql
 ip
-gj
+xc
 mI
 mI
 mI
-qX
-qX
-qX
-Dr
+xu
+xu
+xu
+GG
 Ig
 sP
 cV
 km
 lW
-Dr
+GG
 Sv
 SH
 dX
@@ -43960,7 +44544,7 @@ bW
 pT
 ia
 Rg
-WO
+DF
 YD
 WO
 vC
@@ -43968,12 +44552,12 @@ nR
 kU
 Hy
 DN
-Ze
+RZ
 CS
-gI
+Qz
 WL
 oE
-gI
+Qz
 Yt
 Ht
 ct
@@ -44055,40 +44639,40 @@ mI
 mI
 mI
 qX
-mI
+YT
 qX
-mI
+YT
 qX
-Dr
-Dr
-Dr
-Dr
-Dr
+SL
+SL
+SL
+SL
+SL
 Sm
 Ur
 SG
 Al
-wH
+cb
 Nz
 PG
 fg
 dW
 HZ
-NH
+GX
 yS
-Dr
+fl
 oe
 SX
 kL
 Ww
-Dr
-TO
+fl
+dH
 Vw
 hF
-Dr
+Ql
 ZT
 qy
-Dr
+Ql
 mI
 mI
 mI
@@ -44096,18 +44680,18 @@ mI
 mI
 mI
 mI
-qX
-Dr
-Dr
+xu
+GG
+GG
 wD
-Dr
+GG
 Uc
-Vw
-Dr
+Ji
+GG
 Sv
 Df
-Dr
-Dr
+GG
+GG
 cN
 cN
 nT
@@ -44211,14 +44795,14 @@ nM
 Qh
 AU
 MZ
-zd
+QC
 kH
 gZ
 js
 fb
 yp
 zn
-MR
+Xm
 ft
 nS
 le
@@ -44226,13 +44810,13 @@ le
 le
 Xn
 WQ
-MR
-gI
+VZ
+Qz
 fo
-gI
-gI
+Qz
+Qz
 FT
-gI
+Qz
 sB
 sB
 bu
@@ -44316,7 +44900,7 @@ qX
 qX
 qX
 qX
-Dr
+SL
 KO
 qf
 qf
@@ -44324,28 +44908,28 @@ gH
 Nh
 sp
 mQ
-Zl
-Dr
-Dr
-Dr
-Dr
-Dr
+Oz
+jH
+jH
+jH
+jH
+jH
 Qj
-NH
-Dr
-Dr
+GX
+yC
+fl
 qt
 lK
 kL
 Ml
-Dr
-TO
-lW
-NH
-wY
-NH
+fl
+dH
+vk
+vd
+Tn
+vd
 kR
-Dr
+Ql
 mI
 mI
 mI
@@ -44353,17 +44937,17 @@ mI
 mI
 mI
 mI
-qX
-Dr
-Dr
-Dr
-Dr
+xu
+GG
+GG
+GG
+GG
 Uc
 lW
-Dr
+GG
 CY
 Ia
-Dr
+GG
 vz
 cN
 cN
@@ -44468,14 +45052,14 @@ Ul
 eT
 AU
 cP
-zd
+QC
 tv
 Ze
 bi
 wZ
 Ze
 tp
-MR
+Xm
 UH
 Dj
 oc
@@ -44483,13 +45067,13 @@ oc
 oc
 Ft
 Tt
-MR
-gI
+VZ
+Qz
 kK
-MR
-MR
-MR
-MR
+VZ
+VZ
+VZ
+VZ
 sB
 sB
 bu
@@ -44569,40 +45153,40 @@ mI
 mI
 mI
 qX
-mI
+YT
 qX
-Dr
-Dr
-Dr
-Dr
+SL
+SL
+SL
+SL
 qr
-Dr
-Dr
-Dr
+SL
+SL
+jH
 aM
-Dr
-Dr
-Dr
+jH
+jH
+jH
 AI
 bY
 fI
-Dr
+jH
 Zk
 Iz
 Ay
-wY
-eK
+Zg
+SI
 eK
 eK
 qb
-mn
+ro
 LM
-lW
+vk
 EP
-Dr
-Dr
-Dr
-Dr
+Ql
+Ql
+Ql
+Ql
 mI
 mI
 mI
@@ -44610,18 +45194,18 @@ mI
 mI
 mI
 mI
-qX
-qX
-qX
-Dr
+xu
+xu
+xu
+GG
 nY
 YG
-Vw
-Vw
-NH
+Ji
+Ji
+nq
 mt
-Dr
-Dr
+GG
+GG
 nT
 nT
 mV
@@ -44725,28 +45309,28 @@ OA
 nr
 eO
 cP
-zd
+QC
 dd
 dd
 Jo
 wZ
 gJ
 mf
-MR
+Xm
 qD
-Ze
-Ze
+RZ
+RZ
 iu
-Ze
-SZ
+RZ
+Zd
 Vo
-MR
-gI
+VZ
+Qz
 oE
 rU
-Ib
+zp
 RQ
-MR
+VZ
 sB
 sB
 bu
@@ -44828,13 +45412,13 @@ qX
 qX
 qX
 qX
-Dr
-Dr
+SL
+SL
 nQ
 nJ
 ua
 dT
-Dr
+SL
 aR
 Ea
 dE
@@ -44843,11 +45427,11 @@ wu
 AI
 id
 fI
-Dr
-Li
-NH
+jH
+jY
+GX
 Qj
-Dr
+fl
 wJ
 Jq
 Jq
@@ -44856,7 +45440,7 @@ Sd
 Vw
 cY
 Bt
-Dr
+Ql
 mI
 mI
 mI
@@ -44869,8 +45453,8 @@ mI
 mI
 mI
 mI
-qX
-Dr
+xu
+GG
 DV
 yX
 TJ
@@ -44878,7 +45462,7 @@ TJ
 ZB
 mt
 Li
-Dr
+GG
 nT
 nT
 nT
@@ -44982,28 +45566,28 @@ ox
 mv
 AU
 Ty
-zd
-MR
-MR
-MR
+QC
+Xm
+Xm
+Xm
 Lq
-MR
-MR
-MR
-MR
+Xm
+Xm
+Xm
+VZ
 hG
-MR
-MR
-tI
+VZ
+VZ
+jU
 Ka
-tI
-tI
-tI
-tI
-tI
-tI
-tI
-tI
+jU
+jU
+jU
+jU
+jU
+jU
+jU
+jU
 sB
 sB
 bu
@@ -45081,17 +45665,17 @@ mI
 mI
 mI
 qX
-mI
+YT
 qX
-mI
+YT
 qX
-Dr
+SL
 xs
 HK
 Uk
 eJ
 oP
-Dr
+SL
 FZ
 aS
 fh
@@ -45100,21 +45684,21 @@ Np
 Fc
 Ex
 Fc
-Dr
-wL
-NH
+jH
+JX
+GX
 Qj
-Dr
+fl
 qz
 Jq
 Jq
 VR
-mn
+ro
 LM
-NH
+vd
 Bt
-Dr
-sK
+Ql
+Ap
 oM
 mI
 mI
@@ -45126,16 +45710,16 @@ mI
 mI
 mI
 mI
-qX
-Dr
-Dr
+xu
+GG
+GG
 GB
 ku
 lU
 eh
 IA
 Li
-Dr
+GG
 nT
 nT
 sB
@@ -45234,33 +45818,33 @@ sB
 sB
 sB
 sB
-zd
+QC
 Sf
 dx
 AU
 nr
-zd
+QC
 Qf
-Qz
+my
 Td
-wh
-Qz
+DL
+my
 Ri
-MR
+Xm
 UD
-Ze
+RZ
 gr
-MR
+VZ
 tL
 Lh
-bZ
-bZ
-bZ
-KK
-iW
-ee
+JY
+JY
+JY
+rj
+pp
+Kg
 rw
-Bo
+nA
 PA
 sB
 bu
@@ -45342,13 +45926,13 @@ qX
 qX
 qX
 qX
-Dr
+SL
 kW
 eJ
 Uk
 Uk
 VL
-Dr
+SL
 jV
 sc
 fh
@@ -45357,25 +45941,25 @@ gs
 GP
 GP
 uT
-Dr
+jH
 Jl
-NH
+GX
 os
-Dr
+fl
 DY
 iR
 rq
 zB
-Dr
+fl
 WI
 WI
 WI
-Dr
+Ql
 ie
 Qw
 WS
 mI
-sK
+Ap
 Tu
 mI
 mI
@@ -45383,16 +45967,16 @@ mI
 mI
 mI
 mI
-qX
-qX
-Dr
+xu
+xu
+GG
 Mo
 KW
-Fe
+eW
 Ac
 Ac
-Dr
-Dr
+GG
+GG
 nT
 nT
 mI
@@ -45491,32 +46075,32 @@ sB
 sB
 sB
 sB
-zd
-zd
-zd
-zd
-zd
-zd
+QC
+QC
+QC
+QC
+QC
+QC
 Be
 UE
 xi
 NY
-Qz
+my
 bp
-MR
+Xm
 aP
-Ze
+RZ
 fj
-MR
+VZ
 aL
 Ki
-bZ
-bZ
+JY
+JY
 kS
-bZ
-bZ
-bZ
-Uq
+JY
+JY
+JY
+uB
 yx
 PA
 kz
@@ -45595,17 +46179,17 @@ mI
 mI
 mI
 qX
-mI
+YT
 qX
-Dr
-Dr
-Dr
+SL
+SL
+SL
 xs
 eJ
 VK
 Ah
 ZW
-Dr
+SL
 Ez
 Hp
 fh
@@ -45614,20 +46198,20 @@ IQ
 PS
 PS
 dz
-Dr
-Dr
-Dr
+jH
+yC
+yC
 Lz
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-TO
+fl
+fl
+fl
+fl
+fl
+fl
+dH
 Vw
 iK
-Dr
+Ql
 NT
 te
 of
@@ -45641,15 +46225,15 @@ mI
 mI
 mI
 mI
-qX
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-qX
+xu
+GG
+GG
+GG
+GG
+GG
+GG
+GG
+xu
 nT
 mI
 mI
@@ -45751,30 +46335,30 @@ sB
 sB
 sB
 Dm
-sa
-sa
+Xm
+Xm
 aD
 Gy
-ax
-Qz
-Qz
-ax
+Xf
+my
+my
+Xf
 bp
-MR
+Xm
 UD
 GZ
 vB
-MR
+VZ
 OL
-bZ
-bZ
-bZ
+JY
+JY
+JY
 xn
-kp
-kp
+UP
+UP
 wp
 AA
-Bo
+nA
 PA
 PA
 bu
@@ -45854,7 +46438,7 @@ mI
 qX
 qX
 qX
-Dr
+SL
 ov
 jz
 HV
@@ -45862,31 +46446,31 @@ eJ
 VK
 eJ
 fW
-Dr
-Dr
-Dr
-Dr
+SL
+SL
+SL
+SL
 op
 Hb
-Vw
-Vw
+yk
+yk
 Fz
-Dr
+jH
 TW
-IW
+BC
 bH
-BE
+nt
 lz
 gx
 gx
 ff
-IW
+BC
 Ni
-lW
+vk
 iK
 mn
-nB
-nB
+ka
+ka
 kQ
 NP
 gm
@@ -45898,15 +46482,15 @@ mI
 mI
 mI
 mI
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
+xu
+xu
+xu
+xu
+xu
+xu
+xu
+xu
+xu
 mI
 mI
 mI
@@ -46008,30 +46592,30 @@ sB
 sB
 sB
 sB
-Qz
-Qz
-ax
+my
+my
+Xf
 fm
 bp
 bp
 bp
 mz
 bp
-MR
-MR
-MR
-MR
-MR
+Xm
+VZ
+VZ
+VZ
+VZ
 Nc
 AR
 YA
-eb
-tI
-tI
-tI
-tI
-tI
-tI
+CL
+jU
+jU
+jU
+jU
+jU
+jU
 sB
 sB
 bu
@@ -46105,13 +46689,13 @@ bu
 bu
 mI
 mI
-gj
-Ow
+cZ
+gG
 mg
 qX
-Yi
+Co
 wA
-Dr
+SL
 Uk
 Uk
 Ah
@@ -46127,29 +46711,29 @@ hr
 Os
 Rj
 dr
-Vw
+yk
 SJ
 Vw
-NH
+vd
 Nk
-NH
+vd
 EL
 rl
 Vw
 ff
 Vw
-lW
-lW
-NH
-Sd
-nB
-nB
+vk
+vk
+vd
+Kp
+ka
+ka
 te
 cH
 Pu
 Ow
 Ow
-sY
+My
 ZC
 XT
 mI
@@ -46265,25 +46849,25 @@ sB
 sB
 sB
 sB
-sa
-sa
-sa
-sa
+Xm
+Xm
+Xm
+Xm
 dg
-sa
-sa
-sa
-sa
-MR
+Xm
+Xm
+Xm
+Xm
+Xm
 sB
 sB
 sB
 Dl
-tI
-tI
-tI
-tI
-tI
+jU
+jU
+jU
+jU
+jU
 sB
 sB
 sB
@@ -46364,10 +46948,10 @@ mI
 mI
 eu
 DR
-Ow
+gG
 gF
 BM
-mE
+Qu
 uJ
 Uk
 Uk
@@ -46379,13 +46963,13 @@ BJ
 QX
 QX
 QX
-Dr
+SL
 NH
 VD
 Mk
 NH
 Ch
-Dr
+jH
 nw
 BI
 gV
@@ -46396,18 +46980,18 @@ BI
 ff
 BI
 EJ
-NH
+vd
 bj
 mn
-nB
-nB
+ka
+ka
 Gs
 tS
 mI
 mI
 Ow
-no
-gj
+rY
+xc
 Ry
 mI
 mI
@@ -46625,7 +47209,7 @@ mI
 qX
 qX
 qX
-Dr
+SL
 Ya
 pd
 HV
@@ -46635,27 +47219,27 @@ vt
 BJ
 QX
 iO
-Dr
-Dr
+SL
+SL
 Rt
-Dr
-Dr
+WH
+WH
 Su
-Dr
-Dr
-Dr
-Dr
+WH
+WH
+WH
+WH
 zr
 wS
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Su
-Dr
-Dr
+jH
+jH
+jH
+jH
+jH
+jH
+Gz
+jH
+Ql
 oU
 he
 he
@@ -46665,7 +47249,7 @@ ik
 hc
 rm
 Um
-no
+rY
 mI
 mI
 mI
@@ -46880,11 +47464,11 @@ mI
 mI
 mI
 qX
-mI
+YT
 qX
-Dr
-Dr
-Dr
+SL
+SL
+SL
 HV
 xM
 yq
@@ -46892,26 +47476,26 @@ eA
 BJ
 QX
 Sx
-Dr
+SL
 pn
 NA
-Dr
+WH
 Ks
-Vw
+uz
 RR
 pB
 EI
-Dr
+WH
 zr
 Tj
-Dr
+jH
 ng
 xf
 Vx
-Dr
+jH
 aY
-Vw
-Dr
+yk
+jH
 mI
 mI
 mI
@@ -47141,7 +47725,7 @@ qX
 qX
 qX
 qX
-Dr
+SL
 HV
 eJ
 Uk
@@ -47149,32 +47733,32 @@ Ah
 BJ
 QX
 lo
-Dr
+SL
 cx
 YZ
-Dr
+WH
 HU
-lW
-TJ
-TJ
+yQ
+Uv
+Uv
 XG
-Dr
-Lz
-Dr
-Dr
-Vw
+WH
+MI
+Ql
+jH
+yk
 KS
 xQ
-Dr
+jH
 Tc
-Vw
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-qX
+yk
+jH
+jH
+jH
+jH
+jH
+jH
+oB
 mI
 pZ
 pZ
@@ -47394,11 +47978,11 @@ mI
 mI
 mI
 qX
-mI
+YT
 qX
-mI
+YT
 qX
-Dr
+SL
 HV
 eJ
 VK
@@ -47409,34 +47993,34 @@ Ts
 KZ
 xJ
 YU
-Dr
+WH
 Wk
+Ng
+Oo
+Oo
+Oo
+WH
+Bf
+Ee
+jH
 NH
-Oo
-Oo
-Oo
-Dr
-Qj
-wL
-Dr
-NH
-TJ
-Vw
+Lw
+yk
 wY
-Vw
-Vw
+yk
+yk
 qq
-Dr
+jH
 fG
 vq
 lv
-Dr
-qX
+jH
+oB
 mI
 hu
-no
-no
-no
+rY
+rY
+rY
 mI
 mI
 mI
@@ -47655,7 +48239,7 @@ qX
 qX
 qX
 qX
-Dr
+SL
 GF
 TQ
 nC
@@ -47663,37 +48247,37 @@ WB
 Ke
 XP
 qP
-Dr
-Dr
-Dr
-Dr
+SL
+WH
+WH
+WH
 pV
 fM
 mO
 gp
 uD
-Dr
+WH
 BW
 Zl
-Dr
+jH
 FB
 NH
 sN
-Dr
+jH
 nj
-lW
-Vw
+lA
+yk
 wY
 NA
 KL
 pw
-Dr
-qX
+jH
+oB
 mI
 hK
-no
-no
-no
+rY
+rY
+rY
 mI
 mI
 mI
@@ -47910,47 +48494,47 @@ mI
 mI
 mI
 qX
-mI
+YT
 qX
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
+SL
+SL
+SL
+SL
+SL
+SL
+SL
+SL
+SL
+WH
+WH
 pt
 wo
 UX
 QV
 QV
 np
-Dr
+WH
 VY
 rn
-Dr
-Dr
-Dr
-Dr
-Dr
+jH
+jH
+jH
+jH
+jH
 PL
-lW
+lA
 GM
-Dr
-Dr
-Dr
-Dr
-Dr
-qX
+jH
+jH
+jH
+jH
+jH
+oB
 mI
 mI
-no
+rY
 eF
-no
+rY
 mI
 mI
 mI
@@ -48178,15 +48762,15 @@ qX
 qX
 qX
 qX
-qX
-Dr
+ao
+WH
 uv
 oH
 RE
 zk
 xY
 xY
-wH
+Io
 kg
 QM
 wH
@@ -48197,16 +48781,16 @@ kj
 yl
 yy
 mX
-Dr
+jH
 vM
-Vw
+yk
 WG
-Dr
-qX
+jH
+oB
 mI
 mI
 dU
-no
+rY
 mI
 mI
 mI
@@ -48424,42 +49008,42 @@ mI
 mI
 mI
 qX
-mI
+YT
 qX
-mI
+YT
 qX
-mI
+YT
 qX
-mI
+YT
 qX
-mI
+YT
 qX
-mI
-qX
-Dr
+YT
+ao
+WH
 WD
 fM
 Un
 Up
 vJ
 nf
-Dr
+WH
 Yz
 xZ
-Dr
+jH
 od
-Dr
+jH
 YI
 eN
-lW
-Vw
-Vw
+lA
+yk
+yk
 wY
-Vw
+yk
 IF
 Xz
-Dr
-qX
+jH
+oB
 mI
 mI
 mI
@@ -48692,31 +49276,31 @@ qX
 qX
 qX
 qX
-qX
-Dr
-Dr
-Dr
-Dr
-Dr
+ao
+WH
+WH
+WH
+WH
+WH
 jq
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
+WH
+WH
+WH
+WH
+WH
+jH
+jH
 XI
 eN
 xE
-Vw
+yk
 sO
-Dr
+jH
 NH
-oK
+xL
 fr
-Dr
-qX
+jH
+oB
 mI
 mI
 mI
@@ -48949,31 +49533,31 @@ mI
 mI
 mI
 mI
-qX
-qX
-qX
-qX
-Dr
+ao
+ao
+ao
+ao
+WH
 sC
 IU
 gM
-Dr
+WH
 sz
 eP
 DE
-Dr
-Dr
+jH
+jH
 Wn
 Vj
 El
 Zw
 Zi
-Dr
+jH
 Nf
 bc
 rD
-Dr
-qX
+jH
+oB
 mI
 mI
 mI
@@ -49209,28 +49793,28 @@ mI
 mI
 mI
 mI
-qX
-Dr
+ao
+WH
 ZR
 CZ
 Ne
-ri
+iQ
 wX
 eB
 TH
-Dr
-Dr
-Dr
+jH
+jH
+jH
 Rt
-Dr
+jH
 Rt
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-qX
+jH
+jH
+jH
+jH
+jH
+jH
+oB
 mI
 mI
 mI
@@ -49466,8 +50050,8 @@ mI
 mI
 mI
 mI
-qX
-Dr
+ao
+WH
 gO
 Tb
 Gc
@@ -49475,19 +50059,19 @@ TN
 hZ
 Jx
 oz
-Dr
+jH
 Gn
 xH
-Vw
-Dr
-Vw
-Vw
+yk
+jH
+yk
+yk
 vc
 gi
-Dr
-qX
-qX
-qX
+jH
+oB
+oB
+oB
 mI
 mI
 mI
@@ -49723,26 +50307,26 @@ mI
 mI
 mI
 mI
-qX
-Dr
+ao
+WH
 Se
 IU
 sh
-Dr
+WH
 eq
 PY
 Sk
-Dr
+jH
 NH
-TJ
+Lw
 NH
-Dr
+jH
 Uf
-lW
-TJ
+lA
+Lw
 sX
-Dr
-qX
+jH
+oB
 mI
 mI
 mI
@@ -49980,26 +50564,26 @@ mI
 mI
 mI
 mI
-qX
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
+ao
+WH
+WH
+WH
+WH
+WH
+WH
+WH
+WH
+jH
 ng
-lW
+lA
 Qe
-Dr
+jH
 vI
 KD
 YV
 Rl
-Dr
-qX
+jH
+oB
 mI
 mI
 mI
@@ -50237,26 +50821,26 @@ mI
 mI
 mI
 mI
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-Dr
+ao
+ao
+ao
+ao
+ao
+ao
+ao
+ao
+ao
+jH
 Vb
 Bz
 aa
-Dr
+jH
 nl
 qC
 FR
 HJ
-Dr
-qX
+jH
+oB
 mI
 mI
 mI
@@ -50502,18 +51086,18 @@ mI
 mI
 mI
 mI
-qX
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-Dr
-qX
+ao
+jH
+jH
+jH
+jH
+jH
+jH
+jH
+jH
+jH
+jH
+oB
 mI
 mI
 mI
@@ -50759,18 +51343,18 @@ mI
 mI
 mI
 mI
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
-qX
+ao
+oB
+oB
+oB
+oB
+oB
+oB
+oB
+oB
+oB
+oB
+oB
 mI
 mI
 mI

--- a/maps/away/away_site/goon_base/goon_base_areas.dm
+++ b/maps/away/away_site/goon_base/goon_base_areas.dm
@@ -1,32 +1,89 @@
-/area/goonbase
-	name = "goon base"
-	icon_state = "outpost_mine_main"
-	requires_power = FALSE
+// base
 
-/area/shuttle/goon_ship
+/area/goonbase
+	name = "goon base base/abstract area"
+	icon_state = "outpost_mine_main"
+	requires_power = TRUE
+
+/area/goonbase/equipment
+	name = ""
+	icon_state = "eva"
+
+/area/goonbase/living
+	name = ""
+	icon_state = "crew_area"
+
+/area/goonbase/kitchen
+	name = ""
+	icon_state = "kitchen"
+
+/area/goonbase/quarters
+	name = ""
+	icon_state = "crew_quarters"
+
+/area/goonbase/atmos
+	name = ""
+	icon_state = "atmos"
+
+/area/goonbase/power
+	name = ""
+	icon_state = "engine"
+
+/area/goonbase/hallway_north
+	name = ""
+	icon_state = "hallC1"
+
+/area/goonbase/hallway_south
+	name = ""
+	icon_state = "hallC1"
+
+/area/goonbase/maint_north
+	name = ""
+	icon_state = "maintenance"
+
+/area/goonbase/maint_south
+	name = ""
+	icon_state = "maintenance"
+
+/area/goonbase/medbay
+	name = ""
+	icon_state = "medbay"
+
+/area/goonbase/eva
+	name = ""
+	icon_state = "eva"
+
+/area/goonbase/maint_airlock
+	name = ""
+	icon_state = "maintenance"
+
+// shuttle
+
+/area/shuttle/goon_shuttle
+	name = "goon shuttle base/abstract area"
 	icon_state = "red"
 	requires_power = TRUE
 
-/area/shuttle/goon_ship/living
+/area/shuttle/goon_shuttle/living
 	name = "Wanted Vessel Living Area"
 	icon_state = "hallC1"
 
-/area/shuttle/goon_ship/port
+/area/shuttle/goon_shuttle/port
 	name = "Wanted Vessel Port Thruster"
 	icon_state = "substation"
 
-/area/shuttle/goon_ship/starboard
+/area/shuttle/goon_shuttle/starboard
 	name = "Wanted Vessel Starboard Thruster"
 	icon_state = "substation"
 
-/area/shuttle/goon_ship/med
+/area/shuttle/goon_shuttle/med
 	name = "Wanted Vessel Medical"
 	icon_state = "medbay"
 
-/area/shuttle/goon_ship/storage
+/area/shuttle/goon_shuttle/storage
 	name = "Wanted Vessel Storage"
 	icon_state = "maintcentral"
 
-/area/shuttle/goon_ship/bridge
+/area/shuttle/goon_shuttle/bridge
 	name = "Wanted Vessel Bridge"
 	icon_state = "bridge_helm"

--- a/maps/away/away_site/goon_base/goon_base_items.dm
+++ b/maps/away/away_site/goon_base/goon_base_items.dm
@@ -1,0 +1,36 @@
+
+/obj/item/paper/goon_base
+	name = "/obj/item/paper/goon_base/ parent object"
+
+/obj/item/paper/goon_base/shuttle_power_note
+	name = "dirty note"
+	info = "hey, boss <br>\
+			<br>\
+		<br>\
+		i had a bit of an acidnet when i was workig the smes <br>\
+		it fuckcng blew up <br>\
+		it wasnt my fault this time. i dident fuck up like u always say i do. it just blew op on its own <br>\
+		<br>\
+		only reason im teling you throgh this note insted of in person <br>\
+		(i fuckimg hate writing) is becaus i knew youd kill me <br>\
+		you threw jake, the olnly real enginer we ever had in this crew out of the airlock cause he short circiuted the booze vendor by accidnet <br>\
+		<br>\
+		so honestely if you guys are stuck here now and have to cannibelaize that dork we snatched last job to not starve then seriusly its ur fault not mine <br>\
+		i got a contact to pick me up, im far gon. u wont find me. dont try to find me if you dont end up starveng here <br>\
+		<br>\
+		<br>\
+		~love, daryl <br>\
+		"
+
+/obj/item/paper/goon_base/shuttle_fuel_note
+	name = "note"
+	info = "we are out of hydrogen for the shuttle. need to get some to fly it. ~jake"
+
+/obj/item/paper/goon_base/secret_base_note
+	name = "note"
+	info = "there is secret entrance to gear equipment room with guns and stuff here in fake walls you can just move by over. here in living room and in bathroom. do not let any visitors see it ~jake"
+
+/obj/item/paper/goon_base/secret_back_exit_note
+	name = "note"
+	info = "this is for emergency time exit when everything is fucked. take pickaxe or drill or whatever and dig straight directly forward north to get to space. remember eva suit and air ~jake"
+


### PR DESCRIPTION
![image](https://github.com/Aurorastation/Aurora.3/assets/107256943/a0d3aeaa-2413-4593-a94e-599721015de5)

changes:
  - maptweak: "Remaps the goon base to be nicer visually and in gameplay."
  - maptweak: "Goon base shuttle now has an empty fuel canister."
