### PR TITLE
Goon base, less rads

### DIFF
--- a/html/changelogs/DreamySkrell-goon-base-no-rads.yml
+++ b/html/changelogs/DreamySkrell-goon-base-no-rads.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Goon base, radioactive goo changed to mostly be the non-radiactive variant."

--- a/maps/away/away_site/goon_base/goon_base.dmm
+++ b/maps/away/away_site/goon_base/goon_base.dmm
@@ -266,8 +266,8 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/effect/decal/cleanable/greenglow/radioactive{
-	pixel_x = 12;
-	pixel_y = -5
+	pixel_x = 8;
+	pixel_y = -6
 	},
 /turf/simulated/floor/plating/asteroid,
 /area/goonbase/maint_south)
@@ -928,7 +928,7 @@
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/hallway_north)
 "eH" = (
-/obj/effect/decal/cleanable/greenglow/radioactive{
+/obj/effect/decal/cleanable/greenglow{
 	pixel_x = -10;
 	pixel_y = 9
 	},
@@ -1794,7 +1794,7 @@
 	pixel_y = 6
 	},
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/greenglow/radioactive{
+/obj/effect/decal/cleanable/greenglow{
 	pixel_x = -4;
 	pixel_y = 9
 	},
@@ -2586,7 +2586,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/effect/decal/cleanable/greenglow,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating/asteroid,
 /area/goonbase/maint_south)
@@ -3587,7 +3587,7 @@
 	pixel_y = -7;
 	pixel_x = 2
 	},
-/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/effect/decal/cleanable/greenglow,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -3720,7 +3720,7 @@
 "rW" = (
 /obj/structure/reagent_dispensers/radioactive_waste,
 /obj/effect/decal/cleanable/acid_remnants,
-/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/effect/decal/cleanable/greenglow,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
@@ -3991,7 +3991,7 @@
 	pixel_x = 2
 	},
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/greenglow/radioactive{
+/obj/effect/decal/cleanable/greenglow{
 	pixel_x = -10;
 	pixel_y = 9
 	},
@@ -4867,7 +4867,7 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/effect/decal/cleanable/greenglow,
 /obj/random/dirt_75,
 /turf/simulated/floor/plating/asteroid,
 /area/goonbase/maint_south)
@@ -6116,7 +6116,7 @@
 	pixel_x = 6
 	},
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/greenglow/radioactive{
+/obj/effect/decal/cleanable/greenglow{
 	pixel_x = -10;
 	pixel_y = 9
 	},
@@ -6698,7 +6698,7 @@
 /obj/random/dirt_75,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/greenglow/radioactive{
+/obj/effect/decal/cleanable/greenglow{
 	pixel_x = -13;
 	pixel_y = 9
 	},
@@ -7454,7 +7454,7 @@
 	},
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/greenglow/radioactive{
+/obj/effect/decal/cleanable/greenglow{
 	pixel_x = -4;
 	pixel_y = 9
 	},
@@ -8565,7 +8565,7 @@
 	pixel_x = 2
 	},
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/effect/decal/cleanable/greenglow,
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/maint_south)
 "Rg" = (
@@ -10258,7 +10258,7 @@
 	pixel_x = -9
 	},
 /obj/random/dirt_75,
-/obj/effect/decal/cleanable/greenglow/radioactive,
+/obj/effect/decal/cleanable/greenglow,
 /turf/simulated/floor/exoplanet/barren,
 /area/goonbase/maint_south)
 "Zs" = (


### PR DESCRIPTION
changes:
  - bugfix: "Goon base, radioactive goo changed to mostly be the non-radiactive variant."

there is one actually radioactive goo on the back, but it has a range of 4, and does not irradiate you through walls when just walking through maint tunnels