### PR TITLE
Stops the INDRA from exploding on click as stationbound

### DIFF
--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -66,13 +66,6 @@
 	if(owned_field)
 		owned_field.ChangeFieldStrength(value)
 
-/obj/machinery/power/fusion_core/attack_hand(mob/user)
-	. = ..()
-	visible_message(SPAN_NOTICE("\The [user] hugs \the [src] to make it feel better!"))
-	if(owned_field)
-		Shutdown()
-	return TRUE
-
 /obj/machinery/power/fusion_core/attackby(obj/item/W, mob/user)
 
 	if(owned_field)

--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -66,6 +66,14 @@
 	if(owned_field)
 		owned_field.ChangeFieldStrength(value)
 
+/obj/machinery/power/fusion_core/attack_hand(mob/user)
+	. = ..()
+	if(ishuman(user))
+		visible_message(SPAN_NOTICE("\The [user] hugs \the [src] to make it feel better!"))
+		if(owned_field)
+			Shutdown()
+	return TRUE
+
 /obj/machinery/power/fusion_core/attackby(obj/item/W, mob/user)
 
 	if(owned_field)

--- a/html/changelogs/nauticall-indrahotfix.yml
+++ b/html/changelogs/nauticall-indrahotfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: nauticall
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Clicking on the INDRA reactor as a stationbound, AI, or drone will no longer instantly detonate it."


### PR DESCRIPTION
Clicking the INDRA reactor as a stationbound unit (drone, AI, or cyborg) will no longer cause it to spontaneously explode.

I don't know why nobody hasn't done this sooner and I don't know why this code block was ever there to begin with besides being some strange easter egg.