### PR TITLE
Fixes Horizon Flag Stand Icons

### DIFF
--- a/html/changelogs/RustingWithYou - flagfixes.yml
+++ b/html/changelogs/RustingWithYou - flagfixes.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Removes flag stands from wall-mounted banners on the Horizon."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -22927,10 +22927,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/assembly/chargebay)
-"pYa" = (
-/obj/structure/sign/flag/scc,
-/turf/simulated/wall,
-/area/hangar/intrepid/interstitial)
 "pYu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24710,6 +24706,10 @@
 	},
 /obj/structure/bed/stool/chair/padded/black{
 	dir = 4
+	},
+/obj/structure/sign/flag/scc{
+	pixel_y = 32;
+	stand_icon = "banner"
 	},
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
@@ -32430,9 +32430,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/port/deck1)
 "wIJ" = (
-/obj/effect/floor_decal/corner/dark_green/full{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -32441,6 +32438,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/sign/flag/scc{
+	pixel_y = 32;
+	stand_icon = "banner"
 	},
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid/interstitial)
@@ -33734,6 +33735,10 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/low/east,
+/obj/structure/sign/flag/scc{
+	pixel_y = 32;
+	stand_icon = "banner"
+	},
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid/interstitial)
 "xtK" = (
@@ -55024,7 +55029,7 @@ uUZ
 rCq
 gOP
 qnt
-pYa
+dVM
 wIJ
 fXS
 lnt
@@ -55032,7 +55037,7 @@ uoF
 xFB
 uSG
 uqn
-pYa
+dVM
 rkQ
 oqE
 rLm
@@ -55633,7 +55638,7 @@ jvl
 wLL
 vhY
 lVN
-pYa
+dVM
 xtH
 fuL
 ifd

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -535,7 +535,8 @@
 	dir = 1
 	},
 /obj/structure/sign/flag/scc{
-	pixel_y = 32
+	pixel_y = 32;
+	stand_icon = "banner"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/zta)
@@ -12315,7 +12316,8 @@
 	dir = 5
 	},
 /obj/structure/sign/flag/scc{
-	pixel_y = 32
+	pixel_y = 32;
+	stand_icon = "banner"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
@@ -21198,7 +21200,8 @@
 	dir = 8
 	},
 /obj/structure/sign/flag/scc{
-	pixel_y = 32
+	pixel_y = 32;
+	stand_icon = "banner"
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -91,7 +91,7 @@
 /obj/effect/map_effect/door_helper/unres,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/map_effect/door_helper/level_access/command_foyer{
-	req_one_access_by_level = list("green","yellow" = list(19,38,72),"blue"=list(19,38,72),"red"=list(19,38,72),"delta"=list(19,38,72));
+	req_one_access_by_level = list("green","yellow"=list(19,38,72),"blue"=list(19,38,72),"red"=list(19,38,72),"delta"=list(19,38,72));
 	access_by_level = null
 	},
 /obj/machinery/door/airlock/glass_command{
@@ -907,6 +907,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/structure/sign/flag/scc/unmovable{
+	stand_icon = "banner";
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/full,
 /area/bridge)
@@ -4330,7 +4334,8 @@
 	dir = 8
 	},
 /obj/structure/sign/flag/idris{
-	pixel_y = -32
+	pixel_y = -32;
+	stand_icon = "banner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5009,7 +5014,7 @@
 	req_one_access = list(19,38,72)
 	},
 /obj/effect/map_effect/door_helper/level_access/command_foyer{
-	req_one_access_by_level = list("green","yellow" = list(19,38,72),"blue"=list(19,38,72),"red"=list(19,38,72),"delta"=list(19,38,72));
+	req_one_access_by_level = list("green","yellow"=list(19,38,72),"blue"=list(19,38,72),"red"=list(19,38,72),"delta"=list(19,38,72));
 	access_by_level = null
 	},
 /turf/simulated/floor/tiled/full,
@@ -13094,10 +13099,6 @@
 /obj/effect/floor_decal/corner/dark_green/diagonal,
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/starboard)
-"jnZ" = (
-/obj/structure/sign/flag/scc/unmovable,
-/turf/simulated/wall/r_wall,
-/area/horizon/hallway/deck_three/primary/central)
 "jok" = (
 /obj/structure/table/reinforced/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup{
@@ -13179,7 +13180,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/map_effect/door_helper/level_access/command_foyer{
-	req_one_access_by_level = list("green","yellow" = list(19,38,72),"blue"=list(19,38,72),"red"=list(19,38,72),"delta"=list(19,38,72));
+	req_one_access_by_level = list("green","yellow"=list(19,38,72),"blue"=list(19,38,72),"red"=list(19,38,72),"delta"=list(19,38,72));
 	access_by_level = null
 	},
 /obj/machinery/door/airlock/glass_command{
@@ -17146,6 +17147,10 @@
 	dir = 5
 	},
 /obj/machinery/photocopier,
+/obj/structure/sign/flag/scc/unmovable{
+	stand_icon = "banner";
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
 "mcf" = (
@@ -24582,10 +24587,6 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
-"rqN" = (
-/obj/structure/sign/flag/scc/unmovable,
-/turf/simulated/wall/r_wall,
-/area/bridge/controlroom)
 "rqU" = (
 /obj/structure/platform/cutout{
 	dir = 8
@@ -30722,6 +30723,10 @@
 	pixel_x = 10
 	},
 /obj/machinery/papershredder,
+/obj/structure/sign/flag/scc/unmovable{
+	stand_icon = "banner";
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/controlroom)
 "vDv" = (
@@ -53946,7 +53951,7 @@ vIv
 cJU
 sGJ
 tYp
-rqN
+asO
 mcd
 olJ
 jmA
@@ -54754,7 +54759,7 @@ wAf
 gKI
 iwW
 jDJ
-rqN
+asO
 vCY
 qaE
 aGi
@@ -55343,7 +55348,7 @@ dla
 wTy
 wdy
 eSk
-jnZ
+wdy
 aFm
 tHx
 agT


### PR DESCRIPTION
The various SCC flags on the Horizon will no longer have stands if they're wall-mounted.