### PR TITLE
Point Verdant ID Fixes & Shutter Tweaks

### DIFF
--- a/html/changelogs/RustingWithYou - verdantaccess.yml
+++ b/html/changelogs/RustingWithYou - verdantaccess.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Adds shutters to the corporate offices on Point Verdant and adds IDs to ghostroles."

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
@@ -4911,13 +4911,6 @@
 /obj/item/ammo_magazine/c45/revolver,
 /turf/simulated/floor/tiled/dark,
 /area/point_verdant/interior/police)
-"tT" = (
-/obj/effect/ghostspawpoint{
-	name = "igs - konyang_bar";
-	identifier = "konyang_bar"
-	},
-/turf/simulated/floor/lino/diamond,
-/area/point_verdant/interior/bar)
 "tW" = (
 /obj/structure/rod_railing,
 /obj/structure/rod_railing{
@@ -39066,7 +39059,7 @@ iw
 sZ
 mj
 eN
-tT
+eN
 eN
 oQ
 sZ

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-2.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-2.dmm
@@ -3867,9 +3867,9 @@
 /obj/effect/floor_decal/corner_wide/mauve/full{
 	dir = 1
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	id = "konyang_corporate"
+/obj/machinery/door/blast/shutters/open{
+	id = "konyang_corporate";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/shallow)
@@ -6421,6 +6421,10 @@
 /area/point_verdant/outdoors)
 "th" = (
 /obj/machinery/door/urban,
+/obj/machinery/door/blast/shutters/open{
+	id = "konyang_corporate";
+	dir = 2
+	},
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/offices)
 "ti" = (
@@ -7411,10 +7415,6 @@
 /obj/effect/floor_decal/corner_wide/mauve{
 	dir = 6
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	id = "konyang_corporate"
-	},
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/offices)
 "vZ" = (
@@ -7868,6 +7868,10 @@
 	},
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/effect/ghostspawpoint{
+	name = "igs - konyang_bar";
+	identifier = "konyang_bar"
 	},
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/bar)
@@ -10733,9 +10737,12 @@
 /turf/simulated/floor/asphalt,
 /area/point_verdant/outdoors)
 "Fi" = (
-/obj/machinery/door/blast/shutters,
 /obj/effect/decal/curb{
 	dir = 8
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "konyang_corporate_entrance"
 	},
 /turf/simulated/floor/asphalt,
 /area/point_verdant/interior/offices)
@@ -10852,6 +10859,19 @@
 	},
 /turf/simulated/floor/sidewalk,
 /area/point_verdant/outdoors)
+"FG" = (
+/obj/effect/decal/curb{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "konyang_corporate_entrance";
+	name = "Entrance Shutters";
+	req_access = list(225);
+	pixel_x = 20;
+	dir = 4
+	},
+/turf/simulated/floor/asphalt,
+/area/point_verdant/interior/offices)
 "FH" = (
 /obj/item/reagent_containers/food/drinks/waterbottle{
 	pixel_y = 7;
@@ -14904,6 +14924,15 @@
 /obj/structure/flora/tree/konyang/fall,
 /turf/simulated/floor/exoplanet/konyang/pink,
 /area/point_verdant/interior/shallow)
+"Re" = (
+/obj/machinery/button/remote/blast_door{
+	id = "konyang_corporate_entrance";
+	name = "Entrance Shutters";
+	req_access = list(225);
+	pixel_y = 24
+	},
+/turf/simulated/floor/sidewalk/detail,
+/area/point_verdant/outdoors)
 "Rf" = (
 /obj/structure/rod_railing{
 	dir = 4
@@ -15401,9 +15430,9 @@
 /obj/effect/floor_decal/corner_wide/mauve{
 	dir = 6
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	id = "konyang_corporate"
+/obj/machinery/door/blast/shutters/open{
+	id = "konyang_corporate";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/shallow)
@@ -15414,9 +15443,12 @@
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/offices)
 "SV" = (
-/obj/machinery/door/blast/shutters,
 /obj/effect/decal/curb{
 	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "konyang_corporate_entrance"
 	},
 /turf/simulated/floor/asphalt,
 /area/point_verdant/interior/offices)
@@ -15525,7 +15557,10 @@
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/hotel)
 "Tk" = (
-/obj/machinery/door/blast/shutters,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "konyang_corporate_entrance"
+	},
 /turf/simulated/floor/asphalt,
 /area/point_verdant/interior/offices)
 "Tm" = (
@@ -15708,7 +15743,7 @@
 /obj/structure/table/wood,
 /obj/machinery/button/remote/blast_door{
 	id = "konyang_corporate";
-	name = "Building Shutters";
+	name = "Building Lockdown";
 	req_access = list(225)
 	},
 /turf/simulated/floor/wood,
@@ -16936,9 +16971,9 @@
 /obj/effect/floor_decal/corner_wide/mauve/full{
 	dir = 4
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	id = "konyang_corporate"
+/obj/machinery/door/blast/shutters/open{
+	id = "konyang_corporate";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/shallow)
@@ -26067,7 +26102,7 @@ ci
 ci
 ci
 ci
-bh
+Re
 BT
 iF
 LN
@@ -26836,7 +26871,7 @@ ci
 id
 iG
 sH
-hC
+FG
 Fi
 cC
 Jo

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-2.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-2.dmm
@@ -14929,7 +14929,8 @@
 	id = "konyang_corporate_entrance";
 	name = "Entrance Shutters";
 	req_access = list(225);
-	pixel_y = 24
+	pixel_y = 24;
+	dir = 1
 	},
 /turf/simulated/floor/sidewalk/detail,
 /area/point_verdant/outdoors)

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-3.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-3.dmm
@@ -142,6 +142,10 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
 	},
+/obj/machinery/door/blast/shutters/open{
+	id = "konyang_corporate";
+	dir = 2
+	},
 /turf/simulated/floor/sidewalk/flat,
 /area/point_verdant/interior)
 "bz" = (
@@ -274,6 +278,10 @@
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
+	},
+/obj/machinery/door/blast/shutters/open{
+	id = "konyang_corporate";
+	dir = 2
 	},
 /turf/simulated/floor/sidewalk/flat,
 /area/point_verdant/interior)
@@ -1081,6 +1089,15 @@
 /obj/structure/table/stone/marble,
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior)
+"lc" = (
+/obj/structure/table/stone/marble,
+/obj/machinery/button/remote/blast_door{
+	id = "konyang_corporate";
+	name = "Building Lockdown";
+	req_access = list(225)
+	},
+/turf/simulated/floor/carpet/purple,
+/area/point_verdant/interior)
 "lm" = (
 /obj/structure/dressing_divider{
 	icon_state = "divider3"
@@ -1324,6 +1341,17 @@
 /obj/structure/ladder,
 /turf/simulated/open,
 /area/point_verdant/outdoors)
+"oF" = (
+/obj/machinery/door/urban/glass_sliding/double,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
+	},
+/obj/machinery/door/blast/shutters/open{
+	id = "konyang_corporate";
+	dir = 2
+	},
+/turf/simulated/floor/sidewalk/flat,
+/area/point_verdant/interior)
 "oG" = (
 /obj/effect/decal/road_marking/reflector{
 	dir = 8
@@ -1657,12 +1685,29 @@
 	},
 /turf/simulated/floor/concrete,
 /area/point_verdant/outdoors)
+"td" = (
+/obj/machinery/door/urban/glass_sliding/double{
+	dir = 1
+	},
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/obj/machinery/door/blast/shutters/open{
+	id = "konyang_corporate";
+	dir = 2
+	},
+/turf/simulated/floor/sidewalk/flat,
+/area/point_verdant/interior)
 "tg" = (
 /turf/simulated/floor/carpet/lightblue,
 /area/point_verdant/interior)
 "th" = (
 /obj/machinery/door/urban/glass_sliding,
 /obj/effect/floor_decal/spline/fancy/wood,
+/obj/machinery/door/blast/shutters/open{
+	id = "konyang_corporate";
+	dir = 2
+	},
 /turf/simulated/floor/sidewalk/flat,
 /area/point_verdant/interior)
 "tk" = (
@@ -1837,6 +1882,14 @@
 /obj/item/wrench,
 /turf/simulated/floor/lino,
 /area/point_verdant/interior/restaurant)
+"vm" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/blast/shutters/open{
+	id = "konyang_corporate";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/point_verdant/interior)
 "vo" = (
 /obj/effect/decal/curb{
 	dir = 10
@@ -2901,6 +2954,10 @@
 "FV" = (
 /obj/structure/window/urban/full,
 /obj/structure/window_frame/urban/full,
+/obj/machinery/door/blast/shutters/open{
+	id = "konyang_corporate";
+	dir = 2
+	},
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior)
 "Ge" = (
@@ -3582,6 +3639,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/arcade)
+"NW" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/blast/shutters/open{
+	id = "konyang_corporate";
+	dir = 2
+	},
+/turf/simulated/floor/tiled,
+/area/point_verdant/interior)
 "NZ" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 8
@@ -14819,17 +14884,17 @@ bf
 bf
 bf
 bf
-jm
-jm
+vm
+vm
 bf
-jm
-jm
+vm
+vm
 bf
-jm
-jm
+vm
+vm
 bf
-jm
-jm
+vm
+vm
 bf
 IJ
 Xr
@@ -15328,7 +15393,7 @@ DD
 DD
 sh
 hw
-mp
+oF
 nX
 nX
 nX
@@ -15585,7 +15650,7 @@ DD
 DD
 sh
 hw
-Mf
+td
 lx
 lx
 lx
@@ -16366,7 +16431,7 @@ ZD
 Hx
 IH
 zU
-ES
+lc
 lp
 Tm
 tN
@@ -17641,7 +17706,7 @@ hw
 hw
 hw
 hw
-jm
+NW
 bM
 Zq
 eV
@@ -17898,7 +17963,7 @@ lW
 lW
 TE
 hw
-jm
+NW
 Vi
 Zq
 eV
@@ -18426,8 +18491,8 @@ kX
 lp
 lp
 bf
-jm
-jm
+vm
+vm
 bf
 wy
 HW
@@ -18669,7 +18734,7 @@ DD
 DD
 Ue
 hw
-jm
+NW
 WK
 Zq
 eV
@@ -18926,7 +18991,7 @@ DD
 DD
 Ue
 hw
-jm
+NW
 WK
 Zq
 Ag
@@ -18939,7 +19004,7 @@ Zq
 kX
 lp
 lp
-jm
+NW
 hw
 hw
 hw
@@ -19183,7 +19248,7 @@ DD
 DD
 Ue
 hw
-jm
+NW
 WK
 Wl
 wx
@@ -19196,7 +19261,7 @@ Zq
 kX
 lp
 lp
-jm
+NW
 hw
 hw
 mK
@@ -19440,7 +19505,7 @@ DD
 DD
 sh
 hw
-jm
+NW
 WK
 Oi
 KU
@@ -19453,7 +19518,7 @@ Zq
 Zq
 lp
 lp
-jm
+NW
 hw
 hw
 UV
@@ -19697,7 +19762,7 @@ DD
 DD
 sh
 hw
-jm
+NW
 UG
 aq
 aq
@@ -19955,18 +20020,18 @@ kv
 sY
 MX
 bf
-jm
-jm
-jm
-jm
-jm
+vm
+vm
+vm
+vm
+vm
 bf
 bf
-jm
-jm
+vm
+vm
 bf
-jm
-jm
+vm
+vm
 bf
 hw
 um

--- a/maps/away/away_site/konyang/point_verdant/point_verdant_ghostroles.dm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant_ghostroles.dm
@@ -164,6 +164,7 @@
 	suit = /obj/item/clothing/suit/storage/toggle/konyang/akira
 	back = /obj/item/storage/backpack/satchel
 	l_pocket = /obj/item/storage/wallet/random
+	id = /obj/item/card/id
 
 /datum/outfit/admin/konyang_vendor/get_id_access()
 	return list(ACCESS_KONYANG_VENDORS)
@@ -211,6 +212,7 @@
 	shoes = /obj/item/clothing/shoes/sneakers/medsci
 	back = /obj/item/storage/backpack/satchel/pharm
 	l_pocket = /obj/item/storage/wallet/random
+	id = /obj/item/card/id
 
 /datum/outfit/admin/konyang_pharm/get_id_access()
 	return list(ACCESS_KONYANG_VENDORS)
@@ -234,6 +236,7 @@
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	l_pocket = /obj/item/storage/wallet/random
 	back = /obj/item/storage/backpack/satchel
+	id = /obj/item/card/id
 
 /datum/ghostspawner/human/konyang_utility
 	short_name = "konyang_utility"


### PR DESCRIPTION
Adds shutters to the Point Verdant corporate tower where they were missing.

Point Verdant ghostroles will now all spawn with IDs so that their accesses work correctly.