### PR TITLE
Flashbang nerfs, grenade priming animation.

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -7,8 +7,8 @@
 /obj/item/grenade/flashbang/prime()
 	..()
 	/// Holding a flashbang when it goes off is bad news.
-	if(isliving(loc))
-		var/mob/living/victim = loc
+	if(ishuman(loc))
+		var/mob/living/carbon/human/victim = loc
 		var/obj/item/organ/external/exploded_hand
 		if(victim.hand == src)
 			exploded_hand = victim.organs_by_name[BP_R_HAND]

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -6,38 +6,28 @@
 
 /obj/item/grenade/flashbang/prime()
 	..()
-	/// Holding a flashbang when it goes off is bad news.
-	if(ishuman(loc))
-		var/mob/living/carbon/human/victim = loc
-		var/obj/item/organ/external/exploded_hand
-		if(victim.hand == src)
-			exploded_hand = victim.organs_by_name[BP_R_HAND]
-		else if(victim.l_hand == src)
-			exploded_hand = victim.organs_by_name[BP_L_HAND]
-		/// The flashbang was held in their hand, and we have one.
-		if(exploded_hand)
-			to_chat(victim, SPAN_HIGHDANGER("\The [src] goes off in your hand!"))
-			victim.apply_damage(30, DAMAGE_BRUTE, exploded_hand, src, DAMAGE_FLAG_EXPLODE, 20)
-			victim.apply_damage(20, DAMAGE_BURN, exploded_hand, src, DAMAGE_FLAG_EXPLODE, 20)
-		else
-			/// No hand, so it's in a bag or pocket.
-			to_chat(victim, SPAN_HIGHDANGER("\The [src] goes off on you!"))
-			victim.apply_damage(20, DAMAGE_BRUTE, exploded_hand, src, DAMAGE_FLAG_EXPLODE|DAMAGE_FLAG_DISPERSED, 20)
-			victim.apply_damage(30, DAMAGE_BURN, exploded_hand, src, DAMAGE_FLAG_EXPLODE|DAMAGE_FLAG_DISPERSED, 20)
-
 	var/turf/T = get_turf(src)
 	for(var/mob/living/L in get_hearers_in_view(7, src))
 		bang(T, L)
 
-	/// Damage blobs.
+	// Damage blobs.
 	for(var/obj/effect/blob/B in get_hear(8,get_turf(src)))
 		var/damage = round(30/(get_dist(B,get_turf(src))+1))
 		B.health -= damage
 		B.update_icon()
 
 	single_spark(T)
-	new/obj/effect/effect/smoke/illumination(T, brightness=15)
+	new /obj/effect/effect/smoke/illumination(T, brightness=15)
 	qdel(src)
+
+/obj/item/grenade/flashbang/explode_in_hand(var/mob/living/carbon/human/victim, var/obj/item/organ/external/exploded_hand)
+	. = ..()
+	if(exploded_hand)
+		victim.apply_damage(30, DAMAGE_BRUTE, exploded_hand, src, DAMAGE_FLAG_EXPLODE, 20)
+		victim.apply_damage(20, DAMAGE_BURN, exploded_hand, src, DAMAGE_FLAG_EXPLODE, 20)
+	else
+		victim.apply_damage(20, DAMAGE_BRUTE, exploded_hand, src, DAMAGE_FLAG_EXPLODE|DAMAGE_FLAG_DISPERSED, 20)
+		victim.apply_damage(30, DAMAGE_BURN, exploded_hand, src, DAMAGE_FLAG_EXPLODE|DAMAGE_FLAG_DISPERSED, 20)
 
 /obj/item/grenade/flashbang/proc/bang(turf/T, mob/living/M)
 	to_chat(M, SPAN_HIGHDANGER("BANG!"))

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -6,11 +6,30 @@
 
 /obj/item/grenade/flashbang/prime()
 	..()
+	/// Holding a flashbang when it goes off is bad news.
+	if(isliving(loc))
+		var/mob/living/victim = loc
+		var/obj/item/organ/external/exploded_hand
+		if(victim.hand == src)
+			exploded_hand = victim.organs_by_name[BP_R_HAND]
+		else if(victim.l_hand == src)
+			exploded_hand = victim.organs_by_name[BP_L_HAND]
+		/// The flashbang was held in their hand, and we have one.
+		if(exploded_hand)
+			to_chat(victim, SPAN_HIGHDANGER("\The [src] goes off in your hand!"))
+			victim.apply_damage(30, DAMAGE_BRUTE, exploded_hand, src, DAMAGE_FLAG_EXPLODE, 20)
+			victim.apply_damage(20, DAMAGE_BURN, exploded_hand, src, DAMAGE_FLAG_EXPLODE, 20)
+		else
+			/// No hand, so it's in a bag or pocket.
+			to_chat(victim, SPAN_HIGHDANGER("\The [src] goes off on you!"))
+			victim.apply_damage(20, DAMAGE_BRUTE, exploded_hand, src, DAMAGE_FLAG_EXPLODE|DAMAGE_FLAG_DISPERSED, 20)
+			victim.apply_damage(30, DAMAGE_BURN, exploded_hand, src, DAMAGE_FLAG_EXPLODE|DAMAGE_FLAG_DISPERSED, 20)
+
 	var/turf/T = get_turf(src)
 	for(var/mob/living/L in get_hearers_in_view(7, src))
 		bang(T, L)
 
-	// Damage blobs
+	/// Damage blobs.
 	for(var/obj/effect/blob/B in get_hear(8,get_turf(src)))
 		var/damage = round(30/(get_dist(B,get_turf(src))+1))
 		B.health -= damage
@@ -21,7 +40,7 @@
 	qdel(src)
 
 /obj/item/grenade/flashbang/proc/bang(turf/T, mob/living/M)
-	to_chat(M, SPAN_DANGER("BANG!"))
+	to_chat(M, SPAN_HIGHDANGER("BANG!"))
 	playsound(T, 'sound/weapons/flashbang.ogg', 50, 1, 3, 0.5, 1)
 
 	if(M.flash_act(ignore_inherent = TRUE))
@@ -29,7 +48,7 @@
 
 	// 1 - 9x/70 gives us 100% at zero, 87% at 1 turf, all the way to 10% at 7
 	var/bang_intensity = 1 - (9 * get_dist(T, M) / 70)
-	M.noise_act(intensity = EAR_PROTECTION_MAJOR, damage_pwr = 10 * bang_intensity, deafen_pwr = 15 * (1 - bang_intensity))
+	M.noise_act(intensity = EAR_PROTECTION_MODERATE, damage_pwr = 10 * bang_intensity, deafen_pwr = 15 * (1 - bang_intensity))
 
 	if(M.get_hearing_sensitivity()) // we only stun if they've got sensitive ears
 		// checking for protection is handled by noise_act
@@ -38,7 +57,7 @@
 	M.disable_cloaking_device()
 	M.update_icon()
 
-/obj/item/grenade/flashbang/clusterbang //Created by Polymorph, fixed by Sieve
+/obj/item/grenade/flashbang/clusterbang
 	name = "clusterbang"
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "clusterbang"

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -76,8 +76,8 @@
 	playsound(loc, activation_sound, 75, 1, -3)
 
 	addtimer(CALLBACK(src, PROC_REF(prime)), det_time)
-	/// Randomize the timing a bit. You wouldn't be aware of when exactly a grenade is going to pop.
-	/// Nor do we want people to instantly know when to throw a perfectly timed grenade.
+	// Randomize the timing a bit. You wouldn't be aware of when exactly a grenade is going to pop.
+	// Nor do we want people to instantly know when to throw a perfectly timed grenade.
 	animate(src, det_time + rand(-5, 5), -1, LINEAR_EASING, color = COLOR_RED)
 
 /obj/item/grenade/proc/prime()

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -85,6 +85,23 @@
 	if(T)
 		T.hotspot_expose(700,125)
 
+	if(ishuman(loc))
+		var/mob/living/carbon/human/victim = loc
+		var/obj/item/organ/external/exploded_hand
+		if(victim.hand == src)
+			exploded_hand = victim.organs_by_name[BP_R_HAND]
+		else if(victim.l_hand == src)
+			exploded_hand = victim.organs_by_name[BP_L_HAND]
+		explode_in_hand(victim, exploded_hand)
+
+/// This proc is called when the grenade explodes in your hand or on you. Exploded_hand can be null in case the grenade explodes in a pocket or something.
+/obj/item/grenade/proc/explode_in_hand(var/mob/living/carbon/human/victim, var/obj/item/organ/external/exploded_hand)
+	SHOULD_CALL_PARENT(TRUE)
+	if(exploded_hand)
+		to_chat(victim, SPAN_HIGHDANGER("\The [src] goes off in your hand!"))
+	else
+		to_chat(victim, SPAN_HIGHDANGER("\The [src] goes off on you!"))
+
 /obj/item/grenade/attack_hand()
 	walk(src, null, null)
 	..()

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -76,6 +76,9 @@
 	playsound(loc, activation_sound, 75, 1, -3)
 
 	addtimer(CALLBACK(src, PROC_REF(prime)), det_time)
+	/// Randomize the timing a bit. You wouldn't be aware of when exactly a grenade is going to pop.
+	/// Nor do we want people to instantly know when to throw a perfectly timed grenade.
+	animate(src, det_time + rand(-5, 5), -1, LINEAR_EASING, color = COLOR_RED)
 
 /obj/item/grenade/proc/prime()
 	var/turf/T = get_turf(src)

--- a/html/changelogs/mattatlas-flashbangnerfs.yml
+++ b/html/changelogs/mattatlas-flashbangnerfs.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: MattAtlas
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Flashbangs now no longer stun you if you have moderate ear protection (aka a helmet)."
+  - tweak: "Flashbangs now damage you quite a bit if they explode while in your hand or in your pockets. Be careful!"
+  - tweak: "The BANG message after being stunned by a flashbang is now bigger."
+  - tweak: "Grenades now get redder as they're about to explode. The timing is slightly randomized, so don't use it as an exact indicator of when to throw a grenade."


### PR DESCRIPTION
  - tweak: "Flashbangs now no longer stun you if you have moderate ear protection (aka a helmet)."
  - tweak: "Flashbangs now damage you quite a bit if they explode while in your hand or in your pockets. Be careful!"
  - tweak: "The BANG message after being stunned by a flashbang is now bigger."
  - tweak: "Grenades now get redder as they're about to explode. The timing is slightly randomized, so don't use it as an exact indicator of when to throw a grenade."

https://github.com/Aurorastation/Aurora.3/assets/13016572/7183d047-38b3-4b60-bec2-4911e17eede9

