### PR TITLE
Adds follow button to hivenet broadcasts, fixes follow button falling off observer manifest

### DIFF
--- a/code/controllers/subsystems/records.dm
+++ b/code/controllers/subsystems/records.dm
@@ -210,7 +210,7 @@ SUBSYSTEM_DEF(records)
 /datum/controller/subsystem/records/ui_static_data(mob/user)
 	var/list/data = list()
 	data["manifest"] = SSrecords.get_manifest_list()
-	data["allow_follow"] = isobserver(usr)
+	data["allow_follow"] = isobserver(user)
 	return data
 
 /datum/controller/subsystem/records/proc/open_manifest_tgui(mob/user, datum/tgui/ui)

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -258,7 +258,7 @@
 		if(player == speaker)
 			to_chat(player, msg)
 		else if(isobserver(player))
-			player.show_message("[ghost_follow_link(speaker, player)] [msg]", 1)
+			to_chat(player, "[ghost_follow_link(speaker, player)] [msg]")
 		else if(!within_jamming_range(player) && check_special_condition(player))
 			if(speaker_encryption_key)
 				var/mob/living/carbon/human/listener_human = player

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -255,8 +255,10 @@
 			speaker_encryption_key = speaker_socket.encryption_key
 
 	for(var/mob/player in GLOB.player_list)
-		if(istype(player, /mob/abstract/observer) || player == speaker)
+		if(player == speaker)
 			to_chat(player, msg)
+		else if(isobserver(player))
+			player.show_message("[ghost_follow_link(speaker, player)] [msg]", 1)
 		else if(!within_jamming_range(player) && check_special_condition(player))
 			if(speaker_encryption_key)
 				var/mob/living/carbon/human/listener_human = player

--- a/html/changelogs/AlaunusLux-ghost-follow-button-fixes.yml
+++ b/html/changelogs/AlaunusLux-ghost-follow-button-fixes.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: AlaunusLux
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added follow button on Vaurca broadcasts."
+  - bugfix: "Manifest ghost follow button doesn't fall off anymore."


### PR DESCRIPTION
Title. Follow on broadcast not strictly necessary since it's on the emote of their antennae, but for consistency I thought I would add it.

Fixes #18190