### PR TITLE
Tweaks the names of the marksman rifle and mag.

### DIFF
--- a/code/datums/uplink/ammunition.dm
+++ b/code/datums/uplink/ammunition.dm
@@ -134,10 +134,10 @@
 	desc = "A magazine for an assault rifle."
 
 /datum/uplink_item/item/ammo/sniper_ammo
-	name = "7.62 Sniper Magazine"
+	name = "7.62 Marksman Magazine"
 	telecrystal_cost = 4
 	path = /obj/item/ammo_magazine/d762
-	desc = "A magazine for a 7.62 sniper rifle."
+	desc = "A magazine for a 7.62 marksman rifle."
 
 /datum/uplink_item/item/ammo/bullpup_magazine
 	name = "5.56 Rifle Magazine"

--- a/code/datums/uplink/highly visible and dangerous weapons.dm
+++ b/code/datums/uplink/highly visible and dangerous weapons.dm
@@ -240,6 +240,11 @@
 	telecrystal_cost = 12
 	path = /obj/item/gun/projectile/automatic/rifle/shorty
 
+/datum/uplink_item/item/visible_weapons/dragunov
+	name = "Adhomian Marksman Rifle"
+	telecrystal_cost = 12
+	path = /obj/item/gun/projectile/dragunov
+
 /datum/uplink_item/item/visible_weapons/assault_rifle
 	name = "Assault Rifle"
 	telecrystal_cost = 12

--- a/code/datums/uplink/highly visible and dangerous weapons.dm
+++ b/code/datums/uplink/highly visible and dangerous weapons.dm
@@ -240,11 +240,6 @@
 	telecrystal_cost = 12
 	path = /obj/item/gun/projectile/automatic/rifle/shorty
 
-/datum/uplink_item/item/visible_weapons/dragunov
-	name = "Adhomian Marksman Rifle"
-	telecrystal_cost = 12
-	path = /obj/item/gun/projectile/dragunov
-
 /datum/uplink_item/item/visible_weapons/assault_rifle
 	name = "Assault Rifle"
 	telecrystal_cost = 12

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -173,7 +173,7 @@
 		icon_state = "tranqsniper"
 
 /obj/item/gun/projectile/dragunov
-	name = "marksman rifle"
+	name = "adhomian marksman rifle"
 	desc = "A semi-automatic marksman rifle."
 	icon = 'icons/obj/guns/dragunov.dmi'
 	icon_state = "dragunov"

--- a/html/changelogs/LynxSolstice-Adds-sniper-to-uplink.yml
+++ b/html/changelogs/LynxSolstice-Adds-sniper-to-uplink.yml
@@ -38,5 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added the marksman rifle to the uplink, since it's magazine was there, but not the rifle itself."
   - tweak: "Tweaked the name of the 'marksman rifle' made in adhomai to the 'adhomian marksman rifle', also tweaked the name of the '7.62 Sniper Magazine' to the '7.62 Marksman Magazine' since it was the mag for the adhomian marksman rifle."

--- a/html/changelogs/LynxSolstice-Adds-sniper-to-uplink.yml
+++ b/html/changelogs/LynxSolstice-Adds-sniper-to-uplink.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: LynxSolstice
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added the marksman rifle to the uplink, since it's magazine was there, but not the rifle itself."
+  - tweak: "Tweaked the name of the 'marksman rifle' made in adhomai to the 'adhomian marksman rifle', also tweaked the name of the '7.62 Sniper Magazine' to the '7.62 Marksman Magazine' since it was the mag for the adhomian marksman rifle."


### PR DESCRIPTION
~~This is intended to fix an oversight with having the magazines for a weapon in the uplink, but not the weapon itself. This also adds an option for someone wanting to utilize a sniper rifle, without having to order one from Ops as a traitor/merc/uplink'd antag.~~
Matt said no.

This PR tweaks the names of the marksman rifle's magazines to be "marksman magazine" instead of "sniper magazine" which was incorrect, this PR also tweaks the name of the DPRA made Marksman rifle to the 'Adhomian marksman rifle'.