### PR TITLE
Fixes napalm grenades failing to detonate if still held after their timer expires, fixes description of Napalm in uplink, and reduces cost by three

### DIFF
--- a/code/datums/uplink/grenades.dm
+++ b/code/datums/uplink/grenades.dm
@@ -41,7 +41,7 @@
 	desc = "A box of five grenades that deploy cardox smoke in the thrown area. This smoke is incredibly toxic, especially to vaurca. It can also clear K'ois outbreaks with ease."
 
 /datum/uplink_item/item/grenades/napalm
-	name = "5x Napalm Grenades"
-	telecrystal_cost = 8
+	name = "3x Napalm Grenades"
+	telecrystal_cost = 5
 	path = /obj/item/storage/box/grenades/napalm
-	desc = "A box of five grenades that deploy napalm in the thrown area, and ignite it."
+	desc = "A box of three grenades that deploy napalm in the thrown area, and ignite it."

--- a/code/game/objects/items/weapons/grenades/napalm_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/napalm_grenade.dm
@@ -8,5 +8,7 @@
 /obj/item/grenade/napalm/prime()
 	. = ..()
 
-	for(var/turf/turf in view(5, src))
+	for(var/turf/turf in view(5, get_turf(src)))
 		new /obj/effect/decal/cleanable/liquid_fuel/napalm(turf, 100, TRUE)
+
+	qdel(src)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -491,11 +491,11 @@
 
 /obj/item/storage/box/grenades/napalm
 	name = "box of napalm grenades"
-	desc = "A box containing 3 napalm grenades."
+	desc = "A box containing 5 napalm grenades."
 	icon_state = "secbox"
 	item_state = "secbox"
 	illustration = "grenade"
-	starts_with = list(/obj/item/grenade/napalm = 3)
+	starts_with = list(/obj/item/grenade/napalm = 5)
 
 /obj/item/storage/box/cardox
 	name = "box of cardox grenades"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -491,11 +491,11 @@
 
 /obj/item/storage/box/grenades/napalm
 	name = "box of napalm grenades"
-	desc = "A box containing 5 napalm grenades."
+	desc = "A box containing 3 napalm grenades."
 	icon_state = "secbox"
 	item_state = "secbox"
 	illustration = "grenade"
-	starts_with = list(/obj/item/grenade/napalm = 5)
+	starts_with = list(/obj/item/grenade/napalm = 3)
 
 /obj/item/storage/box/cardox
 	name = "box of cardox grenades"

--- a/html/changelogs/AlaunusLux-napalm-held-detonation-fix.yml
+++ b/html/changelogs/AlaunusLux-napalm-held-detonation-fix.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Held napalm grenades will now properly detonate."
+  - tweak: "Napalm boxes contain five grenades, to match uplink description."

--- a/html/changelogs/AlaunusLux-napalm-held-detonation-fix.yml
+++ b/html/changelogs/AlaunusLux-napalm-held-detonation-fix.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: AlaunusLux
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/AlaunusLux-napalm-held-detonation-fix.yml
+++ b/html/changelogs/AlaunusLux-napalm-held-detonation-fix.yml
@@ -39,4 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Held napalm grenades will now properly detonate."
-  - tweak: "Napalm boxes contain five grenades, to match uplink description."
+  - tweak: "Box of Napalm Grenades description now says three grenades, now costs five credits."


### PR DESCRIPTION
Also changes the description in the uplink, changes the cost to five (from eight).

Fixes #18046