### PR TITLE
Freebooter tweaks and fixes

### DIFF
--- a/html/changelogs/hazelmouse - freebooter_tweaks.yml
+++ b/html/changelogs/hazelmouse - freebooter_tweaks.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds tank-based propulsion to the freebooter ship."
+  - rscadd: "Adds multi-species insulated gloves, condiments, and k'ois bars to the freebooter ship, in addition to (slightly) more comprehensive medical and surgical supplies."
+  - bugfix: "Fixes freebooter ship not needing power to function. Adapts airlocks throughout the ship to airlock markers."

--- a/maps/away/ships/freebooter/freebooter_ship.dm
+++ b/maps/away/ships/freebooter/freebooter_ship.dm
@@ -25,8 +25,38 @@
 /area/ship/freebooter_ship/gunnery
 	name = "Freebooter Gunnery"
 
+/area/ship/freebooter_ship/ammo
+	name = "Freebooter Ammunition Storage"
+
+/area/ship/freebooter_ship/gunneryentrance
+	name = "Freebooter Ship Gunnery Entrance"
+
 /area/ship/freebooter_ship/bridge
 	name = "Freebooter Bridge"
+
+/area/ship/freebooter_ship/forehallway
+	name = "Freebooter Fore Hallway"
+
+/area/ship/freebooter_ship/forehallwayport
+	name = "Freebooter Fore Hallway Port"
+
+/area/ship/freebooter_ship/closet
+	name = "Freebooter Multi-Purpose Closet"
+
+/area/ship/freebooter_ship/cryo
+	name = "Freebooter Cryogenics Storage"
+
+/area/ship/freebooter_ship/dorms
+	name = "Freebooter Dormitories"
+
+/area/ship/freebooter_ship/lockers
+	name = "Freebooter Locker Rooms"
+
+/area/ship/freebooter_ship/head
+	name = "Freebooter Head"
+
+/area/ship/freebooter_ship/medical
+	name = "Freebooter Medical Bay"
 
 /area/ship/freebooter_ship/pod1
 	name = "Freebooter Pod One"
@@ -60,6 +90,11 @@
 
 /area/ship/freebooter_ship/engineering
 	name = "Freebooter Engineering"
+
+
+/area/ship/freebooter_ship/exterior
+	name = "Freebooter Ship Exterior"
+	requires_power = FALSE
 
 /area/shuttle/freebooter_shuttle
 	name = "Freebooter Shuttle"

--- a/maps/away/ships/freebooter/freebooter_ship.dm
+++ b/maps/away/ships/freebooter/freebooter_ship.dm
@@ -99,6 +99,7 @@
 /area/shuttle/freebooter_shuttle
 	name = "Freebooter Shuttle"
 	icon_state = "shuttle2"
+	requires_power = TRUE
 
 //ship stuff
 

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -81,7 +81,8 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "ahD" = (
@@ -269,19 +270,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "ayy" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -379,12 +382,6 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
-"aEI" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "aFI" = (
 /obj/item/stack/tile/floor_dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -548,12 +545,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aOU" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "junker_gun"
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/gunnery)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/forehallwayport)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -1418,21 +1411,6 @@
 /obj/effect/shuttle_landmark/freebooter_ship,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
-"cBR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/forehallway)
 "cDf" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -1970,22 +1948,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
-"ebH" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/machinery/access_button{
-	pixel_x = -8;
-	pixel_y = 28;
-	dir = 8
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/foyer)
 "ebW" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2539,8 +2501,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fGM" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/medical)
+/obj/machinery/cryopod,
+/obj/structure/cryofeed/pipes{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/freebooter_ship/cryo)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -2891,16 +2861,16 @@
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
 /obj/machinery/access_button{
 	pixel_x = -8;
 	pixel_y = 28;
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "gzr" = (
@@ -2946,6 +2916,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/light{
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "gGE" = (
@@ -3297,6 +3271,9 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
+"hMh" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunneryentrance)
 "hPM" = (
 /obj/machinery/atmospherics/unary/engine,
 /obj/structure/window/reinforced,
@@ -3712,12 +3689,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/forehallway)
-"iKs" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "iKH" = (
 /turf/simulated/wall,
 /area/ship/freebooter_ship/foyer)
@@ -3897,14 +3868,22 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "jrC" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/medical)
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "jvN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
-	dir = 4
-	},
-/obj/machinery/light/small/emergency{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow{
@@ -4240,21 +4219,8 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "kqx" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/medical)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
 /obj/effect/decal/cleanable/dirt,
@@ -4718,11 +4684,6 @@
 	layer = 2.8
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
-/obj/machinery/light{
-	dir = 8;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "lgM" = (
@@ -5103,6 +5064,12 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
+"mba" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "mbg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/decal/fake_object{
@@ -5346,6 +5313,9 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/thruster2)
+"mDC" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/medical)
 "mEc" = (
 /obj/structure/flora/pottedplant{
 	dead = 1;
@@ -5462,6 +5432,12 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
+"mRB" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "mSI" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -6282,6 +6258,11 @@
 	dead = 1;
 	icon_state = "plant-dead";
 	name = "dead plant"
+	},
+/obj/machinery/light{
+	dir = 8;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallwayport)
@@ -7396,7 +7377,9 @@
 	output_tag = "freebooter_thrust_out"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	frequency = 1336
+	},
 /area/ship/freebooter_ship/thruster1)
 "qHK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -7432,7 +7415,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm/north,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
 "qMB" = (
@@ -7541,6 +7526,9 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/pod6)
+"raI" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/gunneryentrance)
 "rbz" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/lockers)
@@ -7780,22 +7768,6 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
-"rDi" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/access_button{
-	pixel_x = 8;
-	pixel_y = 28;
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/foyer)
 "rDZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8203,7 +8175,8 @@
 	name = "airlock_freebooter_shuttle";
 	shuttle_tag = "Freebooter Shuttle"
 	},
-/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "szY" = (
@@ -8289,9 +8262,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
-"sLx" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunneryentrance)
 "sLP" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -8310,6 +8280,22 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/lockers)
+"sQu" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "sQA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -8454,7 +8440,8 @@
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
 	},
-/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "tcY" = (
@@ -8529,6 +8516,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
+"tqJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/forehallway)
 "tra" = (
 /obj/machinery/door/firedoor/noid{
 	dir = 8
@@ -8953,6 +8953,11 @@
 	layer = 2.8
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/light{
+	dir = 8;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "ulo" = (
@@ -9014,22 +9019,6 @@
 /obj/structure/ship_weapon_dummy,
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
-"uzM" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
 "uCl" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
@@ -9627,17 +9616,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
-"vLO" = (
-/obj/machinery/cryopod,
-/obj/structure/cryofeed/pipes{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/cryo)
 "vMG" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
@@ -9807,8 +9785,8 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "vZW" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/gunneryentrance)
+/turf/space/dynamic,
+/area/space)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/stool/chair{
@@ -9868,6 +9846,22 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
+"wio" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/access_button{
+	pixel_x = 8;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "wji" = (
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 8
@@ -10013,8 +10007,12 @@
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "wGc" = (
-/turf/space/dynamic,
-/area/space)
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "junker_gun"
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/gunnery)
 "wHo" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/ship_engine.dmi';
@@ -10253,7 +10251,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "xal" = (
@@ -10334,6 +10332,22 @@
 "xqI" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/ammo)
+"xrw" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/access_button{
+	pixel_x = -8;
+	pixel_y = 28;
+	dir = 8
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "xtX" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 5
@@ -10376,9 +10390,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
-"xvh" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/forehallwayport)
 "xvt" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/closet/crate/freezer/rations,
@@ -37808,7 +37819,7 @@ xRX
 xRX
 xRX
 uCl
-wGc
+vZW
 uCl
 fZq
 xRX
@@ -38322,7 +38333,7 @@ xRX
 rtf
 vUu
 uyM
-wGc
+vZW
 aHs
 xRX
 xRX
@@ -38869,7 +38880,7 @@ imE
 imE
 iOV
 iOV
-aOU
+wGc
 xRX
 xRX
 xRX
@@ -39126,7 +39137,7 @@ rjL
 tQn
 sxw
 www
-aOU
+wGc
 xRX
 xRX
 xRX
@@ -39383,7 +39394,7 @@ fNl
 tQn
 sxw
 sxw
-aOU
+wGc
 xRX
 xRX
 xRX
@@ -39634,13 +39645,13 @@ npb
 oxR
 tfK
 sxk
-aEI
+mRB
 soh
 soh
 aDv
 iOV
 iOV
-aOU
+wGc
 xRX
 xRX
 xRX
@@ -39892,8 +39903,8 @@ jhd
 tfK
 nwH
 wLI
-iKs
-iKs
+mba
+mba
 fnE
 xRX
 xRX
@@ -40400,11 +40411,11 @@ xRX
 xRX
 ajO
 xRX
-vZW
+raI
 rEb
 xTu
 cbE
-sLx
+hMh
 klp
 llD
 euj
@@ -40657,8 +40668,8 @@ xRX
 xRX
 ajO
 xRX
-vZW
-vZW
+raI
+raI
 jgM
 vVy
 aMQ
@@ -40915,10 +40926,10 @@ xRX
 ajO
 xRX
 xRX
-vZW
-vZW
+raI
+raI
 tmo
-sLx
+hMh
 mwo
 mwo
 mwo
@@ -41176,11 +41187,11 @@ xRX
 uLO
 ebn
 atj
-jrC
+mDC
 exg
 iGK
 aBD
-fGM
+kqx
 xRX
 xRX
 xRX
@@ -41437,7 +41448,7 @@ jLL
 aab
 qDe
 nVi
-fGM
+kqx
 saW
 xRX
 xRX
@@ -41690,12 +41701,12 @@ ajO
 pvm
 kou
 dWF
-jrC
+mDC
 gLO
 npJ
 kAt
 lpe
-fGM
+kqx
 xRX
 xRX
 xRX
@@ -41902,7 +41913,7 @@ xRX
 ajO
 xRX
 wyp
-kqx
+ayy
 wyp
 xRX
 xRX
@@ -41910,7 +41921,7 @@ xRX
 xRX
 xRX
 wyp
-kqx
+ayy
 wyp
 xRX
 xRX
@@ -41918,7 +41929,7 @@ xRX
 xRX
 xRX
 wyp
-kqx
+ayy
 wyp
 xRX
 xRX
@@ -41926,7 +41937,7 @@ xRX
 xRX
 xRX
 wyp
-kqx
+ayy
 wyp
 xRX
 xRX
@@ -41934,7 +41945,7 @@ xRX
 xRX
 xRX
 wyp
-kqx
+ayy
 wyp
 xRX
 xRX
@@ -41947,12 +41958,12 @@ xRX
 pvm
 vfD
 kOP
-jrC
-jrC
+mDC
+mDC
 tra
-fGM
-jrC
-fGM
+kqx
+mDC
+kqx
 ydf
 ewy
 ewy
@@ -42202,7 +42213,7 @@ xRX
 xRX
 xRX
 uLO
-qIf
+tqJ
 kbX
 kzS
 kvJ
@@ -43444,14 +43455,14 @@ wyp
 kXG
 vGw
 wyp
-ebH
+gyl
 bzm
 wyp
 vGw
 vGw
 vGw
 wyp
-gyl
+xrw
 odb
 wyp
 wyp
@@ -43487,7 +43498,7 @@ vGw
 wyp
 wyp
 uLO
-cBR
+qIf
 fZr
 wUa
 oKE
@@ -43958,7 +43969,7 @@ xRX
 ajO
 xRX
 wyp
-uzM
+sQu
 xvT
 wyp
 xRX
@@ -43974,7 +43985,7 @@ xRX
 xRX
 xRX
 wyp
-kqx
+ayy
 wyp
 xRX
 xRX
@@ -43982,7 +43993,7 @@ xRX
 xRX
 xRX
 wyp
-kqx
+ayy
 wyp
 xRX
 xRX
@@ -43990,7 +44001,7 @@ xRX
 xRX
 xRX
 wyp
-kqx
+ayy
 wyp
 xRX
 xRX
@@ -44222,7 +44233,7 @@ ajO
 ajO
 ajO
 wyp
-rDi
+wio
 bst
 wyp
 ajO
@@ -44469,22 +44480,22 @@ kMx
 jhL
 jhL
 ajO
-wGc
+vZW
 sUX
 ppp
 ppp
 ppp
 ppp
-ayy
+jrC
 kQs
-ayy
+jrC
 wtm
 rhN
 ciM
 rhN
 rmm
-wGc
-wGc
+vZW
+vZW
 uwT
 uwT
 lgM
@@ -44724,7 +44735,7 @@ aEa
 lJH
 jhL
 jhL
-wGc
+vZW
 ajO
 iGW
 wnf
@@ -44741,7 +44752,7 @@ iQg
 clU
 nKq
 rmm
-wGc
+vZW
 htS
 lfg
 jFY
@@ -44776,7 +44787,7 @@ ebn
 cDf
 quS
 cQs
-vLO
+fGM
 aSJ
 oxG
 xRX
@@ -45237,8 +45248,8 @@ mOF
 qED
 uPa
 uZl
-wGc
-wGc
+vZW
+vZW
 ajO
 bcf
 aSb
@@ -45255,7 +45266,7 @@ eqD
 aSb
 qeJ
 vOL
-wGc
+vZW
 uwT
 oZH
 pZI
@@ -45283,8 +45294,8 @@ xRX
 xRX
 ajO
 xRX
-xvh
-xvh
+aOU
+aOU
 nZj
 ess
 lzb
@@ -45495,7 +45506,7 @@ bpj
 fdV
 uZl
 uZl
-wGc
+vZW
 ajO
 rJT
 rsE
@@ -45512,7 +45523,7 @@ afL
 sVT
 oSp
 vOL
-wGc
+vZW
 uwT
 bDX
 mCb
@@ -45540,7 +45551,7 @@ xRX
 xRX
 ajO
 xRX
-xvh
+aOU
 xMA
 uWU
 oVL
@@ -45752,7 +45763,7 @@ ieM
 mwO
 uoZ
 uZl
-wGc
+vZW
 ajO
 iUd
 vdX
@@ -45769,7 +45780,7 @@ tcV
 rXx
 cJt
 vOL
-wGc
+vZW
 uwT
 fYr
 lGK
@@ -45797,7 +45808,7 @@ xRX
 xRX
 ajO
 xRX
-xvh
+aOU
 oyG
 cnH
 ess
@@ -46009,7 +46020,7 @@ mCl
 kuj
 rFB
 uZl
-wGc
+vZW
 ajO
 lkK
 hZH
@@ -46026,7 +46037,7 @@ kTf
 bzW
 hhA
 vOL
-wGc
+vZW
 uwT
 cgU
 hhQ
@@ -46266,7 +46277,7 @@ uiV
 vDk
 rFB
 uZl
-wGc
+vZW
 ajO
 bcf
 aSb
@@ -46283,7 +46294,7 @@ tDp
 aSb
 hhA
 vOL
-wGc
+vZW
 uwT
 cgU
 onn
@@ -46779,8 +46790,8 @@ uZl
 osl
 stV
 uZl
-wGc
-wGc
+vZW
+vZW
 ajO
 aCG
 dqF
@@ -46797,7 +46808,7 @@ rhN
 rhN
 mYn
 tOu
-wGc
+vZW
 htS
 hXO
 uwA
@@ -47037,9 +47048,9 @@ xRX
 xRX
 ajO
 ajO
-wGc
+vZW
 ajO
-wGc
+vZW
 kOK
 rfz
 rfz
@@ -47053,8 +47064,8 @@ vTv
 vTv
 vTv
 tOu
-wGc
-wGc
+vZW
+vZW
 uwT
 uwT
 nti

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1650,7 +1650,6 @@
 	},
 /obj/effect/floor_decal/industrial/outline/service,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb2,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -777,11 +777,11 @@
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -1045,7 +1045,12 @@
 	master_tag = "freebooter_port_1"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "bzr" = (
@@ -2941,6 +2946,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "gzr" = (
@@ -3382,7 +3390,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -3487,6 +3495,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
+"ial" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/foyer)
 "iaK" = (
 /obj/effect/floor_decal/corner/beige,
 /turf/simulated/floor/tiled/dark,
@@ -4012,8 +4030,8 @@
 	master_tag = "freebooter_port_1"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
@@ -4968,6 +4986,9 @@
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "lvR" = (
@@ -5094,7 +5115,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "lHL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/decal/cleanable/generic,
 /obj/structure/table/rack,
 /obj/item/device/suit_cooling_unit,
@@ -5102,6 +5122,7 @@
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "lJH" = (
@@ -5327,6 +5348,7 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "moJ" = (
@@ -6107,6 +6129,9 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "odX" = (
@@ -7907,6 +7932,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
+	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "rDZ" = (
@@ -7989,8 +8017,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "rHI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
@@ -8331,6 +8359,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "szY" = (
@@ -8883,6 +8914,9 @@
 "tSG" = (
 /obj/effect/decal/cleanable/ash,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "tSV" = (
@@ -10425,10 +10459,10 @@
 	layer = 2.45;
 	name = "lattice"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "xhE" = (
@@ -10656,6 +10690,9 @@
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "xRt" = (
@@ -43298,7 +43335,7 @@ oXj
 rnp
 bdI
 lHL
-rnp
+ial
 mvP
 ruW
 lwO

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -5081,10 +5081,6 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
-	},
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
 "lNV" = (
@@ -5756,13 +5752,16 @@
 /area/ship/freebooter_ship/pod8)
 "ntt" = (
 /obj/effect/floor_decal/corner/dark_green/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallwayport)
 "nty" = (
@@ -8488,15 +8487,16 @@
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
 "sWG" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
+/obj/effect/floor_decal/corner/dark_green/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
-/area/shuttle/freebooter_shuttle)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/forehallwayport)
 "sZw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -9691,20 +9691,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
-"vIj" = (
-/obj/effect/floor_decal/corner/dark_green/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1;
-	icon_state = "map-supply"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/forehallwayport)
 "vMG" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
@@ -45072,7 +45058,7 @@ amu
 amu
 amu
 elW
-sWG
+lKV
 qVW
 vOL
 vZW
@@ -45877,7 +45863,7 @@ xRX
 rrT
 oyG
 cnH
-ntt
+sWG
 lzb
 csG
 wIJ
@@ -46391,7 +46377,7 @@ wLV
 aMB
 qqX
 tyf
-vIj
+ntt
 oEs
 jcW
 tli
@@ -46614,7 +46600,7 @@ aSb
 kVa
 iTc
 elW
-sWG
+lKV
 cei
 vOL
 vZW

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -679,13 +679,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
-"aZC" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster2)
 "baj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/walnut,
@@ -1650,6 +1643,17 @@
 "dlZ" = (
 /turf/simulated/wall,
 /area/ship/freebooter_ship/gunneryentrance)
+"dmI" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster1)
+"dnc" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/firealarm/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "doC" = (
 /obj/effect/floor_decal/industrial/outline/service,
 /obj/effect/decal/cleanable/dirt,
@@ -3026,12 +3030,6 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/dorms)
-"gPS" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/machinery/firealarm/east,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster1)
 "gSo" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3917,6 +3915,11 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod8)
+"jkR" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "jlr" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
@@ -4077,6 +4080,12 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/medical)
+"jMa" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/firealarm/east,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster1)
 "jMu" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -4130,13 +4139,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/lockers)
-"jTM" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster1)
 "jUk" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -4513,6 +4515,7 @@
 /obj/machinery/alarm/east{
 	req_one_access = null
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "kEe" = (
@@ -5503,6 +5506,13 @@
 /obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
+"mOd" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster1)
 "mOF" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -5797,12 +5807,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
-"nuX" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/machinery/firealarm/west,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster2)
 "nwD" = (
 /obj/effect/floor_decal/corner{
 	dir = 8
@@ -6623,6 +6627,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
+"pbd" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "peJ" = (
 /obj/machinery/seed_storage/garden,
 /obj/effect/floor_decal/industrial/outline/service,
@@ -7344,9 +7352,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "qwx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/shuttle/space_ship/mercenary,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "qxl" = (
 /obj/effect/floor_decal/spline/plain{
@@ -7659,6 +7667,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
+"rfa" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "rfn" = (
 /obj/effect/floor_decal/corner/orange/full,
 /obj/machinery/autolathe,
@@ -7716,10 +7731,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
-"rmr" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster1)
 "rnp" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
@@ -9373,7 +9384,6 @@
 	target_pressure = 15000
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "vdz" = (
@@ -9389,10 +9399,6 @@
 "vdX" = (
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship)
-"vec" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster2)
 "veq" = (
 /obj/effect/floor_decal/corner/red/full{
 	dir = 4
@@ -39408,7 +39414,7 @@ xRX
 xRX
 vkx
 aKs
-rmr
+mOd
 tcI
 plx
 foU
@@ -39665,7 +39671,7 @@ xRX
 xRX
 vkx
 ugG
-jTM
+dmI
 lfb
 plx
 pfE
@@ -39921,8 +39927,8 @@ xRX
 xRX
 xRX
 hPM
+ugG
 qwx
-rmr
 jGn
 plx
 wMd
@@ -40179,7 +40185,7 @@ xRX
 xRX
 vkx
 xPD
-gPS
+jMa
 kCv
 wRm
 jvN
@@ -45833,7 +45839,7 @@ xRX
 xRX
 vFo
 nXu
-nuX
+dnc
 tjz
 pvL
 vhv
@@ -46090,7 +46096,7 @@ xRX
 xRX
 icO
 joM
-vec
+jkR
 jlr
 rXk
 tYU
@@ -46347,7 +46353,7 @@ xRX
 xRX
 vFo
 joM
-aZC
+pbd
 qgY
 rXk
 lqh
@@ -46604,7 +46610,7 @@ xRX
 xRX
 vFo
 aKF
-vec
+rfa
 lUK
 rXk
 ofb

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -2298,11 +2298,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/oil,
-/obj/item/trash/broken_electronics{
-	pixel_y = 8;
-	pixel_x = 5
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "eYO" = (
@@ -2571,9 +2566,6 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "fJo" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2589,6 +2581,9 @@
 	specialfunctions = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "fNl" = (
@@ -2716,6 +2711,12 @@
 	req_access = null
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod8)
 "fZq" = (
@@ -3168,7 +3169,10 @@
 	dir = 10
 	},
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod8)
 "hik" = (
 /obj/effect/floor_decal/corner/lime{
@@ -3470,6 +3474,9 @@
 	dir = 4;
 	id_tag = "freebooter_brig"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "iaK" = (
@@ -3650,9 +3657,6 @@
 "irq" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
-	},
-/obj/effect/floor_decal/corner{
-	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/bed/padded,
@@ -5069,18 +5073,14 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
 "lGK" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/miningcart,
 /obj/item/reagent_containers/food/snacks/tastybread,
 /obj/item/reagent_containers/food/snacks/tastybread,
 /obj/item/storage/box/produce{
 	layer = 2.99
+	},
+/obj/effect/floor_decal/corner/dark_blue/full{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -5427,6 +5427,11 @@
 /area/ship/freebooter_ship/pod4)
 "mCb" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/trash/broken_electronics{
+	pixel_y = 8;
+	pixel_x = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "mCl" = (
@@ -6030,7 +6035,7 @@
 /area/ship/freebooter_ship/pod3)
 "nYq" = (
 /obj/effect/floor_decal/corner/dark_blue{
-	dir = 1
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -6224,12 +6229,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
-"onn" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod8)
 "onx" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 4
@@ -6692,14 +6691,9 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod6)
 "pik" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner{
-	dir = 5
-	},
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/dark_blue/full,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "piw" = (
@@ -6999,10 +6993,10 @@
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
 	},
-/obj/effect/floor_decal/corner{
-	dir = 5
-	},
 /obj/structure/closet/crate/security,
+/obj/effect/floor_decal/corner{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "pOI" = (
@@ -8351,9 +8345,6 @@
 	},
 /area/shuttle/freebooter_shuttle)
 "sCd" = (
-/obj/effect/floor_decal/corner{
-	dir = 9
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -9249,9 +9240,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "uOr" = (
-/obj/effect/floor_decal/corner{
-	dir = 9
-	},
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9356,6 +9344,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "vbe" = (
@@ -9746,9 +9738,6 @@
 "vMG" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
-	},
-/obj/effect/floor_decal/corner{
-	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/machinery/light{
@@ -45879,9 +45868,9 @@ vOL
 xRX
 uwT
 fYr
-onn
+hil
 fJo
-nYq
+hil
 pMN
 uwT
 xRX
@@ -46395,7 +46384,7 @@ uwT
 lGK
 cFm
 uZC
-iok
+nYq
 pik
 uwT
 xRX
@@ -46650,7 +46639,7 @@ vOL
 vZW
 uwT
 vMG
-hil
+iok
 uOr
 sCd
 irq

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1318,7 +1318,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "cgU" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/ship/freebooter_ship/pod8)
 "ciM" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -3069,7 +3069,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall,
 /area/ship/freebooter_ship/pod8)
 "gVa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -3165,13 +3165,10 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
 "hhQ" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 10
-	},
-/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced,
 /obj/machinery/door/firedoor/noid{
 	dir = 8
 	},
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod8)
 "hik" = (
@@ -3242,9 +3239,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
-"htS" = (
-/turf/simulated/wall/shuttle/space_ship,
-/area/ship/freebooter_ship/pod8)
 "huE" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -44838,13 +44832,13 @@ clU
 nKq
 rmm
 xRX
-htS
+uwT
 lfg
 jFY
 sGi
 naw
 omd
-htS
+uwT
 xRX
 eiL
 kfX
@@ -46894,13 +46888,13 @@ btW
 mYn
 tOu
 xRX
-htS
+uwT
 hXO
 uwA
 kkT
 ivW
 mNi
-htS
+uwT
 xRX
 eiL
 aJd

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -7478,9 +7478,7 @@
 	frequency = 1336
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark{
-	frequency = 1336
-	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "qHK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -37,8 +37,8 @@
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/thruster2)
 "acn" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/structure/reagent_dispensers/extinguisher,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "acU" = (
@@ -66,6 +66,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
@@ -188,6 +191,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod2)
+"aqJ" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship)
 "ary" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -349,6 +363,9 @@
 	name = "Generator Compartment";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/engineering)
 "aEq" = (
@@ -460,14 +477,14 @@
 	},
 /area/shuttle/freebooter_shuttle)
 "aKs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "aKD" = (
 /obj/machinery/door/blast/shutters/open{
@@ -482,11 +499,11 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aKF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "aMa" = (
 /obj/effect/floor_decal/corner/lime{
@@ -818,6 +835,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "bpG" = (
@@ -879,6 +899,9 @@
 /area/ship/freebooter_ship/engineering)
 "btW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "buA" = (
@@ -993,6 +1016,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "bBW" = (
@@ -1007,6 +1031,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
@@ -1055,7 +1082,8 @@
 "bEH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/machinery/door/airlock/maintenance_hatch{
-	dir = 1
+	dir = 1;
+	name = "Fuel Input"
 	},
 /obj/structure/cable/yellow{
 	dir = 1;
@@ -1088,8 +1116,16 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
 "bPw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
@@ -1148,6 +1184,7 @@
 /area/ship/freebooter_ship/gunnery)
 "bWt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "caS" = (
@@ -1289,6 +1326,22 @@
 /obj/effect/shuttle_landmark/freebooter_ship,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
+"cCX" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/access_button{
+	pixel_x = -8;
+	pixel_y = 28;
+	dir = 8
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship)
 "cDf" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -1391,12 +1444,28 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
 "cNi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
+"cOq" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/map_effect/marker_helper/airlock/out,
+/turf/simulated/floor,
+/area/shuttle/freebooter_shuttle)
 "cQs" = (
 /obj/structure/cryofeed/pipes{
 	dir = 4
@@ -1453,10 +1522,8 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "dbA" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "dbV" = (
 /obj/structure/noticeboard{
@@ -1721,6 +1788,20 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/gunnery)
+"dTP" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/obj/structure/sign/vacuum{
+	pixel_y = 30
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship)
 "dWi" = (
 /obj/effect/floor_decal/corner{
 	dir = 6
@@ -1889,6 +1970,12 @@
 /obj/structure/cable/yellow{
 	dir = 8
 	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'HIGH VOLTAGE'";
+	icon_state = "shock";
+	name = "HIGH VOLTAGE";
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
 "ekP" = (
@@ -2019,15 +2106,14 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "ezV" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/structure/railing/mapped{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "eDX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2077,6 +2163,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/gunnery)
+"ePC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/structure/curtain/open/bed{
+	name = "curtain"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "eST" = (
 /turf/simulated/wall,
 /area/ship/freebooter_ship/pod7)
@@ -2206,14 +2302,16 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod7)
 "fjD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/effect/decal/fake_object{
+	desc = "A lightweight support lattice.";
+	icon = 'icons/obj/smooth/lattice.dmi';
+	icon_state = "lattice";
+	layer = 2.45;
+	name = "lattice"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6;
-	pixel_y = 0
-	},
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "fjW" = (
@@ -2241,10 +2339,14 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/gunnery)
 "foU" = (
-/obj/structure/janitorialcart/full,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/hydrogen,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "fpc" = (
@@ -2307,7 +2409,7 @@
 	},
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/door/airlock/atmos{
-	name = "Engineering Storage Compartment";
+	name = "Propellant Management";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -2457,6 +2559,17 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
+"fVQ" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship)
 "fXt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2514,13 +2627,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
 "gap" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/structure/railing/mapped{
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 4
 	},
-/obj/structure/railing/mapped{
-	dir = 1
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
@@ -2540,6 +2655,7 @@
 "ggq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
 "ggz" = (
@@ -2644,6 +2760,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
 "gwg" = (
@@ -2681,6 +2800,16 @@
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/access_button{
+	pixel_x = 8;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship)
 "gzr" = (
@@ -2723,10 +2852,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
 "gFA" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/light/small/emergency{
+	dir = 8
 	},
-/obj/machinery/firealarm/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "gGE" = (
@@ -2815,6 +2946,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/engineering)
+"gVf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "gVT" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
@@ -2849,12 +2985,14 @@
 /turf/simulated/floor/carpet/art,
 /area/ship/freebooter_ship/pod1)
 "hfM" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/railing/mapped{
-	dir = 1
+/obj/machinery/atmospherics/binary/pump/high_power{
+	name = "Thrusters to Canister";
+	target_pressure = 15000;
+	dir = 8
 	},
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "hgx" = (
 /obj/structure/noticeboard{
@@ -3012,6 +3150,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/holofloor/tiled/ramp/bottom,
 /area/ship/freebooter_ship/bridge)
+"hFU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship)
 "hFX" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -3047,16 +3199,24 @@
 	},
 /area/ship/freebooter_ship/pod1)
 "hLa" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "hPM" = (
 /obj/machinery/atmospherics/unary/engine,
@@ -3183,6 +3343,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
 "idP" = (
@@ -3211,6 +3374,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3405,6 +3571,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
 "iGK" = (
@@ -3578,6 +3747,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
+"jhJ" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship)
 "jhL" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/engineering)
@@ -3599,23 +3779,20 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod8)
 "jlr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
-	dir = 5
+	dir = 9
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "jnK" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 4;
-	layer = 2.8
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	dir = 1;
+	id_tag = "freebooter_thrust_out";
+	frequency = 1336
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/reinforced/carbon_dioxide,
 /area/ship/freebooter_ship/thruster1)
 "jrC" = (
 /obj/structure/railing/mapped{
@@ -3634,6 +3811,19 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship)
+"jvN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 4
+	},
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/thruster1)
 "jzk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -3702,15 +3892,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "jGn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
-	dir = 9
+	dir = 5
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "jJb" = (
 /obj/effect/floor_decal/corner/red{
@@ -4164,28 +4350,27 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod3)
 "kCv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9;
-	icon_state = "intact"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 1
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "kEe" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 9
+/obj/structure/railing/mapped{
+	dir = 4
 	},
+/obj/structure/railing/mapped,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/shuttle/freebooter_shuttle)
 "kHb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4274,6 +4459,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "kPY" = (
@@ -4327,9 +4513,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod2)
 "kSC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 6
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/terminal{
 	dir = 1
@@ -4337,16 +4520,16 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
 "kTf" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 1;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/freebooter_shuttle)
 "kUE" = (
 /obj/structure/closet/crate/hydroponics,
@@ -4402,12 +4585,12 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod5)
 "lfb" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 4;
-	layer = 2.8
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "lfg" = (
 /obj/effect/floor_decal/corner/dark_blue/full{
@@ -4433,10 +4616,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "lgr" = (
-/obj/effect/floor_decal/industrial/loading/yellow{
-	dir = 1
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4;
+	layer = 2.8
 	},
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/industrial/hatch/grey,
+/turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "lgM" = (
 /obj/effect/floor_decal/corner/dark_blue/full{
@@ -4575,6 +4760,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship)
 "lvR" = (
@@ -4620,10 +4812,26 @@
 /obj/item/tank/jetpack/carbondioxide,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
+"lxC" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "lzu" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/obj/structure/sign/vacuum{
+	pixel_y = 30
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -4781,12 +4989,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/engineering)
 "lUK" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "mbg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
@@ -4820,11 +5028,21 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/firealarm/south,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
@@ -4877,6 +5095,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
 "mjX" = (
@@ -4886,6 +5107,13 @@
 /area/ship/freebooter_ship/pod5)
 "mkb" = (
 /obj/machinery/door/airlock/external,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "moJ" = (
@@ -4931,6 +5159,21 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
+"mto" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/bed/stool/chair/shuttle{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/turf/simulated/floor,
+/area/shuttle/freebooter_shuttle)
 "mtT" = (
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 4
@@ -5261,6 +5504,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
 "nmL" = (
@@ -5409,8 +5655,23 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
+"nxK" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship)
 "nyh" = (
 /obj/effect/floor_decal/corner/beige,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -5430,14 +5691,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "nCr" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	layer = 2.45;
-	name = "lattice"
+/obj/machinery/atmospherics/binary/pump/high_power{
+	layer = 2.8;
+	target_pressure = 15000;
+	name = "Canister to Tank"
 	},
-/turf/simulated/floor,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "nDn" = (
 /turf/simulated/floor/wood/walnut,
@@ -5545,15 +5806,16 @@
 /turf/template_noop,
 /area/space)
 "nXu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "nXA" = (
 /obj/effect/floor_decal/corner/lime{
@@ -5632,6 +5894,11 @@
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship)
 "odX" = (
@@ -5786,6 +6053,12 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/thruster2)
+"osW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/shuttle/freebooter_shuttle)
 "ovG" = (
 /obj/item/stack/tile/floor_dark,
 /obj/structure/barricade/wooden{
@@ -5878,6 +6151,26 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/bridge)
+"oBO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/obj/machinery/light{
+	dir = 4;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor,
+/area/shuttle/freebooter_shuttle)
 "oBX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -5909,17 +6202,21 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
 "oHt" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/structure/railing/mapped{
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/oil,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "oHP" = (
@@ -5960,6 +6257,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
@@ -6110,8 +6410,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "peJ" = (
 /obj/machinery/seed_storage/garden,
@@ -6137,7 +6444,10 @@
 /area/ship/freebooter_ship/foyer)
 "pfE" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/extinguisher_cabinet/north,
+/obj/machinery/portable_atmospherics/canister/sleeping_agent,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "pih" = (
 /obj/machinery/shower{
@@ -6208,7 +6518,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
 "plx" = (
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/ship/freebooter_ship/thruster1)
 "plG" = (
 /obj/effect/floor_decal/corner/red{
@@ -6230,10 +6540,28 @@
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/thruster2)
+"pnk" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship)
 "pob" = (
 /obj/machinery/computer/ship/sensors,
-/obj/machinery/alarm/east{
-	req_one_access = null
+/obj/machinery/light{
+	dir = 4;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
@@ -6321,8 +6649,15 @@
 	name = "Propulsion";
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster2)
+"pxD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 6
+	},
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/shuttle/freebooter_shuttle)
 "pzX" = (
 /obj/structure/toilet,
 /obj/effect/floor_decal/corner{
@@ -6381,6 +6716,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
 "pDZ" = (
@@ -6419,7 +6757,7 @@
 "pHN" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "pMN" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -6651,11 +6989,11 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship)
 "qgY" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "qiz" = (
 /turf/simulated/wall/shuttle/space_ship{
@@ -6710,6 +7048,7 @@
 	dir = 2;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
 "qoJ" = (
@@ -6796,9 +7135,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "qwx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "qxl" = (
 /obj/effect/floor_decal/spline/plain{
@@ -6940,15 +7279,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "qFl" = (
-/obj/effect/floor_decal/corner/brown/full{
-	dir = 1
+/obj/machinery/computer/general_air_control/large_tank_control{
+	name = "Carbon Dioxide Supply Monitor";
+	sensors = list("freebooter_thrust_sensor"="Tank");
+	input_tag = "freebooter_thrust_in";
+	output_tag = "freebooter_thrust_out"
 	},
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "qHK" = (
@@ -7055,11 +7398,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "qUV" = (
-/obj/effect/floor_decal/industrial/loading/yellow{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/full,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "qVW" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -7073,12 +7423,13 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship)
 "qWF" = (
-/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
-	dir = 4
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 1;
+	frequency = 1336;
+	icon_state = "map_injector";
+	id = "freebooter_thrust_in"
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/reinforced/carbon_dioxide,
 /area/ship/freebooter_ship/thruster1)
 "raF" = (
 /obj/effect/landmark/entry_point/port{
@@ -7182,6 +7533,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "rpZ" = (
@@ -7194,6 +7546,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
@@ -7270,17 +7625,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "rvC" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/structure/sign/securearea{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/unary/heater,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "rzA" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 32
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -7288,10 +7639,11 @@
 	dir = 8;
 	layer = 2.71
 	},
-/obj/machinery/light{
-	dir = 1;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
+/obj/machinery/alarm/north{
+	req_one_access = null
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
@@ -7312,15 +7664,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "rAU" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
 	icon = 'icons/obj/smooth/lattice.dmi';
 	icon_state = "lattice";
 	layer = 2.45;
 	name = "lattice"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -7329,6 +7681,16 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/access_button{
+	pixel_x = 30;
+	pixel_y = 8
+	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "rEb" = (
@@ -7480,6 +7842,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
+"rXk" = (
+/turf/simulated/wall/r_wall,
+/area/ship/freebooter_ship/thruster2)
 "rXx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7488,6 +7853,15 @@
 	name = "aft, engines"
 	},
 /obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
 "rYv" = (
@@ -7545,6 +7919,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
+"skr" = (
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 1;
+	layer = 2.8;
+	name = "Tank to Thrusters";
+	target_pressure = 15000
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/thruster1)
 "soh" = (
 /turf/simulated/floor,
 /area/ship/freebooter_ship/gunnery)
@@ -7558,6 +7952,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/valve/open{
+	dir = 4;
+	name = "Fuel Line Merge Valve"
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
@@ -7613,6 +8011,7 @@
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "svN" = (
@@ -7678,6 +8077,12 @@
 /area/ship/freebooter_ship/pod5)
 "syX" = (
 /obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "szY" = (
@@ -7856,6 +8261,19 @@
 /area/ship/freebooter_ship/pod6)
 "sVT" = (
 /obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = -30;
+	pixel_y = -2
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 5
+	},
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
 "sWG" = (
@@ -7885,18 +8303,28 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "tcI" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4;
-	layer = 2.8
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "tcV" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_x = 23;
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -7912,18 +8340,9 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
 "tjz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 1
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "tld" = (
 /obj/structure/table/steel,
@@ -8092,7 +8511,6 @@
 /area/ship/freebooter_ship)
 "tDp" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/railing/mapped,
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -8186,6 +8604,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
+"tSV" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4;
+	layer = 2.8
+	},
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/thruster1)
 "tSZ" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/decal/cleanable/dirt,
@@ -8328,9 +8757,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ugG" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/railing/mapped,
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/freebooter_shuttle)
 "uhG" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -8384,6 +8812,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
+"ukw" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4;
+	layer = 2.8
+	},
+/obj/effect/floor_decal/industrial/hatch/grey,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/thruster1)
 "ulo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plating,
@@ -8442,6 +8878,12 @@
 /obj/structure/ship_weapon_dummy,
 /turf/template_noop,
 /area/ship/freebooter_ship)
+"uAI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "uCl" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
@@ -8451,7 +8893,9 @@
 /area/ship/freebooter_ship)
 "uDc" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/binary/pump/high_power,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	name = "Canister to Thrusters"
+	},
 /obj/structure/cable/yellow{
 	dir = 1;
 	icon_state = "1-2"
@@ -8599,6 +9043,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
 "uWn" = (
@@ -8665,18 +9112,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "vdj" = (
-/obj/machinery/power/apc/west{
-	req_access = null
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4;
+	name = "Canister to Thrusters";
+	target_pressure = 15000
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/corner/brown/full,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/emergency{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "vdz" = (
 /obj/structure/railing/mapped{
@@ -8860,6 +9303,7 @@
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "viT" = (
@@ -8947,7 +9391,8 @@
 /area/ship/freebooter_ship/bridge)
 "vxO" = (
 /obj/machinery/door/airlock/maintenance_hatch{
-	dir = 1
+	dir = 1;
+	name = "Thrust Control"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled/dark/full,
@@ -8998,10 +9443,25 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
-"vIj" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
+"vHg" = (
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
 /turf/simulated/floor,
+/area/ship/freebooter_ship)
+"vIj" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "vMG" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -9165,16 +9625,23 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
+"vZV" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster1)
 "vZW" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/rods,
 /turf/template_noop,
 /area/ship/freebooter_ship)
 "wcN" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/stool/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "wdp" = (
 /obj/structure/railing/mapped{
@@ -9241,9 +9708,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "wmT" = (
-/obj/structure/reagent_dispensers/extinguisher,
-/obj/effect/floor_decal/industrial/outline/firefighting_closet,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/heater,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "wnf" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -9331,11 +9801,12 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/gunnery)
 "wxS" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
+/obj/machinery/air_sensor{
+	id_tag = "freebooter_thrust_sensor";
+	frequency = 1336;
+	output = 31
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/reinforced/carbon_dioxide,
 /area/ship/freebooter_ship/thruster1)
 "wyp" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
@@ -9417,6 +9888,17 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "wMd" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/north{
+	req_access = null
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "wMH" = (
@@ -9457,13 +9939,11 @@
 /area/ship/freebooter_ship/pod1)
 "wRm" = (
 /obj/machinery/door/firedoor/noid,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/hatch{
 	name = "Propulsion";
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "wTo" = (
@@ -9581,6 +10061,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
 "xbK" = (
@@ -9607,6 +10090,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "xfg" = (
@@ -9647,6 +10132,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
@@ -9741,12 +10229,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod2)
 "xHX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
-	dir = 4
-	},
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/black,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "xIQ" = (
@@ -9807,11 +10293,11 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "xPD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "xPX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9825,6 +10311,16 @@
 /area/ship/freebooter_ship/pod6)
 "xQS" = (
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/structure/sign/vacuum{
+	pixel_y = 30
+	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship)
 "xRt" = (
@@ -9855,17 +10351,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
 "xUb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	layer = 2.45;
-	name = "lattice"
-	},
-/turf/simulated/floor,
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "xWB" = (
 /obj/machinery/door/firedoor/noid,
@@ -38602,11 +39090,11 @@ aKs
 tcI
 plx
 foU
-ezV
+ukw
 lgr
-ezV
-lgr
-vdj
+tSV
+gFA
+ewW
 ewW
 ewW
 fGM
@@ -38860,10 +39348,10 @@ lfb
 plx
 pfE
 hfM
-lgr
+vdj
 ezV
 nCr
-pab
+xUb
 qWF
 ewW
 xRX
@@ -39112,14 +39600,14 @@ xRX
 xRX
 xRX
 hPM
-qwx
+vZV
 jGn
 plx
 wMd
 gap
 qUV
 oHt
-lgr
+skr
 xUb
 jnK
 ewW
@@ -39372,7 +39860,7 @@ vkx
 xPD
 kCv
 wRm
-bPw
+jvN
 bPw
 cNi
 fjD
@@ -39634,7 +40122,7 @@ ewW
 qFl
 wcN
 mdy
-gFA
+ewW
 ewW
 ewW
 xRX
@@ -39890,7 +40378,7 @@ xRX
 ewW
 ewW
 rvC
-xdo
+pab
 acn
 ewW
 xRX
@@ -42726,15 +43214,15 @@ wyp
 kXG
 vGw
 wGc
-gyl
-gyl
+cCX
+fVQ
 wGc
 vGw
 vGw
 vGw
 wGc
-gyl
-odb
+cCX
+hFU
 wGc
 wyp
 vGw
@@ -42983,8 +43471,8 @@ xRX
 vZW
 xRX
 wGc
-xQS
-xQS
+dTP
+nxK
 wGc
 xRX
 xRX
@@ -43240,15 +43728,15 @@ xRX
 fGM
 xRX
 wGc
-xQS
-xQS
+pnk
+jhJ
 wGc
 xRX
 xRX
 xRX
 wGc
-xQS
-lvN
+pnk
+vHg
 wGc
 xRX
 xRX
@@ -43498,7 +43986,7 @@ fGM
 fGM
 wGc
 gyl
-gyl
+aqJ
 wGc
 kqx
 aOU
@@ -44529,11 +45017,11 @@ aEB
 aSb
 iCP
 bFv
-nRY
+uAI
 rHI
 aSb
 lzu
-lzu
+mto
 aSb
 qeJ
 vOL
@@ -44790,7 +45278,7 @@ btW
 rAU
 mkb
 syX
-syX
+cOq
 sVT
 oSp
 vOL
@@ -45047,7 +45535,7 @@ nxF
 kPW
 rDZ
 tcV
-tcV
+oBO
 rXx
 cJt
 vOL
@@ -45280,9 +45768,9 @@ xRX
 xRX
 xRX
 icO
-vIj
+lxC
 jlr
-rFB
+rXk
 tYU
 rkc
 ace
@@ -45302,10 +45790,10 @@ aSb
 aSb
 rzA
 yeH
-aSb
-kTf
+pxD
 ugG
-aEB
+ugG
+kTf
 hhA
 vOL
 xRX
@@ -45539,7 +46027,7 @@ xRX
 vFo
 vIj
 qgY
-rFB
+rXk
 lqh
 rkc
 wCl
@@ -45558,11 +46046,11 @@ aSb
 aSb
 ejm
 kSC
-amu
-amu
+gVf
+ePC
 bck
 tDp
-aEB
+aSb
 hhA
 vOL
 xRX
@@ -45796,7 +46284,7 @@ xRX
 vFo
 aKF
 lUK
-rFB
+rXk
 ofb
 pml
 pml
@@ -45816,7 +46304,7 @@ bEH
 qnz
 ggq
 aSb
-aSb
+osW
 iTc
 elW
 sWG

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -134,19 +134,22 @@
 /area/ship/freebooter_ship/pod3)
 "ajO" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 1
+	layer = 2.71;
+	dir = 9
 	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "akg" = (
-/obj/structure/sign/poster{
-	pixel_y = 32
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
@@ -166,13 +169,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/engineering)
-"anz" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "junker_gun"
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/gunnery)
 "aok" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -292,6 +288,13 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
+"ayL" = (
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 10
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -331,20 +334,24 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
 /obj/item/hullbeacon/red,
+/obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
+"aDe" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed/pipes{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/freebooter_ship/cryo)
 "aDv" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, main gun"
@@ -389,6 +396,23 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
+"aEE" = (
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 5
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "aFI" = (
 /obj/item/stack/tile/floor_dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -552,8 +576,18 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aOU" = (
-/obj/structure/lattice/catwalk,
-/turf/space/dynamic,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -715,17 +749,8 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "bcf" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/gunneryentrance)
 "bci" = (
 /obj/machinery/appliance/cooker/grill,
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -940,6 +965,7 @@
 	master_tag = "freebooter_port_2"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "btH" = (
@@ -958,15 +984,25 @@
 /obj/item/clothing/gloves/yellow/specialu,
 /obj/item/clothing/gloves/yellow/specialt,
 /obj/item/device/multitool,
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
 "btW" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 8
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/freebooter_shuttle)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "buA" = (
 /obj/structure/flora/pottedplant{
 	dead = 1;
@@ -1067,6 +1103,7 @@
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "bzr" = (
@@ -1179,6 +1216,9 @@
 	layer = 2.45;
 	name = "lattice"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "bJc" = (
@@ -1190,6 +1230,7 @@
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "bJj" = (
@@ -1274,22 +1315,12 @@
 	icon_state = "dmg4"
 	},
 /area/ship/freebooter_ship/ammo)
-"bUy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm/north,
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/forehallway)
 "bWt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /obj/machinery/light{
 	dir = 8;
 	inserted_light = /obj/item/light/tube/colored/blue;
@@ -1602,6 +1633,10 @@
 /area/ship/freebooter_ship/foyer)
 "dbA" = (
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced,
+/obj/machinery/door/blast/regular/open{
+	dir = 8;
+	id = "freebooter_co2_shutters"
+	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "dbV" = (
@@ -1622,10 +1657,6 @@
 "dgS" = (
 /obj/machinery/computer/ship/navigation{
 	dir = 4
-	},
-/obj/machinery/light{
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
@@ -1691,12 +1722,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
 "dqF" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 4
-	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/shuttle/freebooter_shuttle)
+/turf/simulated/wall,
+/area/ship/freebooter_ship/medical)
 "drK" = (
 /turf/simulated/wall/shuttle/space_ship{
 	color = "#E14644"
@@ -1844,11 +1871,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod1)
 "dOw" = (
@@ -1989,13 +2011,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
 "edN" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 5
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/area/shuttle/freebooter_shuttle)
 "efd" = (
 /obj/structure/inflatable/wall,
 /obj/effect/landmark/entry_point/port{
@@ -2182,9 +2203,8 @@
 	dir = 8
 	},
 /obj/structure/bed/roller,
-/obj/effect/floor_decal/industrial/outline/security,
 /obj/structure/closet/walllocker/medical{
-	name = "i hope we dont have to open this (Surgical Closet)";
+	name = "I hope we don't have to open this (Surgical Closet)";
 	pixel_y = 32
 	},
 /obj/item/surgery/circular_saw,
@@ -2195,24 +2215,10 @@
 /obj/item/wrench,
 /obj/item/tape_roll,
 /obj/item/stack/cable_coil,
+/obj/item/reagent_containers/inhaler/soporific,
+/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/medical)
-"ezi" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/access_button{
-	pixel_x = -8;
-	pixel_y = 28;
-	dir = 8
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/foyer)
 "ezT" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -2411,17 +2417,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod7)
-"fjs" = (
-/obj/machinery/cryopod,
-/obj/structure/cryofeed/pipes{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/cryo)
 "fjD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
@@ -2474,7 +2469,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/firealarm/south,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -2484,6 +2478,10 @@
 	icon_state = "lattice";
 	layer = 2.45;
 	name = "lattice"
+	},
+/obj/machinery/light{
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
@@ -2530,6 +2528,9 @@
 	name = "Propellant Management";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/engineering)
 "fBb" = (
@@ -2549,8 +2550,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fGM" = (
+/obj/structure/lattice/catwalk,
 /turf/space/dynamic,
-/area/space)
+/area/ship/freebooter_ship/exterior)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -2575,6 +2577,9 @@
 	dir = 4
 	},
 /obj/effect/overmap/visitable/ship/landable/freebooter_shuttle,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "fNZ" = (
@@ -2868,6 +2873,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
+"guH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/forehallway)
 "gwg" = (
 /turf/simulated/wall/shuttle/space_ship{
 	color = "#E14644"
@@ -2901,16 +2921,17 @@
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
 /obj/machinery/access_button{
 	pixel_x = -8;
 	pixel_y = 28;
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "gzr" = (
@@ -3696,15 +3717,11 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/obj/structure/railing/mapped{
-	dir = 8
-	},
 /obj/item/hullbeacon/red,
 /obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 9
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/effect/floor_decal/industrial/warning{
 	layer = 2.71
 	},
 /turf/simulated/floor/airless,
@@ -3744,9 +3761,10 @@
 /area/ship/freebooter_ship/gunnery)
 "iOV" = (
 /obj/machinery/door/blast/regular/open{
-	dir = 2;
+	dir = 4;
 	id = "junker_gun"
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/gunnery)
 "iQg" = (
@@ -3771,6 +3789,12 @@
 /obj/item/ammo_casing/rifle/used,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
+"iRt" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "iTc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 10
@@ -3891,6 +3915,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
+"jlF" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/forehallwayport)
 "jnK" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	dir = 1;
@@ -3905,8 +3932,11 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "jrC" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/medical)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "jvN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -3915,6 +3945,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "jzk" = (
@@ -4245,21 +4276,8 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "kqx" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/medical)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
 /obj/effect/decal/cleanable/dirt,
@@ -4465,10 +4483,6 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "kEe" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/structure/railing/mapped,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
@@ -4479,24 +4493,11 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
-"kFh" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/machinery/access_button{
-	pixel_x = 8;
-	pixel_y = 28;
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/foyer)
 "kHb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4537,17 +4538,14 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
 /obj/item/hullbeacon/red,
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
 	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
@@ -4577,10 +4575,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "kPY" = (
@@ -4780,7 +4778,7 @@
 "llB" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
-	dir = 4
+	dir = 5
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
@@ -4969,6 +4967,10 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	layer = 2.71;
 	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	layer = 2.71
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
@@ -5160,7 +5162,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/firealarm/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
 	},
@@ -5169,6 +5170,12 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	name = "Port Propulsion Blast Shutters";
+	id = "freebooter_co2_shutters";
+	pixel_x = null;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
@@ -5240,6 +5247,7 @@
 	shuttle_tag = "Freebooter Shuttle"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "moJ" = (
@@ -5773,7 +5781,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 8
 	},
@@ -5878,6 +5885,19 @@
 "nRY" = (
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
+"nSY" = (
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "nVi" = (
 /obj/structure/table/steel,
 /obj/item/storage/firstaid/fire{
@@ -5896,6 +5916,10 @@
 	},
 /obj/item/storage/firstaid/trauma{
 	pixel_x = -4
+	},
+/obj/item/reagent_containers/hypospray{
+	pixel_x = -3;
+	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/medical)
@@ -5989,10 +6013,6 @@
 /obj/machinery/computer/ship/helm{
 	dir = 8
 	},
-/obj/machinery/light{
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
 "obe" = (
@@ -6002,6 +6022,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
+"obM" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor,
+/area/shuttle/freebooter_shuttle)
 "odb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6014,6 +6039,7 @@
 	master_tag = "freebooter_port_2"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "odX" = (
@@ -6052,6 +6078,7 @@
 	name = "graphite locker";
 	pixel_y = 32
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "ofV" = (
@@ -6434,6 +6461,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
+"oQl" = (
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	id = "junker_gun"
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/gunnery)
 "oRN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /obj/machinery/meter,
@@ -6865,12 +6900,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
-"pJZ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "pMN" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -7458,9 +7487,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
 "qMB" = (
@@ -7607,6 +7634,10 @@
 	layer = 2.71;
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 4
+	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
 "rjL" = (
@@ -7694,7 +7725,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
 "rsh" = (
@@ -7733,6 +7763,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
+"rtO" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunneryentrance)
 "ruo" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -7803,8 +7836,8 @@
 	layer = 2.45;
 	name = "lattice"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -7828,6 +7861,7 @@
 	pixel_y = 9;
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "rEb" = (
@@ -7896,18 +7930,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "rHI" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4;
+	layer = 2.8
 	},
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/northleft,
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 4
-	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "rJT" = (
@@ -7966,15 +7993,14 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod5)
 "rQJ" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+	dir = 1
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/shuttle/freebooter_shuttle)
 "rRa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -8002,6 +8028,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
 "rYv" = (
@@ -8046,9 +8073,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod2)
-"sek" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/gunneryentrance)
 "sjD" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -8358,16 +8382,14 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
 /obj/item/hullbeacon/red,
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
-	dir = 9
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
@@ -8415,6 +8437,7 @@
 	pixel_x = -40;
 	pixel_y = -3
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
 "sWG" = (
@@ -8471,6 +8494,23 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
+"tcX" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/access_button{
+	pixel_x = 8;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "tcY" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 8
@@ -8600,6 +8640,7 @@
 /area/ship/freebooter_ship/pod3)
 "tuB" = (
 /obj/machinery/computer/shuttle_control/explore/freebooter_shuttle,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "tuT" = (
@@ -8798,22 +8839,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/dorms)
-"tVP" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
 "tXx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 9
@@ -8983,11 +9008,6 @@
 	layer = 2.8
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
-/obj/machinery/light{
-	dir = 8;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "ulo" = (
@@ -9071,10 +9091,12 @@
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "uFc" = (
-/obj/structure/railing/mapped{
+/obj/machinery/iff_beacon/name_change,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
 	dir = 1
 	},
-/obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
 "uGz" = (
@@ -9091,16 +9113,17 @@
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
 /obj/machinery/access_button{
 	pixel_x = 8;
 	pixel_y = 28;
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "uJN" = (
@@ -9607,10 +9630,6 @@
 /area/ship/freebooter_ship/thruster2)
 "vDD" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	dir = 2;
 	pixel_y = 28;
@@ -9618,6 +9637,10 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -9815,8 +9838,17 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "vZW" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/medical)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod1)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/stool/chair{
@@ -9825,13 +9857,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "wdp" = (
-/obj/structure/railing/mapped{
+/obj/machinery/shipsensors/weak,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
 	dir = 1
 	},
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/machinery/shipsensors/weak,
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
 "wdL" = (
@@ -9894,20 +9925,13 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/head)
 "wmT" = (
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/heater,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "wnf" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
-	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/shuttle/freebooter_shuttle)
+/turf/space/dynamic,
+/area/space)
 "wnq" = (
 /obj/structure/table/steel,
 /obj/item/gun/projectile/automatic/improvised,
@@ -9966,8 +9990,7 @@
 	layer = 2.71;
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/airless,
@@ -10021,8 +10044,12 @@
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "wGc" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/forehallwayport)
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "wHo" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/ship_engine.dmi';
@@ -10237,9 +10264,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod3)
-"wZp" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunneryentrance)
 "wZX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/rifle/used,
@@ -10296,6 +10320,23 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
+"xcD" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	pixel_x = -8;
+	pixel_y = 28;
+	dir = 8
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "xcR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10330,6 +10371,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/light/small/emergency{
 	dir = 4
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
+"xfP" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -10600,6 +10657,10 @@
 "xUb" = (
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/blast/regular/open{
+	dir = 8;
+	id = "freebooter_co2_shutters"
+	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "xWB" = (
@@ -10671,10 +10732,9 @@
 	layer = 2.71
 	},
 /obj/machinery/atmospherics/portables_connector{
-	layer = 2.8;
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "ygA" = (
@@ -37816,7 +37876,7 @@ xRX
 xRX
 xRX
 uCl
-fGM
+wnf
 uCl
 fZq
 xRX
@@ -38330,7 +38390,7 @@ xRX
 rtf
 vUu
 uyM
-fGM
+wnf
 aHs
 xRX
 xRX
@@ -38563,17 +38623,17 @@ xRX
 xRX
 xRX
 xRX
-aOU
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
+fGM
 eIb
 wUi
 ldw
 wUi
 eIb
-aOU
-aOU
+fGM
+fGM
 esB
 gwg
 esB
@@ -38581,32 +38641,32 @@ wHo
 esB
 gwg
 esB
-aOU
-aOU
+fGM
+fGM
 cLC
 cLC
 kwe
 tKj
 tKj
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
 qiz
 qiz
 mWz
 qiz
 qiz
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
 eUq
 eUq
 pRf
 eUq
 eUq
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
 xRX
 xRX
 xRX
@@ -38819,8 +38879,8 @@ xRX
 xRX
 xRX
 xRX
-aOU
-aOU
+fGM
+fGM
 xRX
 xRX
 eIb
@@ -38863,7 +38923,7 @@ fTG
 eUq
 eUq
 xRX
-aOU
+fGM
 xqI
 xqI
 xqI
@@ -38875,9 +38935,9 @@ imE
 imE
 imE
 imE
+oQl
+oQl
 iOV
-iOV
-anz
 xRX
 xRX
 xRX
@@ -39134,7 +39194,7 @@ rjL
 tQn
 sxw
 www
-anz
+iOV
 xRX
 xRX
 xRX
@@ -39335,8 +39395,8 @@ gFA
 ewW
 ewW
 ewW
-aOU
-aOU
+fGM
+fGM
 wUi
 syV
 bhd
@@ -39344,7 +39404,7 @@ xBh
 bhd
 tvh
 wUi
-aOU
+fGM
 gwg
 pUP
 kmP
@@ -39352,7 +39412,7 @@ qDn
 kev
 jcX
 gwg
-aOU
+fGM
 cLC
 wZf
 ttI
@@ -39360,7 +39420,7 @@ krH
 lKT
 vmX
 cLC
-aOU
+fGM
 qiz
 pYB
 bPT
@@ -39368,7 +39428,7 @@ jzk
 fRD
 buM
 qiz
-aOU
+fGM
 eUq
 aTX
 iUK
@@ -39376,8 +39436,8 @@ iUK
 iUK
 fTT
 eUq
-aOU
-aOU
+fGM
+fGM
 xqI
 ahD
 kfJ
@@ -39391,7 +39451,7 @@ fNl
 tQn
 sxw
 sxw
-anz
+iOV
 xRX
 xRX
 xRX
@@ -39593,7 +39653,7 @@ xUb
 qWF
 ewW
 xRX
-aOU
+fGM
 wUi
 syV
 bhd
@@ -39642,13 +39702,13 @@ npb
 oxR
 tfK
 sxk
-ajO
+jrC
 soh
 soh
 aDv
+oQl
+oQl
 iOV
-iOV
-anz
 xRX
 xRX
 xRX
@@ -39850,7 +39910,7 @@ xUb
 jnK
 ewW
 xRX
-aOU
+fGM
 wUi
 syV
 grD
@@ -39900,8 +39960,8 @@ jhd
 tfK
 nwH
 wLI
-pJZ
-pJZ
+iRt
+iRt
 fnE
 xRX
 xRX
@@ -40107,7 +40167,7 @@ dbA
 wxS
 ewW
 xRX
-aOU
+fGM
 eIb
 oPu
 bhd
@@ -40149,7 +40209,7 @@ cEH
 eUq
 xRX
 xRX
-aOU
+fGM
 xqI
 xqI
 tfK
@@ -40364,7 +40424,7 @@ ewW
 ewW
 ewW
 xRX
-aOU
+fGM
 wUi
 cLL
 bhd
@@ -40401,18 +40461,18 @@ eUq
 lnp
 heP
 iUK
-qpm
+vZW
 avE
 eUq
 xRX
 xRX
-aOU
+fGM
 xRX
-sek
+bcf
 rEb
 xTu
 cbE
-wZp
+rtO
 klp
 llD
 euj
@@ -40621,7 +40681,7 @@ acn
 ewW
 xRX
 xRX
-aOU
+fGM
 wUi
 glJ
 ihN
@@ -40663,10 +40723,10 @@ hIE
 eUq
 xRX
 xRX
-aOU
+fGM
 xRX
-sek
-sek
+bcf
+bcf
 jgM
 vVy
 aMQ
@@ -40878,7 +40938,7 @@ pHN
 ewW
 xRX
 xRX
-aOU
+fGM
 wUi
 wNA
 bhd
@@ -40920,13 +40980,13 @@ iUK
 eUq
 xRX
 xRX
-aOU
+fGM
 xRX
 xRX
-sek
-sek
+bcf
+bcf
 tmo
-wZp
+rtO
 mwo
 mwo
 mwo
@@ -41135,7 +41195,7 @@ lJH
 jhL
 jhL
 xRX
-aOU
+fGM
 wUi
 peJ
 bhd
@@ -41177,18 +41237,18 @@ mtT
 eUq
 xRX
 xRX
-aOU
+fGM
 xRX
 xRX
 xRX
 uLO
 ebn
 atj
-jrC
+dqF
 exg
 iGK
 aBD
-vZW
+kqx
 xRX
 xRX
 xRX
@@ -41392,7 +41452,7 @@ pCG
 iZM
 jhL
 jhL
-aOU
+fGM
 eIb
 eIb
 pPk
@@ -41434,7 +41494,7 @@ eUq
 eUq
 xRX
 xRX
-aOU
+fGM
 xRX
 xRX
 xRX
@@ -41445,7 +41505,7 @@ jLL
 aab
 qDe
 nVi
-vZW
+kqx
 saW
 xRX
 xRX
@@ -41649,61 +41709,61 @@ mhq
 tcY
 rfn
 jhL
-aOU
-aOU
+fGM
+fGM
 eIb
 eIb
 qEc
 eIb
 eIb
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
 gwg
 wzO
 dXK
 wzO
 gwg
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
 cLC
 cLC
 mbX
 cLC
 cLC
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
 qiz
 qiz
 dFi
 qiz
 qiz
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
 eUq
 eUq
 wRc
 eUq
 eUq
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
 pvm
 kou
 dWF
-jrC
+dqF
 gLO
 npJ
 kAt
 lpe
-vZW
+kqx
 xRX
 xRX
 xRX
@@ -41907,18 +41967,10 @@ jbh
 tYn
 jhL
 xRX
-aOU
+fGM
 xRX
 wyp
-kqx
-wyp
-xRX
-xRX
-xRX
-xRX
-xRX
-wyp
-kqx
+btW
 wyp
 xRX
 xRX
@@ -41926,7 +41978,7 @@ xRX
 xRX
 xRX
 wyp
-kqx
+btW
 wyp
 xRX
 xRX
@@ -41934,7 +41986,7 @@ xRX
 xRX
 xRX
 wyp
-kqx
+btW
 wyp
 xRX
 xRX
@@ -41942,25 +41994,33 @@ xRX
 xRX
 xRX
 wyp
-kqx
+btW
 wyp
 xRX
 xRX
 xRX
 xRX
-aOU
+xRX
+wyp
+btW
+wyp
+xRX
+xRX
+xRX
+xRX
+fGM
 xRX
 xRX
 xRX
 pvm
 vfD
 kOP
-jrC
-jrC
+dqF
+dqF
 tra
-vZW
-jrC
-vZW
+kqx
+dqF
+kqx
 ydf
 ewy
 ewy
@@ -42164,7 +42224,7 @@ rRa
 nKC
 jhL
 xRX
-aOU
+fGM
 xRX
 wyp
 mGn
@@ -42205,12 +42265,12 @@ xRX
 xRX
 xRX
 xRX
-aOU
+fGM
 xRX
 xRX
 xRX
 uLO
-bUy
+qIf
 kbX
 kzS
 kvJ
@@ -43452,14 +43512,14 @@ wyp
 kXG
 vGw
 wyp
-gyl
+xcD
 bzm
 wyp
 vGw
 vGw
 vGw
 wyp
-ezi
+gyl
 odb
 wyp
 wyp
@@ -43495,7 +43555,7 @@ vGw
 wyp
 wyp
 uLO
-qIf
+guH
 fZr
 wUa
 oKE
@@ -43706,7 +43766,7 @@ pkY
 bJj
 jhL
 xRX
-aOU
+fGM
 xRX
 wyp
 bhA
@@ -43747,7 +43807,7 @@ xRX
 xRX
 xRX
 xRX
-aOU
+fGM
 xRX
 xRX
 xRX
@@ -43963,17 +44023,17 @@ doW
 nEK
 jhL
 xRX
-aOU
+fGM
 xRX
 wyp
-tVP
+vDD
 xvT
 wyp
 xRX
 xRX
 xRX
 wyp
-vDD
+xfP
 bsf
 wyp
 xRX
@@ -43982,7 +44042,7 @@ xRX
 xRX
 xRX
 wyp
-kqx
+btW
 wyp
 xRX
 xRX
@@ -43990,7 +44050,7 @@ xRX
 xRX
 xRX
 wyp
-kqx
+btW
 wyp
 xRX
 xRX
@@ -43998,13 +44058,13 @@ xRX
 xRX
 xRX
 wyp
-kqx
+btW
 wyp
 xRX
 xRX
 xRX
 xRX
-aOU
+fGM
 xRX
 xRX
 xRX
@@ -44219,52 +44279,52 @@ ngJ
 gwl
 xZh
 jhL
-aOU
-aOU
-aOU
-wyp
-kFh
-bJc
-wyp
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
 wyp
 uJz
+bJc
+wyp
+fGM
+fGM
+fGM
+wyp
+tcX
 bst
 wyp
-aOU
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
+fGM
 uwT
 uwT
 jjA
 uwT
 uwT
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
 eiL
 eiL
 gSo
 eiL
 eiL
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
 tRo
 tRo
 sVs
 tRo
 tRo
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
 gzr
 iHV
 kOP
@@ -44476,8 +44536,8 @@ oGU
 kMx
 jhL
 jhL
-aOU
 fGM
+aOU
 sUX
 ppp
 ppp
@@ -44489,10 +44549,10 @@ ayy
 wtm
 rhN
 ciM
-rhN
+wGc
 rmm
-fGM
-fGM
+wnf
+wnf
 uwT
 uwT
 lgM
@@ -44518,7 +44578,7 @@ tRo
 tRo
 xRX
 xRX
-aOU
+fGM
 xRX
 xRX
 xRX
@@ -44732,10 +44792,10 @@ aEa
 lJH
 jhL
 jhL
-fGM
-aOU
-iGW
 wnf
+fGM
+iGW
+aSb
 aSb
 sBA
 aSb
@@ -44749,7 +44809,7 @@ iQg
 clU
 nKq
 rmm
-fGM
+wnf
 htS
 lfg
 jFY
@@ -44775,7 +44835,7 @@ cMo
 tRo
 xRX
 xRX
-aOU
+fGM
 xRX
 xRX
 xRX
@@ -44784,7 +44844,7 @@ ebn
 cDf
 quS
 cQs
-fjs
+aDe
 aSJ
 oxG
 xRX
@@ -44988,9 +45048,9 @@ xKt
 adF
 eqi
 uZl
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
 rrT
 ntt
 sUq
@@ -45006,7 +45066,7 @@ elW
 sWG
 qVW
 vOL
-aOU
+fGM
 uwT
 dkz
 hHq
@@ -45032,7 +45092,7 @@ bxM
 tRo
 xRX
 xRX
-aOU
+fGM
 xRX
 xRX
 uLO
@@ -45245,10 +45305,10 @@ mOF
 qED
 uPa
 uZl
+wnf
+wnf
 fGM
-fGM
-aOU
-bcf
+rrT
 aSb
 aEB
 aEB
@@ -45263,7 +45323,7 @@ eqD
 aSb
 qeJ
 vOL
-fGM
+wnf
 uwT
 oZH
 pZI
@@ -45289,10 +45349,10 @@ ieZ
 tRo
 xRX
 xRX
-aOU
+fGM
 xRX
-wGc
-wGc
+jlF
+jlF
 nZj
 ess
 lzb
@@ -45503,16 +45563,16 @@ bpj
 fdV
 uZl
 uZl
+wnf
 fGM
-aOU
 rJT
 rsE
-rsE
+ayL
 rQJ
-aEB
+obM
 tuB
 fNL
-btW
+bkh
 rAU
 mkb
 syX
@@ -45520,7 +45580,7 @@ afL
 sVT
 oSp
 vOL
-fGM
+wnf
 uwT
 bDX
 mCb
@@ -45546,9 +45606,9 @@ uNJ
 tRo
 xRX
 xRX
-aOU
+fGM
 xRX
-wGc
+jlF
 xMA
 uWU
 oVL
@@ -45760,8 +45820,8 @@ ieM
 mwO
 uoZ
 uZl
+wnf
 fGM
-aOU
 iUd
 vdX
 atI
@@ -45777,7 +45837,7 @@ tcV
 rXx
 cJt
 vOL
-fGM
+wnf
 uwT
 fYr
 lGK
@@ -45803,9 +45863,9 @@ lvR
 tRo
 xRX
 xRX
-aOU
+fGM
 xRX
-wGc
+jlF
 oyG
 cnH
 ess
@@ -46017,8 +46077,8 @@ mCl
 kuj
 rFB
 uZl
+wnf
 fGM
-aOU
 lkK
 hZH
 kti
@@ -46034,7 +46094,7 @@ kTf
 bzW
 hhA
 vOL
-fGM
+wnf
 uwT
 cgU
 hhQ
@@ -46274,9 +46334,9 @@ uiV
 vDk
 rFB
 uZl
+wnf
 fGM
-aOU
-bcf
+rrT
 aSb
 aSb
 aSb
@@ -46291,7 +46351,7 @@ tDp
 aSb
 hhA
 vOL
-fGM
+wnf
 uwT
 cgU
 onn
@@ -46531,9 +46591,9 @@ aEt
 ldf
 uZl
 uZl
-aOU
-aOU
-bcf
+fGM
+fGM
+rrT
 sBA
 ruo
 sum
@@ -46548,7 +46608,7 @@ elW
 sWG
 cei
 vOL
-aOU
+fGM
 uwT
 vMG
 hil
@@ -46556,7 +46616,7 @@ uOr
 hil
 irq
 uwT
-aOU
+fGM
 eiL
 upC
 buI
@@ -46564,7 +46624,7 @@ hdb
 pZo
 fVv
 eiL
-aOU
+fGM
 tRo
 pDZ
 bxM
@@ -46572,8 +46632,8 @@ bxM
 bxM
 pZO
 tRo
-aOU
-aOU
+fGM
+fGM
 wjn
 qqX
 vwi
@@ -46787,11 +46847,11 @@ uZl
 osl
 stV
 uZl
+wnf
+wnf
 fGM
-fGM
-aOU
 aCG
-dqF
+aSb
 aSb
 sBA
 aSb
@@ -46800,12 +46860,12 @@ vCg
 iTc
 lKV
 kEe
-rhN
-rhN
-rhN
+ajO
+wGc
+wGc
 mYn
 tOu
-fGM
+wnf
 htS
 hXO
 uwA
@@ -47043,11 +47103,11 @@ xRX
 xRX
 xRX
 xRX
-aOU
-aOU
 fGM
-aOU
 fGM
+wnf
+fGM
+aEE
 kOK
 rfz
 rfz
@@ -47057,12 +47117,12 @@ rfz
 rfz
 rfz
 lCe
-vTv
+nSY
 vTv
 vTv
 tOu
-fGM
-fGM
+wnf
+wnf
 uwT
 uwT
 nti
@@ -47087,7 +47147,7 @@ rEV
 tRo
 tRo
 xRX
-aOU
+fGM
 wjn
 wjn
 wjn
@@ -47301,50 +47361,50 @@ xRX
 xRX
 xRX
 xRX
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
 ibm
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
 fro
-aOU
-aOU
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
+fGM
+fGM
 uwT
 uwT
 qju
 uwT
 uwT
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
 eiL
 eiL
 sal
 eiL
 eiL
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
 tRo
 tRo
 raF
 tRo
 tRo
-aOU
-aOU
-aOU
+fGM
+fGM
+fGM
 xRX
 xRX
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -2141,6 +2141,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
+"esB" = (
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "etF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/west,
@@ -3341,19 +3355,13 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "hQh" = (
-/obj/structure/railing/mapped{
-	dir = 4
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/handrail{
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/freebooter_shuttle)
 "hQA" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -3374,14 +3382,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod7)
-"hRt" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/handrail{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/freebooter_shuttle)
 "hUF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4781,15 +4781,6 @@
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
-"llB" = (
-/obj/structure/bed/stool/chair/shuttle{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/freebooter_shuttle)
 "llD" = (
 /obj/structure/bed/stool/chair/office/bridge/generic,
 /obj/structure/railing/mapped{
@@ -5945,6 +5936,14 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod1)
+"nVq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 10
+	},
+/turf/simulated/wall/shuttle/space_ship{
+	color = "#E14644"
+	},
+/area/shuttle/freebooter_shuttle)
 "nWh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -7062,14 +7061,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
-"pZx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 10
-	},
-/turf/simulated/wall/shuttle/space_ship{
-	color = "#E14644"
-	},
-/area/shuttle/freebooter_shuttle)
 "pZI" = (
 /obj/effect/floor_decal/corner/dark_blue,
 /obj/structure/bed/stool/chair/office/light{
@@ -7656,6 +7647,15 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
+"rhN" = (
+/obj/structure/bed/stool/chair/shuttle{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "rjL" = (
 /obj/machinery/ship_weapon/blaster{
 	pixel_y = -195;
@@ -45032,7 +45032,7 @@ vxO
 mbg
 bWt
 xHX
-llB
+rhN
 amu
 amu
 elW
@@ -46574,10 +46574,10 @@ uDc
 bEH
 qnz
 ggq
-hRt
+hQh
 aSb
 kVa
-pZx
+nVq
 lKV
 cei
 vOL
@@ -47091,7 +47091,7 @@ rfz
 rfz
 lCe
 rfz
-hQh
+esB
 vTv
 tOu
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -134,8 +134,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ajO" = (
+/obj/structure/lattice/catwalk,
 /turf/space/dynamic,
-/area/space)
+/area/ship/freebooter_ship/exterior)
 "akg" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
@@ -207,6 +208,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/engineering)
+"asG" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed/pipes{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/freebooter_ship/cryo)
 "atj" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -270,8 +282,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "ayy" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunneryentrance)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/forehallwayport)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -532,12 +544,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aOU" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "junker_gun"
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/gunnery)
+/turf/space/dynamic,
+/area/space)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -785,12 +793,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/structure/sign/vacuum{
+	pixel_y = 30
+	},
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
-	},
-/obj/structure/sign/vacuum{
-	pixel_y = 30
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -1041,11 +1049,11 @@
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "bzr" = (
@@ -1164,11 +1172,11 @@
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "bJj" = (
@@ -1341,12 +1349,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
-"cjX" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "clU" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
@@ -1662,23 +1664,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
-"dqw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/forehallway)
 "dqF" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	layer = 2.71;
@@ -2206,6 +2191,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
+"eCC" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunneryentrance)
 "eDX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -2509,18 +2497,9 @@
 /obj/item/rig/eva,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
-"fCC" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "fGM" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/gunneryentrance)
-"fIO" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/medical)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -2748,6 +2727,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
+"giQ" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	pixel_x = 8;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "gji" = (
 /obj/structure/table/rack,
 /obj/item/ship_ammunition/blaster,
@@ -2871,16 +2866,16 @@
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
 /obj/machinery/access_button{
 	pixel_x = -8;
 	pixel_y = 28;
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "gzr" = (
@@ -4166,7 +4161,6 @@
 	dir = 8;
 	layer = 2.71
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -4226,9 +4220,12 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "kqx" = (
-/obj/structure/lattice/catwalk,
-/turf/space/dynamic,
-/area/ship/freebooter_ship/exterior)
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "junker_gun"
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/gunnery)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
 /obj/effect/decal/cleanable/dirt,
@@ -5577,6 +5574,9 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
+"nim" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/medical)
 "nmL" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -5683,6 +5683,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
+"nuo" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "nwD" = (
 /obj/effect/floor_decal/corner{
 	dir = 8
@@ -6996,10 +7012,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 1;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
+/obj/machinery/light/small/emergency{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
@@ -7177,6 +7191,21 @@
 /obj/effect/step_trigger/teleporter,
 /turf/space,
 /area/space)
+"quJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/forehallway)
 "quS" = (
 /turf/simulated/wall,
 /area/ship/freebooter_ship/cryo)
@@ -7860,7 +7889,6 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
 "rKl" = (
-/obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7871,6 +7899,9 @@
 	},
 /obj/machinery/light/small/emergency{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/full{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
@@ -8013,17 +8044,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
-"snn" = (
-/obj/machinery/cryopod,
-/obj/structure/cryofeed/pipes{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/cryo)
 "soh" = (
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/gunnery)
@@ -9545,6 +9565,22 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
+"vGR" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/access_button{
+	pixel_x = -8;
+	pixel_y = 28;
+	dir = 8
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "vHQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/structure/curtain/open/bed{
@@ -9634,6 +9670,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/ammo)
+"vRK" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "vSY" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/pod4)
@@ -9730,8 +9772,11 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "vZW" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/forehallwayport)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/stool/chair{
@@ -9936,7 +9981,7 @@
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "wGc" = (
-/turf/simulated/wall,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/medical)
 "wHo" = (
 /obj/effect/decal/fake_object{
@@ -10310,12 +10355,12 @@
 /area/ship/freebooter_ship/closet)
 "xvT" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -10465,8 +10510,8 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -37721,7 +37766,7 @@ xRX
 xRX
 xRX
 uCl
-ajO
+aOU
 uCl
 fZq
 xRX
@@ -38235,7 +38280,7 @@ xRX
 rtf
 vUu
 uyM
-ajO
+aOU
 aHs
 xRX
 xRX
@@ -38468,17 +38513,17 @@ xRX
 xRX
 xRX
 xRX
-kqx
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
+ajO
 eIb
 wUi
 ldw
 wUi
 eIb
-kqx
-kqx
+ajO
+ajO
 esB
 gwg
 esB
@@ -38486,32 +38531,32 @@ wHo
 esB
 gwg
 esB
-kqx
-kqx
+ajO
+ajO
 cLC
 cLC
 kwe
 tKj
 tKj
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 qiz
 qiz
 mWz
 qiz
 qiz
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 eUq
 eUq
 pRf
 eUq
 eUq
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 xRX
 xRX
 xRX
@@ -38724,8 +38769,8 @@ xRX
 xRX
 xRX
 xRX
-kqx
-kqx
+ajO
+ajO
 xRX
 xRX
 eIb
@@ -38768,7 +38813,7 @@ fTG
 eUq
 eUq
 xRX
-kqx
+ajO
 xqI
 xqI
 xqI
@@ -38782,7 +38827,7 @@ imE
 imE
 iOV
 iOV
-aOU
+kqx
 xRX
 xRX
 xRX
@@ -39039,7 +39084,7 @@ rjL
 tQn
 sxw
 www
-aOU
+kqx
 xRX
 xRX
 xRX
@@ -39240,8 +39285,8 @@ gFA
 ewW
 ewW
 ewW
-kqx
-kqx
+ajO
+ajO
 wUi
 syV
 bhd
@@ -39249,7 +39294,7 @@ xBh
 bhd
 tvh
 wUi
-kqx
+ajO
 gwg
 pUP
 kmP
@@ -39257,7 +39302,7 @@ qDn
 kev
 jcX
 gwg
-kqx
+ajO
 cLC
 wZf
 ttI
@@ -39265,7 +39310,7 @@ krH
 lKT
 vmX
 cLC
-kqx
+ajO
 qiz
 pYB
 bPT
@@ -39273,7 +39318,7 @@ jzk
 fRD
 buM
 qiz
-kqx
+ajO
 eUq
 aTX
 iUK
@@ -39281,8 +39326,8 @@ iUK
 iUK
 fTT
 eUq
-kqx
-kqx
+ajO
+ajO
 xqI
 ahD
 kfJ
@@ -39296,7 +39341,7 @@ fNl
 tQn
 sxw
 sxw
-aOU
+kqx
 xRX
 xRX
 xRX
@@ -39498,7 +39543,7 @@ xUb
 qWF
 ewW
 xRX
-kqx
+ajO
 wUi
 syV
 bhd
@@ -39547,13 +39592,13 @@ npb
 oxR
 tfK
 sxk
-fCC
+vZW
 soh
 soh
 aDv
 iOV
 iOV
-aOU
+kqx
 xRX
 xRX
 xRX
@@ -39755,7 +39800,7 @@ xUb
 jnK
 ewW
 xRX
-kqx
+ajO
 wUi
 syV
 grD
@@ -39805,8 +39850,8 @@ jhd
 tfK
 nwH
 wLI
-cjX
-cjX
+vRK
+vRK
 fnE
 xRX
 xRX
@@ -40012,7 +40057,7 @@ dbA
 wxS
 ewW
 xRX
-kqx
+ajO
 eIb
 oPu
 bhd
@@ -40054,7 +40099,7 @@ cEH
 eUq
 xRX
 xRX
-kqx
+ajO
 xqI
 xqI
 tfK
@@ -40269,7 +40314,7 @@ ewW
 ewW
 ewW
 xRX
-kqx
+ajO
 wUi
 cLL
 bhd
@@ -40311,13 +40356,13 @@ avE
 eUq
 xRX
 xRX
-kqx
+ajO
 xRX
 fGM
 rEb
 xTu
 cbE
-ayy
+eCC
 klp
 llD
 euj
@@ -40526,7 +40571,7 @@ acn
 ewW
 xRX
 xRX
-kqx
+ajO
 wUi
 glJ
 ihN
@@ -40568,7 +40613,7 @@ hIE
 eUq
 xRX
 xRX
-kqx
+ajO
 xRX
 fGM
 fGM
@@ -40783,7 +40828,7 @@ pHN
 ewW
 xRX
 xRX
-kqx
+ajO
 wUi
 wNA
 bhd
@@ -40825,13 +40870,13 @@ iUK
 eUq
 xRX
 xRX
-kqx
+ajO
 xRX
 xRX
 fGM
 fGM
 tmo
-ayy
+eCC
 mwo
 mwo
 mwo
@@ -41040,7 +41085,7 @@ lJH
 jhL
 jhL
 xRX
-kqx
+ajO
 wUi
 peJ
 bhd
@@ -41082,18 +41127,18 @@ mtT
 eUq
 xRX
 xRX
-kqx
+ajO
 xRX
 xRX
 xRX
 uLO
 ebn
 atj
-wGc
+nim
 exg
 iGK
 aBD
-fIO
+wGc
 xRX
 xRX
 xRX
@@ -41297,7 +41342,7 @@ pCG
 iZM
 jhL
 jhL
-kqx
+ajO
 eIb
 eIb
 pPk
@@ -41339,7 +41384,7 @@ eUq
 eUq
 xRX
 xRX
-kqx
+ajO
 xRX
 xRX
 xRX
@@ -41350,7 +41395,7 @@ jLL
 aab
 qDe
 nVi
-fIO
+wGc
 saW
 xRX
 xRX
@@ -41554,61 +41599,61 @@ mhq
 tcY
 rfn
 jhL
-kqx
-kqx
+ajO
+ajO
 eIb
 eIb
 qEc
 eIb
 eIb
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 gwg
 wzO
 dXK
 wzO
 gwg
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 cLC
 cLC
 mbX
 cLC
 cLC
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 qiz
 qiz
 dFi
 qiz
 qiz
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 eUq
 eUq
 wRc
 eUq
 eUq
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 pvm
 kou
 dWF
-wGc
+nim
 gLO
 npJ
 kAt
 lpe
-fIO
+wGc
 xRX
 xRX
 xRX
@@ -41812,7 +41857,7 @@ jbh
 tYn
 jhL
 xRX
-kqx
+ajO
 xRX
 wyp
 mGn
@@ -41853,19 +41898,19 @@ xRX
 xRX
 xRX
 xRX
-kqx
+ajO
 xRX
 xRX
 xRX
 pvm
 vfD
 kOP
-wGc
-wGc
+nim
+nim
 tra
-fIO
 wGc
-fIO
+nim
+wGc
 ydf
 ewy
 ewy
@@ -42069,7 +42114,7 @@ rRa
 nKC
 jhL
 xRX
-kqx
+ajO
 xRX
 wyp
 mGn
@@ -42110,7 +42155,7 @@ xRX
 xRX
 xRX
 xRX
-kqx
+ajO
 xRX
 xRX
 xRX
@@ -43364,7 +43409,7 @@ vGw
 vGw
 vGw
 wyp
-gyl
+vGR
 odb
 wyp
 wyp
@@ -43400,7 +43445,7 @@ vGw
 wyp
 wyp
 uLO
-dqw
+quJ
 fZr
 wUa
 oKE
@@ -43611,7 +43656,7 @@ pkY
 bJj
 jhL
 xRX
-kqx
+ajO
 xRX
 wyp
 bhA
@@ -43652,7 +43697,7 @@ xRX
 xRX
 xRX
 xRX
-kqx
+ajO
 xRX
 xRX
 xRX
@@ -43868,10 +43913,10 @@ doW
 nEK
 jhL
 xRX
-kqx
+ajO
 xRX
 wyp
-vDD
+nuo
 xvT
 wyp
 xRX
@@ -43909,7 +43954,7 @@ xRX
 xRX
 xRX
 xRX
-kqx
+ajO
 xRX
 xRX
 xRX
@@ -44124,52 +44169,52 @@ ngJ
 gwl
 xZh
 jhL
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 wyp
-uJz
+giQ
 bJc
 wyp
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 wyp
 uJz
 bst
 wyp
-kqx
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
+ajO
 uwT
 uwT
 jjA
 uwT
 uwT
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 eiL
 eiL
 gSo
 eiL
 eiL
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 tRo
 tRo
 sVs
 tRo
 tRo
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 gzr
 iHV
 kOP
@@ -44381,8 +44426,8 @@ oGU
 kMx
 jhL
 jhL
-kqx
 ajO
+aOU
 sUX
 ppp
 ppp
@@ -44396,8 +44441,8 @@ rhN
 ciM
 rhN
 rmm
-ajO
-ajO
+aOU
+aOU
 uwT
 uwT
 lgM
@@ -44423,7 +44468,7 @@ tRo
 tRo
 xRX
 xRX
-kqx
+ajO
 xRX
 xRX
 xRX
@@ -44637,8 +44682,8 @@ aEa
 lJH
 jhL
 jhL
+aOU
 ajO
-kqx
 iGW
 wnf
 aSb
@@ -44654,7 +44699,7 @@ iQg
 clU
 nKq
 rmm
-ajO
+aOU
 htS
 lfg
 jFY
@@ -44680,7 +44725,7 @@ cMo
 tRo
 xRX
 xRX
-kqx
+ajO
 xRX
 xRX
 xRX
@@ -44689,7 +44734,7 @@ ebn
 cDf
 quS
 cQs
-snn
+asG
 aSJ
 oxG
 xRX
@@ -44893,9 +44938,9 @@ xKt
 adF
 eqi
 uZl
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 rrT
 ntt
 sUq
@@ -44911,7 +44956,7 @@ elW
 sWG
 qVW
 vOL
-kqx
+ajO
 uwT
 dkz
 hHq
@@ -44937,7 +44982,7 @@ bxM
 tRo
 xRX
 xRX
-kqx
+ajO
 xRX
 xRX
 uLO
@@ -45150,9 +45195,9 @@ mOF
 qED
 uPa
 uZl
+aOU
+aOU
 ajO
-ajO
-kqx
 bcf
 aSb
 aEB
@@ -45168,7 +45213,7 @@ eqD
 aSb
 qeJ
 vOL
-ajO
+aOU
 uwT
 oZH
 pZI
@@ -45194,10 +45239,10 @@ ieZ
 tRo
 xRX
 xRX
-kqx
+ajO
 xRX
-vZW
-vZW
+ayy
+ayy
 nZj
 ess
 lzb
@@ -45408,8 +45453,8 @@ bpj
 fdV
 uZl
 uZl
+aOU
 ajO
-kqx
 rJT
 rsE
 rsE
@@ -45425,7 +45470,7 @@ afL
 sVT
 oSp
 vOL
-ajO
+aOU
 uwT
 bDX
 mCb
@@ -45451,9 +45496,9 @@ uNJ
 tRo
 xRX
 xRX
-kqx
+ajO
 xRX
-vZW
+ayy
 xMA
 uWU
 oVL
@@ -45665,8 +45710,8 @@ ieM
 mwO
 uoZ
 uZl
+aOU
 ajO
-kqx
 iUd
 vdX
 atI
@@ -45682,7 +45727,7 @@ tcV
 rXx
 cJt
 vOL
-ajO
+aOU
 uwT
 fYr
 lGK
@@ -45708,9 +45753,9 @@ lvR
 tRo
 xRX
 xRX
-kqx
+ajO
 xRX
-vZW
+ayy
 oyG
 cnH
 ess
@@ -45922,8 +45967,8 @@ mCl
 kuj
 rFB
 uZl
+aOU
 ajO
-kqx
 lkK
 hZH
 kti
@@ -45939,7 +45984,7 @@ kTf
 bzW
 hhA
 vOL
-ajO
+aOU
 uwT
 cgU
 hhQ
@@ -46179,8 +46224,8 @@ uiV
 vDk
 rFB
 uZl
+aOU
 ajO
-kqx
 bcf
 aSb
 aSb
@@ -46196,7 +46241,7 @@ tDp
 aSb
 hhA
 vOL
-ajO
+aOU
 uwT
 cgU
 onn
@@ -46436,8 +46481,8 @@ aEt
 ldf
 uZl
 uZl
-kqx
-kqx
+ajO
+ajO
 bcf
 sBA
 ruo
@@ -46453,7 +46498,7 @@ elW
 sWG
 cei
 vOL
-kqx
+ajO
 uwT
 vMG
 hil
@@ -46461,7 +46506,7 @@ uOr
 hil
 irq
 uwT
-kqx
+ajO
 eiL
 upC
 buI
@@ -46469,7 +46514,7 @@ hdb
 pZo
 fVv
 eiL
-kqx
+ajO
 tRo
 pDZ
 bxM
@@ -46477,8 +46522,8 @@ bxM
 bxM
 pZO
 tRo
-kqx
-kqx
+ajO
+ajO
 wjn
 qqX
 vwi
@@ -46692,9 +46737,9 @@ uZl
 osl
 stV
 uZl
+aOU
+aOU
 ajO
-ajO
-kqx
 aCG
 dqF
 aSb
@@ -46710,7 +46755,7 @@ rhN
 rhN
 mYn
 tOu
-ajO
+aOU
 htS
 hXO
 uwA
@@ -46948,11 +46993,11 @@ xRX
 xRX
 xRX
 xRX
-kqx
-kqx
 ajO
-kqx
 ajO
+aOU
+ajO
+aOU
 kOK
 rfz
 rfz
@@ -46966,8 +47011,8 @@ vTv
 vTv
 vTv
 tOu
-ajO
-ajO
+aOU
+aOU
 uwT
 uwT
 nti
@@ -46992,7 +47037,7 @@ rEV
 tRo
 tRo
 xRX
-kqx
+ajO
 wjn
 wjn
 wjn
@@ -47206,50 +47251,50 @@ xRX
 xRX
 xRX
 xRX
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 ibm
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 fro
-kqx
-kqx
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
+ajO
+ajO
 uwT
 uwT
 qju
 uwT
 uwT
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 eiL
 eiL
 sal
 eiL
 eiL
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 tRo
 tRo
 raF
 tRo
 tRo
-kqx
-kqx
-kqx
+ajO
+ajO
+ajO
 xRX
 xRX
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -702,10 +702,11 @@
 /area/ship/freebooter_ship/pod7)
 "bck" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 5
-	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "bcz" = (
@@ -1335,6 +1336,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
@@ -2142,6 +2147,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
+"esB" = (
+/obj/structure/bed/stool/chair/shuttle{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "etF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/west,
@@ -3340,19 +3354,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
-"hQh" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
 "hQA" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -3373,6 +3374,13 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod7)
+"hRt" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/bed/handrail{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "hUF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3762,12 +3770,12 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/gunnery)
 "iQg" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 5
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
@@ -4773,12 +4781,13 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
 "llB" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 10
 	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/wall/shuttle/space_ship{
+	color = "#E14644"
+	},
+/area/shuttle/freebooter_shuttle)
 "llD" = (
 /obj/structure/bed/stool/chair/office/bridge/generic,
 /obj/structure/railing/mapped{
@@ -5937,9 +5946,6 @@
 "nWh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/bed/handrail{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "nXu" = (
@@ -7054,6 +7060,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
+"pZx" = (
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "pZI" = (
 /obj/effect/floor_decal/corner/dark_blue,
 /obj/structure/bed/stool/chair/office/light{
@@ -7637,17 +7657,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
 	dir = 8
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
-"rhN" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
@@ -8727,6 +8736,9 @@
 "tDp" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 5
+	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "tES" = (
@@ -9675,9 +9687,6 @@
 /obj/structure/curtain/open/bed{
 	name = "curtain"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "vMG" = (
@@ -10499,11 +10508,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod2)
 "xHX" = (
-/obj/structure/bed/stool/chair/shuttle{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
@@ -44518,7 +44524,7 @@ jrC
 kQs
 jrC
 wtm
-rhN
+wtm
 ciM
 btW
 rmm
@@ -44772,10 +44778,10 @@ sBA
 aSb
 aSb
 aKq
+aSb
 fjW
 lKV
 edN
-llB
 iQg
 clU
 nKq
@@ -45030,7 +45036,7 @@ vxO
 mbg
 bWt
 xHX
-amu
+esB
 amu
 amu
 elW
@@ -46059,8 +46065,8 @@ aSb
 aSb
 rzA
 yeH
+aSb
 tUO
-kTf
 kTf
 bzW
 hhA
@@ -46571,11 +46577,11 @@ sum
 uDc
 bEH
 qnz
+hRt
 ggq
 aSb
 kVa
-iTc
-elW
+llB
 lKV
 cei
 vOL
@@ -46828,11 +46834,11 @@ sBA
 aSb
 aSb
 vCg
+aSb
 iTc
 lKV
 kEe
 wBf
-btW
 btW
 mYn
 tOu
@@ -47088,8 +47094,8 @@ rfz
 rfz
 rfz
 lCe
-hQh
-vTv
+rfz
+pZx
 vTv
 tOu
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1316,20 +1316,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "cgU" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate/miningcart,
-/obj/item/reagent_containers/food/snacks/tastybread,
-/obj/item/reagent_containers/food/snacks/tastybread,
-/obj/item/storage/box/produce{
-	layer = 2.99
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/wall/r_wall,
 /area/ship/freebooter_ship/pod8)
 "ciM" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1454,8 +1441,12 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
-"cFh" = (
-/turf/simulated/wall/r_wall,
+"cFm" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "cJt" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2493,6 +2484,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod2)
+"fsi" = (
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/magenta,
+/area/ship/freebooter_ship/pod6)
 "fws" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -2696,13 +2700,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "fYr" = (
-/obj/structure/sign/fire{
-	pixel_x = 32
-	},
 /obj/machinery/suit_cycler/security{
 	req_access = null
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/securearea{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod8)
 "fZq" = (
@@ -3031,13 +3035,6 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/dorms)
-"gQN" = (
-/obj/effect/floor_decal/corner{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod8)
 "gSo" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3055,6 +3052,15 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod7)
+"gTL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/ship/freebooter_ship/pod8)
 "gVa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -3445,11 +3451,6 @@
 /obj/machinery/portable_atmospherics/canister/empty/phoron{
 	destroyed = 1
 	},
-/obj/machinery/light{
-	dir = 1;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "hZH" = (
@@ -3629,13 +3630,6 @@
 	},
 /turf/simulated/floor/carpet/magenta,
 /area/ship/freebooter_ship/pod6)
-"ioW" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod8)
 "ipt" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 4
@@ -3657,9 +3651,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/bed/padded,
-/obj/structure/sign/securearea{
-	pixel_y = -32
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "irX" = (
@@ -4796,6 +4788,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm/north{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "lho" = (
@@ -5066,13 +5061,20 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
 "lGK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/corner{
+	dir = 10
 	},
-/turf/simulated/wall/r_wall,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate/miningcart,
+/obj/item/reagent_containers/food/snacks/tastybread,
+/obj/item/reagent_containers/food/snacks/tastybread,
+/obj/item/storage/box/produce{
+	layer = 2.99
+	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "lHL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -5520,7 +5522,6 @@
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/padded,
-/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "mOF" = (
@@ -6387,19 +6388,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallwayport)
-"oGd" = (
-/obj/structure/sign/poster{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/magenta,
-/area/ship/freebooter_ship/pod6)
 "oGU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -7008,10 +6996,10 @@
 /obj/effect/floor_decal/corner{
 	dir = 5
 	},
-/obj/structure/sign/fire{
+/obj/structure/closet/crate/security,
+/obj/structure/sign/securearea{
 	pixel_x = 32
 	},
-/obj/structure/closet/crate/security,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "pOI" = (
@@ -8356,6 +8344,13 @@
 	color = "#E14644"
 	},
 /area/shuttle/freebooter_shuttle)
+"sCd" = (
+/obj/effect/floor_decal/corner{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod8)
 "sCs" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
@@ -8708,9 +8703,6 @@
 	},
 /obj/effect/floor_decal/corner{
 	dir = 4
-	},
-/obj/machinery/alarm/south{
-	req_one_access = null
 	},
 /obj/machinery/portable_atmospherics/canister/phoron{
 	start_pressure = 165
@@ -9758,8 +9750,10 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
-/obj/structure/sign/securearea{
-	pixel_y = 32
+/obj/machinery/light{
+	dir = 1;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -45388,7 +45382,7 @@ tRo
 bxf
 aFI
 bxM
-oGd
+fsi
 ieZ
 tRo
 xRX
@@ -46140,11 +46134,11 @@ hhA
 vOL
 xRX
 uwT
-cFh
+cgU
 hhQ
-lGK
+gTL
 hZY
-cFh
+cgU
 uwT
 xRX
 eiL
@@ -46397,8 +46391,8 @@ hhA
 vOL
 xRX
 uwT
-cgU
-ioW
+lGK
+cFm
 uZC
 iok
 pik
@@ -46657,7 +46651,7 @@ uwT
 vMG
 hil
 uOr
-gQN
+sCd
 irq
 uwT
 vZW

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -132,8 +132,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ajO" = (
+/obj/structure/lattice/catwalk,
 /turf/space/dynamic,
-/area/space)
+/area/ship/freebooter_ship/exterior)
 "akg" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
@@ -273,8 +274,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "ayy" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/forehallwayport)
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -534,8 +546,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aOU" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/medical)
+/turf/space/dynamic,
+/area/space)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -2473,9 +2485,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fGM" = (
-/obj/structure/lattice/catwalk,
-/turf/space/dynamic,
-/area/ship/freebooter_ship/exterior)
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "junker_gun"
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/gunnery)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -3828,19 +3843,8 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "jrC" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/gunneryentrance)
 "jvN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -4018,6 +4022,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
+"jZO" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed/pipes{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/freebooter_ship/cryo)
 "jZY" = (
 /obj/structure/railing/mapped,
 /obj/machinery/iff_beacon/name_change,
@@ -4184,7 +4199,7 @@
 /area/ship/freebooter_ship/pod7)
 "kqx" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/gunneryentrance)
+/area/ship/freebooter_ship/forehallwayport)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
 /obj/effect/decal/cleanable/dirt,
@@ -4578,13 +4593,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/freebooter_shuttle)
-"kWi" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "junker_gun"
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/gunnery)
 "kXq" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -5545,6 +5553,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
+"now" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunneryentrance)
 "npb" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -5998,6 +6009,17 @@
 	},
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
+	},
+/obj/machinery/button/distress{
+	pixel_x = 6;
+	pixel_y = 29
+	},
+/obj/machinery/button/remote/blast_door{
+	pixel_y = 29;
+	pixel_x = -6;
+	id = "junker_bridge";
+	name = "bridge blast door-control";
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
@@ -9645,7 +9667,7 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "vZW" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
+/turf/simulated/wall,
 /area/ship/freebooter_ship/medical)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9706,17 +9728,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
-"wgh" = (
-/obj/machinery/cryopod,
-/obj/structure/cryofeed/pipes{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/cryo)
 "wji" = (
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 8
@@ -9862,8 +9873,8 @@
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "wGc" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunneryentrance)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/medical)
 "wHo" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/ship_engine.dmi';
@@ -10538,12 +10549,7 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod7)
 "ylw" = (
-/obj/structure/railing/mapped,
 /obj/structure/table/steel,
-/obj/machinery/button/distress{
-	pixel_x = 6;
-	pixel_y = -4
-	},
 /obj/item/paper/crumpled{
 	pixel_x = -4;
 	pixel_y = 5
@@ -10552,12 +10558,7 @@
 	pixel_x = 7;
 	pixel_y = 6
 	},
-/obj/machinery/button/remote/blast_door{
-	pixel_y = -2;
-	pixel_x = -5;
-	id = "junker_bridge";
-	name = "bridge blast door-control"
-	},
+/obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
 
@@ -38392,17 +38393,17 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
+ajO
 eIb
 wUi
 ldw
 wUi
 eIb
-fGM
-fGM
+ajO
+ajO
 esB
 gwg
 esB
@@ -38410,32 +38411,32 @@ wHo
 esB
 gwg
 esB
-fGM
-fGM
+ajO
+ajO
 cLC
 cLC
 kwe
 tKj
 tKj
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 qiz
 qiz
 mWz
 qiz
 qiz
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 eUq
 eUq
 pRf
 eUq
 eUq
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 xRX
 xRX
 xRX
@@ -38648,8 +38649,8 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
+ajO
+ajO
 xRX
 xRX
 eIb
@@ -38692,7 +38693,7 @@ fTG
 eUq
 eUq
 xRX
-fGM
+ajO
 xqI
 xqI
 xqI
@@ -38706,7 +38707,7 @@ imE
 imE
 iOV
 iOV
-kWi
+fGM
 xRX
 xRX
 xRX
@@ -38963,7 +38964,7 @@ rjL
 tQn
 sxw
 www
-kWi
+fGM
 xRX
 xRX
 xRX
@@ -39164,8 +39165,8 @@ gFA
 ewW
 ewW
 ewW
-fGM
-fGM
+ajO
+ajO
 wUi
 syV
 bhd
@@ -39173,7 +39174,7 @@ xBh
 bhd
 tvh
 wUi
-fGM
+ajO
 gwg
 pUP
 kmP
@@ -39181,7 +39182,7 @@ qDn
 kev
 jcX
 gwg
-fGM
+ajO
 cLC
 wZf
 ttI
@@ -39189,7 +39190,7 @@ krH
 lKT
 vmX
 cLC
-fGM
+ajO
 qiz
 pYB
 bPT
@@ -39197,7 +39198,7 @@ jzk
 fRD
 buM
 qiz
-fGM
+ajO
 eUq
 aTX
 iUK
@@ -39205,8 +39206,8 @@ iUK
 iUK
 fTT
 eUq
-fGM
-fGM
+ajO
+ajO
 xqI
 ahD
 kfJ
@@ -39220,7 +39221,7 @@ fNl
 tQn
 sxw
 sxw
-kWi
+fGM
 xRX
 xRX
 xRX
@@ -39422,7 +39423,7 @@ xUb
 qWF
 ewW
 xRX
-fGM
+ajO
 wUi
 syV
 bhd
@@ -39477,7 +39478,7 @@ soh
 aDv
 iOV
 iOV
-kWi
+fGM
 xRX
 xRX
 xRX
@@ -39679,7 +39680,7 @@ xUb
 jnK
 ewW
 xRX
-fGM
+ajO
 wUi
 syV
 grD
@@ -39936,7 +39937,7 @@ dbA
 wxS
 ewW
 xRX
-fGM
+ajO
 eIb
 oPu
 bhd
@@ -39978,7 +39979,7 @@ cEH
 eUq
 xRX
 xRX
-fGM
+ajO
 xqI
 xqI
 tfK
@@ -40193,7 +40194,7 @@ ewW
 ewW
 ewW
 xRX
-fGM
+ajO
 wUi
 cLL
 bhd
@@ -40235,13 +40236,13 @@ avE
 eUq
 xRX
 xRX
-fGM
+ajO
 xRX
-kqx
+jrC
 rEb
 xTu
 cbE
-wGc
+now
 klp
 llD
 euj
@@ -40450,7 +40451,7 @@ acn
 ewW
 xRX
 xRX
-fGM
+ajO
 wUi
 glJ
 ihN
@@ -40492,10 +40493,10 @@ hIE
 eUq
 xRX
 xRX
-fGM
+ajO
 xRX
-kqx
-kqx
+jrC
+jrC
 jgM
 vVy
 aMQ
@@ -40707,7 +40708,7 @@ pHN
 ewW
 xRX
 xRX
-fGM
+ajO
 wUi
 wNA
 bhd
@@ -40749,13 +40750,13 @@ iUK
 eUq
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
-kqx
-kqx
+jrC
+jrC
 tmo
-wGc
+now
 mwo
 mwo
 mwo
@@ -40964,7 +40965,7 @@ lJH
 jhL
 jhL
 xRX
-fGM
+ajO
 wUi
 peJ
 bhd
@@ -41006,18 +41007,18 @@ mtT
 eUq
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
 uLO
 ebn
 atj
-aOU
+vZW
 exg
 iGK
 aBD
-vZW
+wGc
 xRX
 xRX
 xRX
@@ -41221,7 +41222,7 @@ pCG
 iZM
 jhL
 jhL
-fGM
+ajO
 eIb
 eIb
 pPk
@@ -41263,7 +41264,7 @@ eUq
 eUq
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -41274,7 +41275,7 @@ jLL
 aab
 qDe
 nVi
-vZW
+wGc
 saW
 xRX
 xRX
@@ -41478,61 +41479,61 @@ mhq
 tcY
 rfn
 jhL
-fGM
-fGM
+ajO
+ajO
 eIb
 eIb
 qEc
 eIb
 eIb
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 gwg
 wzO
 dXK
 wzO
 gwg
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 cLC
 cLC
 mbX
 cLC
 cLC
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 qiz
 qiz
 dFi
 qiz
 qiz
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 eUq
 eUq
 wRc
 eUq
 eUq
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 pvm
 kou
 dWF
-aOU
+vZW
 gLO
 npJ
 kAt
 lpe
-vZW
+wGc
 xRX
 xRX
 xRX
@@ -41736,7 +41737,7 @@ jbh
 tYn
 jhL
 xRX
-fGM
+ajO
 xRX
 wyp
 mGn
@@ -41777,19 +41778,19 @@ xRX
 xRX
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
 pvm
 vfD
 kOP
-aOU
-aOU
+vZW
+vZW
 tra
+wGc
 vZW
-aOU
-vZW
+wGc
 ydf
 ewy
 ewy
@@ -41993,7 +41994,7 @@ rRa
 nKC
 jhL
 xRX
-fGM
+ajO
 xRX
 wyp
 mGn
@@ -42034,7 +42035,7 @@ xRX
 xRX
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -43534,9 +43535,9 @@ bBW
 pkY
 bJj
 jhL
+aOU
 ajO
-fGM
-ajO
+aOU
 wyp
 bhA
 xQS
@@ -43576,7 +43577,7 @@ xRX
 xRX
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -43791,9 +43792,9 @@ rpZ
 doW
 nEK
 jhL
+aOU
 ajO
-fGM
-ajO
+aOU
 wyp
 vDD
 xvT
@@ -43833,7 +43834,7 @@ xRX
 xRX
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -44048,52 +44049,52 @@ ngJ
 gwl
 xZh
 jhL
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 wyp
 uJz
 bJc
 wyp
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 wyp
 uJz
 bst
 wyp
-fGM
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
+ajO
 uwT
 uwT
 jjA
 uwT
 uwT
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 eiL
 eiL
 gSo
 eiL
 eiL
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 tRo
 tRo
 sVs
 tRo
 tRo
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 gzr
 iHV
 kOP
@@ -44305,23 +44306,23 @@ oGU
 kMx
 jhL
 jhL
-fGM
 ajO
+aOU
 sUX
 ppp
 ppp
 ppp
 ppp
-jrC
+ayy
 kQs
-jrC
+ayy
 wtm
 rhN
 ciM
 rhN
 rmm
-ajO
-ajO
+aOU
+aOU
 uwT
 uwT
 lgM
@@ -44347,7 +44348,7 @@ tRo
 tRo
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -44561,8 +44562,8 @@ aEa
 lJH
 jhL
 jhL
+aOU
 ajO
-fGM
 iGW
 wnf
 aSb
@@ -44578,7 +44579,7 @@ iQg
 clU
 nKq
 rmm
-ajO
+aOU
 htS
 lfg
 jFY
@@ -44604,7 +44605,7 @@ cMo
 tRo
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -44613,7 +44614,7 @@ ebn
 cDf
 quS
 cQs
-wgh
+jZO
 aSJ
 oxG
 xRX
@@ -44817,9 +44818,9 @@ xKt
 adF
 eqi
 uZl
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 rrT
 ntt
 sUq
@@ -44835,7 +44836,7 @@ elW
 sWG
 qVW
 vOL
-fGM
+ajO
 uwT
 dkz
 hHq
@@ -44861,7 +44862,7 @@ bxM
 tRo
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 uLO
@@ -45074,9 +45075,9 @@ mOF
 qED
 uPa
 uZl
+aOU
+aOU
 ajO
-ajO
-fGM
 bcf
 aSb
 aEB
@@ -45092,7 +45093,7 @@ eqD
 aSb
 qeJ
 vOL
-ajO
+aOU
 uwT
 oZH
 pZI
@@ -45118,10 +45119,10 @@ ieZ
 tRo
 xRX
 xRX
-fGM
+ajO
 xRX
-ayy
-ayy
+kqx
+kqx
 nZj
 ess
 lzb
@@ -45332,8 +45333,8 @@ bpj
 fdV
 uZl
 uZl
+aOU
 ajO
-fGM
 rJT
 rsE
 rsE
@@ -45349,7 +45350,7 @@ afL
 sVT
 oSp
 vOL
-ajO
+aOU
 uwT
 bDX
 mCb
@@ -45375,9 +45376,9 @@ uNJ
 tRo
 xRX
 xRX
-fGM
+ajO
 xRX
-ayy
+kqx
 xMA
 uWU
 oVL
@@ -45589,8 +45590,8 @@ ieM
 mwO
 uoZ
 uZl
+aOU
 ajO
-fGM
 iUd
 vdX
 atI
@@ -45606,7 +45607,7 @@ tcV
 rXx
 cJt
 vOL
-ajO
+aOU
 uwT
 fYr
 lGK
@@ -45632,9 +45633,9 @@ lvR
 tRo
 xRX
 xRX
-fGM
+ajO
 xRX
-ayy
+kqx
 oyG
 cnH
 ess
@@ -45846,8 +45847,8 @@ mCl
 kuj
 rFB
 uZl
+aOU
 ajO
-fGM
 lkK
 hZH
 kti
@@ -45863,7 +45864,7 @@ kTf
 bzW
 hhA
 vOL
-ajO
+aOU
 uwT
 cgU
 hhQ
@@ -46103,8 +46104,8 @@ uiV
 vDk
 rFB
 uZl
+aOU
 ajO
-fGM
 bcf
 aSb
 aSb
@@ -46120,7 +46121,7 @@ tDp
 aSb
 hhA
 vOL
-ajO
+aOU
 uwT
 cgU
 onn
@@ -46360,8 +46361,8 @@ aEt
 ldf
 uZl
 uZl
-fGM
-fGM
+ajO
+ajO
 bcf
 sBA
 ruo
@@ -46377,7 +46378,7 @@ elW
 sWG
 cei
 vOL
-fGM
+ajO
 uwT
 vMG
 hil
@@ -46385,7 +46386,7 @@ uOr
 hil
 irq
 uwT
-fGM
+ajO
 eiL
 upC
 buI
@@ -46393,7 +46394,7 @@ hdb
 pZo
 fVv
 eiL
-fGM
+ajO
 tRo
 pDZ
 bxM
@@ -46401,8 +46402,8 @@ bxM
 bxM
 pZO
 tRo
-fGM
-fGM
+ajO
+ajO
 wjn
 qqX
 vwi
@@ -46616,9 +46617,9 @@ uZl
 osl
 stV
 uZl
+aOU
+aOU
 ajO
-ajO
-fGM
 aCG
 dqF
 aSb
@@ -46634,7 +46635,7 @@ rhN
 rhN
 mYn
 tOu
-ajO
+aOU
 htS
 hXO
 uwA
@@ -46872,11 +46873,11 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
 ajO
-fGM
 ajO
+aOU
+ajO
+aOU
 kOK
 rfz
 rfz
@@ -46890,8 +46891,8 @@ vTv
 vTv
 vTv
 tOu
-ajO
-ajO
+aOU
+aOU
 uwT
 uwT
 nti
@@ -46916,7 +46917,7 @@ rEV
 tRo
 tRo
 xRX
-fGM
+ajO
 wjn
 wjn
 wjn
@@ -47130,50 +47131,50 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 ibm
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 fro
-fGM
-fGM
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
+ajO
+ajO
 uwT
 uwT
 qju
 uwT
 uwT
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 eiL
 eiL
 sal
 eiL
 eiL
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 tRo
 tRo
 raF
 tRo
 tRo
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 xRX
 xRX
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -2547,7 +2547,7 @@
 	},
 /obj/machinery/button/remote/airlock{
 	dir = 4;
-	id = "scarab_washroom";
+	id = "freebooter_brig";
 	name = "Phoron Storage Bolt Control";
 	pixel_x = 24;
 	pixel_y = 4;
@@ -3250,6 +3250,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/holofloor/tiled/ramp/bottom,
 /area/ship/freebooter_ship/bridge)
+"hBa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/ship/freebooter_ship/pod8)
 "hFX" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -3377,6 +3386,13 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
+"hTr" = (
+/obj/effect/floor_decal/corner{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod8)
 "hUF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3429,7 +3445,8 @@
 "hZY" = (
 /obj/machinery/door/airlock/vault{
 	dir = 4;
-	name = "Phoron Storage Compartment"
+	name = "Phoron Storage Compartment";
+	id = "freebooter_brig"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -4082,6 +4099,33 @@
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/engineering)
+"jRh" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner{
+	dir = 10
+	},
+/obj/structure/closet/crate/miningcart,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/reagent_containers/food/snacks/tastybread,
+/obj/item/reagent_containers/food/snacks/tastybread,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/mushroom,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod8)
 "jSy" = (
 /obj/machinery/hologram/holopad/long_range,
 /turf/simulated/floor/tiled/dark,
@@ -4835,13 +4879,6 @@
 	},
 /turf/simulated/floor/carpet/art,
 /area/ship/freebooter_ship/pod1)
-"lnG" = (
-/obj/effect/floor_decal/corner{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod8)
 "loq" = (
 /obj/structure/grille/broken,
 /obj/structure/blocker/steel,
@@ -5447,15 +5484,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
-"mFp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/ship/freebooter_ship/pod8)
 "mGn" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5677,33 +5705,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
-"niZ" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner{
-	dir = 10
-	},
-/obj/structure/closet/crate/miningcart,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/reagent_containers/food/snacks/tastybread,
-/obj/item/reagent_containers/food/snacks/tastybread,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/mushroom,
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod8)
 "nmL" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -46114,7 +46115,7 @@ xRX
 uwT
 cgU
 hhQ
-mFp
+hBa
 hZY
 cgU
 uwT
@@ -46369,7 +46370,7 @@ hhA
 vOL
 xRX
 uwT
-niZ
+jRh
 onn
 uZC
 iok
@@ -46629,7 +46630,7 @@ uwT
 vMG
 hil
 uOr
-lnG
+hTr
 irq
 uwT
 vZW

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -73,7 +73,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "afL" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_freebooter_shuttle";
@@ -81,9 +80,8 @@
 	shuttle_tag = "Freebooter Shuttle"
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 1
-	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/structure/lattice/catwalk,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "ahD" = (
@@ -133,15 +131,9 @@
 /obj/item/paper/crumpled,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
-"ajM" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "ajO" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/medical)
+/turf/space/dynamic,
+/area/space)
 "akg" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
@@ -276,19 +268,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "ayy" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -386,6 +380,12 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
+"aEO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "aFI" = (
 /obj/item/stack/tile/floor_dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -549,8 +549,9 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aOU" = (
+/obj/structure/lattice/catwalk,
 /turf/space/dynamic,
-/area/space)
+/area/ship/freebooter_ship/exterior)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -912,6 +913,10 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
+/obj/machinery/light{
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "bsp" = (
@@ -1173,6 +1178,22 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
+"bFA" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	pixel_x = -8;
+	pixel_y = 28;
+	dir = 8
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "bJc" = (
 /obj/machinery/door/airlock/external{
 	dir = 8
@@ -2194,7 +2215,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "eDX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2386,9 +2408,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
-"fjE" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/forehallwayport)
 "fjW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 6
@@ -2503,8 +2522,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fGM" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/medical)
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -3137,6 +3169,21 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
+"hnd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/forehallway)
 "hnl" = (
 /obj/effect/floor_decal/corner/beige/full,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3855,12 +3902,19 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "jrC" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "junker_gun"
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/exterior)
 "jvN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -4202,9 +4256,8 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "kqx" = (
-/obj/structure/lattice/catwalk,
-/turf/space/dynamic,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/medical)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
 /obj/effect/decal/cleanable/dirt,
@@ -4606,6 +4659,22 @@
 /obj/structure/inflatable/wall,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
+"las" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	pixel_x = 8;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "lck" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4887,7 +4956,7 @@
 	dir = 4
 	},
 /obj/machinery/airlock_sensor{
-	pixel_x = -32;
+	pixel_x = -27;
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -5265,22 +5334,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
-"myo" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/machinery/access_button{
-	pixel_x = -8;
-	pixel_y = 28;
-	dir = 8
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/foyer)
 "mAl" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = null
@@ -5748,6 +5801,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
+"nAX" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/gunneryentrance)
 "nCr" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	layer = 2.8;
@@ -6372,19 +6428,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
-"oNl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm/north,
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/forehallway)
 "oPu" = (
 /obj/structure/sink/kitchen{
 	name = "sink";
@@ -6641,12 +6684,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
-"ppD" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "prU" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/spline/plain/corner{
@@ -7019,22 +7056,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
-"qeb" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/machinery/access_button{
-	pixel_x = 8;
-	pixel_y = 28;
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/foyer)
 "qej" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7433,9 +7454,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
 "qMB" = (
@@ -8184,13 +8203,13 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod5)
 "syX" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_freebooter_shuttle";
 	name = "airlock_freebooter_shuttle";
 	shuttle_tag = "Freebooter Shuttle"
 	},
+/obj/structure/lattice/catwalk,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "szY" = (
@@ -8209,6 +8228,12 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
+"sAi" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "sBA" = (
 /turf/simulated/wall/shuttle/space_ship{
 	color = "#E14644"
@@ -8264,17 +8289,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
-"sKj" = (
-/obj/machinery/cryopod,
-/obj/structure/cryofeed/pipes{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/cryo)
 "sLq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8378,6 +8392,9 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod6)
+"sVB" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunneryentrance)
 "sVT" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
@@ -8433,10 +8450,12 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "tcV" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_freebooter_shuttle";
 	name = "airlock_freebooter_shuttle";
@@ -8447,9 +8466,7 @@
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
+/obj/structure/lattice/catwalk,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "tcY" = (
@@ -8840,6 +8857,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
+"tZg" = (
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "junker_gun"
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/gunnery)
 "uaE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/railing/mapped{
@@ -9567,10 +9591,6 @@
 /area/ship/freebooter_ship/thruster2)
 "vDD" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	dir = 2;
 	pixel_y = 28;
@@ -9578,6 +9598,10 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -9606,6 +9630,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
+"vMm" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed/pipes{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/freebooter_ship/cryo)
 "vMG" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
@@ -9775,8 +9810,8 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "vZW" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/gunneryentrance)
+/turf/simulated/wall,
+/area/ship/freebooter_ship/medical)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/stool/chair{
@@ -9981,21 +10016,8 @@
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "wGc" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/forehallwayport)
 "wHo" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/ship_engine.dmi';
@@ -10222,7 +10244,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_freebooter_shuttle";
 	name = "airlock_freebooter_shuttle";
@@ -10235,6 +10256,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "xal" = (
@@ -10289,9 +10311,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
-"xey" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunneryentrance)
 "xfg" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -10377,6 +10396,10 @@
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
+	},
+/obj/machinery/light{
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -37785,7 +37808,7 @@ xRX
 xRX
 xRX
 uCl
-aOU
+ajO
 uCl
 fZq
 xRX
@@ -38299,7 +38322,7 @@ xRX
 rtf
 vUu
 uyM
-aOU
+ajO
 aHs
 xRX
 xRX
@@ -38532,17 +38555,17 @@ xRX
 xRX
 xRX
 xRX
-kqx
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
+aOU
 eIb
 wUi
 ldw
 wUi
 eIb
-kqx
-kqx
+aOU
+aOU
 esB
 gwg
 esB
@@ -38550,32 +38573,32 @@ wHo
 esB
 gwg
 esB
-kqx
-kqx
+aOU
+aOU
 cLC
 cLC
 kwe
 tKj
 tKj
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 qiz
 qiz
 mWz
 qiz
 qiz
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 eUq
 eUq
 pRf
 eUq
 eUq
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 xRX
 xRX
 xRX
@@ -38788,8 +38811,8 @@ xRX
 xRX
 xRX
 xRX
-kqx
-kqx
+aOU
+aOU
 xRX
 xRX
 eIb
@@ -38832,7 +38855,7 @@ fTG
 eUq
 eUq
 xRX
-kqx
+aOU
 xqI
 xqI
 xqI
@@ -38846,7 +38869,7 @@ imE
 imE
 iOV
 iOV
-jrC
+tZg
 xRX
 xRX
 xRX
@@ -39103,7 +39126,7 @@ rjL
 tQn
 sxw
 www
-jrC
+tZg
 xRX
 xRX
 xRX
@@ -39304,8 +39327,8 @@ gFA
 ewW
 ewW
 ewW
-kqx
-kqx
+aOU
+aOU
 wUi
 syV
 bhd
@@ -39313,7 +39336,7 @@ xBh
 bhd
 tvh
 wUi
-kqx
+aOU
 gwg
 pUP
 kmP
@@ -39321,7 +39344,7 @@ qDn
 kev
 jcX
 gwg
-kqx
+aOU
 cLC
 wZf
 ttI
@@ -39329,7 +39352,7 @@ krH
 lKT
 vmX
 cLC
-kqx
+aOU
 qiz
 pYB
 bPT
@@ -39337,7 +39360,7 @@ jzk
 fRD
 buM
 qiz
-kqx
+aOU
 eUq
 aTX
 iUK
@@ -39345,8 +39368,8 @@ iUK
 iUK
 fTT
 eUq
-kqx
-kqx
+aOU
+aOU
 xqI
 ahD
 kfJ
@@ -39360,7 +39383,7 @@ fNl
 tQn
 sxw
 sxw
-jrC
+tZg
 xRX
 xRX
 xRX
@@ -39562,7 +39585,7 @@ xUb
 qWF
 ewW
 xRX
-kqx
+aOU
 wUi
 syV
 bhd
@@ -39611,13 +39634,13 @@ npb
 oxR
 tfK
 sxk
-ajM
+sAi
 soh
 soh
 aDv
 iOV
 iOV
-jrC
+tZg
 xRX
 xRX
 xRX
@@ -39819,7 +39842,7 @@ xUb
 jnK
 ewW
 xRX
-kqx
+aOU
 wUi
 syV
 grD
@@ -39869,8 +39892,8 @@ jhd
 tfK
 nwH
 wLI
-ppD
-ppD
+aEO
+aEO
 fnE
 xRX
 xRX
@@ -40076,7 +40099,7 @@ dbA
 wxS
 ewW
 xRX
-kqx
+aOU
 eIb
 oPu
 bhd
@@ -40118,7 +40141,7 @@ cEH
 eUq
 xRX
 xRX
-kqx
+aOU
 xqI
 xqI
 tfK
@@ -40333,7 +40356,7 @@ ewW
 ewW
 ewW
 xRX
-kqx
+aOU
 wUi
 cLL
 bhd
@@ -40375,13 +40398,13 @@ avE
 eUq
 xRX
 xRX
-kqx
+aOU
 xRX
-vZW
+nAX
 rEb
 xTu
 cbE
-xey
+sVB
 klp
 llD
 euj
@@ -40590,7 +40613,7 @@ acn
 ewW
 xRX
 xRX
-kqx
+aOU
 wUi
 glJ
 ihN
@@ -40632,10 +40655,10 @@ hIE
 eUq
 xRX
 xRX
-kqx
+aOU
 xRX
-vZW
-vZW
+nAX
+nAX
 jgM
 vVy
 aMQ
@@ -40847,7 +40870,7 @@ pHN
 ewW
 xRX
 xRX
-kqx
+aOU
 wUi
 wNA
 bhd
@@ -40889,13 +40912,13 @@ iUK
 eUq
 xRX
 xRX
-kqx
+aOU
 xRX
 xRX
-vZW
-vZW
+nAX
+nAX
 tmo
-xey
+sVB
 mwo
 mwo
 mwo
@@ -41104,7 +41127,7 @@ lJH
 jhL
 jhL
 xRX
-kqx
+aOU
 wUi
 peJ
 bhd
@@ -41146,18 +41169,18 @@ mtT
 eUq
 xRX
 xRX
-kqx
+aOU
 xRX
 xRX
 xRX
 uLO
 ebn
 atj
-fGM
+vZW
 exg
 iGK
 aBD
-ajO
+kqx
 xRX
 xRX
 xRX
@@ -41361,7 +41384,7 @@ pCG
 iZM
 jhL
 jhL
-kqx
+aOU
 eIb
 eIb
 pPk
@@ -41403,7 +41426,7 @@ eUq
 eUq
 xRX
 xRX
-kqx
+aOU
 xRX
 xRX
 xRX
@@ -41414,7 +41437,7 @@ jLL
 aab
 qDe
 nVi
-ajO
+kqx
 saW
 xRX
 xRX
@@ -41618,61 +41641,61 @@ mhq
 tcY
 rfn
 jhL
-kqx
-kqx
+aOU
+aOU
 eIb
 eIb
 qEc
 eIb
 eIb
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 gwg
 wzO
 dXK
 wzO
 gwg
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 cLC
 cLC
 mbX
 cLC
 cLC
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 qiz
 qiz
 dFi
 qiz
 qiz
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 eUq
 eUq
 wRc
 eUq
 eUq
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
 pvm
 kou
 dWF
-fGM
+vZW
 gLO
 npJ
 kAt
 lpe
-ajO
+kqx
 xRX
 xRX
 xRX
@@ -41876,18 +41899,10 @@ jbh
 tYn
 jhL
 xRX
-kqx
+aOU
 xRX
 wyp
-mGn
-wyp
-xRX
-xRX
-xRX
-xRX
-xRX
-wyp
-mGn
+ayy
 wyp
 xRX
 xRX
@@ -41895,7 +41910,7 @@ xRX
 xRX
 xRX
 wyp
-mGn
+ayy
 wyp
 xRX
 xRX
@@ -41903,7 +41918,7 @@ xRX
 xRX
 xRX
 wyp
-mGn
+ayy
 wyp
 xRX
 xRX
@@ -41911,25 +41926,33 @@ xRX
 xRX
 xRX
 wyp
-mGn
+ayy
 wyp
 xRX
 xRX
 xRX
 xRX
-kqx
+xRX
+wyp
+ayy
+wyp
+xRX
+xRX
+xRX
+xRX
+aOU
 xRX
 xRX
 xRX
 pvm
 vfD
 kOP
-fGM
-fGM
+vZW
+vZW
 tra
-ajO
-fGM
-ajO
+kqx
+vZW
+kqx
 ydf
 ewy
 ewy
@@ -42133,7 +42156,7 @@ rRa
 nKC
 jhL
 xRX
-kqx
+aOU
 xRX
 wyp
 mGn
@@ -42174,12 +42197,12 @@ xRX
 xRX
 xRX
 xRX
-kqx
+aOU
 xRX
 xRX
 xRX
 uLO
-oNl
+qIf
 kbX
 kzS
 kvJ
@@ -43421,7 +43444,7 @@ wyp
 kXG
 vGw
 wyp
-myo
+bFA
 bzm
 wyp
 vGw
@@ -43464,7 +43487,7 @@ vGw
 wyp
 wyp
 uLO
-qIf
+hnd
 fZr
 wUa
 oKE
@@ -43675,7 +43698,7 @@ pkY
 bJj
 jhL
 xRX
-kqx
+aOU
 xRX
 wyp
 bhA
@@ -43716,7 +43739,7 @@ xRX
 xRX
 xRX
 xRX
-kqx
+aOU
 xRX
 xRX
 xRX
@@ -43932,17 +43955,17 @@ doW
 nEK
 jhL
 xRX
-kqx
+aOU
 xRX
 wyp
-wGc
+vDD
 xvT
 wyp
 xRX
 xRX
 xRX
 wyp
-vDD
+fGM
 bsf
 wyp
 xRX
@@ -43951,7 +43974,7 @@ xRX
 xRX
 xRX
 wyp
-mGn
+ayy
 wyp
 xRX
 xRX
@@ -43959,7 +43982,7 @@ xRX
 xRX
 xRX
 wyp
-mGn
+ayy
 wyp
 xRX
 xRX
@@ -43967,13 +43990,13 @@ xRX
 xRX
 xRX
 wyp
-mGn
+ayy
 wyp
 xRX
 xRX
 xRX
 xRX
-kqx
+aOU
 xRX
 xRX
 xRX
@@ -44188,52 +44211,52 @@ ngJ
 gwl
 xZh
 jhL
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 wyp
-qeb
+las
 bJc
 wyp
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 wyp
 uJz
 bst
 wyp
-kqx
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
+aOU
 uwT
 uwT
 jjA
 uwT
 uwT
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 eiL
 eiL
 gSo
 eiL
 eiL
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 tRo
 tRo
 sVs
 tRo
 tRo
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
 gzr
 iHV
 kOP
@@ -44445,23 +44468,23 @@ oGU
 kMx
 jhL
 jhL
-kqx
 aOU
+ajO
 sUX
 ppp
 ppp
 ppp
 ppp
-ayy
+jrC
 kQs
-ayy
+jrC
 wtm
 rhN
 ciM
 rhN
 rmm
-aOU
-aOU
+ajO
+ajO
 uwT
 uwT
 lgM
@@ -44487,7 +44510,7 @@ tRo
 tRo
 xRX
 xRX
-kqx
+aOU
 xRX
 xRX
 xRX
@@ -44701,8 +44724,8 @@ aEa
 lJH
 jhL
 jhL
+ajO
 aOU
-kqx
 iGW
 wnf
 aSb
@@ -44718,7 +44741,7 @@ iQg
 clU
 nKq
 rmm
-aOU
+ajO
 htS
 lfg
 jFY
@@ -44744,7 +44767,7 @@ cMo
 tRo
 xRX
 xRX
-kqx
+aOU
 xRX
 xRX
 xRX
@@ -44753,7 +44776,7 @@ ebn
 cDf
 quS
 cQs
-sKj
+vMm
 aSJ
 oxG
 xRX
@@ -44957,9 +44980,9 @@ xKt
 adF
 eqi
 uZl
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 rrT
 ntt
 sUq
@@ -44975,7 +44998,7 @@ elW
 sWG
 qVW
 vOL
-kqx
+aOU
 uwT
 dkz
 hHq
@@ -45001,7 +45024,7 @@ bxM
 tRo
 xRX
 xRX
-kqx
+aOU
 xRX
 xRX
 uLO
@@ -45214,9 +45237,9 @@ mOF
 qED
 uPa
 uZl
+ajO
+ajO
 aOU
-aOU
-kqx
 bcf
 aSb
 aEB
@@ -45232,7 +45255,7 @@ eqD
 aSb
 qeJ
 vOL
-aOU
+ajO
 uwT
 oZH
 pZI
@@ -45258,10 +45281,10 @@ ieZ
 tRo
 xRX
 xRX
-kqx
+aOU
 xRX
-fjE
-fjE
+wGc
+wGc
 nZj
 ess
 lzb
@@ -45472,8 +45495,8 @@ bpj
 fdV
 uZl
 uZl
+ajO
 aOU
-kqx
 rJT
 rsE
 rsE
@@ -45489,7 +45512,7 @@ afL
 sVT
 oSp
 vOL
-aOU
+ajO
 uwT
 bDX
 mCb
@@ -45515,9 +45538,9 @@ uNJ
 tRo
 xRX
 xRX
-kqx
+aOU
 xRX
-fjE
+wGc
 xMA
 uWU
 oVL
@@ -45729,8 +45752,8 @@ ieM
 mwO
 uoZ
 uZl
+ajO
 aOU
-kqx
 iUd
 vdX
 atI
@@ -45746,7 +45769,7 @@ tcV
 rXx
 cJt
 vOL
-aOU
+ajO
 uwT
 fYr
 lGK
@@ -45772,9 +45795,9 @@ lvR
 tRo
 xRX
 xRX
-kqx
+aOU
 xRX
-fjE
+wGc
 oyG
 cnH
 ess
@@ -45986,8 +46009,8 @@ mCl
 kuj
 rFB
 uZl
+ajO
 aOU
-kqx
 lkK
 hZH
 kti
@@ -46003,7 +46026,7 @@ kTf
 bzW
 hhA
 vOL
-aOU
+ajO
 uwT
 cgU
 hhQ
@@ -46243,8 +46266,8 @@ uiV
 vDk
 rFB
 uZl
+ajO
 aOU
-kqx
 bcf
 aSb
 aSb
@@ -46260,7 +46283,7 @@ tDp
 aSb
 hhA
 vOL
-aOU
+ajO
 uwT
 cgU
 onn
@@ -46500,8 +46523,8 @@ aEt
 ldf
 uZl
 uZl
-kqx
-kqx
+aOU
+aOU
 bcf
 sBA
 ruo
@@ -46517,7 +46540,7 @@ elW
 sWG
 cei
 vOL
-kqx
+aOU
 uwT
 vMG
 hil
@@ -46525,7 +46548,7 @@ uOr
 hil
 irq
 uwT
-kqx
+aOU
 eiL
 upC
 buI
@@ -46533,7 +46556,7 @@ hdb
 pZo
 fVv
 eiL
-kqx
+aOU
 tRo
 pDZ
 bxM
@@ -46541,8 +46564,8 @@ bxM
 bxM
 pZO
 tRo
-kqx
-kqx
+aOU
+aOU
 wjn
 qqX
 vwi
@@ -46756,9 +46779,9 @@ uZl
 osl
 stV
 uZl
+ajO
+ajO
 aOU
-aOU
-kqx
 aCG
 dqF
 aSb
@@ -46774,7 +46797,7 @@ rhN
 rhN
 mYn
 tOu
-aOU
+ajO
 htS
 hXO
 uwA
@@ -47012,11 +47035,11 @@ xRX
 xRX
 xRX
 xRX
-kqx
-kqx
 aOU
-kqx
 aOU
+ajO
+aOU
+ajO
 kOK
 rfz
 rfz
@@ -47030,8 +47053,8 @@ vTv
 vTv
 vTv
 tOu
-aOU
-aOU
+ajO
+ajO
 uwT
 uwT
 nti
@@ -47056,7 +47079,7 @@ rEV
 tRo
 tRo
 xRX
-kqx
+aOU
 wjn
 wjn
 wjn
@@ -47270,50 +47293,50 @@ xRX
 xRX
 xRX
 xRX
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
 ibm
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
 fro
-kqx
-kqx
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
+aOU
+aOU
 uwT
 uwT
 qju
 uwT
 uwT
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 eiL
 eiL
 sal
 eiL
 eiL
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 tRo
 tRo
 raF
 tRo
 tRo
-kqx
-kqx
-kqx
+aOU
+aOU
+aOU
 xRX
 xRX
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1045,12 +1045,10 @@
 	master_tag = "freebooter_port_1"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "bzr" = (
@@ -3495,16 +3493,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
-"ial" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/foyer)
 "iaK" = (
 /obj/effect/floor_decal/corner/beige,
 /turf/simulated/floor/tiled/dark,
@@ -4033,6 +4021,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "jEu" = (
@@ -4555,6 +4546,16 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod3)
+"kCq" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/foyer)
 "kCv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/structure/lattice/catwalk/indoor/grate/dark,
@@ -43335,7 +43336,7 @@ oXj
 rnp
 bdI
 lHL
-ial
+kCq
 mvP
 ruW
 lwO

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -133,11 +133,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ajO" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 9
-	},
-/turf/simulated/floor/airless,
+/obj/structure/lattice/catwalk,
+/turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "akg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -288,13 +285,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
-"ayL" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 10
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -341,17 +331,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
-"aDe" = (
-/obj/machinery/cryopod,
-/obj/structure/cryofeed/pipes{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/cryo)
 "aDv" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, main gun"
@@ -396,23 +375,6 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
-"aEE" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 5
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
 "aFI" = (
 /obj/item/stack/tile/floor_dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -576,19 +538,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aOU" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/wall,
+/area/ship/freebooter_ship/medical)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -749,8 +700,12 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "bcf" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/gunneryentrance)
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 9
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "bci" = (
 /obj/machinery/appliance/cooker/grill,
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -822,6 +777,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
+"bhw" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/access_button{
+	pixel_x = -8;
+	pixel_y = 28;
+	dir = 8
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "bhA" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -855,6 +827,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
+"bkP" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "bkX" = (
 /obj/structure/mirror{
 	icon_state = "mirror_mask_broken";
@@ -988,21 +966,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
 "btW" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "buA" = (
 /obj/structure/flora/pottedplant{
 	dead = 1;
@@ -1722,8 +1690,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
 "dqF" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/medical)
+/turf/space/dynamic,
+/area/space)
 "drK" = (
 /turf/simulated/wall/shuttle/space_ship{
 	color = "#E14644"
@@ -2329,6 +2297,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
+"fcl" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed/pipes{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/freebooter_ship/cryo)
 "fdD" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -2533,6 +2512,19 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/engineering)
+"fyi" = (
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "fBb" = (
 /obj/structure/table/glass,
 /obj/item/pen/multi{
@@ -2550,9 +2542,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fGM" = (
-/obj/structure/lattice/catwalk,
-/turf/space/dynamic,
-/area/ship/freebooter_ship/exterior)
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor,
+/area/shuttle/freebooter_shuttle)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -2676,6 +2669,9 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
+"fVy" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunneryentrance)
 "fXt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2873,21 +2869,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
-"guH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/forehallway)
 "gwg" = (
 /turf/simulated/wall/shuttle/space_ship{
 	color = "#E14644"
@@ -2921,16 +2902,16 @@
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
 /obj/machinery/access_button{
 	pixel_x = -8;
 	pixel_y = 28;
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
@@ -3761,7 +3742,7 @@
 /area/ship/freebooter_ship/gunnery)
 "iOV" = (
 /obj/machinery/door/blast/regular/open{
-	dir = 4;
+	dir = 2;
 	id = "junker_gun"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -3789,12 +3770,6 @@
 /obj/item/ammo_casing/rifle/used,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
-"iRt" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "iTc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 10
@@ -3907,6 +3882,9 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod8)
+"jli" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/forehallwayport)
 "jlr" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
@@ -3915,9 +3893,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
-"jlF" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/forehallwayport)
 "jnK" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	dir = 1;
@@ -3932,10 +3907,12 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "jrC" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "junker_gun"
 	},
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/airless,
 /area/ship/freebooter_ship/gunnery)
 "jvN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4277,7 +4254,7 @@
 /area/ship/freebooter_ship/pod7)
 "kqx" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/medical)
+/area/ship/freebooter_ship/gunneryentrance)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
 /obj/effect/decal/cleanable/dirt,
@@ -5882,22 +5859,26 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
+"nOj" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/access_button{
+	pixel_x = 8;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "nRY" = (
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
-"nSY" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
 "nVi" = (
 /obj/structure/table/steel,
 /obj/item/storage/firstaid/fire{
@@ -6022,11 +6003,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
-"obM" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor,
-/area/shuttle/freebooter_shuttle)
 "odb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6195,6 +6171,18 @@
 	dir = 1;
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod1)
+"oqi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/sign/poster{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
@@ -6461,14 +6449,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
-"oQl" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	id = "junker_gun"
-	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/gunnery)
 "oRN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /obj/machinery/meter,
@@ -6855,6 +6835,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
+"pDo" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "pDZ" = (
 /obj/effect/floor_decal/corner{
 	dir = 8
@@ -7763,9 +7759,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
-"rtO" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunneryentrance)
 "ruo" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -8073,6 +8066,20 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod2)
+"sgL" = (
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "sjD" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -8372,6 +8379,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
+"sUg" = (
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 10
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship)
 "sUq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/machinery/computer/ship/engines,
@@ -8494,23 +8508,6 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
-"tcX" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/access_button{
-	pixel_x = 8;
-	pixel_y = 28;
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/floor_decal/industrial/hatch/red,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/foyer)
 "tcY" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 8
@@ -8718,6 +8715,21 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
+"tHg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/forehallway)
 "tHQ" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/decal/cleanable/dirt,
@@ -9630,6 +9642,10 @@
 /area/ship/freebooter_ship/thruster2)
 "vDD" = (
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	dir = 2;
 	pixel_y = 28;
@@ -9637,10 +9653,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -9838,17 +9850,22 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "vZW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/structure/railing/mapped{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 8
 	},
-/obj/structure/sign/poster{
-	pixel_y = 32
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod1)
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/stool/chair{
@@ -9930,8 +9947,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "wnf" = (
-/turf/space/dynamic,
-/area/space)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/medical)
 "wnq" = (
 /obj/structure/table/steel,
 /obj/item/gun/projectile/automatic/improvised,
@@ -10044,12 +10061,21 @@
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "wGc" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "wHo" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/ship_engine.dmi';
@@ -10216,6 +10242,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
+"wUI" = (
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "wUJ" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
@@ -10320,23 +10353,6 @@
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
-"xcD" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/machinery/access_button{
-	pixel_x = -8;
-	pixel_y = 28;
-	dir = 8
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/foyer)
 "xcR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10371,22 +10387,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/light/small/emergency{
 	dir = 4
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
-"xfP" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -37876,7 +37876,7 @@ xRX
 xRX
 xRX
 uCl
-wnf
+dqF
 uCl
 fZq
 xRX
@@ -38390,7 +38390,7 @@ xRX
 rtf
 vUu
 uyM
-wnf
+dqF
 aHs
 xRX
 xRX
@@ -38623,17 +38623,17 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
+ajO
 eIb
 wUi
 ldw
 wUi
 eIb
-fGM
-fGM
+ajO
+ajO
 esB
 gwg
 esB
@@ -38641,32 +38641,32 @@ wHo
 esB
 gwg
 esB
-fGM
-fGM
+ajO
+ajO
 cLC
 cLC
 kwe
 tKj
 tKj
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 qiz
 qiz
 mWz
 qiz
 qiz
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 eUq
 eUq
 pRf
 eUq
 eUq
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 xRX
 xRX
 xRX
@@ -38879,8 +38879,8 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
+ajO
+ajO
 xRX
 xRX
 eIb
@@ -38923,7 +38923,7 @@ fTG
 eUq
 eUq
 xRX
-fGM
+ajO
 xqI
 xqI
 xqI
@@ -38935,9 +38935,9 @@ imE
 imE
 imE
 imE
-oQl
-oQl
 iOV
+iOV
+jrC
 xRX
 xRX
 xRX
@@ -39194,7 +39194,7 @@ rjL
 tQn
 sxw
 www
-iOV
+jrC
 xRX
 xRX
 xRX
@@ -39395,8 +39395,8 @@ gFA
 ewW
 ewW
 ewW
-fGM
-fGM
+ajO
+ajO
 wUi
 syV
 bhd
@@ -39404,7 +39404,7 @@ xBh
 bhd
 tvh
 wUi
-fGM
+ajO
 gwg
 pUP
 kmP
@@ -39412,7 +39412,7 @@ qDn
 kev
 jcX
 gwg
-fGM
+ajO
 cLC
 wZf
 ttI
@@ -39420,7 +39420,7 @@ krH
 lKT
 vmX
 cLC
-fGM
+ajO
 qiz
 pYB
 bPT
@@ -39428,7 +39428,7 @@ jzk
 fRD
 buM
 qiz
-fGM
+ajO
 eUq
 aTX
 iUK
@@ -39436,8 +39436,8 @@ iUK
 iUK
 fTT
 eUq
-fGM
-fGM
+ajO
+ajO
 xqI
 ahD
 kfJ
@@ -39451,7 +39451,7 @@ fNl
 tQn
 sxw
 sxw
-iOV
+jrC
 xRX
 xRX
 xRX
@@ -39653,7 +39653,7 @@ xUb
 qWF
 ewW
 xRX
-fGM
+ajO
 wUi
 syV
 bhd
@@ -39702,13 +39702,13 @@ npb
 oxR
 tfK
 sxk
-jrC
+bkP
 soh
 soh
 aDv
-oQl
-oQl
 iOV
+iOV
+jrC
 xRX
 xRX
 xRX
@@ -39910,7 +39910,7 @@ xUb
 jnK
 ewW
 xRX
-fGM
+ajO
 wUi
 syV
 grD
@@ -39960,8 +39960,8 @@ jhd
 tfK
 nwH
 wLI
-iRt
-iRt
+btW
+btW
 fnE
 xRX
 xRX
@@ -40167,7 +40167,7 @@ dbA
 wxS
 ewW
 xRX
-fGM
+ajO
 eIb
 oPu
 bhd
@@ -40209,7 +40209,7 @@ cEH
 eUq
 xRX
 xRX
-fGM
+ajO
 xqI
 xqI
 tfK
@@ -40424,7 +40424,7 @@ ewW
 ewW
 ewW
 xRX
-fGM
+ajO
 wUi
 cLL
 bhd
@@ -40461,18 +40461,18 @@ eUq
 lnp
 heP
 iUK
-vZW
+oqi
 avE
 eUq
 xRX
 xRX
-fGM
+ajO
 xRX
-bcf
+kqx
 rEb
 xTu
 cbE
-rtO
+fVy
 klp
 llD
 euj
@@ -40681,7 +40681,7 @@ acn
 ewW
 xRX
 xRX
-fGM
+ajO
 wUi
 glJ
 ihN
@@ -40723,10 +40723,10 @@ hIE
 eUq
 xRX
 xRX
-fGM
+ajO
 xRX
-bcf
-bcf
+kqx
+kqx
 jgM
 vVy
 aMQ
@@ -40938,7 +40938,7 @@ pHN
 ewW
 xRX
 xRX
-fGM
+ajO
 wUi
 wNA
 bhd
@@ -40980,13 +40980,13 @@ iUK
 eUq
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
-bcf
-bcf
+kqx
+kqx
 tmo
-rtO
+fVy
 mwo
 mwo
 mwo
@@ -41195,7 +41195,7 @@ lJH
 jhL
 jhL
 xRX
-fGM
+ajO
 wUi
 peJ
 bhd
@@ -41237,18 +41237,18 @@ mtT
 eUq
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
 uLO
 ebn
 atj
-dqF
+aOU
 exg
 iGK
 aBD
-kqx
+wnf
 xRX
 xRX
 xRX
@@ -41452,7 +41452,7 @@ pCG
 iZM
 jhL
 jhL
-fGM
+ajO
 eIb
 eIb
 pPk
@@ -41494,7 +41494,7 @@ eUq
 eUq
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -41505,7 +41505,7 @@ jLL
 aab
 qDe
 nVi
-kqx
+wnf
 saW
 xRX
 xRX
@@ -41709,61 +41709,61 @@ mhq
 tcY
 rfn
 jhL
-fGM
-fGM
+ajO
+ajO
 eIb
 eIb
 qEc
 eIb
 eIb
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 gwg
 wzO
 dXK
 wzO
 gwg
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 cLC
 cLC
 mbX
 cLC
 cLC
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 qiz
 qiz
 dFi
 qiz
 qiz
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 eUq
 eUq
 wRc
 eUq
 eUq
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 pvm
 kou
 dWF
-dqF
+aOU
 gLO
 npJ
 kAt
 lpe
-kqx
+wnf
 xRX
 xRX
 xRX
@@ -41967,18 +41967,10 @@ jbh
 tYn
 jhL
 xRX
-fGM
+ajO
 xRX
 wyp
-btW
-wyp
-xRX
-xRX
-xRX
-xRX
-xRX
-wyp
-btW
+wGc
 wyp
 xRX
 xRX
@@ -41986,7 +41978,7 @@ xRX
 xRX
 xRX
 wyp
-btW
+wGc
 wyp
 xRX
 xRX
@@ -41994,7 +41986,7 @@ xRX
 xRX
 xRX
 wyp
-btW
+wGc
 wyp
 xRX
 xRX
@@ -42002,25 +41994,33 @@ xRX
 xRX
 xRX
 wyp
-btW
+wGc
 wyp
 xRX
 xRX
 xRX
 xRX
-fGM
+xRX
+wyp
+wGc
+wyp
+xRX
+xRX
+xRX
+xRX
+ajO
 xRX
 xRX
 xRX
 pvm
 vfD
 kOP
-dqF
-dqF
+aOU
+aOU
 tra
-kqx
-dqF
-kqx
+wnf
+aOU
+wnf
 ydf
 ewy
 ewy
@@ -42224,7 +42224,7 @@ rRa
 nKC
 jhL
 xRX
-fGM
+ajO
 xRX
 wyp
 mGn
@@ -42265,7 +42265,7 @@ xRX
 xRX
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -43512,14 +43512,14 @@ wyp
 kXG
 vGw
 wyp
-xcD
+gyl
 bzm
 wyp
 vGw
 vGw
 vGw
 wyp
-gyl
+bhw
 odb
 wyp
 wyp
@@ -43555,7 +43555,7 @@ vGw
 wyp
 wyp
 uLO
-guH
+tHg
 fZr
 wUa
 oKE
@@ -43766,7 +43766,7 @@ pkY
 bJj
 jhL
 xRX
-fGM
+ajO
 xRX
 wyp
 bhA
@@ -43807,7 +43807,7 @@ xRX
 xRX
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -44023,17 +44023,17 @@ doW
 nEK
 jhL
 xRX
-fGM
+ajO
 xRX
 wyp
-vDD
+pDo
 xvT
 wyp
 xRX
 xRX
 xRX
 wyp
-xfP
+vDD
 bsf
 wyp
 xRX
@@ -44042,7 +44042,7 @@ xRX
 xRX
 xRX
 wyp
-btW
+wGc
 wyp
 xRX
 xRX
@@ -44050,7 +44050,7 @@ xRX
 xRX
 xRX
 wyp
-btW
+wGc
 wyp
 xRX
 xRX
@@ -44058,13 +44058,13 @@ xRX
 xRX
 xRX
 wyp
-btW
+wGc
 wyp
 xRX
 xRX
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -44279,52 +44279,52 @@ ngJ
 gwl
 xZh
 jhL
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 wyp
 uJz
 bJc
 wyp
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 wyp
-tcX
+nOj
 bst
 wyp
-fGM
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
+ajO
 uwT
 uwT
 jjA
 uwT
 uwT
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 eiL
 eiL
 gSo
 eiL
 eiL
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 tRo
 tRo
 sVs
 tRo
 tRo
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 gzr
 iHV
 kOP
@@ -44536,8 +44536,8 @@ oGU
 kMx
 jhL
 jhL
-fGM
-aOU
+ajO
+sgL
 sUX
 ppp
 ppp
@@ -44549,10 +44549,10 @@ ayy
 wtm
 rhN
 ciM
-wGc
+wUI
 rmm
-wnf
-wnf
+dqF
+dqF
 uwT
 uwT
 lgM
@@ -44578,7 +44578,7 @@ tRo
 tRo
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -44792,8 +44792,8 @@ aEa
 lJH
 jhL
 jhL
-wnf
-fGM
+dqF
+ajO
 iGW
 aSb
 aSb
@@ -44809,7 +44809,7 @@ iQg
 clU
 nKq
 rmm
-wnf
+dqF
 htS
 lfg
 jFY
@@ -44835,7 +44835,7 @@ cMo
 tRo
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -44844,7 +44844,7 @@ ebn
 cDf
 quS
 cQs
-aDe
+fcl
 aSJ
 oxG
 xRX
@@ -45048,9 +45048,9 @@ xKt
 adF
 eqi
 uZl
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 rrT
 ntt
 sUq
@@ -45066,7 +45066,7 @@ elW
 sWG
 qVW
 vOL
-fGM
+ajO
 uwT
 dkz
 hHq
@@ -45092,7 +45092,7 @@ bxM
 tRo
 xRX
 xRX
-fGM
+ajO
 xRX
 xRX
 uLO
@@ -45305,9 +45305,9 @@ mOF
 qED
 uPa
 uZl
-wnf
-wnf
-fGM
+dqF
+dqF
+ajO
 rrT
 aSb
 aEB
@@ -45323,7 +45323,7 @@ eqD
 aSb
 qeJ
 vOL
-wnf
+dqF
 uwT
 oZH
 pZI
@@ -45349,10 +45349,10 @@ ieZ
 tRo
 xRX
 xRX
-fGM
+ajO
 xRX
-jlF
-jlF
+jli
+jli
 nZj
 ess
 lzb
@@ -45563,13 +45563,13 @@ bpj
 fdV
 uZl
 uZl
-wnf
-fGM
+dqF
+ajO
 rJT
 rsE
-ayL
+sUg
 rQJ
-obM
+fGM
 tuB
 fNL
 bkh
@@ -45580,7 +45580,7 @@ afL
 sVT
 oSp
 vOL
-wnf
+dqF
 uwT
 bDX
 mCb
@@ -45606,9 +45606,9 @@ uNJ
 tRo
 xRX
 xRX
-fGM
+ajO
 xRX
-jlF
+jli
 xMA
 uWU
 oVL
@@ -45820,8 +45820,8 @@ ieM
 mwO
 uoZ
 uZl
-wnf
-fGM
+dqF
+ajO
 iUd
 vdX
 atI
@@ -45837,7 +45837,7 @@ tcV
 rXx
 cJt
 vOL
-wnf
+dqF
 uwT
 fYr
 lGK
@@ -45863,9 +45863,9 @@ lvR
 tRo
 xRX
 xRX
-fGM
+ajO
 xRX
-jlF
+jli
 oyG
 cnH
 ess
@@ -46077,8 +46077,8 @@ mCl
 kuj
 rFB
 uZl
-wnf
-fGM
+dqF
+ajO
 lkK
 hZH
 kti
@@ -46094,7 +46094,7 @@ kTf
 bzW
 hhA
 vOL
-wnf
+dqF
 uwT
 cgU
 hhQ
@@ -46334,8 +46334,8 @@ uiV
 vDk
 rFB
 uZl
-wnf
-fGM
+dqF
+ajO
 rrT
 aSb
 aSb
@@ -46351,7 +46351,7 @@ tDp
 aSb
 hhA
 vOL
-wnf
+dqF
 uwT
 cgU
 onn
@@ -46591,8 +46591,8 @@ aEt
 ldf
 uZl
 uZl
-fGM
-fGM
+ajO
+ajO
 rrT
 sBA
 ruo
@@ -46608,7 +46608,7 @@ elW
 sWG
 cei
 vOL
-fGM
+ajO
 uwT
 vMG
 hil
@@ -46616,7 +46616,7 @@ uOr
 hil
 irq
 uwT
-fGM
+ajO
 eiL
 upC
 buI
@@ -46624,7 +46624,7 @@ hdb
 pZo
 fVv
 eiL
-fGM
+ajO
 tRo
 pDZ
 bxM
@@ -46632,8 +46632,8 @@ bxM
 bxM
 pZO
 tRo
-fGM
-fGM
+ajO
+ajO
 wjn
 qqX
 vwi
@@ -46847,9 +46847,9 @@ uZl
 osl
 stV
 uZl
-wnf
-wnf
-fGM
+dqF
+dqF
+ajO
 aCG
 aSb
 aSb
@@ -46860,12 +46860,12 @@ vCg
 iTc
 lKV
 kEe
-ajO
-wGc
-wGc
+bcf
+wUI
+wUI
 mYn
 tOu
-wnf
+dqF
 htS
 hXO
 uwA
@@ -47103,11 +47103,11 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
-wnf
-fGM
-aEE
+ajO
+ajO
+dqF
+ajO
+vZW
 kOK
 rfz
 rfz
@@ -47117,12 +47117,12 @@ rfz
 rfz
 rfz
 lCe
-nSY
+fyi
 vTv
 vTv
 tOu
-wnf
-wnf
+dqF
+dqF
 uwT
 uwT
 nti
@@ -47147,7 +47147,7 @@ rEV
 tRo
 tRo
 xRX
-fGM
+ajO
 wjn
 wjn
 wjn
@@ -47361,50 +47361,50 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 ibm
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 fro
-fGM
-fGM
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
+ajO
+ajO
 uwT
 uwT
 qju
 uwT
 uwT
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 eiL
 eiL
 sal
 eiL
 eiL
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 tRo
 tRo
 raF
 tRo
 tRo
-fGM
-fGM
-fGM
+ajO
+ajO
+ajO
 xRX
 xRX
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -455,14 +455,10 @@
 	},
 /area/shuttle/freebooter_shuttle)
 "aKs" = (
-/obj/machinery/light/small/emergency{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 5
 	},
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/thruster1)
 "aKD" = (
 /obj/machinery/door/blast/shutters/open{
@@ -480,11 +476,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
 	},
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/machinery/light/small/emergency{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/thruster2)
 "aMa" = (
 /obj/effect/floor_decal/corner/lime{
@@ -1257,7 +1249,6 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/ammo)
 "bWt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -1381,6 +1372,7 @@
 	layer = 2.31;
 	name = "lattice"
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/forehallwayport)
 "cok" = (
@@ -1401,7 +1393,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/overmap/visitable/ship/freebooter_ship,
-/obj/effect/shuttle_landmark/freebooter_ship,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
 "cCu" = (
@@ -1618,7 +1609,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
 "dhX" = (
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -3319,7 +3309,6 @@
 /area/ship/freebooter_ship/thruster1)
 "hPM" = (
 /obj/machinery/atmospherics/unary/engine,
-/obj/structure/window/reinforced,
 /obj/effect/landmark/entry_point/aft{
 	name = "aft, starboard thruster"
 	},
@@ -3457,7 +3446,6 @@
 /area/ship/freebooter_ship/exterior)
 "icO" = (
 /obj/machinery/atmospherics/unary/engine,
-/obj/structure/window/reinforced,
 /obj/effect/landmark/entry_point/aft{
 	name = "aft, port thruster"
 	},
@@ -3930,8 +3918,7 @@
 /area/ship/freebooter_ship/thruster1)
 "joM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/thruster2)
 "jrC" = (
 /obj/structure/railing/mapped{
@@ -4728,6 +4715,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "lfg" = (
@@ -5156,10 +5146,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "mbg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
 	icon = 'icons/obj/smooth/lattice.dmi';
@@ -5765,10 +5755,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "ntt" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/structure/window/reinforced,
-/turf/simulated/floor,
-/area/shuttle/freebooter_shuttle)
+/obj/effect/floor_decal/corner/dark_green/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/forehallwayport)
 "nty" = (
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
@@ -5978,11 +5974,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/firealarm/west,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/thruster2)
 "nXA" = (
 /obj/effect/floor_decal/corner/lime{
@@ -6362,6 +6354,9 @@
 	dir = 8;
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallwayport)
@@ -7169,6 +7164,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "qiz" = (
@@ -7324,9 +7322,8 @@
 /area/ship/freebooter_ship/foyer)
 "qwx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
-/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/thruster1)
 "qxl" = (
 /obj/effect/floor_decal/spline/plain{
@@ -7526,7 +7523,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
 "qMB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/structure/bed/stool/chair/office/bridge/pilot{
 	dir = 1
 	},
@@ -8425,7 +8421,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
 "sUq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/machinery/computer/ship/engines,
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor,
@@ -8523,6 +8518,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "tcV" = (
@@ -8982,8 +8978,7 @@
 /area/ship/freebooter_ship/pod3)
 "ugG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/thruster1)
 "uhG" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -9551,7 +9546,6 @@
 /area/ship/freebooter_ship/pod4)
 "vkx" = (
 /obj/machinery/atmospherics/unary/engine,
-/obj/structure/window/reinforced,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/thruster1)
 "vmX" = (
@@ -9629,7 +9623,6 @@
 	dir = 1;
 	name = "Thrust Control"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
 "vAb" = (
@@ -9682,7 +9675,6 @@
 /area/ship/freebooter_ship/foyer)
 "vFo" = (
 /obj/machinery/atmospherics/unary/engine,
-/obj/structure/window/reinforced,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/thruster2)
 "vGw" = (
@@ -9700,11 +9692,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "vIj" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster2)
+/obj/effect/floor_decal/corner/dark_green/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/forehallwayport)
 "vMG" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
@@ -10052,7 +10052,7 @@
 	frequency = 1336;
 	output = 31
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced/carbon_dioxide,
 /area/ship/freebooter_ship/thruster1)
 "wyp" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
@@ -10537,7 +10537,9 @@
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/black,
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "xIQ" = (
@@ -10603,9 +10605,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/machinery/firealarm/east,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/thruster1)
 "xPX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -45061,7 +45061,7 @@ vZW
 vZW
 vZW
 bcf
-ntt
+aSb
 sUq
 qMB
 vxO
@@ -45877,7 +45877,7 @@ xRX
 rrT
 oyG
 cnH
-ess
+ntt
 lzb
 csG
 wIJ
@@ -46332,7 +46332,7 @@ xRX
 xRX
 xRX
 vFo
-vIj
+joM
 qgY
 rXk
 lqh
@@ -46391,7 +46391,7 @@ wLV
 aMB
 qqX
 tyf
-ess
+vIj
 oEs
 jcW
 tli

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -133,9 +133,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ajO" = (
-/obj/structure/lattice/catwalk,
-/turf/space/dynamic,
-/area/ship/freebooter_ship/exterior)
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 10
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship)
 "akg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -272,19 +275,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "ayy" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/gunneryentrance)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -538,7 +530,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aOU" = (
-/turf/simulated/wall,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/medical)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -700,9 +692,14 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "bcf" = (
+/obj/structure/railing/mapped{
+	dir = 1
+	},
 /obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 9
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
@@ -777,23 +774,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
-"bhw" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/access_button{
-	pixel_x = -8;
-	pixel_y = 28;
-	dir = 8
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/floor_decal/industrial/hatch/red,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/foyer)
 "bhA" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -827,12 +807,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
-"bkP" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "bkX" = (
 /obj/structure/mirror{
 	icon_state = "mirror_mask_broken";
@@ -967,10 +941,11 @@
 /area/ship/freebooter_ship/engineering)
 "btW" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 4
+	layer = 2.71;
+	dir = 8
 	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "buA" = (
 /obj/structure/flora/pottedplant{
 	dead = 1;
@@ -1431,6 +1406,22 @@
 /obj/effect/shuttle_landmark/freebooter_ship,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
+"cCu" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "cDf" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -1661,6 +1652,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
+"dlZ" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunneryentrance)
 "doC" = (
 /mob/living/bot/farmbot{
 	req_one_access = null;
@@ -1690,8 +1684,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
 "dqF" = (
-/turf/space/dynamic,
-/area/space)
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 5
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "drK" = (
 /turf/simulated/wall/shuttle/space_ship{
 	color = "#E14644"
@@ -2297,17 +2305,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
-"fcl" = (
-/obj/machinery/cryopod,
-/obj/structure/cryofeed/pipes{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/cryo)
 "fdD" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -2512,19 +2509,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/engineering)
-"fyi" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
 "fBb" = (
 /obj/structure/table/glass,
 /obj/item/pen/multi{
@@ -2542,10 +2526,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fGM" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor,
-/area/shuttle/freebooter_shuttle)
+/area/ship/freebooter_ship/foyer)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -2669,9 +2664,6 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
-"fVy" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunneryentrance)
 "fXt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2902,16 +2894,16 @@
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
 /obj/machinery/access_button{
 	pixel_x = -8;
 	pixel_y = 28;
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
@@ -3344,6 +3336,19 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
+"hQh" = (
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "hQA" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -3378,6 +3383,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
+"hVL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/forehallway)
 "hWE" = (
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 8
@@ -3882,9 +3900,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod8)
-"jli" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/forehallwayport)
 "jlr" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
@@ -3907,13 +3922,19 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "jrC" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "junker_gun"
+/obj/structure/railing/mapped{
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/exterior)
 "jvN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -3934,6 +3955,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod2)
+"jzx" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	pixel_x = -8;
+	pixel_y = 28;
+	dir = 8
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "jEu" = (
 /obj/structure/table/stone/marble,
 /obj/machinery/reagentgrinder{
@@ -4049,9 +4087,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/engineering)
 "jSy" = (
@@ -4253,8 +4288,8 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "kqx" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/gunneryentrance)
+/turf/space/dynamic,
+/area/space)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
 /obj/effect/decal/cleanable/dirt,
@@ -4848,6 +4883,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
+"lsh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod1)
 "lvN" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -5672,6 +5719,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
+"nrq" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor,
+/area/shuttle/freebooter_shuttle)
 "nrR" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
@@ -5858,23 +5910,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
-"nOj" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/access_button{
-	pixel_x = 8;
-	pixel_y = 28;
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/floor_decal/industrial/hatch/red,
-/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "nRY" = (
 /turf/simulated/floor/tiled/dark,
@@ -6109,6 +6144,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
+"okU" = (
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "omd" = (
 /obj/effect/floor_decal/corner/dark_blue/full,
 /obj/effect/floor_decal/industrial/warning{
@@ -6171,18 +6220,6 @@
 	dir = 1;
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod1)
-"oqi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/sign/poster{
-	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
@@ -6639,6 +6676,14 @@
 /obj/item/spacecash/c1,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod2)
+"pkP" = (
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "junker_gun"
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/gunnery)
 "pkY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -6835,22 +6880,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
-"pDo" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
 "pDZ" = (
 /obj/effect/floor_decal/corner{
 	dir = 8
@@ -6890,10 +6919,6 @@
 "pHN" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light{
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "pMN" = (
@@ -7483,7 +7508,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm/north,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
 "qMB" = (
@@ -7712,17 +7739,8 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
 "rrT" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/forehallwayport)
 "rsh" = (
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, munitions"
@@ -8033,6 +8051,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
+"rZo" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	pixel_x = 8;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "rZw" = (
 /obj/effect/floor_decal/corner/dark_blue/full,
 /obj/structure/cable,
@@ -8066,20 +8101,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod2)
-"sgL" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
 "sjD" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -8140,6 +8161,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
+"ssB" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed/pipes{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/freebooter_ship/cryo)
 "ssK" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
@@ -8379,13 +8411,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
-"sUg" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 10
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
 "sUq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/machinery/computer/ship/engines,
@@ -8715,21 +8740,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
-"tHg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/forehallway)
 "tHQ" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/decal/cleanable/dirt,
@@ -9125,16 +9135,16 @@
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
 /obj/machinery/access_button{
 	pixel_x = 8;
 	pixel_y = 28;
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
@@ -9754,6 +9764,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/ammo)
+"vST" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "vSY" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/pod4)
@@ -9850,21 +9866,8 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "vZW" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 5
-	},
-/turf/simulated/floor/airless,
+/obj/structure/lattice/catwalk,
+/turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9947,7 +9950,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "wnf" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
+/turf/simulated/wall,
 /area/ship/freebooter_ship/medical)
 "wnq" = (
 /obj/structure/table/steel,
@@ -10032,7 +10035,7 @@
 	frequency = 1336;
 	output = 31
 	},
-/turf/simulated/floor/reinforced/carbon_dioxide,
+/turf/simulated/floor/reinforced/airless,
 /area/ship/freebooter_ship/thruster1)
 "wyp" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
@@ -10050,6 +10053,13 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod4)
+"wBf" = (
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 9
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "wCl" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/loading/yellow,
@@ -10061,21 +10071,11 @@
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "wGc" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "wHo" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/ship_engine.dmi';
@@ -10242,13 +10242,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
-"wUI" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
 "wUJ" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
@@ -37876,7 +37869,7 @@ xRX
 xRX
 xRX
 uCl
-dqF
+kqx
 uCl
 fZq
 xRX
@@ -38390,7 +38383,7 @@ xRX
 rtf
 vUu
 uyM
-dqF
+kqx
 aHs
 xRX
 xRX
@@ -38623,17 +38616,17 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
+vZW
 eIb
 wUi
 ldw
 wUi
 eIb
-ajO
-ajO
+vZW
+vZW
 esB
 gwg
 esB
@@ -38641,32 +38634,32 @@ wHo
 esB
 gwg
 esB
-ajO
-ajO
+vZW
+vZW
 cLC
 cLC
 kwe
 tKj
 tKj
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
 qiz
 qiz
 mWz
 qiz
 qiz
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
 eUq
 eUq
 pRf
 eUq
 eUq
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
 xRX
 xRX
 xRX
@@ -38879,8 +38872,8 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
+vZW
+vZW
 xRX
 xRX
 eIb
@@ -38923,7 +38916,7 @@ fTG
 eUq
 eUq
 xRX
-ajO
+vZW
 xqI
 xqI
 xqI
@@ -38937,7 +38930,7 @@ imE
 imE
 iOV
 iOV
-jrC
+pkP
 xRX
 xRX
 xRX
@@ -39194,7 +39187,7 @@ rjL
 tQn
 sxw
 www
-jrC
+pkP
 xRX
 xRX
 xRX
@@ -39395,8 +39388,8 @@ gFA
 ewW
 ewW
 ewW
-ajO
-ajO
+vZW
+vZW
 wUi
 syV
 bhd
@@ -39404,7 +39397,7 @@ xBh
 bhd
 tvh
 wUi
-ajO
+vZW
 gwg
 pUP
 kmP
@@ -39412,7 +39405,7 @@ qDn
 kev
 jcX
 gwg
-ajO
+vZW
 cLC
 wZf
 ttI
@@ -39420,7 +39413,7 @@ krH
 lKT
 vmX
 cLC
-ajO
+vZW
 qiz
 pYB
 bPT
@@ -39428,7 +39421,7 @@ jzk
 fRD
 buM
 qiz
-ajO
+vZW
 eUq
 aTX
 iUK
@@ -39436,8 +39429,8 @@ iUK
 iUK
 fTT
 eUq
-ajO
-ajO
+vZW
+vZW
 xqI
 ahD
 kfJ
@@ -39451,7 +39444,7 @@ fNl
 tQn
 sxw
 sxw
-jrC
+pkP
 xRX
 xRX
 xRX
@@ -39653,7 +39646,7 @@ xUb
 qWF
 ewW
 xRX
-ajO
+vZW
 wUi
 syV
 bhd
@@ -39702,13 +39695,13 @@ npb
 oxR
 tfK
 sxk
-bkP
+vST
 soh
 soh
 aDv
 iOV
 iOV
-jrC
+pkP
 xRX
 xRX
 xRX
@@ -39910,7 +39903,7 @@ xUb
 jnK
 ewW
 xRX
-ajO
+vZW
 wUi
 syV
 grD
@@ -39960,8 +39953,8 @@ jhd
 tfK
 nwH
 wLI
-btW
-btW
+wGc
+wGc
 fnE
 xRX
 xRX
@@ -40167,7 +40160,7 @@ dbA
 wxS
 ewW
 xRX
-ajO
+vZW
 eIb
 oPu
 bhd
@@ -40209,7 +40202,7 @@ cEH
 eUq
 xRX
 xRX
-ajO
+vZW
 xqI
 xqI
 tfK
@@ -40424,7 +40417,7 @@ ewW
 ewW
 ewW
 xRX
-ajO
+vZW
 wUi
 cLL
 bhd
@@ -40461,18 +40454,18 @@ eUq
 lnp
 heP
 iUK
-oqi
+lsh
 avE
 eUq
 xRX
 xRX
-ajO
+vZW
 xRX
-kqx
+ayy
 rEb
 xTu
 cbE
-fVy
+dlZ
 klp
 llD
 euj
@@ -40681,7 +40674,7 @@ acn
 ewW
 xRX
 xRX
-ajO
+vZW
 wUi
 glJ
 ihN
@@ -40723,10 +40716,10 @@ hIE
 eUq
 xRX
 xRX
-ajO
+vZW
 xRX
-kqx
-kqx
+ayy
+ayy
 jgM
 vVy
 aMQ
@@ -40938,7 +40931,7 @@ pHN
 ewW
 xRX
 xRX
-ajO
+vZW
 wUi
 wNA
 bhd
@@ -40980,13 +40973,13 @@ iUK
 eUq
 xRX
 xRX
-ajO
+vZW
 xRX
 xRX
-kqx
-kqx
+ayy
+ayy
 tmo
-fVy
+dlZ
 mwo
 mwo
 mwo
@@ -41195,7 +41188,7 @@ lJH
 jhL
 jhL
 xRX
-ajO
+vZW
 wUi
 peJ
 bhd
@@ -41237,18 +41230,18 @@ mtT
 eUq
 xRX
 xRX
-ajO
+vZW
 xRX
 xRX
 xRX
 uLO
 ebn
 atj
-aOU
+wnf
 exg
 iGK
 aBD
-wnf
+aOU
 xRX
 xRX
 xRX
@@ -41452,7 +41445,7 @@ pCG
 iZM
 jhL
 jhL
-ajO
+vZW
 eIb
 eIb
 pPk
@@ -41494,7 +41487,7 @@ eUq
 eUq
 xRX
 xRX
-ajO
+vZW
 xRX
 xRX
 xRX
@@ -41505,7 +41498,7 @@ jLL
 aab
 qDe
 nVi
-wnf
+aOU
 saW
 xRX
 xRX
@@ -41709,61 +41702,61 @@ mhq
 tcY
 rfn
 jhL
-ajO
-ajO
+vZW
+vZW
 eIb
 eIb
 qEc
 eIb
 eIb
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
 gwg
 wzO
 dXK
 wzO
 gwg
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
 cLC
 cLC
 mbX
 cLC
 cLC
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
 qiz
 qiz
 dFi
 qiz
 qiz
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
 eUq
 eUq
 wRc
 eUq
 eUq
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
 pvm
 kou
 dWF
-aOU
+wnf
 gLO
 npJ
 kAt
 lpe
-wnf
+aOU
 xRX
 xRX
 xRX
@@ -41967,18 +41960,10 @@ jbh
 tYn
 jhL
 xRX
-ajO
+vZW
 xRX
 wyp
-wGc
-wyp
-xRX
-xRX
-xRX
-xRX
-xRX
-wyp
-wGc
+fGM
 wyp
 xRX
 xRX
@@ -41986,7 +41971,7 @@ xRX
 xRX
 xRX
 wyp
-wGc
+fGM
 wyp
 xRX
 xRX
@@ -41994,7 +41979,7 @@ xRX
 xRX
 xRX
 wyp
-wGc
+fGM
 wyp
 xRX
 xRX
@@ -42002,25 +41987,33 @@ xRX
 xRX
 xRX
 wyp
-wGc
+fGM
 wyp
 xRX
 xRX
 xRX
 xRX
-ajO
+xRX
+wyp
+fGM
+wyp
+xRX
+xRX
+xRX
+xRX
+vZW
 xRX
 xRX
 xRX
 pvm
 vfD
 kOP
-aOU
-aOU
+wnf
+wnf
 tra
-wnf
 aOU
 wnf
+aOU
 ydf
 ewy
 ewy
@@ -42224,7 +42217,7 @@ rRa
 nKC
 jhL
 xRX
-ajO
+vZW
 xRX
 wyp
 mGn
@@ -42265,12 +42258,12 @@ xRX
 xRX
 xRX
 xRX
-ajO
+vZW
 xRX
 xRX
 xRX
 uLO
-qIf
+hVL
 kbX
 kzS
 kvJ
@@ -43512,14 +43505,14 @@ wyp
 kXG
 vGw
 wyp
-gyl
+jzx
 bzm
 wyp
 vGw
 vGw
 vGw
 wyp
-bhw
+gyl
 odb
 wyp
 wyp
@@ -43555,7 +43548,7 @@ vGw
 wyp
 wyp
 uLO
-tHg
+qIf
 fZr
 wUa
 oKE
@@ -43766,7 +43759,7 @@ pkY
 bJj
 jhL
 xRX
-ajO
+vZW
 xRX
 wyp
 bhA
@@ -43807,7 +43800,7 @@ xRX
 xRX
 xRX
 xRX
-ajO
+vZW
 xRX
 xRX
 xRX
@@ -44023,10 +44016,10 @@ doW
 nEK
 jhL
 xRX
-ajO
+vZW
 xRX
 wyp
-pDo
+cCu
 xvT
 wyp
 xRX
@@ -44042,7 +44035,7 @@ xRX
 xRX
 xRX
 wyp
-wGc
+fGM
 wyp
 xRX
 xRX
@@ -44050,7 +44043,7 @@ xRX
 xRX
 xRX
 wyp
-wGc
+fGM
 wyp
 xRX
 xRX
@@ -44058,13 +44051,13 @@ xRX
 xRX
 xRX
 wyp
-wGc
+fGM
 wyp
 xRX
 xRX
 xRX
 xRX
-ajO
+vZW
 xRX
 xRX
 xRX
@@ -44279,52 +44272,52 @@ ngJ
 gwl
 xZh
 jhL
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
 wyp
-uJz
+rZo
 bJc
 wyp
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
 wyp
-nOj
+uJz
 bst
 wyp
-ajO
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
+vZW
 uwT
 uwT
 jjA
 uwT
 uwT
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
 eiL
 eiL
 gSo
 eiL
 eiL
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
 tRo
 tRo
 sVs
 tRo
 tRo
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
 gzr
 iHV
 kOP
@@ -44536,23 +44529,23 @@ oGU
 kMx
 jhL
 jhL
-ajO
-sgL
+vZW
+okU
 sUX
 ppp
 ppp
 ppp
 ppp
-ayy
+jrC
 kQs
-ayy
+jrC
 wtm
 rhN
 ciM
-wUI
+btW
 rmm
-dqF
-dqF
+xRX
+xRX
 uwT
 uwT
 lgM
@@ -44578,7 +44571,7 @@ tRo
 tRo
 xRX
 xRX
-ajO
+vZW
 xRX
 xRX
 xRX
@@ -44792,8 +44785,8 @@ aEa
 lJH
 jhL
 jhL
-dqF
-ajO
+xRX
+vZW
 iGW
 aSb
 aSb
@@ -44809,7 +44802,7 @@ iQg
 clU
 nKq
 rmm
-dqF
+xRX
 htS
 lfg
 jFY
@@ -44835,7 +44828,7 @@ cMo
 tRo
 xRX
 xRX
-ajO
+vZW
 xRX
 xRX
 xRX
@@ -44844,7 +44837,7 @@ ebn
 cDf
 quS
 cQs
-fcl
+ssB
 aSJ
 oxG
 xRX
@@ -45048,10 +45041,10 @@ xKt
 adF
 eqi
 uZl
-ajO
-ajO
-ajO
-rrT
+vZW
+vZW
+vZW
+bcf
 ntt
 sUq
 qMB
@@ -45066,7 +45059,7 @@ elW
 sWG
 qVW
 vOL
-ajO
+vZW
 uwT
 dkz
 hHq
@@ -45092,7 +45085,7 @@ bxM
 tRo
 xRX
 xRX
-ajO
+vZW
 xRX
 xRX
 uLO
@@ -45305,10 +45298,10 @@ mOF
 qED
 uPa
 uZl
-dqF
-dqF
-ajO
-rrT
+xRX
+xRX
+vZW
+bcf
 aSb
 aEB
 aEB
@@ -45323,7 +45316,7 @@ eqD
 aSb
 qeJ
 vOL
-dqF
+xRX
 uwT
 oZH
 pZI
@@ -45349,10 +45342,10 @@ ieZ
 tRo
 xRX
 xRX
-ajO
+vZW
 xRX
-jli
-jli
+rrT
+rrT
 nZj
 ess
 lzb
@@ -45563,13 +45556,13 @@ bpj
 fdV
 uZl
 uZl
-dqF
-ajO
+xRX
+vZW
 rJT
 rsE
-sUg
+ajO
 rQJ
-fGM
+nrq
 tuB
 fNL
 bkh
@@ -45580,7 +45573,7 @@ afL
 sVT
 oSp
 vOL
-dqF
+xRX
 uwT
 bDX
 mCb
@@ -45606,9 +45599,9 @@ uNJ
 tRo
 xRX
 xRX
-ajO
+vZW
 xRX
-jli
+rrT
 xMA
 uWU
 oVL
@@ -45820,8 +45813,8 @@ ieM
 mwO
 uoZ
 uZl
-dqF
-ajO
+xRX
+vZW
 iUd
 vdX
 atI
@@ -45837,7 +45830,7 @@ tcV
 rXx
 cJt
 vOL
-dqF
+xRX
 uwT
 fYr
 lGK
@@ -45863,9 +45856,9 @@ lvR
 tRo
 xRX
 xRX
-ajO
+vZW
 xRX
-jli
+rrT
 oyG
 cnH
 ess
@@ -46077,8 +46070,8 @@ mCl
 kuj
 rFB
 uZl
-dqF
-ajO
+xRX
+vZW
 lkK
 hZH
 kti
@@ -46094,7 +46087,7 @@ kTf
 bzW
 hhA
 vOL
-dqF
+xRX
 uwT
 cgU
 hhQ
@@ -46334,9 +46327,9 @@ uiV
 vDk
 rFB
 uZl
-dqF
-ajO
-rrT
+xRX
+vZW
+bcf
 aSb
 aSb
 aSb
@@ -46351,7 +46344,7 @@ tDp
 aSb
 hhA
 vOL
-dqF
+xRX
 uwT
 cgU
 onn
@@ -46591,9 +46584,9 @@ aEt
 ldf
 uZl
 uZl
-ajO
-ajO
-rrT
+vZW
+vZW
+bcf
 sBA
 ruo
 sum
@@ -46608,7 +46601,7 @@ elW
 sWG
 cei
 vOL
-ajO
+vZW
 uwT
 vMG
 hil
@@ -46616,7 +46609,7 @@ uOr
 hil
 irq
 uwT
-ajO
+vZW
 eiL
 upC
 buI
@@ -46624,7 +46617,7 @@ hdb
 pZo
 fVv
 eiL
-ajO
+vZW
 tRo
 pDZ
 bxM
@@ -46632,8 +46625,8 @@ bxM
 bxM
 pZO
 tRo
-ajO
-ajO
+vZW
+vZW
 wjn
 qqX
 vwi
@@ -46847,9 +46840,9 @@ uZl
 osl
 stV
 uZl
-dqF
-dqF
-ajO
+xRX
+xRX
+vZW
 aCG
 aSb
 aSb
@@ -46860,12 +46853,12 @@ vCg
 iTc
 lKV
 kEe
-bcf
-wUI
-wUI
+wBf
+btW
+btW
 mYn
 tOu
-dqF
+xRX
 htS
 hXO
 uwA
@@ -47103,11 +47096,11 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
-dqF
-ajO
 vZW
+vZW
+xRX
+vZW
+dqF
 kOK
 rfz
 rfz
@@ -47117,12 +47110,12 @@ rfz
 rfz
 rfz
 lCe
-fyi
+hQh
 vTv
 vTv
 tOu
-dqF
-dqF
+xRX
+xRX
 uwT
 uwT
 nti
@@ -47147,7 +47140,7 @@ rEV
 tRo
 tRo
 xRX
-ajO
+vZW
 wjn
 wjn
 wjn
@@ -47361,50 +47354,50 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
 ibm
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
 fro
-ajO
-ajO
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
+vZW
+vZW
 uwT
 uwT
 qju
 uwT
 uwT
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
 eiL
 eiL
 sal
 eiL
 eiL
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
 tRo
 tRo
 raF
 tRo
 tRo
-ajO
-ajO
-ajO
+vZW
+vZW
+vZW
 xRX
 xRX
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -780,7 +780,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -1045,9 +1045,6 @@
 	master_tag = "freebooter_port_1"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
@@ -2944,9 +2941,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "gzr" = (
@@ -3388,7 +3382,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -4546,16 +4540,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod3)
-"kCq" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/foyer)
 "kCv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/structure/lattice/catwalk/indoor/grate/dark,
@@ -4987,9 +4971,6 @@
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 8
-	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "lvR" = (
@@ -5117,13 +5098,13 @@
 /area/ship/freebooter_ship/pod8)
 "lHL" = (
 /obj/effect/decal/cleanable/generic,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/table/rack,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/obj/item/device/suit_cooling_unit,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "lJH" = (
@@ -5349,7 +5330,6 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "moJ" = (
@@ -6130,9 +6110,6 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 5
-	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "odX" = (
@@ -7933,9 +7910,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 10
-	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "rDZ" = (
@@ -8018,8 +7992,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "rHI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
@@ -8360,9 +8334,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 1
-	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "szY" = (
@@ -8915,9 +8886,6 @@
 "tSG" = (
 /obj/effect/decal/cleanable/ash,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 5
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "tSV" = (
@@ -10463,7 +10431,7 @@
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "xhE" = (
@@ -10691,9 +10659,6 @@
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 8
-	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "xRt" = (
@@ -43336,7 +43301,7 @@ oXj
 rnp
 bdI
 lHL
-kCq
+rnp
 mvP
 ruW
 lwO

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1657,14 +1657,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/robot_parts/r_arm{
-	pixel_y = 10;
-	pixel_x = 10
-	},
-/obj/item/device/assembly/prox_sensor{
-	pixel_x = -9;
-	pixel_y = -7
+/mob/living/bot/farmbot{
+	req_one_access = list()
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
@@ -2147,15 +2141,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
-"esB" = (
-/obj/structure/bed/stool/chair/shuttle{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/freebooter_shuttle)
 "etF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/west,
@@ -2755,13 +2740,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
 "ggq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/handrail{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/full,
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "ggz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -3354,6 +3340,20 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
+"hQh" = (
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "hQA" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -3376,10 +3376,11 @@
 /area/ship/freebooter_ship/pod7)
 "hRt" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/handrail{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
 "hUF" = (
 /obj/structure/cable{
@@ -4781,12 +4782,13 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
 "llB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 10
+/obj/structure/bed/stool/chair/shuttle{
+	dir = 4
 	},
-/turf/simulated/wall/shuttle/space_ship{
-	color = "#E14644"
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 4
 	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "llD" = (
 /obj/structure/bed/stool/chair/office/bridge/generic,
@@ -7061,19 +7063,13 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
 "pZx" = (
-/obj/structure/railing/mapped{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 10
 	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
+/turf/simulated/wall/shuttle/space_ship{
+	color = "#E14644"
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/area/shuttle/freebooter_shuttle)
 "pZI" = (
 /obj/effect/floor_decal/corner/dark_blue,
 /obj/structure/bed/stool/chair/office/light{
@@ -45036,7 +45032,7 @@ vxO
 mbg
 bWt
 xHX
-esB
+llB
 amu
 amu
 elW
@@ -46577,11 +46573,11 @@ sum
 uDc
 bEH
 qnz
-hRt
 ggq
+hRt
 aSb
 kVa
-llB
+pZx
 lKV
 cei
 vOL
@@ -47095,7 +47091,7 @@ rfz
 rfz
 lCe
 rfz
-pZx
+hQh
 vTv
 tOu
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1314,15 +1314,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "cgU" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner{
-	dir = 10
-	},
-/obj/structure/closet/crate/miningcart,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/wall/r_wall,
 /area/ship/freebooter_ship/pod8)
 "ciM" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2547,14 +2539,19 @@
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/button/remote/airlock{
+	dir = 4;
+	id = "scarab_washroom";
+	name = "Phoron Storage Bolt Control";
+	pixel_x = 24;
+	pixel_y = 4;
+	specialfunctions = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -2679,26 +2676,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "fYr" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/structure/sign/fire{
+	pixel_x = 32
 	},
-/obj/machinery/door/window/southleft{
-	name = "Security Voidsuits"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
-	},
-/obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod8)
 "fZq" = (
@@ -3141,6 +3123,7 @@
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
 	},
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "hik" = (
@@ -3427,11 +3410,13 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
 /obj/machinery/light{
 	dir = 1;
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
+	},
+/obj/machinery/portable_atmospherics/canister/empty/phoron{
+	destroyed = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -3442,11 +3427,10 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship)
 "hZY" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 4
+/obj/machinery/door/airlock/vault{
+	dir = 4;
+	name = "Phoron Storage Compartment"
 	},
-/obj/item/material/shard,
-/obj/item/trash/broken_electronics,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "iaK" = (
@@ -3598,6 +3582,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "iok" = (
+/obj/item/trash/tastybread{
+	pixel_y = -7;
+	pixel_x = -1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "ioS" = (
@@ -3631,8 +3619,12 @@
 /obj/effect/floor_decal/corner{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/padded,
+/obj/structure/sign/securearea{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "irX" = (
@@ -4213,13 +4205,28 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "kkT" = (
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 1;
+	pixel_x = 6
+	},
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 11;
+	pixel_x = -12
+	},
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_y = 15;
+	pixel_x = -5
+	},
+/obj/structure/bed/stool/chair/folding{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -4828,6 +4835,13 @@
 	},
 /turf/simulated/floor/carpet/art,
 /area/ship/freebooter_ship/pod1)
+"lnG" = (
+/obj/effect/floor_decal/corner{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod8)
 "loq" = (
 /obj/structure/grille/broken,
 /obj/structure/blocker/steel,
@@ -5029,9 +5043,8 @@
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "lHL" = (
@@ -5434,6 +5447,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
+"mFp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/ship/freebooter_ship/pod8)
 "mGn" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5477,8 +5499,9 @@
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/padded,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "mOF" = (
@@ -5541,7 +5564,6 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -5655,6 +5677,33 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
+"niZ" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner{
+	dir = 10
+	},
+/obj/structure/closet/crate/miningcart,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/reagent_containers/food/snacks/tastybread,
+/obj/item/reagent_containers/food/snacks/tastybread,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/mushroom,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod8)
 "nmL" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -5746,6 +5795,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "ntt" = (
@@ -6180,6 +6230,7 @@
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "onx" = (
@@ -6938,11 +6989,11 @@
 /obj/effect/floor_decal/corner{
 	dir = 5
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/suit_cycler/security{
 	req_access = null
+	},
+/obj/structure/sign/fire{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -9180,7 +9231,6 @@
 /obj/effect/floor_decal/corner{
 	dir = 9
 	},
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9188,6 +9238,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "uOX" = (
@@ -9284,6 +9335,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "vbe" = (
@@ -9674,7 +9726,13 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/tastybread{
+	pixel_x = 8
+	},
+/obj/structure/sign/securearea{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "vOi" = (
@@ -10177,6 +10235,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "wUa" = (
@@ -46055,9 +46114,9 @@ xRX
 uwT
 cgU
 hhQ
-bDB
+mFp
 hZY
-pik
+cgU
 uwT
 xRX
 eiL
@@ -46310,7 +46369,7 @@ hhA
 vOL
 xRX
 uwT
-cgU
+niZ
 onn
 uZC
 iok
@@ -46570,7 +46629,7 @@ uwT
 vMG
 hil
 uOr
-hil
+lnG
 irq
 uwT
 vZW

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -15,11 +15,11 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/medical)
 "aaI" = (
 /obj/structure/ship_weapon_dummy,
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "aaJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72,6 +72,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
+"afL" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/map_effect/marker_helper/airlock/out,
+/turf/simulated/floor,
+/area/shuttle/freebooter_shuttle)
 "ahD" = (
 /obj/structure/target_stake,
 /obj/item/toy/plushie/ipc{
@@ -79,7 +91,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "ajb" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -120,13 +132,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ajO" = (
-/obj/structure/lattice/catwalk,
-/obj/item/material/shard{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/turf/template_noop,
-/area/ship/freebooter_ship)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/medical)
 "akg" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
@@ -149,7 +156,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "amu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/wall/shuttle/space_ship/mercenary,
@@ -216,7 +223,7 @@
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "atI" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71
@@ -278,23 +285,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
-"azU" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/access_button{
-	pixel_x = -8;
-	pixel_y = 28;
-	dir = 8
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -308,7 +299,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/closet)
 "aBD" = (
 /obj/item/storage/firstaid/adv{
 	pixel_x = 4
@@ -328,7 +319,7 @@
 	pixel_y = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/medical)
 "aCG" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -346,7 +337,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "aDv" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, main gun"
@@ -417,7 +408,7 @@
 	dir = 4
 	},
 /turf/template_noop,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "aHt" = (
 /obj/machinery/vending/dinnerware{
 	pixel_y = 23;
@@ -442,12 +433,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/light{
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
+/obj/machinery/power/apc/south,
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/cryo)
 "aHW" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
@@ -508,6 +496,9 @@
 	dir = 9
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "aMa" = (
@@ -529,8 +520,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/alarm/west{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/head)
 "aMQ" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -543,7 +537,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/gunneryentrance)
 "aMY" = (
 /obj/machinery/door/blast/shutters/open{
 	dir = 4
@@ -551,8 +545,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aOU" = (
-/turf/simulated/wall,
-/area/space)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/forehallwayport)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -622,7 +616,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/cryo)
 "aSK" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -672,13 +666,13 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "aVd" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "aVH" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -695,7 +689,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "aYs" = (
 /obj/effect/landmark/entry_point/port{
 	name = "port, reactor room"
@@ -721,7 +715,7 @@
 	layer = 2.71
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "bci" = (
 /obj/machinery/appliance/cooker/grill,
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -793,6 +787,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
+"bhA" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/obj/structure/sign/vacuum{
+	pixel_y = 30
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "bhB" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -805,7 +813,13 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/lockers)
+"bkh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "bkX" = (
 /obj/structure/mirror{
 	icon_state = "mirror_mask_broken";
@@ -814,7 +828,7 @@
 /obj/item/material/shard,
 /obj/structure/curtain/black,
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/lockers)
 "bnv" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -880,12 +894,40 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
+"bsf" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "bsp" = (
 /obj/machinery/computer/ship/engines{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
+"bst" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "btH" = (
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/mechanical{
@@ -1002,6 +1044,17 @@
 "bxM" = (
 /turf/simulated/wall,
 /area/ship/freebooter_ship/pod6)
+"bzm" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "bzr" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -1026,6 +1079,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
+"bzW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 9
+	},
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/shuttle/freebooter_shuttle)
 "bBW" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 10
@@ -1108,6 +1167,17 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
+"bJc" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "bJj" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1;
@@ -1164,8 +1234,9 @@
 	name = "crumpled diary page"
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/east,
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/lockers)
 "bSi" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
@@ -1188,7 +1259,7 @@
 /turf/simulated/floor{
 	icon_state = "dmg4"
 	},
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "bWt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/decal/cleanable/dirt,
@@ -1219,7 +1290,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/gunneryentrance)
 "cei" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
@@ -1227,7 +1298,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "ceK" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -1262,9 +1333,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "ciM" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
 	dir = 8
@@ -1273,7 +1341,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "clU" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
@@ -1283,7 +1351,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "cmI" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -1300,20 +1368,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod1)
-"cmW" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/structure/sign/vacuum{
-	pixel_y = 30
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship)
 "cnH" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -1323,7 +1377,7 @@
 	name = "lattice"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "cok" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
@@ -1334,7 +1388,7 @@
 	pixel_y = 13
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/dorms)
 "cAU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1358,7 +1412,7 @@
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "cEH" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1392,22 +1446,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
-"cKm" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/bed/stool/chair/shuttle{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_freebooter_shuttle";
-	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
-	},
-/turf/simulated/floor,
-/area/shuttle/freebooter_shuttle)
+/area/ship/freebooter_ship/exterior)
 "cLe" = (
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 1
@@ -1481,7 +1520,7 @@
 	name = "trashbin"
 	},
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/cryo)
 "cVA" = (
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 8
@@ -1509,7 +1548,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/head)
 "cYw" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71
@@ -1571,7 +1610,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "dkz" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
@@ -1605,20 +1644,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
-"doK" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/obj/structure/sign/vacuum{
-	pixel_y = 30
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship)
 "doW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -1651,7 +1676,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "dut" = (
 /obj/structure/table/steel,
 /obj/item/toy/desk/fan{
@@ -1662,22 +1687,11 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
+/obj/machinery/alarm/west{
+	req_one_access = null
+	},
 /turf/simulated/floor/carpet/rubber,
-/area/ship/freebooter_ship/bridge)
-"dAi" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/dorms)
 "dBJ" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/status_display.dmi';
@@ -1730,7 +1744,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "dFi" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1852,7 +1866,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "dXK" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1915,7 +1929,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "ebW" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1926,8 +1940,9 @@
 	pixel_x = 32;
 	name = "sidearm locker"
 	},
+/obj/machinery/power/apc/south,
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/closet)
 "edn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/spiderling_remains,
@@ -1941,14 +1956,14 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "efd" = (
 /obj/structure/inflatable/wall,
 /obj/effect/landmark/entry_point/port{
 	name = "port, habitation"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "efj" = (
 /obj/machinery/computer/ship/navigation,
 /obj/structure/railing/mapped,
@@ -2008,6 +2023,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/east,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
 "elW" = (
@@ -2037,6 +2053,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
+"eqD" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/bed/stool/chair/shuttle{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/turf/simulated/floor,
+/area/shuttle/freebooter_shuttle)
 "eqU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
@@ -2062,7 +2093,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "esx" = (
 /obj/effect/decal/cleanable/spiderling_remains,
 /obj/structure/cable{
@@ -2103,7 +2134,7 @@
 "ewy" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "ewW" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/thruster1)
@@ -2126,7 +2157,7 @@
 /obj/item/tape_roll,
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/medical)
 "ezT" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -2158,25 +2189,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
-"eFB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_freebooter_shuttle";
-	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	pixel_x = 23;
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/shuttle/freebooter_shuttle)
 "eHy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -2213,7 +2225,7 @@
 "eND" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "eST" = (
 /turf/simulated/wall,
 /area/ship/freebooter_ship/pod7)
@@ -2416,7 +2428,7 @@
 	name = "port, landing pad 2"
 	},
 /turf/template_noop,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "frC" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/floor_decal/industrial/warning{
@@ -2472,9 +2484,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fGM" = (
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/ship/freebooter_ship)
+/turf/simulated/wall,
+/area/ship/freebooter_ship/medical)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -2491,14 +2502,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "fNl" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/rods,
-/obj/item/material/shard{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/turf/template_noop,
-/area/ship/freebooter_ship)
+/obj/structure/ship_weapon_dummy,
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "fNL" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot{
 	dir = 4
@@ -2645,7 +2651,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/reinforced/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "fZr" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -2655,7 +2661,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "gap" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 4
@@ -2701,12 +2707,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
-"ghb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster2)
 "ghi" = (
 /obj/machinery/alarm/east{
 	req_one_access = null
@@ -2729,7 +2729,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "glJ" = (
 /obj/machinery/reagentgrinder{
 	pixel_x = 1;
@@ -2763,6 +2763,10 @@
 	pixel_x = -5;
 	id = "junker_gun";
 	name = "bridge blast door-control"
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_y = 7;
+	pixel_x = 3
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/gunnery)
@@ -2829,7 +2833,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "gyl" = (
 /obj/machinery/door/airlock/external{
 	dir = 8
@@ -2838,15 +2842,20 @@
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
 	},
+/obj/machinery/access_button{
+	pixel_x = -8;
+	pixel_y = 28;
+	dir = 8
+	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/foyer)
 "gzr" = (
 /obj/structure/inflatable/wall,
 /turf/simulated/floor{
 	icon_state = "dmg4"
 	},
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "gBf" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = null
@@ -2879,7 +2888,7 @@
 	},
 /obj/item/ammo_casing/rifle/used,
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "gFA" = (
 /obj/machinery/light/small/emergency{
 	dir = 8
@@ -2935,8 +2944,11 @@
 	pixel_y = 32
 	},
 /obj/item/reagent_containers/inhaler/pneumalin,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/medical)
 "gMa" = (
 /obj/structure/table/steel,
 /obj/item/modular_computer/laptop/preset/civilian,
@@ -2944,7 +2956,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/dorms)
 "gSo" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2982,6 +2994,9 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "hdb" = (
@@ -3045,7 +3060,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "hhQ" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -3100,7 +3115,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "hmk" = (
 /obj/item/material/shard,
 /obj/item/trash/broken_electronics,
@@ -3139,7 +3154,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/cryo)
 "hyv" = (
 /obj/structure/bed/stool/bar/padded/brown,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3183,19 +3198,7 @@
 /obj/structure/cryofeed/pipes,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
-"hGJ" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_freebooter_shuttle";
-	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/map_effect/marker_helper/airlock/out,
-/turf/simulated/floor,
-/area/shuttle/freebooter_shuttle)
+/area/ship/freebooter_ship/cryo)
 "hHq" = (
 /obj/effect/floor_decal/corner{
 	dir = 6
@@ -3259,6 +3262,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
+"hQd" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/structure/sign/vacuum{
+	pixel_y = 30
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "hQA" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -3339,7 +3356,7 @@
 	name = "port, landing pad 1"
 	},
 /turf/template_noop,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "icO" = (
 /obj/machinery/atmospherics/unary/engine,
 /obj/structure/window/reinforced,
@@ -3383,7 +3400,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "ieM" = (
 /obj/effect/floor_decal/spline/plain/corner{
 	dir = 4
@@ -3431,7 +3448,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "ihN" = (
 /obj/structure/bed/stool/chair/office/light{
 	dir = 1
@@ -3552,13 +3569,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/light{
-	dir = 1;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
+/obj/machinery/power/apc/north,
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "iCP" = (
 /obj/machinery/computer/ship/helm{
 	req_access = list(203)
@@ -3609,8 +3622,9 @@
 	pixel_x = -4;
 	pixel_y = 15
 	},
+/obj/machinery/power/apc/west,
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/medical)
 "iGW" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -3627,7 +3641,7 @@
 	layer = 2.71
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "iHV" = (
 /obj/structure/barricade/wooden{
 	dir = 1;
@@ -3644,18 +3658,18 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "iKH" = (
 /turf/simulated/wall,
 /area/ship/freebooter_ship/foyer)
 "iNM" = (
+/obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
 "iOV" = (
@@ -3674,7 +3688,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "iQC" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
@@ -3704,12 +3718,6 @@
 /obj/item/paper/crumpled,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
-"iTJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 8
-	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/shuttle/freebooter_shuttle)
 "iUd" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -3718,7 +3726,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "iUK" = (
 /turf/simulated/wall,
 /area/ship/freebooter_ship/pod1)
@@ -3745,6 +3753,9 @@
 /obj/structure/bed/stool/chair,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
+"jcW" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/lockers)
 "jcX" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -3764,8 +3775,11 @@
 	},
 /mob/living/heavy_vehicle/premade/miner,
 /obj/machinery/mech_recharger,
+/obj/machinery/alarm/north{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/gunneryentrance)
 "jhd" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3778,7 +3792,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "jhL" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/engineering)
@@ -3815,23 +3829,18 @@
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/ship/freebooter_ship/thruster1)
+"joM" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "jrC" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "junker_gun"
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/gunnery)
 "jvN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -3942,7 +3951,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/medical)
 "jMu" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -3998,7 +4007,7 @@
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/lockers)
 "jUk" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -4013,7 +4022,7 @@
 /obj/structure/railing/mapped,
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "kaR" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -4049,7 +4058,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "kdO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4083,7 +4092,7 @@
 /turf/simulated/floor{
 	icon_state = "dmg2"
 	},
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "kfX" = (
 /obj/structure/bed/stool/chair/office/wheelchair{
 	dir = 4
@@ -4157,7 +4166,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "koD" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4176,7 +4185,7 @@
 "kqx" = (
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/space)
+/area/ship/freebooter_ship/exterior)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
 /obj/effect/decal/cleanable/dirt,
@@ -4270,7 +4279,7 @@
 	name = "starboard, pod three"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "kyk" = (
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 8
@@ -4358,7 +4367,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/medical)
 "kBd" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
@@ -4376,6 +4385,9 @@
 "kCv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "kEe" = (
@@ -4415,7 +4427,7 @@
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "kHz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
@@ -4453,13 +4465,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "kOP" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "kPs" = (
 /obj/effect/floor_decal/corner/beige/full,
 /obj/structure/table/glass,
@@ -4501,22 +4513,15 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "kQs" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/west{
-	req_access = null
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
 	dir = 4
 	},
+/obj/structure/railing/mapped{
+	dir = 8
+	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "kQR" = (
 /obj/machinery/door/firedoor/noid,
 /obj/structure/cable{
@@ -4527,7 +4532,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "kSw" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -4568,6 +4573,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
+"kVa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/shuttle/freebooter_shuttle)
 "kXq" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -4680,14 +4691,14 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "llB" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
 	dir = 4
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "llD" = (
 /obj/structure/bed/stool/chair/office/bridge/generic,
 /obj/structure/railing/mapped{
@@ -4724,14 +4735,14 @@
 /obj/structure/grille/broken,
 /obj/structure/blocker/steel,
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "lpe" = (
 /obj/effect/floor_decal/industrial/outline/medical,
 /obj/machinery/sleeper{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/medical)
 "lqh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4790,7 +4801,7 @@
 	master_tag = "freebooter_port_2"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/foyer)
 "lvR" = (
 /obj/item/toy/plushie/bee{
 	pixel_x = -6;
@@ -4834,6 +4845,9 @@
 /obj/item/tank/jetpack/carbondioxide,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
+"lzb" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/dorms)
 "lzu" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/bed/stool/chair/shuttle{
@@ -4865,7 +4879,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "lDh" = (
 /obj/structure/closet/walllocker{
 	pixel_x = 32
@@ -4882,7 +4896,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/lockers)
 "lFZ" = (
 /obj/machinery/portable_atmospherics/canister/empty{
 	name = "waste canister"
@@ -4969,7 +4983,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "lPl" = (
 /obj/machinery/power/smes/buildable/horizon_shuttle,
 /obj/structure/sign/securearea{
@@ -5024,6 +5038,9 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
+"mbN" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/forehallway)
 "mbX" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5073,7 +5090,7 @@
 	prices = list()
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "meJ" = (
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop/preset/civilian,
@@ -5313,7 +5330,7 @@
 /obj/structure/table/steel,
 /obj/item/clothing/ears/earmuffs,
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "mJE" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71
@@ -5334,7 +5351,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/lockers)
 "mNi" = (
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 4
@@ -5363,7 +5380,7 @@
 	},
 /obj/item/gamehelm/black,
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/lockers)
 "mPM" = (
 /obj/machinery/appliance/cooker/oven,
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -5418,7 +5435,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "mZR" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
@@ -5529,7 +5546,7 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "npJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5538,7 +5555,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/medical)
 "npU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 9
@@ -5643,13 +5660,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
 "nwH" = (
-/obj/structure/railing/mapped,
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
+/obj/machinery/alarm/north{
+	req_one_access = null
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
 "nxF" = (
@@ -5707,7 +5727,7 @@
 	},
 /obj/structure/bed/stool/padded/black,
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/lockers)
 "nKq" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	layer = 2.71;
@@ -5721,7 +5741,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "nKC" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 10
@@ -5781,7 +5801,7 @@
 	pixel_x = -4
 	},
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/medical)
 "nVl" = (
 /obj/item/stack/tile/floor_dark,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -5796,19 +5816,18 @@
 	},
 /area/ship/freebooter_ship/pod4)
 "nWh" = (
-/obj/machinery/body_scanconsole,
-/turf/template_noop,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "nXu" = (
-/obj/machinery/light/small/emergency{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 8
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "nXA" = (
@@ -5862,8 +5881,11 @@
 	dir = 4;
 	pixel_x = 9
 	},
+/obj/machinery/alarm/west{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "oaH" = (
 /obj/machinery/computer/ship/helm{
 	dir = 8
@@ -5894,7 +5916,7 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/foyer)
 "odX" = (
 /obj/effect/floor_decal/corner{
 	dir = 8
@@ -5925,6 +5947,11 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/plain,
+/obj/machinery/power/portgen/basic,
+/obj/item/stack/material/graphite/full{
+	pixel_x = -4;
+	pixel_y = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "ofV" = (
@@ -5936,6 +5963,9 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/machinery/alarm/north{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
@@ -6054,6 +6084,9 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
+"oxG" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/cryo)
 "oxR" = (
 /obj/item/ammo_casing/rifle/used{
 	pixel_x = -8;
@@ -6071,24 +6104,24 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "oyG" = (
 /obj/structure/trash_pile,
 /obj/structure/bed{
-	pixel_x = 12;
+	pixel_x = -3;
 	pixel_y = 5
 	},
 /obj/structure/bed,
 /obj/structure/bed{
 	pixel_y = 11;
-	pixel_x = 7
+	pixel_x = 2
 	},
 /obj/item/modular_computer/laptop/preset/civilian{
 	pixel_y = 10;
-	pixel_x = 8
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "oyT" = (
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 8
@@ -6138,7 +6171,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/dorms)
 "oBX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6152,7 +6185,7 @@
 	name = "dead plant"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "oGU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -6259,8 +6292,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/alarm/west{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/closet)
 "oKQ" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -6302,13 +6338,13 @@
 	},
 /obj/effect/shuttle_landmark/freebooter_shuttle/hangar,
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "oUu" = (
 /obj/structure/table/steel,
 /obj/item/clothing/ears/earmuffs/earphones/headphones,
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "oVE" = (
 /obj/structure/table/rack,
 /obj/item/storage/bag/inflatable,
@@ -6330,7 +6366,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "oWj" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
@@ -6508,17 +6544,6 @@
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/thruster2)
-"pno" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship)
 "pob" = (
 /obj/machinery/computer/ship/sensors,
 /obj/machinery/light{
@@ -6542,7 +6567,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "prU" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/spline/plain/corner{
@@ -6603,6 +6628,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/engineering)
+"pvm" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/turf/simulated/floor,
+/area/ship/freebooter_ship/forehallway)
 "pvL" = (
 /obj/machinery/door/firedoor/noid,
 /obj/structure/cable{
@@ -6627,8 +6656,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/north,
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/head)
 "pAh" = (
 /obj/machinery/smartfridge/foodheater,
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -6702,7 +6732,7 @@
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/gunnery)
 "pEW" = (
 /obj/effect/decal/cleanable/blood,
@@ -6711,17 +6741,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
-"pFM" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship)
 "pHN" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/reagent_dispensers/fueltank,
@@ -6814,7 +6833,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/dorms)
 "pUP" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -6909,7 +6928,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "qej" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6946,7 +6965,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/closet)
 "qeJ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -6955,7 +6974,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "qgY" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -7055,6 +7074,9 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
+"qqX" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/head)
 "qst" = (
 /obj/machinery/door/firedoor/noid,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -7076,6 +7098,9 @@
 /obj/effect/step_trigger/teleporter,
 /turf/space,
 /area/space)
+"quS" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/cryo)
 "qvJ" = (
 /obj/machinery/atmospherics/binary/pump,
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -7192,7 +7217,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/medical)
 "qDn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7298,7 +7323,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "qMB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/structure/bed/stool/chair/office/bridge/pilot{
@@ -7332,7 +7357,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/dorms)
 "qPN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/spline/plain{
@@ -7390,7 +7415,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "qWF" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
@@ -7406,6 +7431,9 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/pod6)
+"rbz" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/lockers)
 "rcW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7435,17 +7463,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "rhN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
 	dir = 8
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "rjL" = (
 /obj/machinery/ship_weapon/blaster{
 	pixel_y = -195;
@@ -7453,7 +7478,7 @@
 	weapon_id = "Freebooter Ship Blaster"
 	},
 /obj/structure/ship_weapon_dummy,
-/turf/simulated/floor,
+/turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/gunnery)
 "rkc" = (
 /turf/simulated/floor/carpet/rubber,
@@ -7469,7 +7494,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "rnp" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
@@ -7521,22 +7546,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
-"rrI" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/access_button{
-	pixel_x = 8;
-	pixel_y = 28;
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship)
 "rrT" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -7549,13 +7558,13 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "rsh" = (
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, munitions"
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "rsE" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
@@ -7569,7 +7578,7 @@
 	dir = 1
 	},
 /turf/template_noop,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "rtt" = (
 /obj/effect/floor_decal/corner{
 	dir = 8
@@ -7693,8 +7702,14 @@
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
+/obj/machinery/power/apc/north{
+	req_access = null
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/gunneryentrance)
 "rEr" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -7769,7 +7784,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "rKl" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/decal/cleanable/dirt,
@@ -7798,20 +7813,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
-"rNB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship)
 "rQk" = (
 /obj/machinery/seed_storage/garden,
 /obj/effect/floor_decal/industrial/outline/service,
@@ -7863,12 +7864,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
-"rXI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 6
-	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/shuttle/freebooter_shuttle)
 "rYv" = (
 /obj/machinery/computer/ship/navigation{
 	dir = 8
@@ -7897,7 +7892,7 @@
 	name = "fore, medbay"
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/medical)
 "sck" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -7924,11 +7919,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
-"sjU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster1)
 "skr" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 1;
@@ -7950,7 +7940,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "soh" = (
-/turf/simulated/floor,
+/turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/gunnery)
 "spw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -8033,7 +8023,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "swf" = (
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
@@ -8195,7 +8185,7 @@
 	name = "fore, shower room"
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/lockers)
 "sQA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -8204,7 +8194,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/dorms)
 "sUa" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/floor_decal/industrial/outline/service,
@@ -8243,7 +8233,7 @@
 	layer = 2.71
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "sUZ" = (
 /obj/machinery/biogenerator{
 	icon_state = "biogen-empty"
@@ -8350,9 +8340,15 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
+"tfK" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/ammo)
 "tjz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/alarm/west{
+	req_one_access = null
+	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "tld" = (
@@ -8378,7 +8374,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/lockers)
 "tmo" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8395,23 +8391,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/gunneryentrance)
 "tmK" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
-"tno" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/structure/curtain/open/bed{
-	name = "curtain"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/freebooter_shuttle)
 "tra" = (
 /obj/machinery/door/firedoor/noid,
 /obj/structure/cable{
@@ -8422,7 +8408,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/medical)
 "tsH" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -8499,7 +8485,7 @@
 	},
 /obj/effect/floor_decal/corner/dark_green/diagonal,
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "tzw" = (
 /obj/structure/barricade/wooden{
 	dir = 1;
@@ -8522,12 +8508,12 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "tAn" = (
 /obj/structure/grille,
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "tDp" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/powered/scrubber,
@@ -8584,7 +8570,7 @@
 "tMA" = (
 /obj/structure/grille,
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "tOu" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -8596,12 +8582,12 @@
 	dir = 6
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "tPr" = (
 /obj/structure/railing/mapped,
 /obj/machinery/shipsensors/weak,
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "tQn" = (
 /obj/structure/ship_weapon_dummy,
 /turf/simulated/floor,
@@ -8650,16 +8636,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "tUO" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 6
 	},
-/obj/machinery/alarm/north{
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/gunnery)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/shuttle/freebooter_shuttle)
 "tVf" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/black,
@@ -8668,7 +8649,7 @@
 	name = "igs - freebooter crew captain"
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/dorms)
 "tXx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 9
@@ -8765,7 +8746,7 @@
 	info = "Don't forget - all of the crew's clothing is now in the cargo pod!"
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/dorms)
 "ufC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8776,11 +8757,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ugG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/freebooter_shuttle)
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster1)
 "uhG" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/railing/mapped{
@@ -8832,7 +8812,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/head)
 "ukw" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4;
@@ -8845,12 +8825,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/engineering)
-"umJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 9
-	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/shuttle/freebooter_shuttle)
 "unp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8891,7 +8865,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/cryo)
 "uxz" = (
 /obj/machinery/door/firedoor/noid,
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -8904,14 +8878,14 @@
 	},
 /obj/structure/ship_weapon_dummy,
 /turf/template_noop,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "uCl" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
 /turf/template_noop,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "uDc" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/binary/pump/high_power{
@@ -8944,13 +8918,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "uJz" = (
-/obj/structure/lattice/catwalk,
-/obj/item/material/shard{
-	pixel_x = -4;
-	pixel_y = 7
+/obj/machinery/door/airlock/external{
+	dir = 8
 	},
-/turf/template_noop,
-/area/ship/freebooter_ship)
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/access_button{
+	pixel_x = 8;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "uJN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8958,12 +8940,10 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
-"uNx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/freebooter_shuttle)
+/area/ship/freebooter_ship/forehallway)
+"uLO" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/forehallway)
 "uNJ" = (
 /obj/structure/table/steel,
 /obj/item/toy/plushie/pennyplush{
@@ -9037,6 +9017,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
+"uPM" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed/pipes{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/freebooter_ship/cryo)
 "uQV" = (
 /obj/effect/floor_decal/corner/dark_green/diagonal,
 /obj/item/stack/rods,
@@ -9050,7 +9041,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "uSp" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -9081,7 +9072,7 @@
 "uWU" = (
 /obj/effect/floor_decal/corner/dark_green/diagonal,
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "uYP" = (
 /obj/machinery/vending/boozeomat{
 	req_access = null;
@@ -9111,7 +9102,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "vbh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9181,7 +9172,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "vgl" = (
 /obj/machinery/door/firedoor/noid,
 /obj/effect/floor_decal/spline/plain{
@@ -9390,7 +9381,7 @@
 	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/head)
 "vwF" = (
 /obj/structure/cryofeed/pipes,
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -9402,7 +9393,7 @@
 	},
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/cryo)
 "vxN" = (
 /obj/structure/sign/greencross{
 	pixel_x = -32
@@ -9437,7 +9428,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/lockers)
 "vCg" = (
 /obj/effect/landmark/entry_point/west{
 	name = "starboard, crew compartment"
@@ -9456,10 +9447,21 @@
 /turf/simulated/floor/greengrid,
 /area/ship/freebooter_ship/thruster2)
 "vDD" = (
-/obj/structure/lattice/catwalk,
-/obj/item/material/shard,
-/turf/template_noop,
-/area/ship/freebooter_ship)
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "vFo" = (
 /obj/machinery/atmospherics/unary/engine,
 /obj/structure/window/reinforced,
@@ -9469,9 +9471,20 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
+"vHQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/structure/curtain/open/bed{
+	name = "curtain"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "vIj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "vMG" = (
@@ -9488,6 +9501,9 @@
 "vOi" = (
 /obj/item/ammo_casing/rifle/used,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "vOo" = (
@@ -9512,7 +9528,7 @@
 	layer = 2.71
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "vPH" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9529,7 +9545,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "vRc" = (
 /obj/item/ammo_casing/rifle/used{
 	pixel_y = 4
@@ -9543,7 +9559,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "vSY" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/pod4)
@@ -9556,7 +9572,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
+"vTz" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/dorms)
 "vUh" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9582,7 +9601,7 @@
 	},
 /obj/structure/ship_weapon_dummy,
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "vVy" = (
 /obj/item/ammo_casing/rifle/used{
 	pixel_x = -8;
@@ -9604,7 +9623,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/gunneryentrance)
 "vWd" = (
 /obj/effect/floor_decal/corner/dark_green/full{
 	dir = 8
@@ -9623,7 +9642,7 @@
 	is_barrel = 1
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "vYJ" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
@@ -9637,10 +9656,8 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "vZW" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/rods,
-/turf/template_noop,
-/area/ship/freebooter_ship)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/gunneryentrance)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/stool/chair{
@@ -9668,8 +9685,11 @@
 	pixel_x = -1;
 	pixel_y = -6
 	},
+/obj/machinery/alarm/south{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/lockers)
 "wfo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -9707,11 +9727,13 @@
 	},
 /obj/item/handcuffs/cable,
 /obj/machinery/alarm/west{
-	pixel_x = -32;
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
+"wjn" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/head)
 "wmT" = (
 /obj/machinery/light/small/emergency{
 	dir = 1
@@ -9762,8 +9784,11 @@
 /obj/item/ship_ammunition/blaster,
 /obj/item/ship_ammunition/blaster,
 /obj/item/ship_ammunition/blaster,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "wrx" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/spline/plain{
@@ -9776,11 +9801,8 @@
 	name = "fore, cryo"
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/cryo)
 "wtm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
 	dir = 8
@@ -9790,7 +9812,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "wuO" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
@@ -9838,10 +9860,10 @@
 /obj/structure/grille/broken,
 /obj/structure/blocker,
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/exterior)
 "wGc" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship)
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunneryentrance)
 "wHo" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/ship_engine.dmi';
@@ -9865,8 +9887,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/east,
 /turf/simulated/floor/carpet/rubber,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/dorms)
 "wJR" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1;
@@ -9885,13 +9908,22 @@
 /obj/structure/bed/stool/bar/padded/brown,
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
+"wLI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "wLV" = (
 /obj/machinery/shower{
 	pixel_y = 17
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/head)
 "wMd" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -9914,7 +9946,7 @@
 /obj/structure/curtain/black,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/lockers)
 "wNA" = (
 /obj/machinery/chem_master,
 /obj/effect/floor_decal/industrial/outline/service,
@@ -9960,6 +9992,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
+"wUa" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/closet)
 "wUf" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -9990,7 +10025,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "wUJ" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 6
@@ -10047,6 +10082,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
+"xad" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_x = 23;
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/shuttle/freebooter_shuttle)
 "xal" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 5
@@ -10117,24 +10171,11 @@
 /obj/machinery/ammunition_loader/blaster{
 	weapon_id = "Freebooter Ship Blaster"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/gunnery)
-"xjC" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship)
+"xqI" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/ammo)
 "xtX" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 5
@@ -10184,15 +10225,18 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/closet)
 "xvT" = (
-/obj/structure/lattice/catwalk,
-/obj/item/material/shard{
-	pixel_x = 5;
-	pixel_y = 15
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/template_noop,
-/area/ship/freebooter_ship)
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "xxd" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
@@ -10242,7 +10286,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallway)
 "xHQ" = (
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 8
@@ -10308,7 +10352,7 @@
 	},
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "xOG" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/wood/walnut,
@@ -10318,6 +10362,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "xPX" = (
@@ -10332,21 +10377,21 @@
 /area/ship/freebooter_ship/pod6)
 "xQS" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
 	},
 /turf/simulated/floor,
-/area/ship/freebooter_ship)
+/area/ship/freebooter_ship/foyer)
 "xRt" = (
 /obj/structure/barricade/wooden{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "xRX" = (
 /turf/template_noop,
 /area/space)
@@ -10366,8 +10411,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/gunneryentrance)
 "xUb" = (
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -10385,7 +10433,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/cryo)
 "xZh" = (
 /obj/effect/floor_decal/corner/orange/full{
 	dir = 4
@@ -10414,12 +10462,13 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/west,
 /turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/gunnery)
+/area/ship/freebooter_ship/ammo)
 "yar" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
-/area/ship/freebooter_ship/bridge)
+/area/ship/freebooter_ship/forehallwayport)
 "ydf" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/bridge)
@@ -38343,17 +38392,17 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
+kqx
 eIb
 wUi
 ldw
 wUi
 eIb
-fGM
-fGM
+kqx
+kqx
 esB
 gwg
 esB
@@ -38361,32 +38410,32 @@ wHo
 esB
 gwg
 esB
-fGM
-fGM
+kqx
+kqx
 cLC
 cLC
 kwe
 tKj
 tKj
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 qiz
 qiz
 mWz
 qiz
 qiz
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 eUq
 eUq
 pRf
 eUq
 eUq
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 xRX
 xRX
 xRX
@@ -38599,8 +38648,8 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
+kqx
+kqx
 xRX
 xRX
 eIb
@@ -38643,12 +38692,12 @@ fTG
 eUq
 eUq
 xRX
-fGM
-fGM
-imE
-imE
-imE
-imE
+kqx
+xqI
+xqI
+xqI
+xqI
+xqI
 rsh
 imE
 imE
@@ -38657,7 +38706,7 @@ imE
 imE
 iOV
 iOV
-xRX
+jrC
 xRX
 xRX
 xRX
@@ -38901,20 +38950,20 @@ nYr
 eUq
 xRX
 xRX
-imE
+xqI
 bTz
 eND
 mJt
 xZo
-mwo
+tfK
 tuT
 xhE
-tQn
+fNl
 rjL
 tQn
 sxw
 www
-iOV
+jrC
 xRX
 xRX
 xRX
@@ -39115,8 +39164,8 @@ gFA
 ewW
 ewW
 ewW
-fGM
-fGM
+kqx
+kqx
 wUi
 syV
 bhd
@@ -39124,7 +39173,7 @@ xBh
 bhd
 tvh
 wUi
-fGM
+kqx
 gwg
 pUP
 kmP
@@ -39132,7 +39181,7 @@ qDn
 kev
 jcX
 gwg
-fGM
+kqx
 cLC
 wZf
 ttI
@@ -39140,7 +39189,7 @@ krH
 lKT
 vmX
 cLC
-fGM
+kqx
 qiz
 pYB
 bPT
@@ -39148,7 +39197,7 @@ jzk
 fRD
 buM
 qiz
-fGM
+kqx
 eUq
 aTX
 iUK
@@ -39156,22 +39205,22 @@ iUK
 iUK
 fTT
 eUq
-fGM
-fGM
-imE
+kqx
+kqx
+xqI
 ahD
 kfJ
 oUu
 vRc
-mwo
+tfK
 xKj
 pEN
-tQn
-tQn
+fNl
+fNl
 tQn
 sxw
 sxw
-iOV
+jrC
 xRX
 xRX
 xRX
@@ -39361,7 +39410,7 @@ xRX
 xRX
 xRX
 vkx
-sjU
+ugG
 lfb
 plx
 pfE
@@ -39373,7 +39422,7 @@ xUb
 qWF
 ewW
 xRX
-fGM
+kqx
 wUi
 syV
 bhd
@@ -39415,12 +39464,12 @@ qNb
 eUq
 xRX
 xRX
-imE
+xqI
 xRt
 aVd
 npb
 oxR
-mwo
+tfK
 sxk
 soh
 soh
@@ -39428,7 +39477,7 @@ soh
 aDv
 iOV
 iOV
-xRX
+jrC
 xRX
 xRX
 xRX
@@ -39630,7 +39679,7 @@ xUb
 jnK
 ewW
 xRX
-fGM
+kqx
 wUi
 syV
 grD
@@ -39672,14 +39721,14 @@ wYH
 eUq
 xRX
 xRX
-fGM
-imE
+xqI
+xqI
 gji
 wpf
 jhd
-mwo
+tfK
 nwH
-soh
+wLI
 soh
 soh
 fnE
@@ -39887,7 +39936,7 @@ dbA
 wxS
 ewW
 xRX
-fGM
+kqx
 eIb
 oPu
 bhd
@@ -39929,13 +39978,13 @@ cEH
 eUq
 xRX
 xRX
-fGM
-xRX
-imE
-mwo
+kqx
+xqI
+xqI
+tfK
 aVH
+tfK
 mwo
-tUO
 iNM
 tSZ
 imE
@@ -40144,7 +40193,7 @@ ewW
 ewW
 ewW
 xRX
-fGM
+kqx
 wUi
 cLL
 bhd
@@ -40186,13 +40235,13 @@ avE
 eUq
 xRX
 xRX
-fGM
+kqx
 xRX
-imE
+vZW
 rEb
 xTu
 cbE
-mwo
+wGc
 klp
 llD
 euj
@@ -40401,7 +40450,7 @@ acn
 ewW
 xRX
 xRX
-fGM
+kqx
 wUi
 glJ
 ihN
@@ -40443,10 +40492,10 @@ hIE
 eUq
 xRX
 xRX
-fGM
+kqx
 xRX
-imE
-imE
+vZW
+vZW
 jgM
 vVy
 aMQ
@@ -40658,7 +40707,7 @@ pHN
 ewW
 xRX
 xRX
-fGM
+kqx
 wUi
 wNA
 bhd
@@ -40700,13 +40749,13 @@ iUK
 eUq
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
-imE
-imE
+vZW
+vZW
 tmo
-mwo
+wGc
 mwo
 mwo
 mwo
@@ -40915,7 +40964,7 @@ lJH
 jhL
 jhL
 xRX
-fGM
+kqx
 wUi
 peJ
 bhd
@@ -40957,18 +41006,18 @@ mtT
 eUq
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 xRX
-ydf
+uLO
 ebn
 atj
-kzS
+fGM
 exg
 iGK
 aBD
-ydf
+ajO
 xRX
 xRX
 xRX
@@ -41172,7 +41221,7 @@ pCG
 iZM
 jhL
 jhL
-fGM
+kqx
 eIb
 eIb
 pPk
@@ -41214,18 +41263,18 @@ eUq
 eUq
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 xRX
-yar
+pvm
 lNV
 uJN
 jLL
 aab
 qDe
 nVi
-ydf
+ajO
 saW
 xRX
 xRX
@@ -41429,61 +41478,61 @@ mhq
 tcY
 rfn
 jhL
-fGM
-fGM
+kqx
+kqx
 eIb
 eIb
 qEc
 eIb
 eIb
-vZW
-uJz
-xvT
+kqx
+kqx
+kqx
 gwg
 wzO
 dXK
 wzO
 gwg
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 cLC
 cLC
 mbX
 cLC
 cLC
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 qiz
 qiz
 dFi
 qiz
 qiz
-vZW
-vDD
-fGM
+kqx
+kqx
+kqx
 eUq
 eUq
 wRc
 eUq
 eUq
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
-yar
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
+pvm
 kou
 dWF
-kzS
+fGM
 gLO
 npJ
 kAt
 lpe
-ydf
+ajO
 xRX
 xRX
 xRX
@@ -41687,7 +41736,7 @@ jbh
 tYn
 jhL
 xRX
-fGM
+kqx
 xRX
 wyp
 mGn
@@ -41728,19 +41777,19 @@ xRX
 xRX
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 xRX
-yar
+pvm
 vfD
 kOP
-kzS
-kzS
+fGM
+fGM
 tra
-ydf
-kzS
-ydf
+ajO
+fGM
+ajO
 ydf
 ewy
 ewy
@@ -41944,7 +41993,7 @@ rRa
 nKC
 jhL
 xRX
-fGM
+kqx
 xRX
 wyp
 mGn
@@ -41985,11 +42034,11 @@ xRX
 xRX
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 xRX
-ydf
+uLO
 qIf
 kbX
 kzS
@@ -42246,7 +42295,7 @@ vGw
 vGw
 wyp
 wyp
-ydf
+uLO
 qcb
 kOP
 kzS
@@ -42760,7 +42809,7 @@ koD
 koD
 cEX
 pQc
-kzS
+mbN
 kHb
 wUy
 kzS
@@ -43020,10 +43069,10 @@ esx
 kQR
 dDy
 kOP
-kzS
-kzS
-kzS
-kzS
+wUa
+wUa
+wUa
+wUa
 ofV
 nbF
 sCs
@@ -43231,17 +43280,17 @@ wyp
 wyp
 kXG
 vGw
-wGc
-azU
+wyp
 gyl
-wGc
+bzm
+wyp
 vGw
 vGw
 vGw
-wGc
-azU
+wyp
+gyl
 odb
-wGc
+wyp
 wyp
 vGw
 vGw
@@ -43274,13 +43323,13 @@ kXG
 vGw
 wyp
 wyp
-ydf
+uLO
 qIf
 fZr
-kzS
+wUa
 oKE
 xvt
-kzS
+wUa
 okc
 tmK
 sCs
@@ -43486,26 +43535,18 @@ pkY
 bJj
 jhL
 xRX
-vZW
+kqx
 xRX
-wGc
-doK
-pno
-wGc
+wyp
+bhA
+xQS
+wyp
 xRX
 xRX
 xRX
-wGc
-cmW
+wyp
+hQd
 lvN
-wGc
-xRX
-xRX
-xRX
-xRX
-xRX
-wyp
-mGn
 wyp
 xRX
 xRX
@@ -43527,17 +43568,25 @@ xRX
 xRX
 xRX
 xRX
-vZW
+xRX
+wyp
+mGn
+wyp
 xRX
 xRX
 xRX
-ydf
+xRX
+kqx
+xRX
+xRX
+xRX
+uLO
 hjh
 igB
 qeH
 aAs
 ebW
-kzS
+wUa
 dHd
 oaH
 ydf
@@ -43743,26 +43792,18 @@ doW
 nEK
 jhL
 xRX
-fGM
+kqx
 xRX
-wGc
-xjC
-xQS
-wGc
-xRX
-xRX
-xRX
-wGc
-xjC
-dAi
-wGc
-xRX
-xRX
+wyp
+vDD
+xvT
+wyp
 xRX
 xRX
 xRX
 wyp
-mGn
+vDD
+bsf
 wyp
 xRX
 xRX
@@ -43782,19 +43823,27 @@ mGn
 wyp
 xRX
 xRX
-nWh
 xRX
-fGM
+xRX
+xRX
+wyp
+mGn
+wyp
+xRX
+xRX
+xRX
+xRX
+kqx
 xRX
 xRX
 xRX
 gzr
 tzw
 gDJ
-kzS
-kzS
-kzS
-kzS
+wUa
+wUa
+wUa
+wUa
 kzS
 ydf
 ydf
@@ -43999,61 +44048,61 @@ ngJ
 gwl
 xZh
 jhL
-ajO
-fGM
-fGM
-wGc
-rrI
-pFM
-wGc
 kqx
-aOU
 kqx
-wGc
-rrI
-rNB
-wGc
-fGM
-fGM
-fGM
-fGM
+kqx
+wyp
+uJz
+bJc
+wyp
+kqx
+kqx
+kqx
+wyp
+uJz
+bst
+wyp
+kqx
+kqx
+kqx
+kqx
 uwT
 uwT
 jjA
 uwT
 uwT
-fNl
-fGM
-fGM
+kqx
+kqx
+kqx
 eiL
 eiL
 gSo
 eiL
 eiL
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 tRo
 tRo
 sVs
 tRo
 tRo
-fGM
-fGM
-vDD
-fGM
-fGM
-vDD
-fGM
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
 gzr
 iHV
 kOP
-kzS
+quS
 vwF
 hFX
 hFX
-ydf
-ydf
+oxG
+oxG
 xRX
 xRX
 xRX
@@ -44256,7 +44305,7 @@ oGU
 kMx
 jhL
 jhL
-fGM
+kqx
 xRX
 sUX
 ppp
@@ -44265,11 +44314,11 @@ ppp
 ppp
 ayy
 kQs
-jrC
+ayy
 wtm
 rhN
 ciM
-rsE
+rhN
 rmm
 xRX
 xRX
@@ -44298,18 +44347,18 @@ tRo
 tRo
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 xRX
-yar
+pvm
 xED
 drP
 xWB
 huE
 uxb
 aHw
-ydf
+oxG
 wrJ
 xRX
 xRX
@@ -44513,7 +44562,7 @@ lJH
 jhL
 jhL
 xRX
-fGM
+kqx
 iGW
 wnf
 aSb
@@ -44555,18 +44604,18 @@ cMo
 tRo
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 xRX
-ydf
+uLO
 ebn
 cDf
-kzS
+quS
 cQs
+uPM
 aSJ
-aSJ
-ydf
+oxG
 xRX
 xRX
 xRX
@@ -44768,9 +44817,9 @@ xKt
 adF
 eqi
 uZl
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 rrT
 ntt
 sUq
@@ -44786,7 +44835,7 @@ elW
 sWG
 qVW
 vOL
-fGM
+kqx
 uwT
 dkz
 hHq
@@ -44812,18 +44861,18 @@ bxM
 tRo
 xRX
 xRX
-vZW
+kqx
 xRX
 xRX
-ydf
-ydf
+uLO
+uLO
 vPH
-kzS
-kzS
-kzS
-kzS
-kzS
-ydf
+mbN
+quS
+quS
+quS
+quS
+oxG
 xRX
 xRX
 xRX
@@ -45027,7 +45076,7 @@ uPa
 uZl
 xRX
 xRX
-fGM
+kqx
 bcf
 aSb
 aEB
@@ -45035,11 +45084,11 @@ aEB
 aSb
 iCP
 bFv
-ugG
+bkh
 rHI
 aSb
 lzu
-cKm
+eqD
 aSb
 qeJ
 vOL
@@ -45069,18 +45118,18 @@ ieZ
 tRo
 xRX
 xRX
-fGM
+kqx
 xRX
-ydf
-ydf
+aOU
+aOU
 nZj
 ess
-kzS
+lzb
 uaR
 dut
 gMa
-ydf
-ydf
+vTz
+vTz
 ewy
 ewy
 ewy
@@ -45284,7 +45333,7 @@ fdV
 uZl
 uZl
 xRX
-fGM
+kqx
 rJT
 rsE
 rsE
@@ -45296,7 +45345,7 @@ btW
 rAU
 mkb
 syX
-hGJ
+afL
 sVT
 oSp
 vOL
@@ -45326,9 +45375,9 @@ uNJ
 tRo
 xRX
 xRX
-fGM
+kqx
 xRX
-ydf
+aOU
 xMA
 uWU
 oVL
@@ -45336,7 +45385,7 @@ oBL
 pSD
 sQA
 qNZ
-ydf
+vTz
 tPr
 xRX
 xRX
@@ -45541,7 +45590,7 @@ mwO
 uoZ
 uZl
 xRX
-fGM
+kqx
 iUd
 vdX
 atI
@@ -45552,7 +45601,7 @@ nRY
 nxF
 kPW
 rDZ
-eFB
+xad
 tcV
 rXx
 cJt
@@ -45583,17 +45632,17 @@ lvR
 tRo
 xRX
 xRX
-fGM
+kqx
 xRX
-ydf
+aOU
 oyG
 cnH
 ess
-kzS
+lzb
 csG
 wIJ
 tVf
-ydf
+vTz
 jZY
 xRX
 xRX
@@ -45786,7 +45835,7 @@ xRX
 xRX
 xRX
 icO
-vIj
+joM
 jlr
 rXk
 tYU
@@ -45798,7 +45847,7 @@ kuj
 rFB
 uZl
 xRX
-fGM
+kqx
 lkK
 hZH
 kti
@@ -45808,10 +45857,10 @@ aSb
 aSb
 rzA
 yeH
-rXI
+tUO
 kTf
 kTf
-umJ
+bzW
 hhA
 vOL
 xRX
@@ -45840,18 +45889,18 @@ fbi
 tRo
 xRX
 xRX
-fGM
-ydf
-kzS
-kzS
+wjn
+wjn
+wjn
+qqX
 iwL
 dhX
-kzS
-kzS
-kzS
-kzS
-ydf
-ydf
+lzb
+lzb
+lzb
+lzb
+vTz
+vTz
 xRX
 xRX
 xRX
@@ -46043,7 +46092,7 @@ xRX
 xRX
 xRX
 vFo
-ghb
+vIj
 qgY
 rXk
 lqh
@@ -46055,7 +46104,7 @@ vDk
 rFB
 uZl
 xRX
-fGM
+kqx
 bcf
 aSb
 aSb
@@ -46064,8 +46113,8 @@ aSb
 aSb
 ejm
 kSC
-uNx
-tno
+nWh
+vHQ
 bck
 tDp
 aSb
@@ -46097,19 +46146,19 @@ bhn
 tRo
 xRX
 xRX
-ydf
+wjn
 wLV
 aMB
-kzS
+qqX
 tyf
 ess
 oEs
-kzS
+jcW
 tli
 mLD
 mON
 wMH
-ydf
+rbz
 xRX
 xRX
 xRX
@@ -46311,8 +46360,8 @@ aEt
 ldf
 uZl
 uZl
-fGM
-fGM
+kqx
+kqx
 bcf
 sBA
 ruo
@@ -46322,13 +46371,13 @@ bEH
 qnz
 ggq
 aSb
-iTJ
+kVa
 iTc
 elW
 sWG
 cei
 vOL
-fGM
+kqx
 uwT
 vMG
 hil
@@ -46336,7 +46385,7 @@ uOr
 hil
 irq
 uwT
-fGM
+kqx
 eiL
 upC
 buI
@@ -46344,7 +46393,7 @@ hdb
 pZo
 fVv
 eiL
-fGM
+kqx
 tRo
 pDZ
 bxM
@@ -46352,20 +46401,20 @@ bxM
 bxM
 pZO
 tRo
-fGM
-fGM
-ydf
-kzS
+kqx
+kqx
+wjn
+qqX
 vwi
-kzS
+qqX
 mdX
 uQV
 akl
-kzS
+jcW
 jSG
 nGG
 wdL
-kzS
+jcW
 sOb
 xRX
 xRX
@@ -46569,7 +46618,7 @@ stV
 uZl
 xRX
 xRX
-fGM
+kqx
 aCG
 dqF
 aSb
@@ -46580,9 +46629,9 @@ vCg
 iTc
 lKV
 kEe
-rsE
-rsE
-rsE
+rhN
+rhN
+rhN
 mYn
 tOu
 xRX
@@ -46611,7 +46660,7 @@ rtt
 tRo
 xRX
 xRX
-ydf
+wjn
 pzX
 ujq
 cYs
@@ -46623,7 +46672,7 @@ lDh
 vAb
 bQe
 bkX
-ydf
+rbz
 xRX
 xRX
 xRX
@@ -46823,10 +46872,10 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
+kqx
+kqx
 xRX
-fGM
+kqx
 xRX
 kOK
 rfz
@@ -46867,19 +46916,19 @@ rEV
 tRo
 tRo
 xRX
-fGM
-fGM
-ydf
-ydf
-ydf
+kqx
+wjn
+wjn
+wjn
+wjn
 yar
 efd
 yar
-ydf
-ydf
-ydf
-ydf
-ydf
+rbz
+rbz
+rbz
+rbz
+rbz
 xRX
 xRX
 xRX
@@ -47081,50 +47130,50 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
 ibm
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
 fro
-fGM
-fGM
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
+kqx
+kqx
 uwT
 uwT
 qju
 uwT
 uwT
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 eiL
 eiL
 sal
 eiL
 eiL
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 tRo
 tRo
 raF
 tRo
 tRo
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 xRX
 xRX
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -2071,6 +2071,12 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/walllocker/emerglocker/north,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
 "epB" = (
@@ -3115,6 +3121,12 @@
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 1
 	},
+/obj/structure/closet/walllocker/emerglocker/north,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
 "hhA" = (

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -3373,14 +3373,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod7)
-"hRt" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
-/turf/simulated/wall/shuttle/space_ship{
-	color = "#E14644"
-	},
-/area/ship/freebooter_ship/pod4)
 "hUF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4002,9 +3994,6 @@
 /obj/structure/table/steel,
 /obj/item/melee/energy/sword/pirate/generic,
 /obj/item/laser_components/modifier/stock,
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod4)
 "jFM" = (
@@ -4232,9 +4221,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
 "kmP" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 8
-	},
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
 	icon = 'icons/obj/smooth/lattice.dmi';
@@ -5948,14 +5934,6 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod1)
-"nVq" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
-	},
-/turf/simulated/wall/shuttle/space_ship{
-	color = "#E14644"
-	},
-/area/ship/freebooter_ship/pod4)
 "nWh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -7076,12 +7054,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
-"pZx" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/wall/shuttle/space_ship{
-	color = "#E14644"
-	},
-/area/ship/freebooter_ship/pod4)
 "pZI" = (
 /obj/effect/floor_decal/corner/dark_blue,
 /obj/structure/bed/stool/chair/office/light{
@@ -7366,7 +7338,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "qAl" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
 	icon = 'icons/obj/smooth/lattice.dmi';
@@ -9981,9 +9952,6 @@
 /obj/structure/table/steel,
 /obj/item/gun/projectile/automatic/improvised,
 /obj/effect/floor_decal/corner/red/full,
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "woF" = (
@@ -10289,9 +10257,6 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /obj/item/material/twohanded/baseballbat/metal,
 /obj/item/material/twohanded/baseballbat/metal,
 /turf/simulated/floor/tiled/dark,
@@ -10581,9 +10546,6 @@
 /obj/item/receivergun,
 /obj/effect/floor_decal/corner/red{
 	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
 	},
 /obj/item/material/kitchen/utensil/knife/boot,
 /turf/simulated/floor/tiled/dark,
@@ -38900,13 +38862,13 @@ eHQ
 eIb
 eIb
 xRX
-nVq
-pZx
+gwg
+gwg
 jEO
 xLr
 wnq
-pZx
-hRt
+gwg
+gwg
 xRX
 cLC
 cLC

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -2973,6 +2973,10 @@
 	dir = 10
 	},
 /obj/item/ammo_casing/rifle/used,
+/obj/item/ammo_casing/rifle/used{
+	pixel_x = 7;
+	pixel_y = 7
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
 "gFA" = (

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -132,8 +132,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ajO" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/medical)
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunneryentrance)
 "akg" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
@@ -407,7 +407,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "aHt" = (
 /obj/machinery/vending/dinnerware{
@@ -545,8 +545,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aOU" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/forehallwayport)
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "junker_gun"
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/gunnery)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -2133,7 +2137,7 @@
 /area/ship/freebooter_ship/gunnery)
 "ewy" = (
 /obj/structure/lattice,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "ewW" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
@@ -2427,7 +2431,7 @@
 /obj/effect/landmark/entry_point/port{
 	name = "port, landing pad 2"
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "frC" = (
 /obj/effect/decal/cleanable/blood,
@@ -2484,8 +2488,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fGM" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/medical)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/gunneryentrance)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -3355,7 +3359,7 @@
 /obj/effect/landmark/entry_point/port{
 	name = "port, landing pad 1"
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "icO" = (
 /obj/machinery/atmospherics/unary/engine,
@@ -3434,6 +3438,17 @@
 	},
 /turf/simulated/floor/carpet/magenta,
 /area/ship/freebooter_ship/pod6)
+"ife" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed/pipes{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/freebooter_ship/cryo)
 "igB" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -3670,6 +3685,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/alarm/north{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
 "iOV" = (
@@ -3835,12 +3853,8 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "jrC" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "junker_gun"
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/gunnery)
+/turf/simulated/wall,
+/area/ship/freebooter_ship/medical)
 "jvN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -4184,7 +4198,7 @@
 /area/ship/freebooter_ship/pod7)
 "kqx" = (
 /obj/structure/lattice/catwalk,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
@@ -4734,7 +4748,7 @@
 "loq" = (
 /obj/structure/grille/broken,
 /obj/structure/blocker/steel,
-/turf/simulated/floor/airless,
+/turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "lpe" = (
 /obj/effect/floor_decal/industrial/outline/medical,
@@ -5663,13 +5677,13 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/alarm/north{
-	req_one_access = null
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/power/apc/north{
+	req_access = null
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
 "nxF" = (
@@ -6638,7 +6652,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/hatch{
-	name = "Propulsion";
+	name = "Port Propulsion";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
@@ -7577,7 +7591,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "rtt" = (
 /obj/effect/floor_decal/corner{
@@ -7842,6 +7856,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
+"rSw" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/medical)
 "rXk" = (
 /turf/simulated/wall/r_wall,
 /area/ship/freebooter_ship/thruster2)
@@ -8041,12 +8058,6 @@
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/north{
-	req_access = null
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
 "sxw" = (
@@ -8512,7 +8523,7 @@
 "tAn" = (
 /obj/structure/grille,
 /obj/structure/barricade/wooden,
-/turf/simulated/floor/airless,
+/turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "tDp" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -8569,7 +8580,7 @@
 /area/ship/freebooter_ship/engineering)
 "tMA" = (
 /obj/structure/grille,
-/turf/simulated/floor/airless,
+/turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "tOu" = (
 /obj/structure/railing/mapped,
@@ -8877,14 +8888,14 @@
 	dir = 4
 	},
 /obj/structure/ship_weapon_dummy,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "uCl" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "uDc" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -9017,17 +9028,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
-"uPM" = (
-/obj/machinery/cryopod,
-/obj/structure/cryofeed/pipes{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/cryo)
 "uQV" = (
 /obj/effect/floor_decal/corner/dark_green/diagonal,
 /obj/item/stack/rods,
@@ -9657,7 +9657,7 @@
 /area/ship/freebooter_ship/bridge)
 "vZW" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/gunneryentrance)
+/area/ship/freebooter_ship/forehallwayport)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/stool/chair{
@@ -9859,11 +9859,11 @@
 "wCo" = (
 /obj/structure/grille/broken,
 /obj/structure/blocker,
-/turf/simulated/floor/airless,
+/turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "wGc" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunneryentrance)
+/turf/space/dynamic,
+/area/space)
 "wHo" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/ship_engine.dmi';
@@ -9977,7 +9977,7 @@
 "wRm" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/door/airlock/hatch{
-	name = "Propulsion";
+	name = "Starboard Propulsion";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
@@ -38706,7 +38706,7 @@ imE
 imE
 iOV
 iOV
-jrC
+aOU
 xRX
 xRX
 xRX
@@ -38963,7 +38963,7 @@ rjL
 tQn
 sxw
 www
-jrC
+aOU
 xRX
 xRX
 xRX
@@ -39220,7 +39220,7 @@ fNl
 tQn
 sxw
 sxw
-jrC
+aOU
 xRX
 xRX
 xRX
@@ -39477,7 +39477,7 @@ soh
 aDv
 iOV
 iOV
-jrC
+aOU
 xRX
 xRX
 xRX
@@ -40237,11 +40237,11 @@ xRX
 xRX
 kqx
 xRX
-vZW
+fGM
 rEb
 xTu
 cbE
-wGc
+ajO
 klp
 llD
 euj
@@ -40494,8 +40494,8 @@ xRX
 xRX
 kqx
 xRX
-vZW
-vZW
+fGM
+fGM
 jgM
 vVy
 aMQ
@@ -40752,10 +40752,10 @@ xRX
 kqx
 xRX
 xRX
-vZW
-vZW
+fGM
+fGM
 tmo
-wGc
+ajO
 mwo
 mwo
 mwo
@@ -41013,11 +41013,11 @@ xRX
 uLO
 ebn
 atj
-fGM
+jrC
 exg
 iGK
 aBD
-ajO
+rSw
 xRX
 xRX
 xRX
@@ -41274,7 +41274,7 @@ jLL
 aab
 qDe
 nVi
-ajO
+rSw
 saW
 xRX
 xRX
@@ -41527,12 +41527,12 @@ kqx
 pvm
 kou
 dWF
-fGM
+jrC
 gLO
 npJ
 kAt
 lpe
-ajO
+rSw
 xRX
 xRX
 xRX
@@ -41784,12 +41784,12 @@ xRX
 pvm
 vfD
 kOP
-fGM
-fGM
+jrC
+jrC
 tra
-ajO
-fGM
-ajO
+rSw
+jrC
+rSw
 ydf
 ewy
 ewy
@@ -43534,9 +43534,9 @@ bBW
 pkY
 bJj
 jhL
-xRX
+wGc
 kqx
-xRX
+wGc
 wyp
 bhA
 xQS
@@ -43791,9 +43791,9 @@ rpZ
 doW
 nEK
 jhL
-xRX
+wGc
 kqx
-xRX
+wGc
 wyp
 vDD
 xvT
@@ -44306,7 +44306,7 @@ kMx
 jhL
 jhL
 kqx
-xRX
+wGc
 sUX
 ppp
 ppp
@@ -44320,8 +44320,8 @@ rhN
 ciM
 rhN
 rmm
-xRX
-xRX
+wGc
+wGc
 uwT
 uwT
 lgM
@@ -44561,7 +44561,7 @@ aEa
 lJH
 jhL
 jhL
-xRX
+wGc
 kqx
 iGW
 wnf
@@ -44578,7 +44578,7 @@ iQg
 clU
 nKq
 rmm
-xRX
+wGc
 htS
 lfg
 jFY
@@ -44613,7 +44613,7 @@ ebn
 cDf
 quS
 cQs
-uPM
+ife
 aSJ
 oxG
 xRX
@@ -45074,8 +45074,8 @@ mOF
 qED
 uPa
 uZl
-xRX
-xRX
+wGc
+wGc
 kqx
 bcf
 aSb
@@ -45092,7 +45092,7 @@ eqD
 aSb
 qeJ
 vOL
-xRX
+wGc
 uwT
 oZH
 pZI
@@ -45120,8 +45120,8 @@ xRX
 xRX
 kqx
 xRX
-aOU
-aOU
+vZW
+vZW
 nZj
 ess
 lzb
@@ -45332,7 +45332,7 @@ bpj
 fdV
 uZl
 uZl
-xRX
+wGc
 kqx
 rJT
 rsE
@@ -45349,7 +45349,7 @@ afL
 sVT
 oSp
 vOL
-xRX
+wGc
 uwT
 bDX
 mCb
@@ -45377,7 +45377,7 @@ xRX
 xRX
 kqx
 xRX
-aOU
+vZW
 xMA
 uWU
 oVL
@@ -45589,7 +45589,7 @@ ieM
 mwO
 uoZ
 uZl
-xRX
+wGc
 kqx
 iUd
 vdX
@@ -45606,7 +45606,7 @@ tcV
 rXx
 cJt
 vOL
-xRX
+wGc
 uwT
 fYr
 lGK
@@ -45634,7 +45634,7 @@ xRX
 xRX
 kqx
 xRX
-aOU
+vZW
 oyG
 cnH
 ess
@@ -45846,7 +45846,7 @@ mCl
 kuj
 rFB
 uZl
-xRX
+wGc
 kqx
 lkK
 hZH
@@ -45863,7 +45863,7 @@ kTf
 bzW
 hhA
 vOL
-xRX
+wGc
 uwT
 cgU
 hhQ
@@ -46103,7 +46103,7 @@ uiV
 vDk
 rFB
 uZl
-xRX
+wGc
 kqx
 bcf
 aSb
@@ -46120,7 +46120,7 @@ tDp
 aSb
 hhA
 vOL
-xRX
+wGc
 uwT
 cgU
 onn
@@ -46616,8 +46616,8 @@ uZl
 osl
 stV
 uZl
-xRX
-xRX
+wGc
+wGc
 kqx
 aCG
 dqF
@@ -46634,7 +46634,7 @@ rhN
 rhN
 mYn
 tOu
-xRX
+wGc
 htS
 hXO
 uwA
@@ -46874,9 +46874,9 @@ xRX
 xRX
 kqx
 kqx
-xRX
+wGc
 kqx
-xRX
+wGc
 kOK
 rfz
 rfz
@@ -46890,8 +46890,8 @@ vTv
 vTv
 vTv
 tOu
-xRX
-xRX
+wGc
+wGc
 uwT
 uwT
 nti

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1314,23 +1314,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "cgU" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/mushroom,
-/obj/structure/closet/crate/miningcart,
-/obj/item/reagent_containers/food/snacks/tastybread,
-/obj/item/reagent_containers/food/snacks/tastybread,
-/obj/item/storage/box/produce{
-	layer = 2.99
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/wall/r_wall,
 /area/ship/freebooter_ship/pod8)
 "ciM" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2691,6 +2675,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
+"fXU" = (
+/obj/effect/floor_decal/corner{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod8)
 "fYr" = (
 /obj/machinery/portable_atmospherics/canister/empty/phoron,
 /obj/effect/floor_decal/industrial/outline/engineering,
@@ -3216,15 +3207,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
-"hqJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/ship/freebooter_ship/pod8)
 "htS" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/ship/freebooter_ship/pod8)
@@ -4602,6 +4584,25 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
+"kPA" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/mushroom,
+/obj/structure/closet/crate/miningcart,
+/obj/item/reagent_containers/food/snacks/tastybread,
+/obj/item/reagent_containers/food/snacks/tastybread,
+/obj/item/storage/box/produce{
+	layer = 2.99
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod8)
 "kPJ" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/status_display.dmi';
@@ -8885,6 +8886,15 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/freebooter_shuttle)
+"tVd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/ship/freebooter_ship/pod8)
 "tVf" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/black,
@@ -9705,9 +9715,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
-"vHR" = (
-/turf/simulated/wall/r_wall,
-/area/ship/freebooter_ship/pod8)
 "vMG" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
@@ -10499,13 +10506,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
-"xAd" = (
-/obj/effect/floor_decal/corner{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod8)
 "xBh" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/decal/cleanable/dirt,
@@ -46109,11 +46109,11 @@ hhA
 vOL
 xRX
 uwT
-vHR
+cgU
 hhQ
-hqJ
+tVd
 hZY
-vHR
+cgU
 uwT
 xRX
 eiL
@@ -46366,7 +46366,7 @@ hhA
 vOL
 xRX
 uwT
-cgU
+kPA
 onn
 uZC
 iok
@@ -46626,7 +46626,7 @@ uwT
 vMG
 hil
 uOr
-xAd
+fXU
 irq
 uwT
 vZW

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -5217,9 +5217,6 @@
 	dir = 4;
 	target_pressure = 250
 	},
-/obj/effect/floor_decal/industrial/hatch{
-	color = "#557EA3"
-	},
 /obj/structure/railing/mapped,
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/floor_decal/industrial/warning{
@@ -8011,8 +8008,7 @@
 /obj/effect/floor_decal/corner{
 	dir = 4
 	},
-/obj/machinery/alarm/north{
-	pixel_y = -32;
+/obj/machinery/alarm/south{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1532,14 +1532,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
-"cPy" = (
-/obj/machinery/ship_weapon/blaster{
-	pixel_y = -195;
-	pixel_x = -24;
-	weapon_id = "Freebooter Ship Blaster"
-	},
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunnery)
 "cQs" = (
 /obj/structure/cryofeed/pipes{
 	dir = 4
@@ -2461,9 +2453,8 @@
 	layer = 2.45;
 	name = "lattice"
 	},
-/obj/machinery/light{
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
+/obj/machinery/light/small/emergency{
+	dir = 2
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
@@ -5198,7 +5189,7 @@
 	dir = 8
 	},
 /obj/machinery/button/remote/blast_door{
-	name = "Port Propulsion Blast Shutters";
+	name = "Propellant Tank Blast Shutters";
 	id = "freebooter_co2_shutters";
 	pixel_x = null;
 	pixel_y = -24
@@ -9751,6 +9742,14 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/forehallway)
+"vPP" = (
+/obj/machinery/ship_weapon/blaster{
+	pixel_y = -195;
+	pixel_x = -24;
+	weapon_id = "Freebooter Ship Blaster"
+	},
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunnery)
 "vRc" = (
 /obj/item/ammo_casing/rifle/used{
 	pixel_y = 4
@@ -9948,6 +9947,9 @@
 "wmT" = (
 /obj/machinery/atmospherics/unary/heater,
 /obj/effect/decal/cleanable/cobweb2,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "wnf" = (
@@ -40983,7 +40985,7 @@ tmo
 dlZ
 mwo
 mwo
-cPy
+vPP
 imE
 imE
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1145,8 +1145,9 @@
 	dir = 1;
 	name = "Fuel Input"
 	},
-/obj/structure/cable/yellow{
-	dir = 1;
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -1197,7 +1198,6 @@
 /obj/machinery/alarm/east{
 	req_one_access = null
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -2036,14 +2036,14 @@
 "ejm" = (
 /obj/machinery/power/smes/buildable/third_party_shuttle,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/yellow{
-	dir = 8
-	},
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
 	name = "HIGH VOLTAGE";
 	pixel_y = 32
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
@@ -2260,6 +2260,9 @@
 /area/ship/freebooter_ship/pod3)
 "eND" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/ammo)
 "eST" = (
@@ -3290,7 +3293,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 5
 	},
@@ -7200,15 +7202,16 @@
 "qnz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/yellow{
-	dir = 2;
-	icon_state = "1-8"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 4;
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
@@ -8202,13 +8205,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/machinery/power/apc/high/east,
-/obj/structure/cable/yellow{
-	dir = 1
-	},
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "svN" = (
@@ -9094,12 +9098,13 @@
 /obj/machinery/atmospherics/binary/pump/high_power{
 	name = "Canister to Thrusters"
 	},
-/obj/structure/cable/yellow{
-	dir = 1;
-	icon_state = "1-2"
-	},
 /obj/structure/fuel_port/phoron{
 	pixel_x = -32
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -9666,14 +9671,6 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
-"vGR" = (
-/obj/machinery/ship_weapon/blaster{
-	pixel_y = -195;
-	pixel_x = -24;
-	weapon_id = "Freebooter Ship Blaster"
-	},
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunnery)
 "vHQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/structure/curtain/open/bed{
@@ -10367,7 +10364,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
@@ -40984,7 +40980,7 @@ tmo
 dlZ
 mwo
 mwo
-vGR
+mwo
 imE
 imE
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -2549,7 +2549,7 @@
 	dir = 4;
 	id = "freebooter_brig";
 	name = "Phoron Storage Bolt Control";
-	pixel_x = 24;
+	pixel_x = 21;
 	pixel_y = 4;
 	specialfunctions = 4
 	},
@@ -3250,15 +3250,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/holofloor/tiled/ramp/bottom,
 /area/ship/freebooter_ship/bridge)
-"hBa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/ship/freebooter_ship/pod8)
 "hFX" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -3386,13 +3377,6 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
-"hTr" = (
-/obj/effect/floor_decal/corner{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod8)
 "hUF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3560,6 +3544,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
+"iiy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/ship/freebooter_ship/pod8)
 "iiZ" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 1
@@ -3876,6 +3869,13 @@
 /obj/structure/cable,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
+"jfC" = (
+/obj/effect/floor_decal/corner{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod8)
 "jgM" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -4099,33 +4099,6 @@
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/engineering)
-"jRh" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner{
-	dir = 10
-	},
-/obj/structure/closet/crate/miningcart,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/reagent_containers/food/snacks/tastybread,
-/obj/item/reagent_containers/food/snacks/tastybread,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/mushroom,
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod8)
 "jSy" = (
 /obj/machinery/hologram/holopad/long_range,
 /turf/simulated/floor/tiled/dark,
@@ -5530,6 +5503,7 @@
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/padded,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "mOF" = (
@@ -6281,6 +6255,25 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/thruster2)
+"osW" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/mushroom,
+/obj/structure/closet/crate/miningcart,
+/obj/item/reagent_containers/food/snacks/tastybread,
+/obj/item/reagent_containers/food/snacks/tastybread,
+/obj/item/storage/box/produce{
+	layer = 2.99
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod8)
 "ovG" = (
 /obj/item/stack/tile/floor_dark,
 /obj/structure/barricade/wooden{
@@ -7101,6 +7094,9 @@
 	},
 /obj/item/stack/material/gold{
 	pixel_x = 8
+	},
+/obj/item/cell/super{
+	pixel_y = 11
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
@@ -46115,7 +46111,7 @@ xRX
 uwT
 cgU
 hhQ
-hBa
+iiy
 hZY
 cgU
 uwT
@@ -46370,7 +46366,7 @@ hhA
 vOL
 xRX
 uwT
-jRh
+osW
 onn
 uZC
 iok
@@ -46630,7 +46626,7 @@ uwT
 vMG
 hil
 uOr
-hTr
+jfC
 irq
 uwT
 vZW

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -2750,6 +2750,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/handrail{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
 "ggz" = (
@@ -5954,6 +5957,9 @@
 "nWh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/bed/handrail{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "nXu" = (

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -770,15 +770,18 @@
 /area/ship/freebooter_ship/pod6)
 "bhA" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/structure/sign/vacuum{
 	pixel_y = 30
 	},
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -1042,6 +1045,7 @@
 	master_tag = "freebooter_port_1"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "bzr" = (
@@ -2934,6 +2938,9 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "gzr" = (
@@ -3374,6 +3381,12 @@
 	},
 /obj/structure/sign/vacuum{
 	pixel_y = 30
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -4002,6 +4015,9 @@
 	master_tag = "freebooter_port_1"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "jEu" = (
@@ -4947,9 +4963,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
@@ -4957,6 +4970,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = -25
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "lvR" = (
@@ -6095,6 +6109,7 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "odX" = (
@@ -10636,9 +10651,6 @@
 /area/ship/freebooter_ship/pod6)
 "xQS" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
@@ -10646,6 +10658,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = -25
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "xRt" = (

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1452,6 +1452,10 @@
 	name = "lattice"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/trash/tastybread{
+	pixel_y = 3;
+	pixel_x = -5
+	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod8)
 "cJt" = (
@@ -2579,7 +2583,7 @@
 /obj/machinery/button/remote/airlock{
 	dir = 4;
 	id = "freebooter_brig";
-	name = "Secure Storage Bolt Control";
+	name = "Phoron Storage Bolt Control";
 	pixel_x = 23;
 	pixel_y = 4;
 	specialfunctions = 4
@@ -2712,9 +2716,6 @@
 	req_access = null
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/securearea{
-	pixel_x = 32
-	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod8)
 "fZq" = (
@@ -3465,7 +3466,7 @@
 /area/ship/freebooter_ship)
 "hZY" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Secure Storage Compartment";
+	name = "Phoron Storage Compartment";
 	dir = 4;
 	id_tag = "freebooter_brig"
 	},
@@ -3655,7 +3656,6 @@
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/bed/padded,
-/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "irX" = (
@@ -7003,9 +7003,6 @@
 	dir = 5
 	},
 /obj/structure/closet/crate/security,
-/obj/structure/sign/securearea{
-	pixel_x = 32
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "pOI" = (
@@ -8439,9 +8436,6 @@
 /obj/effect/floor_decal/corner{
 	dir = 5
 	},
-/obj/machinery/light{
-	icon_state = "tube_empty"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/phoron{
 	start_pressure = 332
@@ -8621,7 +8615,7 @@
 /obj/machinery/alarm/west{
 	req_one_access = null
 	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
+/turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "tld" = (
 /obj/structure/table/steel,

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1314,7 +1314,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "cgU" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate/miningcart,
+/obj/item/reagent_containers/food/snacks/tastybread,
+/obj/item/reagent_containers/food/snacks/tastybread,
+/obj/item/storage/box/produce{
+	layer = 2.99
+	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "ciM" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1851,6 +1864,13 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/gunnery)
+"dUF" = (
+/obj/effect/floor_decal/corner{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod8)
 "dWi" = (
 /obj/effect/floor_decal/corner{
 	dir = 6
@@ -2675,13 +2695,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
-"fXU" = (
-/obj/effect/floor_decal/corner{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod8)
 "fYr" = (
 /obj/machinery/portable_atmospherics/canister/empty/phoron,
 /obj/effect/floor_decal/industrial/outline/engineering,
@@ -3417,13 +3430,14 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/machinery/portable_atmospherics/canister/empty/phoron{
+	destroyed = 1
+	},
 /obj/machinery/light{
 	dir = 1;
 	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
-/obj/machinery/portable_atmospherics/canister/empty/phoron{
-	destroyed = 1
+	icon_state = "tube_empty";
+	status = 2
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -3437,7 +3451,7 @@
 /obj/machinery/door/airlock/highsecurity{
 	name = "Secure Storage Compartment";
 	dir = 4;
-	id = "freebooter_brig"
+	id_tag = "freebooter_brig"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -3867,6 +3881,15 @@
 /obj/structure/cable,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
+"jfl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/ship/freebooter_ship/pod8)
 "jgM" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -4584,25 +4607,6 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
-"kPA" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/mushroom,
-/obj/structure/closet/crate/miningcart,
-/obj/item/reagent_containers/food/snacks/tastybread,
-/obj/item/reagent_containers/food/snacks/tastybread,
-/obj/item/storage/box/produce{
-	layer = 2.99
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod8)
 "kPJ" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/status_display.dmi';
@@ -4761,11 +4765,6 @@
 	layer = 2.71
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/light{
-	dir = 1;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "lfB" = (
@@ -5513,7 +5512,9 @@
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/padded,
-/obj/machinery/light,
+/obj/machinery/light{
+	status = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "mOF" = (
@@ -5581,6 +5582,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/machinery/light/small/emergency{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -6604,6 +6608,11 @@
 /obj/structure/table/glass,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/machinery/light{
+	dir = 1;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "pab" = (
@@ -8410,6 +8419,9 @@
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
 	},
+/obj/machinery/light{
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "sOb" = (
@@ -8886,15 +8898,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/freebooter_shuttle)
-"tVd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/ship/freebooter_ship/pod8)
 "tVf" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/black,
@@ -9587,6 +9590,9 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
+"vnO" = (
+/turf/simulated/wall/r_wall,
+/area/ship/freebooter_ship/pod8)
 "vsx" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
@@ -46109,11 +46115,11 @@ hhA
 vOL
 xRX
 uwT
-cgU
+vnO
 hhQ
-tVd
+jfl
 hZY
-cgU
+vnO
 uwT
 xRX
 eiL
@@ -46366,7 +46372,7 @@ hhA
 vOL
 xRX
 uwT
-kPA
+cgU
 onn
 uZC
 iok
@@ -46626,7 +46632,7 @@ uwT
 vMG
 hil
 uOr
-fXU
+dUF
 irq
 uwT
 vZW

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -191,17 +191,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod2)
-"aqJ" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship)
 "ary" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -215,9 +204,6 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/engineering)
 "atj" = (
-/obj/structure/sign/greencross{
-	pixel_y = -32
-	},
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
 	},
@@ -293,6 +279,22 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship)
+"azU" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/access_button{
+	pixel_x = -8;
+	pixel_y = 28;
+	dir = 8
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -321,7 +323,10 @@
 /obj/item/reagent_containers/hypospray/autoinjector/hyronalin,
 /obj/item/reagent_containers/hypospray/autoinjector/hyronalin,
 /obj/effect/floor_decal/corner_wide/paleblue/full,
-/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_x = 12;
+	pixel_y = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/bridge)
 "aCG" = (
@@ -894,6 +899,8 @@
 	dir = 10
 	},
 /obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow/specialu,
+/obj/item/clothing/gloves/yellow/specialt,
 /obj/item/device/multitool,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
@@ -1293,6 +1300,20 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod1)
+"cmW" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/structure/sign/vacuum{
+	pixel_y = 30
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship)
 "cnH" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -1301,9 +1322,7 @@
 	layer = 2.31;
 	name = "lattice"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg1"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "cok" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1326,22 +1345,6 @@
 /obj/effect/shuttle_landmark/freebooter_ship,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
-"cCX" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/access_button{
-	pixel_x = -8;
-	pixel_y = 28;
-	dir = 8
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship)
 "cDf" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -1390,6 +1393,21 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship)
+"cKm" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/bed/stool/chair/shuttle{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/turf/simulated/floor,
+/area/shuttle/freebooter_shuttle)
 "cLe" = (
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 1
@@ -1454,18 +1472,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
-"cOq" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_freebooter_shuttle";
-	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/map_effect/marker_helper/airlock/out,
-/turf/simulated/floor,
-/area/shuttle/freebooter_shuttle)
 "cQs" = (
 /obj/structure/cryofeed/pipes{
 	dir = 4
@@ -1599,6 +1605,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
+"doK" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/obj/structure/sign/vacuum{
+	pixel_y = 30
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship)
 "doW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -1644,6 +1664,20 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/bridge)
+"dAi" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship)
 "dBJ" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/status_display.dmi';
@@ -1788,20 +1822,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/gunnery)
-"dTP" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/obj/structure/sign/vacuum{
-	pixel_y = 30
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship)
 "dWi" = (
 /obj/effect/floor_decal/corner{
 	dir = 6
@@ -2093,6 +2113,18 @@
 	},
 /obj/structure/bed/roller,
 /obj/effect/floor_decal/industrial/outline/security,
+/obj/structure/closet/walllocker/medical{
+	name = "i hope we dont have to open this (Surgical Closet)";
+	pixel_y = 32
+	},
+/obj/item/surgery/circular_saw,
+/obj/item/surgery/retractor,
+/obj/item/surgery/hemostat,
+/obj/item/surgery/cautery,
+/obj/item/surgery/scalpel,
+/obj/item/wrench,
+/obj/item/tape_roll,
+/obj/item/stack/cable_coil,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/bridge)
 "ezT" = (
@@ -2126,6 +2158,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
+"eFB" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_x = 23;
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/shuttle/freebooter_shuttle)
 "eHy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -2163,16 +2214,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/gunnery)
-"ePC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/structure/curtain/open/bed{
-	name = "curtain"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/freebooter_shuttle)
 "eST" = (
 /turf/simulated/wall,
 /area/ship/freebooter_ship/pod7)
@@ -2559,17 +2600,6 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
-"fVQ" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship)
 "fXt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2671,6 +2701,12 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
+"ghb" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "ghi" = (
 /obj/machinery/alarm/east{
 	req_one_access = null
@@ -2792,9 +2828,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "gyl" = (
 /obj/machinery/door/airlock/external{
@@ -2804,12 +2838,7 @@
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
 	},
-/obj/machinery/access_button{
-	pixel_x = 8;
-	pixel_y = 28;
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship)
 "gzr" = (
@@ -2893,10 +2922,6 @@
 /obj/effect/floor_decal/corner_wide/paleblue/full{
 	dir = 1
 	},
-/obj/structure/closet/walllocker/medical{
-	name = "medical supplies";
-	pixel_y = 32
-	},
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
@@ -2904,6 +2929,12 @@
 /obj/machinery/iv_drip,
 /obj/item/tank/oxygen,
 /obj/item/clothing/mask/breath/medical,
+/obj/structure/closet/walllocker/medical/secure{
+	name = "Stabilization Kit";
+	req_access = null;
+	pixel_y = 32
+	},
+/obj/item/reagent_containers/inhaler/pneumalin,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/bridge)
 "gMa" = (
@@ -2946,11 +2977,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/engineering)
-"gVf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/freebooter_shuttle)
 "gVT" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
@@ -3150,20 +3176,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/holofloor/tiled/ramp/bottom,
 /area/ship/freebooter_ship/bridge)
-"hFU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship)
 "hFX" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -3172,6 +3184,18 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/bridge)
+"hGJ" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/map_effect/marker_helper/airlock/out,
+/turf/simulated/floor,
+/area/shuttle/freebooter_shuttle)
 "hHq" = (
 /obj/effect/floor_decal/corner{
 	dir = 6
@@ -3406,9 +3430,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "ihN" = (
 /obj/structure/bed/stool/chair/office/light{
@@ -3583,6 +3605,10 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/item/storage/backpack/duffel/med{
+	pixel_x = -4;
+	pixel_y = 15
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/bridge)
 "iGW" = (
@@ -3678,6 +3704,12 @@
 /obj/item/paper/crumpled,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
+"iTJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/shuttle/freebooter_shuttle)
 "iUd" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -3747,17 +3779,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
-"jhJ" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship)
 "jhL" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/engineering)
@@ -4305,6 +4326,9 @@
 	pixel_y = 5
 	},
 /obj/effect/floor_decal/corner/lime/diagonal,
+/obj/item/reagent_containers/food/snacks/koisbar,
+/obj/item/reagent_containers/food/snacks/koisbar,
+/obj/item/reagent_containers/food/snacks/koisbar,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
 "kzS" = (
@@ -4526,9 +4550,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
 "kTf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red,
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/freebooter_shuttle)
 "kUE" = (
@@ -4812,11 +4834,6 @@
 /obj/item/tank/jetpack/carbondioxide,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
-"lxC" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster2)
 "lzu" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/bed/stool/chair/shuttle{
@@ -5159,21 +5176,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
-"mto" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/bed/stool/chair/shuttle{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_freebooter_shuttle";
-	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
-	},
-/turf/simulated/floor,
-/area/shuttle/freebooter_shuttle)
 "mtT" = (
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 4
@@ -5661,17 +5663,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
-"nxK" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship)
 "nyh" = (
 /obj/effect/floor_decal/corner/beige,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -5773,18 +5764,21 @@
 "nVi" = (
 /obj/structure/table/steel,
 /obj/item/storage/firstaid/fire{
+	pixel_x = 8
+	},
+/obj/item/storage/firstaid/regular{
 	pixel_x = 4
 	},
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/o2{
-	pixel_x = -4
-	},
+/obj/item/storage/firstaid/o2,
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 10
 	},
 /obj/machinery/light{
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
+	},
+/obj/item/storage/firstaid/trauma{
+	pixel_x = -4
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/bridge)
@@ -5898,7 +5892,7 @@
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
 	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship)
 "odX" = (
@@ -6053,12 +6047,6 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/thruster2)
-"osW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 8
-	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/shuttle/freebooter_shuttle)
 "ovG" = (
 /obj/item/stack/tile/floor_dark,
 /obj/structure/barricade/wooden{
@@ -6151,26 +6139,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/bridge)
-"oBO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_freebooter_shuttle";
-	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
-	},
-/obj/machinery/light{
-	dir = 4;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
-/turf/simulated/floor,
-/area/shuttle/freebooter_shuttle)
 "oBX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6540,19 +6508,14 @@
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/thruster2)
-"pnk" = (
+"pno" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship)
@@ -6652,12 +6615,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster2)
-"pxD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 6
-	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/shuttle/freebooter_shuttle)
 "pzX" = (
 /obj/structure/toilet,
 /obj/effect/floor_decal/corner{
@@ -6754,6 +6711,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
+"pFM" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship)
 "pHN" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/reagent_dispensers/fueltank,
@@ -7137,6 +7105,7 @@
 "qwx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "qxl" = (
@@ -7552,6 +7521,22 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
+"rrI" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/access_button{
+	pixel_x = 8;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship)
 "rrT" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -7813,6 +7798,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
+"rNB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship)
 "rQk" = (
 /obj/machinery/seed_storage/garden,
 /obj/effect/floor_decal/industrial/outline/service,
@@ -7863,6 +7862,12 @@
 	dir = 8
 	},
 /turf/simulated/floor/airless,
+/area/shuttle/freebooter_shuttle)
+"rXI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 6
+	},
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/freebooter_shuttle)
 "rYv" = (
 /obj/machinery/computer/ship/navigation{
@@ -7919,6 +7924,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
+"sjU" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster1)
 "skr" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 1;
@@ -8322,9 +8332,10 @@
 	name = "airlock_freebooter_shuttle";
 	shuttle_tag = "Freebooter Shuttle"
 	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	pixel_x = 23;
-	dir = 8
+/obj/machinery/light{
+	dir = 4;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -8391,6 +8402,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
+"tno" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/structure/curtain/open/bed{
+	name = "curtain"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "tra" = (
 /obj/machinery/door/firedoor/noid,
 /obj/structure/cable{
@@ -8500,9 +8521,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "tAn" = (
 /obj/structure/grille,
@@ -8757,8 +8776,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ugG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red,
-/turf/simulated/wall/shuttle/space_ship/mercenary,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "uhG" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -8824,6 +8845,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/engineering)
+"umJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 9
+	},
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/shuttle/freebooter_shuttle)
 "unp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8878,12 +8905,6 @@
 /obj/structure/ship_weapon_dummy,
 /turf/template_noop,
 /area/ship/freebooter_ship)
-"uAI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/freebooter_shuttle)
 "uCl" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
@@ -8938,6 +8959,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
+"uNx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "uNJ" = (
 /obj/structure/table/steel,
 /obj/item/toy/plushie/pennyplush{
@@ -9443,24 +9469,9 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
-"vHg" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship)
 "vIj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "vMG" = (
@@ -9625,12 +9636,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
-"vZV" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster1)
 "vZW" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/rods,
@@ -10114,6 +10119,22 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/gunnery)
+"xjC" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship)
 "xtX" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 5
@@ -10311,15 +10332,12 @@
 /area/ship/freebooter_ship/pod6)
 "xQS" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
-	},
-/obj/structure/sign/vacuum{
-	pixel_y = 30
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship)
@@ -39343,7 +39361,7 @@ xRX
 xRX
 xRX
 vkx
-qwx
+sjU
 lfb
 plx
 pfE
@@ -39600,7 +39618,7 @@ xRX
 xRX
 xRX
 hPM
-vZV
+qwx
 jGn
 plx
 wMd
@@ -43214,15 +43232,15 @@ wyp
 kXG
 vGw
 wGc
-cCX
-fVQ
+azU
+gyl
 wGc
 vGw
 vGw
 vGw
 wGc
-cCX
-hFU
+azU
+odb
 wGc
 wyp
 vGw
@@ -43471,14 +43489,14 @@ xRX
 vZW
 xRX
 wGc
-dTP
-nxK
+doK
+pno
 wGc
 xRX
 xRX
 xRX
 wGc
-xQS
+cmW
 lvN
 wGc
 xRX
@@ -43728,15 +43746,15 @@ xRX
 fGM
 xRX
 wGc
-pnk
-jhJ
+xjC
+xQS
 wGc
 xRX
 xRX
 xRX
 wGc
-pnk
-vHg
+xjC
+dAi
 wGc
 xRX
 xRX
@@ -43985,15 +44003,15 @@ ajO
 fGM
 fGM
 wGc
-gyl
-aqJ
+rrI
+pFM
 wGc
 kqx
 aOU
 kqx
 wGc
-gyl
-odb
+rrI
+rNB
 wGc
 fGM
 fGM
@@ -45017,11 +45035,11 @@ aEB
 aSb
 iCP
 bFv
-uAI
+ugG
 rHI
 aSb
 lzu
-mto
+cKm
 aSb
 qeJ
 vOL
@@ -45278,7 +45296,7 @@ btW
 rAU
 mkb
 syX
-cOq
+hGJ
 sVT
 oSp
 vOL
@@ -45534,8 +45552,8 @@ nRY
 nxF
 kPW
 rDZ
+eFB
 tcV
-oBO
 rXx
 cJt
 vOL
@@ -45768,7 +45786,7 @@ xRX
 xRX
 xRX
 icO
-lxC
+vIj
 jlr
 rXk
 tYU
@@ -45790,10 +45808,10 @@ aSb
 aSb
 rzA
 yeH
-pxD
-ugG
-ugG
+rXI
 kTf
+kTf
+umJ
 hhA
 vOL
 xRX
@@ -46025,7 +46043,7 @@ xRX
 xRX
 xRX
 vFo
-vIj
+ghb
 qgY
 rXk
 lqh
@@ -46046,8 +46064,8 @@ aSb
 aSb
 ejm
 kSC
-gVf
-ePC
+uNx
+tno
 bck
 tDp
 aSb
@@ -46304,7 +46322,7 @@ bEH
 qnz
 ggq
 aSb
-osW
+iTJ
 iTc
 elW
 sWG

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1644,10 +1644,6 @@
 /turf/simulated/wall,
 /area/ship/freebooter_ship/gunneryentrance)
 "doC" = (
-/mob/living/bot/farmbot{
-	req_one_access = null;
-	req_access = null
-	},
 /obj/effect/floor_decal/industrial/outline/service,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1655,6 +1651,15 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/robot_parts/r_arm{
+	pixel_y = 10;
+	pixel_x = 10
+	},
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -9;
+	pixel_y = -7
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
@@ -7197,6 +7202,7 @@
 /obj/item/reagent_containers/food/snacks/grown/ambrosiavulgaris,
 /obj/item/reagent_containers/food/snacks/grown/ambrosiavulgaris,
 /obj/item/reagent_containers/food/snacks/grown/ambrosiavulgaris,
+/obj/item/device/analyzer/plant_analyzer,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod5)
 "qkA" = (

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1314,7 +1314,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "cgU" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/mushroom,
+/obj/structure/closet/crate/miningcart,
+/obj/item/reagent_containers/food/snacks/tastybread,
+/obj/item/reagent_containers/food/snacks/tastybread,
+/obj/item/storage/box/produce{
+	layer = 2.99
+	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "ciM" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2548,8 +2564,8 @@
 /obj/machinery/button/remote/airlock{
 	dir = 4;
 	id = "freebooter_brig";
-	name = "Phoron Storage Bolt Control";
-	pixel_x = 21;
+	name = "Secure Storage Bolt Control";
+	pixel_x = 23;
 	pixel_y = 4;
 	specialfunctions = 4
 	},
@@ -3200,6 +3216,15 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
+"hqJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/ship/freebooter_ship/pod8)
 "htS" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/ship/freebooter_ship/pod8)
@@ -3427,9 +3452,9 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship)
 "hZY" = (
-/obj/machinery/door/airlock/vault{
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Storage Compartment";
 	dir = 4;
-	name = "Phoron Storage Compartment";
 	id = "freebooter_brig"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3544,15 +3569,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
-"iiy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/ship/freebooter_ship/pod8)
 "iiZ" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 1
@@ -3869,13 +3885,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
-"jfC" = (
-/obj/effect/floor_decal/corner{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod8)
 "jgM" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -6255,25 +6264,6 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/thruster2)
-"osW" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/mushroom,
-/obj/structure/closet/crate/miningcart,
-/obj/item/reagent_containers/food/snacks/tastybread,
-/obj/item/reagent_containers/food/snacks/tastybread,
-/obj/item/storage/box/produce{
-	layer = 2.99
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod8)
 "ovG" = (
 /obj/item/stack/tile/floor_dark,
 /obj/structure/barricade/wooden{
@@ -9715,6 +9705,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
+"vHR" = (
+/turf/simulated/wall/r_wall,
+/area/ship/freebooter_ship/pod8)
 "vMG" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
@@ -10506,6 +10499,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
+"xAd" = (
+/obj/effect/floor_decal/corner{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod8)
 "xBh" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/decal/cleanable/dirt,
@@ -46109,11 +46109,11 @@ hhA
 vOL
 xRX
 uwT
-cgU
+vHR
 hhQ
-iiy
+hqJ
 hZY
-cgU
+vHR
 uwT
 xRX
 eiL
@@ -46366,7 +46366,7 @@ hhA
 vOL
 xRX
 uwT
-osW
+cgU
 onn
 uZC
 iok
@@ -46626,7 +46626,7 @@ uwT
 vMG
 hil
 uOr
-jfC
+xAd
 irq
 uwT
 vZW

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -132,8 +132,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ajO" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunneryentrance)
+/turf/space/dynamic,
+/area/space)
 "akg" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
@@ -273,19 +273,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "ayy" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/forehallwayport)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -545,12 +534,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aOU" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "junker_gun"
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/gunnery)
+/turf/simulated/wall,
+/area/ship/freebooter_ship/medical)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -2488,8 +2473,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fGM" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/gunneryentrance)
+/obj/structure/lattice/catwalk,
+/turf/space/dynamic,
+/area/ship/freebooter_ship/exterior)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -3438,17 +3424,6 @@
 	},
 /turf/simulated/floor/carpet/magenta,
 /area/ship/freebooter_ship/pod6)
-"ife" = (
-/obj/machinery/cryopod,
-/obj/structure/cryofeed/pipes{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/cryo)
 "igB" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -3853,8 +3828,19 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "jrC" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/medical)
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "jvN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -4197,9 +4183,8 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "kqx" = (
-/obj/structure/lattice/catwalk,
-/turf/space/dynamic,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/gunneryentrance)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
 /obj/effect/decal/cleanable/dirt,
@@ -4593,6 +4578,13 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/freebooter_shuttle)
+"kWi" = (
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "junker_gun"
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/gunnery)
 "kXq" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -7856,9 +7848,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
-"rSw" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/medical)
 "rXk" = (
 /turf/simulated/wall/r_wall,
 /area/ship/freebooter_ship/thruster2)
@@ -9657,7 +9646,7 @@
 /area/ship/freebooter_ship/bridge)
 "vZW" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/forehallwayport)
+/area/ship/freebooter_ship/medical)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/stool/chair{
@@ -9717,6 +9706,17 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
+"wgh" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed/pipes{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/freebooter_ship/cryo)
 "wji" = (
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 8
@@ -9862,8 +9862,8 @@
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "wGc" = (
-/turf/space/dynamic,
-/area/space)
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunneryentrance)
 "wHo" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/ship_engine.dmi';
@@ -38392,17 +38392,17 @@ xRX
 xRX
 xRX
 xRX
-kqx
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
+fGM
 eIb
 wUi
 ldw
 wUi
 eIb
-kqx
-kqx
+fGM
+fGM
 esB
 gwg
 esB
@@ -38410,32 +38410,32 @@ wHo
 esB
 gwg
 esB
-kqx
-kqx
+fGM
+fGM
 cLC
 cLC
 kwe
 tKj
 tKj
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 qiz
 qiz
 mWz
 qiz
 qiz
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 eUq
 eUq
 pRf
 eUq
 eUq
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 xRX
 xRX
 xRX
@@ -38648,8 +38648,8 @@ xRX
 xRX
 xRX
 xRX
-kqx
-kqx
+fGM
+fGM
 xRX
 xRX
 eIb
@@ -38692,7 +38692,7 @@ fTG
 eUq
 eUq
 xRX
-kqx
+fGM
 xqI
 xqI
 xqI
@@ -38706,7 +38706,7 @@ imE
 imE
 iOV
 iOV
-aOU
+kWi
 xRX
 xRX
 xRX
@@ -38963,7 +38963,7 @@ rjL
 tQn
 sxw
 www
-aOU
+kWi
 xRX
 xRX
 xRX
@@ -39164,8 +39164,8 @@ gFA
 ewW
 ewW
 ewW
-kqx
-kqx
+fGM
+fGM
 wUi
 syV
 bhd
@@ -39173,7 +39173,7 @@ xBh
 bhd
 tvh
 wUi
-kqx
+fGM
 gwg
 pUP
 kmP
@@ -39181,7 +39181,7 @@ qDn
 kev
 jcX
 gwg
-kqx
+fGM
 cLC
 wZf
 ttI
@@ -39189,7 +39189,7 @@ krH
 lKT
 vmX
 cLC
-kqx
+fGM
 qiz
 pYB
 bPT
@@ -39197,7 +39197,7 @@ jzk
 fRD
 buM
 qiz
-kqx
+fGM
 eUq
 aTX
 iUK
@@ -39205,8 +39205,8 @@ iUK
 iUK
 fTT
 eUq
-kqx
-kqx
+fGM
+fGM
 xqI
 ahD
 kfJ
@@ -39220,7 +39220,7 @@ fNl
 tQn
 sxw
 sxw
-aOU
+kWi
 xRX
 xRX
 xRX
@@ -39422,7 +39422,7 @@ xUb
 qWF
 ewW
 xRX
-kqx
+fGM
 wUi
 syV
 bhd
@@ -39477,7 +39477,7 @@ soh
 aDv
 iOV
 iOV
-aOU
+kWi
 xRX
 xRX
 xRX
@@ -39679,7 +39679,7 @@ xUb
 jnK
 ewW
 xRX
-kqx
+fGM
 wUi
 syV
 grD
@@ -39936,7 +39936,7 @@ dbA
 wxS
 ewW
 xRX
-kqx
+fGM
 eIb
 oPu
 bhd
@@ -39978,7 +39978,7 @@ cEH
 eUq
 xRX
 xRX
-kqx
+fGM
 xqI
 xqI
 tfK
@@ -40193,7 +40193,7 @@ ewW
 ewW
 ewW
 xRX
-kqx
+fGM
 wUi
 cLL
 bhd
@@ -40235,13 +40235,13 @@ avE
 eUq
 xRX
 xRX
-kqx
-xRX
 fGM
+xRX
+kqx
 rEb
 xTu
 cbE
-ajO
+wGc
 klp
 llD
 euj
@@ -40450,7 +40450,7 @@ acn
 ewW
 xRX
 xRX
-kqx
+fGM
 wUi
 glJ
 ihN
@@ -40492,10 +40492,10 @@ hIE
 eUq
 xRX
 xRX
-kqx
+fGM
 xRX
-fGM
-fGM
+kqx
+kqx
 jgM
 vVy
 aMQ
@@ -40707,7 +40707,7 @@ pHN
 ewW
 xRX
 xRX
-kqx
+fGM
 wUi
 wNA
 bhd
@@ -40749,13 +40749,13 @@ iUK
 eUq
 xRX
 xRX
+fGM
+xRX
+xRX
 kqx
-xRX
-xRX
-fGM
-fGM
+kqx
 tmo
-ajO
+wGc
 mwo
 mwo
 mwo
@@ -40964,7 +40964,7 @@ lJH
 jhL
 jhL
 xRX
-kqx
+fGM
 wUi
 peJ
 bhd
@@ -41006,18 +41006,18 @@ mtT
 eUq
 xRX
 xRX
-kqx
+fGM
 xRX
 xRX
 xRX
 uLO
 ebn
 atj
-jrC
+aOU
 exg
 iGK
 aBD
-rSw
+vZW
 xRX
 xRX
 xRX
@@ -41221,7 +41221,7 @@ pCG
 iZM
 jhL
 jhL
-kqx
+fGM
 eIb
 eIb
 pPk
@@ -41263,7 +41263,7 @@ eUq
 eUq
 xRX
 xRX
-kqx
+fGM
 xRX
 xRX
 xRX
@@ -41274,7 +41274,7 @@ jLL
 aab
 qDe
 nVi
-rSw
+vZW
 saW
 xRX
 xRX
@@ -41478,61 +41478,61 @@ mhq
 tcY
 rfn
 jhL
-kqx
-kqx
+fGM
+fGM
 eIb
 eIb
 qEc
 eIb
 eIb
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 gwg
 wzO
 dXK
 wzO
 gwg
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 cLC
 cLC
 mbX
 cLC
 cLC
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 qiz
 qiz
 dFi
 qiz
 qiz
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 eUq
 eUq
 wRc
 eUq
 eUq
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
 pvm
 kou
 dWF
-jrC
+aOU
 gLO
 npJ
 kAt
 lpe
-rSw
+vZW
 xRX
 xRX
 xRX
@@ -41736,7 +41736,7 @@ jbh
 tYn
 jhL
 xRX
-kqx
+fGM
 xRX
 wyp
 mGn
@@ -41777,19 +41777,19 @@ xRX
 xRX
 xRX
 xRX
-kqx
+fGM
 xRX
 xRX
 xRX
 pvm
 vfD
 kOP
-jrC
-jrC
+aOU
+aOU
 tra
-rSw
-jrC
-rSw
+vZW
+aOU
+vZW
 ydf
 ewy
 ewy
@@ -41993,7 +41993,7 @@ rRa
 nKC
 jhL
 xRX
-kqx
+fGM
 xRX
 wyp
 mGn
@@ -42034,7 +42034,7 @@ xRX
 xRX
 xRX
 xRX
-kqx
+fGM
 xRX
 xRX
 xRX
@@ -43534,9 +43534,9 @@ bBW
 pkY
 bJj
 jhL
-wGc
-kqx
-wGc
+ajO
+fGM
+ajO
 wyp
 bhA
 xQS
@@ -43576,7 +43576,7 @@ xRX
 xRX
 xRX
 xRX
-kqx
+fGM
 xRX
 xRX
 xRX
@@ -43791,9 +43791,9 @@ rpZ
 doW
 nEK
 jhL
-wGc
-kqx
-wGc
+ajO
+fGM
+ajO
 wyp
 vDD
 xvT
@@ -43833,7 +43833,7 @@ xRX
 xRX
 xRX
 xRX
-kqx
+fGM
 xRX
 xRX
 xRX
@@ -44048,52 +44048,52 @@ ngJ
 gwl
 xZh
 jhL
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 wyp
 uJz
 bJc
 wyp
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 wyp
 uJz
 bst
 wyp
-kqx
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
+fGM
 uwT
 uwT
 jjA
 uwT
 uwT
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 eiL
 eiL
 gSo
 eiL
 eiL
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 tRo
 tRo
 sVs
 tRo
 tRo
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
 gzr
 iHV
 kOP
@@ -44305,23 +44305,23 @@ oGU
 kMx
 jhL
 jhL
-kqx
-wGc
+fGM
+ajO
 sUX
 ppp
 ppp
 ppp
 ppp
-ayy
+jrC
 kQs
-ayy
+jrC
 wtm
 rhN
 ciM
 rhN
 rmm
-wGc
-wGc
+ajO
+ajO
 uwT
 uwT
 lgM
@@ -44347,7 +44347,7 @@ tRo
 tRo
 xRX
 xRX
-kqx
+fGM
 xRX
 xRX
 xRX
@@ -44561,8 +44561,8 @@ aEa
 lJH
 jhL
 jhL
-wGc
-kqx
+ajO
+fGM
 iGW
 wnf
 aSb
@@ -44578,7 +44578,7 @@ iQg
 clU
 nKq
 rmm
-wGc
+ajO
 htS
 lfg
 jFY
@@ -44604,7 +44604,7 @@ cMo
 tRo
 xRX
 xRX
-kqx
+fGM
 xRX
 xRX
 xRX
@@ -44613,7 +44613,7 @@ ebn
 cDf
 quS
 cQs
-ife
+wgh
 aSJ
 oxG
 xRX
@@ -44817,9 +44817,9 @@ xKt
 adF
 eqi
 uZl
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 rrT
 ntt
 sUq
@@ -44835,7 +44835,7 @@ elW
 sWG
 qVW
 vOL
-kqx
+fGM
 uwT
 dkz
 hHq
@@ -44861,7 +44861,7 @@ bxM
 tRo
 xRX
 xRX
-kqx
+fGM
 xRX
 xRX
 uLO
@@ -45074,9 +45074,9 @@ mOF
 qED
 uPa
 uZl
-wGc
-wGc
-kqx
+ajO
+ajO
+fGM
 bcf
 aSb
 aEB
@@ -45092,7 +45092,7 @@ eqD
 aSb
 qeJ
 vOL
-wGc
+ajO
 uwT
 oZH
 pZI
@@ -45118,10 +45118,10 @@ ieZ
 tRo
 xRX
 xRX
-kqx
+fGM
 xRX
-vZW
-vZW
+ayy
+ayy
 nZj
 ess
 lzb
@@ -45332,8 +45332,8 @@ bpj
 fdV
 uZl
 uZl
-wGc
-kqx
+ajO
+fGM
 rJT
 rsE
 rsE
@@ -45349,7 +45349,7 @@ afL
 sVT
 oSp
 vOL
-wGc
+ajO
 uwT
 bDX
 mCb
@@ -45375,9 +45375,9 @@ uNJ
 tRo
 xRX
 xRX
-kqx
+fGM
 xRX
-vZW
+ayy
 xMA
 uWU
 oVL
@@ -45589,8 +45589,8 @@ ieM
 mwO
 uoZ
 uZl
-wGc
-kqx
+ajO
+fGM
 iUd
 vdX
 atI
@@ -45606,7 +45606,7 @@ tcV
 rXx
 cJt
 vOL
-wGc
+ajO
 uwT
 fYr
 lGK
@@ -45632,9 +45632,9 @@ lvR
 tRo
 xRX
 xRX
-kqx
+fGM
 xRX
-vZW
+ayy
 oyG
 cnH
 ess
@@ -45846,8 +45846,8 @@ mCl
 kuj
 rFB
 uZl
-wGc
-kqx
+ajO
+fGM
 lkK
 hZH
 kti
@@ -45863,7 +45863,7 @@ kTf
 bzW
 hhA
 vOL
-wGc
+ajO
 uwT
 cgU
 hhQ
@@ -46103,8 +46103,8 @@ uiV
 vDk
 rFB
 uZl
-wGc
-kqx
+ajO
+fGM
 bcf
 aSb
 aSb
@@ -46120,7 +46120,7 @@ tDp
 aSb
 hhA
 vOL
-wGc
+ajO
 uwT
 cgU
 onn
@@ -46360,8 +46360,8 @@ aEt
 ldf
 uZl
 uZl
-kqx
-kqx
+fGM
+fGM
 bcf
 sBA
 ruo
@@ -46377,7 +46377,7 @@ elW
 sWG
 cei
 vOL
-kqx
+fGM
 uwT
 vMG
 hil
@@ -46385,7 +46385,7 @@ uOr
 hil
 irq
 uwT
-kqx
+fGM
 eiL
 upC
 buI
@@ -46393,7 +46393,7 @@ hdb
 pZo
 fVv
 eiL
-kqx
+fGM
 tRo
 pDZ
 bxM
@@ -46401,8 +46401,8 @@ bxM
 bxM
 pZO
 tRo
-kqx
-kqx
+fGM
+fGM
 wjn
 qqX
 vwi
@@ -46616,9 +46616,9 @@ uZl
 osl
 stV
 uZl
-wGc
-wGc
-kqx
+ajO
+ajO
+fGM
 aCG
 dqF
 aSb
@@ -46634,7 +46634,7 @@ rhN
 rhN
 mYn
 tOu
-wGc
+ajO
 htS
 hXO
 uwA
@@ -46872,11 +46872,11 @@ xRX
 xRX
 xRX
 xRX
-kqx
-kqx
-wGc
-kqx
-wGc
+fGM
+fGM
+ajO
+fGM
+ajO
 kOK
 rfz
 rfz
@@ -46890,8 +46890,8 @@ vTv
 vTv
 vTv
 tOu
-wGc
-wGc
+ajO
+ajO
 uwT
 uwT
 nti
@@ -46916,7 +46916,7 @@ rEV
 tRo
 tRo
 xRX
-kqx
+fGM
 wjn
 wjn
 wjn
@@ -47130,50 +47130,50 @@ xRX
 xRX
 xRX
 xRX
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
 ibm
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
 fro
-kqx
-kqx
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
+fGM
+fGM
 uwT
 uwT
 qju
 uwT
 uwT
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 eiL
 eiL
 sal
 eiL
 eiL
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 tRo
 tRo
 raF
 tRo
 tRo
-kqx
-kqx
-kqx
+fGM
+fGM
+fGM
 xRX
 xRX
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1104,16 +1104,21 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "bDB" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/decal/fake_object{
+	desc = "A lightweight support lattice.";
+	icon = 'icons/obj/smooth/lattice.dmi';
+	icon_state = "lattice";
+	layer = 2.45;
+	name = "lattice"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod8)
 "bDX" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -1121,9 +1126,6 @@
 	},
 /obj/effect/floor_decal/corner{
 	dir = 10
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = null
@@ -1442,11 +1444,15 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "cFm" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 8
+/obj/effect/decal/fake_object{
+	desc = "A lightweight support lattice.";
+	icon = 'icons/obj/smooth/lattice.dmi';
+	icon_state = "lattice";
+	layer = 2.45;
+	name = "lattice"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod8)
 "cJt" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2282,14 +2288,16 @@
 /area/ship/freebooter_ship/thruster1)
 "eYy" = (
 /obj/effect/floor_decal/corner/dark_blue/diagonal,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/trash/broken_electronics{
+	pixel_y = 8;
+	pixel_x = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -3210,15 +3218,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
-"hmk" = (
-/obj/item/material/shard,
-/obj/item/trash/broken_electronics{
-	pixel_y = 8;
-	pixel_x = 5
-	},
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod8)
 "hnl" = (
 /obj/effect/floor_decal/corner/beige/full,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3301,7 +3300,12 @@
 	dir = 6
 	},
 /obj/structure/table/glass,
-/obj/item/gun/energy/disruptorpistol/magnum,
+/obj/item/gun/energy/disruptorpistol/magnum{
+	pixel_y = 10
+	},
+/obj/item/handcuffs/cable/white{
+	pixel_x = 7
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "hIE" = (
@@ -4791,6 +4795,10 @@
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
+/obj/item/paper/crumpled{
+	pixel_y = 2;
+	pixel_x = -4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "lho" = (
@@ -5418,9 +5426,6 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod4)
 "mCb" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -6199,6 +6204,7 @@
 	dir = 8;
 	layer = 2.71
 	},
+/obj/item/material/shard,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "omr" = (
@@ -8108,12 +8114,15 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "rZw" = (
-/obj/effect/floor_decal/corner/dark_blue/full,
 /obj/structure/cable,
 /obj/machinery/power/apc/south{
 	req_access = null
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/item/stack/tile/floor_dark{
+	pixel_y = 4;
+	pixel_x = -6
+	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod8)
 "sal" = (
 /obj/effect/landmark/entry_point/port{
@@ -8683,9 +8692,6 @@
 	},
 /obj/effect/floor_decal/corner{
 	dir = 5
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
@@ -9355,6 +9361,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "vbe" = (
@@ -45623,7 +45630,7 @@ uwT
 bDX
 mCb
 eYy
-hmk
+iok
 tsH
 uwT
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -132,8 +132,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ajO" = (
+/obj/structure/lattice/catwalk,
 /turf/space/dynamic,
-/area/space)
+/area/ship/freebooter_ship/exterior)
 "akg" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
@@ -268,21 +269,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "ayy" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -380,9 +379,9 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
-"aEO" = (
+"aEI" = (
 /obj/effect/floor_decal/industrial/warning{
-	dir = 4
+	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/gunnery)
@@ -549,9 +548,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aOU" = (
-/obj/structure/lattice/catwalk,
-/turf/space/dynamic,
-/area/ship/freebooter_ship/exterior)
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "junker_gun"
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/gunnery)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -1178,22 +1180,6 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
-"bFA" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/machinery/access_button{
-	pixel_x = -8;
-	pixel_y = 28;
-	dir = 8
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/foyer)
 "bJc" = (
 /obj/machinery/door/airlock/external{
 	dir = 8
@@ -1432,6 +1418,21 @@
 /obj/effect/shuttle_landmark/freebooter_ship,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
+"cBR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/forehallway)
 "cDf" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -1969,6 +1970,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
+"ebH" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	pixel_x = -8;
+	pixel_y = 28;
+	dir = 8
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "ebW" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2522,21 +2539,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fGM" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/medical)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -3169,21 +3173,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
-"hnd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/forehallway)
 "hnl" = (
 /obj/effect/floor_decal/corner/beige/full,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3723,6 +3712,12 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/forehallway)
+"iKs" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "iKH" = (
 /turf/simulated/wall,
 /area/ship/freebooter_ship/foyer)
@@ -3902,19 +3897,8 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "jrC" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/wall,
+/area/ship/freebooter_ship/medical)
 "jvN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -4256,8 +4240,21 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "kqx" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/medical)
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
 /obj/effect/decal/cleanable/dirt,
@@ -4658,22 +4655,6 @@
 "kXG" = (
 /obj/structure/inflatable/wall,
 /turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
-"las" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/machinery/access_button{
-	pixel_x = 8;
-	pixel_y = 28;
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "lck" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -5801,9 +5782,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
-"nAX" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/gunneryentrance)
 "nCr" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	layer = 2.8;
@@ -7802,6 +7780,22 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
+"rDi" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/access_button{
+	pixel_x = 8;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "rDZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8228,12 +8222,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
-"sAi" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "sBA" = (
 /turf/simulated/wall/shuttle/space_ship{
 	color = "#E14644"
@@ -8301,6 +8289,9 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
+"sLx" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunneryentrance)
 "sLP" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -8392,9 +8383,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod6)
-"sVB" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunneryentrance)
 "sVT" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
@@ -8857,13 +8845,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
-"tZg" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "junker_gun"
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/gunnery)
 "uaE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/railing/mapped{
@@ -9033,6 +9014,22 @@
 /obj/structure/ship_weapon_dummy,
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
+"uzM" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "uCl" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
@@ -9075,16 +9072,16 @@
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
 /obj/machinery/access_button{
 	pixel_x = 8;
 	pixel_y = 28;
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "uJN" = (
@@ -9591,6 +9588,10 @@
 /area/ship/freebooter_ship/thruster2)
 "vDD" = (
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	dir = 2;
 	pixel_y = 28;
@@ -9598,10 +9599,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -9630,7 +9627,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
-"vMm" = (
+"vLO" = (
 /obj/machinery/cryopod,
 /obj/structure/cryofeed/pipes{
 	dir = 4
@@ -9810,8 +9807,8 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "vZW" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/medical)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/gunneryentrance)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/stool/chair{
@@ -10016,8 +10013,8 @@
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "wGc" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/forehallwayport)
+/turf/space/dynamic,
+/area/space)
 "wHo" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/ship_engine.dmi';
@@ -10379,6 +10376,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
+"xvh" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/forehallwayport)
 "xvt" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/structure/closet/crate/freezer/rations,
@@ -37808,7 +37808,7 @@ xRX
 xRX
 xRX
 uCl
-ajO
+wGc
 uCl
 fZq
 xRX
@@ -38322,7 +38322,7 @@ xRX
 rtf
 vUu
 uyM
-ajO
+wGc
 aHs
 xRX
 xRX
@@ -38555,17 +38555,17 @@ xRX
 xRX
 xRX
 xRX
-aOU
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
+ajO
 eIb
 wUi
 ldw
 wUi
 eIb
-aOU
-aOU
+ajO
+ajO
 esB
 gwg
 esB
@@ -38573,32 +38573,32 @@ wHo
 esB
 gwg
 esB
-aOU
-aOU
+ajO
+ajO
 cLC
 cLC
 kwe
 tKj
 tKj
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
 qiz
 qiz
 mWz
 qiz
 qiz
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
 eUq
 eUq
 pRf
 eUq
 eUq
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
 xRX
 xRX
 xRX
@@ -38811,8 +38811,8 @@ xRX
 xRX
 xRX
 xRX
-aOU
-aOU
+ajO
+ajO
 xRX
 xRX
 eIb
@@ -38855,7 +38855,7 @@ fTG
 eUq
 eUq
 xRX
-aOU
+ajO
 xqI
 xqI
 xqI
@@ -38869,7 +38869,7 @@ imE
 imE
 iOV
 iOV
-tZg
+aOU
 xRX
 xRX
 xRX
@@ -39126,7 +39126,7 @@ rjL
 tQn
 sxw
 www
-tZg
+aOU
 xRX
 xRX
 xRX
@@ -39327,8 +39327,8 @@ gFA
 ewW
 ewW
 ewW
-aOU
-aOU
+ajO
+ajO
 wUi
 syV
 bhd
@@ -39336,7 +39336,7 @@ xBh
 bhd
 tvh
 wUi
-aOU
+ajO
 gwg
 pUP
 kmP
@@ -39344,7 +39344,7 @@ qDn
 kev
 jcX
 gwg
-aOU
+ajO
 cLC
 wZf
 ttI
@@ -39352,7 +39352,7 @@ krH
 lKT
 vmX
 cLC
-aOU
+ajO
 qiz
 pYB
 bPT
@@ -39360,7 +39360,7 @@ jzk
 fRD
 buM
 qiz
-aOU
+ajO
 eUq
 aTX
 iUK
@@ -39368,8 +39368,8 @@ iUK
 iUK
 fTT
 eUq
-aOU
-aOU
+ajO
+ajO
 xqI
 ahD
 kfJ
@@ -39383,7 +39383,7 @@ fNl
 tQn
 sxw
 sxw
-tZg
+aOU
 xRX
 xRX
 xRX
@@ -39585,7 +39585,7 @@ xUb
 qWF
 ewW
 xRX
-aOU
+ajO
 wUi
 syV
 bhd
@@ -39634,13 +39634,13 @@ npb
 oxR
 tfK
 sxk
-sAi
+aEI
 soh
 soh
 aDv
 iOV
 iOV
-tZg
+aOU
 xRX
 xRX
 xRX
@@ -39842,7 +39842,7 @@ xUb
 jnK
 ewW
 xRX
-aOU
+ajO
 wUi
 syV
 grD
@@ -39892,8 +39892,8 @@ jhd
 tfK
 nwH
 wLI
-aEO
-aEO
+iKs
+iKs
 fnE
 xRX
 xRX
@@ -40099,7 +40099,7 @@ dbA
 wxS
 ewW
 xRX
-aOU
+ajO
 eIb
 oPu
 bhd
@@ -40141,7 +40141,7 @@ cEH
 eUq
 xRX
 xRX
-aOU
+ajO
 xqI
 xqI
 tfK
@@ -40356,7 +40356,7 @@ ewW
 ewW
 ewW
 xRX
-aOU
+ajO
 wUi
 cLL
 bhd
@@ -40398,13 +40398,13 @@ avE
 eUq
 xRX
 xRX
-aOU
+ajO
 xRX
-nAX
+vZW
 rEb
 xTu
 cbE
-sVB
+sLx
 klp
 llD
 euj
@@ -40613,7 +40613,7 @@ acn
 ewW
 xRX
 xRX
-aOU
+ajO
 wUi
 glJ
 ihN
@@ -40655,10 +40655,10 @@ hIE
 eUq
 xRX
 xRX
-aOU
+ajO
 xRX
-nAX
-nAX
+vZW
+vZW
 jgM
 vVy
 aMQ
@@ -40870,7 +40870,7 @@ pHN
 ewW
 xRX
 xRX
-aOU
+ajO
 wUi
 wNA
 bhd
@@ -40912,13 +40912,13 @@ iUK
 eUq
 xRX
 xRX
-aOU
+ajO
 xRX
 xRX
-nAX
-nAX
+vZW
+vZW
 tmo
-sVB
+sLx
 mwo
 mwo
 mwo
@@ -41127,7 +41127,7 @@ lJH
 jhL
 jhL
 xRX
-aOU
+ajO
 wUi
 peJ
 bhd
@@ -41169,18 +41169,18 @@ mtT
 eUq
 xRX
 xRX
-aOU
+ajO
 xRX
 xRX
 xRX
 uLO
 ebn
 atj
-vZW
+jrC
 exg
 iGK
 aBD
-kqx
+fGM
 xRX
 xRX
 xRX
@@ -41384,7 +41384,7 @@ pCG
 iZM
 jhL
 jhL
-aOU
+ajO
 eIb
 eIb
 pPk
@@ -41426,7 +41426,7 @@ eUq
 eUq
 xRX
 xRX
-aOU
+ajO
 xRX
 xRX
 xRX
@@ -41437,7 +41437,7 @@ jLL
 aab
 qDe
 nVi
-kqx
+fGM
 saW
 xRX
 xRX
@@ -41641,61 +41641,61 @@ mhq
 tcY
 rfn
 jhL
-aOU
-aOU
+ajO
+ajO
 eIb
 eIb
 qEc
 eIb
 eIb
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
 gwg
 wzO
 dXK
 wzO
 gwg
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
 cLC
 cLC
 mbX
 cLC
 cLC
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
 qiz
 qiz
 dFi
 qiz
 qiz
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
 eUq
 eUq
 wRc
 eUq
 eUq
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 pvm
 kou
 dWF
-vZW
+jrC
 gLO
 npJ
 kAt
 lpe
-kqx
+fGM
 xRX
 xRX
 xRX
@@ -41899,18 +41899,10 @@ jbh
 tYn
 jhL
 xRX
-aOU
+ajO
 xRX
 wyp
-ayy
-wyp
-xRX
-xRX
-xRX
-xRX
-xRX
-wyp
-ayy
+kqx
 wyp
 xRX
 xRX
@@ -41918,7 +41910,7 @@ xRX
 xRX
 xRX
 wyp
-ayy
+kqx
 wyp
 xRX
 xRX
@@ -41926,7 +41918,7 @@ xRX
 xRX
 xRX
 wyp
-ayy
+kqx
 wyp
 xRX
 xRX
@@ -41934,25 +41926,33 @@ xRX
 xRX
 xRX
 wyp
-ayy
+kqx
 wyp
 xRX
 xRX
 xRX
 xRX
-aOU
+xRX
+wyp
+kqx
+wyp
+xRX
+xRX
+xRX
+xRX
+ajO
 xRX
 xRX
 xRX
 pvm
 vfD
 kOP
-vZW
-vZW
+jrC
+jrC
 tra
-kqx
-vZW
-kqx
+fGM
+jrC
+fGM
 ydf
 ewy
 ewy
@@ -42156,7 +42156,7 @@ rRa
 nKC
 jhL
 xRX
-aOU
+ajO
 xRX
 wyp
 mGn
@@ -42197,7 +42197,7 @@ xRX
 xRX
 xRX
 xRX
-aOU
+ajO
 xRX
 xRX
 xRX
@@ -43444,7 +43444,7 @@ wyp
 kXG
 vGw
 wyp
-bFA
+ebH
 bzm
 wyp
 vGw
@@ -43487,7 +43487,7 @@ vGw
 wyp
 wyp
 uLO
-hnd
+cBR
 fZr
 wUa
 oKE
@@ -43698,7 +43698,7 @@ pkY
 bJj
 jhL
 xRX
-aOU
+ajO
 xRX
 wyp
 bhA
@@ -43739,7 +43739,7 @@ xRX
 xRX
 xRX
 xRX
-aOU
+ajO
 xRX
 xRX
 xRX
@@ -43955,17 +43955,17 @@ doW
 nEK
 jhL
 xRX
-aOU
+ajO
 xRX
 wyp
-vDD
+uzM
 xvT
 wyp
 xRX
 xRX
 xRX
 wyp
-fGM
+vDD
 bsf
 wyp
 xRX
@@ -43974,7 +43974,7 @@ xRX
 xRX
 xRX
 wyp
-ayy
+kqx
 wyp
 xRX
 xRX
@@ -43982,7 +43982,7 @@ xRX
 xRX
 xRX
 wyp
-ayy
+kqx
 wyp
 xRX
 xRX
@@ -43990,13 +43990,13 @@ xRX
 xRX
 xRX
 wyp
-ayy
+kqx
 wyp
 xRX
 xRX
 xRX
 xRX
-aOU
+ajO
 xRX
 xRX
 xRX
@@ -44211,52 +44211,52 @@ ngJ
 gwl
 xZh
 jhL
-aOU
-aOU
-aOU
-wyp
-las
-bJc
-wyp
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
 wyp
 uJz
+bJc
+wyp
+ajO
+ajO
+ajO
+wyp
+rDi
 bst
 wyp
-aOU
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
+ajO
 uwT
 uwT
 jjA
 uwT
 uwT
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
 eiL
 eiL
 gSo
 eiL
 eiL
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
 tRo
 tRo
 sVs
 tRo
 tRo
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 gzr
 iHV
 kOP
@@ -44468,23 +44468,23 @@ oGU
 kMx
 jhL
 jhL
-aOU
 ajO
+wGc
 sUX
 ppp
 ppp
 ppp
 ppp
-jrC
+ayy
 kQs
-jrC
+ayy
 wtm
 rhN
 ciM
 rhN
 rmm
-ajO
-ajO
+wGc
+wGc
 uwT
 uwT
 lgM
@@ -44510,7 +44510,7 @@ tRo
 tRo
 xRX
 xRX
-aOU
+ajO
 xRX
 xRX
 xRX
@@ -44724,8 +44724,8 @@ aEa
 lJH
 jhL
 jhL
+wGc
 ajO
-aOU
 iGW
 wnf
 aSb
@@ -44741,7 +44741,7 @@ iQg
 clU
 nKq
 rmm
-ajO
+wGc
 htS
 lfg
 jFY
@@ -44767,7 +44767,7 @@ cMo
 tRo
 xRX
 xRX
-aOU
+ajO
 xRX
 xRX
 xRX
@@ -44776,7 +44776,7 @@ ebn
 cDf
 quS
 cQs
-vMm
+vLO
 aSJ
 oxG
 xRX
@@ -44980,9 +44980,9 @@ xKt
 adF
 eqi
 uZl
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
 rrT
 ntt
 sUq
@@ -44998,7 +44998,7 @@ elW
 sWG
 qVW
 vOL
-aOU
+ajO
 uwT
 dkz
 hHq
@@ -45024,7 +45024,7 @@ bxM
 tRo
 xRX
 xRX
-aOU
+ajO
 xRX
 xRX
 uLO
@@ -45237,9 +45237,9 @@ mOF
 qED
 uPa
 uZl
+wGc
+wGc
 ajO
-ajO
-aOU
 bcf
 aSb
 aEB
@@ -45255,7 +45255,7 @@ eqD
 aSb
 qeJ
 vOL
-ajO
+wGc
 uwT
 oZH
 pZI
@@ -45281,10 +45281,10 @@ ieZ
 tRo
 xRX
 xRX
-aOU
+ajO
 xRX
-wGc
-wGc
+xvh
+xvh
 nZj
 ess
 lzb
@@ -45495,8 +45495,8 @@ bpj
 fdV
 uZl
 uZl
+wGc
 ajO
-aOU
 rJT
 rsE
 rsE
@@ -45512,7 +45512,7 @@ afL
 sVT
 oSp
 vOL
-ajO
+wGc
 uwT
 bDX
 mCb
@@ -45538,9 +45538,9 @@ uNJ
 tRo
 xRX
 xRX
-aOU
+ajO
 xRX
-wGc
+xvh
 xMA
 uWU
 oVL
@@ -45752,8 +45752,8 @@ ieM
 mwO
 uoZ
 uZl
+wGc
 ajO
-aOU
 iUd
 vdX
 atI
@@ -45769,7 +45769,7 @@ tcV
 rXx
 cJt
 vOL
-ajO
+wGc
 uwT
 fYr
 lGK
@@ -45795,9 +45795,9 @@ lvR
 tRo
 xRX
 xRX
-aOU
+ajO
 xRX
-wGc
+xvh
 oyG
 cnH
 ess
@@ -46009,8 +46009,8 @@ mCl
 kuj
 rFB
 uZl
+wGc
 ajO
-aOU
 lkK
 hZH
 kti
@@ -46026,7 +46026,7 @@ kTf
 bzW
 hhA
 vOL
-ajO
+wGc
 uwT
 cgU
 hhQ
@@ -46266,8 +46266,8 @@ uiV
 vDk
 rFB
 uZl
+wGc
 ajO
-aOU
 bcf
 aSb
 aSb
@@ -46283,7 +46283,7 @@ tDp
 aSb
 hhA
 vOL
-ajO
+wGc
 uwT
 cgU
 onn
@@ -46523,8 +46523,8 @@ aEt
 ldf
 uZl
 uZl
-aOU
-aOU
+ajO
+ajO
 bcf
 sBA
 ruo
@@ -46540,7 +46540,7 @@ elW
 sWG
 cei
 vOL
-aOU
+ajO
 uwT
 vMG
 hil
@@ -46548,7 +46548,7 @@ uOr
 hil
 irq
 uwT
-aOU
+ajO
 eiL
 upC
 buI
@@ -46556,7 +46556,7 @@ hdb
 pZo
 fVv
 eiL
-aOU
+ajO
 tRo
 pDZ
 bxM
@@ -46564,8 +46564,8 @@ bxM
 bxM
 pZO
 tRo
-aOU
-aOU
+ajO
+ajO
 wjn
 qqX
 vwi
@@ -46779,9 +46779,9 @@ uZl
 osl
 stV
 uZl
+wGc
+wGc
 ajO
-ajO
-aOU
 aCG
 dqF
 aSb
@@ -46797,7 +46797,7 @@ rhN
 rhN
 mYn
 tOu
-ajO
+wGc
 htS
 hXO
 uwA
@@ -47035,11 +47035,11 @@ xRX
 xRX
 xRX
 xRX
-aOU
-aOU
 ajO
-aOU
 ajO
+wGc
+ajO
+wGc
 kOK
 rfz
 rfz
@@ -47053,8 +47053,8 @@ vTv
 vTv
 vTv
 tOu
-ajO
-ajO
+wGc
+wGc
 uwT
 uwT
 nti
@@ -47079,7 +47079,7 @@ rEV
 tRo
 tRo
 xRX
-aOU
+ajO
 wjn
 wjn
 wjn
@@ -47293,50 +47293,50 @@ xRX
 xRX
 xRX
 xRX
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 ibm
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
+ajO
 fro
-aOU
-aOU
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
+ajO
+ajO
 uwT
 uwT
 qju
 uwT
 uwT
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
 eiL
 eiL
 sal
 eiL
 eiL
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
 tRo
 tRo
 raF
 tRo
 tRo
-aOU
-aOU
-aOU
+ajO
+ajO
+ajO
 xRX
 xRX
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -2141,20 +2141,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
-"esB" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
 "etF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/west,
@@ -3359,6 +3345,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/handrail{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
@@ -7061,6 +7050,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
+"pZx" = (
+/obj/structure/bed/stool/chair/shuttle{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/freebooter_shuttle)
 "pZI" = (
 /obj/effect/floor_decal/corner/dark_blue,
 /obj/structure/bed/stool/chair/office/light{
@@ -7648,14 +7646,19 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
 "rhN" = (
-/obj/structure/bed/stool/chair/shuttle{
+/obj/structure/railing/mapped{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/freebooter_shuttle)
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "rjL" = (
 /obj/machinery/ship_weapon/blaster{
 	pixel_y = -195;
@@ -45032,7 +45035,7 @@ vxO
 mbg
 bWt
 xHX
-rhN
+pZx
 amu
 amu
 elW
@@ -47091,7 +47094,7 @@ rfz
 rfz
 lCe
 rfz
-esB
+rhN
 vTv
 tOu
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1643,17 +1643,6 @@
 "dlZ" = (
 /turf/simulated/wall,
 /area/ship/freebooter_ship/gunneryentrance)
-"dmI" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster1)
-"dnc" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/machinery/firealarm/west,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster2)
 "doC" = (
 /obj/effect/floor_decal/industrial/outline/service,
 /obj/effect/decal/cleanable/dirt,
@@ -3195,6 +3184,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
+"hjN" = (
+/obj/machinery/firealarm/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 6
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "hmk" = (
 /obj/item/material/shard,
 /obj/item/trash/broken_electronics,
@@ -3915,17 +3915,9 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod8)
-"jkR" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster2)
 "jlr" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 9
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "jnK" = (
@@ -4050,10 +4042,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "jGn" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 5
-	},
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "jJb" = (
@@ -4080,12 +4069,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/medical)
-"jMa" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/machinery/firealarm/east,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster1)
 "jMu" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -4737,11 +4720,12 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod5)
 "lfb" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "lfg" = (
@@ -5506,13 +5490,6 @@
 /obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
-"mOd" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/machinery/light/small/emergency{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster1)
 "mOF" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -6109,6 +6086,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
+"odZ" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "ofb" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -6627,10 +6611,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
-"pbd" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster2)
 "peJ" = (
 /obj/machinery/seed_storage/garden,
 /obj/effect/floor_decal/industrial/outline/service,
@@ -6900,6 +6880,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
+"pBB" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "pCG" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	layer = 2.71;
@@ -7193,9 +7177,15 @@
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
 "qgY" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/warning{
-	dir = 1
+	layer = 2.71;
+	dir = 9
 	},
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
+"qhf" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
@@ -7667,13 +7657,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
-"rfa" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/machinery/light/small/emergency{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster2)
 "rfn" = (
 /obj/effect/floor_decal/corner/orange/full,
 /obj/machinery/autolathe,
@@ -9157,6 +9140,16 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
+"uEu" = (
+/obj/machinery/firealarm/east,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 10
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster1)
 "uFc" = (
 /obj/machinery/iff_beacon/name_change,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -10456,6 +10449,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
+"xuo" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster1)
 "xuR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -39414,7 +39414,7 @@ xRX
 xRX
 vkx
 aKs
-mOd
+xuo
 tcI
 plx
 foU
@@ -39671,7 +39671,7 @@ xRX
 xRX
 vkx
 ugG
-dmI
+jGn
 lfb
 plx
 pfE
@@ -40185,7 +40185,7 @@ xRX
 xRX
 vkx
 xPD
-jMa
+uEu
 kCv
 wRm
 jvN
@@ -45839,7 +45839,7 @@ xRX
 xRX
 vFo
 nXu
-dnc
+hjN
 tjz
 pvL
 vhv
@@ -46096,7 +46096,7 @@ xRX
 xRX
 icO
 joM
-jkR
+qhf
 jlr
 rXk
 tYU
@@ -46353,7 +46353,7 @@ xRX
 xRX
 vFo
 joM
-pbd
+pBB
 qgY
 rXk
 lqh
@@ -46610,7 +46610,7 @@ xRX
 xRX
 vFo
 aKF
-rfa
+odZ
 lUK
 rXk
 ofb

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1913,6 +1913,13 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod4)
+"dZn" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "dZH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2135,19 +2142,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
-"esB" = (
-/obj/effect/decal/fake_object{
-	icon = 'icons/obj/ship_engine.dmi';
-	icon_state = "nozzle";
-	name = "jurry rigged rocket nozzle";
-	desc = "Simple rocket nozzle, expelling gas at hypersonic velocities to propell the ship. This one no longer works.";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
 "etF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/west,
@@ -2864,6 +2858,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
+"gwc" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "gwg" = (
 /turf/simulated/wall/shuttle/space_ship{
 	color = "#E14644"
@@ -3184,17 +3183,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
-"hjN" = (
-/obj/machinery/firealarm/west,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 6
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster2)
 "hmk" = (
 /obj/item/material/shard,
 /obj/item/trash/broken_electronics,
@@ -6086,13 +6074,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
-"odZ" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/machinery/light/small/emergency{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster2)
 "ofb" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -6611,6 +6592,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
+"pbw" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster1)
 "peJ" = (
 /obj/machinery/seed_storage/garden,
 /obj/effect/floor_decal/industrial/outline/service,
@@ -6747,6 +6735,17 @@
 /obj/effect/shuttle_landmark/freebooter_ship/transit,
 /turf/space,
 /area/space)
+"poS" = (
+/obj/machinery/firealarm/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 6
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "ppp" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
@@ -6880,10 +6879,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
-"pBB" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster2)
 "pCG" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	layer = 2.71;
@@ -7182,11 +7177,6 @@
 	layer = 2.71;
 	dir = 9
 	},
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster2)
-"qhf" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "qiz" = (
@@ -8384,6 +8374,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
+"sIz" = (
+/obj/machinery/firealarm/east,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 10
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster1)
 "sLq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9140,16 +9140,6 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
-"uEu" = (
-/obj/machinery/firealarm/east,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 10
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster1)
 "uFc" = (
 /obj/machinery/iff_beacon/name_change,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -9792,6 +9782,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/ammo)
+"vSe" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "vST" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -10108,21 +10102,13 @@
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/gunnery)
 "wHo" = (
-/obj/effect/decal/fake_object{
-	icon = 'icons/obj/ship_engine.dmi';
-	icon_state = "nozzle";
-	name = "jurry rigged rocket nozzle";
-	desc = "Simple rocket nozzle, expelling gas at hypersonic velocities to propell the ship. This one no longer works.";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, pod four"
 	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship)
+/turf/simulated/wall/shuttle/space_ship{
+	color = "#E14644"
+	},
+/area/ship/freebooter_ship/pod4)
 "wIJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -10449,13 +10435,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
-"xuo" = (
-/obj/structure/lattice/catwalk/indoor/grate/dark,
-/obj/machinery/light/small/emergency{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/ship/freebooter_ship/thruster1)
 "xuR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -38664,13 +38643,13 @@ wUi
 eIb
 vZW
 vZW
-esB
+vZW
 gwg
-esB
+gwg
 wHo
-esB
 gwg
-esB
+gwg
+vZW
 vZW
 vZW
 cLC
@@ -39414,7 +39393,7 @@ xRX
 xRX
 vkx
 aKs
-xuo
+pbw
 tcI
 plx
 foU
@@ -40185,7 +40164,7 @@ xRX
 xRX
 vkx
 xPD
-uEu
+sIz
 kCv
 wRm
 jvN
@@ -45839,7 +45818,7 @@ xRX
 xRX
 vFo
 nXu
-hjN
+poS
 tjz
 pvL
 vhv
@@ -46096,7 +46075,7 @@ xRX
 xRX
 icO
 joM
-qhf
+gwc
 jlr
 rXk
 tYU
@@ -46353,7 +46332,7 @@ xRX
 xRX
 vFo
 joM
-pBB
+vSe
 qgY
 rXk
 lqh
@@ -46610,7 +46589,7 @@ xRX
 xRX
 vFo
 aKF
-odZ
+dZn
 lUK
 rXk
 ofb

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -30,9 +30,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/wood/walnut{
-	icon_state = "woodcolour_broken5"
-	},
+/turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "ace" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -91,9 +89,7 @@
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "ajh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -143,9 +139,7 @@
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
 	},
-/turf/simulated/floor/tiled/dark{
-	icon_state = "dark_broken0"
-	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
 "akl" = (
 /obj/structure/noticeboard{
@@ -163,23 +157,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/engineering)
-"anN" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	layer = 2.45;
-	name = "lattice"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	icon_state = "dmg1"
-	},
-/area/ship/freebooter_ship/foyer)
 "aok" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -260,13 +237,15 @@
 	icon = 'icons/obj/computer.dmi';
 	icon_state = "wallframe";
 	name = "Telescreen";
-	pixel_x = 32
+	pixel_x = 32;
+	pixel_y = 3
 	},
 /obj/machinery/button/remote/blast_door{
 	name = "Habitation Moduel Lockdown";
 	pixel_x = 25;
 	pixel_y = -8;
-	id = "hab_module"
+	id = "hab_module";
+	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -331,18 +310,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/bridge)
-"aCd" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	layer = 2.31;
-	name = "lattice"
-	},
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
-/area/ship/freebooter_ship/foyer)
 "aCG" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -802,9 +769,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark{
-	icon_state = "dark_broken0"
-	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
 "bhB" = (
 /obj/machinery/door/firedoor/noid,
@@ -869,9 +834,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dmg1"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod2)
 "bpT" = (
 /obj/item/stack/tile/floor_dark,
@@ -951,9 +914,7 @@
 	layer = 2.31;
 	name = "lattice"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod2)
 "buM" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -997,9 +958,7 @@
 	name = "old captain's note";
 	info = "Don't forget - all of the crew's clothing is now in the cargo pod!"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg1"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod6)
 "bxH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
@@ -1060,9 +1019,7 @@
 	name = "lattice"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor{
-	icon_state = "dmg1"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "bDB" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -1114,9 +1071,7 @@
 	layer = 2.45;
 	name = "lattice"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "bJj" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -1299,9 +1254,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod1)
 "cnH" = (
 /obj/effect/decal/fake_object{
@@ -1370,9 +1323,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "cJt" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1384,7 +1335,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/shuttle_landmark/freebooter_shuttle/hangar,
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship)
 "cLe" = (
@@ -1500,9 +1450,7 @@
 /area/ship/freebooter_ship/pod3)
 "cYK" = (
 /obj/item/stack/tile/floor_dark,
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "dbA" = (
 /obj/structure/cable{
@@ -1569,7 +1517,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "doC" = (
-/mob/living/bot/farmbot,
+/mob/living/bot/farmbot{
+	req_one_access = null;
+	req_access = null
+	},
 /obj/effect/floor_decal/industrial/outline/service,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
@@ -1744,9 +1695,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod1)
 "dOw" = (
 /obj/effect/floor_decal/corner/lime{
@@ -1833,9 +1782,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "eaO" = (
 /obj/effect/decal/fake_object{
@@ -1973,9 +1920,7 @@
 /obj/structure/bed/stool/chair/sofa/left/brown{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut{
-	icon_state = "woodcolour_broken6"
-	},
+/turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "eqi" = (
 /obj/effect/floor_decal/corner/yellow/full,
@@ -2084,10 +2029,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
-"eBK" = (
-/obj/effect/map_effect/airlock/w_to_e/long/square,
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship)
 "eDX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -2123,10 +2064,6 @@
 	color = "#88A866"
 	},
 /area/ship/freebooter_ship/pod5)
-"eMq" = (
-/obj/effect/map_effect/airlock/long/square,
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/shuttle/freebooter_shuttle)
 "eMT" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 10
@@ -2205,7 +2142,6 @@
 	dir = 8
 	},
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2267,9 +2203,7 @@
 	name = "wooden lattice";
 	color = "#CE9175"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg1"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod7)
 "fjD" = (
 /obj/structure/cable{
@@ -2447,9 +2381,7 @@
 	pixel_y = 18;
 	pixel_x = 5
 	},
-/turf/simulated/floor/wood/walnut{
-	icon_state = "woodcolour_broken3"
-	},
+/turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "fQq" = (
 /obj/effect/floor_decal/corner/beige{
@@ -2624,9 +2556,11 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "ghi" = (
-/obj/machinery/alarm/east,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/freebooter_shuttle)
+/area/ship/freebooter_ship/foyer)
 "gji" = (
 /obj/structure/table/rack,
 /obj/item/ship_ammunition/blaster,
@@ -2743,25 +2677,12 @@
 	icon_state = "dmg2"
 	},
 /area/ship/freebooter_ship/bridge)
-"gxW" = (
-/turf/simulated/floor/tiled/dark{
-	icon_state = "dark_broken0"
-	},
-/area/ship/freebooter_ship/pod2)
 "gyl" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship)
-"gyH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/alarm/east{
-	pixel_x = 32;
-	req_one_access = null
-	},
-/obj/machinery/light/small/emergency{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/foyer)
 "gzr" = (
 /obj/structure/inflatable/wall,
 /turf/simulated/floor{
@@ -2842,13 +2763,16 @@
 	dir = 1
 	},
 /obj/structure/closet/walllocker/medical{
-	name = "blood closet";
-	pixel_x = 32
+	name = "medical supplies";
+	pixel_y = 32
 	},
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
+/obj/machinery/iv_drip,
+/obj/item/tank/oxygen,
+/obj/item/clothing/mask/breath/medical,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/bridge)
 "gMa" = (
@@ -2944,9 +2868,7 @@
 	layer = 2.31;
 	name = "lattice"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "hhf" = (
 /obj/effect/floor_decal/corner/beige/full{
@@ -3027,7 +2949,6 @@
 	dir = 4
 	},
 /obj/machinery/alarm/west{
-	pixel_x = -32;
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3172,9 +3093,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod7)
 "hRt" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -3492,15 +3411,8 @@
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 9
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/bridge)
@@ -3618,6 +3530,9 @@
 /obj/effect/floor_decal/corner/orange/full,
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
+	},
+/obj/machinery/alarm/west{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
@@ -3802,10 +3717,10 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "jLL" = (
@@ -3905,9 +3820,7 @@
 /obj/machinery/power/apc/south{
 	req_access = null
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod7)
 "kbC" = (
 /obj/effect/floor_decal/corner/dark_green/full{
@@ -3915,7 +3828,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4157,7 +4069,6 @@
 	dir = 8
 	},
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4230,9 +4141,7 @@
 	layer = 2.45;
 	name = "lattice"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "kAt" = (
 /obj/effect/floor_decal/corner_wide/lime{
@@ -4553,9 +4462,7 @@
 /obj/structure/bed/stool/chair/sofa/right/brown{
 	dir = 4
 	},
-/turf/simulated/floor/wood/walnut{
-	icon_state = "woodcolour_broken5"
-	},
+/turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "lkK" = (
 /obj/structure/railing/mapped{
@@ -4654,13 +4561,12 @@
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 4
 	},
-/obj/machinery/alarm/east{
-	pixel_x = 32;
-	req_one_access = null
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/south{
 	req_access = null
+	},
+/obj/machinery/alarm/east{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
@@ -4891,9 +4797,7 @@
 	layer = 2.45;
 	name = "lattice"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "mbX" = (
 /obj/machinery/door/firedoor/noid,
@@ -4981,6 +4885,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod5)
 "mkb" = (
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "moJ" = (
@@ -5024,9 +4929,7 @@
 /obj/structure/barricade/wooden{
 	dir = 8
 	},
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "mtT" = (
 /obj/effect/floor_decal/corner/beige/full{
@@ -5124,9 +5027,7 @@
 /obj/machinery/power/apc/east{
 	req_access = null
 	},
-/turf/simulated/floor/tiled/dark{
-	icon_state = "dark_broken0"
-	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
 "mET" = (
 /obj/machinery/door/firedoor/multi_tile{
@@ -5145,6 +5046,9 @@
 	pixel_x = -5
 	},
 /obj/item/reagent_containers/inhaler/space_drugs,
+/obj/item/storage/box/condiment{
+	pixel_y = 16
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
 "mGn" = (
@@ -5220,12 +5124,6 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
-"mRH" = (
-/obj/item/stack/tile/floor_dark,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
-/area/ship/freebooter_ship/foyer)
 "mSI" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -5242,9 +5140,7 @@
 	identifier = "freebooter_crew";
 	name = "igs - freebooter crew"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg1"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod6)
 "mWz" = (
 /obj/effect/landmark/entry_point/starboard{
@@ -5390,11 +5286,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
 "npJ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/bridge)
@@ -5544,9 +5440,7 @@
 	layer = 2.45;
 	name = "lattice"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg1"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/thruster1)
 "nDn" = (
 /turf/simulated/floor/wood/walnut,
@@ -5582,10 +5476,6 @@
 "nKC" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 10
-	},
-/obj/machinery/alarm/north{
-	pixel_y = -32;
-	req_one_access = null
 	},
 /obj/structure/table/steel,
 /obj/item/stack/material/steel/full,
@@ -5633,6 +5523,10 @@
 	},
 /obj/effect/floor_decal/corner_wide/paleblue{
 	dir = 10
+	},
+/obj/machinery/light{
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/bridge)
@@ -5738,6 +5632,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship)
 "odX" = (
@@ -5788,9 +5685,7 @@
 /obj/structure/bed/stool/chair/office/bridge{
 	dir = 8
 	},
-/turf/simulated/floor/wood/walnut{
-	icon_state = "woodcolour_broken6"
-	},
+/turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "ogz" = (
 /obj/effect/decal/cleanable/blood,
@@ -5899,9 +5794,7 @@
 /obj/structure/barricade/wooden{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "oxR" = (
 /obj/item/ammo_casing/rifle/used{
@@ -6142,6 +6035,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/shuttle_landmark/freebooter_shuttle/hangar,
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship)
 "oUu" = (
@@ -6201,9 +6095,7 @@
 "oXj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/item/stack/tile/floor_dark,
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "oZH" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -6343,6 +6235,9 @@
 /area/ship/freebooter_ship/thruster2)
 "pob" = (
 /obj/machinery/computer/ship/sensors,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "poF" = (
@@ -6402,9 +6297,7 @@
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod6)
 "put" = (
 /obj/machinery/computer/ship/sensors{
@@ -6477,14 +6370,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
-"pCa" = (
-/obj/structure/bed/stool/chair{
-	dir = 1
-	},
-/turf/simulated/floor/wood/walnut{
-	icon_state = "woodcolour_broken0"
-	},
-/area/ship/freebooter_ship/pod7)
 "pCG" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	layer = 2.71;
@@ -6608,9 +6493,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod5)
 "pRO" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
 /obj/machinery/door/firedoor/noid,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "blast door";
@@ -6990,9 +6874,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "qDe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -7001,6 +6882,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/bridge)
@@ -7026,9 +6910,7 @@
 	name = "old captain's note";
 	info = "Don't forget - all of the crew's clothing is now in the cargo pod!"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod1)
 "qEc" = (
 /obj/machinery/door/firedoor/noid,
@@ -7068,7 +6950,6 @@
 	dir = 1
 	},
 /obj/machinery/alarm/east{
-	pixel_x = 32;
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
@@ -7135,9 +7016,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod1)
 "qNZ" = (
 /obj/structure/bed/stool/chair/padded/black{
@@ -7446,14 +7325,13 @@
 	layer = 2.45;
 	name = "lattice"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "rDZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "rEb" = (
@@ -7481,9 +7359,7 @@
 	layer = 2.31;
 	name = "lattice"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg1"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "rEV" = (
 /obj/machinery/shower{
@@ -7614,6 +7490,7 @@
 /obj/effect/landmark/entry_point/north{
 	name = "aft, engines"
 	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
 "rYv" = (
@@ -7656,9 +7533,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "dmg1"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod2)
 "sjD" = (
 /obj/effect/floor_decal/corner/dark_green{
@@ -7983,6 +7858,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod6)
 "sVT" = (
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
 "sWG" = (
@@ -8126,9 +8002,7 @@
 "tsO" = (
 /obj/item/stack/tile/floor_dark,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "tte" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -8295,23 +8169,6 @@
 /obj/machinery/shipsensors/weak,
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship)
-"tPv" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	layer = 2.45;
-	name = "lattice"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
-/area/ship/freebooter_ship/foyer)
 "tQn" = (
 /obj/structure/ship_weapon_dummy,
 /turf/simulated/floor,
@@ -8350,12 +8207,12 @@
 /area/ship/freebooter_ship/pod4)
 "tUO" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/alarm/north{
-	req_one_access = null
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/alarm/north{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
@@ -8391,9 +8248,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "tYn" = (
 /obj/effect/floor_decal/corner/orange{
@@ -8697,12 +8552,12 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/alarm/north{
-	pixel_y = -32;
-	req_one_access = null
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/machinery/alarm/south{
+	req_one_access = null;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
@@ -8752,9 +8607,7 @@
 /area/ship/freebooter_ship/engineering)
 "uWn" = (
 /obj/structure/girder,
-/turf/simulated/floor/tiled/dark{
-	icon_state = "dark_full_broken0"
-	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod2)
 "uWU" = (
 /obj/effect/floor_decal/corner/dark_green/diagonal,
@@ -8807,9 +8660,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "vcz" = (
 /obj/effect/floor_decal/corner{
@@ -9739,9 +9590,7 @@
 "xbK" = (
 /obj/structure/bed/stool/bar/padded/brown,
 /obj/machinery/firealarm/south,
-/turf/simulated/floor/wood/walnut{
-	icon_state = "woodcolour_broken1"
-	},
+/turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "xcR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9776,9 +9625,7 @@
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dmg1"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "xhE" = (
 /obj/machinery/ammunition_loader/blaster{
@@ -9978,9 +9825,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/dark{
-	icon_state = "dark_broken0"
-	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
 "xQS" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -10024,9 +9869,7 @@
 	layer = 2.45;
 	name = "lattice"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/thruster1)
 "xWB" = (
 /obj/machinery/door/firedoor/noid,
@@ -10121,9 +9964,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dmg1"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod6)
 "yjk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10143,9 +9984,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg1"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod7)
 "ylw" = (
 /obj/structure/railing/mapped,
@@ -39832,7 +39671,7 @@ qiz
 xHQ
 xHQ
 bpG
-gxW
+wuP
 xHQ
 qiz
 xRX
@@ -42118,7 +41957,7 @@ oIl
 qqi
 qwm
 moJ
-mRH
+cYK
 wUJ
 unp
 dBJ
@@ -42155,7 +41994,7 @@ axn
 fie
 mqm
 bSi
-aCd
+rEr
 etF
 moJ
 mpM
@@ -42397,7 +42236,7 @@ qTW
 koD
 koD
 kPY
-anN
+cEX
 qoJ
 koD
 koD
@@ -42408,16 +42247,16 @@ ggz
 koD
 koD
 qoJ
-tPv
+cEX
 ptN
 koD
 koD
-anN
-tPv
+cEX
+cEX
 nOe
 koD
 koD
-anN
+cEX
 pQc
 kzS
 kHb
@@ -42656,7 +42495,7 @@ kuG
 oWj
 lwB
 kXq
-mRH
+cYK
 gVT
 oKx
 kPJ
@@ -42669,8 +42508,8 @@ sIh
 vbh
 qkA
 iQC
-axn
-gyH
+ghi
+sIh
 oWj
 ovG
 oJq
@@ -42893,14 +42732,14 @@ vGw
 wGc
 gyl
 gyl
-eBK
+wGc
 vGw
 vGw
 vGw
 wGc
 gyl
 odb
-eBK
+wGc
 wyp
 vGw
 vGw
@@ -44456,7 +44295,7 @@ uwT
 xRX
 pRO
 fNZ
-pCa
+kpR
 hQA
 wLs
 wLs
@@ -44699,7 +44538,7 @@ rHI
 aSb
 lzu
 lzu
-eMq
+aSb
 qeJ
 vOL
 xRX
@@ -45207,7 +45046,7 @@ atI
 wdp
 dBR
 pob
-ghi
+nRY
 nxF
 kPW
 rDZ

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1138,11 +1138,6 @@
 	dir = 1;
 	name = "Fuel Input"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
 "bFv" = (
@@ -2141,6 +2136,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
+"esB" = (
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "etF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/west,
@@ -3349,6 +3358,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 5
 	},
+/obj/machinery/light{
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
 "hQA" = (
@@ -3371,6 +3383,17 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod7)
+"hRt" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4;
+	layer = 2.8
+	},
+/turf/simulated/floor,
+/area/shuttle/freebooter_shuttle)
 "hUF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3655,11 +3678,6 @@
 "iCP" = (
 /obj/machinery/computer/ship/helm{
 	req_access = list(203)
-	},
-/obj/machinery/light{
-	dir = 1;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
@@ -4770,6 +4788,14 @@
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
+"llB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 10
+	},
+/turf/simulated/wall/shuttle/space_ship{
+	color = "#E14644"
+	},
+/area/shuttle/freebooter_shuttle)
 "llD" = (
 /obj/structure/bed/stool/chair/office/bridge/generic,
 /obj/structure/railing/mapped{
@@ -5925,14 +5951,6 @@
 /obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod1)
-"nVq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 10
-	},
-/turf/simulated/wall/shuttle/space_ship{
-	color = "#E14644"
-	},
-/area/shuttle/freebooter_shuttle)
 "nWh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -7050,15 +7068,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
-"pZx" = (
-/obj/structure/bed/stool/chair/shuttle{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/freebooter_shuttle)
 "pZI" = (
 /obj/effect/floor_decal/corner/dark_blue,
 /obj/structure/bed/stool/chair/office/light{
@@ -7207,15 +7216,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
+/obj/machinery/power/apc/high/east,
 /obj/structure/cable/green{
-	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
@@ -7645,20 +7649,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
-"rhN" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
 "rjL" = (
 /obj/machinery/ship_weapon/blaster{
 	pixel_y = -195;
@@ -7937,12 +7927,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "rHI" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4;
-	layer = 2.8
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "rJT" = (
 /obj/structure/railing/mapped{
@@ -8206,14 +8194,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/machinery/power/apc/high/east,
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/fuel_port/phoron{
+	pixel_x = -32
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -9111,14 +9097,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/binary/pump/high_power{
 	name = "Canister to Thrusters"
-	},
-/obj/structure/fuel_port/phoron{
-	pixel_x = -32
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -10509,6 +10487,9 @@
 "xHX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 6
+	},
+/obj/structure/bed/stool/chair/shuttle{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
@@ -45035,7 +45016,7 @@ vxO
 mbg
 bWt
 xHX
-pZx
+hRt
 amu
 amu
 elW
@@ -46580,7 +46561,7 @@ ggq
 hQh
 aSb
 kVa
-nVq
+llB
 lKV
 cei
 vOL
@@ -47094,7 +47075,7 @@ rfz
 rfz
 lCe
 rfz
-rhN
+esB
 vTv
 tOu
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -765,6 +765,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
 "bhA" = (
@@ -872,6 +873,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "bsf" = (
@@ -1452,6 +1454,9 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
+"cFh" = (
+/turf/simulated/wall/r_wall,
+/area/ship/freebooter_ship/pod8)
 "cJt" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -1515,6 +1520,10 @@
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
 	},
+/obj/item/material/shard{
+	pixel_x = 13
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
 "cNi" = (
@@ -1641,7 +1650,8 @@
 	pixel_x = 12;
 	name = "Nexus Corporate Security softcap";
 	desc = "It's a softcap in Nexus Corporate Security colors.";
-	color = "#4F6583"
+	color = "#4F6583";
+	pixel_y = 14
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -1864,28 +1874,9 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/gunnery)
-"dUF" = (
-/obj/effect/floor_decal/corner{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/pod8)
 "dWi" = (
 /obj/effect/floor_decal/corner{
 	dir = 6
-	},
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/nt{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/obj/item/clipboard{
-	pixel_x = -4;
-	pixel_y = 0
-	},
-/obj/item/folder/sec{
-	pixel_x = -4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1893,6 +1884,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/material/shard{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "dWF" = (
@@ -2318,6 +2316,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
 "fdD" = (
@@ -2573,6 +2572,7 @@
 	pixel_y = 4;
 	specialfunctions = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "fNl" = (
@@ -2696,11 +2696,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
 "fYr" = (
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
-/obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/sign/fire{
 	pixel_x = 32
 	},
+/obj/machinery/suit_cycler/security{
+	req_access = null
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod8)
 "fZq" = (
@@ -3029,6 +3031,13 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/dorms)
+"gQN" = (
+/obj/effect/floor_decal/corner{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod8)
 "gSo" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3197,7 +3206,10 @@
 /area/ship/freebooter_ship/forehallway)
 "hmk" = (
 /obj/item/material/shard,
-/obj/item/trash/broken_electronics,
+/obj/item/trash/broken_electronics{
+	pixel_y = 8;
+	pixel_x = 5
+	},
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -3283,7 +3295,7 @@
 	dir = 6
 	},
 /obj/structure/table/glass,
-/obj/item/modular_computer/laptop/preset/security,
+/obj/item/gun/energy/disruptorpistol/magnum,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "hIE" = (
@@ -3436,8 +3448,7 @@
 /obj/machinery/light{
 	dir = 1;
 	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty";
-	status = 2
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -3604,10 +3615,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "iok" = (
-/obj/item/trash/tastybread{
-	pixel_y = -7;
-	pixel_x = -1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "ioS" = (
@@ -3622,6 +3629,13 @@
 	},
 /turf/simulated/floor/carpet/magenta,
 /area/ship/freebooter_ship/pod6)
+"ioW" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/pod8)
 "ipt" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 4
@@ -3642,7 +3656,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/padded,
 /obj/structure/sign/securearea{
 	pixel_y = -32
@@ -3881,15 +3894,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
-"jfl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/ship/freebooter_ship/pod8)
 "jgM" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -4096,6 +4100,7 @@
 	dir = 1;
 	icon_state = "map-supply"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
 "jMT" = (
@@ -4253,8 +4258,8 @@
 	pixel_x = -12
 	},
 /obj/effect/decal/cleanable/blood/drip{
-	pixel_y = 15;
-	pixel_x = -5
+	pixel_y = 20;
+	pixel_x = -1
 	},
 /obj/structure/bed/stool/chair/folding{
 	dir = 8
@@ -4386,13 +4391,14 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/light{
 	dir = 1;
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
@@ -4789,6 +4795,7 @@
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "lho" = (
@@ -5059,12 +5066,13 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
 "lGK" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
-/obj/effect/floor_decal/industrial/outline/engineering,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
 /area/ship/freebooter_ship/pod8)
 "lHL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -5095,7 +5103,6 @@
 	pixel_x = -24;
 	icon_state = "mirror_mask_broken"
 	},
-/obj/item/material/shard,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -5412,6 +5419,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "mCl" = (
@@ -5512,9 +5520,7 @@
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/padded,
-/obj/machinery/light{
-	status = 2
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "mOF" = (
@@ -5582,9 +5588,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
-	},
-/obj/machinery/light/small/emergency{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -5784,7 +5787,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "ntt" = (
@@ -6188,14 +6190,14 @@
 /area/ship/freebooter_ship/exterior)
 "omd" = (
 /obj/effect/floor_decal/corner/dark_blue/full,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	layer = 2.71
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/machinery/firealarm/south,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	layer = 2.71
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "omr" = (
@@ -6219,7 +6221,6 @@
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "onx" = (
@@ -6386,6 +6387,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallwayport)
+"oGd" = (
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/magenta,
+/area/ship/freebooter_ship/pod6)
 "oGU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -6606,12 +6620,17 @@
 	dir = 10
 	},
 /obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/paper_bin{
+	pixel_y = 5;
+	pixel_x = 6
+	},
 /obj/machinery/light{
 	dir = 1;
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
+	},
+/obj/item/pen{
+	pixel_y = 7
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -6908,6 +6927,12 @@
 	dir = 10;
 	pixel_y = 0
 	},
+/obj/item/ipc_overloader/rainbow{
+	uses = 0
+	},
+/obj/item/ipc_overloader/jitterbug{
+	uses = 0
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
 "pBl" = (
@@ -6983,12 +7008,10 @@
 /obj/effect/floor_decal/corner{
 	dir = 5
 	},
-/obj/machinery/suit_cycler/security{
-	req_access = null
-	},
 /obj/structure/sign/fire{
 	pixel_x = 32
 	},
+/obj/structure/closet/crate/security,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "pOI" = (
@@ -7802,13 +7825,18 @@
 /obj/effect/floor_decal/corner{
 	dir = 4
 	},
-/obj/item/device/paicard,
+/obj/item/device/paicard{
+	pixel_x = 5;
+	pixel_y = 6
+	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9;
+	pixel_y = 0
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
 "ruo" = (
@@ -7938,17 +7966,8 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "rEV" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/toilet{
-	dir = 8;
-	icon_state = "toilet01"
-	},
-/obj/machinery/door/window{
-	dir = 8;
-	req_one_access = list(150)
-	},
+/obj/machinery/recharge_station,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod6)
 "rFB" = (
@@ -8416,11 +8435,12 @@
 /obj/effect/floor_decal/corner{
 	dir = 5
 	},
-/obj/structure/closet/crate/bin{
-	name = "trashbin"
-	},
 /obj/machinery/light{
 	icon_state = "tube_empty"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/phoron{
+	start_pressure = 332
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -8672,7 +8692,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/closet/crate/security,
+/obj/structure/closet/crate/bin{
+	name = "trashbin"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "tsO" = (
@@ -8689,6 +8711,9 @@
 	},
 /obj/machinery/alarm/south{
 	req_one_access = null
+	},
+/obj/machinery/portable_atmospherics/canister/phoron{
+	start_pressure = 165
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
@@ -9206,6 +9231,10 @@
 /obj/item/toy/plushie/ipc{
 	pixel_x = -8
 	},
+/obj/item/storage/overloader/classic{
+	pixel_x = 6;
+	pixel_y = 11
+	},
 /turf/simulated/floor/carpet/magenta,
 /area/ship/freebooter_ship/pod6)
 "uNN" = (
@@ -9238,7 +9267,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "uOX" = (
@@ -9335,7 +9363,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "vbe" = (
@@ -9370,6 +9397,7 @@
 /obj/effect/floor_decal/corner{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod8)
 "vdj" = (
@@ -9590,9 +9618,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
-"vnO" = (
-/turf/simulated/wall/r_wall,
-/area/ship/freebooter_ship/pod8)
 "vsx" = (
 /obj/effect/floor_decal/corner/beige{
 	dir = 5
@@ -9645,9 +9670,13 @@
 	},
 /obj/structure/railing/mapped,
 /obj/structure/table/steel,
-/obj/item/device/binoculars,
 /obj/item/device/binoculars{
-	pixel_y = 6
+	pixel_x = 12;
+	pixel_y = 8
+	},
+/obj/item/device/binoculars{
+	pixel_y = 10;
+	pixel_x = -4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
@@ -9729,10 +9758,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/trash/tastybread{
-	pixel_x = 8
-	},
 /obj/structure/sign/securearea{
 	pixel_y = 32
 	},
@@ -10801,7 +10826,7 @@
 /obj/structure/table/steel,
 /obj/item/paper/crumpled{
 	pixel_x = -4;
-	pixel_y = 5
+	pixel_y = 9
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/nt{
 	pixel_x = 7;
@@ -38155,7 +38180,7 @@ aaI
 aaI
 aaI
 vWo
-xRX
+kqx
 xRX
 xRX
 xRX
@@ -38411,8 +38436,8 @@ vUu
 uyM
 kqx
 aHs
-xRX
-xRX
+kqx
+kqx
 xRX
 xRX
 xRX
@@ -45363,7 +45388,7 @@ tRo
 bxf
 aFI
 bxM
-ioS
+oGd
 ieZ
 tRo
 xRX
@@ -45859,7 +45884,7 @@ vOL
 xRX
 uwT
 fYr
-lGK
+onn
 fJo
 nYq
 pMN
@@ -46115,11 +46140,11 @@ hhA
 vOL
 xRX
 uwT
-vnO
+cFh
 hhQ
-jfl
+lGK
 hZY
-vnO
+cFh
 uwT
 xRX
 eiL
@@ -46373,7 +46398,7 @@ vOL
 xRX
 uwT
 cgU
-onn
+ioW
 uZC
 iok
 pik
@@ -46632,7 +46657,7 @@ uwT
 vMG
 hil
 uOr
-dUF
+gQN
 irq
 uwT
 vZW

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -133,10 +133,15 @@
 /obj/item/paper/crumpled,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
+"ajM" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "ajO" = (
-/obj/structure/lattice/catwalk,
-/turf/space/dynamic,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/medical)
 "akg" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
@@ -208,17 +213,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/engineering)
-"asG" = (
-/obj/machinery/cryopod,
-/obj/structure/cryofeed/pipes{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/cryo)
 "atj" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -282,8 +276,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "ayy" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/forehallwayport)
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2191,9 +2196,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
-"eCC" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunneryentrance)
 "eDX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -2384,6 +2386,9 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
+"fjE" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/forehallwayport)
 "fjW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 6
@@ -2498,8 +2503,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fGM" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/gunneryentrance)
+/turf/simulated/wall,
+/area/ship/freebooter_ship/medical)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -2727,22 +2732,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
-"giQ" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/machinery/access_button{
-	pixel_x = 8;
-	pixel_y = 28;
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/foyer)
 "gji" = (
 /obj/structure/table/rack,
 /obj/item/ship_ammunition/blaster,
@@ -2866,16 +2855,16 @@
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
 /obj/machinery/access_button{
 	pixel_x = -8;
 	pixel_y = 28;
 	dir = 8
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "gzr" = (
@@ -3866,19 +3855,12 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "jrC" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "junker_gun"
 	},
 /turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/area/ship/freebooter_ship/gunnery)
 "jvN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -4220,12 +4202,9 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "kqx" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "junker_gun"
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/gunnery)
+/obj/structure/lattice/catwalk,
+/turf/space/dynamic,
+/area/ship/freebooter_ship/exterior)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
 /obj/effect/decal/cleanable/dirt,
@@ -4840,6 +4819,9 @@
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
 	},
+/obj/machinery/airlock_sensor{
+	pixel_y = -25
+	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
 "lvR" = (
@@ -4902,6 +4884,10 @@
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = -32;
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -5279,6 +5265,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
+"myo" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	pixel_x = -8;
+	pixel_y = 28;
+	dir = 8
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "mAl" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = null
@@ -5574,9 +5576,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/engineering)
-"nim" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/medical)
 "nmL" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -5683,22 +5682,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
-"nuo" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
 "nwD" = (
 /obj/effect/floor_decal/corner{
 	dir = 8
@@ -6389,6 +6372,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
+"oNl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/forehallway)
 "oPu" = (
 /obj/structure/sink/kitchen{
 	name = "sink";
@@ -6645,6 +6641,12 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
+"ppD" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "prU" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/spline/plain/corner{
@@ -7017,6 +7019,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
+"qeb" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	pixel_x = 8;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "qej" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7191,21 +7209,6 @@
 /obj/effect/step_trigger/teleporter,
 /turf/space,
 /area/space)
-"quJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/forehallway)
 "quS" = (
 /turf/simulated/wall,
 /area/ship/freebooter_ship/cryo)
@@ -7430,7 +7433,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/firealarm/north,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
 "qMB" = (
@@ -7790,8 +7795,13 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/access_button{
-	pixel_x = 30;
+	pixel_x = 27;
 	pixel_y = 8
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = 38;
+	pixel_y = 9;
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -8254,6 +8264,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
+"sKj" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed/pipes{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/freebooter_ship/cryo)
 "sLq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8360,7 +8381,7 @@
 "sVT" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
-	pixel_x = -30;
+	pixel_x = -27;
 	pixel_y = -2
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
@@ -8371,6 +8392,10 @@
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 5
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = -40;
+	pixel_y = -3
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
@@ -9565,22 +9590,6 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
-"vGR" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/access_button{
-	pixel_x = -8;
-	pixel_y = 28;
-	dir = 8
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/foyer)
 "vHQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/structure/curtain/open/bed{
@@ -9670,12 +9679,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/ammo)
-"vRK" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "vSY" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/pod4)
@@ -9772,11 +9775,8 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "vZW" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/gunneryentrance)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/stool/chair{
@@ -9981,8 +9981,21 @@
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "wGc" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/medical)
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "wHo" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/ship_engine.dmi';
@@ -10276,6 +10289,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
+"xey" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunneryentrance)
 "xfg" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -10512,6 +10528,9 @@
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_1";
 	master_tag = "freebooter_port_1"
+	},
+/obj/machinery/airlock_sensor{
+	pixel_y = -25
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -38513,17 +38532,17 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
+kqx
 eIb
 wUi
 ldw
 wUi
 eIb
-ajO
-ajO
+kqx
+kqx
 esB
 gwg
 esB
@@ -38531,32 +38550,32 @@ wHo
 esB
 gwg
 esB
-ajO
-ajO
+kqx
+kqx
 cLC
 cLC
 kwe
 tKj
 tKj
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 qiz
 qiz
 mWz
 qiz
 qiz
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 eUq
 eUq
 pRf
 eUq
 eUq
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 xRX
 xRX
 xRX
@@ -38769,8 +38788,8 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
+kqx
+kqx
 xRX
 xRX
 eIb
@@ -38813,7 +38832,7 @@ fTG
 eUq
 eUq
 xRX
-ajO
+kqx
 xqI
 xqI
 xqI
@@ -38827,7 +38846,7 @@ imE
 imE
 iOV
 iOV
-kqx
+jrC
 xRX
 xRX
 xRX
@@ -39084,7 +39103,7 @@ rjL
 tQn
 sxw
 www
-kqx
+jrC
 xRX
 xRX
 xRX
@@ -39285,8 +39304,8 @@ gFA
 ewW
 ewW
 ewW
-ajO
-ajO
+kqx
+kqx
 wUi
 syV
 bhd
@@ -39294,7 +39313,7 @@ xBh
 bhd
 tvh
 wUi
-ajO
+kqx
 gwg
 pUP
 kmP
@@ -39302,7 +39321,7 @@ qDn
 kev
 jcX
 gwg
-ajO
+kqx
 cLC
 wZf
 ttI
@@ -39310,7 +39329,7 @@ krH
 lKT
 vmX
 cLC
-ajO
+kqx
 qiz
 pYB
 bPT
@@ -39318,7 +39337,7 @@ jzk
 fRD
 buM
 qiz
-ajO
+kqx
 eUq
 aTX
 iUK
@@ -39326,8 +39345,8 @@ iUK
 iUK
 fTT
 eUq
-ajO
-ajO
+kqx
+kqx
 xqI
 ahD
 kfJ
@@ -39341,7 +39360,7 @@ fNl
 tQn
 sxw
 sxw
-kqx
+jrC
 xRX
 xRX
 xRX
@@ -39543,7 +39562,7 @@ xUb
 qWF
 ewW
 xRX
-ajO
+kqx
 wUi
 syV
 bhd
@@ -39592,13 +39611,13 @@ npb
 oxR
 tfK
 sxk
-vZW
+ajM
 soh
 soh
 aDv
 iOV
 iOV
-kqx
+jrC
 xRX
 xRX
 xRX
@@ -39800,7 +39819,7 @@ xUb
 jnK
 ewW
 xRX
-ajO
+kqx
 wUi
 syV
 grD
@@ -39850,8 +39869,8 @@ jhd
 tfK
 nwH
 wLI
-vRK
-vRK
+ppD
+ppD
 fnE
 xRX
 xRX
@@ -40057,7 +40076,7 @@ dbA
 wxS
 ewW
 xRX
-ajO
+kqx
 eIb
 oPu
 bhd
@@ -40099,7 +40118,7 @@ cEH
 eUq
 xRX
 xRX
-ajO
+kqx
 xqI
 xqI
 tfK
@@ -40314,7 +40333,7 @@ ewW
 ewW
 ewW
 xRX
-ajO
+kqx
 wUi
 cLL
 bhd
@@ -40356,13 +40375,13 @@ avE
 eUq
 xRX
 xRX
-ajO
+kqx
 xRX
-fGM
+vZW
 rEb
 xTu
 cbE
-eCC
+xey
 klp
 llD
 euj
@@ -40571,7 +40590,7 @@ acn
 ewW
 xRX
 xRX
-ajO
+kqx
 wUi
 glJ
 ihN
@@ -40613,10 +40632,10 @@ hIE
 eUq
 xRX
 xRX
-ajO
+kqx
 xRX
-fGM
-fGM
+vZW
+vZW
 jgM
 vVy
 aMQ
@@ -40828,7 +40847,7 @@ pHN
 ewW
 xRX
 xRX
-ajO
+kqx
 wUi
 wNA
 bhd
@@ -40870,13 +40889,13 @@ iUK
 eUq
 xRX
 xRX
-ajO
+kqx
 xRX
 xRX
-fGM
-fGM
+vZW
+vZW
 tmo
-eCC
+xey
 mwo
 mwo
 mwo
@@ -41085,7 +41104,7 @@ lJH
 jhL
 jhL
 xRX
-ajO
+kqx
 wUi
 peJ
 bhd
@@ -41127,18 +41146,18 @@ mtT
 eUq
 xRX
 xRX
-ajO
+kqx
 xRX
 xRX
 xRX
 uLO
 ebn
 atj
-nim
+fGM
 exg
 iGK
 aBD
-wGc
+ajO
 xRX
 xRX
 xRX
@@ -41342,7 +41361,7 @@ pCG
 iZM
 jhL
 jhL
-ajO
+kqx
 eIb
 eIb
 pPk
@@ -41384,7 +41403,7 @@ eUq
 eUq
 xRX
 xRX
-ajO
+kqx
 xRX
 xRX
 xRX
@@ -41395,7 +41414,7 @@ jLL
 aab
 qDe
 nVi
-wGc
+ajO
 saW
 xRX
 xRX
@@ -41599,61 +41618,61 @@ mhq
 tcY
 rfn
 jhL
-ajO
-ajO
+kqx
+kqx
 eIb
 eIb
 qEc
 eIb
 eIb
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 gwg
 wzO
 dXK
 wzO
 gwg
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 cLC
 cLC
 mbX
 cLC
 cLC
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 qiz
 qiz
 dFi
 qiz
 qiz
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 eUq
 eUq
 wRc
 eUq
 eUq
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
 pvm
 kou
 dWF
-nim
+fGM
 gLO
 npJ
 kAt
 lpe
-wGc
+ajO
 xRX
 xRX
 xRX
@@ -41857,7 +41876,7 @@ jbh
 tYn
 jhL
 xRX
-ajO
+kqx
 xRX
 wyp
 mGn
@@ -41898,19 +41917,19 @@ xRX
 xRX
 xRX
 xRX
-ajO
+kqx
 xRX
 xRX
 xRX
 pvm
 vfD
 kOP
-nim
-nim
+fGM
+fGM
 tra
-wGc
-nim
-wGc
+ajO
+fGM
+ajO
 ydf
 ewy
 ewy
@@ -42114,7 +42133,7 @@ rRa
 nKC
 jhL
 xRX
-ajO
+kqx
 xRX
 wyp
 mGn
@@ -42155,12 +42174,12 @@ xRX
 xRX
 xRX
 xRX
-ajO
+kqx
 xRX
 xRX
 xRX
 uLO
-qIf
+oNl
 kbX
 kzS
 kvJ
@@ -43402,14 +43421,14 @@ wyp
 kXG
 vGw
 wyp
-gyl
+myo
 bzm
 wyp
 vGw
 vGw
 vGw
 wyp
-vGR
+gyl
 odb
 wyp
 wyp
@@ -43445,7 +43464,7 @@ vGw
 wyp
 wyp
 uLO
-quJ
+qIf
 fZr
 wUa
 oKE
@@ -43656,7 +43675,7 @@ pkY
 bJj
 jhL
 xRX
-ajO
+kqx
 xRX
 wyp
 bhA
@@ -43697,7 +43716,7 @@ xRX
 xRX
 xRX
 xRX
-ajO
+kqx
 xRX
 xRX
 xRX
@@ -43913,10 +43932,10 @@ doW
 nEK
 jhL
 xRX
-ajO
+kqx
 xRX
 wyp
-nuo
+wGc
 xvT
 wyp
 xRX
@@ -43954,7 +43973,7 @@ xRX
 xRX
 xRX
 xRX
-ajO
+kqx
 xRX
 xRX
 xRX
@@ -44169,52 +44188,52 @@ ngJ
 gwl
 xZh
 jhL
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 wyp
-giQ
+qeb
 bJc
 wyp
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 wyp
 uJz
 bst
 wyp
-ajO
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
+kqx
 uwT
 uwT
 jjA
 uwT
 uwT
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 eiL
 eiL
 gSo
 eiL
 eiL
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 tRo
 tRo
 sVs
 tRo
 tRo
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
 gzr
 iHV
 kOP
@@ -44426,16 +44445,16 @@ oGU
 kMx
 jhL
 jhL
-ajO
+kqx
 aOU
 sUX
 ppp
 ppp
 ppp
 ppp
-jrC
+ayy
 kQs
-jrC
+ayy
 wtm
 rhN
 ciM
@@ -44468,7 +44487,7 @@ tRo
 tRo
 xRX
 xRX
-ajO
+kqx
 xRX
 xRX
 xRX
@@ -44683,7 +44702,7 @@ lJH
 jhL
 jhL
 aOU
-ajO
+kqx
 iGW
 wnf
 aSb
@@ -44725,7 +44744,7 @@ cMo
 tRo
 xRX
 xRX
-ajO
+kqx
 xRX
 xRX
 xRX
@@ -44734,7 +44753,7 @@ ebn
 cDf
 quS
 cQs
-asG
+sKj
 aSJ
 oxG
 xRX
@@ -44938,9 +44957,9 @@ xKt
 adF
 eqi
 uZl
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 rrT
 ntt
 sUq
@@ -44956,7 +44975,7 @@ elW
 sWG
 qVW
 vOL
-ajO
+kqx
 uwT
 dkz
 hHq
@@ -44982,7 +45001,7 @@ bxM
 tRo
 xRX
 xRX
-ajO
+kqx
 xRX
 xRX
 uLO
@@ -45197,7 +45216,7 @@ uPa
 uZl
 aOU
 aOU
-ajO
+kqx
 bcf
 aSb
 aEB
@@ -45239,10 +45258,10 @@ ieZ
 tRo
 xRX
 xRX
-ajO
+kqx
 xRX
-ayy
-ayy
+fjE
+fjE
 nZj
 ess
 lzb
@@ -45454,7 +45473,7 @@ fdV
 uZl
 uZl
 aOU
-ajO
+kqx
 rJT
 rsE
 rsE
@@ -45496,9 +45515,9 @@ uNJ
 tRo
 xRX
 xRX
-ajO
+kqx
 xRX
-ayy
+fjE
 xMA
 uWU
 oVL
@@ -45711,7 +45730,7 @@ mwO
 uoZ
 uZl
 aOU
-ajO
+kqx
 iUd
 vdX
 atI
@@ -45753,9 +45772,9 @@ lvR
 tRo
 xRX
 xRX
-ajO
+kqx
 xRX
-ayy
+fjE
 oyG
 cnH
 ess
@@ -45968,7 +45987,7 @@ kuj
 rFB
 uZl
 aOU
-ajO
+kqx
 lkK
 hZH
 kti
@@ -46225,7 +46244,7 @@ vDk
 rFB
 uZl
 aOU
-ajO
+kqx
 bcf
 aSb
 aSb
@@ -46481,8 +46500,8 @@ aEt
 ldf
 uZl
 uZl
-ajO
-ajO
+kqx
+kqx
 bcf
 sBA
 ruo
@@ -46498,7 +46517,7 @@ elW
 sWG
 cei
 vOL
-ajO
+kqx
 uwT
 vMG
 hil
@@ -46506,7 +46525,7 @@ uOr
 hil
 irq
 uwT
-ajO
+kqx
 eiL
 upC
 buI
@@ -46514,7 +46533,7 @@ hdb
 pZo
 fVv
 eiL
-ajO
+kqx
 tRo
 pDZ
 bxM
@@ -46522,8 +46541,8 @@ bxM
 bxM
 pZO
 tRo
-ajO
-ajO
+kqx
+kqx
 wjn
 qqX
 vwi
@@ -46739,7 +46758,7 @@ stV
 uZl
 aOU
 aOU
-ajO
+kqx
 aCG
 dqF
 aSb
@@ -46993,10 +47012,10 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
+kqx
+kqx
 aOU
-ajO
+kqx
 aOU
 kOK
 rfz
@@ -47037,7 +47056,7 @@ rEV
 tRo
 tRo
 xRX
-ajO
+kqx
 wjn
 wjn
 wjn
@@ -47251,50 +47270,50 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
 ibm
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
 fro
-ajO
-ajO
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
+kqx
+kqx
 uwT
 uwT
 qju
 uwT
 uwT
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 eiL
 eiL
 sal
 eiL
 eiL
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 tRo
 tRo
 raF
 tRo
 tRo
-ajO
-ajO
-ajO
+kqx
+kqx
+kqx
 xRX
 xRX
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -34,7 +34,6 @@
 /area/ship/freebooter_ship/pod7)
 "ace" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light,
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/thruster2)
 "acn" = (
@@ -135,12 +134,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ajO" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "junker_gun"
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/gunnery)
+/turf/space/dynamic,
+/area/space)
 "akg" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
@@ -150,11 +145,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
@@ -280,7 +270,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "ayy" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
+/turf/simulated/wall,
 /area/ship/freebooter_ship/gunneryentrance)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -418,10 +408,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
 "aHw" = (
@@ -542,8 +532,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aOU" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunneryentrance)
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "junker_gun"
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/gunnery)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -1347,6 +1341,12 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
+"cjX" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "clU" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
@@ -1662,6 +1662,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/engineering)
+"dqw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/forehallway)
 "dqF" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	layer = 2.71;
@@ -1815,6 +1832,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod1)
@@ -2176,9 +2198,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "ezV" = (
@@ -2490,10 +2509,18 @@
 /obj/item/rig/eva,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
+"fCC" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "fGM" = (
-/obj/structure/lattice/catwalk,
-/turf/space/dynamic,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/gunneryentrance)
+"fIO" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/medical)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -2899,10 +2926,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube_empty"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "gGE" = (
@@ -3229,6 +3252,7 @@
 	identifier = "freebooter_crew";
 	name = "igs - freebooter crew"
 	},
+/obj/machinery/light/small/emergency,
 /turf/simulated/floor{
 	icon_state = "dmg2"
 	},
@@ -3440,6 +3464,7 @@
 	identifier = "freebooter_crew";
 	name = "igs - freebooter crew"
 	},
+/obj/machinery/light/small/emergency,
 /turf/simulated/floor/carpet/magenta,
 /area/ship/freebooter_ship/pod6)
 "igB" = (
@@ -3468,11 +3493,11 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
@@ -3780,12 +3805,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
-"jfm" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "jgM" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -4207,8 +4226,9 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "kqx" = (
+/obj/structure/lattice/catwalk,
 /turf/space/dynamic,
-/area/space)
+/area/ship/freebooter_ship/exterior)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
 /obj/effect/decal/cleanable/dirt,
@@ -4672,6 +4692,11 @@
 	layer = 2.8
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/light{
+	dir = 8;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "lgM" = (
@@ -5420,6 +5445,9 @@
 	identifier = "freebooter_crew";
 	name = "igs - freebooter crew"
 	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod6)
 "mWz" = (
@@ -5489,6 +5517,9 @@
 /obj/effect/ghostspawpoint{
 	identifier = "freebooter_crew";
 	name = "igs - freebooter crew"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
 	},
 /turf/simulated/floor/carpet/art,
 /area/ship/freebooter_ship/pod1)
@@ -5822,6 +5853,7 @@
 "nVl" = (
 /obj/item/stack/tile/floor_dark,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/firealarm/north,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod1)
 "nVq" = (
@@ -5966,9 +5998,10 @@
 	},
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/power/portgen/basic,
-/obj/item/stack/material/graphite/full{
-	pixel_x = -4;
-	pixel_y = 2
+/obj/item/stack/material/graphite/full,
+/obj/structure/closet/walllocker{
+	name = "graphite locker";
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
@@ -6132,7 +6165,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
+/obj/machinery/light{
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/ammo)
 "oyG" = (
@@ -6576,11 +6612,6 @@
 /area/ship/freebooter_ship/thruster2)
 "pob" = (
 /obj/machinery/computer/ship/sensors,
-/obj/machinery/light{
-	dir = 4;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "poF" = (
@@ -6966,7 +6997,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
@@ -7411,7 +7444,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/firealarm/north,
 /obj/machinery/light{
 	dir = 1;
 	inserted_light = /obj/item/light/tube/colored/blue;
@@ -7619,17 +7651,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship)
-"rsH" = (
-/obj/machinery/cryopod,
-/obj/structure/cryofeed/pipes{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/cryo)
 "rtf" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
@@ -7992,6 +8013,17 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
+"snn" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed/pipes{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/freebooter_ship/cryo)
 "soh" = (
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/gunnery)
@@ -8799,12 +8831,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/dorms)
-"ucf" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "ufC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8877,10 +8903,6 @@
 	layer = 2.8
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube_empty"
-	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "ulo" = (
@@ -8949,9 +8971,6 @@
 	},
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
-"uCM" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/medical)
 "uDc" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/binary/pump/high_power{
@@ -9711,8 +9730,8 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "vZW" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/medical)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/forehallwayport)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/stool/chair{
@@ -9917,8 +9936,8 @@
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "wGc" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/forehallwayport)
+/turf/simulated/wall,
+/area/ship/freebooter_ship/medical)
 "wHo" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/ship_engine.dmi';
@@ -10333,21 +10352,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod5)
-"xDD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/forehallway)
 "xED" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -10471,7 +10475,9 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/ammo)
@@ -37715,7 +37721,7 @@ xRX
 xRX
 xRX
 uCl
-kqx
+ajO
 uCl
 fZq
 xRX
@@ -38229,7 +38235,7 @@ xRX
 rtf
 vUu
 uyM
-kqx
+ajO
 aHs
 xRX
 xRX
@@ -38462,17 +38468,17 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
+kqx
 eIb
 wUi
 ldw
 wUi
 eIb
-fGM
-fGM
+kqx
+kqx
 esB
 gwg
 esB
@@ -38480,32 +38486,32 @@ wHo
 esB
 gwg
 esB
-fGM
-fGM
+kqx
+kqx
 cLC
 cLC
 kwe
 tKj
 tKj
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 qiz
 qiz
 mWz
 qiz
 qiz
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 eUq
 eUq
 pRf
 eUq
 eUq
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 xRX
 xRX
 xRX
@@ -38718,8 +38724,8 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
+kqx
+kqx
 xRX
 xRX
 eIb
@@ -38762,7 +38768,7 @@ fTG
 eUq
 eUq
 xRX
-fGM
+kqx
 xqI
 xqI
 xqI
@@ -38776,7 +38782,7 @@ imE
 imE
 iOV
 iOV
-ajO
+aOU
 xRX
 xRX
 xRX
@@ -39033,7 +39039,7 @@ rjL
 tQn
 sxw
 www
-ajO
+aOU
 xRX
 xRX
 xRX
@@ -39234,8 +39240,8 @@ gFA
 ewW
 ewW
 ewW
-fGM
-fGM
+kqx
+kqx
 wUi
 syV
 bhd
@@ -39243,7 +39249,7 @@ xBh
 bhd
 tvh
 wUi
-fGM
+kqx
 gwg
 pUP
 kmP
@@ -39251,7 +39257,7 @@ qDn
 kev
 jcX
 gwg
-fGM
+kqx
 cLC
 wZf
 ttI
@@ -39259,7 +39265,7 @@ krH
 lKT
 vmX
 cLC
-fGM
+kqx
 qiz
 pYB
 bPT
@@ -39267,7 +39273,7 @@ jzk
 fRD
 buM
 qiz
-fGM
+kqx
 eUq
 aTX
 iUK
@@ -39275,8 +39281,8 @@ iUK
 iUK
 fTT
 eUq
-fGM
-fGM
+kqx
+kqx
 xqI
 ahD
 kfJ
@@ -39290,7 +39296,7 @@ fNl
 tQn
 sxw
 sxw
-ajO
+aOU
 xRX
 xRX
 xRX
@@ -39492,7 +39498,7 @@ xUb
 qWF
 ewW
 xRX
-fGM
+kqx
 wUi
 syV
 bhd
@@ -39541,13 +39547,13 @@ npb
 oxR
 tfK
 sxk
-jfm
+fCC
 soh
 soh
 aDv
 iOV
 iOV
-ajO
+aOU
 xRX
 xRX
 xRX
@@ -39749,7 +39755,7 @@ xUb
 jnK
 ewW
 xRX
-fGM
+kqx
 wUi
 syV
 grD
@@ -39799,8 +39805,8 @@ jhd
 tfK
 nwH
 wLI
-ucf
-ucf
+cjX
+cjX
 fnE
 xRX
 xRX
@@ -40006,7 +40012,7 @@ dbA
 wxS
 ewW
 xRX
-fGM
+kqx
 eIb
 oPu
 bhd
@@ -40048,7 +40054,7 @@ cEH
 eUq
 xRX
 xRX
-fGM
+kqx
 xqI
 xqI
 tfK
@@ -40263,7 +40269,7 @@ ewW
 ewW
 ewW
 xRX
-fGM
+kqx
 wUi
 cLL
 bhd
@@ -40305,13 +40311,13 @@ avE
 eUq
 xRX
 xRX
-fGM
+kqx
 xRX
-ayy
+fGM
 rEb
 xTu
 cbE
-aOU
+ayy
 klp
 llD
 euj
@@ -40520,7 +40526,7 @@ acn
 ewW
 xRX
 xRX
-fGM
+kqx
 wUi
 glJ
 ihN
@@ -40562,10 +40568,10 @@ hIE
 eUq
 xRX
 xRX
-fGM
+kqx
 xRX
-ayy
-ayy
+fGM
+fGM
 jgM
 vVy
 aMQ
@@ -40777,7 +40783,7 @@ pHN
 ewW
 xRX
 xRX
-fGM
+kqx
 wUi
 wNA
 bhd
@@ -40819,13 +40825,13 @@ iUK
 eUq
 xRX
 xRX
+kqx
+xRX
+xRX
 fGM
-xRX
-xRX
-ayy
-ayy
+fGM
 tmo
-aOU
+ayy
 mwo
 mwo
 mwo
@@ -41034,7 +41040,7 @@ lJH
 jhL
 jhL
 xRX
-fGM
+kqx
 wUi
 peJ
 bhd
@@ -41076,18 +41082,18 @@ mtT
 eUq
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 xRX
 uLO
 ebn
 atj
-vZW
+wGc
 exg
 iGK
 aBD
-uCM
+fIO
 xRX
 xRX
 xRX
@@ -41291,7 +41297,7 @@ pCG
 iZM
 jhL
 jhL
-fGM
+kqx
 eIb
 eIb
 pPk
@@ -41333,7 +41339,7 @@ eUq
 eUq
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 xRX
@@ -41344,7 +41350,7 @@ jLL
 aab
 qDe
 nVi
-uCM
+fIO
 saW
 xRX
 xRX
@@ -41548,61 +41554,61 @@ mhq
 tcY
 rfn
 jhL
-fGM
-fGM
+kqx
+kqx
 eIb
 eIb
 qEc
 eIb
 eIb
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 gwg
 wzO
 dXK
 wzO
 gwg
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 cLC
 cLC
 mbX
 cLC
 cLC
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 qiz
 qiz
 dFi
 qiz
 qiz
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 eUq
 eUq
 wRc
 eUq
 eUq
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
 pvm
 kou
 dWF
-vZW
+wGc
 gLO
 npJ
 kAt
 lpe
-uCM
+fIO
 xRX
 xRX
 xRX
@@ -41806,7 +41812,7 @@ jbh
 tYn
 jhL
 xRX
-fGM
+kqx
 xRX
 wyp
 mGn
@@ -41847,19 +41853,19 @@ xRX
 xRX
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 xRX
 pvm
 vfD
 kOP
-vZW
-vZW
+wGc
+wGc
 tra
-uCM
-vZW
-uCM
+fIO
+wGc
+fIO
 ydf
 ewy
 ewy
@@ -42063,7 +42069,7 @@ rRa
 nKC
 jhL
 xRX
-fGM
+kqx
 xRX
 wyp
 mGn
@@ -42104,7 +42110,7 @@ xRX
 xRX
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 xRX
@@ -43394,7 +43400,7 @@ vGw
 wyp
 wyp
 uLO
-xDD
+dqw
 fZr
 wUa
 oKE
@@ -43604,9 +43610,9 @@ bBW
 pkY
 bJj
 jhL
+xRX
 kqx
-fGM
-kqx
+xRX
 wyp
 bhA
 xQS
@@ -43646,7 +43652,7 @@ xRX
 xRX
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 xRX
@@ -43861,9 +43867,9 @@ rpZ
 doW
 nEK
 jhL
+xRX
 kqx
-fGM
-kqx
+xRX
 wyp
 vDD
 xvT
@@ -43903,7 +43909,7 @@ xRX
 xRX
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 xRX
@@ -44118,52 +44124,52 @@ ngJ
 gwl
 xZh
 jhL
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 wyp
 uJz
 bJc
 wyp
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 wyp
 uJz
 bst
 wyp
-fGM
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
+kqx
 uwT
 uwT
 jjA
 uwT
 uwT
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 eiL
 eiL
 gSo
 eiL
 eiL
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 tRo
 tRo
 sVs
 tRo
 tRo
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
 gzr
 iHV
 kOP
@@ -44375,8 +44381,8 @@ oGU
 kMx
 jhL
 jhL
-fGM
 kqx
+ajO
 sUX
 ppp
 ppp
@@ -44390,8 +44396,8 @@ rhN
 ciM
 rhN
 rmm
-kqx
-kqx
+ajO
+ajO
 uwT
 uwT
 lgM
@@ -44417,7 +44423,7 @@ tRo
 tRo
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 xRX
@@ -44631,8 +44637,8 @@ aEa
 lJH
 jhL
 jhL
+ajO
 kqx
-fGM
 iGW
 wnf
 aSb
@@ -44648,7 +44654,7 @@ iQg
 clU
 nKq
 rmm
-kqx
+ajO
 htS
 lfg
 jFY
@@ -44674,7 +44680,7 @@ cMo
 tRo
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 xRX
@@ -44683,7 +44689,7 @@ ebn
 cDf
 quS
 cQs
-rsH
+snn
 aSJ
 oxG
 xRX
@@ -44887,9 +44893,9 @@ xKt
 adF
 eqi
 uZl
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 rrT
 ntt
 sUq
@@ -44905,7 +44911,7 @@ elW
 sWG
 qVW
 vOL
-fGM
+kqx
 uwT
 dkz
 hHq
@@ -44931,7 +44937,7 @@ bxM
 tRo
 xRX
 xRX
-fGM
+kqx
 xRX
 xRX
 uLO
@@ -45144,9 +45150,9 @@ mOF
 qED
 uPa
 uZl
+ajO
+ajO
 kqx
-kqx
-fGM
 bcf
 aSb
 aEB
@@ -45162,7 +45168,7 @@ eqD
 aSb
 qeJ
 vOL
-kqx
+ajO
 uwT
 oZH
 pZI
@@ -45188,10 +45194,10 @@ ieZ
 tRo
 xRX
 xRX
-fGM
+kqx
 xRX
-wGc
-wGc
+vZW
+vZW
 nZj
 ess
 lzb
@@ -45402,8 +45408,8 @@ bpj
 fdV
 uZl
 uZl
+ajO
 kqx
-fGM
 rJT
 rsE
 rsE
@@ -45419,7 +45425,7 @@ afL
 sVT
 oSp
 vOL
-kqx
+ajO
 uwT
 bDX
 mCb
@@ -45445,9 +45451,9 @@ uNJ
 tRo
 xRX
 xRX
-fGM
+kqx
 xRX
-wGc
+vZW
 xMA
 uWU
 oVL
@@ -45659,8 +45665,8 @@ ieM
 mwO
 uoZ
 uZl
+ajO
 kqx
-fGM
 iUd
 vdX
 atI
@@ -45676,7 +45682,7 @@ tcV
 rXx
 cJt
 vOL
-kqx
+ajO
 uwT
 fYr
 lGK
@@ -45702,9 +45708,9 @@ lvR
 tRo
 xRX
 xRX
-fGM
+kqx
 xRX
-wGc
+vZW
 oyG
 cnH
 ess
@@ -45916,8 +45922,8 @@ mCl
 kuj
 rFB
 uZl
+ajO
 kqx
-fGM
 lkK
 hZH
 kti
@@ -45933,7 +45939,7 @@ kTf
 bzW
 hhA
 vOL
-kqx
+ajO
 uwT
 cgU
 hhQ
@@ -46173,8 +46179,8 @@ uiV
 vDk
 rFB
 uZl
+ajO
 kqx
-fGM
 bcf
 aSb
 aSb
@@ -46190,7 +46196,7 @@ tDp
 aSb
 hhA
 vOL
-kqx
+ajO
 uwT
 cgU
 onn
@@ -46430,8 +46436,8 @@ aEt
 ldf
 uZl
 uZl
-fGM
-fGM
+kqx
+kqx
 bcf
 sBA
 ruo
@@ -46447,7 +46453,7 @@ elW
 sWG
 cei
 vOL
-fGM
+kqx
 uwT
 vMG
 hil
@@ -46455,7 +46461,7 @@ uOr
 hil
 irq
 uwT
-fGM
+kqx
 eiL
 upC
 buI
@@ -46463,7 +46469,7 @@ hdb
 pZo
 fVv
 eiL
-fGM
+kqx
 tRo
 pDZ
 bxM
@@ -46471,8 +46477,8 @@ bxM
 bxM
 pZO
 tRo
-fGM
-fGM
+kqx
+kqx
 wjn
 qqX
 vwi
@@ -46686,9 +46692,9 @@ uZl
 osl
 stV
 uZl
+ajO
+ajO
 kqx
-kqx
-fGM
 aCG
 dqF
 aSb
@@ -46704,7 +46710,7 @@ rhN
 rhN
 mYn
 tOu
-kqx
+ajO
 htS
 hXO
 uwA
@@ -46942,11 +46948,11 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
 kqx
-fGM
 kqx
+ajO
+kqx
+ajO
 kOK
 rfz
 rfz
@@ -46960,8 +46966,8 @@ vTv
 vTv
 vTv
 tOu
-kqx
-kqx
+ajO
+ajO
 uwT
 uwT
 nti
@@ -46986,7 +46992,7 @@ rEV
 tRo
 tRo
 xRX
-fGM
+kqx
 wjn
 wjn
 wjn
@@ -47200,50 +47206,50 @@ xRX
 xRX
 xRX
 xRX
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
 ibm
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
+kqx
 fro
-fGM
-fGM
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
+kqx
+kqx
 uwT
 uwT
 qju
 uwT
 uwT
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 eiL
 eiL
 sal
 eiL
 eiL
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 tRo
 tRo
 raF
 tRo
 tRo
-fGM
-fGM
-fGM
+kqx
+kqx
+kqx
 xRX
 xRX
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -4742,6 +4742,9 @@
 	layer = 2.8
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "lgM" = (
@@ -6077,11 +6080,6 @@
 	},
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/power/portgen/basic,
-/obj/item/stack/material/graphite/full,
-/obj/structure/closet/walllocker{
-	name = "graphite locker";
-	pixel_y = 32
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
@@ -8909,9 +8907,10 @@
 	dir = 8
 	},
 /obj/structure/closet/walllocker{
-	name = "tritium locker";
+	name = "graphite locker";
 	pixel_y = 32
 	},
+/obj/item/stack/material/graphite/full,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "uaE" = (
@@ -9667,6 +9666,14 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
+"vGR" = (
+/obj/machinery/ship_weapon/blaster{
+	pixel_y = -195;
+	pixel_x = -24;
+	weapon_id = "Freebooter Ship Blaster"
+	},
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunnery)
 "vHQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/structure/curtain/open/bed{
@@ -9742,14 +9749,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/forehallway)
-"vPP" = (
-/obj/machinery/ship_weapon/blaster{
-	pixel_y = -195;
-	pixel_x = -24;
-	weapon_id = "Freebooter Ship Blaster"
-	},
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunnery)
 "vRc" = (
 /obj/item/ammo_casing/rifle/used{
 	pixel_y = 4
@@ -40985,7 +40984,7 @@ tmo
 dlZ
 mwo
 mwo
-vPP
+vGR
 imE
 imE
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -34,6 +34,7 @@
 /area/ship/freebooter_ship/pod7)
 "ace" = (
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/light,
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/thruster2)
 "acn" = (
@@ -80,8 +81,10 @@
 	name = "airlock_freebooter_shuttle";
 	shuttle_tag = "Freebooter Shuttle"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/map_effect/marker_helper/airlock/out,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "ahD" = (
@@ -132,9 +135,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ajO" = (
-/obj/structure/lattice/catwalk,
-/turf/space/dynamic,
-/area/ship/freebooter_ship/exterior)
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "junker_gun"
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/gunnery)
 "akg" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
@@ -274,19 +280,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "ayy" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/gunneryentrance)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -317,8 +312,9 @@
 /obj/effect/floor_decal/corner_wide/paleblue/full,
 /obj/item/reagent_containers/food/drinks/bottle/vodka{
 	pixel_x = 12;
-	pixel_y = 8
+	pixel_y = 4
 	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/medical)
 "aCG" = (
@@ -546,8 +542,8 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aOU" = (
-/turf/space/dynamic,
-/area/space)
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunneryentrance)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -675,7 +671,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/ammo)
 "aVH" = (
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -688,6 +683,9 @@
 /obj/machinery/door/airlock/security{
 	name = "Ship Armament Ammo Storage";
 	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/ammo)
@@ -900,12 +898,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -1264,6 +1262,11 @@
 "bWt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/freebooter_shuttle)
 "caS" = (
@@ -1290,6 +1293,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/south,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunneryentrance)
 "cei" = (
@@ -1520,6 +1524,7 @@
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
 	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/cryo)
 "cVA" = (
@@ -2059,13 +2064,13 @@
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_freebooter_shuttle";
 	name = "airlock_freebooter_shuttle";
 	shuttle_tag = "Freebooter Shuttle"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -2171,6 +2176,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "ezV" = (
@@ -2306,16 +2314,17 @@
 	dir = 10
 	},
 /obj/machinery/button/remote/blast_door{
-	pixel_y = -32;
-	pixel_x = 6;
+	pixel_y = -23;
+	pixel_x = 5;
 	id = "pirate_core_shunt"
 	},
 /obj/machinery/button/mass_driver{
 	_wifi_id = "pirate_core_driver";
 	id = "pirate_core_driver";
 	layer = 3.2;
-	pixel_y = -32;
-	pixel_x = -6
+	pixel_y = -24;
+	pixel_x = -7;
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
@@ -2396,9 +2405,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
-/obj/machinery/light/small/emergency{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/hydrogen,
 /turf/simulated/floor/tiled/dark,
@@ -2485,12 +2491,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fGM" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "junker_gun"
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/gunnery)
+/obj/structure/lattice/catwalk,
+/turf/space/dynamic,
+/area/ship/freebooter_ship/exterior)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -2730,9 +2733,7 @@
 /obj/item/ship_ammunition/blaster,
 /obj/item/ship_ammunition/blaster,
 /obj/item/ship_ammunition/blaster,
-/obj/machinery/light/small/emergency{
-	dir = 4
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/ammo)
 "glJ" = (
@@ -2895,12 +2896,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
 "gFA" = (
-/obj/machinery/light/small/emergency{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster1)
 "gGE" = (
@@ -2960,6 +2962,7 @@
 /obj/structure/sign/poster{
 	pixel_y = -32
 	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/dorms)
 "gSo" = (
@@ -3777,6 +3780,12 @@
 /obj/structure/cable,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
+"jfm" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "jgM" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -3843,8 +3852,19 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "jrC" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/gunneryentrance)
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "jvN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -4022,17 +4042,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod1)
-"jZO" = (
-/obj/machinery/cryopod,
-/obj/structure/cryofeed/pipes{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/cryo)
 "jZY" = (
 /obj/structure/railing/mapped,
 /obj/machinery/iff_beacon/name_change,
@@ -4198,8 +4207,8 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "kqx" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/forehallwayport)
+/turf/space/dynamic,
+/area/space)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
 /obj/effect/decal/cleanable/dirt,
@@ -4434,11 +4443,6 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/forehallway)
@@ -4867,9 +4871,6 @@
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_freebooter_shuttle";
 	name = "airlock_freebooter_shuttle";
@@ -4877,6 +4878,9 @@
 	},
 /obj/structure/sign/vacuum{
 	pixel_y = 30
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -5553,9 +5557,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod4)
-"now" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunneryentrance)
 "npb" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -5678,7 +5679,6 @@
 /area/ship/freebooter_ship/pod1)
 "nwH" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/power/apc/north{
@@ -5901,6 +5901,7 @@
 /obj/machinery/alarm/west{
 	req_one_access = null
 	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallwayport)
 "oaH" = (
@@ -6131,6 +6132,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/ammo)
 "oyG" = (
@@ -6685,6 +6687,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/north,
+/obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/head)
 "pAh" = (
@@ -6757,6 +6760,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
 "pEN" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 8
 	},
@@ -6772,6 +6778,10 @@
 "pHN" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light{
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "pMN" = (
@@ -6955,6 +6965,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
 "qej" = (
@@ -7064,6 +7077,11 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4;
+	inserted_light = /obj/item/light/tube/colored/blue;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/freebooter_shuttle)
 "qoJ" = (
@@ -7350,6 +7368,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/forehallway)
 "qMB" = (
@@ -7600,6 +7619,17 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship)
+"rsH" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed/pipes{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/freebooter_ship/cryo)
 "rtf" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
@@ -7730,12 +7760,7 @@
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
-/obj/machinery/power/apc/north{
-	req_access = null
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunneryentrance)
 "rEr" = (
@@ -8068,7 +8093,6 @@
 "sxk" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
 "sxw" = (
@@ -8336,9 +8360,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_freebooter_shuttle";
 	name = "airlock_freebooter_shuttle";
@@ -8348,6 +8369,9 @@
 	dir = 4;
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -8395,10 +8419,13 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/firealarm/north,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/lockers)
 "tmo" = (
-/obj/machinery/door/firedoor/noid,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -8421,7 +8448,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
 "tra" = (
-/obj/machinery/door/firedoor/noid,
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -8479,17 +8508,18 @@
 /area/shuttle/freebooter_shuttle)
 "tuT" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing/mapped{
 	icon_state = "railing0-0";
 	density = 0
 	},
 /obj/item/storage/toolbox/mechanical{
-	pixel_y = -5
+	pixel_y = 5;
+	pixel_x = -4
 	},
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
+/obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
 "tvh" = (
@@ -8769,6 +8799,12 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/dorms)
+"ucf" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "ufC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8841,6 +8877,10 @@
 	layer = 2.8
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube_empty"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "ulo" = (
@@ -8862,6 +8902,7 @@
 "uoZ" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/closet/radiation,
+/obj/machinery/light,
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/thruster2)
 "upC" = (
@@ -8908,6 +8949,9 @@
 	},
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
+"uCM" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/medical)
 "uDc" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/binary/pump/high_power{
@@ -9328,10 +9372,10 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/light/small/emergency{
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/thruster2)
 "viT" = (
@@ -9459,9 +9503,6 @@
 /area/ship/freebooter_ship/thruster2)
 "vDD" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
@@ -9470,6 +9511,9 @@
 	dir = 2;
 	pixel_y = 28;
 	pixel_x = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -9874,7 +9918,7 @@
 /area/ship/freebooter_ship/exterior)
 "wGc" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/medical)
+/area/ship/freebooter_ship/forehallwayport)
 "wHo" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/ship_engine.dmi';
@@ -9925,6 +9969,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 5
 	},
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/gunnery)
@@ -10098,9 +10146,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_freebooter_shuttle";
 	name = "airlock_freebooter_shuttle";
@@ -10108,6 +10153,9 @@
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	pixel_x = 23;
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -10182,6 +10230,9 @@
 /obj/machinery/ammunition_loader/blaster{
 	weapon_id = "Freebooter Ship Blaster"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/gunnery)
 "xqI" = (
@@ -10235,16 +10286,17 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/machinery/firealarm/west,
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/closet)
 "xvT" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/foyer)
@@ -10281,6 +10333,21 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod5)
+"xDD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/forehallway)
 "xED" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -10327,8 +10394,10 @@
 "xKj" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/effect/floor_decal/industrial/warning,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
 "xKt" = (
@@ -10401,6 +10470,9 @@
 /obj/structure/barricade/wooden{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/ammo)
 "xRX" = (
@@ -10421,9 +10493,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunneryentrance)
@@ -37646,7 +37715,7 @@ xRX
 xRX
 xRX
 uCl
-xRX
+kqx
 uCl
 fZq
 xRX
@@ -38160,7 +38229,7 @@ xRX
 rtf
 vUu
 uyM
-xRX
+kqx
 aHs
 xRX
 xRX
@@ -38393,17 +38462,17 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
+fGM
 eIb
 wUi
 ldw
 wUi
 eIb
-ajO
-ajO
+fGM
+fGM
 esB
 gwg
 esB
@@ -38411,32 +38480,32 @@ wHo
 esB
 gwg
 esB
-ajO
-ajO
+fGM
+fGM
 cLC
 cLC
 kwe
 tKj
 tKj
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 qiz
 qiz
 mWz
 qiz
 qiz
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 eUq
 eUq
 pRf
 eUq
 eUq
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 xRX
 xRX
 xRX
@@ -38649,8 +38718,8 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
+fGM
+fGM
 xRX
 xRX
 eIb
@@ -38693,7 +38762,7 @@ fTG
 eUq
 eUq
 xRX
-ajO
+fGM
 xqI
 xqI
 xqI
@@ -38707,7 +38776,7 @@ imE
 imE
 iOV
 iOV
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -38964,7 +39033,7 @@ rjL
 tQn
 sxw
 www
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -39165,8 +39234,8 @@ gFA
 ewW
 ewW
 ewW
-ajO
-ajO
+fGM
+fGM
 wUi
 syV
 bhd
@@ -39174,7 +39243,7 @@ xBh
 bhd
 tvh
 wUi
-ajO
+fGM
 gwg
 pUP
 kmP
@@ -39182,7 +39251,7 @@ qDn
 kev
 jcX
 gwg
-ajO
+fGM
 cLC
 wZf
 ttI
@@ -39190,7 +39259,7 @@ krH
 lKT
 vmX
 cLC
-ajO
+fGM
 qiz
 pYB
 bPT
@@ -39198,7 +39267,7 @@ jzk
 fRD
 buM
 qiz
-ajO
+fGM
 eUq
 aTX
 iUK
@@ -39206,8 +39275,8 @@ iUK
 iUK
 fTT
 eUq
-ajO
-ajO
+fGM
+fGM
 xqI
 ahD
 kfJ
@@ -39221,7 +39290,7 @@ fNl
 tQn
 sxw
 sxw
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -39423,7 +39492,7 @@ xUb
 qWF
 ewW
 xRX
-ajO
+fGM
 wUi
 syV
 bhd
@@ -39472,13 +39541,13 @@ npb
 oxR
 tfK
 sxk
-soh
+jfm
 soh
 soh
 aDv
 iOV
 iOV
-fGM
+ajO
 xRX
 xRX
 xRX
@@ -39680,7 +39749,7 @@ xUb
 jnK
 ewW
 xRX
-ajO
+fGM
 wUi
 syV
 grD
@@ -39730,8 +39799,8 @@ jhd
 tfK
 nwH
 wLI
-soh
-soh
+ucf
+ucf
 fnE
 xRX
 xRX
@@ -39937,7 +40006,7 @@ dbA
 wxS
 ewW
 xRX
-ajO
+fGM
 eIb
 oPu
 bhd
@@ -39979,7 +40048,7 @@ cEH
 eUq
 xRX
 xRX
-ajO
+fGM
 xqI
 xqI
 tfK
@@ -40194,7 +40263,7 @@ ewW
 ewW
 ewW
 xRX
-ajO
+fGM
 wUi
 cLL
 bhd
@@ -40236,13 +40305,13 @@ avE
 eUq
 xRX
 xRX
-ajO
+fGM
 xRX
-jrC
+ayy
 rEb
 xTu
 cbE
-now
+aOU
 klp
 llD
 euj
@@ -40451,7 +40520,7 @@ acn
 ewW
 xRX
 xRX
-ajO
+fGM
 wUi
 glJ
 ihN
@@ -40493,10 +40562,10 @@ hIE
 eUq
 xRX
 xRX
-ajO
+fGM
 xRX
-jrC
-jrC
+ayy
+ayy
 jgM
 vVy
 aMQ
@@ -40708,7 +40777,7 @@ pHN
 ewW
 xRX
 xRX
-ajO
+fGM
 wUi
 wNA
 bhd
@@ -40750,13 +40819,13 @@ iUK
 eUq
 xRX
 xRX
-ajO
+fGM
 xRX
 xRX
-jrC
-jrC
+ayy
+ayy
 tmo
-now
+aOU
 mwo
 mwo
 mwo
@@ -40965,7 +41034,7 @@ lJH
 jhL
 jhL
 xRX
-ajO
+fGM
 wUi
 peJ
 bhd
@@ -41007,7 +41076,7 @@ mtT
 eUq
 xRX
 xRX
-ajO
+fGM
 xRX
 xRX
 xRX
@@ -41018,7 +41087,7 @@ vZW
 exg
 iGK
 aBD
-wGc
+uCM
 xRX
 xRX
 xRX
@@ -41222,7 +41291,7 @@ pCG
 iZM
 jhL
 jhL
-ajO
+fGM
 eIb
 eIb
 pPk
@@ -41264,7 +41333,7 @@ eUq
 eUq
 xRX
 xRX
-ajO
+fGM
 xRX
 xRX
 xRX
@@ -41275,7 +41344,7 @@ jLL
 aab
 qDe
 nVi
-wGc
+uCM
 saW
 xRX
 xRX
@@ -41479,52 +41548,52 @@ mhq
 tcY
 rfn
 jhL
-ajO
-ajO
+fGM
+fGM
 eIb
 eIb
 qEc
 eIb
 eIb
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 gwg
 wzO
 dXK
 wzO
 gwg
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 cLC
 cLC
 mbX
 cLC
 cLC
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 qiz
 qiz
 dFi
 qiz
 qiz
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 eUq
 eUq
 wRc
 eUq
 eUq
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
 pvm
 kou
 dWF
@@ -41533,7 +41602,7 @@ gLO
 npJ
 kAt
 lpe
-wGc
+uCM
 xRX
 xRX
 xRX
@@ -41737,7 +41806,7 @@ jbh
 tYn
 jhL
 xRX
-ajO
+fGM
 xRX
 wyp
 mGn
@@ -41778,7 +41847,7 @@ xRX
 xRX
 xRX
 xRX
-ajO
+fGM
 xRX
 xRX
 xRX
@@ -41788,9 +41857,9 @@ kOP
 vZW
 vZW
 tra
-wGc
+uCM
 vZW
-wGc
+uCM
 ydf
 ewy
 ewy
@@ -41994,7 +42063,7 @@ rRa
 nKC
 jhL
 xRX
-ajO
+fGM
 xRX
 wyp
 mGn
@@ -42035,7 +42104,7 @@ xRX
 xRX
 xRX
 xRX
-ajO
+fGM
 xRX
 xRX
 xRX
@@ -43325,7 +43394,7 @@ vGw
 wyp
 wyp
 uLO
-qIf
+xDD
 fZr
 wUa
 oKE
@@ -43535,9 +43604,9 @@ bBW
 pkY
 bJj
 jhL
-aOU
-ajO
-aOU
+kqx
+fGM
+kqx
 wyp
 bhA
 xQS
@@ -43577,7 +43646,7 @@ xRX
 xRX
 xRX
 xRX
-ajO
+fGM
 xRX
 xRX
 xRX
@@ -43792,9 +43861,9 @@ rpZ
 doW
 nEK
 jhL
-aOU
-ajO
-aOU
+kqx
+fGM
+kqx
 wyp
 vDD
 xvT
@@ -43834,7 +43903,7 @@ xRX
 xRX
 xRX
 xRX
-ajO
+fGM
 xRX
 xRX
 xRX
@@ -44049,52 +44118,52 @@ ngJ
 gwl
 xZh
 jhL
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 wyp
 uJz
 bJc
 wyp
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 wyp
 uJz
 bst
 wyp
-ajO
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
+fGM
 uwT
 uwT
 jjA
 uwT
 uwT
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 eiL
 eiL
 gSo
 eiL
 eiL
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 tRo
 tRo
 sVs
 tRo
 tRo
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
 gzr
 iHV
 kOP
@@ -44306,23 +44375,23 @@ oGU
 kMx
 jhL
 jhL
-ajO
-aOU
+fGM
+kqx
 sUX
 ppp
 ppp
 ppp
 ppp
-ayy
+jrC
 kQs
-ayy
+jrC
 wtm
 rhN
 ciM
 rhN
 rmm
-aOU
-aOU
+kqx
+kqx
 uwT
 uwT
 lgM
@@ -44348,7 +44417,7 @@ tRo
 tRo
 xRX
 xRX
-ajO
+fGM
 xRX
 xRX
 xRX
@@ -44562,8 +44631,8 @@ aEa
 lJH
 jhL
 jhL
-aOU
-ajO
+kqx
+fGM
 iGW
 wnf
 aSb
@@ -44579,7 +44648,7 @@ iQg
 clU
 nKq
 rmm
-aOU
+kqx
 htS
 lfg
 jFY
@@ -44605,7 +44674,7 @@ cMo
 tRo
 xRX
 xRX
-ajO
+fGM
 xRX
 xRX
 xRX
@@ -44614,7 +44683,7 @@ ebn
 cDf
 quS
 cQs
-jZO
+rsH
 aSJ
 oxG
 xRX
@@ -44818,9 +44887,9 @@ xKt
 adF
 eqi
 uZl
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 rrT
 ntt
 sUq
@@ -44836,7 +44905,7 @@ elW
 sWG
 qVW
 vOL
-ajO
+fGM
 uwT
 dkz
 hHq
@@ -44862,7 +44931,7 @@ bxM
 tRo
 xRX
 xRX
-ajO
+fGM
 xRX
 xRX
 uLO
@@ -45075,9 +45144,9 @@ mOF
 qED
 uPa
 uZl
-aOU
-aOU
-ajO
+kqx
+kqx
+fGM
 bcf
 aSb
 aEB
@@ -45093,7 +45162,7 @@ eqD
 aSb
 qeJ
 vOL
-aOU
+kqx
 uwT
 oZH
 pZI
@@ -45119,10 +45188,10 @@ ieZ
 tRo
 xRX
 xRX
-ajO
+fGM
 xRX
-kqx
-kqx
+wGc
+wGc
 nZj
 ess
 lzb
@@ -45333,8 +45402,8 @@ bpj
 fdV
 uZl
 uZl
-aOU
-ajO
+kqx
+fGM
 rJT
 rsE
 rsE
@@ -45350,7 +45419,7 @@ afL
 sVT
 oSp
 vOL
-aOU
+kqx
 uwT
 bDX
 mCb
@@ -45376,9 +45445,9 @@ uNJ
 tRo
 xRX
 xRX
-ajO
+fGM
 xRX
-kqx
+wGc
 xMA
 uWU
 oVL
@@ -45590,8 +45659,8 @@ ieM
 mwO
 uoZ
 uZl
-aOU
-ajO
+kqx
+fGM
 iUd
 vdX
 atI
@@ -45607,7 +45676,7 @@ tcV
 rXx
 cJt
 vOL
-aOU
+kqx
 uwT
 fYr
 lGK
@@ -45633,9 +45702,9 @@ lvR
 tRo
 xRX
 xRX
-ajO
+fGM
 xRX
-kqx
+wGc
 oyG
 cnH
 ess
@@ -45847,8 +45916,8 @@ mCl
 kuj
 rFB
 uZl
-aOU
-ajO
+kqx
+fGM
 lkK
 hZH
 kti
@@ -45864,7 +45933,7 @@ kTf
 bzW
 hhA
 vOL
-aOU
+kqx
 uwT
 cgU
 hhQ
@@ -46104,8 +46173,8 @@ uiV
 vDk
 rFB
 uZl
-aOU
-ajO
+kqx
+fGM
 bcf
 aSb
 aSb
@@ -46121,7 +46190,7 @@ tDp
 aSb
 hhA
 vOL
-aOU
+kqx
 uwT
 cgU
 onn
@@ -46361,8 +46430,8 @@ aEt
 ldf
 uZl
 uZl
-ajO
-ajO
+fGM
+fGM
 bcf
 sBA
 ruo
@@ -46378,7 +46447,7 @@ elW
 sWG
 cei
 vOL
-ajO
+fGM
 uwT
 vMG
 hil
@@ -46386,7 +46455,7 @@ uOr
 hil
 irq
 uwT
-ajO
+fGM
 eiL
 upC
 buI
@@ -46394,7 +46463,7 @@ hdb
 pZo
 fVv
 eiL
-ajO
+fGM
 tRo
 pDZ
 bxM
@@ -46402,8 +46471,8 @@ bxM
 bxM
 pZO
 tRo
-ajO
-ajO
+fGM
+fGM
 wjn
 qqX
 vwi
@@ -46617,9 +46686,9 @@ uZl
 osl
 stV
 uZl
-aOU
-aOU
-ajO
+kqx
+kqx
+fGM
 aCG
 dqF
 aSb
@@ -46635,7 +46704,7 @@ rhN
 rhN
 mYn
 tOu
-aOU
+kqx
 htS
 hXO
 uwA
@@ -46873,11 +46942,11 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
-aOU
-ajO
-aOU
+fGM
+fGM
+kqx
+fGM
+kqx
 kOK
 rfz
 rfz
@@ -46891,8 +46960,8 @@ vTv
 vTv
 vTv
 tOu
-aOU
-aOU
+kqx
+kqx
 uwT
 uwT
 nti
@@ -46917,7 +46986,7 @@ rEV
 tRo
 tRo
 xRX
-ajO
+fGM
 wjn
 wjn
 wjn
@@ -47131,50 +47200,50 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
 ibm
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
+fGM
 fro
-ajO
-ajO
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
+fGM
+fGM
 uwT
 uwT
 qju
 uwT
 uwT
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 eiL
 eiL
 sal
 eiL
 eiL
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 tRo
 tRo
 raF
 tRo
 tRo
-ajO
-ajO
-ajO
+fGM
+fGM
+fGM
 xRX
 xRX
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -3372,9 +3372,6 @@
 /area/ship/freebooter_ship/pod4)
 "hQd" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/effect/map_effect/marker/airlock{
 	name = "freebooter_port_2";
 	master_tag = "freebooter_port_2"

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -679,6 +679,13 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
+"aZC" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "baj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/walnut,
@@ -3019,6 +3026,12 @@
 /obj/machinery/firealarm/west,
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/dorms)
+"gPS" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/firealarm/east,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster1)
 "gSo" = (
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4117,6 +4130,13 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/lockers)
+"jTM" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster1)
 "jUk" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
@@ -4719,9 +4739,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "lfg" = (
@@ -5146,7 +5163,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
-/obj/machinery/firealarm/east,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "mbg" = (
@@ -5781,6 +5797,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod6)
+"nuX" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/machinery/firealarm/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "nwD" = (
 /obj/effect/floor_decal/corner{
 	dir = 8
@@ -7167,9 +7189,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "qiz" = (
@@ -7697,6 +7716,10 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship/exterior)
+"rmr" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster1)
 "rnp" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 9
@@ -8521,7 +8544,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/west,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster1)
 "tcV" = (
@@ -8565,7 +8587,7 @@
 /obj/machinery/alarm/west{
 	req_one_access = null
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/thruster2)
 "tld" = (
 /obj/structure/table/steel,
@@ -9367,6 +9389,10 @@
 "vdX" = (
 /turf/simulated/floor/airless,
 /area/ship/freebooter_ship)
+"vec" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/turf/simulated/floor/plating,
+/area/ship/freebooter_ship/thruster2)
 "veq" = (
 /obj/effect/floor_decal/corner/red/full{
 	dir = 4
@@ -39123,7 +39149,7 @@ xRX
 xRX
 xRX
 xRX
-xRX
+ewW
 ewW
 ewW
 ewW
@@ -39380,9 +39406,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
 vkx
 aKs
+rmr
 tcI
 plx
 foU
@@ -39637,9 +39663,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
 vkx
 ugG
+jTM
 lfb
 plx
 pfE
@@ -39894,9 +39920,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
 hPM
 qwx
+rmr
 jGn
 plx
 wMd
@@ -40151,9 +40177,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
 vkx
 xPD
+gPS
 kCv
 wRm
 jvN
@@ -40408,7 +40434,7 @@ xRX
 xRX
 xRX
 xRX
-xRX
+ewW
 ewW
 ewW
 ewW
@@ -45548,7 +45574,7 @@ xRX
 xRX
 xRX
 xRX
-xRX
+uZl
 uZl
 uZl
 uZl
@@ -45805,9 +45831,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
 vFo
 nXu
+nuX
 tjz
 pvL
 vhv
@@ -46062,9 +46088,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
 icO
 joM
+vec
 jlr
 rXk
 tYU
@@ -46319,9 +46345,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
 vFo
 joM
+aZC
 qgY
 rXk
 lqh
@@ -46576,9 +46602,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
 vFo
 aKF
+vec
 lUK
 rXk
 ofb
@@ -46833,7 +46859,7 @@ xRX
 xRX
 xRX
 xRX
-xRX
+uZl
 uZl
 uZl
 uZl

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -133,9 +133,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "ajO" = (
-/obj/structure/lattice/catwalk,
-/turf/space/dynamic,
-/area/ship/freebooter_ship/exterior)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "akg" = (
 /obj/structure/sign/poster{
 	pixel_y = 32
@@ -164,6 +166,13 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/engineering)
+"anz" = (
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "junker_gun"
+	},
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/gunnery)
 "aok" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -270,21 +279,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/foyer)
 "ayy" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
+/turf/simulated/floor/airless,
+/area/ship/freebooter_ship/exterior)
 "aAs" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -545,8 +552,9 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
 "aOU" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/forehallwayport)
+/obj/structure/lattice/catwalk,
+/turf/space/dynamic,
+/area/ship/freebooter_ship/exterior)
 "aQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -1266,6 +1274,19 @@
 	icon_state = "dmg4"
 	},
 /area/ship/freebooter_ship/ammo)
+"bUy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm/north,
+/turf/simulated/floor/tiled/dark,
+/area/ship/freebooter_ship/forehallway)
 "bWt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/decal/cleanable/dirt,
@@ -2176,6 +2197,22 @@
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/medical)
+"ezi" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
+/obj/machinery/access_button{
+	pixel_x = -8;
+	pixel_y = 28;
+	dir = 8
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "ezT" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
@@ -2374,6 +2411,17 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod7)
+"fjs" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed/pipes{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/ship/freebooter_ship/cryo)
 "fjD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
@@ -2501,16 +2549,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/pod3)
 "fGM" = (
-/obj/machinery/cryopod,
-/obj/structure/cryofeed/pipes{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/freebooter_ship/cryo)
+/turf/space/dynamic,
+/area/space)
 "fJo" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -3271,9 +3311,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
-"hMh" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/gunneryentrance)
 "hPM" = (
 /obj/machinery/atmospherics/unary/engine,
 /obj/structure/window/reinforced,
@@ -3868,19 +3905,8 @@
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
 "jrC" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
+/turf/simulated/wall,
+/area/ship/freebooter_ship/medical)
 "jvN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -4219,8 +4245,21 @@
 /turf/simulated/floor/wood/walnut,
 /area/ship/freebooter_ship/pod7)
 "kqx" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/medical)
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "krH" = (
 /obj/item/paper/crumpled/bloody,
 /obj/effect/decal/cleanable/dirt,
@@ -4442,6 +4481,22 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
+"kFh" = (
+/obj/machinery/door/airlock/external{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	pixel_x = 8;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/freebooter_ship/foyer)
 "kHb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5064,12 +5119,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
-"mba" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "mbg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/effect/decal/fake_object{
@@ -5313,9 +5362,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/ship/freebooter_ship/thruster2)
-"mDC" = (
-/turf/simulated/wall,
-/area/ship/freebooter_ship/medical)
 "mEc" = (
 /obj/structure/flora/pottedplant{
 	dead = 1;
@@ -5432,12 +5478,6 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/freebooter_ship/pod7)
-"mRB" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/ship/freebooter_ship/gunnery)
 "mSI" = (
 /obj/effect/decal/fake_object{
 	desc = "A lightweight support lattice.";
@@ -6174,10 +6214,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/ammo)
 "oyG" = (
@@ -6829,6 +6865,12 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
+"pJZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/ship/freebooter_ship/gunnery)
 "pMN" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -7374,7 +7416,8 @@
 	name = "Carbon Dioxide Supply Monitor";
 	sensors = list("freebooter_thrust_sensor"="Tank");
 	input_tag = "freebooter_thrust_in";
-	output_tag = "freebooter_thrust_out"
+	output_tag = "freebooter_thrust_out";
+	frequency = 1336
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark{
@@ -7526,9 +7569,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/pod6)
-"raI" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/freebooter_ship/gunneryentrance)
 "rbz" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/lockers)
@@ -8006,6 +8046,9 @@
 	},
 /turf/simulated/floor,
 /area/ship/freebooter_ship/pod2)
+"sek" = (
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/gunneryentrance)
 "sjD" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -8280,22 +8323,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/lockers)
-"sQu" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/foyer)
 "sQA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -8516,19 +8543,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/bridge)
-"tqJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm/north,
-/turf/simulated/floor/tiled/dark,
-/area/ship/freebooter_ship/forehallway)
 "tra" = (
 /obj/machinery/door/firedoor/noid{
 	dir = 8
@@ -8784,6 +8798,22 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/freebooter_ship/dorms)
+"tVP" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_1";
+	master_tag = "freebooter_port_1"
+	},
+/turf/simulated/floor,
+/area/ship/freebooter_ship/foyer)
 "tXx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 9
@@ -9061,16 +9091,16 @@
 /obj/machinery/door/airlock/external{
 	dir = 8
 	},
+/obj/effect/map_effect/marker/airlock{
+	name = "freebooter_port_2";
+	master_tag = "freebooter_port_2"
+	},
 /obj/machinery/access_button{
 	pixel_x = 8;
 	pixel_y = 28;
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_1";
-	master_tag = "freebooter_port_1"
-	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/foyer)
 "uJN" = (
@@ -9785,8 +9815,8 @@
 /turf/simulated/floor,
 /area/ship/freebooter_ship/bridge)
 "vZW" = (
-/turf/space/dynamic,
-/area/space)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/medical)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/stool/chair{
@@ -9846,22 +9876,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod2)
-"wio" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/access_button{
-	pixel_x = 8;
-	pixel_y = 28;
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/foyer)
 "wji" = (
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 8
@@ -10007,12 +10021,8 @@
 /turf/space/dynamic,
 /area/ship/freebooter_ship/exterior)
 "wGc" = (
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	id = "junker_gun"
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/gunnery)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/ship/freebooter_ship/forehallwayport)
 "wHo" = (
 /obj/effect/decal/fake_object{
 	icon = 'icons/obj/ship_engine.dmi';
@@ -10227,6 +10237,9 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/pod3)
+"wZp" = (
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunneryentrance)
 "wZX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/rifle/used,
@@ -10332,22 +10345,6 @@
 "xqI" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/freebooter_ship/ammo)
-"xrw" = (
-/obj/machinery/door/airlock/external{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/airlock{
-	name = "freebooter_port_2";
-	master_tag = "freebooter_port_2"
-	},
-/obj/machinery/access_button{
-	pixel_x = -8;
-	pixel_y = 28;
-	dir = 8
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/freebooter_ship/foyer)
 "xtX" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 5
@@ -37819,7 +37816,7 @@ xRX
 xRX
 xRX
 uCl
-vZW
+fGM
 uCl
 fZq
 xRX
@@ -38333,7 +38330,7 @@ xRX
 rtf
 vUu
 uyM
-vZW
+fGM
 aHs
 xRX
 xRX
@@ -38566,17 +38563,17 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
+aOU
 eIb
 wUi
 ldw
 wUi
 eIb
-ajO
-ajO
+aOU
+aOU
 esB
 gwg
 esB
@@ -38584,32 +38581,32 @@ wHo
 esB
 gwg
 esB
-ajO
-ajO
+aOU
+aOU
 cLC
 cLC
 kwe
 tKj
 tKj
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 qiz
 qiz
 mWz
 qiz
 qiz
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 eUq
 eUq
 pRf
 eUq
 eUq
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 xRX
 xRX
 xRX
@@ -38822,8 +38819,8 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
+aOU
+aOU
 xRX
 xRX
 eIb
@@ -38866,7 +38863,7 @@ fTG
 eUq
 eUq
 xRX
-ajO
+aOU
 xqI
 xqI
 xqI
@@ -38880,7 +38877,7 @@ imE
 imE
 iOV
 iOV
-wGc
+anz
 xRX
 xRX
 xRX
@@ -39137,7 +39134,7 @@ rjL
 tQn
 sxw
 www
-wGc
+anz
 xRX
 xRX
 xRX
@@ -39338,8 +39335,8 @@ gFA
 ewW
 ewW
 ewW
-ajO
-ajO
+aOU
+aOU
 wUi
 syV
 bhd
@@ -39347,7 +39344,7 @@ xBh
 bhd
 tvh
 wUi
-ajO
+aOU
 gwg
 pUP
 kmP
@@ -39355,7 +39352,7 @@ qDn
 kev
 jcX
 gwg
-ajO
+aOU
 cLC
 wZf
 ttI
@@ -39363,7 +39360,7 @@ krH
 lKT
 vmX
 cLC
-ajO
+aOU
 qiz
 pYB
 bPT
@@ -39371,7 +39368,7 @@ jzk
 fRD
 buM
 qiz
-ajO
+aOU
 eUq
 aTX
 iUK
@@ -39379,8 +39376,8 @@ iUK
 iUK
 fTT
 eUq
-ajO
-ajO
+aOU
+aOU
 xqI
 ahD
 kfJ
@@ -39394,7 +39391,7 @@ fNl
 tQn
 sxw
 sxw
-wGc
+anz
 xRX
 xRX
 xRX
@@ -39596,7 +39593,7 @@ xUb
 qWF
 ewW
 xRX
-ajO
+aOU
 wUi
 syV
 bhd
@@ -39645,13 +39642,13 @@ npb
 oxR
 tfK
 sxk
-mRB
+ajO
 soh
 soh
 aDv
 iOV
 iOV
-wGc
+anz
 xRX
 xRX
 xRX
@@ -39853,7 +39850,7 @@ xUb
 jnK
 ewW
 xRX
-ajO
+aOU
 wUi
 syV
 grD
@@ -39903,8 +39900,8 @@ jhd
 tfK
 nwH
 wLI
-mba
-mba
+pJZ
+pJZ
 fnE
 xRX
 xRX
@@ -40110,7 +40107,7 @@ dbA
 wxS
 ewW
 xRX
-ajO
+aOU
 eIb
 oPu
 bhd
@@ -40152,7 +40149,7 @@ cEH
 eUq
 xRX
 xRX
-ajO
+aOU
 xqI
 xqI
 tfK
@@ -40367,7 +40364,7 @@ ewW
 ewW
 ewW
 xRX
-ajO
+aOU
 wUi
 cLL
 bhd
@@ -40409,13 +40406,13 @@ avE
 eUq
 xRX
 xRX
-ajO
+aOU
 xRX
-raI
+sek
 rEb
 xTu
 cbE
-hMh
+wZp
 klp
 llD
 euj
@@ -40624,7 +40621,7 @@ acn
 ewW
 xRX
 xRX
-ajO
+aOU
 wUi
 glJ
 ihN
@@ -40666,10 +40663,10 @@ hIE
 eUq
 xRX
 xRX
-ajO
+aOU
 xRX
-raI
-raI
+sek
+sek
 jgM
 vVy
 aMQ
@@ -40881,7 +40878,7 @@ pHN
 ewW
 xRX
 xRX
-ajO
+aOU
 wUi
 wNA
 bhd
@@ -40923,13 +40920,13 @@ iUK
 eUq
 xRX
 xRX
-ajO
+aOU
 xRX
 xRX
-raI
-raI
+sek
+sek
 tmo
-hMh
+wZp
 mwo
 mwo
 mwo
@@ -41138,7 +41135,7 @@ lJH
 jhL
 jhL
 xRX
-ajO
+aOU
 wUi
 peJ
 bhd
@@ -41180,18 +41177,18 @@ mtT
 eUq
 xRX
 xRX
-ajO
+aOU
 xRX
 xRX
 xRX
 uLO
 ebn
 atj
-mDC
+jrC
 exg
 iGK
 aBD
-kqx
+vZW
 xRX
 xRX
 xRX
@@ -41395,7 +41392,7 @@ pCG
 iZM
 jhL
 jhL
-ajO
+aOU
 eIb
 eIb
 pPk
@@ -41437,7 +41434,7 @@ eUq
 eUq
 xRX
 xRX
-ajO
+aOU
 xRX
 xRX
 xRX
@@ -41448,7 +41445,7 @@ jLL
 aab
 qDe
 nVi
-kqx
+vZW
 saW
 xRX
 xRX
@@ -41652,61 +41649,61 @@ mhq
 tcY
 rfn
 jhL
-ajO
-ajO
+aOU
+aOU
 eIb
 eIb
 qEc
 eIb
 eIb
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 gwg
 wzO
 dXK
 wzO
 gwg
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 cLC
 cLC
 mbX
 cLC
 cLC
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 qiz
 qiz
 dFi
 qiz
 qiz
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 eUq
 eUq
 wRc
 eUq
 eUq
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
 pvm
 kou
 dWF
-mDC
+jrC
 gLO
 npJ
 kAt
 lpe
-kqx
+vZW
 xRX
 xRX
 xRX
@@ -41910,18 +41907,10 @@ jbh
 tYn
 jhL
 xRX
-ajO
+aOU
 xRX
 wyp
-ayy
-wyp
-xRX
-xRX
-xRX
-xRX
-xRX
-wyp
-ayy
+kqx
 wyp
 xRX
 xRX
@@ -41929,7 +41918,7 @@ xRX
 xRX
 xRX
 wyp
-ayy
+kqx
 wyp
 xRX
 xRX
@@ -41937,7 +41926,7 @@ xRX
 xRX
 xRX
 wyp
-ayy
+kqx
 wyp
 xRX
 xRX
@@ -41945,25 +41934,33 @@ xRX
 xRX
 xRX
 wyp
-ayy
+kqx
 wyp
 xRX
 xRX
 xRX
 xRX
-ajO
+xRX
+wyp
+kqx
+wyp
+xRX
+xRX
+xRX
+xRX
+aOU
 xRX
 xRX
 xRX
 pvm
 vfD
 kOP
-mDC
-mDC
+jrC
+jrC
 tra
-kqx
-mDC
-kqx
+vZW
+jrC
+vZW
 ydf
 ewy
 ewy
@@ -42167,7 +42164,7 @@ rRa
 nKC
 jhL
 xRX
-ajO
+aOU
 xRX
 wyp
 mGn
@@ -42208,12 +42205,12 @@ xRX
 xRX
 xRX
 xRX
-ajO
+aOU
 xRX
 xRX
 xRX
 uLO
-tqJ
+bUy
 kbX
 kzS
 kvJ
@@ -43462,7 +43459,7 @@ vGw
 vGw
 vGw
 wyp
-xrw
+ezi
 odb
 wyp
 wyp
@@ -43709,7 +43706,7 @@ pkY
 bJj
 jhL
 xRX
-ajO
+aOU
 xRX
 wyp
 bhA
@@ -43750,7 +43747,7 @@ xRX
 xRX
 xRX
 xRX
-ajO
+aOU
 xRX
 xRX
 xRX
@@ -43966,10 +43963,10 @@ doW
 nEK
 jhL
 xRX
-ajO
+aOU
 xRX
 wyp
-sQu
+tVP
 xvT
 wyp
 xRX
@@ -43985,7 +43982,7 @@ xRX
 xRX
 xRX
 wyp
-ayy
+kqx
 wyp
 xRX
 xRX
@@ -43993,7 +43990,7 @@ xRX
 xRX
 xRX
 wyp
-ayy
+kqx
 wyp
 xRX
 xRX
@@ -44001,13 +43998,13 @@ xRX
 xRX
 xRX
 wyp
-ayy
+kqx
 wyp
 xRX
 xRX
 xRX
 xRX
-ajO
+aOU
 xRX
 xRX
 xRX
@@ -44222,52 +44219,52 @@ ngJ
 gwl
 xZh
 jhL
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 wyp
-uJz
+kFh
 bJc
 wyp
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 wyp
-wio
+uJz
 bst
 wyp
-ajO
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
+aOU
 uwT
 uwT
 jjA
 uwT
 uwT
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 eiL
 eiL
 gSo
 eiL
 eiL
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 tRo
 tRo
 sVs
 tRo
 tRo
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
 gzr
 iHV
 kOP
@@ -44479,23 +44476,23 @@ oGU
 kMx
 jhL
 jhL
-ajO
-vZW
+aOU
+fGM
 sUX
 ppp
 ppp
 ppp
 ppp
-jrC
+ayy
 kQs
-jrC
+ayy
 wtm
 rhN
 ciM
 rhN
 rmm
-vZW
-vZW
+fGM
+fGM
 uwT
 uwT
 lgM
@@ -44521,7 +44518,7 @@ tRo
 tRo
 xRX
 xRX
-ajO
+aOU
 xRX
 xRX
 xRX
@@ -44735,8 +44732,8 @@ aEa
 lJH
 jhL
 jhL
-vZW
-ajO
+fGM
+aOU
 iGW
 wnf
 aSb
@@ -44752,7 +44749,7 @@ iQg
 clU
 nKq
 rmm
-vZW
+fGM
 htS
 lfg
 jFY
@@ -44778,7 +44775,7 @@ cMo
 tRo
 xRX
 xRX
-ajO
+aOU
 xRX
 xRX
 xRX
@@ -44787,7 +44784,7 @@ ebn
 cDf
 quS
 cQs
-fGM
+fjs
 aSJ
 oxG
 xRX
@@ -44991,9 +44988,9 @@ xKt
 adF
 eqi
 uZl
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 rrT
 ntt
 sUq
@@ -45009,7 +45006,7 @@ elW
 sWG
 qVW
 vOL
-ajO
+aOU
 uwT
 dkz
 hHq
@@ -45035,7 +45032,7 @@ bxM
 tRo
 xRX
 xRX
-ajO
+aOU
 xRX
 xRX
 uLO
@@ -45248,9 +45245,9 @@ mOF
 qED
 uPa
 uZl
-vZW
-vZW
-ajO
+fGM
+fGM
+aOU
 bcf
 aSb
 aEB
@@ -45266,7 +45263,7 @@ eqD
 aSb
 qeJ
 vOL
-vZW
+fGM
 uwT
 oZH
 pZI
@@ -45292,10 +45289,10 @@ ieZ
 tRo
 xRX
 xRX
-ajO
+aOU
 xRX
-aOU
-aOU
+wGc
+wGc
 nZj
 ess
 lzb
@@ -45506,8 +45503,8 @@ bpj
 fdV
 uZl
 uZl
-vZW
-ajO
+fGM
+aOU
 rJT
 rsE
 rsE
@@ -45523,7 +45520,7 @@ afL
 sVT
 oSp
 vOL
-vZW
+fGM
 uwT
 bDX
 mCb
@@ -45549,9 +45546,9 @@ uNJ
 tRo
 xRX
 xRX
-ajO
-xRX
 aOU
+xRX
+wGc
 xMA
 uWU
 oVL
@@ -45763,8 +45760,8 @@ ieM
 mwO
 uoZ
 uZl
-vZW
-ajO
+fGM
+aOU
 iUd
 vdX
 atI
@@ -45780,7 +45777,7 @@ tcV
 rXx
 cJt
 vOL
-vZW
+fGM
 uwT
 fYr
 lGK
@@ -45806,9 +45803,9 @@ lvR
 tRo
 xRX
 xRX
-ajO
-xRX
 aOU
+xRX
+wGc
 oyG
 cnH
 ess
@@ -46020,8 +46017,8 @@ mCl
 kuj
 rFB
 uZl
-vZW
-ajO
+fGM
+aOU
 lkK
 hZH
 kti
@@ -46037,7 +46034,7 @@ kTf
 bzW
 hhA
 vOL
-vZW
+fGM
 uwT
 cgU
 hhQ
@@ -46277,8 +46274,8 @@ uiV
 vDk
 rFB
 uZl
-vZW
-ajO
+fGM
+aOU
 bcf
 aSb
 aSb
@@ -46294,7 +46291,7 @@ tDp
 aSb
 hhA
 vOL
-vZW
+fGM
 uwT
 cgU
 onn
@@ -46534,8 +46531,8 @@ aEt
 ldf
 uZl
 uZl
-ajO
-ajO
+aOU
+aOU
 bcf
 sBA
 ruo
@@ -46551,7 +46548,7 @@ elW
 sWG
 cei
 vOL
-ajO
+aOU
 uwT
 vMG
 hil
@@ -46559,7 +46556,7 @@ uOr
 hil
 irq
 uwT
-ajO
+aOU
 eiL
 upC
 buI
@@ -46567,7 +46564,7 @@ hdb
 pZo
 fVv
 eiL
-ajO
+aOU
 tRo
 pDZ
 bxM
@@ -46575,8 +46572,8 @@ bxM
 bxM
 pZO
 tRo
-ajO
-ajO
+aOU
+aOU
 wjn
 qqX
 vwi
@@ -46790,9 +46787,9 @@ uZl
 osl
 stV
 uZl
-vZW
-vZW
-ajO
+fGM
+fGM
+aOU
 aCG
 dqF
 aSb
@@ -46808,7 +46805,7 @@ rhN
 rhN
 mYn
 tOu
-vZW
+fGM
 htS
 hXO
 uwA
@@ -47046,11 +47043,11 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
-vZW
-ajO
-vZW
+aOU
+aOU
+fGM
+aOU
+fGM
 kOK
 rfz
 rfz
@@ -47064,8 +47061,8 @@ vTv
 vTv
 vTv
 tOu
-vZW
-vZW
+fGM
+fGM
 uwT
 uwT
 nti
@@ -47090,7 +47087,7 @@ rEV
 tRo
 tRo
 xRX
-ajO
+aOU
 wjn
 wjn
 wjn
@@ -47304,50 +47301,50 @@ xRX
 xRX
 xRX
 xRX
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
 ibm
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
 fro
-ajO
-ajO
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
+aOU
+aOU
 uwT
 uwT
 qju
 uwT
 uwT
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 eiL
 eiL
 sal
 eiL
 eiL
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 tRo
 tRo
 raF
 tRo
 tRo
-ajO
-ajO
-ajO
+aOU
+aOU
+aOU
 xRX
 xRX
 xRX

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -1254,9 +1254,7 @@
 	layer = 2.31;
 	name = "lattice"
 	},
-/turf/simulated/floor{
-	icon_state = "dmg4"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/ammo)
 "bWt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
@@ -1534,6 +1532,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
+"cPy" = (
+/obj/machinery/ship_weapon/blaster{
+	pixel_y = -195;
+	pixel_x = -24;
+	weapon_id = "Freebooter Ship Blaster"
+	},
+/turf/simulated/wall,
+/area/ship/freebooter_ship/gunnery)
 "cQs" = (
 /obj/structure/cryofeed/pipes{
 	dir = 4
@@ -3281,9 +3287,7 @@
 	name = "igs - freebooter crew"
 	},
 /obj/machinery/light/small/emergency,
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/pod1)
 "hLa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4195,9 +4199,7 @@
 /obj/item/stack/tile/floor_dark{
 	layer = 2.81
 	},
-/turf/simulated/floor{
-	icon_state = "dmg2"
-	},
+/turf/simulated/floor,
 /area/ship/freebooter_ship/ammo)
 "kfX" = (
 /obj/structure/bed/stool/chair/office/wheelchair{
@@ -8828,7 +8830,6 @@
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/freebooter_ship/thruster1)
 "tSZ" = (
@@ -9871,7 +9872,7 @@
 /area/ship/freebooter_ship/exterior)
 "wcN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/stool/chair{
+/obj/structure/bed/stool/chair/folding{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -40982,7 +40983,7 @@ tmo
 dlZ
 mwo
 mwo
-mwo
+cPy
 imE
 imE
 xRX


### PR DESCRIPTION
Adds several new areas. Previously, freebooter_ship/bridge covered around a dozen separate rooms off a single APC, despite the wires for the APCs of each room still being under the floors. These are now all separate.

Revamps propulsion to fit in with more modern standards. There's now two tiles of 25000kPa CO2 in a multi-tile tank in the starboard nacelle, that feeds all eight thrusters with a line running through the ship, plus a pair of heat gas heaters and some combustibles if you want to get really funny. Balance with this could be iffy, the top speed you can reasonably expect by dumping virtually the entire tank in at 100% thrust limit is around 5Gm/h, but running it that fast will run you dry very quickly. One of the tiles in the CO2 tank is vacuum to drop the pressure a little, and in my testing the crew would still have to carefully moderate fuel usage to keep themselves floating, it's just a much less annoying system to work with than using canisters. If we want to reduce that maximum speed, the best way would just be to knock their thrusters from 8 to 6, though I don't think that's necessary.

![image](https://github.com/Aurorastation/Aurora.3/assets/83198434/1d679e1f-9b3e-4869-864c-48de0a7727c0)

Fixes improper plating throughout the ship.

Adds some more medical supplies, including pneumalin, soporific, a trauma kit, and a hypospray. All surgical supplies are either ghetto, or can be already made from the autolathe. 

Adds a condiment box, and k'ois bars, to the kitchen.

Added tajaran and unathi insulated gloves.

You can now actually see the distress beacon and bridge blast doors buttons!

Adapted the airlocks to markers, and reworked the shuttle airlock to be much, much faster. The docking port should also line up with the actual airlocks now, and the shuttle should no longer be able to function without power. All thrusters are also connected, now - five thrusters is a *lot*, but they only have the one tiny CO2 tank. The underpipe walls are horrifying, but I don't have it in me to redesign the shuttle.

![image](https://github.com/Aurorastation/Aurora.3/assets/83198434/65b46c77-604c-4cb5-83e1-bdb5865edb3b)

All air alarms *should* have open access, now.

Note: ship still probably needs proper docking ports, but I'm not tackling those right now. If someone else wants to take that upon themselves, it would definitely be useful. 