### PR TITLE
Away Site Sector Blacklists

### DIFF
--- a/html/changelogs/RustingWithYou - konyangawaysites.yml
+++ b/html/changelogs/RustingWithYou - konyangawaysites.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Removes various away sites from spawning in Haneunim, Tau Ceti, and Burzsia which don't fit the sectors."

--- a/maps/away/away_site/abandoned_industrial/abandoned_industrial_station.dm
+++ b/maps/away/away_site/abandoned_industrial/abandoned_industrial_station.dm
@@ -8,8 +8,8 @@
 	spawn_weight = 1
 	suffixes = list("away_site/abandoned_industrial/abandoned_industrial_station.dmm")
 
-	sectors = list(ALL_TAU_CETI_SECTORS, ALL_COALITION_SECTORS, SECTOR_BADLANDS, SECTOR_VALLEY_HALE, SECTOR_GAKAL, SECTOR_LIGHTS_EDGE)
-	sectors_blacklist = list(SECTOR_TAU_CETI, SECTOR_BURZSIA, SECTOR_HANEUNIM)
+	sectors = list(ALL_POSSIBLE_SECTORS)
+	sectors_blacklist = list(SECTOR_TAU_CETI, SECTOR_HANEUNIM)
 
 /singleton/submap_archetype/abandoned_industrial_station//Arbitrary duplicates of the above name/desc
 	map = "abandoned industrial station"

--- a/maps/away/away_site/abandoned_industrial/abandoned_industrial_station.dm
+++ b/maps/away/away_site/abandoned_industrial/abandoned_industrial_station.dm
@@ -8,7 +8,8 @@
 	spawn_weight = 1
 	suffixes = list("away_site/abandoned_industrial/abandoned_industrial_station.dmm")
 
-	sectors = list(ALL_POSSIBLE_SECTORS)
+	sectors = list(ALL_TAU_CETI_SECTORS, ALL_COALITION_SECTORS, SECTOR_BADLANDS, SECTOR_VALLEY_HALE, SECTOR_GAKAL, SECTOR_LIGHTS_EDGE)
+	sectors_blacklist = list(SECTOR_TAU_CETI, SECTOR_BURZSIA, SECTOR_HANEUNIM)
 
 /singleton/submap_archetype/abandoned_industrial_station//Arbitrary duplicates of the above name/desc
 	map = "abandoned industrial station"

--- a/maps/away/away_site/abandoned_mining/cursed.dm
+++ b/maps/away/away_site/abandoned_mining/cursed.dm
@@ -2,7 +2,8 @@
 	name = "lone asteroid"
 	description = "A lone asteroid with a hangar. Latest data from this sector shows it as a Hephaestus mining station, two years ago."
 	suffixes = list("away_site/abandoned_mining/cursed.dmm")
-	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, ALL_COALITION_SECTORS)
+	sectors = list(ALL_TAU_CETI_SECTORS, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, ALL_COALITION_SECTORS)
+	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA, SECTOR_TAU_CETI) //you're not gonna have a station left alone for 2 years in the middle of inhabited space
 	spawn_weight = 1
 	spawn_cost = 1
 	id = "cursed"

--- a/maps/away/away_site/big_derelict/bigderelict.dm
+++ b/maps/away/away_site/big_derelict/bigderelict.dm
@@ -3,7 +3,7 @@
 	description = "A very large derelict station. According to the starmap, it shouldn't exist."
 	suffixes = list("away_site/big_derelict/bigderelict.dmm")
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_NEW_ANKARA, SECTOR_BADLANDS, SECTOR_AEMAQ, ALL_COALITION_SECTORS)
-	sectors_blacklist = list(SECTOR_BURZSIA, SECTOR_HANEUNIM)
+	sectors_blacklist = list(SECTOR_HANEUNIM)
 	spawn_weight = 1
 	spawn_cost = 2
 	id = "big_derelict"

--- a/maps/away/away_site/big_derelict/bigderelict.dm
+++ b/maps/away/away_site/big_derelict/bigderelict.dm
@@ -2,7 +2,8 @@
 	name = "large derelict"
 	description = "A very large derelict station. According to the starmap, it shouldn't exist."
 	suffixes = list("away_site/big_derelict/bigderelict.dmm")
-	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_NEW_ANKARA, SECTOR_BADLANDS, SECTOR_AEMAQ, ALL_COALITION_SECTORS)
+	sectors = list(SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_NEW_ANKARA, SECTOR_BADLANDS, SECTOR_AEMAQ, ALL_COALITION_SECTORS)
+	sectors_blacklist = list(SECTOR_BURZSIA, SECTOR_HANEUNIM)
 	spawn_weight = 1
 	spawn_cost = 2
 	id = "big_derelict"

--- a/maps/away/away_site/blueriver/blueriver.dm
+++ b/maps/away/away_site/blueriver/blueriver.dm
@@ -7,6 +7,7 @@
 	suffixes = list("away_site/blueriver/blueriver-1.dmm","away_site/blueriver/blueriver-2.dmm")
 	generate_mining_by_z = 2
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, ALL_COALITION_SECTORS)
+	sectors_blacklist = list(SECTOR_BURZSIA, SECTOR_HANEUNIM) //it's a whole ass planet, shouldn't have it in predefined sectors
 
 	unit_test_groups = list(1)
 

--- a/maps/away/away_site/shady/shady.dm
+++ b/maps/away/away_site/shady/shady.dm
@@ -2,7 +2,8 @@
 	name = "shady asteroid"
 	description = "An asteroid with a hangar carved out inside it. Scans detect an unregistered structure within, with multiple lifeforms present."
 	suffixes = list("away_site/shady/shady.dmm")
-	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, ALL_COALITION_SECTORS)
+	sectors = list(SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, ALL_COALITION_SECTORS)
+	sectors_blacklist = list(SECTOR_BURZSIA, SECTOR_HANEUNIM)
 	spawn_weight = 1
 	spawn_cost = 1
 	id = "shady"

--- a/maps/away/away_site/wrecked_nt_ship/wrecked_nt_ship.dm
+++ b/maps/away/away_site/wrecked_nt_ship/wrecked_nt_ship.dm
@@ -3,6 +3,7 @@
 	description = "A wrecked ship once owned by NanoTrasen."
 	suffixes = list("away_site/wrecked_nt_ship/wrecked_nt_ship.dmm")
 	sectors = list(SECTOR_TAU_CETI, SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, ALL_COALITION_SECTORS)
+	sectors_blacklist = list(SECTOR_BURZSIA, SECTOR_HANEUNIM) //NT has pretty much no presence in either of these, why would there be a wrecked ship
 	spawn_weight = 1
 	spawn_cost = 2
 	id = "wrecked_nt_ship"


### PR DESCRIPTION
Removes several away sites from spawning in Konyang, Tau Ceti, and Burzsia, as they did not make sense to be in the middle of civilised space/in those specific systems.