### PR TITLE
Fixes Dominian & Hammertail gear crates

### DIFF
--- a/code/datums/uplink/gear loadout.dm
+++ b/code/datums/uplink/gear loadout.dm
@@ -160,12 +160,12 @@
 
 /datum/uplink_item/item/gear_loadout/hammertail
 	name = "Hammertail Smiths Assets (Group)"
-	desc = "A crate containing gear for a group. The voidsuits are are only usable by humans."
+	desc = "A crate containing gear for a group. The voidsuits are are only usable by Unathi."
 	path = /obj/structure/closet/crate/secure/gear_loadout/hammertail
 
 /datum/uplink_item/item/gear_loadout/hammertail_single
 	name = "Hammertail Smiths Assets (Single)"
-	desc = "A crate containing gear for a single individual. The voidsuit is only usable by humans."
+	desc = "A crate containing gear for a single individual. The voidsuit is only usable by Unathi."
 	path = /obj/structure/closet/crate/secure/gear_loadout/hammertail/single
 	telecrystal_cost = 10
 

--- a/code/game/objects/structures/crates_lockers/crates/gear_loadout.dm
+++ b/code/game/objects/structures/crates_lockers/crates/gear_loadout.dm
@@ -341,10 +341,10 @@
 	new /obj/item/clothing/suit/space/void/dominia(src)
 	new /obj/item/gun/projectile/automatic/rifle/dominia(src)
 	new /obj/item/gun/projectile/automatic/rifle/dominia(src)
-	new /obj/item/ammo_magazine/c762(src)
-	new /obj/item/ammo_magazine/c762(src)
-	new /obj/item/ammo_magazine/c762(src)
-	new /obj/item/ammo_magazine/c762(src)
+	new /obj/item/ammo_magazine/a556(src)
+	new /obj/item/ammo_magazine/a556(src)
+	new /obj/item/ammo_magazine/a556(src)
+	new /obj/item/ammo_magazine/a556(src)
 	new /obj/item/gun/projectile/automatic/tommygun/dom(src)
 	new /obj/item/gun/projectile/automatic/tommygun/dom(src)
 	new /obj/item/gun/projectile/automatic/tommygun/dom(src)
@@ -372,8 +372,8 @@
 	new /obj/item/clothing/head/helmet/space/void/dominia(src)
 	new /obj/item/clothing/suit/space/void/dominia(src)
 	new /obj/item/gun/projectile/automatic/rifle/dominia(src)
-	new /obj/item/ammo_magazine/c762(src)
-	new /obj/item/ammo_magazine/c762(src)
+	new /obj/item/ammo_magazine/a556(src)
+	new /obj/item/ammo_magazine/a556(src)
 	new /obj/item/melee/energy/sword/pirate(src)
 	new /obj/item/shield/energy/dominia(src)
 	new /obj/item/voidsuit_modkit/dominianvoid(src)
@@ -811,8 +811,8 @@
 	for(i=0, i<6, i++) //6 outfits
 		new /obj/item/clothing/under/syndicate/hammertail(src)
 	for(i=0, i<4, i++) //4 voidsuits w/helmets
-		new /obj/item/clothing/head/helmet/space/void/merc(src)
-		new /obj/item/clothing/suit/space/void/merc(src)
+		new /obj/item/clothing/head/helmet/space/void/merc/unathi(src)
+		new /obj/item/clothing/suit/space/void/merc/unathi(src)
 	for(i=0, i<4, i++) //4 e-swords
 		new /obj/item/melee/energy/sword(src)
 	for(i=0, i<4, i++) //4 heavy pistols w/spare magazines
@@ -827,8 +827,8 @@
 
 /obj/structure/closet/crate/secure/gear_loadout/hammertail/single/fill()
 	new /obj/item/clothing/under/syndicate/hammertail(src) //1 outfit
-	new /obj/item/clothing/head/helmet/space/void/merc(src) //1 voidsuit w/helmet
-	new /obj/item/clothing/suit/space/void/merc(src)
+	new /obj/item/clothing/head/helmet/space/void/merc/unathi(src) //1 voidsuit w/helmet
+	new /obj/item/clothing/suit/space/void/merc/unathi(src)
 	new /obj/item/melee/energy/sword(src) //1 e-sword
 	new /obj/item/gun/projectile/revolver(src) //1 .357 pistol w/spare speedloader
 	new /obj/item/ammo_magazine/a357(src)

--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -47,3 +47,9 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword,/obj/item/handcuffs)
 	siemens_coefficient = 0.35
 	species_restricted = list(BODYTYPE_HUMAN, BODYTYPE_SKRELL, BODYTYPE_IPC_INDUSTRIAL, BODYTYPE_IPC_ZENGHU, BODYTYPE_IPC_BISHOP)
+
+/obj/item/clothing/head/helmet/space/void/merc/unathi/Initialize()
+	refit_for_species(BODYTYPE_UNATHI)
+
+/obj/item/clothing/suit/space/void/merc/unathi/Initialize()
+	refit_for_species(BODYTYPE_UNATHI)

--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -49,7 +49,9 @@
 	species_restricted = list(BODYTYPE_HUMAN, BODYTYPE_SKRELL, BODYTYPE_IPC_INDUSTRIAL, BODYTYPE_IPC_ZENGHU, BODYTYPE_IPC_BISHOP)
 
 /obj/item/clothing/head/helmet/space/void/merc/unathi/Initialize()
+	. = ..()
 	refit_for_species(BODYTYPE_UNATHI)
 
 /obj/item/clothing/suit/space/void/merc/unathi/Initialize()
+	. = ..()
 	refit_for_species(BODYTYPE_UNATHI)

--- a/html/changelogs/RustingWithYou - cratefixes.yml
+++ b/html/changelogs/RustingWithYou - cratefixes.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes Dominian gear crates not spawning with the correct ammo."
+  - tweak: "Hammertail Smiths gear crates now spawn with Unathi-fitted voidsuits."


### PR DESCRIPTION
The Dominian gear crate will now spawn with the correct ammo magazines for the Dominian assault rifle.
The Hammertail Smiths gear crate will now spawn with Unathi-fitted voidsuits, as it was kind of weird that an Unathi faction's gear crate was only available to humans.