### PR TITLE
Passive mobs no longer spawn in the Warehouse

### DIFF
--- a/code/modules/cargo/randomstock.dm
+++ b/code/modules/cargo/randomstock.dm
@@ -97,12 +97,6 @@ var/list/global/random_stock_large = list()
 	var/area/warehouse
 	var/list/warehouseturfs = list()
 
-	var/list/infest_mobs_minor = list(
-		/mob/living/simple_animal/rat = 1,
-		/mob/living/simple_animal/lizard = 0.5,
-		/mob/living/simple_animal/yithian = 0.7,
-		/mob/living/simple_animal/tindalos = 0.6)
-
 	var/list/infest_mobs_moderate = list(
 		/mob/living/simple_animal/bee/standalone = 1,
 		/mob/living/simple_animal/hostile/retaliate/diyaab = 1,
@@ -202,19 +196,14 @@ var/list/global/random_stock_large = list()
 		if ("3")
 			return pickweight(random_stock_common)
 
-//Minor and moderate mobs are checked per crate
-#define INFEST_PROB_MINOR	6
+// Moderate mobs are checked per crate
 #define INFEST_PROB_MODERATE	3
 
 #define INFEST_PROB_SEVERE	3//Severe is once per round, not per crate
 
 /datum/cargospawner/proc/handle_infestation()
 	for (var/obj/O in containers)
-		if (prob(INFEST_PROB_MINOR))
-	//No admin message for the minor mobs, because they are friendly and harmless
-			var/ctype = pickweight(infest_mobs_minor)
-			new ctype(O)
-		else if	 (prob(INFEST_PROB_MODERATE))
+		if(prob(INFEST_PROB_MODERATE))
 			var/ctype = pickweight(infest_mobs_moderate)
 			new ctype(O)
 			msg_admin_attack("Common cargo warehouse critter [ctype] spawned inside [O.name] coords (<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[O.x];Y=[O.y];Z=[O.z]'>JMP</a>)")

--- a/html/changelogs/SimpleMaroon-nomorewarehousepets.yml
+++ b/html/changelogs/SimpleMaroon-nomorewarehousepets.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: SimpleMaroon
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Passive mobs, like lizards and rats, can no longer spawn in the Warehouse."


### PR DESCRIPTION
Passive mobs, including rats, lizards, tindalos, and yithians, can spawn in the Warehouse crates at random chance. They're annoying because they push around crates and cause a mess as soon as they exit the crate, and have to be either relegated to one of the Warehouse storage rooms or allowed to wander freely. I've opted to remove them as they don't really add anything, unlike the hostile mobs, which have been retained. Sorry.