### PR TITLE
You can have a religion with Golden Deep origin

### DIFF
--- a/code/modules/background/origins/origins/ipc/golden_deep.dm
+++ b/code/modules/background/origins/origins/ipc/golden_deep.dm
@@ -11,4 +11,4 @@
 	important_information = "Golden Deep citizenship exists to denote an IPC as a member of the organisation, but it can still be noted in records that the IPC holds a normal citizenship (for instance, an IPC may be a citizen of Biesel and a member of Golden Deep.)"
 	possible_accents = ACCENTS_ALL_IPC
 	possible_citizenships = list(CITIZENSHIP_GOLDEN)
-	possible_religions = list(RELIGION_NONE)
+	possible_religions = RELIGIONS_ALL_IPC

--- a/html/changelogs/sniblet-prosperity-gospel.yml
+++ b/html/changelogs/sniblet-prosperity-gospel.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Sniblet
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Members of the Golden Deep are allowed to have a religion."


### PR DESCRIPTION
Bug I think? Loredevs? The Golden Deep origin is just a secondary citizenship most of the time, so you have Assunzionis and Elyrans with their deeply held faiths joining up and then instantly going "oops i forgetted," or alternatively an IPC is actually made in the Deep and therefore is an obligate atheist forever somehow.
Also, the Grand Camarilla exists. You know those freaks are worshipping the Demiurge.
Members can now have any religion under RELIGIONS_ALL_IPC.