### PR TITLE
Fixes the PMCG pharmacist uniform using the same sprites as the EPMC pharmacist uniform

### DIFF
--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -272,5 +272,5 @@
 	item_state = "pmc_chemist"
 
 /obj/item/clothing/under/rank/medical/pharmacist/pmc/alt
-	icon_state = "pmc_chemist"
-	item_state = "pmc_chemist"
+	icon_state = "pmc_alt_chemist"
+	item_state = "pmc_alt_chemist"

--- a/html/changelogs/Tag114-pmcgchemist.yml
+++ b/html/changelogs/Tag114-pmcgchemist.yml
@@ -1,0 +1,8 @@
+
+author: Tag114
+
+
+delete-after: True
+
+changes:
+  - bugfix: "The PMCG chemist uniform now uses the correct set of sprites instead of the same sprites as the EPMC chemist uniform."

--- a/html/changelogs/Tag114-pmcgchemist.yml
+++ b/html/changelogs/Tag114-pmcgchemist.yml
@@ -5,4 +5,4 @@ author: Tag114
 delete-after: True
 
 changes:
-  - bugfix: "The PMCG chemist uniform now uses the correct set of sprites instead of the same sprites as the EPMC chemist uniform."
+  - bugfix: "The PMCG chemist uniform now uses the set of sprites intended for it instead of the same sprites as the EPMC chemist uniform."

--- a/html/changelogs/Tag114-pmcgchemist.yml
+++ b/html/changelogs/Tag114-pmcgchemist.yml
@@ -5,4 +5,4 @@ author: Tag114
 delete-after: True
 
 changes:
-  - bugfix: "The PMCG chemist uniform now uses the sprites intended for it instead of the same sprites as the EPMC chemist uniform."
+  - bugfix: "The PMCG pharmacist uniform now uses the sprites intended for it instead of the same sprites as the EPMC pharmacist uniform."

--- a/html/changelogs/Tag114-pmcgchemist.yml
+++ b/html/changelogs/Tag114-pmcgchemist.yml
@@ -5,4 +5,4 @@ author: Tag114
 delete-after: True
 
 changes:
-  - bugfix: "The PMCG chemist uniform now uses the set of sprites intended for it instead of the same sprites as the EPMC chemist uniform."
+  - bugfix: "The PMCG chemist uniform now uses the sprites intended for it instead of the same sprites as the EPMC chemist uniform."


### PR DESCRIPTION
Makes the PMCG pharmacist uniform use the set of sprites made for it instead of the same sprites as the EPMC pharmacist uniform.