### PR TITLE
Fix Death Tracking again

### DIFF
--- a/SQL/migrate-2023/V009__fix_death_saving_again.sql
+++ b/SQL/migrate-2023/V009__fix_death_saving_again.sql
@@ -1,0 +1,9 @@
+--
+-- Fixes death saving again by removing the foreign key constraints on the ckeys. (sometimes chey can contain things that arnt ckeys. i.e. @ckey when someone aghosts)
+--
+ALTER TABLE `ss13_death`
+	DROP FOREIGN KEY `FK_ss13_death_ss13_characters`;
+ALTER TABLE `ss13_death`
+	DROP FOREIGN KEY `FK_ss13_death_ss13_player`,
+	DROP FOREIGN KEY `FK_ss13_death_ss13_player_lackey`,
+	ADD CONSTRAINT `FK_ss13_death_ss13_characters_char_id` FOREIGN KEY (`char_id`) REFERENCES `ss13_characters` (`id`) ON UPDATE CASCADE ON DELETE SET NULL;

--- a/code/controllers/subsystems/statistics.dm
+++ b/code/controllers/subsystems/statistics.dm
@@ -259,14 +259,14 @@ GENERAL_PROTECT_DATUM(/datum/controller/subsystem/statistics)
 	if(!query.Execute(list(
 		"name"=H.real_name,
 		"ckey"=H.ckey,
-		"char_id"=H.character_id,
+		"char_id"=H.character_id ? H.character_id : null, //make sure we set the char id to null and not 0 so we dont violate the constraint
 		"job"=H?.mind?.assigned_role,
 		"special"=H?.mind?.special_role,
 		"pod"=podname,
 		"tod"=time2text(world.realtime, "YYYY-MM-DD hh:mm:ss"),
 		"laname"=H?.lastattacker?.real_name,
 		"lackey"=H?.lastattacker?.ckey,
-		"lachar_id"=H?.lastattacker?.character_id,
+		"lachar_id"=H?.lastattacker?.character_id ? H?.lastattacker?.character_id : null, //make sure we set the char id to null and not 0 so we dont violate the constraint
 		"gender"=H.gender,
 		"bruteloss"=H.getBruteLoss(),
 		"fireloss"=H.getFireLoss(),

--- a/html/changelogs/arrow768-fix-death-again.yml
+++ b/html/changelogs/arrow768-fix-death-again.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: arrow768
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes death tracking again by removing unneeded / invalid foreign keys."

--- a/html/changelogs/arrow768-fix-death-again.yml
+++ b/html/changelogs/arrow768-fix-death-again.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "Fixes death tracking again by removing unneeded / invalid foreign keys."
+  - bugfix: "Fixes death tracking again"


### PR DESCRIPTION
Removes the foreign key constraint from the ckeys.
-> Ckeys can have different values i.e. when someone dies while aghosted the ckey becomes `@ckey`

Ensurs that the char_id is set to null and not 0 -> To make sure the foreign key constraint there actually works