### PR TITLE
Fixes Missing Tarwa APC

### DIFF
--- a/html/changelogs/RustingWithYou - tarwafix.yml
+++ b/html/changelogs/RustingWithYou - tarwafix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes missing APC on Tarwa ship."

--- a/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa.dmm
+++ b/maps/away/away_site/unathi_pirate/tarwa/unathi_pirate_tarwa.dmm
@@ -2091,12 +2091,22 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/tarwa_ship/medical)
+"DV" = (
+/obj/machinery/alarm/north{
+	req_one_access = list(210)
+	},
+/turf/simulated/floor/tiled,
+/area/tarwa_ship/bridge)
 "Eb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/alarm/north{
-	req_one_access = list(210)
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/north{
+	pixel_x = 0;
+	req_access = list(210)
 	},
 /turf/simulated/floor/tiled,
 /area/tarwa_ship/bridge)
@@ -15790,7 +15800,7 @@ De
 MP
 Ql
 Uw
-aA
+DV
 aA
 YX
 aA


### PR DESCRIPTION
an apc on the tarwa ship got accidentally deleted. puts it back.