### PR TITLE
Intrepid moved one tile south, tiny expedition prep in front of it

### DIFF
--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Intrepid moved one tile south, with a tiny expedition preparation area added in front of it."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -1535,6 +1535,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
+"bfO" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "bfX" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
@@ -8774,6 +8779,11 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/hangar/starboard)
+"fXM" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "fXS" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -10841,11 +10851,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
-"huO" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "hvO" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -13174,11 +13179,6 @@
 /obj/effect/floor_decal/industrial/outline/custodial,
 /turf/simulated/floor/tiled,
 /area/horizon/custodial)
-"jjx" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "jjZ" = (
 /obj/effect/floor_decal/corner/dark_green/full{
 	dir = 4
@@ -14469,6 +14469,14 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
+"keZ" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/hoist_kit,
+/obj/item/ladder_mobile{
+	pixel_y = 12
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "kfb" = (
 /obj/machinery/gravity_generator/main/station,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -22220,10 +22228,11 @@
 /area/engineering/atmos/propulsion)
 "pwR" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/hoist_kit,
-/obj/item/ladder_mobile{
-	pixel_y = 12
-	},
+/obj/structure/closet/crate,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
 /turf/simulated/floor/plating,
 /area/hangar/intrepid)
 "pxH" = (
@@ -23870,11 +23879,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/custodial)
-"qzW" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "qAj" = (
 /turf/simulated/wall/shuttle/unique/scc/research{
 	icon_state = "14,17"
@@ -24821,8 +24825,8 @@
 "rlc" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/steel,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -8;
+/obj/item/storage/toolbox/emergency{
+	pixel_x = -7;
 	pixel_y = 8
 	},
 /obj/item/device/flashlight{
@@ -27835,6 +27839,11 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage/tech)
+"tsA" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "tsD" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -34474,50 +34483,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/morgue/lower)
-"xNd" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
-/obj/random/glowstick{
-	pixel_x = 4
-	},
-/obj/item/device/flashlight/flare{
-	pixel_x = -6
-	},
-/obj/item/device/flashlight/flare{
-	pixel_x = -6
-	},
-/obj/item/device/flashlight/flare{
-	pixel_x = -6
-	},
-/obj/item/device/flashlight/flare{
-	pixel_x = -6
-	},
-/obj/item/device/flashlight/flare{
-	pixel_x = -6
-	},
-/obj/item/device/flashlight/flare{
-	pixel_x = -6
-	},
-/obj/random/glowstick{
-	pixel_x = 4
-	},
-/obj/random/glowstick{
-	pixel_x = 4
-	},
-/obj/random/glowstick{
-	pixel_x = 4
-	},
-/obj/random/glowstick{
-	pixel_x = 4
-	},
-/obj/random/glowstick{
-	pixel_x = 4
-	},
-/obj/random/glowstick{
-	pixel_x = 4
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "xNw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -34555,17 +34520,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/hangar/intrepid)
-"xNT" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/floor/plating,
 /area/hangar/intrepid)
 "xOb" = (
 /obj/machinery/camera/network/first_deck{
@@ -53841,7 +53795,7 @@ lCX
 wuD
 ybD
 rGK
-jjx
+bfO
 iRC
 iRC
 iRC
@@ -54043,7 +53997,7 @@ eEm
 ifD
 wuD
 xCT
-xNT
+pwR
 evm
 iRC
 iRC
@@ -54449,7 +54403,7 @@ rLm
 mKo
 aHY
 vBN
-huO
+tsA
 iRC
 iRC
 pIR
@@ -56276,7 +56230,7 @@ jgk
 qPF
 rPN
 mrC
-qzW
+aUk
 iRC
 iRC
 hAl
@@ -56479,7 +56433,7 @@ kLb
 qeD
 rPN
 vmL
-aUk
+fXM
 iRC
 iRC
 xtM
@@ -56885,8 +56839,8 @@ mMQ
 gTx
 rPN
 sol
-pwR
-xNd
+keZ
+evm
 iRC
 iRC
 iRC

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -374,11 +374,6 @@
 	},
 /turf/simulated/floor/reinforced/phoron,
 /area/engineering/atmos)
-"aoS" = (
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "apf" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -1546,6 +1541,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"bgu" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "bgP" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -1932,12 +1933,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"bwq" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/freezer/rations,
-/obj/item/storage/box/kitchen,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "bwJ" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 8;
@@ -2429,6 +2424,11 @@
 "bJa" = (
 /turf/simulated/floor/plating,
 /area/hangar/auxiliary)
+"bKi" = (
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "bKx" = (
 /obj/effect/floor_decal/corner/dark_blue/diagonal,
 /obj/structure/table/steel,
@@ -4368,6 +4368,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenoarch_atrium)
+"dbJ" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "dbS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6025,6 +6030,20 @@
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/engineering/atmos)
+"enu" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/steel,
+/obj/item/hoist_kit,
+/obj/item/ladder_mobile{
+	pixel_y = 12
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
+"eny" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "enT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -6370,6 +6389,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/deck1)
+"eyg" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "eyI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7827,11 +7850,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/cockpit)
-"fsc" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "fsf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8206,25 +8224,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/tiled/white,
 /area/rnd/isolation_b)
-"fHQ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/steel,
-/obj/item/storage/box/flares{
-	pixel_x = -6;
-	pixel_y = 11
-	},
-/obj/item/storage/box/led_collars{
-	pixel_x = 8;
-	pixel_y = 11
-	},
-/obj/item/storage/box/flares{
-	pixel_x = -6
-	},
-/obj/item/storage/box/tethers{
-	pixel_x = 8
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "fIg" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -10657,11 +10656,6 @@
 /obj/structure/lattice,
 /turf/space/dynamic,
 /area/template_noop)
-"hpj" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "hpA" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -11143,6 +11137,13 @@
 	roof_type = null
 	},
 /area/horizon/custodial/disposals)
+"hFc" = (
+/obj/effect/shuttle_landmark/intrepid/hangar{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/cee,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "hGu" = (
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/corner/brown{
@@ -11621,18 +11622,6 @@
 "icm" = (
 /turf/simulated/wall,
 /area/maintenance/engineering/auxillary)
-"idf" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/steel,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/item/device/flashlight{
-	pixel_x = 4
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "idq" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -12123,15 +12112,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hangar/operations)
-"iyn" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/steel,
-/obj/item/hoist_kit,
-/obj/item/ladder_mobile{
-	pixel_y = 12
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "iyV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -12307,6 +12287,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/full,
 /area/medical/morgue/lower)
+"iEk" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/reagent_dispensers/extinguisher,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "iEz" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/portables_connector{
@@ -12332,10 +12317,6 @@
 "iFd" = (
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
-"iFf" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "iFH" = (
 /obj/machinery/atmospherics/unary/engine/scc_ship_engine,
 /turf/simulated/floor/reinforced{
@@ -15031,12 +15012,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/cockpit)
-"kzc" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "kzi" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -15620,6 +15595,11 @@
 	},
 /turf/space/dynamic,
 /area/horizon/exterior)
+"kSd" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "kSe" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
@@ -15877,11 +15857,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenoarch_atrium)
-"lbu" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "lcz" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	frequency = 1441;
@@ -16495,6 +16470,20 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
+"lBE" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/steel,
+/obj/item/stack/material/glass/full{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/item/stack/rods{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "lBH" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -16623,11 +16612,6 @@
 "lIg" = (
 /turf/simulated/wall,
 /area/medical/morgue/lower)
-"lIj" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/reagent_dispensers/extinguisher,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "lIu" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -18057,12 +18041,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/carpet/rubber,
 /area/maintenance/engineering/auxillary)
-"mBl" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "mBx" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
@@ -22834,6 +22812,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
+"pQA" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/steel,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/device/flashlight{
+	pixel_x = 4
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "pRb" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
@@ -24258,6 +24248,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage/tech)
+"qPA" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "qPF" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -24780,6 +24779,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/engine_compartment)
+"rhx" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "riF" = (
 /obj/structure/grille/broken,
 /obj/item/material/shard{
@@ -24886,6 +24891,12 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
+"rmL" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "rmY" = (
 /obj/structure/trash_pile,
 /obj/effect/floor_decal/corner/purple/full{
@@ -27870,15 +27881,6 @@
 "tuP" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/engineering/storage/lower)
-"tvc" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "tvn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29071,6 +29073,25 @@
 	},
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
+"ukr" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/steel,
+/obj/item/storage/box/flares{
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/obj/item/storage/box/led_collars{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/storage/box/flares{
+	pixel_x = -6
+	},
+/obj/item/storage/box/tethers{
+	pixel_x = 8
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "ukS" = (
 /turf/simulated/wall,
 /area/hangar/operations)
@@ -31189,18 +31210,6 @@
 /obj/item/hullbeacon/red,
 /turf/space/dynamic,
 /area/template_noop)
-"vHF" = (
-/obj/effect/shuttle_landmark/intrepid/hangar{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "vHR" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -32230,6 +32239,12 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion)
+"wsK" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/freezer/rations,
+/obj/item/storage/box/kitchen,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "wsO" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 4;
@@ -33162,20 +33177,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage/tech)
-"xbU" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/steel,
-/obj/item/stack/material/glass/full{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/obj/item/stack/rods{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "xdE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/suspension_gen{
@@ -53758,9 +53759,9 @@ oPL
 usP
 lCX
 wuD
-lIj
-hpj
-iFf
+iEk
+dbJ
+eyg
 iRC
 iRC
 iRC
@@ -53780,13 +53781,13 @@ iRC
 iRC
 iRC
 iRC
-mBl
+rhx
 kEJ
 kEJ
 kEJ
 kEJ
 kEJ
-tvc
+qPA
 kEJ
 kEJ
 kEJ
@@ -53961,9 +53962,9 @@ oPL
 eEm
 ifD
 wuD
-lbu
-bwq
-iFf
+eny
+wsK
+eyg
 iRC
 iRC
 iRC
@@ -54367,8 +54368,8 @@ oPL
 rLm
 mKo
 aHY
-aoS
-iFf
+bKi
+eyg
 iRC
 iRC
 pIR
@@ -54570,8 +54571,8 @@ oPL
 rLm
 mKo
 aHY
-fsc
-iFf
+kSd
+eyg
 iRC
 iRC
 iSn
@@ -54774,7 +54775,7 @@ rLm
 mKo
 aHY
 dJm
-iFf
+eyg
 iRC
 iRC
 iMt
@@ -55383,9 +55384,9 @@ mey
 hYy
 apf
 aaa
+bgu
 dSQ
-dSQ
-vHF
+hFc
 nvn
 gDj
 dir
@@ -56194,7 +56195,7 @@ aEl
 jgk
 qPF
 rPN
-fHQ
+ukr
 aUk
 iRC
 iRC
@@ -56397,7 +56398,7 @@ wSd
 kLb
 qeD
 rPN
-iyn
+enu
 aUk
 iRC
 iRC
@@ -56803,9 +56804,9 @@ aEl
 mMQ
 gTx
 rPN
-xbU
-iFf
-kzc
+lBE
+eyg
+rmL
 iRC
 iRC
 iRC
@@ -57006,9 +57007,9 @@ hdi
 aKo
 wif
 hdi
-idf
-hpj
-iFf
+pQA
+dbJ
+eyg
 iRC
 iRC
 iRC

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -2952,11 +2952,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/storage/eva)
-"cfl" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "cfJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -5997,6 +5992,11 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/engineering/storage/lower)
+"ema" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "emH" = (
 /obj/effect/floor_decal/corner/dark_green/diagonal,
 /obj/machinery/light{
@@ -8120,6 +8120,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
+"fEH" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "fFb" = (
 /obj/structure/shuttle_part/scc/mining{
 	icon_state = "thrustermount";
@@ -9455,6 +9466,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
+"gwj" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/hoist_kit,
+/obj/item/ladder_mobile{
+	pixel_y = 12
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "gwA" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -21385,11 +21404,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
-"oUR" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "oVe" = (
 /obj/structure/sign/fire{
 	desc = "A caution sign which reads 'PORT PROPULSION'.";
@@ -22642,14 +22656,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/isolation_a)
-"pKK" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/hoist_kit,
-/obj/item/ladder_mobile{
-	pixel_y = 12
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "pLc" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning{
@@ -28854,6 +28860,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"ucq" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "ucs" = (
 /obj/structure/closet/crate,
 /obj/machinery/mineral/stacking_unit_console{
@@ -53785,8 +53796,8 @@ usP
 lCX
 wuD
 ybD
-pwR
-cfl
+rGK
+ucq
 iRC
 iRC
 iRC
@@ -53988,7 +53999,7 @@ eEm
 ifD
 wuD
 xCT
-rGK
+fEH
 evm
 iRC
 iRC
@@ -54394,7 +54405,7 @@ rLm
 mKo
 aHY
 vBN
-oUR
+ema
 iRC
 iRC
 pIR
@@ -56830,7 +56841,7 @@ mMQ
 gTx
 rPN
 sol
-pKK
+gwj
 dnl
 iRC
 iRC

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -5992,11 +5992,6 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/engineering/storage/lower)
-"ema" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "emH" = (
 /obj/effect/floor_decal/corner/dark_green/diagonal,
 /obj/machinery/light{
@@ -8120,17 +8115,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
-"fEH" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "fFb" = (
 /obj/structure/shuttle_part/scc/mining{
 	icon_state = "thrustermount";
@@ -9466,14 +9450,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
-"gwj" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/hoist_kit,
-/obj/item/ladder_mobile{
-	pixel_y = 12
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "gwA" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -10865,6 +10841,11 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
+"huO" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "hvO" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -13193,6 +13174,11 @@
 /obj/effect/floor_decal/industrial/outline/custodial,
 /turf/simulated/floor/tiled,
 /area/horizon/custodial)
+"jjx" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "jjZ" = (
 /obj/effect/floor_decal/corner/dark_green/full{
 	dir = 4
@@ -22234,7 +22220,10 @@
 /area/engineering/atmos/propulsion)
 "pwR" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
+/obj/item/hoist_kit,
+/obj/item/ladder_mobile{
+	pixel_y = 12
+	},
 /turf/simulated/floor/plating,
 /area/hangar/intrepid)
 "pxH" = (
@@ -23881,6 +23870,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/custodial)
+"qzW" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "qAj" = (
 /turf/simulated/wall/shuttle/unique/scc/research{
 	icon_state = "14,17"
@@ -28860,11 +28854,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"ucq" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "ucs" = (
 /obj/structure/closet/crate,
 /obj/machinery/mineral/stacking_unit_console{
@@ -34485,6 +34474,50 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/morgue/lower)
+"xNd" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/obj/random/glowstick{
+	pixel_x = 4
+	},
+/obj/item/device/flashlight/flare{
+	pixel_x = -6
+	},
+/obj/item/device/flashlight/flare{
+	pixel_x = -6
+	},
+/obj/item/device/flashlight/flare{
+	pixel_x = -6
+	},
+/obj/item/device/flashlight/flare{
+	pixel_x = -6
+	},
+/obj/item/device/flashlight/flare{
+	pixel_x = -6
+	},
+/obj/item/device/flashlight/flare{
+	pixel_x = -6
+	},
+/obj/random/glowstick{
+	pixel_x = 4
+	},
+/obj/random/glowstick{
+	pixel_x = 4
+	},
+/obj/random/glowstick{
+	pixel_x = 4
+	},
+/obj/random/glowstick{
+	pixel_x = 4
+	},
+/obj/random/glowstick{
+	pixel_x = 4
+	},
+/obj/random/glowstick{
+	pixel_x = 4
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "xNw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -34522,6 +34555,17 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
+/area/hangar/intrepid)
+"xNT" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/turf/simulated/floor/plating,
 /area/hangar/intrepid)
 "xOb" = (
 /obj/machinery/camera/network/first_deck{
@@ -53797,7 +53841,7 @@ lCX
 wuD
 ybD
 rGK
-ucq
+jjx
 iRC
 iRC
 iRC
@@ -53999,7 +54043,7 @@ eEm
 ifD
 wuD
 xCT
-fEH
+xNT
 evm
 iRC
 iRC
@@ -54405,7 +54449,7 @@ rLm
 mKo
 aHY
 vBN
-ema
+huO
 iRC
 iRC
 pIR
@@ -56232,7 +56276,7 @@ jgk
 qPF
 rPN
 mrC
-aUk
+qzW
 iRC
 iRC
 hAl
@@ -56841,8 +56885,8 @@ mMQ
 gTx
 rPN
 sol
-gwj
-dnl
+pwR
+xNd
 iRC
 iRC
 iRC
@@ -57044,7 +57088,7 @@ aKo
 wif
 hdi
 rlc
-pwR
+dnl
 evm
 iRC
 iRC

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -2952,6 +2952,11 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/storage/eva)
+"cfl" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "cfJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -21380,6 +21385,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
+"oUR" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "oVe" = (
 /obj/structure/sign/fire{
 	desc = "A caution sign which reads 'PORT PROPULSION'.";
@@ -22632,6 +22642,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/isolation_a)
+"pKK" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/hoist_kit,
+/obj/item/ladder_mobile{
+	pixel_y = 12
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "pLc" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning{
@@ -26246,10 +26264,9 @@
 	pixel_x = -1;
 	pixel_y = 6
 	},
-/obj/item/stack/rods{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 4
+/obj/item/stack/rods/full{
+	pixel_y = 2;
+	pixel_x = 7
 	},
 /turf/simulated/floor/plating,
 /area/hangar/intrepid)
@@ -30686,9 +30703,21 @@
 "vmL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/steel,
-/obj/item/hoist_kit,
-/obj/item/ladder_mobile{
-	pixel_y = 12
+/obj/item/device/radio{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = 6;
+	pixel_y = 5
 	},
 /turf/simulated/floor/plating,
 /area/hangar/intrepid)
@@ -53757,7 +53786,7 @@ lCX
 wuD
 ybD
 pwR
-evm
+cfl
 iRC
 iRC
 iRC
@@ -54365,7 +54394,7 @@ rLm
 mKo
 aHY
 vBN
-evm
+oUR
 iRC
 iRC
 pIR
@@ -56801,7 +56830,7 @@ mMQ
 gTx
 rPN
 sol
-evm
+pKK
 dnl
 iRC
 iRC

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -1541,12 +1541,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"bgu" = (
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "bgP" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -2424,11 +2418,6 @@
 "bJa" = (
 /turf/simulated/floor/plating,
 /area/hangar/auxiliary)
-"bKi" = (
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "bKx" = (
 /obj/effect/floor_decal/corner/dark_blue/diagonal,
 /obj/structure/table/steel,
@@ -4368,11 +4357,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenoarch_atrium)
-"dbJ" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "dbS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4637,6 +4621,12 @@
 "dmS" = (
 /turf/simulated/wall/r_wall,
 /area/teleporter)
+"dnl" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "dns" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 6
@@ -6030,20 +6020,6 @@
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/engineering/atmos)
-"enu" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/steel,
-/obj/item/hoist_kit,
-/obj/item/ladder_mobile{
-	pixel_y = 12
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
-"eny" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "enT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -6315,6 +6291,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"evm" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "evr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -6389,10 +6369,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/deck1)
-"eyg" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "eyI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6571,6 +6547,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/auxiliary)
+"eEc" = (
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "eEm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7079,10 +7061,6 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/hullbeacon/red,
-/obj/machinery/camera/network/supply{
-	c_tag = "Operations - Mining Shuttle Dock Port";
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -9432,6 +9410,13 @@
 /obj/machinery/alarm/east,
 /turf/simulated/floor/tiled,
 /area/hangar/operations)
+"guq" = (
+/obj/effect/shuttle_landmark/intrepid/hangar{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/cee,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "gux" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -9745,6 +9730,15 @@
 /obj/effect/floor_decal/corner/mauve/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/storage/eva)
+"gED" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "gFE" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -11137,13 +11131,6 @@
 	roof_type = null
 	},
 /area/horizon/custodial/disposals)
-"hFc" = (
-/obj/effect/shuttle_landmark/intrepid/hangar{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/cee,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "hGu" = (
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/corner/brown{
@@ -12287,11 +12274,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/full,
 /area/medical/morgue/lower)
-"iEk" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/reagent_dispensers/extinguisher,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "iEz" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/portables_connector{
@@ -12870,6 +12852,11 @@
 "iXY" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/engineering)
+"iYQ" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "iYS" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -15595,11 +15582,6 @@
 	},
 /turf/space/dynamic,
 /area/horizon/exterior)
-"kSd" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "kSe" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
@@ -16470,20 +16452,6 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
-"lBE" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/steel,
-/obj/item/stack/material/glass/full{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/obj/item/stack/rods{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "lBH" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -17805,6 +17773,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
+"mrC" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/steel,
+/obj/item/storage/box/flares{
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/obj/item/storage/box/led_collars{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/storage/box/flares{
+	pixel_x = -6
+	},
+/obj/item/storage/box/tethers{
+	pixel_x = 8
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "msd" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot{
 	dir = 8
@@ -20209,6 +20196,12 @@
 "nWF" = (
 /turf/simulated/wall,
 /area/maintenance/hangar/starboard)
+"nWZ" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "nXE" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -22215,6 +22208,11 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/propulsion)
+"pwR" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "pxH" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -22812,18 +22810,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
-"pQA" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/table/steel,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/item/device/flashlight{
-	pixel_x = 4
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "pRb" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
@@ -24248,15 +24234,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage/tech)
-"qPA" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "qPF" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -24779,12 +24756,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/engine_compartment)
-"rhx" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "riF" = (
 /obj/structure/grille/broken,
 /obj/item/material/shard{
@@ -24828,6 +24799,18 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
+/area/hangar/intrepid)
+"rlc" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/steel,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/device/flashlight{
+	pixel_x = 4
+	},
+/turf/simulated/floor/plating,
 /area/hangar/intrepid)
 "rlH" = (
 /obj/structure/cable{
@@ -24891,12 +24874,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
-"rmL" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "rmY" = (
 /obj/structure/trash_pile,
 /obj/effect/floor_decal/corner/purple/full{
@@ -25422,6 +25399,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/morgue/lower)
+"rGK" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/freezer/rations,
+/obj/item/storage/box/kitchen,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "rHr" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -26256,6 +26239,20 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/mining)
+"sol" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/steel,
+/obj/item/stack/material/glass/full{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/item/stack/rods{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "soD" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	dir = 8;
@@ -29073,25 +29070,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/engineering/atmos)
-"ukr" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/table/steel,
-/obj/item/storage/box/flares{
-	pixel_x = -6;
-	pixel_y = 11
-	},
-/obj/item/storage/box/led_collars{
-	pixel_x = 8;
-	pixel_y = 11
-	},
-/obj/item/storage/box/flares{
-	pixel_x = -6
-	},
-/obj/item/storage/box/tethers{
-	pixel_x = 8
-	},
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "ukS" = (
 /turf/simulated/wall,
 /area/hangar/operations)
@@ -30705,6 +30683,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
+"vmL" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/steel,
+/obj/item/hoist_kit,
+/obj/item/ladder_mobile{
+	pixel_y = 12
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "vmR" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -31072,6 +31059,11 @@
 	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/engineering/atmos)
+"vBN" = (
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "vCC" = (
 /obj/structure/trash_pile,
 /obj/effect/floor_decal/industrial/warning{
@@ -32239,12 +32231,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos/propulsion)
-"wsK" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/freezer/rations,
-/obj/item/storage/box/kitchen,
-/turf/simulated/floor/plating,
-/area/hangar/intrepid)
 "wsO" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 4;
@@ -34134,6 +34120,11 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/full,
 /area/medical/morgue/lower)
+"xCT" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "xDI" = (
 /obj/structure/lattice/catwalk/indoor/grate/damaged,
 /turf/simulated/floor/plating,
@@ -34929,6 +34920,11 @@
 	},
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/hangar/auxiliary)
+"ybD" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/reagent_dispensers/extinguisher,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "ych" = (
 /obj/machinery/light{
 	dir = 8
@@ -53759,9 +53755,9 @@ oPL
 usP
 lCX
 wuD
-iEk
-dbJ
-eyg
+ybD
+pwR
+evm
 iRC
 iRC
 iRC
@@ -53781,13 +53777,13 @@ iRC
 iRC
 iRC
 iRC
-rhx
+nWZ
 kEJ
 kEJ
 kEJ
 kEJ
 kEJ
-qPA
+gED
 kEJ
 kEJ
 kEJ
@@ -53962,9 +53958,9 @@ oPL
 eEm
 ifD
 wuD
-eny
-wsK
-eyg
+xCT
+rGK
+evm
 iRC
 iRC
 iRC
@@ -54368,8 +54364,8 @@ oPL
 rLm
 mKo
 aHY
-bKi
-eyg
+vBN
+evm
 iRC
 iRC
 pIR
@@ -54571,8 +54567,8 @@ oPL
 rLm
 mKo
 aHY
-kSd
-eyg
+iYQ
+evm
 iRC
 iRC
 iSn
@@ -54775,7 +54771,7 @@ rLm
 mKo
 aHY
 dJm
-eyg
+evm
 iRC
 iRC
 iMt
@@ -55384,9 +55380,9 @@ mey
 hYy
 apf
 aaa
-bgu
+eEc
 dSQ
-hFc
+guq
 nvn
 gDj
 dir
@@ -56195,7 +56191,7 @@ aEl
 jgk
 qPF
 rPN
-ukr
+mrC
 aUk
 iRC
 iRC
@@ -56398,7 +56394,7 @@ wSd
 kLb
 qeD
 rPN
-enu
+vmL
 aUk
 iRC
 iRC
@@ -56804,9 +56800,9 @@ aEl
 mMQ
 gTx
 rPN
-lBE
-eyg
-rmL
+sol
+evm
+dnl
 iRC
 iRC
 iRC
@@ -57007,9 +57003,9 @@ hdi
 aKo
 wif
 hdi
-pQA
-dbJ
-eyg
+rlc
+pwR
+evm
 iRC
 iRC
 iRC

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -102,7 +102,21 @@
 	dir = 8;
 	must_start_working = 1
 	},
-/obj/structure/lattice/catwalk/indoor,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/steel,
+/obj/item/storage/bag/inflatable{
+	pixel_y = 10;
+	pixel_x = 2
+	},
+/obj/item/device/gps/science{
+	pixel_x = 3
+	},
+/obj/item/device/gps{
+	pixel_x = -6
+	},
+/obj/item/device/gps/mining{
+	pixel_x = 12
+	},
 /turf/simulated/floor/plating,
 /area/hangar/intrepid)
 "adX" = (
@@ -360,6 +374,11 @@
 	},
 /turf/simulated/floor/reinforced/phoron,
 /area/engineering/atmos)
+"aoS" = (
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "apf" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -1072,12 +1091,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "aRG" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/obj/machinery/shieldwallgen,
-/turf/simulated/floor/airless,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/hullbeacon/red,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/hangar/intrepid)
 "aSL" = (
 /obj/structure/cable/green{
@@ -1147,9 +1169,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "aUk" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/hangar/intrepid)
 "aUC" = (
@@ -1912,6 +1932,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"bwq" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/freezer/rations,
+/obj/item/storage/box/kitchen,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "bwJ" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 8;
@@ -2677,7 +2703,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "bSM" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/airless,
 /area/hangar/intrepid)
 "bUN" = (
@@ -5236,7 +5261,8 @@
 	dir = 4;
 	must_start_working = 1
 	},
-/obj/structure/lattice/catwalk/indoor,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plating,
 /area/hangar/intrepid)
 "dJH" = (
@@ -5504,9 +5530,11 @@
 /turf/simulated/floor/lino,
 /area/shuttle/intrepid/quarters)
 "dSQ" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/effect/shuttle_landmark/intrepid/hangar{
-	dir = 1
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/hangar/intrepid)
@@ -7023,12 +7051,19 @@
 /turf/simulated/floor/plating,
 /area/shuttle/mining)
 "eVk" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/shieldwallgen,
-/obj/structure/cable/green{
-	icon_state = "0-4"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
-/turf/simulated/floor/airless,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/hullbeacon/red,
+/obj/machinery/camera/network/supply{
+	c_tag = "Operations - Mining Shuttle Dock Port";
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/hangar/intrepid)
 "eVn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -7792,6 +7827,11 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/cockpit)
+"fsc" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "fsf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8166,6 +8206,25 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/tiled/white,
 /area/rnd/isolation_b)
+"fHQ" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/steel,
+/obj/item/storage/box/flares{
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/obj/item/storage/box/led_collars{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/storage/box/flares{
+	pixel_x = -6
+	},
+/obj/item/storage/box/tethers{
+	pixel_x = 8
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "fIg" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -10032,9 +10091,6 @@
 /obj/effect/floor_decal/corner/black{
 	dir = 9
 	},
-/obj/structure/railing/mapped{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10601,6 +10657,11 @@
 /obj/structure/lattice,
 /turf/space/dynamic,
 /area/template_noop)
+"hpj" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "hpA" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -11560,6 +11621,18 @@
 "icm" = (
 /turf/simulated/wall,
 /area/maintenance/engineering/auxillary)
+"idf" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/steel,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/device/flashlight{
+	pixel_x = 4
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "idq" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -11871,9 +11944,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "ipg" = (
@@ -12053,6 +12123,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/hangar/operations)
+"iyn" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/steel,
+/obj/item/hoist_kit,
+/obj/item/ladder_mobile{
+	pixel_y = 12
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "iyV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -12253,6 +12332,10 @@
 "iFd" = (
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
+"iFf" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "iFH" = (
 /obj/machinery/atmospherics/unary/engine/scc_ship_engine,
 /turf/simulated/floor/reinforced{
@@ -14948,6 +15031,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/cockpit)
+"kzc" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "kzi" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -15788,6 +15877,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenoarch_atrium)
+"lbu" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "lcz" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	frequency = 1441;
@@ -16529,6 +16623,11 @@
 "lIg" = (
 /turf/simulated/wall,
 /area/medical/morgue/lower)
+"lIj" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/reagent_dispensers/extinguisher,
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "lIu" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -17958,6 +18057,12 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/carpet/rubber,
 /area/maintenance/engineering/auxillary)
+"mBl" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "mBx" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
@@ -18699,9 +18804,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/spot{
 	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
@@ -27768,6 +27870,15 @@
 "tuP" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/engineering/storage/lower)
+"tvc" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "tvn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -31078,6 +31189,18 @@
 /obj/item/hullbeacon/red,
 /turf/space/dynamic,
 /area/template_noop)
+"vHF" = (
+/obj/effect/shuttle_landmark/intrepid/hangar{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "vHR" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -33039,6 +33162,20 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/storage/tech)
+"xbU" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/steel,
+/obj/item/stack/material/glass/full{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/item/stack/rods{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/simulated/floor/plating,
+/area/hangar/intrepid)
 "xdE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/suspension_gen{
@@ -33950,7 +34087,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/light/spot{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -53422,10 +53559,10 @@ her
 xVU
 xVU
 pEO
-xVU
-xVU
-xVU
-xVU
+fEy
+mNH
+mNH
+lMA
 aXq
 xVU
 xVU
@@ -53621,8 +53758,9 @@ oPL
 usP
 lCX
 wuD
-pvn
-iRC
+lIj
+hpj
+iFf
 iRC
 iRC
 iRC
@@ -53642,17 +53780,16 @@ iRC
 iRC
 iRC
 iRC
-iRC
-iRC
-iRC
-iRC
-iRC
-iRC
-iRC
-iRC
-iRC
-iRC
-nDI
+mBl
+kEJ
+kEJ
+kEJ
+kEJ
+kEJ
+tvc
+kEJ
+kEJ
+kEJ
 aRG
 nDI
 eSV
@@ -53824,8 +53961,9 @@ oPL
 eEm
 ifD
 wuD
-pvn
-iRC
+lbu
+bwq
+iFf
 iRC
 iRC
 iRC
@@ -53855,8 +53993,7 @@ iRC
 iRC
 iRC
 iRC
-cLV
-bSM
+iRC
 cLV
 eSV
 eSV
@@ -54027,7 +54164,8 @@ oPL
 gpw
 fUS
 aHY
-pvn
+iRC
+iRC
 iRC
 iRC
 eHK
@@ -54058,8 +54196,7 @@ iRC
 iRC
 iRC
 iRC
-cLV
-bSM
+iRC
 cLV
 eSV
 eSV
@@ -54230,7 +54367,8 @@ oPL
 rLm
 mKo
 aHY
-pvn
+aoS
+iFf
 iRC
 iRC
 pIR
@@ -54261,8 +54399,7 @@ iRC
 iRC
 iRC
 iRC
-cLV
-bSM
+iRC
 cLV
 eSV
 eSV
@@ -54433,7 +54570,8 @@ oPL
 rLm
 mKo
 aHY
-pvn
+fsc
+iFf
 iRC
 iRC
 iSn
@@ -54464,8 +54602,7 @@ iRC
 iRC
 iRC
 iRC
-cLV
-bSM
+iRC
 cLV
 eSV
 eSV
@@ -54637,6 +54774,7 @@ rLm
 mKo
 aHY
 dJm
+iFf
 iRC
 iRC
 iMt
@@ -54667,8 +54805,7 @@ iRC
 iRC
 iRC
 iRC
-cLV
-bSM
+iRC
 cLV
 eSV
 eSV
@@ -54842,6 +54979,7 @@ wuD
 wuD
 ahI
 uRt
+uRt
 iAP
 vvK
 wzA
@@ -54870,8 +55008,7 @@ hqo
 iRC
 iRC
 iRC
-cLV
-bSM
+iRC
 cLV
 eSV
 eSV
@@ -55045,6 +55182,7 @@ hUk
 aaa
 pvn
 pvn
+pvn
 fZQ
 jXW
 kki
@@ -55073,8 +55211,7 @@ oKJ
 ebk
 lbc
 iRC
-cLV
-bSM
+iRC
 cLV
 eSV
 eSV
@@ -55246,8 +55383,9 @@ mey
 hYy
 apf
 aaa
-pvn
 dSQ
+dSQ
+vHF
 nvn
 gDj
 dir
@@ -55276,7 +55414,6 @@ kyK
 oSi
 kaM
 iRC
-cLV
 bSM
 xsx
 eSV
@@ -55451,6 +55588,7 @@ hhv
 aaa
 pvn
 pvn
+pvn
 kxk
 rKh
 yib
@@ -55479,8 +55617,7 @@ iQL
 tsR
 bFM
 iRC
-cLV
-bSM
+iRC
 cLV
 eSV
 eSV
@@ -55654,6 +55791,7 @@ wuD
 wuD
 kEJ
 kEJ
+kEJ
 xqv
 inM
 iaD
@@ -55682,8 +55820,7 @@ owM
 iRC
 iRC
 iRC
-cLV
-bSM
+iRC
 cLV
 eSV
 eSV
@@ -55857,6 +55994,7 @@ rPN
 adv
 aUk
 iRC
+iRC
 fNt
 tvK
 inf
@@ -55885,8 +56023,7 @@ iRC
 iRC
 iRC
 iRC
-cLV
-bSM
+iRC
 cLV
 eSV
 eSV
@@ -56057,7 +56194,8 @@ aEl
 jgk
 qPF
 rPN
-pvn
+fHQ
+aUk
 iRC
 iRC
 hAl
@@ -56088,8 +56226,7 @@ iRC
 iRC
 iRC
 iRC
-cLV
-bSM
+iRC
 cLV
 eSV
 eSV
@@ -56260,7 +56397,8 @@ wSd
 kLb
 qeD
 rPN
-pvn
+iyn
+aUk
 iRC
 iRC
 xtM
@@ -56291,8 +56429,7 @@ iRC
 iRC
 iRC
 iRC
-cLV
-bSM
+iRC
 cLV
 eSV
 eSV
@@ -56463,7 +56600,8 @@ aEl
 kLb
 qeD
 rPN
-pvn
+iRC
+iRC
 iRC
 iRC
 dhJ
@@ -56494,8 +56632,7 @@ iRC
 iRC
 iRC
 iRC
-cLV
-bSM
+iRC
 cLV
 eSV
 eSV
@@ -56666,8 +56803,9 @@ aEl
 mMQ
 gTx
 rPN
-pvn
-iRC
+xbU
+iFf
+kzc
 iRC
 iRC
 iRC
@@ -56697,8 +56835,7 @@ iRC
 iRC
 iRC
 iRC
-cLV
-bSM
+iRC
 cLV
 eSV
 eSV
@@ -56869,8 +57006,9 @@ hdi
 aKo
 wif
 hdi
-pvn
-iRC
+idf
+hpj
+iFf
 iRC
 iRC
 iRC
@@ -56880,7 +57018,6 @@ dRx
 kmo
 nrz
 qui
-iRC
 iRC
 iRC
 iRC
@@ -56900,8 +57037,8 @@ iRC
 iRC
 iRC
 iRC
-cLV
-bSM
+iRC
+iRC
 cLV
 eSV
 eSV
@@ -57103,7 +57240,7 @@ uRt
 xAU
 uRt
 uRt
-nDI
+uRt
 eVk
 nDI
 eSV


### PR DESCRIPTION
![image](https://github.com/Aurorastation/Aurora.3/assets/107256943/090841fe-3427-42b6-ad17-eb4beb91c32d)

changes:
  - maptweak: "Intrepid moved one tile south, with a tiny expedition preparation area added in front of it."

Why:
I think it's nice, makes the area just a bit more busy and lived-in, and less boring.