### PR TITLE
Autopsy Now Shows Hostile Mob Attacks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -201,7 +201,7 @@
 		return 0
 
 /mob/living/simple_animal/hostile/proc/on_attack_mob(var/mob/hit_mob, var/obj/item/organ/external/limb)
-	if(isliving(hit_mob) && istype(limb) && !BP_IS_ROBOTIC(limb))
+	if(isliving(hit_mob) && istype(limb))
 		limb.add_autopsy_data("Mauling by [src.name]")
 		return
 	else return

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -201,8 +201,10 @@
 		return 0
 
 /mob/living/simple_animal/hostile/proc/on_attack_mob(var/mob/hit_mob, var/obj/item/organ/external/limb)
-	limb.add_autopsy_data("Mauling by [src.name]")
-	return
+	if(isliving(hit_mob) && istype(limb) && !BP_IS_ROBOTIC(limb))
+		limb.add_autopsy_data("Mauling by [src.name]")
+		return
+	else return
 
 /mob/living/simple_animal/hostile/proc/AttackingTarget()
 	setClickCooldown(attack_delay)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -201,6 +201,7 @@
 		return 0
 
 /mob/living/simple_animal/hostile/proc/on_attack_mob(var/mob/hit_mob, var/obj/item/organ/external/limb)
+	limb.add_autopsy_data("Mauling by [src.name]")
 	return
 
 /mob/living/simple_animal/hostile/proc/AttackingTarget()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -203,8 +203,6 @@
 /mob/living/simple_animal/hostile/proc/on_attack_mob(var/mob/hit_mob, var/obj/item/organ/external/limb)
 	if(isliving(hit_mob) && istype(limb))
 		limb.add_autopsy_data("Mauling by [src.name]")
-		return
-	else return
 
 /mob/living/simple_animal/hostile/proc/AttackingTarget()
 	setClickCooldown(attack_delay)

--- a/html/changelogs/suethecake-patch-1.yml
+++ b/html/changelogs/suethecake-patch-1.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: SueTheCake
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Simple animal attacks now show up on autopsies."


### PR DESCRIPTION
What it says on the tin. 

All hostile simple_animals and retaliatory ones (they use the same proc) will now show on autopsy printouts with the syntax 'Mauling by [animal name'.