### PR TITLE
Offship QOL changes and airlock fixes

### DIFF
--- a/html/changelogs/RustingWithYou - offshippolishing.yml
+++ b/html/changelogs/RustingWithYou - offshippolishing.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Tweaks several away ships to have functional docks, airlocks, and hangars."
+  - maptweak: "Shrinks the Tarwa Conglomerate bridge for QOL, and adds a Francisca for piracy."

--- a/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa.dm
+++ b/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa.dm
@@ -30,7 +30,7 @@
 	designer = "Izweski Hegemony Naval Guilds, Hephaestus Industries"
 	volume = "65 meters length, 35 meters beam/width, 18 meters vertical height"
 	drive = "Low-Speed Warp Acceleration FTL Drive"
-	weapons = "Wingtip-mounted heavy ballistic, port obscured flight craft bay"
+	weapons = "Dual wingtip-mounted heavy ballistic, port obscured flight craft bay"
 	sizeclass = "Modified Azkrazal-class cargo freighter"
 	shiptype = "Unknown"
 	initial_restricted_waypoints = list(
@@ -59,19 +59,19 @@
 	base_area = /area/space
 
 /obj/effect/shuttle_landmark/tarwa_ship/nav1
-	name = "Tarwa Conglomerate Freighter - Fore"
+	name = "Fore"
 	landmark_tag = "nav_tarwa1"
 
 /obj/effect/shuttle_landmark/tarwa_ship/nav2
-	name = "Tarwa Conglomerate Freighter - Port"
+	name = "Port"
 	landmark_tag = "nav_tarwa2"
 
 /obj/effect/shuttle_landmark/tarwa_ship/nav3
-	name = "Tarwa Conglomerate Freighter - Starboard"
+	name = "Starboard"
 	landmark_tag = "nav_tarwa3"
 
 /obj/effect/shuttle_landmark/tarwa_ship/nav4
-	name = "Tarwa Conglomerate Freighter - Aft"
+	name = "Aft"
 	landmark_tag = "nav_tarwa4"
 
 //Shuttle stuff
@@ -101,7 +101,7 @@
 	shuttle_area = list(/area/shuttle/tarwa)
 	current_location = "nav_hangar_tarwa"
 	landmark_transition = "nav_transit_tarwa"
-	dock_target = "tarwa_shuttle"
+	dock_target = "airlock_tarwa_shuttle"
 	range = 1
 	fuel_consumption = 2
 	logging_home_tag = "nav_hangar_tarwa"

--- a/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa.dmm
+++ b/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa.dmm
@@ -21,6 +21,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
 /turf/simulated/floor/diona,
 /area/tarwa_ship/oldhangar)
 "ao" = (
@@ -55,6 +58,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/eva)
+"av" = (
+/obj/structure/ship_weapon_dummy,
+/turf/simulated/floor/diona/airless,
+/area/space)
 "ax" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -67,6 +74,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/corner/dark_green/diagonal,
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/canteen)
 "aA" = (
@@ -165,6 +173,7 @@
 	dir = 1
 	},
 /obj/structure/table/steel,
+/obj/effect/floor_decal/corner/dark_green/diagonal,
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/canteen)
 "bV" = (
@@ -241,6 +250,10 @@
 "cy" = (
 /turf/simulated/wall/diona,
 /area/tarwa_ship/gun)
+"cG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/diona,
+/area/tarwa_ship/oldhangar)
 "cI" = (
 /obj/machinery/light,
 /obj/structure/cable/green{
@@ -289,7 +302,8 @@
 /area/tarwa_ship/hangar)
 "dd" = (
 /obj/structure/sign/flag/tarwa{
-	pixel_y = 25
+	pixel_y = 25;
+	stand_icon = "banner"
 	},
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/eva)
@@ -316,7 +330,6 @@
 /area/tarwa_ship/crew)
 "du" = (
 /obj/structure/table/rack,
-/obj/item/gun/projectile/colt,
 /obj/item/clothing/suit/armor/unathi,
 /obj/random/civgun/rifle,
 /obj/random/civgun/rifle,
@@ -393,44 +406,55 @@
 "fe" = (
 /turf/simulated/floor/lino,
 /area/tarwa_ship/canteen)
-"fw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
+"fm" = (
+/obj/structure/sign/flag/tarwa{
+	pixel_y = 25;
+	stand_icon = "banner"
 	},
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/bridge)
-"fy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+"fw" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
 	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_aft";
+	name = "airlock_tarwa_aft";
+	frequency = 1993
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
-/area/tarwa_ship/oldhangar)
+/area/tarwa_ship)
+"fy" = (
+/obj/structure/ship_weapon_dummy,
+/obj/structure/ship_weapon_dummy,
+/turf/simulated/floor/diona/airless,
+/area/space)
 "fC" = (
 /obj/structure/viewport/unathi,
 /turf/simulated/floor/plating,
 /area/tarwa_ship/gun)
 "fF" = (
-/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
-	frequency = 1411;
-	id_tag = "tarwa_shuttle";
-	layer = 3.3;
-	master_tag = "tarwa_shuttle";
-	cycle_to_external_air = 1;
-	pixel_x = 28;
-	tag_airpump = "tarwa_shuttle_in";
-	tag_exterior_door = "tarwa_shuttle_external";
-	tag_interior_door = "tarwa_shuttle_internal";
-	tag_chamber_sensor = "tarwa_shuttle_sensor_chamber";
-	tag_exterior_sensor = "tarwa_shuttle_sensor_exterior";
-	tag_interior_sensor = "tarwa_shuttle_sensor_interior"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
 	dir = 8;
-	level = 2;
-	id_tag = "tarwa_shuttle_in"
+	pixel_x = 20;
+	pixel_y = 6
+	},
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -6
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tarwa_shuttle";
+	name = "airlock_tarwa_shuttle";
+	req_one_access = list(210);
+	shuttle_tag = "Tarwa Conglomerate Shuttle"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
 	},
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
@@ -457,9 +481,14 @@
 /turf/simulated/wall/diona,
 /area/tarwa_ship/bridge)
 "gg" = (
-/obj/machinery/atmospherics/binary/pump/high_power,
-/turf/simulated/floor/diona,
-/area/shuttle/tarwa)
+/obj/machinery/ship_weapon/francisca{
+	pixel_x = -64;
+	pixel_y = -162;
+	weapon_id = "Tarwa Francisca Rotary Gun"
+	},
+/obj/structure/ship_weapon_dummy,
+/turf/simulated/floor/diona/airless,
+/area/tarwa_ship/oldhangar)
 "gi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -547,21 +576,15 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "starboard"
 	},
-/obj/machinery/door/airlock/diona/external{
-	id_tag = "tarwa_shuttle_external";
-	frequency = 1411;
-	dir = 1
+/obj/machinery/door/airlock/diona/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tarwa_shuttle";
+	name = "airlock_tarwa_shuttle";
+	req_one_access = list(210);
+	shuttle_tag = "Tarwa Conglomerate Shuttle"
 	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1411;
-	master_tag = "tarwa_shuttle";
-	name = "exterior access button";
-	pixel_x = -25;
-	pixel_y = -10;
-	req_one_access = list(31,48,67);
-	dir = 1
-	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
 "hx" = (
@@ -588,6 +611,22 @@
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/armory)
 "hR" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -6
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = 6
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_aft";
+	name = "airlock_tarwa_aft";
+	frequency = 1993
+	},
 /turf/simulated/floor/plating,
 /area/tarwa_ship)
 "ia" = (
@@ -602,23 +641,35 @@
 	dir = 1
 	},
 /obj/structure/sign/flag/tarwa{
-	pixel_y = 25
+	pixel_y = 25;
+	stand_icon = "banner"
 	},
 /turf/simulated/floor/diona,
 /area/tarwa_ship/cic)
 "iv" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	id_tag = "tarwa_shuttle_out"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
-/area/tarwa_ship/bridge)
+/obj/structure/diona/bulb,
+/turf/simulated/floor/diona,
+/area/tarwa_ship/oldhangar)
 "iI" = (
-/obj/machinery/door/airlock/diona/external{
-	id_tag = "tarwa_shuttle_external";
-	frequency = 1411;
-	dir = 1
+/obj/machinery/door/airlock/diona/external,
+/obj/machinery/access_button{
+	pixel_x = 28
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tarwa_shuttle";
+	name = "airlock_tarwa_shuttle";
+	req_one_access = list(210);
+	shuttle_tag = "Tarwa Conglomerate Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
 "jc" = (
@@ -630,6 +681,7 @@
 	dir = 10
 	},
 /obj/structure/table/steel,
+/obj/effect/floor_decal/corner/dark_green/diagonal,
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/canteen)
 "jf" = (
@@ -643,13 +695,12 @@
 	dir = 8
 	},
 /obj/structure/diona/bulb,
-/obj/machinery/airlock_sensor{
-	frequency = 1411;
-	id_tag = "tarwa_shuttle_sensor_chamber";
-	pixel_x = -24;
-	pixel_y = -6;
-	dir = 4;
-	master_tag = "tarwa_shuttle"
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tarwa_shuttle";
+	name = "airlock_tarwa_shuttle";
+	req_one_access = list(210);
+	shuttle_tag = "Tarwa Conglomerate Shuttle"
 	},
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
@@ -703,6 +754,7 @@
 /area/tarwa_ship)
 "jD" = (
 /obj/structure/table/steel,
+/obj/effect/floor_decal/corner/dark_green/diagonal,
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/canteen)
 "jE" = (
@@ -882,22 +934,11 @@
 /turf/simulated/floor/diona,
 /area/tarwa_ship/oldhangar)
 "lY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/ammunition_loader/francisca{
+	weapon_id = "Tarwa Francisca Rotary Gun"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/flag/tarwa{
-	pixel_y = 25
-	},
-/turf/simulated/floor/tiled,
-/area/tarwa_ship/bridge)
+/turf/simulated/floor/plating,
+/area/tarwa_ship/oldhangar)
 "mc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -911,6 +952,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/table/steel,
+/obj/effect/floor_decal/corner/dark_green/diagonal,
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/canteen)
 "mj" = (
@@ -950,19 +992,16 @@
 /turf/simulated/floor/diona,
 /area/tarwa_ship/engineering1)
 "nd" = (
-/obj/machinery/embedded_controller/radio/docking_port_multi{
-	child_names_txt = "West Airlock;Cargo Airlock";
-	child_tags_txt = "intrepid_shuttle_west;intrepid_shuttle_cargo";
-	frequency = 1411;
-	id_tag = "tarwa_shuttle";
-	pixel_y = -28
+/obj/structure/bed/stool/chair/shuttle{
+	dir = 1
 	},
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
 "ns" = (
 /obj/structure/closet,
 /obj/structure/sign/flag/tarwa{
-	pixel_y = 25
+	pixel_y = 25;
+	stand_icon = "banner"
 	},
 /turf/simulated/floor/diona,
 /area/tarwa_ship/diona)
@@ -1050,7 +1089,8 @@
 	name = "waste canister"
 	},
 /obj/structure/sign/flag/tarwa{
-	pixel_y = 25
+	pixel_y = 25;
+	stand_icon = "banner"
 	},
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
@@ -1139,8 +1179,10 @@
 "pV" = (
 /obj/structure/bed/stool/padded/green,
 /obj/structure/sign/flag/tarwa{
-	pixel_y = 25
+	pixel_y = 25;
+	stand_icon = "banner"
 	},
+/obj/effect/floor_decal/corner/dark_green/diagonal,
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/canteen)
 "pZ" = (
@@ -1335,7 +1377,8 @@
 	},
 /obj/item/clothing/suit/unathi/robe/robe_coat/blue,
 /obj/structure/sign/flag/tarwa{
-	pixel_y = 25
+	pixel_y = 25;
+	stand_icon = "banner"
 	},
 /turf/simulated/floor/carpet/orange,
 /area/tarwa_ship/captain)
@@ -1363,24 +1406,20 @@
 /turf/simulated/floor/carpet/orange,
 /area/tarwa_ship/captain)
 "uo" = (
-/obj/machinery/airlock_sensor/airlock_interior{
-	frequency = 1411;
-	id_tag = "tarwa_shuttle_sensor_interior";
-	master_tag = "tarwa_shuttle";
-	pixel_x = 25;
-	pixel_y = -25
-	},
+/obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1411;
-	master_tag = "tarwa_shuttle";
-	name = "interior access button";
-	pixel_x = 37;
-	pixel_y = -24;
-	req_access = list(13)
+	dir = 1;
+	pixel_x = -28;
+	pixel_y = 12
 	},
-/turf/simulated/floor/diona,
-/area/shuttle/tarwa)
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_aft";
+	name = "airlock_tarwa_aft";
+	frequency = 1993
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/plating,
+/area/tarwa_ship)
 "uu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1410,11 +1449,16 @@
 /turf/template_noop,
 /area/space)
 "uJ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor/diona,
-/area/shuttle/tarwa)
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_aft";
+	name = "airlock_tarwa_aft";
+	frequency = 1993
+	},
+/turf/simulated/floor/plating,
+/area/tarwa_ship)
 "uS" = (
 /turf/simulated/wall/shuttle/raider,
 /area/tarwa_ship/crew)
@@ -1429,12 +1473,11 @@
 	req_one_access = list(210)
 	},
 /obj/structure/table/rack,
-/obj/item/ship_ammunition/bruiser/flechette,
-/obj/item/ship_ammunition/bruiser/flechette,
-/obj/item/ship_ammunition/bruiser/flechette,
-/obj/item/ship_ammunition/bruiser/flechette,
-/obj/item/ship_ammunition/bruiser/flechette,
-/obj/item/ship_ammunition/bruiser/flechette,
+/obj/item/ship_ammunition/francisca{
+	pixel_y = 8
+	},
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca/frag,
 /turf/simulated/floor/diona,
 /area/tarwa_ship/armory)
 "vo" = (
@@ -1497,6 +1540,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/tarwa_ship/medical)
+"wH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/floor/diona,
+/area/tarwa_ship/oldhangar)
+"wI" = (
+/obj/structure/diona/bulb,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_stbd";
+	name = "airlock_tarwa_stbd";
+	frequency = 1451
+	},
+/turf/simulated/floor/diona,
+/area/tarwa_ship/oldhangar)
 "wJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 1
@@ -1571,6 +1629,7 @@
 	pixel_x = 0;
 	req_access = list(210)
 	},
+/obj/structure/bed/stool/chair/shuttle,
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
 "xA" = (
@@ -1602,8 +1661,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/crew)
+"yi" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_aft";
+	name = "airlock_tarwa_aft";
+	frequency = 1993
+	},
+/turf/simulated/floor/plating,
+/area/tarwa_ship)
 "yk" = (
 /obj/structure/table/stone/marble,
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 8
+	},
 /turf/simulated/floor/lino,
 /area/tarwa_ship/canteen)
 "ys" = (
@@ -1701,10 +1771,8 @@
 /turf/simulated/floor/plating,
 /area/tarwa_ship/engineering2)
 "zw" = (
-/obj/effect/landmark/entry_point/starboard{
-	name = "starboard, fuel bay"
-	},
-/turf/simulated/wall/diona,
+/obj/structure/table/reinforced/steel,
+/turf/simulated/floor/plating,
 /area/tarwa_ship/oldhangar)
 "zy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -1749,9 +1817,16 @@
 /turf/template_noop,
 /area/space)
 "Ay" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	id_tag = "tarwa_shuttle_out_internal"
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tarwa_shuttle";
+	name = "airlock_tarwa_shuttle";
+	req_one_access = list(210);
+	shuttle_tag = "Tarwa Conglomerate Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
 	},
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
@@ -1814,8 +1889,13 @@
 /obj/item/ship_ammunition/bruiser,
 /obj/item/ship_ammunition/bruiser,
 /obj/structure/sign/flag/tarwa{
-	pixel_y = 25
+	pixel_y = 25;
+	stand_icon = "banner"
 	},
+/obj/item/ship_ammunition/bruiser/he,
+/obj/item/ship_ammunition/bruiser/flechette,
+/obj/item/ship_ammunition/bruiser/flechette,
+/obj/item/ship_ammunition/bruiser/flechette,
 /turf/simulated/floor/diona,
 /area/tarwa_ship/armory)
 "BC" = (
@@ -1834,6 +1914,13 @@
 /obj/effect/landmark/entry_point/aft{
 	name = "aft, airlock"
 	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_aft";
+	name = "airlock_tarwa_aft";
+	frequency = 1993
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/tarwa_ship)
 "BJ" = (
@@ -1843,6 +1930,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/tarwa_ship/engineering2)
+"BL" = (
+/obj/structure/bed/stool/chair/office/bridge/pilot,
+/turf/simulated/floor/plating,
+/area/tarwa_ship/oldhangar)
 "BX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1962,13 +2053,17 @@
 /turf/simulated/floor/carpet/orange,
 /area/tarwa_ship/captain)
 "Dw" = (
-/obj/structure/bed/stool/chair/shuttle{
-	dir = 4
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 1;
+	name = "Fuel to Thrusters"
 	},
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
 "Dy" = (
 /obj/machinery/vending/dinnerware,
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 8
+	},
 /turf/simulated/floor/lino,
 /area/tarwa_ship/canteen)
 "DC" = (
@@ -1985,9 +2080,10 @@
 /area/tarwa_ship)
 "DH" = (
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1411;
+	frequency = 1380;
 	id_tag = "tarwa_shuttle_dock";
-	pixel_x = -28
+	dir = 4;
+	pixel_x = -20
 	},
 /turf/simulated/floor/plating,
 /area/tarwa_ship/hangar)
@@ -2090,7 +2186,8 @@
 	color = "#ba650b"
 	},
 /obj/structure/sign/flag/tarwa{
-	pixel_y = 25
+	pixel_y = 25;
+	stand_icon = "banner"
 	},
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/crew)
@@ -2103,17 +2200,11 @@
 /area/tarwa_ship/bridge)
 "Fb" = (
 /obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/tarwa_ship/oldhangar)
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/diona,
+/area/shuttle/tarwa)
 "Fc" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	dir = 4;
@@ -2171,6 +2262,14 @@
 	},
 /turf/simulated/floor/diona,
 /area/tarwa_ship/gun)
+"Fw" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_stbd";
+	name = "airlock_tarwa_stbd";
+	frequency = 1451
+	},
+/turf/simulated/floor/diona,
+/area/tarwa_ship/oldhangar)
 "Fx" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 4
@@ -2193,11 +2292,18 @@
 /turf/simulated/floor/plating,
 /area/tarwa_ship/engineering2)
 "FT" = (
-/obj/machinery/atmospherics/portables_connector{
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	pixel_y = 25
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/plating,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_stbd";
+	name = "airlock_tarwa_stbd";
+	frequency = 1451
+	},
+/turf/simulated/floor/diona,
 /area/tarwa_ship/oldhangar)
 "FW" = (
 /obj/machinery/light{
@@ -2244,6 +2350,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/tarwa_ship/engineering2)
+"GV" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor/diona,
+/area/shuttle/tarwa)
 "Hc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -2264,6 +2374,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tarwa_ship)
+"Ht" = (
+/obj/machinery/computer/ship/navigation,
+/turf/simulated/floor/plating,
+/area/tarwa_ship/oldhangar)
 "Hy" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc/south{
@@ -2296,7 +2410,10 @@
 "HL" = (
 /obj/structure/diona/bulb,
 /obj/structure/table/rack,
-/obj/item/ship_ammunition/bruiser/he,
+/obj/item/ship_ammunition/francisca/ap{
+	pixel_y = 8
+	},
+/obj/item/ship_ammunition/francisca/ap,
 /turf/simulated/floor/diona,
 /area/tarwa_ship/armory)
 "HP" = (
@@ -2332,6 +2449,7 @@
 /area/tarwa_ship/engineering2)
 "Ie" = (
 /obj/structure/bed/stool/padded/green,
+/obj/effect/floor_decal/corner/dark_green/diagonal,
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/canteen)
 "Ii" = (
@@ -2358,11 +2476,21 @@
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/crew)
 "Il" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
 	},
+/obj/machinery/access_button{
+	pixel_x = 28
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_aft";
+	name = "airlock_tarwa_aft";
+	frequency = 1993
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
-/area/tarwa_ship/oldhangar)
+/area/tarwa_ship)
 "Iz" = (
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/diona/airless,
@@ -2411,6 +2539,7 @@
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/crew)
 "Jw" = (
+/obj/effect/floor_decal/corner/dark_green/diagonal,
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/canteen)
 "JG" = (
@@ -2431,6 +2560,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/plating,
 /area/tarwa_ship/engineering2)
+"JL" = (
+/obj/effect/floor_decal/spline/plain/black{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/tarwa_ship/canteen)
 "JO" = (
 /obj/machinery/alarm/north{
 	req_one_access = list(210)
@@ -2515,6 +2650,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/diona,
 /area/tarwa_ship/oldhangar)
 "KH" = (
@@ -2560,11 +2699,9 @@
 /turf/simulated/floor/diona,
 /area/tarwa_ship/bridge)
 "Lc" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
+/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
 /turf/simulated/floor/diona,
-/area/shuttle/tarwa)
+/area/tarwa_ship/oldhangar)
 "Ld" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -2578,6 +2715,7 @@
 	pixel_x = 0;
 	req_access = list(210)
 	},
+/obj/effect/floor_decal/corner/dark_green/diagonal,
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/canteen)
 "Le" = (
@@ -2588,6 +2726,12 @@
 /obj/effect/overmap/visitable/ship/landable/tarwa_shuttle,
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
+"Lj" = (
+/obj/effect/landmark/entry_point/starboard{
+	name = "starboard, old hangar"
+	},
+/turf/simulated/wall/diona,
+/area/tarwa_ship/oldhangar)
 "Ly" = (
 /obj/machinery/light{
 	dir = 1
@@ -2705,6 +2849,18 @@
 	},
 /turf/simulated/floor/diona,
 /area/tarwa_ship/armory)
+"Mu" = (
+/obj/machinery/door/airlock/diona/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_stbd";
+	name = "airlock_tarwa_stbd";
+	frequency = 1451
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/diona,
+/area/tarwa_ship/oldhangar)
 "My" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -2790,22 +2946,34 @@
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/crew)
 "Nt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/north{
-	pixel_x = 0;
-	req_access = list(210)
-	},
-/turf/simulated/floor/tiled,
-/area/tarwa_ship/bridge)
+/obj/structure/table/reinforced/steel,
+/turf/simulated/floor/diona,
+/area/tarwa_ship/gun)
 "Nw" = (
 /turf/simulated/wall/shuttle/raider,
 /area/tarwa_ship/engineering1)
+"Nz" = (
+/obj/machinery/door/airlock/diona/external{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/access_button{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = -28
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_stbd";
+	name = "airlock_tarwa_stbd";
+	frequency = 1451
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/diona,
+/area/tarwa_ship/oldhangar)
+"NB" = (
+/obj/structure/ship_weapon_dummy/barrel,
+/turf/simulated/floor/diona/airless,
+/area/space)
 "NC" = (
 /obj/effect/landmark/entry_point/aft{
 	name = "port"
@@ -2858,8 +3026,8 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/north{
-	pixel_x = 0;
+/obj/machinery/power/apc/east{
+	is_critical = 1;
 	req_access = list(210)
 	},
 /turf/simulated/floor/tiled,
@@ -2926,6 +3094,23 @@
 /obj/structure/bed/stool/chair/office/bridge/pilot,
 /turf/simulated/floor/diona,
 /area/tarwa_ship/cic)
+"Pv" = (
+/obj/machinery/door/airlock/diona/external{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = -28
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_stbd";
+	name = "airlock_tarwa_stbd";
+	frequency = 1451
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/diona,
+/area/tarwa_ship/oldhangar)
 "Px" = (
 /obj/machinery/computer/ship/engines,
 /turf/simulated/floor/diona,
@@ -2968,8 +3153,10 @@
 "PJ" = (
 /obj/structure/diona/bulb,
 /obj/structure/sign/flag/tarwa{
-	pixel_y = 25
+	pixel_y = 25;
+	stand_icon = "banner"
 	},
+/obj/structure/bed/stool/chair/office/bridge/pilot,
 /turf/simulated/floor/diona,
 /area/tarwa_ship/gun)
 "PL" = (
@@ -2979,8 +3166,19 @@
 /turf/simulated/floor/diona,
 /area/tarwa_ship/oldhangar)
 "PM" = (
-/obj/effect/map_effect/airlock/long/square,
-/turf/simulated/wall/shuttle/raider,
+/obj/machinery/door/airlock/diona/external{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_stbd";
+	name = "airlock_tarwa_stbd";
+	frequency = 1451
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/diona,
 /area/tarwa_ship/oldhangar)
 "PO" = (
 /obj/effect/step_trigger/teleporter,
@@ -3043,6 +3241,9 @@
 /obj/item/ship_ammunition/bruiser,
 /obj/item/ship_ammunition/bruiser,
 /obj/item/ship_ammunition/bruiser,
+/obj/item/ship_ammunition/bruiser/flechette,
+/obj/item/ship_ammunition/bruiser/flechette,
+/obj/item/ship_ammunition/bruiser/flechette,
 /turf/simulated/floor/diona,
 /area/tarwa_ship/armory)
 "QQ" = (
@@ -3090,18 +3291,21 @@
 /area/tarwa_ship/canteen)
 "QW" = (
 /obj/structure/bed/handrail,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8;
-	level = 2;
-	id_tag = "tarwa_shuttle_out_external"
+/obj/machinery/airlock_sensor/airlock_exterior{
+	dir = 1;
+	pixel_y = -31;
+	pixel_x = -24
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1385;
-	id_tag = "tarwa_shuttle_sensor_exterior";
-	pixel_x = -24;
-	pixel_y = -6;
-	dir = 4;
-	master_tag = "tarwa_shuttle"
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tarwa_shuttle";
+	name = "airlock_tarwa_shuttle";
+	req_one_access = list(210);
+	shuttle_tag = "Tarwa Conglomerate Shuttle"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
 	},
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
@@ -3130,11 +3334,15 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/airlock/diona/external{
-	id_tag = "tarwa_shuttle_internal";
-	frequency = 1411;
-	dir = 1
+/obj/machinery/door/airlock/diona/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tarwa_shuttle";
+	name = "airlock_tarwa_shuttle";
+	req_one_access = list(210);
+	shuttle_tag = "Tarwa Conglomerate Shuttle"
 	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
 "Ru" = (
@@ -3177,6 +3385,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/tarwa_ship/engineering2)
+"Sk" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
+/turf/simulated/floor/plating,
+/area/tarwa_ship/oldhangar)
 "Ss" = (
 /obj/structure/diona/bulb,
 /turf/simulated/floor/diona,
@@ -3272,9 +3484,14 @@
 /turf/simulated/floor/plating,
 /area/tarwa_ship/engineering2)
 "TZ" = (
-/obj/effect/map_effect/airlock/s_to_n/long/square,
-/turf/simulated/wall/shuttle/raider,
-/area/tarwa_ship/engineering2)
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_aft";
+	name = "airlock_tarwa_aft";
+	frequency = 1993
+	},
+/turf/simulated/floor/plating,
+/area/tarwa_ship)
 "Uj" = (
 /obj/machinery/air_sensor{
 	id_tag = "tarwa_sensor"
@@ -3389,6 +3606,7 @@
 	req_one_access = list(210)
 	},
 /obj/structure/bed/stool/padded/green,
+/obj/effect/floor_decal/corner/dark_green/diagonal,
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/canteen)
 "Wq" = (
@@ -3415,11 +3633,27 @@
 /turf/simulated/wall/diona,
 /area/tarwa_ship/engineering2)
 "Wx" = (
-/obj/machinery/door/airlock/diona/external{
-	id_tag = "tarwa_shuttle_internal";
+/obj/machinery/door/airlock/diona/external,
+/obj/machinery/airlock_sensor/airlock_interior{
 	frequency = 1411;
-	dir = 1
+	id_tag = "tarwa_shuttle_sensor_interior";
+	master_tag = "tarwa_shuttle";
+	pixel_x = 28;
+	pixel_y = 8
 	},
+/obj/machinery/access_button{
+	dir = 1;
+	pixel_x = 40;
+	pixel_y = 9
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tarwa_shuttle";
+	name = "airlock_tarwa_shuttle";
+	req_one_access = list(210);
+	shuttle_tag = "Tarwa Conglomerate Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
 "Wz" = (
@@ -3518,7 +3752,8 @@
 	dir = 4
 	},
 /obj/structure/sign/flag/tarwa{
-	pixel_y = 25
+	pixel_y = 25;
+	stand_icon = "banner"
 	},
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/bridge)
@@ -3536,12 +3771,18 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1;
-	id_tag = "tarwa_shuttle_in"
-	},
 /obj/structure/fuel_port/hydrogen{
 	pixel_x = -32
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_tarwa_shuttle";
+	name = "airlock_tarwa_shuttle";
+	req_one_access = list(210);
+	shuttle_tag = "Tarwa Conglomerate Shuttle"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
 	},
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
@@ -3556,8 +3797,7 @@
 /turf/simulated/floor/tiled/white,
 /area/tarwa_ship/medical)
 "YL" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/bed/stool/chair/shuttle,
 /turf/simulated/floor/diona,
 /area/shuttle/tarwa)
 "YO" = (
@@ -3622,6 +3862,21 @@
 /obj/random/civgun,
 /turf/simulated/floor/diona,
 /area/tarwa_ship/armory)
+"ZY" = (
+/obj/machinery/airlock_sensor{
+	pixel_y = -23;
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_tarwa_stbd";
+	name = "airlock_tarwa_stbd";
+	frequency = 1451
+	},
+/turf/simulated/floor/diona,
+/area/tarwa_ship/oldhangar)
 
 (1,1,1) = {"
 ef
@@ -12774,7 +13029,7 @@ uB
 uB
 cy
 cy
-cw
+Nt
 cw
 sW
 xT
@@ -13088,9 +13343,9 @@ ef
 ef
 ef
 ef
-ef
-ef
-ef
+uB
+uB
+uB
 uB
 uB
 uB
@@ -13250,19 +13505,19 @@ uB
 uB
 ef
 ef
-ef
 uB
-uB
-uB
-uB
+ND
+Mu
+Pv
+ND
 uB
 uB
 cy
 cs
 zq
 ID
-uB
-uB
+sP
+sP
 uB
 uB
 uB
@@ -13413,21 +13668,21 @@ UV
 uB
 uB
 uB
-uB
-uB
-uB
-uB
-uB
-cy
+ND
+Fw
+wI
+ND
+ND
+Lj
 cy
 Mn
 ID
 ID
-uB
-uB
-uB
-uB
-uB
+av
+fy
+fy
+NB
+NB
 ef
 ef
 ef
@@ -13575,21 +13830,21 @@ MR
 UV
 UV
 UV
-UV
 ND
-uB
+FT
+ZY
 ND
-zw
+ND
 pd
 pd
 lA
+pd
 Gs
-uB
-uB
-uB
-Gs
-uB
-uB
+gg
+av
+av
+sP
+sP
 ef
 ef
 ef
@@ -13737,21 +13992,21 @@ dP
 MR
 MR
 VF
-VF
-SZ
+Gs
+PM
+Nz
 ND
-qt
 KF
 bi
-bi
+iv
 Ii
+pd
 Gs
-Gs
-Gs
-Gs
-Gs
-Gs
-uB
+lY
+Lc
+Lc
+ND
+sP
 ef
 ef
 ef
@@ -13901,19 +14156,19 @@ MR
 VF
 VF
 SZ
-ND
-pd
+wH
+cG
 ag
 pd
 pd
 pd
 pd
-Fb
-FT
+pd
+Up
+Up
+Up
+Up
 ND
-Gs
-Gs
-PM
 uB
 ef
 ef
@@ -14064,18 +14319,18 @@ aa
 aa
 yt
 SZ
-ND
+SZ
 KH
 pd
 pd
 pd
 pd
-fy
-Il
+pd
+pd
 Up
-Up
-Up
-Up
+qt
+zw
+Sk
 uB
 ef
 ef
@@ -14234,10 +14489,10 @@ SZ
 pd
 qt
 pd
-Up
-Up
-Up
-Up
+pd
+BL
+Ht
+ND
 uB
 ef
 ef
@@ -14564,10 +14819,10 @@ GM
 Uw
 Uw
 uB
-uB
-uB
-uB
-uB
+ef
+ef
+ef
+ef
 ef
 ef
 ef
@@ -14725,11 +14980,11 @@ Uw
 Uw
 Uw
 Uw
-ce
-ce
-ce
-ce
-hJ
+uB
+uB
+ef
+ef
+ef
 ef
 ef
 ef
@@ -14887,12 +15142,12 @@ Uw
 dd
 uw
 Uw
-aA
-aA
-aA
 ce
-ce
-Ef
+uB
+uB
+uB
+ef
+ef
 ef
 ef
 ef
@@ -15049,12 +15304,12 @@ Uw
 vO
 Hz
 Uw
-AI
-ac
-ia
-aA
 ce
 ce
+ce
+ce
+hJ
+ef
 ef
 ef
 ef
@@ -15213,10 +15468,10 @@ qy
 Uw
 aA
 aA
-YX
 aA
-aA
-jE
+ce
+ce
+Ef
 ef
 ef
 ef
@@ -15373,12 +15628,12 @@ IS
 as
 Ql
 Uw
-iv
+AI
+ac
+ia
 aA
-aA
-aA
-aA
-jE
+ce
+ce
 ef
 ef
 ef
@@ -15535,9 +15790,9 @@ De
 MP
 Ql
 Uw
-fw
 aA
 aA
+YX
 aA
 aA
 jE
@@ -15671,7 +15926,7 @@ ef
 sC
 sC
 sC
-TZ
+sC
 nA
 uS
 uS
@@ -15830,10 +16085,10 @@ ef
 sP
 ef
 ef
-hR
-hR
-hR
-hR
+uo
+uJ
+TZ
+fw
 xd
 hn
 hn
@@ -15993,9 +16248,9 @@ aY
 ef
 ef
 BH
+yi
 hR
-hR
-hR
+Il
 LY
 Hc
 vG
@@ -16345,12 +16600,12 @@ NU
 MN
 NU
 NU
-lY
+Eb
 XL
-aA
-aA
-aA
-jE
+XL
+XL
+XL
+fP
 ef
 ef
 ef
@@ -16507,13 +16762,13 @@ NU
 aP
 yx
 NU
-Nt
-aA
+ce
 XL
-aA
-aA
-jE
-ef
+Kc
+XL
+XL
+dg
+fP
 ef
 ef
 ef
@@ -16669,13 +16924,13 @@ NU
 wo
 Hy
 NU
-Eb
+ce
+fm
 XL
 XL
-XL
-XL
+SW
+jS
 fP
-ef
 ef
 ef
 ef
@@ -16833,10 +17088,10 @@ Gi
 Ba
 ce
 XL
+XL
+XL
 Kc
 XL
-XL
-dg
 fP
 ef
 ef
@@ -16994,12 +17249,12 @@ FC
 yd
 oF
 ce
-aA
-XL
-XL
-SW
-jS
+ce
 fP
+XL
+XL
+fP
+Iz
 ef
 ef
 ef
@@ -17143,11 +17398,11 @@ MG
 wj
 Px
 ZA
-Lc
-vW
+UN
+GV
 Dw
-Dw
-Dw
+Fb
+wj
 wj
 MG
 Cm
@@ -17155,11 +17410,11 @@ NU
 YI
 aH
 uX
-ce
+NU
+ef
+fP
+fP
 XL
-XL
-XL
-Kc
 XL
 fP
 ef
@@ -17304,8 +17559,8 @@ Wz
 MG
 wj
 YL
-gg
-uJ
+vW
+vW
 vW
 ao
 wj
@@ -17317,13 +17572,13 @@ NU
 yx
 zg
 NU
-ce
-ce
+NU
+ef
+ef
 fP
-XL
-XL
 fP
-Iz
+fP
+ef
 ef
 ef
 ef
@@ -17461,7 +17716,7 @@ Jg
 Dy
 yk
 yk
-fe
+JL
 Wz
 MG
 NC
@@ -17481,11 +17736,11 @@ yx
 NU
 ef
 ef
-fP
-fP
-XL
-XL
-fP
+ef
+ef
+ef
+ef
+ef
 ef
 ef
 ef
@@ -17631,7 +17886,7 @@ ov
 sT
 gD
 lg
-uo
+vW
 Wx
 fF
 Ay
@@ -17644,9 +17899,9 @@ NU
 ef
 ef
 ef
-fP
-fP
-fP
+ef
+ef
+ef
 ef
 ef
 ef

--- a/maps/away/ships/dominia/dominian_unathi_privateer/dominian_unathi_privateer.dm
+++ b/maps/away/ships/dominia/dominian_unathi_privateer/dominian_unathi_privateer.dm
@@ -47,25 +47,25 @@
 	..()
 
 /obj/effect/shuttle_landmark/dominian_unathi/nav1
-	name = "Kazhkz Privateer Ship - Fore"
+	name = "Fore"
 	landmark_tag = "nav_dominian_unathi_1"
 	base_turf = /turf/space/dynamic
 	base_area = /area/space
 
 /obj/effect/shuttle_landmark/dominian_unathi/nav2
-	name = "Kazhkz Privateer Ship - Starboard"
+	name = "Starboard"
 	landmark_tag = "nav_dominian_unathi_2"
 	base_turf = /turf/space/dynamic
 	base_area = /area/space
 
 /obj/effect/shuttle_landmark/dominian_unathi/nav3
-	name = "Kazhkz Privateer Ship - Port"
+	name = "Port"
 	landmark_tag = "nav_dominian_unathi_3"
 	base_turf = /turf/space/dynamic
 	base_area = /area/space
 
 /obj/effect/shuttle_landmark/dominian_unathi/nav4
-	name = "Kazhkz Privateer Ship - Aft"
+	name = "Aft"
 	landmark_tag = "nav_dominian_unathi_4"
 	base_turf = /turf/space/dynamic
 	base_area = /area/space
@@ -97,6 +97,7 @@
 	shuttle_area = list(/area/shuttle/dominian_unathi)
 	current_location = "nav_hangar_kazhkz"
 	landmark_transition = "nav_transit_kazhkz_shuttle"
+	dock_target = "airlock_kazhkz_shuttle"
 	range = 1
 	fuel_consumption = 2
 	logging_home_tag = "nav_hangar_kazhkz"
@@ -105,6 +106,7 @@
 /obj/effect/shuttle_landmark/dominian_unathi_shuttle/hangar
 	name = "Kazhkz Privateer Ship - Fighter Bay"
 	landmark_tag = "nav_hangar_kazhkz"
+	docking_controller = "kazhkz_shuttle_dock"
 	base_area = /area/ship/dominian_unathi/hangar
 	base_turf = /turf/simulated/floor/plating
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE

--- a/maps/away/ships/dominia/dominian_unathi_privateer/dominian_unathi_privateer.dmm
+++ b/maps/away/ships/dominia/dominian_unathi_privateer/dominian_unathi_privateer.dmm
@@ -200,6 +200,7 @@
 /area/ship/dominian_unathi/crew)
 "bo" = (
 /obj/structure/window/shuttle/crescent,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/captain)
 "bx" = (
@@ -313,6 +314,7 @@
 /area/ship/dominian_unathi/hangar)
 "cK" = (
 /obj/structure/window/shuttle,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/gun)
 "cL" = (
@@ -649,6 +651,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/eva)
+"ff" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 28
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_3";
+	name = "airlock_kazhkz_3";
+	frequency = 2126
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/starboardhall)
 "fk" = (
 /obj/structure/toilet{
 	dir = 1
@@ -788,6 +807,14 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/chapel)
+"gi" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_4";
+	name = "airlock_kazhkz_4";
+	frequency = 2222
+	},
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/porthall)
 "gt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1062,6 +1089,18 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/starboardthrust)
+"iW" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_4";
+	name = "airlock_kazhkz_4";
+	frequency = 2222
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/porthall)
 "iX" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -1071,6 +1110,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/cic)
+"jg" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_1";
+	name = "airlock_kazhkz_1";
+	frequency = 1939
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/bridgefoyer)
 "jp" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1478,6 +1530,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/dominian_unathi)
+"mw" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_4";
+	name = "airlock_kazhkz_4";
+	frequency = 2222
+	},
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/porthall)
 "mE" = (
 /obj/machinery/door/airlock/medical{
 	name = "Infirmary";
@@ -1512,10 +1575,39 @@
 /obj/structure/ship_weapon_dummy,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_unathi)
+"mJ" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 28
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_4";
+	name = "airlock_kazhkz_4";
+	frequency = 2222
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/porthall)
 "mK" = (
 /obj/effect/floor_decal/corner/orange/full,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
+/area/ship/dominian_unathi/bridgefoyer)
+"mN" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_1";
+	name = "airlock_kazhkz_1";
+	frequency = 1939
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/plating,
 /area/ship/dominian_unathi/bridgefoyer)
 "mQ" = (
 /obj/structure/cable/green{
@@ -1629,7 +1721,21 @@
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/portthrust)
 "nP" = (
-/turf/simulated/wall,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_2";
+	name = "airlock_kazhkz_2";
+	frequency = 1989
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
 /area/ship/dominian_unathi/bridgefoyer)
 "nQ" = (
 /turf/simulated/floor/tiled/dark,
@@ -2221,8 +2327,8 @@
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	cycle_to_external_air = 1;
-	master_tag = "airlock_kazhkz_shutle";
-	name = "airlock_shutle_kazhkz";
+	master_tag = "airlock_kazhkz_shuttle";
+	name = "airlock_kazhkz_shuttle";
 	shuttle_tag = "Kazhkz Fighter";
 	req_one_access = list(212)
 	},
@@ -2247,12 +2353,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/chapel)
 "rO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/machinery/door/airlock/external{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/dominian_unathi/bridgefoyer)
+/obj/machinery/access_button{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 28
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_4";
+	name = "airlock_kazhkz_4";
+	frequency = 2222
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/porthall)
 "rP" = (
 /obj/machinery/light{
 	dir = 8
@@ -2324,6 +2443,20 @@
 "sl" = (
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/dominian_unathi)
+"sp" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_2";
+	name = "airlock_kazhkz_2";
+	frequency = 1989
+	},
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/bridgefoyer)
 "sq" = (
 /obj/machinery/alarm{
 	req_one_access = null;
@@ -2512,6 +2645,17 @@
 /obj/random/tool,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/starboardthrust)
+"tA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_4";
+	name = "airlock_kazhkz_4";
+	frequency = 2222
+	},
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/porthall)
 "tC" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 5
@@ -2530,9 +2674,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/portthrust)
 "tP" = (
-/obj/effect/map_effect/airlock/e_to_w,
-/turf/simulated/wall,
-/area/ship/dominian_unathi/bridgefoyer)
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_3";
+	name = "airlock_kazhkz_3";
+	frequency = 2126
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_x = -6;
+	pixel_y = 28
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = 6;
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/starboardhall)
 "tR" = (
 /obj/structure/table/wood,
 /turf/simulated/floor/carpet/orange,
@@ -2610,6 +2769,18 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/portthrust)
+"uN" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_3";
+	name = "airlock_kazhkz_3";
+	frequency = 2126
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/starboardhall)
 "uR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -2795,6 +2966,7 @@
 "vW" = (
 /obj/structure/window/shuttle,
 /obj/effect/landmark/entry_point/fore,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_unathi)
 "wb" = (
@@ -2863,6 +3035,12 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/ship/dominian_unathi/engineering)
+"wC" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_unathi/bridgefoyer)
 "wE" = (
 /obj/effect/floor_decal/corner/orange,
 /turf/simulated/floor/tiled/dark,
@@ -3488,15 +3666,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/dominian_unathi)
 "Bi" = (
-/obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
-	master_tag = "airlock_kazhkz_shutle";
-	name = "airlock_shutle_kazhkz";
-	shuttle_tag = "Kazhkz Fighter";
-	req_one_access = list(212)
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_1";
+	name = "airlock_kazhkz_1";
+	frequency = 1939
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/access_button{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 28
 	},
 /turf/simulated/floor/plating,
-/area/ship/dominian_unathi/hangar)
+/area/ship/dominian_unathi/bridgefoyer)
 "Bk" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3733,6 +3921,7 @@
 /area/ship/dominian_unathi/porthall)
 "CI" = (
 /obj/structure/window/shuttle/crescent,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/bridge)
 "CK" = (
@@ -3758,6 +3947,7 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, captain's quarters"
 	},
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/captain)
 "CR" = (
@@ -3921,6 +4111,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/bridgefoyer)
+"DM" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "kazhkz_shuttle_dock";
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/hangar)
 "DP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -3970,6 +4171,7 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, bridge"
 	},
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/bridge)
 "Ej" = (
@@ -4069,6 +4271,18 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi)
+"ES" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_2";
+	name = "airlock_kazhkz_2";
+	frequency = 1989
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/bridgefoyer)
 "EV" = (
 /turf/simulated/wall,
 /area/ship/dominian_unathi/canteen)
@@ -4081,8 +4295,8 @@
 /obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	cycle_to_external_air = 1;
-	master_tag = "airlock_kazhkz_shutle";
-	name = "airlock_shutle_kazhkz";
+	master_tag = "airlock_kazhkz_shuttle";
+	name = "airlock_kazhkz_shuttle";
 	shuttle_tag = "Kazhkz Fighter";
 	req_one_access = list(212)
 	},
@@ -4412,6 +4626,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/canteen)
 "GX" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_4";
+	name = "airlock_kazhkz_4";
+	frequency = 2222
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/porthall)
 "GY" = (
@@ -4491,6 +4715,7 @@
 /area/ship/dominian_unathi/chapel)
 "HC" = (
 /obj/structure/window/shuttle/crescent,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/starboardhall)
 "HH" = (
@@ -4510,6 +4735,7 @@
 /area/ship/dominian_unathi/janitor)
 "Ig" = (
 /obj/structure/window/shuttle/crescent,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/porthall)
 "Im" = (
@@ -4518,9 +4744,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/canteen)
 "In" = (
-/obj/effect/map_effect/airlock/e_to_w/long/square,
-/turf/simulated/wall/shuttle/space_ship,
-/area/ship/dominian_unathi/porthall)
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_1";
+	name = "airlock_kazhkz_1";
+	frequency = 1939
+	},
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/bridgefoyer)
 "Io" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -4569,6 +4805,7 @@
 /area/ship/dominian_unathi/starboardhall)
 "Iy" = (
 /obj/structure/window/shuttle,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/hangar)
 "IA" = (
@@ -4687,6 +4924,26 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/engineering)
+"JE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 28
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_3";
+	name = "airlock_kazhkz_3";
+	frequency = 2126
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/starboardhall)
 "JF" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -4902,6 +5159,19 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/starboardthrust)
+"KZ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_2";
+	name = "airlock_kazhkz_2";
+	frequency = 1989
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/bridgefoyer)
 "Lc" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 9
@@ -5057,6 +5327,17 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/engineering)
+"Mj" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_3";
+	name = "airlock_kazhkz_3";
+	frequency = 2126
+	},
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/starboardhall)
 "Mk" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5109,6 +5390,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/pods)
+"MM" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/dominian_unathi/bridgefoyer)
 "MP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5172,6 +5459,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/bridge)
 "Np" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_3";
+	name = "airlock_kazhkz_3";
+	frequency = 2126
+	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/starboardhall)
 "Nv" = (
@@ -5197,6 +5489,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi)
+"NE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_2";
+	name = "airlock_kazhkz_2";
+	frequency = 1989
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/access_button{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/bridgefoyer)
 "NJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5224,6 +5536,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/starboardhall)
+"NX" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_x = -6;
+	pixel_y = 28
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = 6;
+	pixel_y = 28
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_4";
+	name = "airlock_kazhkz_4";
+	frequency = 2222
+	},
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/porthall)
 "Oe" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5441,6 +5772,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/loot)
+"Qo" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_3";
+	name = "airlock_kazhkz_3";
+	frequency = 2126
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/starboardhall)
 "Qv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -5597,13 +5941,14 @@
 /area/ship/dominian_unathi/bridge)
 "RS" = (
 /obj/structure/window/shuttle,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_unathi)
 "RW" = (
 /obj/effect/map_effect/marker/airlock/shuttle{
 	cycle_to_external_air = 1;
-	master_tag = "airlock_kazhkz_shutle";
-	name = "airlock_shutle_kazhkz";
+	master_tag = "airlock_kazhkz_shuttle";
+	name = "airlock_kazhkz_shuttle";
 	shuttle_tag = "Kazhkz Fighter";
 	req_one_access = list(212)
 	},
@@ -5751,9 +6096,26 @@
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/portthrust)
 "SD" = (
-/obj/effect/map_effect/airlock/w_to_e/long/square,
-/turf/simulated/wall/shuttle/space_ship,
-/area/ship/dominian_unathi/starboardhall)
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 1;
+	pixel_y = -22;
+	pixel_x = -6
+	},
+/obj/machinery/airlock_sensor{
+	dir = 1;
+	pixel_y = -22;
+	pixel_x = 6
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_1";
+	name = "airlock_kazhkz_1";
+	frequency = 1939
+	},
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/bridgefoyer)
 "SF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
@@ -5996,6 +6358,24 @@
 /turf/simulated/floor/greengrid,
 /area/ship/dominian_unathi/engineering)
 "Uc" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 1;
+	pixel_y = -22;
+	pixel_x = -6
+	},
+/obj/machinery/airlock_sensor{
+	dir = 1;
+	pixel_y = -22;
+	pixel_x = 6
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_2";
+	name = "airlock_kazhkz_2";
+	frequency = 1989
+	},
 /turf/simulated/floor/plating,
 /area/ship/dominian_unathi/bridgefoyer)
 "Uj" = (
@@ -6054,6 +6434,17 @@
 "UC" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/ship/dominian_unathi/porthall)
+"UD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_3";
+	name = "airlock_kazhkz_3";
+	frequency = 2126
+	},
+/turf/simulated/floor/plating,
+/area/ship/dominian_unathi/starboardhall)
 "UF" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 6
@@ -6336,8 +6727,8 @@
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	cycle_to_external_air = 1;
-	master_tag = "airlock_kazhkz_shutle";
-	name = "airlock_shutle_kazhkz";
+	master_tag = "airlock_kazhkz_shuttle";
+	name = "airlock_kazhkz_shuttle";
 	shuttle_tag = "Kazhkz Fighter";
 	req_one_access = list(212)
 	},
@@ -6622,8 +7013,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/dominian_unathi/starboardhall)
 "XV" = (
-/obj/effect/map_effect/airlock/w_to_e,
-/turf/simulated/wall,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_kazhkz_1";
+	name = "airlock_kazhkz_1";
+	frequency = 1939
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 28
+	},
+/turf/simulated/floor/plating,
 /area/ship/dominian_unathi/bridgefoyer)
 "XX" = (
 /obj/structure/cable/green{
@@ -6692,8 +7096,8 @@
 /obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	cycle_to_external_air = 1;
-	master_tag = "airlock_kazhkz_shutle";
-	name = "airlock_shutle_kazhkz";
+	master_tag = "airlock_kazhkz_shuttle";
+	name = "airlock_kazhkz_shuttle";
 	shuttle_tag = "Kazhkz Fighter";
 	req_one_access = list(212)
 	},
@@ -6796,8 +7200,8 @@
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	cycle_to_external_air = 1;
-	master_tag = "airlock_kazhkz_shutle";
-	name = "airlock_shutle_kazhkz";
+	master_tag = "airlock_kazhkz_shuttle";
+	name = "airlock_kazhkz_shuttle";
 	shuttle_tag = "Kazhkz Fighter";
 	req_one_access = list(212)
 	},
@@ -17585,9 +17989,9 @@ JT
 NR
 hl
 Pd
-Np
-Np
-SD
+JE
+Qo
+Pd
 qg
 Dj
 uS
@@ -17747,8 +18151,8 @@ Pd
 Pd
 Pd
 Pd
-Np
-Np
+tP
+Mj
 Pd
 Pd
 HC
@@ -17909,7 +18313,7 @@ Wf
 Wf
 Wf
 Pd
-Np
+UD
 Np
 Pd
 Wf
@@ -18071,8 +18475,8 @@ Wf
 Wf
 Wf
 Pd
-Np
-Np
+ff
+uN
 Pd
 Wf
 Wf
@@ -18866,10 +19270,10 @@ iH
 Ro
 RY
 HH
-Wf
-nP
-Uc
-tP
+HH
+XV
+mN
+HH
 Wf
 Wf
 Wf
@@ -19029,8 +19433,8 @@ rR
 HH
 HH
 HH
-HH
-Uc
+In
+SD
 HH
 HH
 HH
@@ -19190,10 +19594,10 @@ VX
 We
 HH
 Cs
-Jw
-nP
-Uc
-nP
+HH
+Bi
+jg
+HH
 Jw
 XZ
 Zi
@@ -19355,7 +19759,7 @@ CF
 SF
 SF
 FP
-Jw
+MM
 Tf
 Zi
 Zi
@@ -20487,9 +20891,9 @@ pu
 HH
 iG
 SF
-rO
+SF
 XD
-Jw
+wC
 mK
 Zi
 Zi
@@ -20648,10 +21052,10 @@ VX
 VX
 HH
 dY
-Jw
-nP
-Uc
-XV
+HH
+NE
+KZ
+HH
 Jw
 Rb
 Zi
@@ -20811,7 +21215,7 @@ VA
 HH
 HH
 HH
-HH
+sp
 Uc
 HH
 HH
@@ -20972,10 +21376,10 @@ BB
 Ro
 RY
 HH
-Wf
+HH
 nP
-Uc
-nP
+ES
+HH
 Wf
 Wf
 Wf
@@ -21799,9 +22203,9 @@ Wf
 Wf
 Wf
 UC
-GX
-GX
-In
+mJ
+iW
+UC
 Wf
 Wf
 Wf
@@ -21961,8 +22365,8 @@ Wf
 Wf
 Wf
 UC
-GX
-GX
+tA
+gi
 UC
 Wf
 Wf
@@ -22123,8 +22527,8 @@ UC
 UC
 UC
 UC
-GX
-GX
+NX
+mw
 UC
 UC
 Ig
@@ -22285,7 +22689,7 @@ hQ
 Tt
 wL
 UC
-GX
+rO
 GX
 UC
 DP
@@ -23102,9 +23506,9 @@ dL
 nd
 ZK
 gY
-cI
+DM
 wt
-Bi
+zW
 CT
 iD
 BQ

--- a/maps/away/ships/golden_deep/golden_deep.dm
+++ b/maps/away/ships/golden_deep/golden_deep.dm
@@ -72,14 +72,17 @@
 
 /obj/effect/shuttle_landmark/golden_deep/dock
 	name = "Golden Deep Mercantile Vessel, Main Docking Port"
+	docking_controller = "airlock_gd_dock"
 	landmark_tag = "gd_dock"
 
 /obj/effect/shuttle_landmark/golden_deep/dock2
 	name = "Golden Deep Mercantile Vessel, Auxiliary Docking Port"
+	docking_controller = "airlock_gd_dock2"
 	landmark_tag = "gd_dock2"
 
 /obj/effect/shuttle_landmark/golden_deep/dock3
 	name = "Golden Deep Mercantile Vessel, Docking Port"
+	docking_controller = "airlock_gd_dock3"
 	landmark_tag = "gd_dock3"
 
 //Shuttle
@@ -109,7 +112,7 @@
 	shuttle_area = list(/area/shuttle/golden_deep)
 	current_location = "gd_nav_hangar"
 	landmark_transition = "gd_nav_transit"
-	dock_target = "golden_shuttle"
+	dock_target = "airlock_golden_shuttle"
 	range = 1
 	fuel_consumption = 2
 	logging_home_tag = "gd_nav_hangar"
@@ -118,6 +121,7 @@
 /obj/effect/shuttle_landmark/golden_deep_shuttle/hangar
 	name = "Golden Deep Mercantile Vessel - Hangar"
 	landmark_tag = "gd_nav_hangar"
+	docking_controller = "golden_deep_hangar"
 	base_turf = /turf/simulated/floor/plating
 	base_area = /area/golden_deep/hangar
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE

--- a/maps/away/ships/golden_deep/golden_deep_merchant.dmm
+++ b/maps/away/ships/golden_deep/golden_deep_merchant.dmm
@@ -400,9 +400,18 @@
 /turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/warehouse)
 "en" = (
-/obj/effect/map_effect/airlock/s_to_n/long/square,
-/turf/simulated/wall/shuttle/dark/cardinal/gold,
-/area/golden_deep/hangar)
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock3";
+	master_tag = "airlock_gd_dock3";
+	name = "airlock_gd_dock3"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/golden_deep/dock/aux)
 "ex" = (
 /obj/machinery/door/window{
 	req_access = list(217)
@@ -456,6 +465,18 @@
 /area/golden_deep/eva)
 "fb" = (
 /obj/effect/shuttle_landmark/golden_deep/dock2,
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = 12;
+	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock2";
+	master_tag = "airlock_gd_dock2";
+	name = "airlock_gd_dock2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/golden_deep/hangar)
 "fc" = (
@@ -504,9 +525,23 @@
 /turf/simulated/floor/plating,
 /area/golden_deep/starboardprop)
 "fO" = (
-/obj/effect/map_effect/airlock/long/square,
-/turf/simulated/wall/shuttle/dark/cardinal/gold,
-/area/golden_deep/dock)
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock3";
+	master_tag = "airlock_gd_dock3";
+	name = "airlock_gd_dock3"
+	},
+/turf/simulated/floor/plating,
+/area/golden_deep/dock/aux)
+"fT" = (
+/obj/machinery/light,
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 1;
+	pixel_y = -20;
+	id_tag = "golden_deep_hangar";
+	frequency = 1380
+	},
+/turf/simulated/floor/plating,
+/area/golden_deep/hangar)
 "fU" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -656,6 +691,19 @@
 	},
 /turf/simulated/floor/gold,
 /area/golden_deep/dock)
+"hc" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock2";
+	master_tag = "airlock_gd_dock2";
+	name = "airlock_gd_dock2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/golden_deep/hangar)
 "hd" = (
 /obj/structure/bed/stool/chair/sofa/brown{
 	dir = 1
@@ -866,6 +914,24 @@
 	},
 /obj/machinery/power/apc/south{
 	req_access = list(217)
+	},
+/turf/simulated/floor/plating,
+/area/golden_deep/hangar)
+"jc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock2";
+	master_tag = "airlock_gd_dock2";
+	name = "airlock_gd_dock2"
 	},
 /turf/simulated/floor/plating,
 /area/golden_deep/hangar)
@@ -1081,15 +1147,23 @@
 /obj/effect/shuttle_landmark/golden_deep/dock3{
 	dir = 8
 	},
+/obj/machinery/access_button{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 28
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock3";
+	master_tag = "airlock_gd_dock3";
+	name = "airlock_gd_dock3"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/golden_deep/dock/aux)
 "lk" = (
-/obj/machinery/airlock_sensor/airlock_interior{
-	pixel_x = -23;
-	id_tag = "golden_shuttle_interior_sensor";
-	frequency = 1385;
-	pixel_y = 10
-	},
 /turf/simulated/floor/plating,
 /area/shuttle/golden_deep)
 "ll" = (
@@ -1309,25 +1383,20 @@
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/bed/handrail,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	id_tag = "golden_shuttle_pump_out_external";
-	frequency = 1385;
-	layer = 2.8
-	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1385;
-	master_tag = "golden_shuttle";
-	name = "exterior access button";
-	pixel_x = -23;
-	pixel_y = -10
+	dir = 8
 	},
 /obj/machinery/airlock_sensor/airlock_exterior{
-	frequency = 1385;
-	id_tag = "golden_shuttle_exterior_sensor";
-	pixel_y = -11;
-	pixel_x = -36
+	pixel_x = -32;
+	pixel_y = -5
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_golden_shuttle";
+	name = "airlock_golden_shuttle";
+	req_one_access = list(217);
+	shuttle_tag = "Golden Deep Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/golden_deep)
 "mR" = (
@@ -1342,6 +1411,21 @@
 	},
 /turf/simulated/floor/gold,
 /area/golden_deep/dock/aux)
+"mV" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock";
+	master_tag = "airlock_gd_dock";
+	name = "airlock_gd_dock"
+	},
+/turf/simulated/floor/plating,
+/area/golden_deep/dock)
 "mY" = (
 /obj/machinery/computer/ship/helm{
 	dir = 4;
@@ -1433,12 +1517,20 @@
 	dir = 8;
 	icon_state = "map"
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "golden_shuttle_in";
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = 12;
 	dir = 1
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_golden_shuttle";
+	name = "airlock_golden_shuttle";
+	req_one_access = list(217);
+	shuttle_tag = "Golden Deep Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/gold,
 /area/shuttle/golden_deep)
 "of" = (
@@ -1508,22 +1600,18 @@
 /area/shuttle/golden_deep)
 "oG" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1385;
-	id_tag = "golden_shuttle_pump_in"
+	dir = 1
 	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
-	id_tag = "hegemony_shuttle";
-	master_tag = "hegemony_shuttle";
-	pixel_y = null;
-	tag_interior_door = "golden_shuttle_in";
-	tag_exterior_door = "golden_shuttle_out";
-	tag_interior_sensor = "golden_shuttle_interior_sensor";
-	tag_exterior_sensor = "golden_shuttle_exterior_sensor";
-	tag_chamber_sensor = "golden_shuttle_chamber_sensor";
-	tag_airpump = "golden_shuttle_pump_in";
-	frequency = 1385;
-	pixel_x = -25
+/obj/machinery/airlock_sensor{
+	pixel_x = -20;
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_golden_shuttle";
+	name = "airlock_golden_shuttle";
+	req_one_access = list(217);
+	shuttle_tag = "Golden Deep Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/gold,
 /area/shuttle/golden_deep)
@@ -1912,11 +2000,18 @@
 /turf/simulated/floor/wood/mahogany,
 /area/golden_deep/captain)
 "tp" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
 	},
-/turf/simulated/floor/gold,
-/area/golden_deep/dock/aux)
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock";
+	master_tag = "airlock_gd_dock";
+	name = "airlock_gd_dock"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/golden_deep/dock)
 "tz" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
@@ -2074,6 +2169,16 @@
 /obj/item/grenade/chem_grenade/cleaner,
 /turf/simulated/floor/tiled,
 /area/golden_deep/custodial)
+"vj" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock2";
+	master_tag = "airlock_gd_dock2";
+	name = "airlock_gd_dock2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/plating,
+/area/golden_deep/hangar)
 "vk" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(217)
@@ -2254,15 +2359,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 5
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "golden_shuttle_out";
-	dir = 1
-	},
 /obj/effect/landmark/entry_point/fore{
 	name = "port"
 	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = -8;
+	dir = 2
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_golden_shuttle";
+	name = "airlock_golden_shuttle";
+	req_one_access = list(217);
+	shuttle_tag = "Golden Deep Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/gold,
 /area/shuttle/golden_deep)
 "wR" = (
@@ -2469,13 +2582,19 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
-	frequency = 1385;
-	id_tag = "golden_shuttle_pump_in"
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_golden_shuttle";
+	name = "airlock_golden_shuttle";
+	req_one_access = list(217);
+	shuttle_tag = "Golden Deep Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/gold,
 /area/shuttle/golden_deep)
@@ -2784,6 +2903,11 @@
 	dir = 4;
 	icon_state = "tube_empty"
 	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock";
+	master_tag = "airlock_gd_dock";
+	name = "airlock_gd_dock"
+	},
 /turf/simulated/floor/plating,
 /area/golden_deep/dock)
 "BW" = (
@@ -2813,6 +2937,25 @@
 	},
 /turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/golden_deep/bridge)
+"Cy" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
+	},
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = -8;
+	dir = 2
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock2";
+	master_tag = "airlock_gd_dock2";
+	name = "airlock_gd_dock2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/golden_deep/hangar)
 "CC" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2830,6 +2973,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/golden_deep/eva)
+"CS" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = -20;
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock";
+	master_tag = "airlock_gd_dock";
+	name = "airlock_gd_dock"
+	},
+/turf/simulated/floor/plating,
+/area/golden_deep/dock)
 "CZ" = (
 /obj/machinery/atmospherics/unary/engine,
 /obj/structure/window/borosilicate/reinforced,
@@ -2959,6 +3117,15 @@
 	},
 /turf/simulated/floor/gold,
 /area/golden_deep/dock)
+"Ei" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock2";
+	master_tag = "airlock_gd_dock2";
+	name = "airlock_gd_dock2"
+	},
+/turf/simulated/floor/plating,
+/area/golden_deep/hangar)
 "Ep" = (
 /obj/effect/shuttle_landmark/golden_deep/nav3,
 /turf/template_noop,
@@ -3388,12 +3555,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "golden_shuttle_in";
-	dir = 1
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_golden_shuttle";
+	name = "airlock_golden_shuttle";
+	req_one_access = list(217);
+	shuttle_tag = "Golden Deep Shuttle";
+	cycle_to_external_air = 1
 	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/gold,
 /area/shuttle/golden_deep)
 "II" = (
@@ -3423,12 +3593,15 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/red,
-/obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "golden_shuttle_out";
-	dir = 1
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_golden_shuttle";
+	name = "airlock_golden_shuttle";
+	req_one_access = list(217);
+	shuttle_tag = "Golden Deep Shuttle";
+	cycle_to_external_air = 1
 	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/gold,
 /area/shuttle/golden_deep)
 "Jf" = (
@@ -3438,6 +3611,14 @@
 	},
 /turf/simulated/floor/gold,
 /area/golden_deep/engineering)
+"Jt" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock";
+	master_tag = "airlock_gd_dock";
+	name = "airlock_gd_dock"
+	},
+/turf/simulated/floor/plating,
+/area/golden_deep/dock)
 "Jz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 1
@@ -3445,19 +3626,18 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2;
-	id_tag = "golden_shuttle_pump_out_internal";
-	frequency = 1385;
-	layer = 2.8
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_golden_shuttle";
+	name = "airlock_golden_shuttle";
+	req_one_access = list(217);
+	shuttle_tag = "Golden Deep Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1385;
-	id_tag = "golden_shuttle_chamber_sensor";
-	pixel_y = null;
-	dir = 1;
-	pixel_x = 23
+/obj/machinery/light{
+	dir = 4
 	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/gold,
 /area/shuttle/golden_deep)
 "JQ" = (
@@ -3532,9 +3712,17 @@
 /turf/simulated/floor/gold,
 /area/golden_deep/dock)
 "Kj" = (
-/obj/effect/map_effect/airlock/w_to_e/long/square,
-/turf/simulated/wall/shuttle/dark/cardinal/gold,
-/area/golden_deep/dock/aux)
+/obj/machinery/airlock_sensor{
+	pixel_x = -20;
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock2";
+	master_tag = "airlock_gd_dock2";
+	name = "airlock_gd_dock2"
+	},
+/turf/simulated/floor/plating,
+/area/golden_deep/hangar)
 "Kq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
@@ -3754,6 +3942,25 @@
 /obj/machinery/computer/ship/engines,
 /turf/simulated/floor/plating,
 /area/shuttle/golden_deep)
+"MS" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_x = -6;
+	pixel_y = 28
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = 6;
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock3";
+	master_tag = "airlock_gd_dock3";
+	name = "airlock_gd_dock3"
+	},
+/turf/simulated/floor/plating,
+/area/golden_deep/dock/aux)
 "MW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -3762,6 +3969,14 @@
 /turf/simulated/floor/plating,
 /area/golden_deep/storage)
 "Nf" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock3";
+	master_tag = "airlock_gd_dock3";
+	name = "airlock_gd_dock3"
+	},
 /turf/simulated/floor/plating,
 /area/golden_deep/dock/aux)
 "Ni" = (
@@ -3868,6 +4083,18 @@
 /turf/simulated/floor/plating,
 /area/shuttle/golden_deep)
 "OD" = (
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = -8;
+	dir = 2
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock";
+	master_tag = "airlock_gd_dock";
+	name = "airlock_gd_dock"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/golden_deep/dock)
 "OH" = (
@@ -3954,6 +4181,13 @@
 /obj/effect/shuttle_landmark/golden_deep/dock{
 	dir = 1
 	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock";
+	master_tag = "airlock_gd_dock";
+	name = "airlock_gd_dock"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/golden_deep/dock)
 "Qe" = (
@@ -4015,6 +4249,15 @@
 /obj/effect/landmark/entry_point/port{
 	name = "port, docking bay"
 	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock3";
+	master_tag = "airlock_gd_dock3";
+	name = "airlock_gd_dock3"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/golden_deep/dock/aux)
 "QX" = (
@@ -4144,6 +4387,25 @@
 	},
 /turf/simulated/floor/gold,
 /area/golden_deep/hangar)
+"Sa" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
+	},
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = 12;
+	dir = 1
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock";
+	master_tag = "airlock_gd_dock";
+	name = "airlock_gd_dock"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/golden_deep/dock)
 "Sg" = (
 /obj/effect/floor_decal/spline/fancy/wood/full,
 /obj/machinery/recharge_station,
@@ -4507,14 +4769,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1385;
-	master_tag = "golden_shuttle";
-	name = "interior access button";
-	pixel_x = -5;
-	pixel_y = -20;
-	dir = 1
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/airlock_sensor/airlock_exterior{
+	pixel_y = -20
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_golden_shuttle";
+	name = "airlock_golden_shuttle";
+	req_one_access = list(217);
+	shuttle_tag = "Golden Deep Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/gold,
 /area/shuttle/golden_deep)
@@ -4566,12 +4830,15 @@
 /turf/simulated/wall/shuttle/dark/cardinal/gold,
 /area/shuttle/golden_deep)
 "WT" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2;
-	id_tag = "golden_shuttle_pump_out_internal";
-	frequency = 1385;
-	layer = 2.8
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_golden_shuttle";
+	name = "airlock_golden_shuttle";
+	req_one_access = list(217);
+	shuttle_tag = "Golden Deep Shuttle";
+	cycle_to_external_air = 1
 	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/gold,
 /area/shuttle/golden_deep)
 "WY" = (
@@ -4670,6 +4937,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/golden_deep/starboardprop)
+"Xl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/machinery/access_button{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 28
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock3";
+	master_tag = "airlock_gd_dock3";
+	name = "airlock_gd_dock3"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/golden_deep/dock/aux)
 "Xm" = (
 /obj/machinery/hologram/holopad/long_range,
 /obj/effect/overmap/visitable/ship/golden_deep,
@@ -4865,6 +5152,17 @@
 /obj/item/book/manual/robotics_cyborgs,
 /turf/simulated/floor/tiled,
 /area/golden_deep/secure)
+"ZS" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "gd_dock3";
+	master_tag = "airlock_gd_dock3";
+	name = "airlock_gd_dock3"
+	},
+/turf/simulated/floor/plating,
+/area/golden_deep/dock/aux)
 
 (1,1,1) = {"
 pu
@@ -16408,7 +16706,7 @@ EV
 Xd
 rB
 aH
-Dt
+fT
 DZ
 Oi
 ka
@@ -18397,7 +18695,7 @@ Ey
 tQ
 tZ
 hK
-tp
+Tg
 Tg
 sz
 VD
@@ -18560,9 +18858,9 @@ JQ
 tZ
 ua
 tZ
-Nf
-Nf
-Kj
+Xl
+en
+tZ
 GA
 lg
 wJ
@@ -18722,7 +19020,7 @@ Di
 tZ
 tZ
 tZ
-Nf
+MS
 Nf
 tZ
 tZ
@@ -18884,8 +19182,8 @@ pu
 pu
 pu
 tZ
-Nf
-Nf
+ZS
+fO
 tZ
 pu
 pu
@@ -18990,7 +19288,7 @@ pu
 pZ
 pZ
 pZ
-en
+pZ
 ZB
 xE
 pZ
@@ -19150,9 +19448,9 @@ pu
 pu
 pu
 fb
-aH
-aH
-aH
+Kj
+Ei
+Cy
 tU
 xE
 NS
@@ -19311,10 +19609,10 @@ pu
 pu
 pu
 pu
-aH
-qP
-aH
-aH
+vj
+jc
+Ei
+hc
 xE
 xE
 pZ
@@ -20469,7 +20767,7 @@ eD
 Mr
 Mr
 Mr
-fO
+Mr
 pu
 pu
 pu
@@ -20628,9 +20926,9 @@ PK
 eD
 eD
 iF
-OD
-OD
-OD
+Sa
+CS
+Jt
 OD
 pu
 pu
@@ -20790,8 +21088,8 @@ PK
 eD
 eD
 yM
-OD
-OD
+tp
+mV
 BS
 Qd
 pu

--- a/maps/away/ships/hegemony/miners_guild/miners_guild_station.dm
+++ b/maps/away/ships/hegemony/miners_guild/miners_guild_station.dm
@@ -37,20 +37,35 @@
 	base_area = /area/space
 
 /obj/effect/shuttle_landmark/miners_guild/nav1
-	name = "Miners' Guild Outpost - Fore"
+	name = "Fore"
 	landmark_tag = "miners_guild_nav1"
 
 /obj/effect/shuttle_landmark/miners_guild/nav2
-	name = "Miners' Guild Outpost - Port"
+	name = "Port"
 	landmark_tag = "miners_guild_nav2"
 
 /obj/effect/shuttle_landmark/miners_guild/nav3
-	name = "Miners' Guild Outpost - Starboard"
+	name = "Starboard"
 	landmark_tag = "miners_guild_nav3"
 
 /obj/effect/shuttle_landmark/miners_guild/nav4
-	name = "Miners' Guild Outpost - Aft"
+	name = "Aft"
 	landmark_tag = "miners_guild_nav4"
+
+/obj/effect/shuttle_landmark/miners_guild/dock1
+	name = "Aft Docking Bay"
+	landmark_tag = "miners_guild_dock1"
+	docking_controller = "airlock_minersguild_dock1"
+
+/obj/effect/shuttle_landmark/miners_guild/dock2
+	name = "Port Docking Bay"
+	landmark_tag = "miners_guild_dock2"
+	docking_controller = "airlock_minersguild_dock2"
+
+/obj/effect/shuttle_landmark/miners_guild/dock3
+	name = "Starboard Docking Bay"
+	landmark_tag = "miners_guild_dock3"
+	docking_controller = "airlock_minersguild_dock3"
 
 /obj/effect/overmap/visitable/sector/miners_guild_station/get_skybox_representation()
 	var/image/skybox_image = image('icons/skybox/subcapital_ships.dmi', "guild_station")
@@ -92,14 +107,16 @@
 	shuttle_area = list(/area/shuttle/miners_guild)
 	current_location = "miners_guild_navhangar"
 	landmark_transition = "miners_guild_navtransit"
+	dock_target = "airlock_guild_shuttle"
 	range = 1
 	fuel_consumption = 2
 	logging_home_tag = "miners_guild_navhangar"
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/miners_guild/hangar
-	name = "Miners' Guild Outpost - Hangar"
+	name = "Hangar"
 	landmark_tag = "miners_guild_navhangar"
+	docking_controller = "guild_shuttle_dock"
 	base_area = /area/miners_guild/hangar
 	base_turf = /turf/simulated/floor/plating
 	movable_flags = MOVABLE_FLAG_EFFECTMOVE

--- a/maps/away/ships/hegemony/miners_guild/miners_guild_station.dmm
+++ b/maps/away/ships/hegemony/miners_guild/miners_guild_station.dmm
@@ -2968,7 +2968,7 @@
 	},
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1380;
-	id_tag = dddd;
+	id_tag = "guild_shuttle_dock";
 	pixel_y = -24;
 	dir = 1
 	},

--- a/maps/away/ships/hegemony/miners_guild/miners_guild_station.dmm
+++ b/maps/away/ships/hegemony/miners_guild/miners_guild_station.dmm
@@ -236,6 +236,29 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/crew)
+"cZ" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock3";
+	master_tag = "airlock_minersguild_dock3";
+	name = "airlock_minersguild_dock3"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/shuttle_landmark/miners_guild/dock3{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/miners_guild)
+"dd" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock1";
+	master_tag = "airlock_minersguild_dock1";
+	name = "airlock_minersguild_dock1"
+	},
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "di" = (
 /turf/template_noop,
 /area/space)
@@ -263,6 +286,18 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/processing)
+"dD" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock2";
+	master_tag = "airlock_minersguild_dock2";
+	name = "airlock_minersguild_dock2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "dG" = (
 /obj/structure/table/steel,
 /obj/item/plastique/seismic,
@@ -299,10 +334,16 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1379;
-	id_tag = "miners_guild_out_internal"
+	dir = 4
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_guild_shuttle";
+	name = "airlock_guild_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Miners' Guild Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/shuttle/miners_guild)
 "er" = (
@@ -359,15 +400,33 @@
 /obj/effect/floor_decal/corner_wide/brown/diagonal,
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild)
+"fm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner_wide/brown/diagonal,
+/obj/effect/floor_decal/corner_wide/brown/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/miners_guild)
 "fz" = (
 /obj/effect/floor_decal/corner_wide/brown/diagonal,
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/sign/flag/hegemony/large/north,
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/bridge)
+"fE" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock3";
+	master_tag = "airlock_minersguild_dock3";
+	name = "airlock_minersguild_dock3"
+	},
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "fF" = (
-/obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/bed/handrail,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/miners_guild)
 "fH" = (
@@ -445,8 +504,12 @@
 /turf/simulated/floor/plating,
 /area/miners_guild/hangar)
 "gy" = (
-/obj/structure/fuel_port/hydrogen{
-	pixel_x = -25
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_guild_shuttle";
+	name = "airlock_guild_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Miners' Guild Shuttle"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/miners_guild)
@@ -838,6 +901,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/miners_guild)
+"jN" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock2";
+	master_tag = "airlock_minersguild_dock2";
+	name = "airlock_minersguild_dock2"
+	},
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "jO" = (
 /turf/simulated/wall/shuttle/raider,
 /area/miners_guild)
@@ -929,6 +1000,13 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/canteen)
+"ln" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_wide/brown/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/miners_guild)
 "lq" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -950,13 +1028,26 @@
 /turf/simulated/floor/lino/diamond,
 /area/miners_guild/canteen)
 "lB" = (
-/obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/bed/handrail,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1;
-	id_tag = "miners_guild_out_external";
-	frequency = 1413
+	dir = 1
 	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 6
+	},
+/obj/machinery/airlock_sensor/airlock_exterior{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_guild_shuttle";
+	name = "airlock_guild_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Miners' Guild Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/miners_guild)
 "lC" = (
@@ -1127,6 +1218,21 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/crew)
+"nq" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_guild_shuttle";
+	name = "airlock_guild_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Miners' Guild Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/shuttle/miners_guild)
 "nr" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -1164,6 +1270,16 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/crew)
+"nO" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock1";
+	master_tag = "airlock_minersguild_dock1";
+	name = "airlock_minersguild_dock1"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "nQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -1205,6 +1321,17 @@
 "ou" = (
 /turf/simulated/wall/shuttle/raider,
 /area/miners_guild/engineering1)
+"oL" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock2";
+	master_tag = "airlock_minersguild_dock2";
+	name = "airlock_minersguild_dock2"
+	},
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "oO" = (
 /obj/machinery/light{
 	dir = 8
@@ -1308,6 +1435,20 @@
 	},
 /turf/simulated/floor/lino/diamond,
 /area/miners_guild/canteen)
+"pU" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock1";
+	master_tag = "airlock_minersguild_dock1";
+	name = "airlock_minersguild_dock1"
+	},
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "pW" = (
 /obj/structure/table/steel,
 /obj/item/gun/energy/plasmacutter,
@@ -1333,6 +1474,17 @@
 /obj/effect/floor_decal/corner/orange,
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/engineering2)
+"qf" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock3";
+	master_tag = "airlock_minersguild_dock3";
+	name = "airlock_minersguild_dock3"
+	},
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "qh" = (
 /obj/machinery/power/solar,
 /obj/structure/cable/yellow{
@@ -1341,6 +1493,23 @@
 	},
 /turf/simulated/floor/airless,
 /area/miners_guild/solars_starboard)
+"qv" = (
+/obj/machinery/access_button{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 28
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock3";
+	master_tag = "airlock_minersguild_dock3";
+	name = "airlock_minersguild_dock3"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "qC" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/storage/box/fancy/egg_box,
@@ -1451,6 +1620,11 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/crew)
+"rp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/corner_wide/brown/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/miners_guild)
 "rv" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 10
@@ -1541,6 +1715,14 @@
 	},
 /turf/simulated/floor/airless,
 /area/miners_guild/solars_port)
+"sA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_wide/brown/diagonal,
+/obj/effect/floor_decal/corner_wide/brown/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/miners_guild)
 "sH" = (
 /turf/simulated/wall/shuttle/raider,
 /area/miners_guild/fuel_bay)
@@ -1629,6 +1811,26 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/miners_guild)
+"tA" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/machinery/access_button{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 28
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock2";
+	master_tag = "airlock_minersguild_dock2";
+	name = "airlock_minersguild_dock2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "tD" = (
 /obj/effect/floor_decal/corner_wide/brown/diagonal,
 /obj/structure/table/steel,
@@ -1693,6 +1895,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild)
+"uI" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/structure/bed/handrail,
+/turf/simulated/floor/plating,
+/area/shuttle/miners_guild)
 "uP" = (
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, crew quarters"
@@ -1823,6 +2032,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/processing)
+"wy" = (
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 6
+	},
+/obj/structure/bed/handrail,
+/turf/simulated/floor/plating,
+/area/shuttle/miners_guild)
 "wA" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -1868,6 +2085,27 @@
 	},
 /obj/effect/floor_decal/corner_wide/brown/diagonal,
 /turf/simulated/floor/tiled/steel,
+/area/miners_guild)
+"wY" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = 6
+	},
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -6
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock1";
+	master_tag = "airlock_minersguild_dock1";
+	name = "airlock_minersguild_dock1"
+	},
+/turf/simulated/floor/plating,
 /area/miners_guild)
 "xd" = (
 /obj/structure/cable/green{
@@ -1926,6 +2164,19 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/engineering2)
+"xw" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock3";
+	master_tag = "airlock_minersguild_dock3";
+	name = "airlock_minersguild_dock3"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "xx" = (
 /obj/item/pickaxe,
 /obj/item/pickaxe,
@@ -1950,6 +2201,26 @@
 	temperature = 278.15
 	},
 /area/miners_guild/processing)
+"xy" = (
+/obj/machinery/access_button{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock3";
+	master_tag = "airlock_minersguild_dock3";
+	name = "airlock_minersguild_dock3"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "xB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2208,6 +2479,23 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/machinery/access_button{
+	dir = 1;
+	pixel_x = 26;
+	pixel_y = 6
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_guild_shuttle";
+	name = "airlock_guild_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Miners' Guild Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/shuttle/miners_guild)
 "Ae" = (
@@ -2247,8 +2535,32 @@
 /turf/simulated/floor/tiled/white,
 /area/miners_guild/cryo)
 "Ar" = (
-/obj/effect/map_effect/airlock/long/square,
-/turf/simulated/wall/shuttle/raider,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	pixel_y = 6;
+	pixel_x = 20
+	},
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -6
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_guild_shuttle";
+	name = "airlock_guild_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Miners' Guild Shuttle"
+	},
+/turf/simulated/floor/plating,
 /area/shuttle/miners_guild)
 "Av" = (
 /obj/structure/cable/green{
@@ -2471,6 +2783,26 @@
 	},
 /turf/simulated/floor/airless,
 /area/miners_guild/solars_starboard)
+"CW" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	dir = 4;
+	pixel_x = 12;
+	pixel_y = 28
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock2";
+	master_tag = "airlock_minersguild_dock2";
+	name = "airlock_minersguild_dock2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/shuttle_landmark/miners_guild/dock2{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "CY" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 10
@@ -2536,6 +2868,20 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/engineering2)
+"DO" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock3";
+	master_tag = "airlock_minersguild_dock3";
+	name = "airlock_minersguild_dock3"
+	},
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "DR" = (
 /obj/effect/floor_decal/corner_wide/brown/diagonal,
 /turf/simulated/floor/tiled/steel,
@@ -2611,6 +2957,23 @@
 /obj/machinery/computer/ship/helm,
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/miners_guild)
+"EG" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = dddd;
+	pixel_y = -24;
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/miners_guild/hangar)
 "EK" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -2677,6 +3040,22 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/engineering1)
+"Gz" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/corner_wide/brown/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/miners_guild)
+"GE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_wide/brown/diagonal,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel,
+/area/miners_guild)
 "GG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/steel,
@@ -2732,6 +3111,27 @@
 	},
 /turf/simulated/floor/airless,
 /area/miners_guild/solars_port)
+"HR" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = 28;
+	pixel_y = -8
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_guild_shuttle";
+	name = "airlock_guild_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Miners' Guild Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/plating,
+/area/shuttle/miners_guild)
 "HT" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -2753,6 +3153,17 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel,
+/area/miners_guild)
+"Il" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock2";
+	master_tag = "airlock_minersguild_dock2";
+	name = "airlock_minersguild_dock2"
+	},
+/turf/simulated/floor/plating,
 /area/miners_guild)
 "Ir" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
@@ -2856,6 +3267,11 @@
 "Kg" = (
 /turf/simulated/wall/shuttle/raider,
 /area/miners_guild/processing)
+"Ko" = (
+/obj/effect/floor_decal/corner_wide/brown/diagonal,
+/obj/effect/floor_decal/corner_wide/brown/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/miners_guild)
 "Kp" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -2971,6 +3387,14 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/processing)
+"La" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/corner_wide/brown/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/miners_guild)
 "Lc" = (
 /obj/structure/bed/stool/chair/shuttle,
 /turf/simulated/floor/tiled/steel,
@@ -3109,6 +3533,15 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "aft"
 	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_guild_shuttle";
+	name = "airlock_guild_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Miners' Guild Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/miners_guild)
 "MJ" = (
@@ -3255,6 +3688,12 @@
 /obj/machinery/chemical_dispenser/bar_alc/full,
 /turf/simulated/floor/lino/diamond,
 /area/miners_guild/canteen)
+"OJ" = (
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/corner_wide/brown/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/miners_guild)
 "OL" = (
 /obj/effect/floor_decal/corner_wide/brown/diagonal,
 /obj/structure/table/steel,
@@ -3336,6 +3775,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/processing)
+"PB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner_wide/brown/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/miners_guild)
 "PC" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -3368,6 +3814,19 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/processing)
+"Qe" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock1";
+	master_tag = "airlock_minersguild_dock1";
+	name = "airlock_minersguild_dock1"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "Qm" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -3406,6 +3865,19 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
+/obj/machinery/airlock_sensor/airlock_interior{
+	dir = 1;
+	pixel_y = -18;
+	pixel_x = -6
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_guild_shuttle";
+	name = "airlock_guild_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Miners' Guild Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/miners_guild)
 "QA" = (
@@ -3689,6 +4161,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/miners_guild/hangar)
+"UZ" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = 28
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock1";
+	master_tag = "airlock_minersguild_dock1";
+	name = "airlock_minersguild_dock1"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/shuttle_landmark/miners_guild/dock1{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "Vc" = (
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 8
@@ -3723,6 +4211,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/processing)
+"Vv" = (
+/obj/effect/floor_decal/corner_wide/brown/diagonal,
+/obj/machinery/door/airlock/multi_tile{
+	name = "Docking Bay"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/miners_guild)
 "Vx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3805,6 +4300,24 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/processing)
+"Wq" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	dir = 1;
+	pixel_x = 40;
+	pixel_y = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock1";
+	master_tag = "airlock_minersguild_dock1";
+	name = "airlock_minersguild_dock1"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "Wv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3822,12 +4335,35 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/miners_guild/crew)
+"WE" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/structure/fuel_port/hydrogen{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/shuttle/miners_guild)
 "WR" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/miners_guild)
+"WZ" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_x = -6;
+	pixel_y = 28
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = 6;
+	pixel_y = 28
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock3";
+	master_tag = "airlock_minersguild_dock3";
+	name = "airlock_minersguild_dock3"
+	},
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "Xe" = (
 /obj/machinery/atmospherics/portables_connector{
 	layer = 2.8
@@ -3987,8 +4523,40 @@
 /turf/simulated/floor/plating,
 /area/miners_guild/hangar)
 "Yd" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_guild_shuttle";
+	name = "airlock_guild_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Miners' Guild Shuttle"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/miners_guild)
+"Yh" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_x = -6;
+	pixel_y = 28
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = 6;
+	pixel_y = 28
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock2";
+	master_tag = "airlock_minersguild_dock2";
+	name = "airlock_minersguild_dock2"
+	},
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "Yi" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -4079,6 +4647,21 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/shuttle/miners_guild)
+"ZP" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "miners_guild_dock2";
+	master_tag = "airlock_minersguild_dock2";
+	name = "airlock_minersguild_dock2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/miners_guild)
 "ZS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
@@ -12297,10 +12880,10 @@ di
 di
 di
 di
-di
-di
-di
-di
+jO
+qv
+cZ
+jO
 di
 di
 di
@@ -12459,10 +13042,10 @@ di
 di
 di
 di
-di
-di
-di
-di
+jO
+WZ
+fE
+jO
 di
 di
 di
@@ -12621,10 +13204,10 @@ di
 di
 di
 di
-di
-di
-di
-di
+jO
+DO
+qf
+jO
 di
 di
 di
@@ -12782,11 +13365,11 @@ di
 di
 di
 di
-di
-di
-di
-di
-di
+jO
+jO
+xy
+xw
+jO
 di
 di
 di
@@ -12944,11 +13527,11 @@ di
 di
 di
 di
-di
-di
-di
-di
-di
+jO
+On
+On
+ln
+jO
 di
 di
 di
@@ -13106,11 +13689,11 @@ di
 di
 di
 di
-di
-di
-di
-di
-di
+jO
+On
+On
+GE
+jO
 di
 di
 di
@@ -13268,11 +13851,11 @@ di
 di
 di
 di
-di
-di
-di
-di
-di
+jO
+On
+On
+ln
+jO
 di
 di
 di
@@ -13424,17 +14007,17 @@ ke
 bj
 bj
 jO
-di
-di
-di
-di
-di
-di
-di
-di
-di
-di
-di
+jO
+jO
+jO
+jO
+jO
+jO
+jO
+On
+On
+ln
+jO
 di
 di
 di
@@ -13586,17 +14169,17 @@ ke
 bj
 bj
 jO
-di
-di
-di
-di
-di
-di
-di
-di
-di
-di
-di
+zn
+On
+On
+On
+On
+On
+zn
+Ko
+Ko
+sA
+jO
 di
 di
 di
@@ -13745,20 +14328,20 @@ jO
 xW
 XY
 jO
-bj
-bj
 jO
-di
-di
-di
-di
-di
-di
-di
-di
-di
-di
-di
+jO
+jO
+On
+On
+On
+On
+On
+On
+On
+On
+On
+Gz
+jO
 di
 di
 di
@@ -13906,21 +14489,21 @@ gs
 Sy
 jh
 On
+Vv
+On
+On
+On
+On
+On
 jO
-bj
-bj
 jO
-di
-di
-di
-di
-di
-di
-di
-di
-di
-di
-di
+jO
+jO
+jO
+jO
+jO
+jO
+jO
 di
 di
 di
@@ -14068,13 +14651,13 @@ ZS
 On
 RO
 On
+On
+On
+jI
+On
+On
+On
 jO
-bj
-bj
-jO
-di
-di
-di
 di
 di
 di
@@ -14231,12 +14814,12 @@ jO
 RO
 On
 jO
-bj
-bj
 jO
-di
-di
-di
+jO
+jO
+jO
+jO
+jO
 di
 di
 di
@@ -15203,10 +15786,10 @@ iR
 On
 On
 jO
-bj
-bj
 jO
-di
+jO
+jO
+jO
 di
 di
 di
@@ -15365,13 +15948,13 @@ iR
 On
 On
 jO
-bj
-bj
+On
+On
+La
 jO
-di
-di
-di
-di
+jO
+jO
+jO
 di
 di
 di
@@ -15526,14 +16109,14 @@ hZ
 jO
 On
 On
-jO
-bj
-bj
-jO
-di
-di
-di
-di
+Vv
+Ko
+Ko
+fm
+Qe
+pU
+dd
+nO
 di
 di
 di
@@ -15688,14 +16271,14 @@ hZ
 jO
 On
 On
-jO
-bj
-bj
-jO
-di
-di
-di
-di
+On
+Ko
+Ko
+Ko
+Wq
+wY
+dd
+UZ
 di
 di
 di
@@ -15851,13 +16434,13 @@ jO
 On
 On
 jO
-bj
-bj
+On
+jI
+On
 jO
-di
-di
-di
-di
+jO
+jO
+jO
 di
 di
 di
@@ -16013,10 +16596,10 @@ jO
 On
 Be
 jO
-bj
-bj
 jO
-di
+jO
+jO
+jO
 di
 di
 di
@@ -16462,7 +17045,7 @@ sV
 oR
 gS
 Mz
-Mz
+WE
 Sm
 nS
 fF
@@ -16626,10 +17209,10 @@ Uu
 nS
 nS
 nS
-Ar
-rI
+nS
+wy
 VT
-UD
+EG
 jO
 yA
 LE
@@ -16785,7 +17368,7 @@ sV
 dn
 Bq
 eB
-Yd
+nq
 Yd
 gy
 MB
@@ -16948,9 +17531,9 @@ EU
 ic
 fH
 zS
-zS
+Ar
 eh
-zS
+HR
 ys
 Yc
 nw
@@ -17113,7 +17696,7 @@ nS
 nS
 th
 Cq
-rI
+uI
 kt
 Vx
 iR
@@ -18443,14 +19026,14 @@ iR
 iA
 On
 jO
-bj
-bj
 jO
-di
-di
-di
-di
-di
+jO
+jO
+jO
+jO
+jO
+jO
+jO
 di
 di
 di
@@ -18604,15 +19187,15 @@ hZ
 iR
 wX
 On
+Vv
+On
+zn
+On
+On
+On
+On
+zn
 jO
-bj
-bj
-jO
-di
-di
-di
-di
-di
 di
 di
 di
@@ -18766,15 +19349,15 @@ jO
 jO
 RO
 On
+On
+On
+On
+On
+On
+On
+On
+On
 jO
-bj
-jO
-jO
-di
-di
-di
-di
-di
 di
 di
 di
@@ -18930,13 +19513,13 @@ RO
 Be
 jO
 jO
+OJ
+rp
+rp
+rp
+PB
+On
 jO
-di
-di
-di
-di
-di
-di
 di
 di
 di
@@ -19092,13 +19675,13 @@ je
 On
 jO
 jO
-di
-di
-di
-di
-di
-di
-di
+jO
+jO
+jO
+jO
+tA
+ZP
+jO
 di
 di
 di
@@ -19257,10 +19840,10 @@ di
 di
 di
 di
-di
-di
-di
-di
+jO
+Yh
+oL
+jO
 di
 di
 di
@@ -19419,10 +20002,10 @@ di
 di
 di
 di
-di
-di
-di
-di
+jO
+Il
+jN
+jO
 di
 di
 di
@@ -19581,10 +20164,10 @@ di
 di
 di
 di
-di
-di
-di
-di
+jO
+CW
+dD
+jO
 di
 di
 di

--- a/maps/away/ships/konyang/air_konyang/air_konyang.dm
+++ b/maps/away/ships/konyang/air_konyang/air_konyang.dm
@@ -55,7 +55,7 @@
 	fuel_consumption = 6
 	shuttle_area = list(/area/shuttle/air_konyang, /area/shuttle/air_konyang/atmos, /area/shuttle/air_konyang/engineering, /area/shuttle/air_konyang/storage, /area/shuttle/air_konyang/starbwing, /area/shuttle/air_konyang/crew, /area/shuttle/air_konyang/mainroom, /area/shuttle/air_konyang/bridge)
 	current_location = "nav_air_konyang_start"
-	dock_target = "air_konyang"
+	dock_target = "airlock_air_konyang"
 	landmark_transition = "nav_air_konyang_transit"
 	logging_home_tag = "nav_air_konyang_start"
 	defer_initialisation = TRUE

--- a/maps/away/ships/konyang/air_konyang/air_konyang.dmm
+++ b/maps/away/ships/konyang/air_konyang/air_konyang.dmm
@@ -116,17 +116,21 @@
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang)
 "dI" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "air_konyang_out"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 6
 	},
 /obj/effect/landmark/entry_point/aft{
 	name = "aft, docking port"
 	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_air_konyang";
+	name = "airlock_air_konyang";
+	req_one_access = null;
+	shuttle_tag = "Air Konyang Transport";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang)
 "dL" = (
@@ -142,24 +146,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/air_konyang/mainroom)
 "ep" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1385;
-	master_tag = "air_konyang";
-	name = "interior access button";
-	pixel_x = 24;
-	pixel_y = 12;
-	dir = 4
-	},
 /obj/machinery/airlock_sensor/airlock_interior{
+	dir = 4;
 	pixel_x = 24;
-	pixel_y = -5;
-	id_tag = "air_konyang_interior_sensor";
-	frequency = 1385;
-	dir = 4
+	pixel_y = -5
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_air_konyang";
+	name = "airlock_air_konyang";
+	req_one_access = null;
+	shuttle_tag = "Air Konyang Transport";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/air_konyang)
@@ -316,11 +314,26 @@
 /area/shuttle/air_konyang/mainroom)
 "ie" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	id_tag = "air_konyang_pump_out_internal";
-	frequency = 1385;
-	layer = 2.8
+	dir = 8
 	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = 6
+	},
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 20;
+	pixel_y = -6
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_air_konyang";
+	name = "airlock_air_konyang";
+	req_one_access = null;
+	shuttle_tag = "Air Konyang Transport";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang)
 "iq" = (
@@ -471,6 +484,13 @@
 /area/shuttle/air_konyang/atmos)
 "nv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_air_konyang";
+	name = "airlock_air_konyang";
+	req_one_access = null;
+	shuttle_tag = "Air Konyang Transport";
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang)
 "nG" = (
@@ -616,6 +636,13 @@
 "qB" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/air_konyang/atmos)
+"qH" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/air_konyang)
 "rk" = (
 /obj/machinery/light{
 	dir = 8
@@ -634,6 +661,23 @@
 "sa" = (
 /turf/simulated/floor/carpet/brown,
 /area/shuttle/air_konyang/mainroom)
+"sl" = (
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	dir = 4;
+	pixel_x = 23;
+	pixel_y = -24
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_air_konyang";
+	name = "airlock_air_konyang";
+	req_one_access = null;
+	shuttle_tag = "Air Konyang Transport";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/shuttle/air_konyang)
 "sA" = (
 /obj/structure/closet/walllocker/firecloset{
 	pixel_x = -32
@@ -653,15 +697,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/air_konyang/mainroom)
 "tN" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	id_tag = "air_konyang_pump_out_external";
-	frequency = 1385;
-	layer = 2.8
-	},
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/bed/handrail{
 	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/machinery/airlock_sensor/airlock_exterior{
+	pixel_x = -32;
+	pixel_y = 10
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_air_konyang";
+	name = "airlock_air_konyang";
+	req_one_access = null;
+	shuttle_tag = "Air Konyang Transport";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/air_konyang)
@@ -718,11 +771,15 @@
 /area/shuttle/air_konyang/bridge)
 "vm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "air_konyang_in"
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_air_konyang";
+	name = "airlock_air_konyang";
+	req_one_access = null;
+	shuttle_tag = "Air Konyang Transport";
+	cycle_to_external_air = 1
 	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang)
 "vs" = (
@@ -973,24 +1030,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/air_konyang/bridge)
 "zL" = (
-/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
-	id_tag = "air_konyang";
-	master_tag = "air_konyang";
-	tag_interior_door = "air_konyang_in";
-	tag_exterior_door = "air_konyang_out";
-	tag_interior_sensor = "air_konyang_interior_sensor";
-	tag_exterior_sensor = "air_konyang_exterior_sensor";
-	tag_chamber_sensor = "air_konyang_chamber_sensor";
-	tag_airpump = "air_konyang_pump_in";
-	frequency = 1385;
-	pixel_x = -26
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	id_tag = "air_konyang_pump_out_internal";
-	frequency = 1385;
-	layer = 2.8
+	dir = 4
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_air_konyang";
+	name = "airlock_air_konyang";
+	req_one_access = null;
+	shuttle_tag = "Air Konyang Transport";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang)
 "Ah" = (
@@ -1186,12 +1236,6 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/air_konyang/mainroom)
 "FS" = (
-/obj/machinery/airlock_sensor/airlock_exterior{
-	frequency = 1385;
-	id_tag = "air_konyang_exterior_sensor";
-	pixel_y = 10;
-	pixel_x = 25
-	},
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/bed/handrail{
 	dir = 1
@@ -1269,11 +1313,15 @@
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang/atmos)
 "Id" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "air_konyang_in"
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_air_konyang";
+	name = "airlock_air_konyang";
+	req_one_access = null;
+	shuttle_tag = "Air Konyang Transport";
+	cycle_to_external_air = 1
 	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang)
 "Iu" = (
@@ -1423,19 +1471,20 @@
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang)
 "MB" = (
+/obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1385;
-	master_tag = "air_konyang";
-	name = "exterior access button";
-	pixel_x = -26;
-	pixel_y = 11
+	dir = 1;
+	pixel_x = -28;
+	pixel_y = 12
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "air_konyang_out"
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_air_konyang";
+	name = "airlock_air_konyang";
+	req_one_access = null;
+	shuttle_tag = "Air Konyang Transport";
+	cycle_to_external_air = 1
 	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang)
 "Ne" = (
@@ -1456,9 +1505,14 @@
 /area/shuttle/air_konyang/mainroom)
 "Ni" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1385;
-	id_tag = "air_konyang_pump_in"
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_air_konyang";
+	name = "airlock_air_konyang";
+	req_one_access = null;
+	shuttle_tag = "Air Konyang Transport";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang)
@@ -1643,19 +1697,18 @@
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang/atmos)
 "RQ" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1385;
-	id_tag = "air_konyang_chamber_sensor";
-	dir = 1;
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	frequency = 1385;
-	id_tag = "air_konyang_pump_in"
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_air_konyang";
+	name = "airlock_air_konyang";
+	req_one_access = null;
+	shuttle_tag = "Air Konyang Transport";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang)
@@ -1663,11 +1716,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1385;
-	icon_state = "door_locked";
-	id_tag = "air_konyang_out"
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_air_konyang";
+	name = "airlock_air_konyang";
+	req_one_access = null;
+	shuttle_tag = "Air Konyang Transport";
+	cycle_to_external_air = 1
 	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang)
 "Sv" = (
@@ -1789,6 +1846,13 @@
 "WQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_air_konyang";
+	name = "airlock_air_konyang";
+	req_one_access = null;
+	shuttle_tag = "Air Konyang Transport";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/air_konyang)
@@ -15407,7 +15471,7 @@ MB
 zL
 Ni
 Id
-hj
+qH
 Gm
 JX
 hj
@@ -15730,7 +15794,7 @@ VJ
 Sf
 ie
 RQ
-Id
+sl
 ep
 YI
 JX

--- a/maps/away/ships/konyang/einstein_shuttle/einstein_shuttle.dmm
+++ b/maps/away/ships/konyang/einstein_shuttle/einstein_shuttle.dmm
@@ -440,21 +440,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1385;
-	master_tag = "einstein_shuttle";
-	name = "interior access button";
-	pixel_x = -5;
-	pixel_y = 25;
-	dir = 1
-	},
-/obj/machinery/airlock_sensor/airlock_interior{
-	pixel_x = 7;
-	pixel_y = 25;
-	id_tag = "einstein_shuttle_interior_sensor";
-	frequency = 1385
-	},
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
@@ -714,15 +699,14 @@
 	icon_state = "tube_empty"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1385;
-	id_tag = "einstein_shuttle_pump_in"
+	dir = 4
 	},
-/obj/machinery/airlock_sensor{
-	frequency = 1385;
-	id_tag = "einstein_shuttle_chamber_sensor";
-	pixel_y = -23;
-	dir = 1
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_einstein_shuttle";
+	name = "airlock_einstein_shuttle";
+	req_one_access = list(205);
+	shuttle_tag = "Einstein Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/einstein_shuttle/dock)
@@ -787,22 +771,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/einstein_shuttle/room/three)
 "uq" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	id_tag = "einstein_shuttle_pump_out_external";
-	frequency = 1385;
-	layer = 2.8
-	},
-/obj/machinery/airlock_sensor/airlock_exterior{
-	frequency = 1385;
-	id_tag = "einstein_shuttle_exterior_sensor";
-	pixel_y = 10;
-	pixel_x = 55
-	},
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/bed/handrail{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_einstein_shuttle";
+	name = "airlock_einstein_shuttle";
+	req_one_access = list(205);
+	shuttle_tag = "Einstein Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/machinery/airlock_sensor/airlock_exterior{
+	pixel_x = 32;
+	pixel_y = 10
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/airless,
 /area/shuttle/einstein_shuttle/dock)
 "uO" = (
@@ -1129,13 +1116,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/einstein_shuttle/helm)
 "CF" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	id_tag = "einstein_shuttle_in";
-	name = "Internal Access";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_einstein_shuttle";
+	name = "airlock_einstein_shuttle";
+	req_one_access = list(205);
+	shuttle_tag = "Einstein Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/machinery/access_button{
+	pixel_x = 28;
+	pixel_y = -9
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/shuttle/einstein_shuttle/dock)
 "CG" = (
@@ -1447,26 +1441,25 @@
 /turf/simulated/floor/tiled/freezer,
 /area/shuttle/einstein_shuttle/bathroom)
 "Kx" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	id_tag = "einstein_shuttle_out";
-	name = "External Access";
-	dir = 1
-	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1385;
-	master_tag = "einstein_shuttle";
-	name = "exterior access button";
-	pixel_x = -25;
-	pixel_y = 11
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
 /obj/effect/landmark/entry_point/aft{
 	name = "aft, airlock"
 	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_einstein_shuttle";
+	name = "airlock_einstein_shuttle";
+	req_one_access = list(205);
+	shuttle_tag = "Einstein Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/machinery/access_button{
+	pixel_x = 28;
+	pixel_y = 12
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/einstein_shuttle/dock)
 "KA" = (
@@ -1608,6 +1601,13 @@
 /area/shuttle/einstein_shuttle/room)
 "Pw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_einstein_shuttle";
+	name = "airlock_einstein_shuttle";
+	req_one_access = list(205);
+	shuttle_tag = "Einstein Shuttle";
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/einstein_shuttle/dock)
 "Py" = (
@@ -1636,9 +1636,14 @@
 /area/space)
 "QI" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	frequency = 1385;
-	id_tag = "einstein_shuttle_pump_in"
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_einstein_shuttle";
+	name = "airlock_einstein_shuttle";
+	req_one_access = list(205);
+	shuttle_tag = "Einstein Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/einstein_shuttle/dock)
@@ -1664,6 +1669,13 @@
 "Ri" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_einstein_shuttle";
+	name = "airlock_einstein_shuttle";
+	req_one_access = list(205);
+	shuttle_tag = "Einstein Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/einstein_shuttle/dock)
@@ -1918,21 +1930,46 @@
 /area/shuttle/einstein_shuttle/room/three)
 "XT" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	id_tag = "einstein_shuttle_pump_out_internal";
-	frequency = 1385;
-	layer = 2.8
+	dir = 4
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_einstein_shuttle";
+	name = "airlock_einstein_shuttle";
+	req_one_access = list(205);
+	shuttle_tag = "Einstein Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_x = -6;
+	pixel_y = 28
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = 6;
+	pixel_y = 28
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/shuttle/einstein_shuttle/dock)
 "Yb" = (
-/obj/machinery/power/apc/high/north{
-	req_access = list(205)
-	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/high/east{
+	req_access = null
+	},
+/obj/machinery/airlock_sensor/airlock_exterior{
+	pixel_y = 22;
+	pixel_x = 6
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_einstein_shuttle";
+	name = "airlock_einstein_shuttle";
+	req_one_access = list(205);
+	shuttle_tag = "Einstein Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/einstein_shuttle/dock)
 "Yd" = (
@@ -1977,23 +2014,16 @@
 /area/shuttle/einstein_shuttle/porteng)
 "Zx" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	id_tag = "einstein_shuttle_pump_out_internal";
-	frequency = 1385;
-	layer = 2.8
+	dir = 8
 	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
-	id_tag = "einstein_shuttle";
-	master_tag = "einstein_shuttle";
-	pixel_y = 25;
-	tag_interior_door = "einstein_shuttle_in";
-	tag_exterior_door = "einstein_shuttle_out";
-	tag_interior_sensor = "einstein_shuttle_interior_sensor";
-	tag_exterior_sensor = "einstein_shuttle_exterior_sensor";
-	tag_chamber_sensor = "einstein_shuttle_chamber_sensor";
-	tag_airpump = "einstein_shuttle_pump_in";
-	frequency = 1385
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_einstein_shuttle";
+	name = "airlock_einstein_shuttle";
+	req_one_access = list(205);
+	shuttle_tag = "Einstein Shuttle";
+	cycle_to_external_air = 1
 	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/shuttle/einstein_shuttle/dock)
 "ZL" = (

--- a/maps/away/ships/konyang/water_barge/water_barge.dm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dm
@@ -70,10 +70,12 @@
 /obj/effect/shuttle_landmark/water_barge/dock
 	name = "PACHROM Water Barge - Port Dock"
 	landmark_tag = "water_barge_dock"
+	docking_controller = "airlock_barge_portdock"
 
 /obj/effect/shuttle_landmark/water_barge/starboarddock
 	name = "PACHROM Water Barge - Starboard Dock"
 	landmark_tag = "water_barge_dock_s"
+	docking_controller = "airlock_barge_stbddock"
 
 //Shuttle Stuff
 
@@ -97,7 +99,7 @@
 	shuttle_area = list(/area/shuttle/water_barge)
 	current_location = "nav_water_barge_hangar"
 	landmark_transition = "nav_water_barge_transit"
-	dock_target = "water_barge_shuttle"
+	dock_target = "airlock_waterbarge_shuttle"
 	range = 1
 	fuel_consumption = 2
 	logging_home_tag = "nav_water_barge_hangar"

--- a/maps/away/ships/konyang/water_barge/water_barge.dmm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dmm
@@ -300,6 +300,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"dA" = (
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = -8;
+	dir = 2
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock";
+	master_tag = "airlock_barge_portdock";
+	name = "airlock_barge_portdock"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport/port)
 "dB" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -491,6 +506,18 @@
 /obj/random/toolbox,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"gd" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube_empty"
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock_s";
+	master_tag = "airlock_barge_stbddock";
+	name = "airlock_barge_stbddock"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport)
 "gm" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -537,6 +564,25 @@
 /obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"gK" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
+	},
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = 12;
+	dir = 1
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock_s";
+	master_tag = "airlock_barge_stbddock";
+	name = "airlock_barge_stbddock"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport)
 "gR" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -718,6 +764,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"je" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 1;
+	pixel_y = -20;
+	id_tag = "water_barge_hangar";
+	frequency = 1380
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "jj" = (
 /obj/machinery/light{
 	dir = 4
@@ -855,22 +910,32 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
 	dir = 1
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_waterbarge_shuttle";
+	name = "airlock_waterbarge_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Water Barge Shuttle";
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
 "kR" = (
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/machinery/airlock_sensor/airlock_exterior{
-	frequency = 1313;
-	id_tag = "barge_shuttle_exterior_sensor";
-	pixel_x = -68;
-	pixel_y = -10
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	id_tag = "barge_shuttle_pump_out_external";
-	frequency = 1313;
-	layer = 2.8
+	dir = 8
 	},
+/obj/machinery/airlock_sensor/airlock_exterior{
+	pixel_x = -64;
+	pixel_y = -5
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_waterbarge_shuttle";
+	name = "airlock_waterbarge_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Water Barge Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
 "kV" = (
@@ -1469,8 +1534,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
 "sK" = (
-/obj/effect/map_effect/airlock/long/square,
-/turf/simulated/wall/shuttle/space_ship,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock";
+	master_tag = "airlock_barge_portdock";
+	name = "airlock_barge_portdock"
+	},
+/turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
 "sV" = (
 /obj/machinery/light,
@@ -1619,6 +1688,13 @@
 /turf/simulated/floor/tiled/dark/cooled,
 /area/water_barge/engineering)
 "uu" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock";
+	master_tag = "airlock_barge_portdock";
+	name = "airlock_barge_portdock"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/shuttle_landmark/water_barge/dock{
 	dir = 1
 	},
@@ -1807,6 +1883,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"wJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock";
+	master_tag = "airlock_barge_portdock";
+	name = "airlock_barge_portdock"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport/port)
 "wK" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
@@ -1954,22 +2043,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
 	},
-/obj/machinery/airlock_sensor/airlock_interior{
-	pixel_x = 5;
-	pixel_y = -22;
-	id_tag = "barge_shuttle_interior_sensor";
-	frequency = 1313;
-	dir = 1
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1313;
-	master_tag = "barge_shuttle";
-	name = "interior access button";
-	pixel_x = -7;
-	pixel_y = -23;
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
 "yr" = (
@@ -2071,6 +2144,21 @@
 "zF" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"zM" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = -20;
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock";
+	master_tag = "airlock_barge_portdock";
+	name = "airlock_barge_portdock"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport/port)
 "zY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
@@ -2375,6 +2463,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"Eu" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock_s";
+	master_tag = "airlock_barge_stbddock";
+	name = "airlock_barge_stbddock"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport)
 "Ew" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -2474,8 +2577,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/breakroom)
 "FW" = (
-/obj/effect/shuttle_landmark/water_barge/starboarddock{
-	dir = 1
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock_s";
+	master_tag = "airlock_barge_stbddock";
+	name = "airlock_barge_stbddock"
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
@@ -2634,6 +2741,18 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"IH" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube_empty"
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock";
+	master_tag = "airlock_barge_portdock";
+	name = "airlock_barge_portdock"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport/port)
 "II" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /turf/simulated/floor/plating,
@@ -2779,18 +2898,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "JM" = (
-/obj/machinery/airlock_sensor{
-	frequency = 1313;
-	id_tag = "barge_shuttle_chamber_sensor";
-	dir = 4;
-	pixel_x = -25
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	id_tag = "barge_shuttle_pump_out_internal";
-	frequency = 1313;
-	layer = 2.8;
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_waterbarge_shuttle";
+	name = "airlock_waterbarge_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Water Barge Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
 "JQ" = (
@@ -2803,6 +2924,21 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
 /area/water_barge/engineering)
+"Kd" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 8;
+	pixel_x = 20
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock";
+	master_tag = "airlock_barge_portdock";
+	name = "airlock_barge_portdock"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport/port)
 "Ke" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 10
@@ -2928,6 +3064,21 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"KW" = (
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = -8;
+	dir = 2
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock_s";
+	master_tag = "airlock_barge_stbddock";
+	name = "airlock_barge_stbddock"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport)
 "Lb" = (
 /obj/machinery/suit_cycler/engineering{
 	req_access = null
@@ -3021,6 +3172,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"LW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock_s";
+	master_tag = "airlock_barge_stbddock";
+	name = "airlock_barge_stbddock"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport)
 "LX" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
@@ -3102,24 +3266,17 @@
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
 "Mz" = (
-/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
-	id_tag = "barge_shuttle";
-	master_tag = "barge_shuttle";
-	tag_interior_door = "barge_shuttle_in";
-	tag_exterior_door = "barge_shuttle_out";
-	tag_interior_sensor = "barge_shuttle_interior_sensor";
-	tag_exterior_sensor = "barge_shuttle_exterior_sensor";
-	tag_chamber_sensor = "barge_shuttle_chamber_sensor";
-	tag_airpump = "barge_shuttle_pump_in";
-	frequency = 1313;
-	pixel_x = 25
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	id_tag = "barge_shuttle_pump_out_internal";
-	frequency = 1313;
-	layer = 2.8;
 	dir = 8
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_waterbarge_shuttle";
+	name = "airlock_waterbarge_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Water Barge Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
 "MO" = (
@@ -3571,6 +3728,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
 	},
+/obj/machinery/airlock_sensor/airlock_exterior{
+	pixel_y = -20
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_waterbarge_shuttle";
+	name = "airlock_waterbarge_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Water Barge Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
 "Rp" = (
@@ -3697,6 +3865,25 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/dockingport)
+"SF" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	icon_state = "map"
+	},
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = 12;
+	dir = 1
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock";
+	master_tag = "airlock_barge_portdock";
+	name = "airlock_barge_portdock"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport/port)
 "SG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
@@ -3878,13 +4065,21 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1313;
-	icon_state = "door_locked";
-	id_tag = "barge_shuttle_in";
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = 12;
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_waterbarge_shuttle";
+	name = "airlock_waterbarge_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Water Barge Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
 "UE" = (
@@ -3936,26 +4131,26 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1313;
-	icon_state = "door_locked";
-	id_tag = "barge_shuttle_out";
-	dir = 1
-	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1313;
-	master_tag = "barge_shuttle";
-	name = "exterior access button";
-	pixel_x = -30;
-	pixel_y = -9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 5
 	},
 /obj/effect/landmark/entry_point/fore{
 	name = "aft"
 	},
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = -8;
+	dir = 2
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_waterbarge_shuttle";
+	name = "airlock_waterbarge_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Water Barge Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
 "UZ" = (
@@ -3977,6 +4172,13 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_waterbarge_shuttle";
+	name = "airlock_waterbarge_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Water Barge Shuttle";
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
 "Vh" = (
@@ -4066,6 +4268,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"Wm" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock_s";
+	master_tag = "airlock_barge_stbddock";
+	name = "airlock_barge_stbddock"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport)
 "Wq" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -4206,8 +4416,19 @@
 /turf/simulated/floor/plating,
 /area/water_barge)
 "XB" = (
-/obj/effect/map_effect/airlock/long/square,
-/turf/simulated/wall/shuttle/space_ship,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = -20;
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock_s";
+	master_tag = "airlock_barge_stbddock";
+	name = "airlock_barge_stbddock"
+	},
+/turf/simulated/floor/plating,
 /area/water_barge/dockingport)
 "XI" = (
 /obj/structure/table/standard,
@@ -4346,9 +4567,18 @@
 /area/water_barge/engineering)
 "YP" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
 	dir = 8;
-	frequency = 1313;
-	id_tag = "barge_shuttle_pump_in"
+	pixel_x = 20
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_waterbarge_shuttle";
+	name = "airlock_waterbarge_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Water Barge Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
@@ -4425,13 +4655,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
 "ZK" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1313;
-	id_tag = "barge_shuttle_pump_in"
+	dir = 4
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = -20;
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_waterbarge_shuttle";
+	name = "airlock_waterbarge_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Water Barge Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
@@ -11970,7 +12206,7 @@ PG
 PG
 PG
 PG
-XB
+PG
 NL
 NL
 NL
@@ -12129,10 +12365,10 @@ NL
 PG
 bf
 DT
-yI
-yI
-yI
-yI
+gK
+XB
+Wm
+KW
 NL
 NL
 NL
@@ -12291,9 +12527,9 @@ NL
 PG
 Va
 Nl
-yI
-yI
-yI
+LW
+Eu
+gd
 FW
 NL
 NL
@@ -17461,7 +17697,7 @@ Xd
 wK
 kR
 pk
-pk
+je
 Zl
 Ut
 Zc
@@ -21528,7 +21764,7 @@ nF
 CS
 CS
 CS
-sK
+CS
 NL
 NL
 NL
@@ -21687,10 +21923,10 @@ NL
 CS
 Hq
 vl
-An
-An
-An
-An
+SF
+zM
+sK
+dA
 NL
 NL
 NL
@@ -21849,9 +22085,9 @@ NL
 CS
 lL
 lL
-An
-An
-An
+wJ
+Kd
+IH
 uu
 NL
 NL

--- a/maps/away/ships/tramp_freighter/tramp_freighter.dmm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter.dmm
@@ -153,7 +153,8 @@
 	},
 /obj/effect/map_effect/marker/airlock/docking{
 	name = "freighter_airlock_port";
-	name_unlabel = "freighter_airlock_port"
+	name_unlabel = "freighter_airlock_port";
+	landmark_tag = "nav_tramp_freighter_dock"
 	},
 /turf/simulated/floor/plating,
 /area/tramp_freighter/engi)
@@ -605,7 +606,8 @@
 	},
 /obj/effect/map_effect/marker/airlock/docking{
 	name = "freighter_airlock_port";
-	name_unlabel = "freighter_airlock_port"
+	name_unlabel = "freighter_airlock_port";
+	landmark_tag = "nav_tramp_freighter_dock"
 	},
 /turf/simulated/floor/plating,
 /area/tramp_freighter/engi)
@@ -698,7 +700,8 @@
 "ip" = (
 /obj/effect/map_effect/marker/airlock/docking{
 	name = "freighter_airlock_port";
-	name_unlabel = "freighter_airlock_port"
+	name_unlabel = "freighter_airlock_port";
+	landmark_tag = "nav_tramp_freighter_dock"
 	},
 /turf/simulated/floor/plating,
 /area/tramp_freighter/engi)
@@ -804,7 +807,8 @@
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	dir = 1;
 	pixel_y = -20;
-	id_tag = "freighter_hangar"
+	id_tag = "freighter_hangar";
+	frequency = 1380
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tramp_freighter/hangar)
@@ -1101,6 +1105,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/tramp_freighter/cargo)
+"mK" = (
+/obj/machinery/airlock_sensor/airlock_exterior{
+	pixel_y = -20
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freight_shuttle";
+	name = "airlock_freight_shuttle";
+	req_one_access = null;
+	shuttle_tag = "Freight Shuttle";
+	cycle_to_external_air = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freighter_shuttle)
 "mM" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/stone/marble,
@@ -1331,7 +1349,8 @@
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/map_effect/marker/airlock/docking{
 	name = "freighter_airlock_port";
-	name_unlabel = "freighter_airlock_port"
+	name_unlabel = "freighter_airlock_port";
+	landmark_tag = "nav_tramp_freighter_dock"
 	},
 /turf/simulated/floor/plating,
 /area/tramp_freighter/engi)
@@ -1816,7 +1835,8 @@
 	},
 /obj/effect/map_effect/marker/airlock/docking{
 	name = "freighter_airlock_port";
-	name_unlabel = "freighter_airlock_port"
+	name_unlabel = "freighter_airlock_port";
+	landmark_tag = "nav_tramp_freighter_dock"
 	},
 /turf/simulated/floor/plating,
 /area/tramp_freighter/engi)
@@ -1826,7 +1846,8 @@
 	},
 /obj/effect/map_effect/marker/airlock/docking{
 	name = "freighter_airlock_port";
-	name_unlabel = "freighter_airlock_port"
+	name_unlabel = "freighter_airlock_port";
+	landmark_tag = "nav_tramp_freighter_dock"
 	},
 /turf/simulated/floor/plating,
 /area/tramp_freighter/engi)
@@ -3003,7 +3024,8 @@
 	},
 /obj/effect/map_effect/marker/airlock/docking{
 	name = "freighter_airlock_port";
-	name_unlabel = "freighter_airlock_port"
+	name_unlabel = "freighter_airlock_port";
+	landmark_tag = "nav_tramp_freighter_dock"
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	pixel_y = 20
@@ -3171,7 +3193,8 @@
 	},
 /obj/effect/map_effect/marker/airlock/docking{
 	name = "freighter_airlock_port";
-	name_unlabel = "freighter_airlock_port"
+	name_unlabel = "freighter_airlock_port";
+	landmark_tag = "nav_tramp_freighter_dock"
 	},
 /turf/simulated/floor/plating,
 /area/tramp_freighter/engi)
@@ -3775,10 +3798,6 @@
 /area/tramp_freighter/mess)
 "VN" = (
 /obj/machinery/door/airlock/external,
-/obj/machinery/airlock_sensor/airlock_exterior{
-	pixel_x = 32;
-	pixel_y = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
@@ -36567,7 +36586,7 @@ Gn
 fH
 Pz
 GM
-GM
+mK
 fH
 fH
 fH


### PR DESCRIPTION
Makes some tweaks to several of my maps to ensure that they have functional airlocks and docks, as well as general QOL improvements. 

Shrinks the Tarwa Conglomerate bridge for QOL, and adds a Francisca for additional acts of piracy.