### PR TITLE
Unified Sadar Fleet Ship - Description Tweak

### DIFF
--- a/html/changelogs/ShakyJake - sadar_desc_tweak.yml
+++ b/html/changelogs/ShakyJake - sadar_desc_tweak.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ShakyJake
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - rscdel: "Removes a piece of the Unified Sadar Fleet ship's description."

--- a/html/changelogs/ShakyJake - sadar_desc_tweak.yml
+++ b/html/changelogs/ShakyJake - sadar_desc_tweak.yml
@@ -38,5 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
   - rscdel: "Removes a piece of the Unified Sadar Fleet ship's description."

--- a/maps/away/ships/sadar_scout/sadar_scout.dm
+++ b/maps/away/ships/sadar_scout/sadar_scout.dm
@@ -1,6 +1,6 @@
 /datum/map_template/ruin/away_site/sadar_scout
 	name = "Unified Sadar Fleet Scout"
-	description = "The Boreas-class is a small and ancient class of expeditionary vessels dating back a couple hundreds years to when it was commissioned by the Solarian Department of Colonization for Colony Fleet SFE-528-RFS - better known now as the Scarab Fleet. Like most scarab ships, this one has been heavily modified with much of necessary equipment retrofitted and superfluous components stripped away. It bears all the hallmarks of a scarab vessel, with the exception of the transponder registering it as independent rather than associated with the Scarab Fleet."
+	description = "The Boreas-class is a small and ancient class of expeditionary vessels dating back a couple hundreds years to when it was commissioned by the Solarian Department of Colonization for Colony Fleet SFE-528-RFS - better known now as the Scarab Fleet. Like most scarab ships, this one has been heavily modified with much of necessary equipment retrofitted and superfluous components stripped away."
 	suffixes = list("ships/sadar_scout/sadar_scout.dmm")
 	sectors = list(ALL_COALITION_SECTORS)
 	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA)
@@ -13,12 +13,12 @@
 
 /singleton/submap_archetype/sadar_scout
 	map = "Unified Sadar Fleet Scout"
-	descriptor = "The Boreas-class is a small and ancient class of expeditionary vessels dating back a couple hundreds years to when it was commissioned by the Solarian Department of Colonization for Colony Fleet SFE-528-RFS - better known now as the Scarab Fleet. Like most scarab ships, this one has been heavily modified with much of necessary equipment retrofitted and superfluous components stripped away. It bears all the hallmarks of a scarab vessel, with the exception of the transponder registering it as independent rather than associated with the Scarab Fleet."
+	descriptor = "The Boreas-class is a small and ancient class of expeditionary vessels dating back a couple hundreds years to when it was commissioned by the Solarian Department of Colonization for Colony Fleet SFE-528-RFS - better known now as the Scarab Fleet. Like most scarab ships, this one has been heavily modified with much of necessary equipment retrofitted and superfluous components stripped away."
 
 /obj/effect/overmap/visitable/ship/sadar_scout
 	name = "Unified Sadar Fleet Scout"
 	class = "ICV"
-	desc = "The Boreas-class is a small and ancient class of expeditionary vessels dating back a couple hundreds years to when it was commissioned by the Solarian Department of Colonization for Colony Fleet SFE-528-RFS - better known now as the Scarab Fleet. Like most scarab ships, this one has been heavily modified with much of necessary equipment retrofitted and superfluous components stripped away. It bears all the hallmarks of a scarab vessel, with the exception of the transponder registering it as independent rather than associated with the Scarab Fleet."
+	desc = "The Boreas-class is a small and ancient class of expeditionary vessels dating back a couple hundreds years to when it was commissioned by the Solarian Department of Colonization for Colony Fleet SFE-528-RFS - better known now as the Scarab Fleet. Like most scarab ships, this one has been heavily modified with much of necessary equipment retrofitted and superfluous components stripped away."
 	icon_state = "freighter"
 	moving_state = "freighter_moving"
 	colors = list("#8a0f8a", "#a201a2")


### PR DESCRIPTION
Description for the Unified Sadar Fleet ship no longer explicitly mentions that the transponder is independent, as this can already be shown with the ship's IFF tag. Tweak made after player feedback.