### PR TITLE
SCC Scout Shuttle Sector Tweak

### DIFF
--- a/html/changelogs/RustingWithYou - sccshuttlesectors.yml
+++ b/html/changelogs/RustingWithYou - sccshuttlesectors.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "SCC scout shuttle is now restricted to SCC-present sectors."

--- a/maps/away/ships/scc/scc_scout_ship.dm
+++ b/maps/away/ships/scc/scc_scout_ship.dm
@@ -3,6 +3,7 @@
 	description = "A small ship commonly fielded by the Stellar Corporate Conglomerate, the Serendipity-class, Hephaestus-designed and produced. It is supposed to be a small platform, entirely self-sufficient general-purpose scouting and surveying ship, the Serendipity is equipped with both a bluespace and a warp drive and two different engines."
 	suffixes = list("ships/scc/scc_scout_ship.dmm")
 	sectors = list(ALL_CORPORATE_SECTORS)
+	sectors_blacklist = list(SECTOR_UUEOAESA)
 	spawn_weight = 1
 	ship_cost = 1
 	id = "scc_scout_ship"

--- a/maps/away/ships/scc/scc_scout_ship.dm
+++ b/maps/away/ships/scc/scc_scout_ship.dm
@@ -2,7 +2,7 @@
 	name = "SCC Scout Ship"
 	description = "A small ship commonly fielded by the Stellar Corporate Conglomerate, the Serendipity-class, Hephaestus-designed and produced. It is supposed to be a small platform, entirely self-sufficient general-purpose scouting and surveying ship, the Serendipity is equipped with both a bluespace and a warp drive and two different engines."
 	suffixes = list("ships/scc/scc_scout_ship.dmm")
-	sectors = list(ALL_POSSIBLE_SECTORS)
+	sectors = list(ALL_CORPORATE_SECTORS)
 	spawn_weight = 1
 	ship_cost = 1
 	id = "scc_scout_ship"


### PR DESCRIPTION
Tweaks the SCC Scout Shuttle to use ALL_CORPORATE_SECTORS rather than ALL_POSSIBLE_SECTORS. The corporate sectors list exists specifically for places that would have some kind of SCC presence, and it doesn't particularly make much sense for an SCC scout to be flying around in Elyra, for instance.

Also blacklists the shuttle from spawning in Uueoa-Esa, as the SCC itself doesn't really have a presence there and that system falls under me as Unathi lore. Future sectors can be blacklisted or added as the relevant lore teams desire.