### PR TITLE
Sector-dependent spawn weight override for ships/sites/ruins

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -763,9 +763,9 @@ var/datum/controller/subsystem/ticker/SSticker
 		var/list/ship_names = list()
 		for(var/datum/map_template/ruin/site in sites)
 			if(site.ship_cost)
-				ship_names += site.name
+				ship_names += "[site.name] ([site.spawn_weight])"
 			else
-				site_names += site.name
+				site_names += "[site.name] ([site.spawn_weight])"
 
 		var/datum/browser/sites_win = new(
 			usr,
@@ -773,7 +773,7 @@ var/datum/controller/subsystem/ticker/SSticker
 			"Sector: " + current_sector.name,
 			500, 500,
 		)
-		var/html = "<h1>Ships and sites that spawn in this sector:</h1>"
+		var/html = "<h1>Ships and sites that spawn in this sector, with their spawn weights:</h1>"
 		html += "<h3>Ships:</h3>"
 		html += english_list(ship_names)
 		html += "<h3>Sites:</h3>"

--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -5,10 +5,22 @@
 	How is there a wooden container filled with 18th century coinage in the middle of a lavawracked hellscape? \
 	It is clearly a mystery."
 
+	/// Spawn weight.
 	var/spawn_weight = 1
+	/// Sector-dependent `spawn_weight` override, changing the weight based on sector.
+	/// Should be assoc list in the form of `= list(X=N)`, where `X` is either a single sector string like `SECTOR_TAU_CETI`
+	/// or a list (of lists) like `ALL_POSSIBLE_SECTORS` which will be flattened later, and where `N` is the weight override like `1` or `2`.
+	/// Setting weight overrides for blacklisted sectors is valid, and `sectors` and `sectors_blacklist` are respected still.
+	/// If current sector is not contained in this assoc list, then `spawn_weight` is not overriden and is used as default value.
+	/// The first matching sector override is applied and further ones are not checked.
+	var/list/spawn_weight_sector_dependent = list()
+
+	/// Spawn cost, to be used by ruins or sites *WITHOUT* any ghost roles.
 	var/spawn_cost = 0
-	var/player_cost = 0
+	/// Spawn cost, to be used by ruins or sites *WITH* ghost roles.
 	var/ship_cost = 0
+	/// Unused?
+	var/player_cost = 0
 
 	/// This ruin can only spawn in the sectors in this list.
 	/// Should contain names of sectors as defined in `space_sectors.dm`.
@@ -34,13 +46,27 @@
 	var/list/ban_ruins   // Listed ruins are removed from the set of available spawns. Beats allowed.
 
 /datum/map_template/ruin/New()
+	// get the map paths
 	if (suffixes)
 		mappaths = list()
 		for (var/suffix in suffixes)
 			mappaths += (prefix + suffix)
+
+	// set up sectors
 	sectors = flatten_list(sectors)
 	sectors_blacklist = flatten_list(sectors_blacklist)
 	sectors -= sectors_blacklist
+
+	// adjust weight from sector dependent override
+	var/datum/space_sector/current_sector = SSatlas.current_sector
+	if(current_sector && spawn_weight_sector_dependent)
+		for(var/sectors in spawn_weight_sector_dependent)
+			var/weight_in_sector = spawn_weight_sector_dependent[sectors]
+			var/list/sectors_flattened = flatten_list(list(sectors))
+			if(current_sector.name in sectors_flattened)
+				spawn_weight = weight_in_sector
+
+	// fin
 	..()
 
 /// Returns `TRUE` if this ruin can spawn in current sector, otherwise `FALSE`.

--- a/html/changelogs/DreamySkrell-weight-sector-dependent.yml
+++ b/html/changelogs/DreamySkrell-weight-sector-dependent.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: DreamySkrell
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds sector-dependent spawn weight override, to allow different weight for away sites or ships in different sectors."
+  - rscadd: "The window that shows ships/sites spawning in current sector, also now shows their spawn weights."

--- a/maps/away/ships/kataphracts/kataphract_ship.dm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dm
@@ -5,9 +5,9 @@
 	suffixes = list("ships/kataphracts/kataphract_ship.dmm")
 	ship_cost = 1
 	spawn_weight = 1
-	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/kataphract_transport)
+	spawn_weight_sector_dependent = list(SECTOR_UUEOAESA=3)
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_TAU_CETI, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_UUEOAESA, SECTOR_WEEPING_STARS)
-
+	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/kataphract_transport)
 	unit_test_groups = list(3)
 
 /obj/effect/overmap/visitable/ship/kataphract_ship


### PR DESCRIPTION
![image](https://github.com/Aurorastation/Aurora.3/assets/107256943/bcc66259-71c1-4cc7-99f7-1eed56ba061f)

changes:
  - rscadd: "Adds sector-dependent spawn weight override, to allow different weight for away sites or ships in different sectors."
  - rscadd: "The window that shows ships/sites spawning in current sector, also now shows their spawn weights."

Kataphract ship here is an example on how to use this. It has weight 1 normally, and weight 3 only in Uueoa-Esa.

The intention for this feature is to allow some ships to be more common in some sectors, and less common in others.
For example we are in CoC now, so CoC ships should be more common here, and ships from outside should be less.

Or when we go to Konyang, currently, actual Konyanger ships will be rare with the 15 or 20 or however many non-Konyang ships can spawn there. This feature could help make them more common potentially.

But the actual balancing and changing weights I leave for another PR, to get this feature out quicker.