### PR TITLE
Revert "Konyang pirate guns can now be spawned by civilian gun spawners"

### DIFF
--- a/code/game/objects/random/weapon.dm
+++ b/code/game/objects/random/weapon.dm
@@ -150,7 +150,6 @@
 		/obj/item/gun/projectile/automatic/x9,
 		/obj/item/gun/energy/disruptorpistol,
 		/obj/item/gun/energy/retro,
-		/obj/item/gun/projectile/revolver/konyang/pirate
 	)
 
 /obj/random/civgun/post_spawn(var/obj/item/gun/projectile/spawned)
@@ -210,9 +209,7 @@
 		/obj/item/gun/projectile/automatic/lebman,
 		/obj/item/gun/projectile/pistol/super_heavy,
 		/obj/item/gun/projectile/deagle,
-		/obj/item/gun/custom_ka/frame01/illegal,
-		/obj/item/gun/projectile/automatic/rifle/konyang/pirate_rifle,
-		/obj/item/gun/projectile/automatic/konyang_pirate
+		/obj/item/gun/custom_ka/frame01/illegal
 	)
 
 /obj/random/vault_weapon


### PR DESCRIPTION
Reverts Aurorastation/Aurora.3#18124 - I was supposed to close this but didn't get around to it. The synth lore team asked me to wait until we got to Konyang to do this.