### PR TITLE
Investigator microscope now shows partial fingerprints

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -409,18 +409,36 @@
 				return 0
 	return newtext
 
+
 /**
- * This proc returns the number of chars of the string that is the character
+ * This proc returns the percentage of chars of the string that is the character
  *
  * This is used for detective work to determine fingerprint completion
  *
- * Returns the percentage of which one character makes up of the string (eg string "1234" with character "2" would be 25%)
+ * Returns the percentage of which one character makes up of the string (eg string "1234" with character "2" would be 25(%))
  *
- * * text - The string to calculate the percent of
+ * * text - The string to calculate the percent against
  * * character - The character you want to know for which it makes the percentage in the string
  *
  */
 /proc/stringpercent(text, character = "*")
+	if(!text || !character)
+		return 0
+
+	var/lentext = length(text)
+	var/count = charcount(text, character)
+	return ((count / lentext) * 100)
+
+
+/**
+ * This proc returns the amount of characters in the string that are the indicated character
+ *
+ * Returns the amount of characters in the string (eg string "1234" with character "2" would return 1)
+ *
+ * * text - The string to check into
+ * * character - The character you want to know how many are in the string
+ */
+/proc/charcount(text, character = "*")
 	if(!text || !character)
 		return 0
 	var/count = 0
@@ -431,6 +449,7 @@
 		if(a == character)
 			count++
 	return count
+
 
 /proc/reverse_text(text = "")
 	var/new_text = ""

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -409,14 +409,25 @@
 				return 0
 	return newtext
 
-//This proc returns the number of chars of the string that is the character
-//This is used for detective work to determine fingerprint completion.
-/proc/stringpercent(text,character = "*")
+/**
+ * This proc returns the number of chars of the string that is the character
+ *
+ * This is used for detective work to determine fingerprint completion
+ *
+ * Returns the percentage of which one character makes up of the string (eg string "1234" with character "2" would be 25%)
+ *
+ * * text - The string to calculate the percent of
+ * * character - The character you want to know for which it makes the percentage in the string
+ *
+ */
+/proc/stringpercent(text, character = "*")
 	if(!text || !character)
 		return 0
 	var/count = 0
-	for(var/i = 1, i <= length(text), i++)
-		var/a = copytext(text,i,i+1)
+	var/lentext = length(text)
+	var/a = ""
+	for(var/i = 1, i <= lentext, i += length(a))
+		a = text[i]
 		if(a == character)
 			count++
 	return count

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -475,7 +475,7 @@
 
 		// Add the fingerprints.
 		if(fingerprints[full_print])
-			switch(stringpercent(fingerprints[full_print]))	// Tells us how many stars are in the current prints.
+			switch(charcount(fingerprints[full_print]))	// Tells us how many stars are in the current prints.
 
 				if(28 to 32)
 					if(prob(1))

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -2,11 +2,26 @@
 	icon = 'icons/obj/forensics.dmi'
 	w_class = ITEMSIZE_TINY
 
-//This is the output of the stringpercent(print) proc, and means about 80% of
-//the print must be there for it to be complete.  (Prints are 32 digits)
-var/const/FINGERPRINT_COMPLETE = 6
+/**
+ * The maximum amount of unknown points in a fingerprint string (represented as asterisks)
+ * before the fingerprint is considered incomplete enough (and thus not recognisable)
+ *
+ * A fingerprint is 32 characters long and every unknown point of it is "*"
+ */
+#define MAX_UNKNOWN_POINTS_IN_FINGERPRINT 31
+
+/**
+ * Returns `TRUE` if the fingerprint is complete (above `FINGERPRINT_COMPLETE`), `FALSE` otherwise
+ *
+ * * print - The fingerprint (a string)
+ */
 /proc/is_complete_print(var/print)
-	return stringpercent(print) <= FINGERPRINT_COMPLETE
+	if(stringpercent(print) <= MAX_UNKNOWN_POINTS_IN_FINGERPRINT)
+		return TRUE
+	else
+		return FALSE
+
+#undef MAX_UNKNOWN_POINTS_IN_FINGERPRINT
 
 /atom/var/list/suit_fibers
 

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -3,12 +3,12 @@
 	w_class = ITEMSIZE_TINY
 
 /**
- * The maximum amount of unknown points in a fingerprint string (represented as asterisks)
+ * The maximum percentage of unknown points in a fingerprint string (represented as asterisks)
  * before the fingerprint is considered incomplete enough (and thus not recognisable)
  *
  * A fingerprint is 32 characters long and every unknown point of it is "*"
  */
-#define MAX_UNKNOWN_POINTS_IN_FINGERPRINT 31
+#define MAX_UNKNOWN_POINTS_FOR_KNOWN_FINGERPRINT_PERCENTAGE 98
 
 /**
  * Returns `TRUE` if the fingerprint is complete (above `FINGERPRINT_COMPLETE`), `FALSE` otherwise
@@ -16,12 +16,13 @@
  * * print - The fingerprint (a string)
  */
 /proc/is_complete_print(var/print)
-	if(stringpercent(print) <= MAX_UNKNOWN_POINTS_IN_FINGERPRINT)
+	var/unknown_points_percentage = stringpercent(print)
+	if(unknown_points_percentage <= MAX_UNKNOWN_POINTS_FOR_KNOWN_FINGERPRINT_PERCENTAGE)
 		return TRUE
 	else
 		return FALSE
 
-#undef MAX_UNKNOWN_POINTS_IN_FINGERPRINT
+#undef MAX_UNKNOWN_POINTS_FOR_KNOWN_FINGERPRINT_PERCENTAGE
 
 /atom/var/list/suit_fibers
 

--- a/code/modules/detectivework/microscope/microscope.dm
+++ b/code/modules/detectivework/microscope/microscope.dm
@@ -85,16 +85,28 @@
 		info = "<b><font size=\"4\">Fingerprint analysis report #[report_print_num]</font></b><HR>"
 		info += "<b>Source locations:</b> "
 		info += "[english_list(card.source, "no sources were found", ", ", ", ", "")].<br><br>"
+
 		if(card.evidence && card.evidence.len)
 			info += "Surface analysis has determined unique fingerprint strings:<ul>"
-			for(var/prints in card.evidence)
+
+			//Get the list of all the COMPLETE fingerprints, use it to acquire the hidden ones, check if they are complete enough, if so show them
+			for(var/full_fingerprint in card.evidence)
+
+				//Acquire the partial fingerprint
+				var/partial_fingerprint = card.evidence[full_fingerprint]
+
 				info += "<li><b>Fingerprint string: </b>"
-				if(!is_complete_print(prints))
+
+				//If the fingerprint is complete enough, show the partial fingerprint
+				if(!is_complete_print(partial_fingerprint))
 					info += "INCOMPLETE PRINT"
 				else
-					info += "[prints]"
+					info += "[partial_fingerprint]"
+
 				info += "</li>"
+
 			info += "</ul>"
+
 		else
 			info += "No information available."
 

--- a/html/changelogs/fluffyghost-microscopepartialfingerprints.yml
+++ b/html/changelogs/fluffyghost-microscopepartialfingerprints.yml
@@ -39,4 +39,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Investigator microscope now shows partial fingerprints instead of the full one."
-  - refactor: "Refactored stringpercent proc to TG version, some DMDoc, turned a global var into a define."
+  - refactor: "Refactored stringpercent proc actually give a string percentage, some DMDoc, turned a global var into a define."
+  - rscadd: "Added a charcount proc and modified the atom fingerprint leaving to use it instead."

--- a/html/changelogs/fluffyghost-microscopepartialfingerprints.yml
+++ b/html/changelogs/fluffyghost-microscopepartialfingerprints.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Investigator microscope now shows partial fingerprints instead of the full one."
+  - refactor: "Refactored stringpercent proc to TG version, some DMDoc, turned a global var into a define."


### PR DESCRIPTION
Investigator microscope now shows partial fingerprints instead of the full one.
Refactored stringpercent proc actually give a string percentage, some DMDoc, turned a global var into a define.
Added a charcount proc and modified the atom fingerprint leaving to use it instead.