### PR TITLE
Reverts/removes the forced sprint and resist keybindings on SPACE and SHIFT+R respectively

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1043,29 +1043,6 @@ default behaviour is:
 	set name = "throw_intent_toggle"
 	toggle_throw_mode()
 
-/**
- * User by a macro in skin.dmf to toggle the running
- */
-/mob/living/verb/run_intent_keyDown()
-	set hidden = 1
-	set name = "run_intent"
-
-	if(usr?.m_intent != M_WALK)
-		return
-
-	if(hud_used?.move_intent)
-		hud_used.move_intent.Click()
-
-/mob/living/verb/run_intent_keyUp()
-	set hidden = 1
-	set name = "run_intent_up"
-
-	if(usr?.m_intent != M_RUN)
-		return
-
-	if(hud_used?.move_intent)
-		hud_used.move_intent.Click()
-
 /mob/living/proc/add_hallucinate(var/amount)
 	hallucination += amount
 	hallucination += amount

--- a/html/changelogs/omi-forcedbindings.yml
+++ b/html/changelogs/omi-forcedbindings.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Omi
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Removed/reverted the addition of forced sprint and resist keybindings."

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -410,15 +410,6 @@ macro "macro"
 	elem
 		name = "."
 		command = "Move-Down"
-	elem
-		name = "Space"
-		command = "run_intent"
-	elem
-		name = "Space+UP"
-		command = "run_intent_up"
-	elem
-		name = "SHIFT+R"
-		command = "Resist"
   elem
     name = "R"
     command = "throw_intent_toggle"
@@ -665,15 +656,6 @@ macro "hotkeymode"
 	elem
 		name = "."
 		command = "Move-Down"
-	elem
-		name = "Space"
-		command = "run_intent"
-	elem
-		name = "Space+UP"
-		command = "run_intent_up"
-	elem
-		name = "SHIFT+R"
-		command = "Resist"
   elem
     name = "R"
     command = "throw_intent_toggle"


### PR DESCRIPTION
See title. SPACE is a key lots of people use as their `unique-action` or `resist` macros already. The existing functionality that forced new mappings onto these keys didn't even allow for you to double-up on the binding with your existing macros, locking them entirely to a functionality I didn't particularly want in the first place.