### PR TITLE
Atmospherics Clothing Locker Contents Tweak

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -168,13 +168,16 @@
 	new /obj/item/clothing/shoes/sneakers/black(src)
 	new /obj/item/clothing/head/hardhat/red(src)
 	new /obj/item/clothing/head/hardhat/green(src)
-	new /obj/item/clothing/head/beret/engineering(src)
+	new /obj/item/clothing/head/beret/atmos(src)
+	new /obj/item/clothing/head/beret/atmos(src)
 	new /obj/item/clothing/head/beret/corporate/heph(src)
 	new /obj/item/clothing/head/beret/corporate/zavod(src)
 	new /obj/item/clothing/head/bandana/atmos(src)
 	new /obj/item/clothing/suit/storage/hazardvest/green(src)
 	new /obj/item/clothing/suit/storage/hazardvest/red(src)
 	new /obj/item/clothing/suit/storage/hazardvest/blue/atmos(src)
+	new /obj/item/clothing/suit/storage/toggle/highvis(src)
+	new /obj/item/clothing/suit/storage/toggle/highvis_alt(src)
 	return
 
 
@@ -202,7 +205,7 @@
 	new /obj/item/clothing/head/bandana/engineering(src)
 	new /obj/item/clothing/head/bandana/engineering(src)
 	new /obj/item/clothing/suit/storage/toggle/highvis(src)
-	new /obj/item/clothing/suit/storage/toggle/highvis(src)
+	new /obj/item/clothing/suit/storage/toggle/highvis_alt(src)
 	new /obj/item/clothing/suit/storage/hazardvest/green(src)
 	new /obj/item/clothing/suit/storage/hazardvest/red(src)
 

--- a/html/changelogs/kermit-atmoshighvis.yml
+++ b/html/changelogs/kermit-atmoshighvis.yml
@@ -1,0 +1,6 @@
+author: kermit
+
+delete-after: True
+
+changes:
+  - tweak: "The Atmospheric Technician clothing locker now has high visibility jackets, same as the Engineer clothing locker. Also swaps out the Engineer berets with Atmospheric berets."


### PR DESCRIPTION
just some small tweaks to the atmos clothing locker.
- The Atmos clothing locker now has 1 of each high-vis. jacket type, mirroring the engineer's locker which already contained such. 
- The Atmos clothing locker now has 2 Atmospheric Technician berets instead of 1 Engineering Beret.
- The Engineer's clothing locker now has 1 high-vis and 1 alt. high-vis., instead of 2 regular high-vis. jackets.

*these high-vis jackets, not the corporate-coloured vests
![alt](https://github.com/Aurorastation/Aurora.3/assets/58568342/395dabdd-e13a-4a26-9366-5d5ca0d6d92d)
![notalt](https://github.com/Aurorastation/Aurora.3/assets/58568342/5b45032f-c7f8-4a3b-8117-6ae459ce8468)