### PR TITLE
Orion Express courier shuttle tweaks

### DIFF
--- a/html/changelogs/hazelmouse - oe_shuttle_tweaks.yml
+++ b/html/changelogs/hazelmouse - oe_shuttle_tweaks.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Orion Express Courier shuttle fixed and redesigned for better QoL."

--- a/maps/away/ships/orion/orion_express_ship.dm
+++ b/maps/away/ships/orion/orion_express_ship.dm
@@ -7,10 +7,8 @@
 	ship_cost = 1
 	id = "orion_express_ship"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/orion_express_shuttle)
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 	unit_test_groups = list(3)
-
 
 /singleton/submap_archetype/orion_express_ship
 	map = "Orion Express Mobile Station"

--- a/maps/away/ships/orion/orion_express_ship.dm
+++ b/maps/away/ships/orion/orion_express_ship.dm
@@ -97,6 +97,7 @@
 /area/shuttle/orion_shuttle/storage
 	name = "Storage Compartment"
 	ambience = AMBIENCE_GENERIC
+
 /area/shuttle/orion_shuttle/cockpit
 	name = "Cockpit"
 	ambience = AMBIENCE_GENERIC

--- a/maps/away/ships/orion/orion_express_ship.dm
+++ b/maps/away/ships/orion/orion_express_ship.dm
@@ -78,21 +78,26 @@
 // Shuttle
 /area/shuttle/orion_shuttle/
 	requires_power = TRUE
-	name = "Orion Courier Shuttle"
+	name = "Orion Courier Shuttle (parent, do not use)"
 	icon_state = "shuttle2"
 	area_flags = AREA_FLAG_RAD_SHIELDED
 
 /area/shuttle/orion_shuttle/storage
 	name = "Storage Compartment"
+	icon_state = "storage"
 
 /area/shuttle/orion_shuttle/cockpit
 	name = "Cockpit"
+	icon_state = "bridge"
 
 /area/shuttle/orion_shuttle/portthrust
 	name = "Port Nacelle"
+	icon_state = "blue-red2"
 
 /area/shuttle/orion_shuttle/starboardthrust
 	name = "Starboard Nacelle"
+	icon_state = "blue-red2"
+
 
 //ship stuff
 
@@ -185,7 +190,7 @@
 /datum/shuttle/autodock/overmap/orion_express_shuttle
 	name = "Orion Express Shuttle"
 	move_time = 20
-	shuttle_area = list(/area/shuttle/orion_shuttle)
+	shuttle_area = list(/area/shuttle/orion_shuttle/cockpit, /area/shuttle/orion_shuttle/portthrust, /area/shuttle/orion_shuttle/storage, /area/shuttle/orion_shuttle/starboardthrust)
 	current_location = "nav_hangar_orion_express"
 	landmark_transition = "nav_transit_orion_express"
 	range = 1

--- a/maps/away/ships/orion/orion_express_ship.dm
+++ b/maps/away/ships/orion/orion_express_ship.dm
@@ -76,12 +76,23 @@
 	ambience = AMBIENCE_MAINTENANCE
 
 // Shuttle
-/area/shuttle/orion_shuttle
+/area/shuttle/orion_shuttle/
 	requires_power = TRUE
 	name = "Orion Courier Shuttle"
 	icon_state = "shuttle2"
 	area_flags = AREA_FLAG_RAD_SHIELDED
 
+/area/shuttle/orion_shuttle/storage
+	name = "Storage Compartment"
+
+/area/shuttle/orion_shuttle/cockpit
+	name = "Cockpit"
+
+/area/shuttle/orion_shuttle/portthrust
+	name = "Port Nacelle"
+
+/area/shuttle/orion_shuttle/starboardthrust
+	name = "Starboard Nacelle"
 
 //ship stuff
 

--- a/maps/away/ships/orion/orion_express_ship.dm
+++ b/maps/away/ships/orion/orion_express_ship.dm
@@ -15,7 +15,7 @@
 	descriptor = "The Traveler-class mobile station is a relatively old design, but nonetheless venerable and one of the building blocks of interstellar commerce. While relatively small, is a treasured asset in the Orion Express corporation's fleet, and has been referred to as “the gas station of the stars”, offering food, supplies, and fuel to anyone who may need it."
 //areas
 /area/ship/orion
-	name = "Orion Express Courier Ship"
+	name = "Orion Express Courier Ship (parent type, do not use!)"
 	requires_power = TRUE
 	dynamic_lighting = TRUE
 	no_light_control = FALSE
@@ -40,6 +40,7 @@
 /area/ship/orion/mainhall
 	name = "Main Hallway"
 	ambience = AMBIENCE_GENERIC
+	icon_state = "hallC"
 
 /area/ship/orion/forehall
 	name = "Lobby"

--- a/maps/away/ships/orion/orion_express_ship.dm
+++ b/maps/away/ships/orion/orion_express_ship.dm
@@ -25,14 +25,17 @@
 /area/ship/orion/engie
 	name = "Engineering"
 	ambience = AMBIENCE_MAINTENANCE
+	icon_state = "engineering"
 
 /area/ship/orion/atmos
 	name = "Atmospherics"
 	ambience = AMBIENCE_MAINTENANCE
+	icon_state = "atmos"
 
 /area/ship/orion/cargo
 	name = "Cargo Bay"
 	ambience = AMBIENCE_GENERIC
+	icon_state = "quartloading"
 
 /area/ship/orion/mainhall
 	name = "Main Hallway"
@@ -41,38 +44,47 @@
 /area/ship/orion/forehall
 	name = "Lobby"
 	ambience = AMBIENCE_GENERIC
+	icon_state = "hallC"
 
 /area/ship/orion/crew
 	name = "Crew Quarters"
 	ambience = AMBIENCE_GENERIC
+	icon_state = "crew_quarters"
 
 /area/ship/orion/captain
 	name = "Captain's Office"
 	ambience = AMBIENCE_GENERIC
+	icon_state = "captain"
 
 /area/ship/orion/bridge
 	name = "Platform Command Center"
 	ambience = AMBIENCE_GENERIC
+	icon_state = "bridge"
 
 /area/ship/orion/comms
 	name = "Telecommunications"
 	ambience = AMBIENCE_MAINTENANCE
+	icon_state = "tcomsatcham"
 
 /area/ship/orion/forehall
 	name = "Cafeteria"
 	ambience = AMBIENCE_GENERIC
+	icon_state = "lounge"
 
 /area/ship/orion/shop
 	name = "Commissary"
 	ambience = AMBIENCE_GENERIC
+	icon_state = "blue"
 
 /area/ship/orion/thruster1
 	name = "Thruster Pod 1"
 	ambience = AMBIENCE_MAINTENANCE
+	icon_state = "engine"
 
 /area/ship/orion/thruster2
 	name = "Thruster Pod 2"
 	ambience = AMBIENCE_MAINTENANCE
+	icon_state = "engine"
 
 // Shuttle
 /area/shuttle/orion_shuttle/
@@ -83,15 +95,18 @@
 
 /area/shuttle/orion_shuttle/storage
 	name = "Storage Compartment"
-
+	ambience = AMBIENCE_GENERIC
 /area/shuttle/orion_shuttle/cockpit
 	name = "Cockpit"
+	ambience = AMBIENCE_GENERIC
 
 /area/shuttle/orion_shuttle/portthrust
 	name = "Port Nacelle"
+	ambience = AMBIENCE_MAINTENANCE
 
 /area/shuttle/orion_shuttle/starboardthrust
 	name = "Starboard Nacelle"
+	ambience = AMBIENCE_MAINTENANCE
 
 //ship stuff
 

--- a/maps/away/ships/orion/orion_express_ship.dm
+++ b/maps/away/ships/orion/orion_express_ship.dm
@@ -42,11 +42,6 @@
 	ambience = AMBIENCE_GENERIC
 	icon_state = "hallC"
 
-/area/ship/orion/forehall
-	name = "Lobby"
-	ambience = AMBIENCE_GENERIC
-	icon_state = "hallC"
-
 /area/ship/orion/crew
 	name = "Crew Quarters"
 	ambience = AMBIENCE_GENERIC

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -551,16 +551,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"bXa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
 "bXG" = (
 /obj/structure/table/rack,
 /obj/item/stack/cable_coil{
@@ -730,6 +720,20 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
+"cym" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
+"czM" = (
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 6
+	},
+/obj/structure/closet/walllocker/firecloset{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "cHm" = (
 /obj/structure/window/reinforced,
 /obj/item/holomenu{
@@ -832,9 +836,6 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"dho" = (
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "dhX" = (
 /obj/structure/table/rack,
 /obj/item/reagent_containers/toothbrush,
@@ -860,14 +861,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
-"dir" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "diy" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
@@ -1283,22 +1276,7 @@
 /turf/simulated/floor,
 /area/ship/orion/engie)
 "fBW" = (
-/obj/machinery/light{
-	dir = 8;
-	inserted_light = /obj/item/light/tube/colored/blue
-	},
-/obj/structure/table/steel,
-/obj/item/clothing/head/helmet/pilot{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/paper_bin{
-	pixel_x = -2
-	},
-/obj/item/pen{
-	pixel_x = -2
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "fJg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
@@ -1380,11 +1358,13 @@
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
 "glh" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 8
 	},
-/turf/simulated/floor/carpet/rubber,
+/obj/structure/bed/handrail{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "goI" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1514,19 +1494,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"gJH" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 9
-	},
-/obj/structure/closet/walllocker/emerglocker/east,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/item/storage/bag/inflatable/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "gJZ" = (
 /obj/machinery/vending/tool,
 /obj/machinery/light{
@@ -1581,12 +1548,14 @@
 	master_tag = "orion_shuttle";
 	shuttle_tag = "Orion Express Shuttle"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/green,
 /obj/machinery/airlock_sensor{
 	pixel_x = -40;
 	pixel_y = -1
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/green{
+	dir = 5
+	},
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)
 "gOp" = (
@@ -1792,16 +1761,6 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
-"hrA" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 6
-	},
-/obj/structure/closet/walllocker/firecloset{
-	pixel_x = -32
-	},
-/obj/effect/floor_decal/industrial/outline/firefighting_closet,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "htX" = (
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/airless,
@@ -1876,6 +1835,19 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/atmos)
+"hJh" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "hKC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/green{
@@ -1986,19 +1958,6 @@
 /obj/item/modular_computer/laptop,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
-"imN" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	layer = 2.71
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "inj" = (
 /obj/machinery/door/airlock/glass{
 	name = "Commissary";
@@ -2132,6 +2091,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
+"iVu" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "iVL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -2420,13 +2384,12 @@
 /turf/simulated/floor,
 /area/ship/orion/cargo)
 "kAZ" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light{
+	dir = 4;
+	inserted_light = /obj/item/light/tube/colored/blue
 	},
-/obj/structure/bed/handrail{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "kDQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -2487,6 +2450,16 @@
 	temperature = 278
 	},
 /area/ship/orion/comms)
+"kWq" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "kYl" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -2691,8 +2664,10 @@
 /turf/simulated/floor,
 /area/ship/orion/engie)
 "lZq" = (
-/obj/structure/bed/stool/chair/shuttle,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "maj" = (
@@ -2810,12 +2785,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
-"moh" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/alarm/north,
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "mpC" = (
 /obj/effect/floor_decal/corner/dark_green/diagonal,
 /obj/structure/cable/green{
@@ -3258,6 +3227,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
+"nYp" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "nYY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -3266,6 +3240,16 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/comms)
+"oaR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/orion_shuttle)
 "ode" = (
 /obj/structure/bed/stool/bar/padded/beige,
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -3393,6 +3377,23 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
+"oNV" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/vending/wallmed1{
+	req_access = null;
+	pixel_y = 30;
+	pixel_x = -7
+	},
+/obj/machinery/button/remote/blast_door{
+	name = "Safety Shutters";
+	id = "orion_shuttle_shutters";
+	dir = 1;
+	pixel_y = 27;
+	pixel_x = 7
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "oQa" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/comms)
@@ -3708,16 +3709,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/airless,
-/area/shuttle/orion_shuttle)
-"qmf" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "qpS" = (
 /obj/structure/cable/green{
@@ -4228,15 +4219,6 @@
 /area/ship/orion/shop)
 "soM" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1413
-	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "orion_shuttle";
-	shuttle_tag = "Orion Express Shuttle"
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/airless,
 /area/shuttle/orion_shuttle)
 "spv" = (
@@ -4428,6 +4410,10 @@
 /area/shuttle/orion_shuttle)
 "sTK" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "sXW" = (
@@ -4570,6 +4556,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/crew)
+"tqG" = (
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 9
+	},
+/obj/structure/closet/walllocker/emerglocker/east,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/item/storage/bag/inflatable/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "trH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -4586,14 +4585,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
-"tsK" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/light{
-	dir = 4;
-	inserted_light = /obj/item/light/tube/colored/blue
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "twl" = (
 /obj/effect/landmark/entry_point/starboard{
 	name = "port, engine entrance"
@@ -4789,6 +4780,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/orion/mainhall)
+"une" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/loading/yellow{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "uon" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -4895,14 +4908,6 @@
 	name = "fore, starboard engines"
 	},
 /turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle)
-"uWs" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/securearea{
-	pixel_x = -32
-	},
-/obj/structure/closet/crate,
-/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "uWQ" = (
 /obj/machinery/computer/ship/engines{
@@ -5167,18 +5172,7 @@
 "vOd" = (
 /obj/structure/bed/stool/chair/shuttle,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/vending/wallmed1{
-	req_access = null;
-	pixel_y = 30;
-	pixel_x = -7
-	},
-/obj/machinery/button/remote/blast_door{
-	name = "Safety Shutters";
-	id = "orion_shuttle_shutters";
-	dir = 1;
-	pixel_y = 27;
-	pixel_x = 7
-	},
+/obj/machinery/alarm/north,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "vPd" = (
@@ -5307,22 +5301,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
 "wkO" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
+/obj/machinery/light{
+	dir = 8;
+	inserted_light = /obj/item/light/tube/colored/blue
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
+/obj/structure/table/steel,
+/obj/item/clothing/head/helmet/pilot{
+	pixel_x = 8;
+	pixel_y = 8
 	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
+/obj/item/paper_bin{
+	pixel_x = -2
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/item/pen{
+	pixel_x = -2
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "wlw" = (
@@ -5746,6 +5739,9 @@
 /area/ship/orion/atmos)
 "xTL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/securearea{
+	pixel_x = -32
+	},
 /obj/structure/closet/crate,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
@@ -37549,17 +37545,17 @@ xRX
 xRX
 wFW
 fau
-fBW
+wkO
 ixH
 qUy
-xTL
+iVu
 ipM
-uWs
+xTL
 kLL
+cym
 sTK
-dir
 qjk
-hrA
+czM
 nzE
 qUy
 soM
@@ -37815,11 +37811,11 @@ sTm
 hvo
 mcD
 oIF
-wkO
+une
 qUy
 qUy
 qUy
-rrQ
+qUy
 haV
 spv
 dGE
@@ -38071,8 +38067,8 @@ rdc
 iEl
 biw
 mzY
-sTK
-imN
+cym
+hJh
 ihA
 oAK
 gXD
@@ -38319,12 +38315,12 @@ xRX
 xRX
 xRX
 qUy
-vOd
+oNV
 vPd
 dte
 qUy
-glh
-glh
+lZq
+lZq
 iEl
 biw
 mzO
@@ -38576,17 +38572,17 @@ xRX
 xRX
 xRX
 qUy
-moh
-dho
+vOd
+fBW
 oey
 qUy
 iPr
 nGq
 qQV
 yaz
-bXa
+oaR
 gdY
-qmf
+kWq
 qUy
 qUy
 qUy
@@ -38833,8 +38829,8 @@ xRX
 xRX
 xRX
 qUy
-lZq
-tsK
+nYp
+kAZ
 kYI
 qUy
 pdw
@@ -38843,8 +38839,8 @@ hNk
 rDd
 uWQ
 iOe
-kAZ
-gJH
+glh
+tqG
 kcS
 qUy
 efO

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -74,6 +74,15 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/crew)
+"aoV" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "asD" = (
 /obj/effect/shuttle_landmark/orion_express_ship/transit,
 /turf/space/transit/north,
@@ -108,6 +117,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
+"aCK" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "aDL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -186,7 +202,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/high/north,
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
 /turf/simulated/floor,
 /area/ship/orion/atmos)
 "aRB" = (
@@ -229,7 +247,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "aXC" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/small/beer,
@@ -246,7 +264,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/starboardthrust)
 "aYE" = (
 /obj/effect/floor_decal/corner_wide/beige/full{
 	dir = 8
@@ -260,7 +278,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/high/north,
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "bbM" = (
@@ -322,7 +342,7 @@
 "biw" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "bjg" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/cargo)
@@ -358,7 +378,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/high/north,
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
 "bol" = (
@@ -385,7 +407,7 @@
 /obj/machinery/meter,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/starboardthrust)
 "buO" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -418,7 +440,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "bvf" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -435,7 +457,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/green,
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "bAQ" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 9
@@ -613,13 +635,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
+"cbv" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "ccK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/portthrust)
 "ceU" = (
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "orion_traveler_port";
@@ -663,6 +691,9 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/bridge)
+"clG" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/starboardthrust)
 "cnJ" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/light{
@@ -708,7 +739,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "cwh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 2
@@ -929,7 +960,7 @@
 	pixel_x = -9
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "dul" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -965,7 +996,7 @@
 	name = "port, engine compartment"
 	},
 /turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/portthrust)
 "dFW" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -1058,7 +1089,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/airless,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "egO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -1173,12 +1204,12 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "fau" = (
 /obj/machinery/computer/shuttle_control/explore/orion_express_shuttle,
 /obj/item/device/radio/intercom/expedition/hailing/west,
 /turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "fbf" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -1192,7 +1223,7 @@
 	req_one_access = null
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "feE" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 6
@@ -1232,7 +1263,7 @@
 	},
 /obj/machinery/meter,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/portthrust)
 "fmY" = (
 /obj/machinery/photocopier,
 /obj/effect/floor_decal/corner/dark_blue{
@@ -1293,7 +1324,7 @@
 /obj/structure/bed/stool/chair/shuttle,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "fJg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /obj/machinery/meter,
@@ -1335,7 +1366,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "gec" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/vending/boozeomat{
@@ -1369,7 +1400,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/starboardthrust)
 "gkw" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
 	dir = 1
@@ -1393,10 +1424,10 @@
 	pixel_x = -2
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "gnR" = (
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "goI" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -1560,7 +1591,9 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/high/north,
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
 /turf/simulated/floor,
 /area/ship/orion/comms)
 "gNW" = (
@@ -1584,7 +1617,7 @@
 	dir = 5
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "gOp" = (
 /obj/effect/landmark/entry_point/starboard{
 	name = "port, bathrooms"
@@ -1619,7 +1652,7 @@
 	pixel_y = -6
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "gYr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -1720,7 +1753,7 @@
 	},
 /obj/structure/closet/crate,
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "hlg" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -1757,12 +1790,15 @@
 	dir = 10
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "hmX" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/loot,
@@ -1814,17 +1850,22 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "hwT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -1893,7 +1934,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "hPo" = (
 /obj/structure/toilet{
 	dir = 8
@@ -1971,7 +2012,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "ilT" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
@@ -2005,7 +2046,7 @@
 	},
 /obj/structure/closet/crate,
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "itr" = (
 /obj/effect/floor_decal/spline/plain/black,
 /obj/structure/railing/mapped{
@@ -2031,8 +2072,13 @@
 /obj/item/clothing/suit/space/emergency,
 /obj/item/clothing/head/helmet/space/emergency,
 /obj/item/clothing/head/helmet/space/emergency,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "iCR" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion/comms)
@@ -2045,7 +2091,7 @@
 	},
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/airless,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "iEl" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
@@ -2054,7 +2100,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "iGD" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
@@ -2092,7 +2138,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "iPn" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -2114,7 +2160,12 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
+"iSX" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "iTn" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 5
@@ -2147,7 +2198,7 @@
 /obj/machinery/computer/ship/sensors,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "jmg" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 10
@@ -2227,6 +2278,15 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
+"jvB" = (
+/obj/machinery/atmospherics/binary/pump/high_power,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "jvY" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -2303,7 +2363,7 @@
 /obj/machinery/hologram/holopad/long_range,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "jLO" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/crew)
@@ -2331,17 +2391,22 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "jWz" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/machinery/chem_master/condimaster{
@@ -2382,8 +2447,13 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "kku" = (
 /obj/effect/map_effect/marker/airlock/docking{
 	landmark_tag = "nav_hangar_orion_express";
@@ -2395,8 +2465,14 @@
 "kog" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/pottedplant,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/west{
+	req_access = list(201)
+	},
 /turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "krv" = (
 /obj/effect/floor_decal/corner/dark_green/diagonal,
 /obj/structure/closet/crate/bin{
@@ -2443,8 +2519,13 @@
 /obj/structure/bed/handrail{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "kDQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/corner_wide/beige{
@@ -2470,12 +2551,14 @@
 /area/ship/orion/cargo)
 "kLL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/power/apc/west,
+/obj/machinery/power/apc/west{
+	req_access = list(201)
+	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "kOl" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
@@ -2484,7 +2567,7 @@
 	name = "aft, starboard engines"
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/starboardthrust)
 "kPI" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
@@ -2523,7 +2606,7 @@
 /obj/structure/closet/crate/freezer/rations,
 /obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "laC" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/thruster1)
@@ -2535,6 +2618,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"lgF" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/cockpit)
 "lhJ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light{
@@ -2619,6 +2705,9 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
+"lBE" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/portthrust)
 "lCK" = (
 /obj/item/trash/can/adhomian_can,
 /turf/simulated/floor,
@@ -2671,8 +2760,11 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "lXJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -2723,7 +2815,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "maj" = (
 /obj/machinery/door/airlock/external{
 	dir = 1;
@@ -2789,15 +2881,21 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "mcN" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/portables_connector{
 	layer = 2.8
 	},
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/starboardthrust)
 "meU" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -2845,7 +2943,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/east,
+/obj/machinery/power/apc/east{
+	req_access = list(201)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
 "mun" = (
@@ -2875,15 +2975,20 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "mzY" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "mBs" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -2932,8 +3037,13 @@
 /area/ship/orion/cargo)
 "mLK" = (
 /obj/machinery/atmospherics/binary/pump/high_power,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/portthrust)
 "mME" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
@@ -2947,7 +3057,7 @@
 	name = "fore, port engines"
 	},
 /turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/portthrust)
 "mOc" = (
 /obj/machinery/button/remote/blast_door{
 	id = "orion_warehouse";
@@ -2986,6 +3096,20 @@
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
+"mRb" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "mSt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -3001,8 +3125,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "mSy" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/vehicle/train/cargo/engine,
@@ -3018,8 +3145,11 @@
 	name = "Cockpit";
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "mXd" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3107,7 +3237,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/high/north,
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
 "nxv" = (
@@ -3122,8 +3254,13 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "nAQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/west{
@@ -3132,7 +3269,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/portthrust)
 "nDV" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/blast/shutters{
@@ -3198,7 +3335,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "nHg" = (
 /obj/effect/step_trigger/teleporter,
 /obj/effect/step_trigger/teleporter,
@@ -3218,7 +3355,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/high/north,
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
 /turf/simulated/floor/carpet,
 /area/ship/orion/crew)
 "nRE" = (
@@ -3329,7 +3468,7 @@
 	pixel_x = -6
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "ojl" = (
 /obj/structure/bookcase,
 /turf/simulated/floor,
@@ -3339,7 +3478,9 @@
 /area/ship/orion/captain)
 "oxU" = (
 /obj/structure/cable/green,
-/obj/machinery/power/apc/high/south,
+/obj/machinery/power/apc/high/south{
+	req_access = list(201)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
 "oAK" = (
@@ -3354,7 +3495,7 @@
 	pixel_x = -30
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "oAP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/emergency{
@@ -3393,7 +3534,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "oKe" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/reagent_dispensers/cookingoil,
@@ -3413,8 +3554,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "oNK" = (
 /obj/structure/window/reinforced,
 /obj/item/toy/xmastree,
@@ -3459,7 +3605,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/starboardthrust)
 "oZS" = (
 /obj/effect/floor_decal/spline/plain/black,
 /obj/structure/fuel_port{
@@ -3473,7 +3619,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "phP" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
@@ -3722,8 +3868,13 @@
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "qkP" = (
 /obj/machinery/shipsensors/weak,
 /obj/structure/railing/mapped{
@@ -3733,7 +3884,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/airless,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "qpS" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3773,8 +3924,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "qsf" = (
 /obj/effect/floor_decal/corner_wide/beige/full,
 /obj/structure/closet/crate/bin{
@@ -3871,7 +4025,7 @@
 	name = "aft, port engines"
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/portthrust)
 "qQV" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -3885,7 +4039,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "qRJ" = (
 /obj/effect/floor_decal/corner/dark_green,
 /obj/structure/cable/green{
@@ -3907,7 +4061,7 @@
 /area/ship/orion/bridge)
 "qUy" = (
 /turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "qXP" = (
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
@@ -3935,7 +4089,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "rgL" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 6
@@ -3979,7 +4133,7 @@
 	dir = 8
 	},
 /turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "rsO" = (
 /turf/simulated/floor/tiled/dark/airless,
 /area/ship/orion/thruster2)
@@ -4064,7 +4218,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "rDS" = (
 /obj/machinery/portable_atmospherics/canister/empty{
 	name = "waste canister"
@@ -4078,7 +4232,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "rKi" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/computer/arcade/orion_trail,
@@ -4092,8 +4246,13 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "rNJ" = (
 /obj/machinery/door/airlock/external{
 	dir = 4;
@@ -4130,7 +4289,7 @@
 	name = "starboard, engine compartment"
 	},
 /turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/starboardthrust)
 "sdS" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -4170,7 +4329,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "sll" = (
 /obj/structure/sign/directions/cryo{
 	dir = 8;
@@ -4214,7 +4373,9 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/high/west,
+/obj/machinery/power/apc/high/west{
+	req_access = list(201)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
 "soa" = (
@@ -4253,7 +4414,7 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/airless,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "spv" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -4280,7 +4441,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/portthrust)
 "ssp" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion/engie)
@@ -4435,12 +4596,10 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "sTK" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
@@ -4448,7 +4607,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "sXW" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -4466,6 +4625,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
+"sZK" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/portables_connector{
+	layer = 2.8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "tcC" = (
 /obj/machinery/light{
 	dir = 8;
@@ -4648,7 +4821,7 @@
 /obj/structure/bed/stool/chair/office/bridge/generic,
 /obj/effect/floor_decal/industrial/outline/custodial,
 /turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "tGB" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
@@ -4702,8 +4875,13 @@
 /obj/structure/bed/handrail{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "tRj" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 5
@@ -4876,8 +5054,11 @@
 	dir = 4;
 	name = "Maintenance"
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "uGk" = (
 /obj/structure/table/wood,
 /obj/item/toy/desk/newtoncradle,
@@ -4914,20 +5095,20 @@
 "uRC" = (
 /obj/machinery/computer/ship/helm,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "uVR" = (
 /obj/effect/landmark/entry_point/aft{
 	name = "fore, starboard engines"
 	},
 /turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/starboardthrust)
 "uWQ" = (
 /obj/machinery/computer/ship/engines{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "uWT" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -5061,7 +5242,9 @@
 	dir = 8
 	},
 /obj/structure/cable/green,
-/obj/machinery/power/apc/high/south,
+/obj/machinery/power/apc/high/south{
+	req_access = list(201)
+	},
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
 "vyC" = (
@@ -5197,11 +5380,11 @@
 	pixel_x = 7
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "vPd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "vPn" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 8
@@ -5215,7 +5398,7 @@
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "vRO" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5236,7 +5419,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/high/north,
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster2)
 "vVk" = (
@@ -5333,7 +5518,7 @@
 /area/ship/orion/shop)
 "wkO" = (
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "wlw" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/grass,
@@ -5463,7 +5648,7 @@
 	name = "Safety Shutter"
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/cockpit)
 "wIx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -5757,7 +5942,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate,
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "xVJ" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
@@ -5796,7 +5981,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "yaV" = (
 /obj/machinery/door/airlock/command{
 	name = "Platform Command Center";
@@ -5826,7 +6011,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/starboardthrust)
 "yfU" = (
 /obj/machinery/appliance/cooker/fryer,
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -5857,7 +6042,7 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
-/area/shuttle/orion_shuttle)
+/area/shuttle/orion_shuttle/storage)
 "yko" = (
 /obj/machinery/atmospherics/binary/passive_gate/supply,
 /turf/simulated/floor/plating,
@@ -36285,8 +36470,8 @@ xRX
 xRX
 xRX
 dwE
-qUy
-qUy
+lBE
+lBE
 xRX
 xRX
 riA
@@ -36539,11 +36724,11 @@ xRX
 xRX
 xRX
 xRX
-qUy
-qUy
-qUy
+lBE
+lBE
+lBE
 sqh
-yfz
+cbv
 xRX
 riA
 riA
@@ -36797,7 +36982,7 @@ xRX
 xRX
 xRX
 mNJ
-aYD
+iSX
 nAQ
 ccK
 qMt
@@ -37053,11 +37238,11 @@ xRX
 xRX
 xRX
 iCX
-qUy
-mcN
+lBE
+sZK
 mLK
 fkX
-yfz
+cbv
 riA
 riA
 xsE
@@ -37299,10 +37484,10 @@ xRX
 xRX
 xRX
 xRX
-qUy
-qUy
-qUy
-qUy
+lgF
+lgF
+lgF
+lgF
 qUy
 qUy
 qUy
@@ -38077,7 +38262,7 @@ jKa
 qUy
 skU
 rdc
-iEl
+biw
 iEl
 mzY
 biw
@@ -38327,15 +38512,15 @@ xRX
 xRX
 xRX
 xRX
-qUy
+lgF
 vOd
 vPd
 dte
 qUy
 lZq
 lZq
-iEl
-iEl
+aoV
+mRb
 mzO
 rLo
 hlA
@@ -38584,7 +38769,7 @@ xRX
 xRX
 xRX
 xRX
-qUy
+lgF
 fdC
 gnR
 oey
@@ -38841,7 +39026,7 @@ xRX
 xRX
 xRX
 xRX
-qUy
+lgF
 fBW
 vRr
 kYI
@@ -39098,10 +39283,10 @@ xRX
 xRX
 xRX
 xRX
-qUy
-qUy
-qUy
-qUy
+lgF
+lgF
+lgF
+lgF
 qUy
 qUy
 qUy
@@ -39366,9 +39551,9 @@ xRX
 xRX
 xRX
 qkP
-qUy
+clG
 mcN
-mLK
+jvB
 boM
 yfz
 xRX
@@ -39626,7 +39811,7 @@ xRX
 uVR
 aYD
 gjQ
-ccK
+aCK
 kOl
 xRX
 riA
@@ -39880,9 +40065,9 @@ xRX
 xRX
 xRX
 xRX
-qUy
-qUy
-qUy
+clG
+clG
+clG
 oXn
 yfz
 xRX
@@ -40140,8 +40325,8 @@ xRX
 xRX
 xRX
 scs
-qUy
-qUy
+clG
+clG
 xRX
 xRX
 riA

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -442,6 +442,16 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle/storage)
+"bAL" = (
+/obj/structure/railing/mapped,
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/ship/orion/thruster1)
 "bAQ" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 9
@@ -2099,6 +2109,10 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/storage)
+"iGB" = (
+/obj/structure/foamedmetal,
+/turf/simulated/floor,
+/area/ship/orion/cargo)
 "iGD" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
@@ -3175,10 +3189,6 @@
 /obj/structure/janitorialcart/full,
 /turf/simulated/floor,
 /area/ship/orion/forehall)
-"nlF" = (
-/obj/structure/foamedmetal,
-/turf/simulated/floor,
-/area/ship/orion/cargo)
 "nnl" = (
 /obj/item/device/assembly/mousetrap/armed,
 /obj/effect/decal/cleanable/dirt,
@@ -3825,16 +3835,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
-"qcY" = (
-/obj/structure/railing/mapped,
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/airless,
-/area/ship/orion/thruster1)
 "qeK" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 10
@@ -3979,9 +3979,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "qBd" = (
-/obj/structure/foamedmetal,
-/turf/simulated/floor,
-/area/ship/orion/engie)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/ship/orion/thruster1)
 "qGl" = (
 /obj/effect/map_effect/marker/airlock/docking{
 	landmark_tag = "nav_hangar_orion_express";
@@ -4794,12 +4796,6 @@
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/atmos)
-"tzS" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/airless,
-/area/ship/orion/thruster1)
 "tAd" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 10
@@ -39903,7 +39899,7 @@ oMV
 xrl
 rxB
 soa
-ssp
+gHc
 ssp
 fwA
 lYc
@@ -40160,7 +40156,7 @@ oMV
 oMV
 rxB
 nGj
-ssp
+gHc
 dFW
 qwu
 hlg
@@ -40417,7 +40413,7 @@ oNK
 sXW
 qRJ
 jsa
-ssp
+gHc
 sff
 wzY
 riA
@@ -40674,7 +40670,7 @@ wzK
 jyA
 vKn
 gHc
-ssp
+gHc
 vtR
 wzW
 riA
@@ -40931,7 +40927,7 @@ gep
 gHc
 gHc
 gHc
-riA
+fsY
 riA
 riA
 riA
@@ -41188,7 +41184,7 @@ gHc
 gHc
 xsE
 xsE
-qBd
+xsE
 riA
 riA
 xRX
@@ -41445,7 +41441,7 @@ xsE
 xsE
 xsE
 xsE
-riA
+fsY
 riA
 xRX
 xRX
@@ -41702,7 +41698,7 @@ xsE
 xsE
 fsY
 coK
-riA
+fsY
 xRX
 xRX
 xRX
@@ -41951,7 +41947,7 @@ icu
 jmN
 xiV
 icu
-nlF
+iGB
 xsE
 xsE
 xsE
@@ -42208,7 +42204,7 @@ icu
 kJM
 dul
 icu
-nlF
+iGB
 xsE
 fsY
 qhi
@@ -42720,7 +42716,7 @@ xRX
 xRX
 xRX
 vyi
-tzS
+qBd
 uon
 xRX
 xRX
@@ -42977,7 +42973,7 @@ xRX
 xRX
 xRX
 xRX
-qcY
+bAL
 xRX
 xRX
 xRX
@@ -43234,7 +43230,7 @@ xRX
 xRX
 xRX
 xRX
-qcY
+bAL
 xRX
 xRX
 xRX

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -78,15 +78,6 @@
 /obj/effect/shuttle_landmark/orion_express_ship/transit,
 /turf/space/transit/north,
 /area/space)
-"auB" = (
-/obj/machinery/atmospherics/binary/pump/high_power,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "auV" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/mainhall)
@@ -299,20 +290,6 @@
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/airless,
 /area/ship/orion)
-"beD" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/portables_connector{
-	layer = 2.8
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/high/north{
-	req_access = list(201)
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "bgb" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/cable/green{
@@ -860,12 +837,6 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"dgQ" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "dhX" = (
 /obj/structure/table/rack,
 /obj/item/reagent_containers/toothbrush,
@@ -902,6 +873,12 @@
 	},
 /turf/simulated/floor/tiled/dark/airless,
 /area/ship/orion/thruster1)
+"diZ" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "dkq" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 6
@@ -1047,15 +1024,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/bridge)
-"dHV" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle/storage)
 "dLy" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/thruster2)
@@ -1130,13 +1098,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster2)
-"ekd" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk/indoor,
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "eml" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -1240,9 +1201,6 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
-"fcT" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/starboardthrust)
 "fdC" = (
 /obj/structure/bed/stool/chair/shuttle,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2012,6 +1970,9 @@
 "icu" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion/cargo)
+"ieC" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/cockpit)
 "ieN" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/door/airlock/hatch{
@@ -2129,9 +2090,9 @@
 "iEl" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/storage)
@@ -2353,6 +2314,13 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/engie)
+"jFA" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "jJY" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/door/airlock/glass{
@@ -2631,11 +2599,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/cockpit)
-"lab" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "laC" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/thruster1)
@@ -3063,10 +3026,10 @@
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
+/area/shuttle/orion_shuttle/portthrust)
 "mME" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
@@ -3144,6 +3107,9 @@
 /obj/vehicle/train/cargo/engine,
 /turf/simulated/floor,
 /area/ship/orion/cargo)
+"mVk" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/starboardthrust)
 "mVQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -3435,6 +3401,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
+"nYD" = (
+/obj/structure/foamedmetal,
+/turf/simulated/floor,
+/area/ship/orion/crew)
 "nYY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -3633,20 +3603,6 @@
 	},
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle/storage)
-"pfG" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/storage)
 "phP" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -4307,9 +4263,6 @@
 "rZA" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion/bridge)
-"sab" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/portthrust)
 "scs" = (
 /obj/effect/landmark/entry_point/west{
 	name = "starboard, engine compartment"
@@ -4697,6 +4650,20 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
+"tgX" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "thd" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -4790,6 +4757,19 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
+"tuM" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4;
+	name = "Starboard Thruster"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/orion_shuttle/storage)
 "twl" = (
 /obj/effect/landmark/entry_point/starboard{
 	name = "port, engine entrance"
@@ -5031,6 +5011,14 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
+"uuK" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
+"uvR" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/portthrust)
 "uwG" = (
 /obj/structure/dispenser/oxygen,
 /obj/structure/sign/vacuum{
@@ -5170,9 +5158,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
-"vgB" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/cockpit)
 "vhp" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5507,18 +5492,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
-"wbF" = (
-/obj/machinery/door/airlock/hatch{
-	dir = 4;
-	name = "Starboard Thruster"
-	},
+"wgM" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/noid{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/storage)
 "wia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -5630,6 +5611,15 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/cargo)
+"wwi" = (
+/obj/machinery/atmospherics/binary/pump/high_power,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "wyY" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5710,7 +5700,7 @@
 	name = "aft, lounge"
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
-/area/ship/orion)
+/area/ship/orion/crew)
 "wOV" = (
 /obj/item/trash/can,
 /turf/simulated/floor,
@@ -6042,12 +6032,26 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/cargo)
+"yet" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/portables_connector{
+	layer = 2.8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "yfz" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
+/area/shuttle/orion_shuttle/starboardthrust)
 "yfU" = (
 /obj/machinery/appliance/cooker/fryer,
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -35484,7 +35488,7 @@ xRX
 xRX
 xRX
 xRX
-riA
+jLO
 gfT
 ppD
 lpC
@@ -35740,8 +35744,8 @@ xRX
 xRX
 xRX
 xRX
-riA
-riA
+jLO
+jLO
 iuL
 fJg
 mNG
@@ -35997,13 +36001,13 @@ xRX
 xRX
 xRX
 xRX
-riA
-riA
-qBd
-qBd
-qBd
-qBd
-qBd
+jLO
+jLO
+eXm
+eXm
+eXm
+eXm
+rZA
 rZA
 rZA
 yaV
@@ -36253,14 +36257,14 @@ xRX
 xRX
 xRX
 xRX
-riA
-qBd
+jLO
+eXm
 aoA
 tWh
 jLO
 mXt
 wlN
-qBd
+rZA
 nEg
 smG
 pBC
@@ -36506,18 +36510,18 @@ xRX
 xRX
 xRX
 dwE
-sab
-sab
+uvR
+uvR
 xRX
 xRX
-riA
-riA
+jLO
+jLO
 hAw
 pDY
 hVK
 jwy
 lNh
-qBd
+rZA
 gDc
 sMm
 hfO
@@ -36760,21 +36764,21 @@ xRX
 xRX
 xRX
 xRX
-sab
-sab
-sab
+uvR
+uvR
+uvR
 sqh
-yfz
+diZ
 xRX
-riA
-riA
-riA
+jLO
+jLO
+jLO
 jLO
 jLO
 jLO
 wYR
 jLO
-qBd
+rZA
 qqs
 uty
 xkx
@@ -37020,18 +37024,18 @@ xRX
 mNJ
 aYD
 nAQ
-ekd
+jFA
 qMt
 xRX
-riA
-xsE
-xsE
+jLO
+nYD
+nYD
 eXm
 dmm
 sll
 jwy
 pVf
-qBd
+rZA
 iGD
 tEO
 qHO
@@ -37274,21 +37278,21 @@ xRX
 xRX
 xRX
 iCX
-sab
-beD
-auB
+uvR
+yet
+mLK
 fkX
-yfz
-riA
-riA
-xsE
-xsE
+diZ
+jLO
+jLO
+nYD
+nYD
 eXm
 aXC
 stX
 eml
 mun
-qBd
+rZA
 phP
 ioB
 dvk
@@ -37520,10 +37524,10 @@ xRX
 xRX
 xRX
 xRX
-vgB
-vgB
-vgB
-vgB
+ieC
+ieC
+ieC
+ieC
 qUy
 qUy
 qUy
@@ -37537,15 +37541,15 @@ uzX
 qUy
 qUy
 wNT
-xsE
-xsE
-xsE
+nYD
+nYD
+nYD
 eXm
 nKX
 vhp
 rvp
 mun
-qBd
+rZA
 rBK
 pxl
 pBC
@@ -37802,7 +37806,7 @@ eXm
 vFS
 mXd
 mun
-qBd
+rZA
 aSO
 qTc
 pBC
@@ -38059,7 +38063,7 @@ eXm
 eXm
 tnO
 jLO
-qBd
+rZA
 rZA
 rZA
 vzk
@@ -38299,7 +38303,7 @@ qUy
 skU
 rdc
 biw
-iEl
+wgM
 mzY
 biw
 aVM
@@ -38548,15 +38552,15 @@ xRX
 xRX
 xRX
 xRX
-vgB
+ieC
 vOd
 vPd
 dte
 qUy
 lZq
 lZq
-dHV
-pfG
+iEl
+tgX
 mzO
 rLo
 hlA
@@ -38805,7 +38809,7 @@ xRX
 xRX
 xRX
 xRX
-vgB
+ieC
 fdC
 gnR
 oey
@@ -39062,7 +39066,7 @@ xRX
 xRX
 xRX
 xRX
-vgB
+ieC
 fBW
 vRr
 kYI
@@ -39319,10 +39323,10 @@ xRX
 xRX
 xRX
 xRX
-vgB
-vgB
-vgB
-vgB
+ieC
+ieC
+ieC
+ieC
 qUy
 qUy
 qUy
@@ -39332,7 +39336,7 @@ qUy
 qUy
 qUy
 qUy
-wbF
+tuM
 qUy
 qUy
 riA
@@ -39587,11 +39591,11 @@ xRX
 xRX
 xRX
 qkP
-fcT
+mVk
 mcN
-mLK
+wwi
 boM
-dgQ
+yfz
 xRX
 oQa
 iCR
@@ -39845,7 +39849,7 @@ xRX
 xRX
 xRX
 uVR
-lab
+uuK
 gjQ
 ccK
 kOl
@@ -40101,11 +40105,11 @@ xRX
 xRX
 xRX
 xRX
-fcT
-fcT
-fcT
+mVk
+mVk
+mVk
 oXn
-dgQ
+yfz
 xRX
 xRX
 riA
@@ -40361,8 +40365,8 @@ xRX
 xRX
 xRX
 scs
-fcT
-fcT
+mVk
+mVk
 xRX
 xRX
 riA

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -248,7 +248,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
+/area/shuttle/orion_shuttle/starboardthrust)
 "aYE" = (
 /obj/effect/floor_decal/corner_wide/beige/full{
 	dir = 8
@@ -267,12 +267,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
-"aYK" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "bbM" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/vehicle/train/cargo/trolley,
@@ -373,6 +367,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
+"bnF" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "bol" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -567,9 +570,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"bWt" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/starboardthrust)
 "bWK" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -695,6 +695,20 @@
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion)
+"cqM" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "crK" = (
 /obj/structure/sign/staff_only{
 	pixel_x = 32
@@ -980,6 +994,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
+"dwu" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "dwE" = (
 /obj/effect/landmark/entry_point/east{
 	name = "port, engine compartment"
@@ -1253,6 +1273,9 @@
 /obj/machinery/meter,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle/portthrust)
+"fma" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/portthrust)
 "fmY" = (
 /obj/machinery/photocopier,
 /obj/effect/floor_decal/corner/dark_blue{
@@ -1347,9 +1370,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/ship/orion/mainhall)
+"fOy" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/cockpit)
 "fUj" = (
 /turf/simulated/floor,
 /area/ship/orion/forehall)
+"fYz" = (
+/obj/machinery/atmospherics/binary/pump/high_power,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "gdY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -1420,7 +1455,8 @@
 	},
 /obj/item/device/flashlight/lamp{
 	pixel_x = -7;
-	pixel_y = 15
+	pixel_y = 15;
+	brightness_level = "low"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle/cockpit)
@@ -1528,15 +1564,6 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
-"gEf" = (
-/obj/machinery/atmospherics/binary/pump/high_power,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "gGv" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 6
@@ -2091,13 +2118,8 @@
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion/comms)
 "iCX" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/railing/mapped{
-	dir = 8
-	},
 /obj/machinery/iff_beacon/name_change,
+/obj/structure/lattice/catwalk,
 /turf/simulated/floor/airless,
 /area/shuttle/orion_shuttle/storage)
 "iEl" = (
@@ -2463,7 +2485,7 @@
 /area/ship/orion/mainhall)
 "kog" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/pottedplant,
+/obj/random/pottedplant,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle/cockpit)
 "krv" = (
@@ -3071,15 +3093,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
-"mPc" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle/storage)
 "mPM" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/window/reinforced{
@@ -3464,11 +3477,6 @@
 /obj/structure/bookcase,
 /turf/simulated/floor,
 /area/ship/orion/atmos)
-"osx" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "ovT" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/captain)
@@ -3479,6 +3487,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
+"oyZ" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4;
+	name = "Port Thruster"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/orion_shuttle/storage)
 "oAK" = (
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "orion_shuttle";
@@ -3677,16 +3695,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"psm" = (
-/obj/machinery/door/airlock/hatch{
-	dir = 4;
-	name = "Starboard Thruster"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle/storage)
 "ptP" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 4
@@ -3738,20 +3746,6 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/crew)
-"pEi" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle/storage)
 "pFY" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
@@ -3897,12 +3891,7 @@
 /area/shuttle/orion_shuttle/storage)
 "qkP" = (
 /obj/machinery/shipsensors/weak,
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
+/obj/structure/lattice/catwalk,
 /turf/simulated/floor/airless,
 /area/shuttle/orion_shuttle/storage)
 "qpS" = (
@@ -4081,7 +4070,7 @@
 /area/ship/orion/bridge)
 "qUy" = (
 /turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/cockpit)
+/area/shuttle/orion_shuttle/storage)
 "qXP" = (
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
@@ -4451,13 +4440,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
-"spX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk/indoor,
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "sqh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -4479,9 +4461,6 @@
 /obj/structure/bed/stool/bar/padded/beige,
 /turf/simulated/floor/carpet,
 /area/ship/orion/crew)
-"syj" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/portthrust)
 "sys" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -5068,7 +5047,7 @@
 "uzX" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
-	name = "Port Thruster"
+	name = "Starboard Thruster"
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5431,6 +5410,11 @@
 /obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
+"vSk" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "vUr" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/light/small/emergency{
@@ -5852,6 +5836,20 @@
 /obj/structure/foamedmetal,
 /turf/simulated/floor,
 /area/ship/orion)
+"xtL" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/portables_connector{
+	layer = 2.8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "xtN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -5916,6 +5914,13 @@
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
+"xEc" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "xFj" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5935,26 +5940,15 @@
 /obj/item/paper/business_card,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
-"xGO" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/portables_connector{
-	layer = 2.8
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/high/north{
-	req_access = list(201)
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "xJk" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "aft, starboard side"
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion)
+"xJR" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/starboardthrust)
 "xPl" = (
 /obj/structure/bed/stool/chair/office/light{
 	dir = 8
@@ -5969,9 +5963,6 @@
 "xRX" = (
 /turf/template_noop,
 /area/space)
-"xSq" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/storage)
 "xSA" = (
 /obj/item/trash/chips/dirtberry,
 /turf/simulated/floor,
@@ -6049,7 +6040,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
+/area/shuttle/orion_shuttle/portthrust)
 "yfU" = (
 /obj/machinery/appliance/cooker/fryer,
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -36508,8 +36499,8 @@ xRX
 xRX
 xRX
 dwE
-syj
-syj
+fma
+fma
 xRX
 xRX
 riA
@@ -36762,11 +36753,11 @@ xRX
 xRX
 xRX
 xRX
-syj
-syj
-syj
+fma
+fma
+fma
 sqh
-aYK
+yfz
 xRX
 riA
 riA
@@ -37020,7 +37011,7 @@ xRX
 xRX
 xRX
 mNJ
-aYD
+vSk
 nAQ
 ccK
 qMt
@@ -37276,11 +37267,11 @@ xRX
 xRX
 xRX
 iCX
-syj
-xGO
+fma
+xtL
 mLK
 fkX
-aYK
+yfz
 riA
 riA
 xsE
@@ -37522,22 +37513,22 @@ xRX
 xRX
 xRX
 xRX
+fOy
+fOy
+fOy
+fOy
 qUy
 qUy
 qUy
 qUy
-xSq
-xSq
-xSq
-xSq
-xSq
-xSq
-xSq
-xSq
-xSq
-uzX
-xSq
-xSq
+qUy
+qUy
+qUy
+qUy
+qUy
+oyZ
+qUy
+qUy
 wNT
 xsE
 xsE
@@ -37783,7 +37774,7 @@ wFW
 fau
 glh
 kog
-xSq
+qUy
 xTL
 ipM
 hld
@@ -37793,7 +37784,7 @@ sTK
 tRi
 qjk
 nzE
-xSq
+qUy
 soM
 haV
 haV
@@ -38048,10 +38039,10 @@ hvo
 mcD
 oIF
 jOD
-xSq
-xSq
-xSq
-xSq
+qUy
+qUy
+qUy
+qUy
 haV
 spv
 dGE
@@ -38297,7 +38288,7 @@ wFW
 jiH
 wkO
 jKa
-xSq
+qUy
 skU
 rdc
 biw
@@ -38550,15 +38541,15 @@ xRX
 xRX
 xRX
 xRX
-qUy
+fOy
 vOd
 vPd
 dte
-xSq
+qUy
 lZq
 lZq
-mPc
-pEi
+bnF
+cqM
 mzO
 rLo
 hlA
@@ -38807,11 +38798,11 @@ xRX
 xRX
 xRX
 xRX
-qUy
+fOy
 fdC
 gnR
 oey
-xSq
+qUy
 iPr
 nGq
 qQV
@@ -38819,9 +38810,9 @@ yaz
 eXD
 gdY
 lTO
-xSq
-xSq
-xSq
+qUy
+qUy
+qUy
 rrQ
 qBd
 qBd
@@ -39064,11 +39055,11 @@ xRX
 xRX
 xRX
 xRX
-qUy
+fOy
 fBW
 vRr
 kYI
-xSq
+qUy
 pdw
 rDS
 hNk
@@ -39078,7 +39069,7 @@ iOe
 kAZ
 ixH
 kcS
-xSq
+qUy
 efO
 bHV
 xzg
@@ -39321,22 +39312,22 @@ xRX
 xRX
 xRX
 xRX
+fOy
+fOy
+fOy
+fOy
 qUy
 qUy
 qUy
 qUy
-xSq
-xSq
-xSq
-xSq
-xSq
-xSq
-xSq
-xSq
-xSq
-psm
-xSq
-xSq
+qUy
+qUy
+qUy
+qUy
+qUy
+uzX
+qUy
+qUy
 riA
 oQa
 gMK
@@ -39589,11 +39580,11 @@ xRX
 xRX
 xRX
 qkP
-bWt
+xJR
 mcN
-gEf
+fYz
 boM
-yfz
+dwu
 xRX
 oQa
 iCR
@@ -39847,9 +39838,9 @@ xRX
 xRX
 xRX
 uVR
-osx
+aYD
 gjQ
-spX
+xEc
 kOl
 xRX
 riA
@@ -40103,11 +40094,11 @@ xRX
 xRX
 xRX
 xRX
-bWt
-bWt
-bWt
+xJR
+xJR
+xJR
 oXn
-yfz
+dwu
 xRX
 xRX
 riA
@@ -40363,8 +40354,8 @@ xRX
 xRX
 xRX
 scs
-bWt
-bWt
+xJR
+xJR
 xRX
 xRX
 riA

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -74,15 +74,6 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/crew)
-"aoV" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle/storage)
 "asD" = (
 /obj/effect/shuttle_landmark/orion_express_ship/transit,
 /turf/space/transit/north,
@@ -117,13 +108,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
-"aCK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk,
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "aDL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -635,19 +619,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
-"cbv" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "ccK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
+/area/shuttle/orion_shuttle/starboardthrust)
 "ceU" = (
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "orion_traveler_port";
@@ -691,9 +669,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/bridge)
-"clG" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/starboardthrust)
 "cnJ" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/light{
@@ -1351,6 +1326,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/ship/orion/mainhall)
+"fNK" = (
+/obj/machinery/atmospherics/binary/pump/high_power,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "fUj" = (
 /turf/simulated/floor,
 /area/ship/orion/forehall)
@@ -1392,6 +1376,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"gim" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/starboardthrust)
 "gjQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/east{
@@ -2099,6 +2086,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/storage)
 "iGD" = (
@@ -2161,11 +2153,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle/storage)
-"iSX" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "iTn" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 5
@@ -2278,15 +2265,6 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
-"jvB" = (
-/obj/machinery/atmospherics/binary/pump/high_power,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "jvY" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -2618,9 +2596,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"lgF" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/cockpit)
 "lhJ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light{
@@ -2705,9 +2680,6 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
-"lBE" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/portthrust)
 "lCK" = (
 /obj/item/trash/can/adhomian_can,
 /turf/simulated/floor,
@@ -2906,6 +2878,15 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/cargo)
+"mfX" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "mgg" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -3019,6 +3000,15 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
+"mGg" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "mGO" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
@@ -3096,20 +3086,6 @@
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
-"mRb" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle/storage)
 "mSt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -3766,6 +3742,12 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster2)
+"pOG" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "pOK" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion/captain)
@@ -4083,6 +4065,11 @@
 	},
 /turf/simulated/floor/tiled/dark/airless,
 /area/ship/orion/thruster2)
+"rbj" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "rdc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -4625,20 +4612,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
-"sZK" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/portables_connector{
-	layer = 2.8
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/high/north{
-	req_access = list(201)
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "tcC" = (
 /obj/machinery/light{
 	dir = 8;
@@ -5155,6 +5128,9 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
+"vgU" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/cockpit)
 "vhp" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5600,6 +5576,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
+"wzu" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/portables_connector{
+	layer = 2.8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "wzK" = (
 /obj/effect/floor_decal/corner/dark_green/diagonal,
 /obj/machinery/door/window{
@@ -5639,6 +5629,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
+"wFa" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/portthrust)
 "wFW" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid,
@@ -5827,6 +5820,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
+"xsv" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "xsE" = (
 /obj/structure/foamedmetal,
 /turf/simulated/floor,
@@ -6011,7 +6011,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
+/area/shuttle/orion_shuttle/portthrust)
 "yfU" = (
 /obj/machinery/appliance/cooker/fryer,
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -36470,8 +36470,8 @@ xRX
 xRX
 xRX
 dwE
-lBE
-lBE
+wFa
+wFa
 xRX
 xRX
 riA
@@ -36724,11 +36724,11 @@ xRX
 xRX
 xRX
 xRX
-lBE
-lBE
-lBE
+wFa
+wFa
+wFa
 sqh
-cbv
+yfz
 xRX
 riA
 riA
@@ -36982,9 +36982,9 @@ xRX
 xRX
 xRX
 mNJ
-iSX
+rbj
 nAQ
-ccK
+xsv
 qMt
 xRX
 riA
@@ -37238,11 +37238,11 @@ xRX
 xRX
 xRX
 iCX
-lBE
-sZK
+wFa
+wzu
 mLK
 fkX
-cbv
+yfz
 riA
 riA
 xsE
@@ -37484,10 +37484,10 @@ xRX
 xRX
 xRX
 xRX
-lgF
-lgF
-lgF
-lgF
+vgU
+vgU
+vgU
+vgU
 qUy
 qUy
 qUy
@@ -38263,7 +38263,7 @@ qUy
 skU
 rdc
 biw
-iEl
+mfX
 mzY
 biw
 aVM
@@ -38512,15 +38512,15 @@ xRX
 xRX
 xRX
 xRX
-lgF
+vgU
 vOd
 vPd
 dte
 qUy
 lZq
 lZq
-aoV
-mRb
+mGg
+iEl
 mzO
 rLo
 hlA
@@ -38769,7 +38769,7 @@ xRX
 xRX
 xRX
 xRX
-lgF
+vgU
 fdC
 gnR
 oey
@@ -39026,7 +39026,7 @@ xRX
 xRX
 xRX
 xRX
-lgF
+vgU
 fBW
 vRr
 kYI
@@ -39283,10 +39283,10 @@ xRX
 xRX
 xRX
 xRX
-lgF
-lgF
-lgF
-lgF
+vgU
+vgU
+vgU
+vgU
 qUy
 qUy
 qUy
@@ -39551,11 +39551,11 @@ xRX
 xRX
 xRX
 qkP
-clG
+gim
 mcN
-jvB
+fNK
 boM
-yfz
+pOG
 xRX
 oQa
 iCR
@@ -39811,7 +39811,7 @@ xRX
 uVR
 aYD
 gjQ
-aCK
+ccK
 kOl
 xRX
 riA
@@ -40065,11 +40065,11 @@ xRX
 xRX
 xRX
 xRX
-clG
-clG
-clG
+gim
+gim
+gim
 oXn
-yfz
+pOG
 xRX
 xRX
 riA
@@ -40325,8 +40325,8 @@ xRX
 xRX
 xRX
 scs
-clG
-clG
+gim
+gim
 xRX
 xRX
 riA

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -22,16 +22,6 @@
 "aev" = (
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
-"afP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
 "afW" = (
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
@@ -227,6 +217,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
+"aVM" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "aXC" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/small/beer,
@@ -317,17 +320,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
 "biw" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 9
-	},
-/obj/structure/closet/walllocker/emerglocker/east,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/item/storage/bag/inflatable/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "bjg" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
@@ -387,8 +381,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/meter,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)
 "buO" = (
@@ -622,7 +617,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor,
+/obj/structure/lattice/catwalk,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)
 "ceU" = (
@@ -1169,6 +1164,16 @@
 "eXm" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion/crew)
+"eXD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/orion_shuttle)
 "fau" = (
 /obj/machinery/computer/shuttle_control/explore/orion_express_shuttle,
 /obj/item/device/radio/intercom/expedition/hailing/west,
@@ -1179,6 +1184,12 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
+"fdC" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/alarm/north,
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "feE" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 6
@@ -1216,7 +1227,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/meter,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)
 "fmY" = (
@@ -1246,24 +1257,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"frt" = (
-/obj/machinery/light{
-	dir = 8;
-	inserted_light = /obj/item/light/tube/colored/blue
-	},
-/obj/structure/table/steel,
-/obj/item/clothing/head/helmet/pilot{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/paper_bin{
-	pixel_x = -2
-	},
-/obj/item/pen{
-	pixel_x = -2
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "frC" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 8
@@ -1294,13 +1287,9 @@
 /turf/simulated/floor,
 /area/ship/orion/engie)
 "fBW" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 8
-	},
-/obj/structure/bed/handrail{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/bed/stool/chair/shuttle,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "fJg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
@@ -1371,8 +1360,8 @@
 /area/ship/orion/forehall)
 "gjQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/alarm/east,
+/obj/structure/lattice/catwalk,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)
 "gkw" = (
@@ -1382,10 +1371,24 @@
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
 "glh" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
+/obj/machinery/light{
+	dir = 8;
+	inserted_light = /obj/item/light/tube/colored/blue
 	},
+/obj/structure/table/steel,
+/obj/item/clothing/head/helmet/pilot{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/paper_bin{
+	pixel_x = -2
+	},
+/obj/item/pen{
+	pixel_x = -2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
+"gnR" = (
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "goI" = (
@@ -1704,6 +1707,14 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/bridge)
+"hld" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/securearea{
+	pixel_x = -32
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "hlg" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -1801,7 +1812,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -1871,7 +1882,8 @@
 /obj/structure/sign/electricshock{
 	pixel_x = 32
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2004,24 +2016,15 @@
 /area/ship/orion/atmos)
 "ixH" = (
 /obj/effect/floor_decal/corner/dark_green{
-	dir = 6
+	dir = 9
 	},
-/obj/structure/closet/walllocker/firecloset{
-	pixel_x = -32
-	},
-/obj/effect/floor_decal/industrial/outline/firefighting_closet,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
-"iBW" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/closet/walllocker/emerglocker/east,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/item/storage/bag/inflatable/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "iCR" = (
@@ -2308,6 +2311,28 @@
 	},
 /turf/simulated/floor/grass,
 /area/ship/orion/forehall)
+"jOD" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/loading/yellow{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "jWz" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/machinery/chem_master/condimaster{
@@ -2403,12 +2428,13 @@
 /turf/simulated/floor,
 /area/ship/orion/cargo)
 "kAZ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/light{
-	dir = 4;
-	inserted_light = /obj/item/light/tube/colored/blue
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 8
 	},
-/turf/simulated/floor/carpet/rubber,
+/obj/structure/bed/handrail{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "kDQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -2436,8 +2462,8 @@
 "kLL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/apc/west,
-/obj/structure/cable{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
@@ -2628,6 +2654,16 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/orion)
+"lTO" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "lXJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -2673,7 +2709,11 @@
 /turf/simulated/floor,
 /area/ship/orion/engie)
 "lZq" = (
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "maj" = (
 /obj/machinery/door/airlock/external{
@@ -2960,13 +3000,15 @@
 /turf/simulated/floor,
 /area/ship/orion/cargo)
 "mVQ" = (
-/obj/machinery/door/airlock/command{
-	name = "Cockpit"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/noid,
+/obj/machinery/door/airlock/glass_command{
+	id_tag = null;
+	name = "Cockpit";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "mXd" = (
@@ -2998,12 +3040,6 @@
 /obj/item/clothing/accessory/bandanna/black,
 /turf/simulated/floor/wood,
 /area/ship/orion/crew)
-"mYs" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/alarm/north,
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "ncx" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
@@ -3082,20 +3118,8 @@
 "nAQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/west,
+/obj/structure/lattice/catwalk,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
-"nCz" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	layer = 2.71
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "nDV" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -3294,10 +3318,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
-"oeF" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "ojl" = (
 /obj/structure/bookcase,
 /turf/simulated/floor,
@@ -3421,15 +3441,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/obj/structure/lattice/catwalk/indoor,
 /obj/machinery/light{
 	dir = 4;
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
+/obj/structure/lattice/catwalk,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle)
-"oYK" = (
-/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "oZS" = (
 /obj/effect/floor_decal/spline/plain/black,
@@ -3643,14 +3660,6 @@
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/ship/orion/atmos)
-"pXh" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/securearea{
-	pixel_x = -32
-	},
-/obj/structure/closet/crate,
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "pXU" = (
 /obj/machinery/shower,
 /obj/structure/curtain/open/shower,
@@ -3694,17 +3703,13 @@
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion)
 "qjk" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	layer = 2.71
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 6
 	},
-/obj/structure/fuel_port/phoron{
+/obj/structure/closet/walllocker/firecloset{
 	pixel_x = -32
 	},
-/obj/effect/floor_decal/corner/dark_green,
-/obj/structure/bed/handrail{
-	dir = 4
-	},
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "qkP" = (
@@ -4041,11 +4046,10 @@
 /obj/structure/closet/secure_closet/package_courier{
 	req_access = list()
 	},
-/obj/structure/cable{
-	d1 = 4;
+/obj/structure/cable/green{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "1-4";
-	dir = 4
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
@@ -4166,23 +4170,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/ship/orion/crew)
-"slp" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/vending/wallmed1{
-	req_access = null;
-	pixel_y = 30;
-	pixel_x = -7
-	},
-/obj/machinery/button/remote/blast_door{
-	name = "Safety Shutters";
-	id = "orion_shuttle_shutters";
-	dir = 1;
-	pixel_y = 27;
-	pixel_x = 7
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "slH" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate,
@@ -4275,11 +4262,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/structure/lattice/catwalk/indoor,
 /obj/machinery/light{
 	dir = 8;
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
+/obj/structure/lattice/catwalk,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)
 "ssp" = (
@@ -4691,6 +4678,20 @@
 /obj/item/tank/phoron/shuttle,
 /turf/simulated/floor,
 /area/ship/orion/cargo)
+"tRi" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/structure/fuel_port/phoron{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/corner/dark_green,
+/obj/structure/bed/handrail{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "tRj" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 5
@@ -5171,6 +5172,18 @@
 "vOd" = (
 /obj/structure/bed/stool/chair/shuttle,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/vending/wallmed1{
+	req_access = null;
+	pixel_y = 30;
+	pixel_x = -7
+	},
+/obj/machinery/button/remote/blast_door{
+	name = "Safety Shutters";
+	id = "orion_shuttle_shutters";
+	dir = 1;
+	pixel_y = 27;
+	pixel_x = 7
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "vPd" = (
@@ -5183,6 +5196,14 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster2)
+"vRr" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light{
+	dir = 4;
+	inserted_light = /obj/item/light/tube/colored/blue
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "vRO" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5299,25 +5320,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
 "wkO" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/loading/yellow{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "wlw" = (
@@ -5333,16 +5335,6 @@
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
 /area/ship/orion/crew)
-"wmb" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "wpk" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/grass,
@@ -5782,13 +5774,16 @@
 /turf/simulated/floor,
 /area/ship/orion/cargo)
 "yaz" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable{
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/rubber,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "yaV" = (
 /obj/machinery/door/airlock/command{
@@ -37551,17 +37546,17 @@ xRX
 xRX
 wFW
 fau
-frt
+glh
 kog
 qUy
 xTL
 ipM
-pXh
+hld
 kLL
-oeF
+biw
 sTK
+tRi
 qjk
-ixH
 nzE
 qUy
 soM
@@ -37817,7 +37812,7 @@ sTm
 hvo
 mcD
 oIF
-wkO
+jOD
 qUy
 qUy
 qUy
@@ -38065,16 +38060,16 @@ xRX
 xRX
 wFW
 jiH
-lZq
+wkO
 jKa
 qUy
 skU
 rdc
 iEl
-yaz
+iEl
 mzY
-oeF
-nCz
+biw
+aVM
 ihA
 oAK
 gXD
@@ -38321,14 +38316,14 @@ xRX
 xRX
 xRX
 qUy
-slp
+vOd
 vPd
 dte
 qUy
-glh
-glh
+lZq
+lZq
 iEl
-yaz
+iEl
 mzO
 rLo
 hlA
@@ -38578,17 +38573,17 @@ xRX
 xRX
 xRX
 qUy
-mYs
-oYK
+fdC
+gnR
 oey
 qUy
 iPr
 nGq
 qQV
-iBW
-afP
+yaz
+eXD
 gdY
-wmb
+lTO
 qUy
 qUy
 qUy
@@ -38835,8 +38830,8 @@ xRX
 xRX
 xRX
 qUy
-vOd
-kAZ
+fBW
+vRr
 kYI
 qUy
 pdw
@@ -38845,8 +38840,8 @@ hNk
 rDd
 uWQ
 iOe
-fBW
-biw
+kAZ
+ixH
 kcS
 qUy
 efO

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -442,16 +442,6 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle/storage)
-"bAL" = (
-/obj/structure/railing/mapped,
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/airless,
-/area/ship/orion/thruster1)
 "bAQ" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 9
@@ -2109,10 +2099,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/storage)
-"iGB" = (
-/obj/structure/foamedmetal,
-/turf/simulated/floor,
-/area/ship/orion/cargo)
 "iGD" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
@@ -3140,7 +3126,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle/storage)
 "mXd" = (
@@ -3979,11 +3964,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "qBd" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/airless,
-/area/ship/orion/thruster1)
+/obj/structure/foamedmetal,
+/turf/simulated/floor,
+/area/ship/orion/cargo)
 "qGl" = (
 /obj/effect/map_effect/marker/airlock/docking{
 	landmark_tag = "nav_hangar_orion_express";
@@ -4240,6 +4223,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"rKH" = (
+/obj/structure/railing/mapped,
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/ship/orion/thruster1)
 "rLo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
@@ -4768,6 +4761,12 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
+"trX" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/ship/orion/thruster1)
 "tsn" = (
 /obj/effect/floor_decal/spline/plain/corner/black{
 	dir = 8
@@ -41947,7 +41946,7 @@ icu
 jmN
 xiV
 icu
-iGB
+qBd
 xsE
 xsE
 xsE
@@ -42204,7 +42203,7 @@ icu
 kJM
 dul
 icu
-iGB
+qBd
 xsE
 fsY
 qhi
@@ -42716,7 +42715,7 @@ xRX
 xRX
 xRX
 vyi
-qBd
+trX
 uon
 xRX
 xRX
@@ -42973,7 +42972,7 @@ xRX
 xRX
 xRX
 xRX
-bAL
+rKH
 xRX
 xRX
 xRX
@@ -43230,7 +43229,7 @@ xRX
 xRX
 xRX
 xRX
-bAL
+rKH
 xRX
 xRX
 xRX

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -289,7 +289,7 @@
 	},
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/airless,
-/area/ship/orion)
+/area/ship/orion/thruster2)
 "bgb" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/cable/green{
@@ -480,7 +480,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
-/area/ship/orion)
+/area/ship/orion/thruster2)
 "bGx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/hatch{
@@ -498,7 +498,7 @@
 	name = "aft, misc storage"
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
-/area/ship/orion)
+/area/ship/orion/comms)
 "bIQ" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -685,7 +685,7 @@
 	name = "starboard, lower commissary"
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
-/area/ship/orion)
+/area/ship/orion/shop)
 "crK" = (
 /obj/structure/sign/staff_only{
 	pixel_x = 32
@@ -1122,7 +1122,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
-/area/ship/orion)
+/area/ship/orion/thruster2)
 "eBK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -1289,6 +1289,9 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/thruster1)
+"fsY" = (
+/turf/simulated/wall/shuttle/scc_space_ship,
+/area/ship/orion/shop)
 "fuh" = (
 /obj/item/clothing/head/beret/janitor,
 /obj/structure/table/steel,
@@ -1620,7 +1623,7 @@
 	name = "port, bathrooms"
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
-/area/ship/orion)
+/area/ship/orion/forehall)
 "gPs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -1673,7 +1676,7 @@
 	name = "aft, port side"
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
-/area/ship/orion)
+/area/ship/orion/forehall)
 "hdZ" = (
 /obj/effect/floor_decal/spline/plain/corner/black{
 	dir = 1
@@ -1966,7 +1969,7 @@
 	name = "starboard, cargo"
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
-/area/ship/orion)
+/area/ship/orion/cargo)
 "icu" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion/cargo)
@@ -2737,7 +2740,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
-/area/ship/orion)
+/area/ship/orion/thruster1)
 "lTO" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	layer = 2.71;
@@ -3081,7 +3084,7 @@
 	},
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
-/area/ship/orion/shop)
+/area/ship/orion/cargo)
 "mSt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -3172,6 +3175,10 @@
 /obj/structure/janitorialcart/full,
 /turf/simulated/floor,
 /area/ship/orion/forehall)
+"nlF" = (
+/obj/structure/foamedmetal,
+/turf/simulated/floor,
+/area/ship/orion/cargo)
 "nnl" = (
 /obj/item/device/assembly/mousetrap/armed,
 /obj/effect/decal/cleanable/dirt,
@@ -3578,7 +3585,7 @@
 	name = "starboard, upper cargo"
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
-/area/ship/orion)
+/area/ship/orion/cargo)
 "oXn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -3818,6 +3825,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
+"qcY" = (
+/obj/structure/railing/mapped,
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/ship/orion/thruster1)
 "qeK" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 10
@@ -3843,7 +3860,7 @@
 	name = "starboard, commissary"
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
-/area/ship/orion)
+/area/ship/orion/shop)
 "qjk" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 6
@@ -3962,8 +3979,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "qBd" = (
-/turf/simulated/wall/shuttle/scc_space_ship/cardinal,
-/area/ship/orion)
+/obj/structure/foamedmetal,
+/turf/simulated/floor,
+/area/ship/orion/engie)
 "qGl" = (
 /obj/effect/map_effect/marker/airlock/docking{
 	landmark_tag = "nav_hangar_orion_express";
@@ -4080,7 +4098,7 @@
 /area/ship/orion/bridge)
 "riA" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
-/area/ship/orion)
+/area/ship/orion/engie)
 "rlw" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4106,7 +4124,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
-/area/ship/orion)
+/area/ship/orion/thruster2)
 "rrQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 8
@@ -4776,6 +4794,12 @@
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/atmos)
+"tzS" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/ship/orion/thruster1)
 "tAd" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 10
@@ -4939,7 +4963,7 @@
 	name = "port, gardens"
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
-/area/ship/orion)
+/area/ship/orion/forehall)
 "ufB" = (
 /obj/structure/table/rack,
 /obj/item/reagent_containers/toothpaste,
@@ -4990,7 +5014,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless,
-/area/ship/orion)
+/area/ship/orion/thruster1)
 "uqu" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5238,7 +5262,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/airless,
-/area/ship/orion)
+/area/ship/orion/thruster1)
 "vyy" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/light/small/emergency{
@@ -5784,7 +5808,7 @@
 /obj/machinery/shipsensors/weak,
 /obj/structure/railing/mapped,
 /turf/simulated/floor/airless,
-/area/ship/orion)
+/area/ship/orion/thruster2)
 "xnY" = (
 /obj/item/reagent_containers/food/drinks/cans/peach_soda{
 	pixel_x = -5
@@ -5856,7 +5880,7 @@
 "xsE" = (
 /obj/structure/foamedmetal,
 /turf/simulated/floor,
-/area/ship/orion)
+/area/ship/orion/shop)
 "xtN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -5945,7 +5969,7 @@
 	name = "aft, starboard side"
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
-/area/ship/orion)
+/area/ship/orion/engie)
 "xPl" = (
 /obj/structure/bed/stool/chair/office/light{
 	dir = 8
@@ -34217,9 +34241,9 @@ rZA
 rZA
 rNJ
 rZA
-riA
-riA
-riA
+wrd
+wrd
+wrd
 xRX
 xRX
 xRX
@@ -34476,9 +34500,9 @@ iVL
 rZA
 pXU
 sMD
-riA
+wrd
 gOp
-riA
+wrd
 xRX
 xRX
 xRX
@@ -34735,9 +34759,9 @@ iIr
 cwI
 vtO
 tOx
-riA
-riA
-riA
+wrd
+wrd
+wrd
 xRX
 xRX
 xRX
@@ -34992,11 +35016,11 @@ qpX
 cwI
 qpX
 nIu
-qBd
-riA
-riA
+qpX
+wrd
+wrd
 udj
-riA
+wrd
 xRX
 xRX
 xRX
@@ -35253,8 +35277,8 @@ qpX
 lhJ
 ilT
 jMZ
-riA
-riA
+wrd
+wrd
 xRX
 xRX
 xRX
@@ -35511,8 +35535,8 @@ oVV
 kFU
 wlw
 wpk
-riA
-riA
+wrd
+wrd
 xRX
 xRX
 xRX
@@ -35769,8 +35793,8 @@ oVV
 kFU
 ilT
 cnJ
-riA
-riA
+wrd
+wrd
 xRX
 xRX
 xRX
@@ -36026,8 +36050,8 @@ oVV
 oVV
 oVV
 wpk
-riA
-riA
+wrd
+wrd
 xRX
 xRX
 xRX
@@ -36283,9 +36307,9 @@ deS
 deS
 oVV
 mGO
-riA
-riA
-riA
+wrd
+wrd
+wrd
 xRX
 xRX
 xRX
@@ -36799,8 +36823,8 @@ qpX
 qpX
 oAP
 nkI
-riA
-riA
+wrd
+wrd
 xRX
 xRX
 xRX
@@ -37057,7 +37081,7 @@ qpX
 fUj
 bld
 qXP
-riA
+wrd
 xRX
 xRX
 xRX
@@ -37314,8 +37338,8 @@ ieN
 fUj
 fUj
 fUj
-riA
-riA
+wrd
+wrd
 xRX
 xRX
 xRX
@@ -37572,7 +37596,7 @@ qpX
 qpX
 ddB
 oQn
-riA
+wrd
 xRX
 xRX
 xRX
@@ -38825,11 +38849,11 @@ qUy
 qUy
 qUy
 rrQ
-qBd
-qBd
-qBd
-qBd
-qBd
+iCR
+iCR
+iCR
+iCR
+iCR
 icu
 nDV
 wSv
@@ -39109,8 +39133,8 @@ gHc
 gHc
 inj
 hwT
-gHc
-gHc
+ssp
+ssp
 ssp
 tUl
 aiv
@@ -39339,11 +39363,11 @@ qUy
 tuM
 qUy
 qUy
-riA
+oQa
 oQa
 gMK
 mgg
-qBd
+iCR
 roN
 stm
 gec
@@ -39600,7 +39624,7 @@ xRX
 oQa
 iCR
 kRQ
-qBd
+iCR
 wlA
 iHS
 ntn
@@ -39854,10 +39878,10 @@ gjQ
 ccK
 kOl
 xRX
-riA
-riA
+oQa
+oQa
 nnl
-qBd
+iCR
 wlA
 stm
 tPq
@@ -40112,9 +40136,9 @@ oXn
 yfz
 xRX
 xRX
-riA
+oQa
 pPC
-qBd
+iCR
 hmX
 stm
 ajL
@@ -40369,9 +40393,9 @@ mVk
 mVk
 xRX
 xRX
-riA
-riA
-qBd
+oQa
+oQa
+iCR
 wlA
 stm
 slH
@@ -40627,8 +40651,8 @@ xRX
 xRX
 xRX
 xRX
-riA
-riA
+oQa
+oQa
 wlA
 aOi
 stm
@@ -40884,8 +40908,8 @@ xRX
 xRX
 xRX
 xRX
-riA
-riA
+oQa
+oQa
 pFY
 stm
 wtd
@@ -40906,9 +40930,9 @@ mpC
 gep
 gHc
 gHc
-qBd
-xsE
-xsE
+gHc
+riA
+riA
 riA
 riA
 xRX
@@ -41142,8 +41166,8 @@ xRX
 xRX
 xRX
 xRX
-riA
-riA
+oQa
+bjg
 gJZ
 tUu
 uHL
@@ -41156,15 +41180,15 @@ tcX
 tcX
 egO
 fqt
-gHc
+icu
 wrk
 krv
 gHc
+gHc
+gHc
+xsE
+xsE
 qBd
-qBd
-xsE
-xsE
-xsE
 riA
 riA
 xRX
@@ -41401,7 +41425,7 @@ xRX
 xRX
 xRX
 oXh
-riA
+bjg
 jub
 ntw
 eEj
@@ -41413,10 +41437,10 @@ jwX
 kYl
 lxT
 uwG
-qBd
-qBd
-qBd
-qBd
+icu
+gHc
+gHc
+gHc
 xsE
 xsE
 xsE
@@ -41658,9 +41682,9 @@ xRX
 xRX
 xRX
 xRX
-riA
-riA
-riA
+bjg
+bjg
+bjg
 maA
 thI
 yau
@@ -41670,13 +41694,13 @@ icu
 icu
 tlv
 icu
-qBd
+icu
 xsE
 xsE
 xsE
 xsE
 xsE
-riA
+fsY
 coK
 riA
 xRX
@@ -41917,9 +41941,9 @@ xRX
 xRX
 xRX
 xRX
-riA
-riA
-riA
+bjg
+bjg
+bjg
 pHQ
 sIh
 uyk
@@ -41927,13 +41951,13 @@ icu
 jmN
 xiV
 icu
+nlF
 xsE
 xsE
 xsE
-xsE
-riA
-riA
-riA
+fsY
+fsY
+fsY
 xRX
 xRX
 xRX
@@ -42176,19 +42200,19 @@ xRX
 xRX
 xRX
 xRX
-riA
+bjg
 ibp
-riA
-riA
+bjg
+bjg
 icu
 kJM
 dul
 icu
+nlF
 xsE
-xsE
-riA
+fsY
 qhi
-riA
+fsY
 xRX
 xRX
 xRX
@@ -42435,15 +42459,15 @@ xRX
 xRX
 xRX
 xRX
-riA
-riA
+bjg
+bjg
 icu
 icu
 kxo
 icu
-riA
-riA
-riA
+bjg
+fsY
+fsY
 xRX
 xRX
 xRX
@@ -42696,7 +42720,7 @@ xRX
 xRX
 xRX
 vyi
-rro
+tzS
 uon
 xRX
 xRX
@@ -42953,7 +42977,7 @@ xRX
 xRX
 xRX
 xRX
-exg
+qcY
 xRX
 xRX
 xRX
@@ -43210,7 +43234,7 @@ xRX
 xRX
 xRX
 xRX
-exg
+qcY
 xRX
 xRX
 xRX

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -78,6 +78,15 @@
 /obj/effect/shuttle_landmark/orion_express_ship/transit,
 /turf/space/transit/north,
 /area/space)
+"auB" = (
+/obj/machinery/atmospherics/binary/pump/high_power,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "auV" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/mainhall)
@@ -290,6 +299,20 @@
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/airless,
 /area/ship/orion)
+"beD" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/portables_connector{
+	layer = 2.8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "bgb" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/cable/green{
@@ -625,7 +648,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
+/area/shuttle/orion_shuttle/starboardthrust)
 "ceU" = (
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "orion_traveler_port";
@@ -770,19 +793,6 @@
 /obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
-"cSp" = (
-/obj/machinery/door/airlock/hatch{
-	dir = 4;
-	name = "Port Thruster"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/noid{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle/storage)
 "cVy" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/dark,
@@ -846,17 +856,16 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/ship/orion/mainhall)
-"deG" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk/indoor,
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "deS" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"dgQ" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "dhX" = (
 /obj/structure/table/rack,
 /obj/item/reagent_containers/toothbrush,
@@ -1038,6 +1047,15 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/bridge)
+"dHV" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "dLy" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/thruster2)
@@ -1112,6 +1130,13 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster2)
+"ekd" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "eml" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -1215,6 +1240,9 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
+"fcT" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/starboardthrust)
 "fdC" = (
 /obj/structure/bed/stool/chair/shuttle,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1271,20 +1299,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
-"foq" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/portables_connector{
-	layer = 2.8
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/high/north{
-	req_access = list(201)
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "fqt" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark,
@@ -1857,20 +1871,6 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
-"htg" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle/storage)
 "htX" = (
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/airless,
@@ -1974,15 +1974,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle/storage)
-"hPi" = (
-/obj/machinery/atmospherics/binary/pump/high_power,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "hPo" = (
 /obj/structure/toilet{
 	dir = 8
@@ -2127,9 +2118,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle/storage)
-"iBO" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/portthrust)
 "iCR" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion/comms)
@@ -2174,9 +2162,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"iMl" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/starboardthrust)
 "iOe" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/portables_connector{
@@ -2567,15 +2552,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
-"kEb" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle/storage)
 "kFU" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
@@ -2655,6 +2631,11 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/cockpit)
+"lab" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "laC" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/thruster1)
@@ -2937,7 +2918,7 @@
 	req_access = list(201)
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
+/area/shuttle/orion_shuttle/starboardthrust)
 "meU" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -3082,10 +3063,10 @@
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
+/area/shuttle/orion_shuttle/starboardthrust)
 "mME" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
@@ -3388,12 +3369,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/ship/orion/crew)
-"nRg" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "nRE" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3659,6 +3634,20 @@
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle/storage)
+"pfG" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "phP" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
@@ -3720,11 +3709,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"psA" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "ptP" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 4
@@ -4323,6 +4307,9 @@
 "rZA" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion/bridge)
+"sab" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/portthrust)
 "scs" = (
 /obj/effect/landmark/entry_point/west{
 	name = "starboard, engine compartment"
@@ -5077,7 +5064,7 @@
 "uzX" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
-	name = "Starboard Thruster"
+	name = "Port Thruster"
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5183,6 +5170,9 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
+"vgB" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/cockpit)
 "vhp" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5517,6 +5507,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
+"wbF" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4;
+	name = "Starboard Thruster"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/orion_shuttle/storage)
 "wia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
@@ -5672,9 +5675,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
-"wEU" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/cockpit)
 "wFW" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid,
@@ -36506,8 +36506,8 @@ xRX
 xRX
 xRX
 dwE
-iBO
-iBO
+sab
+sab
 xRX
 xRX
 riA
@@ -36760,9 +36760,9 @@ xRX
 xRX
 xRX
 xRX
-iBO
-iBO
-iBO
+sab
+sab
+sab
 sqh
 yfz
 xRX
@@ -37020,7 +37020,7 @@ xRX
 mNJ
 aYD
 nAQ
-ccK
+ekd
 qMt
 xRX
 riA
@@ -37274,9 +37274,9 @@ xRX
 xRX
 xRX
 iCX
-iBO
-mcN
-mLK
+sab
+beD
+auB
 fkX
 yfz
 riA
@@ -37520,10 +37520,10 @@ xRX
 xRX
 xRX
 xRX
-wEU
-wEU
-wEU
-wEU
+vgB
+vgB
+vgB
+vgB
 qUy
 qUy
 qUy
@@ -37533,7 +37533,7 @@ qUy
 qUy
 qUy
 qUy
-cSp
+uzX
 qUy
 qUy
 wNT
@@ -38548,15 +38548,15 @@ xRX
 xRX
 xRX
 xRX
-wEU
+vgB
 vOd
 vPd
 dte
 qUy
 lZq
 lZq
-kEb
-htg
+dHV
+pfG
 mzO
 rLo
 hlA
@@ -38805,7 +38805,7 @@ xRX
 xRX
 xRX
 xRX
-wEU
+vgB
 fdC
 gnR
 oey
@@ -39062,7 +39062,7 @@ xRX
 xRX
 xRX
 xRX
-wEU
+vgB
 fBW
 vRr
 kYI
@@ -39319,10 +39319,10 @@ xRX
 xRX
 xRX
 xRX
-wEU
-wEU
-wEU
-wEU
+vgB
+vgB
+vgB
+vgB
 qUy
 qUy
 qUy
@@ -39332,7 +39332,7 @@ qUy
 qUy
 qUy
 qUy
-uzX
+wbF
 qUy
 qUy
 riA
@@ -39587,11 +39587,11 @@ xRX
 xRX
 xRX
 qkP
-iMl
-foq
-hPi
+fcT
+mcN
+mLK
 boM
-nRg
+dgQ
 xRX
 oQa
 iCR
@@ -39845,9 +39845,9 @@ xRX
 xRX
 xRX
 uVR
-psA
+lab
 gjQ
-deG
+ccK
 kOl
 xRX
 riA
@@ -40101,11 +40101,11 @@ xRX
 xRX
 xRX
 xRX
-iMl
-iMl
-iMl
+fcT
+fcT
+fcT
 oXn
-nRg
+dgQ
 xRX
 xRX
 riA
@@ -40361,8 +40361,8 @@ xRX
 xRX
 xRX
 scs
-iMl
-iMl
+fcT
+fcT
 xRX
 xRX
 riA

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -307,13 +307,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
 "biw" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "bjg" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
@@ -374,6 +372,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk/indoor,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)
 "buO" = (
@@ -393,13 +392,18 @@
 	command = "cycle_interior";
 	master_tag = "orion_shuttle";
 	name = "interior access button";
-	pixel_x = 32;
+	pixel_x = 25;
 	pixel_y = 10;
 	dir = 1;
 	frequency = 1379
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = 36;
+	pixel_y = 11;
+	dir = 1
 	},
 /turf/simulated/floor/shuttle/black,
 /area/shuttle/orion_shuttle)
@@ -738,6 +742,16 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster2)
+"cLs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/orion_shuttle)
 "cLW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -886,10 +900,31 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/structure/bed/stool/chair/shuttle{
-	dir = 1
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 7;
+	pixel_y = 11
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 9
+	},
+/obj/item/device/radio/off{
+	pixel_y = 3;
+	pixel_x = -9
+	},
+/obj/item/device/radio/off{
+	pixel_y = 3;
+	pixel_x = -9
+	},
+/obj/item/device/radio/off{
+	pixel_y = 3;
+	pixel_x = -9
+	},
+/obj/item/device/radio/off{
+	pixel_y = 3;
+	pixel_x = -9
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "dul" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1018,7 +1053,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
 	},
-/turf/template_noop,
+/turf/simulated/floor/airless,
 /area/shuttle/orion_shuttle)
 "egO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1054,6 +1089,14 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/atmos)
+"erq" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/securearea{
+	pixel_x = -32
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "etL" = (
 /turf/space/transit/north,
 /area/space)
@@ -1127,7 +1170,8 @@
 /area/ship/orion/crew)
 "fau" = (
 /obj/machinery/computer/shuttle_control/explore/orion_express_shuttle,
-/turf/simulated/floor/shuttle/tan,
+/obj/item/device/radio/intercom/expedition/hailing/west,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "fbf" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -1161,12 +1205,10 @@
 /obj/item/material/ashtray/glass{
 	pixel_x = 6
 	},
-/obj/structure/sign/flag/blank{
-	desc = "The logo of Orion Express on a flag.";
-	name = "Orion Express flag";
+/obj/structure/table/steel,
+/obj/structure/sign/flag/orion_express{
 	pixel_y = 32
 	},
-/obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "fkX" = (
@@ -1233,12 +1275,14 @@
 /turf/simulated/floor,
 /area/ship/orion/engie)
 "fBW" = (
-/obj/machinery/light{
-	dir = 4;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
+/obj/structure/bed/stool/chair/shuttle,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/vending/wallmed1{
+	req_access = null;
+	pixel_y = 30;
+	pixel_x = -6
 	},
-/turf/simulated/wall/shuttle/scc,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "fJg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
@@ -1273,7 +1317,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "gec" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1301,6 +1352,9 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
 "gjQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/machinery/alarm/east,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)
 "gkw" = (
@@ -1310,10 +1364,11 @@
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
 "glh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "goI" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1491,13 +1546,17 @@
 	command = "cycle_exterior";
 	master_tag = "orion_shuttle";
 	name = "exterior access button";
-	pixel_x = -32
+	pixel_x = -27
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "orion_shuttle";
 	shuttle_tag = "Orion Express Shuttle"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/green,
+/obj/machinery/airlock_sensor{
+	pixel_x = -40;
+	pixel_y = -1
+	},
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)
 "gOp" = (
@@ -1528,6 +1587,11 @@
 	frequency = 1380
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
+/obj/machinery/airlock_sensor{
+	pixel_x = -22;
+	dir = 4;
+	pixel_y = -6
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/orion_shuttle)
 "gYr" = (
@@ -1648,13 +1712,22 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
 "hlA" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 2
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "hmX" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1701,7 +1774,20 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "hwT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1766,7 +1852,10 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/smes/buildable/third_party_shuttle,
-/turf/simulated/floor/shuttle/black,
+/obj/structure/sign/electricshock{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "hPo" = (
 /obj/structure/toilet{
@@ -1872,11 +1961,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
 "ipM" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/shuttle/black,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "itr" = (
 /obj/effect/floor_decal/spline/plain/black,
@@ -1888,15 +1978,30 @@
 	initial_gas = list()
 	},
 /area/ship/orion/thruster1)
+"iuC" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "iuL" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor,
 /area/ship/orion/atmos)
 "ixH" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light{
-	icon_state = "tube_empty"
+	dir = 4;
+	inserted_light = /obj/item/light/tube/colored/blue
 	},
-/turf/simulated/wall/shuttle/scc,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "iCR" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
@@ -1912,12 +2017,13 @@
 /turf/simulated/floor/airless,
 /area/shuttle/orion_shuttle)
 "iEl" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "iGD" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -1951,7 +2057,11 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "iPn" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -1961,10 +2071,16 @@
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster2)
 "iPr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/machinery/alarm/north,
+/obj/machinery/atmospherics/binary/passive_gate/on{
+	name = "Air to Distribution";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "iTn" = (
 /obj/effect/floor_decal/corner_wide/beige{
@@ -1996,7 +2112,7 @@
 /area/ship/orion/forehall)
 "jiH" = (
 /obj/machinery/computer/ship/sensors,
-/turf/simulated/floor/shuttle/tan,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "jmg" = (
 /obj/effect/floor_decal/corner_wide/beige{
@@ -2025,6 +2141,16 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/cargo)
+"jrA" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "jsa" = (
 /obj/structure/sign/poster{
 	icon_state = "bsposter32";
@@ -2150,7 +2276,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/tan,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "jLO" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
@@ -2202,19 +2328,46 @@
 /turf/simulated/floor,
 /area/ship/orion/bridge)
 "kcS" = (
-/obj/structure/extinguisher_cabinet/south,
-/turf/simulated/floor/shuttle/black,
+/obj/machinery/light{
+	icon_state = "tube_empty"
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "kku" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/map_effect/marker/airlock/docking{
 	landmark_tag = "nav_hangar_orion_express";
 	master_tag = "orion_traveler_n_port"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 "kog" = (
-/turf/simulated/floor/shuttle/tan,
+/obj/machinery/light{
+	dir = 8;
+	inserted_light = /obj/item/light/tube/colored/blue
+	},
+/obj/structure/table/steel,
+/obj/machinery/button/remote/blast_door{
+	name = "Safety Shutters";
+	id = "orion_shuttle_shutters";
+	dir = 1;
+	pixel_y = 8;
+	pixel_x = -8
+	},
+/obj/item/clothing/head/helmet/pilot{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/paper_bin{
+	pixel_x = 5
+	},
+/obj/item/pen{
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "krv" = (
 /obj/effect/floor_decal/corner/dark_green/diagonal,
@@ -2256,7 +2409,7 @@
 /turf/simulated/floor,
 /area/ship/orion/cargo)
 "kAZ" = (
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "kDQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -2282,11 +2435,12 @@
 /turf/simulated/floor,
 /area/ship/orion/cargo)
 "kLL" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/shuttle/black,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/west,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "kOl" = (
 /obj/machinery/atmospherics/unary/engine{
@@ -2329,10 +2483,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
 "kYI" = (
-/obj/structure/bed/stool/chair/shuttle{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/structure/closet/crate/freezer/rations,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "laC" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
@@ -2358,6 +2513,16 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster2)
+"lmf" = (
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 6
+	},
+/obj/structure/closet/walllocker/firecloset{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "lpC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/meter,
@@ -2377,8 +2542,9 @@
 /obj/machinery/button/remote/blast_door{
 	id = "orion_warehouse";
 	name = "Cargo Bay Shutters";
-	pixel_x = -32;
-	req_access = list(201)
+	pixel_x = -25;
+	req_access = list(201);
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
@@ -2472,6 +2638,13 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/orion)
+"lTv" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "lXJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -2522,10 +2695,11 @@
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "maj" = (
 /obj/machinery/door/airlock/external{
@@ -2545,6 +2719,9 @@
 	master_tag = "orion_traveler_n_port";
 	name = "interior access button";
 	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
 	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
@@ -2570,11 +2747,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
 "mcD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "mcN" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -2656,16 +2846,15 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
 "mzO" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/shuttle/black,
+/obj/machinery/hologram/holopad/long_range,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "mzY" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "mBs" = (
 /obj/structure/cable/green{
@@ -2677,7 +2866,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
 "mBM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/external{
 	dir = 1;
 	frequency = 1380;
@@ -2692,6 +2880,9 @@
 	master_tag = "orion_traveler_n_port"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 "mGO" = (
@@ -2732,8 +2923,9 @@
 /obj/machinery/button/remote/blast_door{
 	id = "orion_warehouse";
 	name = "Cargo Bay Shutters";
-	pixel_x = 32;
-	req_access = list(201)
+	pixel_x = 25;
+	req_access = list(201);
+	dir = 4
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -2766,13 +2958,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
 "mSt" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "mSy" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2885,14 +3083,17 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
 "nzE" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/high/south,
-/turf/simulated/floor/shuttle/black,
+/obj/machinery/light{
+	icon_state = "tube_empty"
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "nAQ" = (
-/obj/structure/fuel_port/phoron{
-	pixel_x = -32
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm/west,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)
 "nDV" = (
@@ -2949,10 +3150,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
 "nGq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "Scrubbers to Waste";
+	use_power = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "nHg" = (
 /obj/effect/step_trigger/teleporter,
@@ -3067,14 +3275,28 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"oey" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+"odD" = (
+/obj/effect/floor_decal/corner/dark_green{
 	dir = 8
 	},
-/obj/structure/bed/stool/chair/shuttle{
-	dir = 1
+/obj/structure/bed/handrail{
+	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
+"oey" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/table/standard,
+/obj/machinery/recharger{
+	pixel_x = 6
+	},
+/obj/item/device/binoculars{
+	pixel_y = 9;
+	pixel_x = -3
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "ojl" = (
 /obj/structure/bookcase,
@@ -3095,6 +3317,9 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
+	},
+/obj/structure/sign/vacuum{
+	pixel_x = -30
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/orion_shuttle)
@@ -3122,7 +3347,20 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "oKe" = (
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -3143,7 +3381,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/shuttle/tan,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "oNK" = (
 /obj/structure/window/reinforced,
@@ -3201,8 +3439,8 @@
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "phP" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -3426,15 +3664,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
 "qgf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/effect/map_effect/marker/airlock/docking{
 	landmark_tag = "nav_hangar_orion_express";
 	master_tag = "orion_traveler_n_port"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
@@ -3445,11 +3683,18 @@
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion)
 "qjk" = (
-/obj/structure/cable{
-	icon_state = "1-2";
-	dir = 1
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/structure/fuel_port/phoron{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/corner/dark_green,
+/obj/structure/bed/handrail{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "qkP" = (
 /obj/machinery/shipsensors/weak,
@@ -3488,9 +3733,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
 "qrd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/turf/simulated/floor/shuttle/black,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "qsf" = (
 /obj/effect/floor_decal/corner_wide/beige/full,
@@ -3549,12 +3806,12 @@
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion)
 "qGl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
 /obj/effect/map_effect/marker/airlock/docking{
 	landmark_tag = "nav_hangar_orion_express";
 	master_tag = "orion_traveler_n_port"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
@@ -3597,7 +3854,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "qRJ" = (
 /obj/effect/floor_decal/corner/dark_green,
@@ -3646,7 +3907,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "rgL" = (
 /obj/effect/floor_decal/corner_wide/beige{
@@ -3769,7 +4034,11 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/structure/closet/secure_closet/package_courier{
+	req_access = list()
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "rDS" = (
 /obj/machinery/portable_atmospherics/canister/empty{
@@ -3780,7 +4049,10 @@
 	layer = 2.8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/shuttle/black,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "rKi" = (
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -3791,13 +4063,11 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
 "rLo" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "rNJ" = (
 /obj/machinery/door/airlock/external{
@@ -3866,14 +4136,15 @@
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
 "skU" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6;
+	pixel_y = 0
 	},
-/obj/machinery/alarm/north{
-	req_one_access = list(201);
-	req_access = list(201)
+/obj/structure/sign/flag/orion_express/large/north{
+	pixel_y = 32
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "sll" = (
 /obj/structure/sign/directions/cryo{
@@ -3955,7 +4226,7 @@
 	shuttle_tag = "Orion Express Shuttle"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/turf/template_noop,
+/turf/simulated/floor/airless,
 /area/shuttle/orion_shuttle)
 "spv" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -4114,6 +4385,19 @@
 /obj/item/bodybag/cryobag,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"sNU" = (
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 9
+	},
+/obj/structure/closet/walllocker/emerglocker/east,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/item/storage/bag/inflatable/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "sOb" = (
 /obj/effect/step_trigger/teleporter,
 /obj/effect/step_trigger/teleporter,
@@ -4129,15 +4413,43 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 2
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "sTK" = (
-/obj/structure/cable{
-	icon_state = "1-2";
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
+"sVL" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "sXW" = (
 /obj/structure/cable/green{
@@ -4279,6 +4591,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/crew)
+"tqy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/pottedplant,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/orion_shuttle)
 "trH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -4335,7 +4652,8 @@
 "tFi" = (
 /obj/effect/overmap/visitable/ship/landable/orion_express_shuttle,
 /obj/structure/bed/stool/chair/office/bridge/generic,
-/turf/simulated/floor/shuttle/tan,
+/obj/effect/floor_decal/industrial/outline/custodial,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "tGB" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -4580,11 +4898,14 @@
 	landmark_tag = "nav_hangar_orion_express";
 	master_tag = "orion_traveler_n_port"
 	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 "uRC" = (
 /obj/machinery/computer/ship/helm,
-/turf/simulated/floor/shuttle/tan,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "uVR" = (
 /obj/effect/landmark/entry_point/aft{
@@ -4596,7 +4917,8 @@
 /obj/machinery/computer/ship/engines{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "uWT" = (
 /obj/effect/floor_decal/corner/dark_green{
@@ -4853,11 +5175,12 @@
 /area/ship/orion/shop)
 "vOd" = (
 /obj/structure/bed/stool/chair/shuttle,
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "vPd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "vPn" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
@@ -4981,10 +5304,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
 "wkO" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/wall/shuttle/scc,
+/obj/structure/bed/stool/chair/shuttle,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/alarm/north,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "wlw" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -5107,9 +5430,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
 "wFW" = (
-/obj/structure/window/shuttle/scc,
-/obj/structure/grille,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid,
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "orion_shuttle_shutters";
+	name = "Safety Shutter"
+	},
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)
 "wIx" = (
@@ -5403,7 +5730,8 @@
 /area/ship/orion/atmos)
 "xTL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/shuttle/black,
+/obj/structure/closet/crate,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "xVJ" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -5436,7 +5764,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "yaV" = (
 /obj/machinery/door/airlock/command{
@@ -5488,11 +5820,6 @@
 "yhG" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
-	},
-/obj/machinery/airlock_sensor{
-	pixel_x = 20;
-	dir = 8;
-	pixel_y = -6
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "orion_shuttle";
@@ -36947,15 +37274,15 @@ xRX
 xRX
 qUy
 qUy
-fBW
 qUy
 qUy
 qUy
 qUy
-fBW
 qUy
 qUy
-fBW
+qUy
+qUy
+qUy
 qUy
 qUy
 uzX
@@ -37205,16 +37532,16 @@ xRX
 wFW
 fau
 kog
-kog
+tqy
 qUy
 xTL
 ipM
-xTL
+erq
 kLL
 sTK
-sTK
+lTv
 qjk
-qjk
+lmf
 nzE
 qUy
 soM
@@ -37470,9 +37797,9 @@ sTm
 hvo
 mcD
 oIF
-kAZ
+sVL
 qUy
-ixH
+qUy
 qUy
 rrQ
 haV
@@ -37718,16 +38045,16 @@ xRX
 xRX
 wFW
 jiH
-kog
+mzO
 jKa
 qUy
 skU
 rdc
-kAZ
-yaz
+iEl
+biw
 mzY
-kAZ
-kAZ
+sTK
+iuC
 ihA
 oAK
 gXD
@@ -37974,7 +38301,7 @@ xRX
 xRX
 xRX
 qUy
-vOd
+fBW
 vPd
 dte
 qUy
@@ -37982,7 +38309,7 @@ lZq
 glh
 iEl
 biw
-mzO
+mzY
 rLo
 hlA
 buO
@@ -38231,7 +38558,7 @@ xRX
 xRX
 xRX
 qUy
-vOd
+wkO
 kAZ
 oey
 qUy
@@ -38239,11 +38566,11 @@ iPr
 nGq
 qQV
 yaz
-kAZ
+cLs
 gdY
-kAZ
+jrA
 qUy
-ixH
+qUy
 qUy
 rrQ
 qBd
@@ -38489,7 +38816,7 @@ xRX
 xRX
 qUy
 vOd
-kAZ
+ixH
 kYI
 qUy
 pdw
@@ -38498,8 +38825,8 @@ hNk
 rDd
 uWQ
 iOe
-kAZ
-kAZ
+odD
+sNU
 kcS
 qUy
 efO
@@ -38746,16 +39073,16 @@ xRX
 xRX
 qUy
 qUy
-wkO
 qUy
 qUy
 qUy
 qUy
 qUy
-wkO
 qUy
 qUy
-wkO
+qUy
+qUy
+qUy
 qUy
 uzX
 qUy

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -130,6 +130,31 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/thruster2)
+"aGd" = (
+/obj/machinery/light{
+	dir = 8;
+	inserted_light = /obj/item/light/tube/colored/blue
+	},
+/obj/structure/table/steel,
+/obj/machinery/button/remote/blast_door{
+	name = "Safety Shutters";
+	id = "orion_shuttle_shutters";
+	dir = 1;
+	pixel_y = 8;
+	pixel_x = -8
+	},
+/obj/item/clothing/head/helmet/pilot{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/paper_bin{
+	pixel_x = 5
+	},
+/obj/item/pen{
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "aHs" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor,
@@ -742,16 +767,6 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster2)
-"cLs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
 "cLW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1089,17 +1104,22 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/atmos)
-"erq" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/securearea{
-	pixel_x = -32
-	},
-/obj/structure/closet/crate,
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "etL" = (
 /turf/space/transit/north,
 /area/space)
+"evN" = (
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 9
+	},
+/obj/structure/closet/walllocker/emerglocker/east,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/item/storage/bag/inflatable/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "exg" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -1257,6 +1277,20 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/thruster1)
+"frR" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/structure/fuel_port/phoron{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/corner/dark_green,
+/obj/structure/bed/handrail{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "fuh" = (
 /obj/item/clothing/head/beret/janitor,
 /obj/structure/table/steel,
@@ -1275,14 +1309,9 @@
 /turf/simulated/floor,
 /area/ship/orion/engie)
 "fBW" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/vending/wallmed1{
-	req_access = null;
-	pixel_y = 30;
-	pixel_x = -6
-	},
-/turf/simulated/floor/carpet/rubber,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/pottedplant,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "fJg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
@@ -1978,19 +2007,6 @@
 	initial_gas = list()
 	},
 /area/ship/orion/thruster1)
-"iuC" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	layer = 2.71
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "iuL" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor,
@@ -2141,16 +2157,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/cargo)
-"jrA" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "jsa" = (
 /obj/structure/sign/poster{
 	icon_state = "bsposter32";
@@ -2345,28 +2351,7 @@
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 "kog" = (
-/obj/machinery/light{
-	dir = 8;
-	inserted_light = /obj/item/light/tube/colored/blue
-	},
-/obj/structure/table/steel,
-/obj/machinery/button/remote/blast_door{
-	name = "Safety Shutters";
-	id = "orion_shuttle_shutters";
-	dir = 1;
-	pixel_y = 8;
-	pixel_x = -8
-	},
-/obj/item/clothing/head/helmet/pilot{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/paper_bin{
-	pixel_x = 5
-	},
-/obj/item/pen{
-	pixel_x = 4
-	},
+/obj/machinery/hologram/holopad/long_range,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "krv" = (
@@ -2409,7 +2394,17 @@
 /turf/simulated/floor,
 /area/ship/orion/cargo)
 "kAZ" = (
-/turf/simulated/floor/carpet/rubber,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "kDQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -2513,16 +2508,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster2)
-"lmf" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 6
-	},
-/obj/structure/closet/walllocker/firecloset{
-	pixel_x = -32
-	},
-/obj/effect/floor_decal/industrial/outline/firefighting_closet,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "lpC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/meter,
@@ -2638,13 +2623,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/orion)
-"lTv" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "lXJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -2846,7 +2824,13 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
 "mzO" = (
-/obj/machinery/hologram/holopad/long_range,
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "mzY" = (
@@ -2885,6 +2869,9 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
+"mFR" = (
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "mGO" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
@@ -3250,6 +3237,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
+"nXs" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/securearea{
+	pixel_x = -32
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "nYY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -3275,15 +3270,6 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"odD" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 8
-	},
-/obj/structure/bed/handrail{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "oey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3310,6 +3296,16 @@
 /obj/machinery/power/apc/high/south,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
+"oyE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/orion_shuttle)
 "oAK" = (
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "orion_shuttle";
@@ -3683,17 +3679,13 @@
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion)
 "qjk" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	layer = 2.71
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 6
 	},
-/obj/structure/fuel_port/phoron{
+/obj/structure/closet/walllocker/firecloset{
 	pixel_x = -32
 	},
-/obj/effect/floor_decal/corner/dark_green,
-/obj/structure/bed/handrail{
-	dir = 4
-	},
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "qkP" = (
@@ -3925,6 +3917,10 @@
 "riA" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion)
+"rkQ" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "rlw" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3945,6 +3941,16 @@
 /obj/structure/closet/crate/loot,
 /turf/simulated/floor,
 /area/ship/orion/cargo)
+"rpe" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/vending/wallmed1{
+	req_access = null;
+	pixel_y = 30;
+	pixel_x = -6
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "rro" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4385,19 +4391,6 @@
 /obj/item/bodybag/cryobag,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"sNU" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 9
-	},
-/obj/structure/closet/walllocker/emerglocker/east,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/item/storage/bag/inflatable/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "sOb" = (
 /obj/effect/step_trigger/teleporter,
 /obj/effect/step_trigger/teleporter,
@@ -4430,26 +4423,10 @@
 /area/shuttle/orion_shuttle)
 "sTK" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
-"sVL" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "sXW" = (
 /obj/structure/cable/green{
@@ -4541,6 +4518,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
+"tiM" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/alarm/north,
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "tlv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
@@ -4591,11 +4574,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/crew)
-"tqy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/pottedplant,
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
 "trH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -5304,10 +5282,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
 "wkO" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/alarm/north,
-/turf/simulated/floor/carpet/rubber,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "wlw" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -5474,6 +5465,15 @@
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"wPg" = (
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 8
+	},
+/obj/structure/bed/handrail{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "wSv" = (
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -37531,17 +37531,17 @@ xRX
 xRX
 wFW
 fau
-kog
-tqy
+aGd
+fBW
 qUy
 xTL
 ipM
-erq
+nXs
 kLL
+rkQ
 sTK
-lTv
+frR
 qjk
-lmf
 nzE
 qUy
 soM
@@ -37797,7 +37797,7 @@ sTm
 hvo
 mcD
 oIF
-sVL
+wkO
 qUy
 qUy
 qUy
@@ -38045,7 +38045,7 @@ xRX
 xRX
 wFW
 jiH
-mzO
+kog
 jKa
 qUy
 skU
@@ -38053,8 +38053,8 @@ rdc
 iEl
 biw
 mzY
-sTK
-iuC
+rkQ
+kAZ
 ihA
 oAK
 gXD
@@ -38301,7 +38301,7 @@ xRX
 xRX
 xRX
 qUy
-fBW
+rpe
 vPd
 dte
 qUy
@@ -38558,17 +38558,17 @@ xRX
 xRX
 xRX
 qUy
-wkO
-kAZ
+tiM
+mFR
 oey
 qUy
 iPr
 nGq
 qQV
 yaz
-cLs
+oyE
 gdY
-jrA
+mzO
 qUy
 qUy
 qUy
@@ -38825,8 +38825,8 @@ hNk
 rDd
 uWQ
 iOe
-odD
-sNU
+wPg
+evN
 kcS
 qUy
 efO

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -770,6 +770,19 @@
 /obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
+"cSp" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4;
+	name = "Port Thruster"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/orion_shuttle/storage)
 "cVy" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/dark,
@@ -833,6 +846,13 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/ship/orion/mainhall)
+"deG" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "deS" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -977,11 +997,6 @@
 	},
 /turf/simulated/wall/shuttle/scc,
 /area/shuttle/orion_shuttle/portthrust)
-"dxt" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "dFW" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -1249,12 +1264,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle/portthrust)
-"flK" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "fmY" = (
 /obj/machinery/photocopier,
 /obj/effect/floor_decal/corner/dark_blue{
@@ -1262,6 +1271,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
+"foq" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/portables_connector{
+	layer = 2.8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "fqt" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark,
@@ -1834,6 +1857,20 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
+"htg" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "htX" = (
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/airless,
@@ -1937,6 +1974,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle/storage)
+"hPi" = (
+/obj/machinery/atmospherics/binary/pump/high_power,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "hPo" = (
 /obj/structure/toilet{
 	dir = 8
@@ -2081,6 +2127,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle/storage)
+"iBO" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/portthrust)
 "iCR" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion/comms)
@@ -2092,9 +2141,9 @@
 "iEl" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/storage)
@@ -2125,6 +2174,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"iMl" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/starboardthrust)
 "iOe" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/portables_connector{
@@ -2186,13 +2238,6 @@
 /obj/structure/table/stone/marble,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"jhG" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk/indoor,
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "jiH" = (
 /obj/machinery/computer/ship/sensors,
 /obj/effect/decal/cleanable/dirt,
@@ -2522,6 +2567,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
+"kEb" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "kFU" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
@@ -2612,9 +2666,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"lgC" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/starboardthrust)
 "lhJ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light{
@@ -2886,7 +2937,7 @@
 	req_access = list(201)
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
+/area/shuttle/orion_shuttle/portthrust)
 "meU" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -3031,10 +3082,10 @@
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
+/area/shuttle/orion_shuttle/portthrust)
 "mME" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
@@ -3125,6 +3176,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle/storage)
 "mXd" = (
@@ -3336,6 +3388,12 @@
 	},
 /turf/simulated/floor/carpet,
 /area/ship/orion/crew)
+"nRg" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "nRE" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3490,20 +3548,6 @@
 /obj/item/stack/material/glass/full,
 /turf/simulated/floor,
 /area/ship/orion/engie)
-"oHZ" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/portables_connector{
-	layer = 2.8
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/high/north{
-	req_access = list(201)
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "oIu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -3676,6 +3720,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"psA" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "ptP" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 4
@@ -4052,9 +4101,6 @@
 "qUy" = (
 /turf/simulated/wall/shuttle/scc,
 /area/shuttle/orion_shuttle/storage)
-"qVj" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/cockpit)
 "qXP" = (
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
@@ -4277,15 +4323,6 @@
 "rZA" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion/bridge)
-"scp" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle/storage)
 "scs" = (
 /obj/effect/landmark/entry_point/west{
 	name = "starboard, engine compartment"
@@ -5040,10 +5077,13 @@
 "uzX" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
-	name = "Port Thruster"
+	name = "Starboard Thruster"
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle/storage)
@@ -5106,20 +5146,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
-"uYz" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle/storage)
 "vcD" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5295,9 +5321,6 @@
 /obj/item/clothing/head/helmet/security,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
-"vBn" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/portthrust)
 "vBY" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -5494,16 +5517,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
-"wew" = (
-/obj/machinery/door/airlock/hatch{
-	dir = 4;
-	name = "Starboard Thruster"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle/storage)
 "wia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
@@ -5659,6 +5672,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
+"wEU" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/cockpit)
 "wFW" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid,
@@ -5934,15 +5950,6 @@
 /obj/item/paper/business_card,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
-"xJc" = (
-/obj/machinery/atmospherics/binary/pump/high_power,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "xJk" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "aft, starboard side"
@@ -6040,7 +6047,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
+/area/shuttle/orion_shuttle/portthrust)
 "yfU" = (
 /obj/machinery/appliance/cooker/fryer,
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -36499,8 +36506,8 @@ xRX
 xRX
 xRX
 dwE
-vBn
-vBn
+iBO
+iBO
 xRX
 xRX
 riA
@@ -36753,11 +36760,11 @@ xRX
 xRX
 xRX
 xRX
-vBn
-vBn
-vBn
+iBO
+iBO
+iBO
 sqh
-flK
+yfz
 xRX
 riA
 riA
@@ -37267,11 +37274,11 @@ xRX
 xRX
 xRX
 iCX
-vBn
-oHZ
-xJc
+iBO
+mcN
+mLK
 fkX
-flK
+yfz
 riA
 riA
 xsE
@@ -37513,10 +37520,10 @@ xRX
 xRX
 xRX
 xRX
-qVj
-qVj
-qVj
-qVj
+wEU
+wEU
+wEU
+wEU
 qUy
 qUy
 qUy
@@ -37526,7 +37533,7 @@ qUy
 qUy
 qUy
 qUy
-uzX
+cSp
 qUy
 qUy
 wNT
@@ -38292,7 +38299,7 @@ qUy
 skU
 rdc
 biw
-scp
+iEl
 mzY
 biw
 aVM
@@ -38541,15 +38548,15 @@ xRX
 xRX
 xRX
 xRX
-qVj
+wEU
 vOd
 vPd
 dte
 qUy
 lZq
 lZq
-iEl
-uYz
+kEb
+htg
 mzO
 rLo
 hlA
@@ -38798,7 +38805,7 @@ xRX
 xRX
 xRX
 xRX
-qVj
+wEU
 fdC
 gnR
 oey
@@ -39055,7 +39062,7 @@ xRX
 xRX
 xRX
 xRX
-qVj
+wEU
 fBW
 vRr
 kYI
@@ -39312,10 +39319,10 @@ xRX
 xRX
 xRX
 xRX
-qVj
-qVj
-qVj
-qVj
+wEU
+wEU
+wEU
+wEU
 qUy
 qUy
 qUy
@@ -39325,7 +39332,7 @@ qUy
 qUy
 qUy
 qUy
-wew
+uzX
 qUy
 qUy
 riA
@@ -39580,11 +39587,11 @@ xRX
 xRX
 xRX
 qkP
-lgC
-mcN
-mLK
+iMl
+foq
+hPi
 boM
-yfz
+nRg
 xRX
 oQa
 iCR
@@ -39838,9 +39845,9 @@ xRX
 xRX
 xRX
 uVR
-dxt
+psA
 gjQ
-jhG
+deG
 kOl
 xRX
 riA
@@ -40094,11 +40101,11 @@ xRX
 xRX
 xRX
 xRX
-lgC
-lgC
-lgC
+iMl
+iMl
+iMl
 oXn
-yfz
+nRg
 xRX
 xRX
 riA
@@ -40354,8 +40361,8 @@ xRX
 xRX
 xRX
 scs
-lgC
-lgC
+iMl
+iMl
 xRX
 xRX
 riA

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -22,6 +22,16 @@
 "aev" = (
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
+"afP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/orion_shuttle)
 "afW" = (
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
@@ -307,13 +317,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
 "biw" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 9
 	},
-/turf/simulated/floor/carpet/rubber,
+/obj/structure/closet/walllocker/emerglocker/east,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/item/storage/bag/inflatable/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "bjg" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
@@ -720,20 +734,6 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
-"cym" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
-"czM" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 6
-	},
-/obj/structure/closet/walllocker/firecloset{
-	pixel_x = -32
-	},
-/obj/effect/floor_decal/industrial/outline/firefighting_closet,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "cHm" = (
 /obj/structure/window/reinforced,
 /obj/item/holomenu{
@@ -1246,6 +1246,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"frt" = (
+/obj/machinery/light{
+	dir = 8;
+	inserted_light = /obj/item/light/tube/colored/blue
+	},
+/obj/structure/table/steel,
+/obj/item/clothing/head/helmet/pilot{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/paper_bin{
+	pixel_x = -2
+	},
+/obj/item/pen{
+	pixel_x = -2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "frC" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 8
@@ -1276,7 +1294,13 @@
 /turf/simulated/floor,
 /area/ship/orion/engie)
 "fBW" = (
-/turf/simulated/floor/carpet/rubber,
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 8
+	},
+/obj/structure/bed/handrail{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "fJg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
@@ -1358,13 +1382,11 @@
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
 "glh" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 8
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
 	},
-/obj/structure/bed/handrail{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "goI" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1547,10 +1569,6 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "orion_shuttle";
 	shuttle_tag = "Orion Express Shuttle"
-	},
-/obj/machinery/airlock_sensor{
-	pixel_x = -40;
-	pixel_y = -1
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
@@ -1835,19 +1853,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/atmos)
-"hJh" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	layer = 2.71
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "hKC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/green{
@@ -1998,9 +2003,26 @@
 /turf/simulated/floor,
 /area/ship/orion/atmos)
 "ixH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/pottedplant,
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 6
+	},
+/obj/structure/closet/walllocker/firecloset{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
+"iBW" = (
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "iCR" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
@@ -2091,11 +2113,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
-"iVu" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate,
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "iVL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -2342,7 +2359,9 @@
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 "kog" = (
-/turf/simulated/floor/tiled/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/pottedplant,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "krv" = (
 /obj/effect/floor_decal/corner/dark_green/diagonal,
@@ -2450,16 +2469,6 @@
 	temperature = 278
 	},
 /area/ship/orion/comms)
-"kWq" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "kYl" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -2664,11 +2673,7 @@
 /turf/simulated/floor,
 /area/ship/orion/engie)
 "lZq" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/rubber,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "maj" = (
 /obj/machinery/door/airlock/external{
@@ -2993,6 +2998,12 @@
 /obj/item/clothing/accessory/bandanna/black,
 /turf/simulated/floor/wood,
 /area/ship/orion/crew)
+"mYs" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/alarm/north,
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "ncx" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
@@ -3072,6 +3083,19 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/west,
 /turf/simulated/floor,
+/area/shuttle/orion_shuttle)
+"nCz" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "nDV" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -3227,11 +3251,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
-"nYp" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "nYY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -3240,16 +3259,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/comms)
-"oaR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
 "ode" = (
 /obj/structure/bed/stool/bar/padded/beige,
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -3283,6 +3292,10 @@
 	pixel_y = -3;
 	pixel_x = -6
 	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
+"oeF" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "ojl" = (
@@ -3377,23 +3390,6 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
-"oNV" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/vending/wallmed1{
-	req_access = null;
-	pixel_y = 30;
-	pixel_x = -7
-	},
-/obj/machinery/button/remote/blast_door{
-	name = "Safety Shutters";
-	id = "orion_shuttle_shutters";
-	dir = 1;
-	pixel_y = 27;
-	pixel_x = 7
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "oQa" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/comms)
@@ -3431,6 +3427,9 @@
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
 /turf/simulated/floor,
+/area/shuttle/orion_shuttle)
+"oYK" = (
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "oZS" = (
 /obj/effect/floor_decal/spline/plain/black,
@@ -3644,6 +3643,14 @@
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/ship/orion/atmos)
+"pXh" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/securearea{
+	pixel_x = -32
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "pXU" = (
 /obj/machinery/shower,
 /obj/structure/curtain/open/shower,
@@ -4159,6 +4166,23 @@
 	},
 /turf/simulated/floor/carpet,
 /area/ship/orion/crew)
+"slp" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/vending/wallmed1{
+	req_access = null;
+	pixel_y = 30;
+	pixel_x = -7
+	},
+/obj/machinery/button/remote/blast_door{
+	name = "Safety Shutters";
+	id = "orion_shuttle_shutters";
+	dir = 1;
+	pixel_y = 27;
+	pixel_x = 7
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "slH" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate,
@@ -4219,6 +4243,16 @@
 /area/ship/orion/shop)
 "soM" = (
 /obj/structure/lattice/catwalk,
+/obj/machinery/airlock_sensor{
+	pixel_x = 24;
+	pixel_y = -1;
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "orion_shuttle";
+	shuttle_tag = "Orion Express Shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/airless,
 /area/shuttle/orion_shuttle)
 "spv" = (
@@ -4556,19 +4590,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/crew)
-"tqG" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 9
-	},
-/obj/structure/closet/walllocker/emerglocker/east,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/item/storage/bag/inflatable/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "trH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -4780,28 +4801,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/orion/mainhall)
-"une" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/floor_decal/industrial/loading/yellow{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "uon" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -5172,7 +5171,6 @@
 "vOd" = (
 /obj/structure/bed/stool/chair/shuttle,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/alarm/north,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "vPd" = (
@@ -5301,20 +5299,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
 "wkO" = (
-/obj/machinery/light{
-	dir = 8;
-	inserted_light = /obj/item/light/tube/colored/blue
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
-/obj/structure/table/steel,
-/obj/item/clothing/head/helmet/pilot{
-	pixel_x = 8;
-	pixel_y = 8
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
 	},
-/obj/item/paper_bin{
-	pixel_x = -2
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
 	},
-/obj/item/pen{
-	pixel_x = -2
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/loading/yellow{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
@@ -5331,6 +5333,16 @@
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
 /area/ship/orion/crew)
+"wmb" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "wpk" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/grass,
@@ -5739,9 +5751,6 @@
 /area/ship/orion/atmos)
 "xTL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/securearea{
-	pixel_x = -32
-	},
 /obj/structure/closet/crate,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
@@ -5773,16 +5782,13 @@
 /turf/simulated/floor,
 /area/ship/orion/cargo)
 "yaz" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "yaV" = (
 /obj/machinery/door/airlock/command{
@@ -37545,17 +37551,17 @@ xRX
 xRX
 wFW
 fau
-wkO
-ixH
+frt
+kog
 qUy
-iVu
-ipM
 xTL
+ipM
+pXh
 kLL
-cym
+oeF
 sTK
 qjk
-czM
+ixH
 nzE
 qUy
 soM
@@ -37811,7 +37817,7 @@ sTm
 hvo
 mcD
 oIF
-une
+wkO
 qUy
 qUy
 qUy
@@ -38059,16 +38065,16 @@ xRX
 xRX
 wFW
 jiH
-kog
+lZq
 jKa
 qUy
 skU
 rdc
 iEl
-biw
+yaz
 mzY
-cym
-hJh
+oeF
+nCz
 ihA
 oAK
 gXD
@@ -38315,14 +38321,14 @@ xRX
 xRX
 xRX
 qUy
-oNV
+slp
 vPd
 dte
 qUy
-lZq
-lZq
+glh
+glh
 iEl
-biw
+yaz
 mzO
 rLo
 hlA
@@ -38572,17 +38578,17 @@ xRX
 xRX
 xRX
 qUy
-vOd
-fBW
+mYs
+oYK
 oey
 qUy
 iPr
 nGq
 qQV
-yaz
-oaR
+iBW
+afP
 gdY
-kWq
+wmb
 qUy
 qUy
 qUy
@@ -38829,7 +38835,7 @@ xRX
 xRX
 xRX
 qUy
-nYp
+vOd
 kAZ
 kYI
 qUy
@@ -38839,8 +38845,8 @@ hNk
 rDd
 uWQ
 iOe
-glh
-tqG
+fBW
+biw
 kcS
 qUy
 efO

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -248,7 +248,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
+/area/shuttle/orion_shuttle/portthrust)
 "aYE" = (
 /obj/effect/floor_decal/corner_wide/beige/full{
 	dir = 8
@@ -367,15 +367,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
-"bnF" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle/storage)
 "bol" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -695,20 +686,6 @@
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion)
-"cqM" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle/storage)
 "crK" = (
 /obj/structure/sign/staff_only{
 	pixel_x = 32
@@ -994,18 +971,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
-"dwu" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "dwE" = (
 /obj/effect/landmark/entry_point/east{
 	name = "port, engine compartment"
 	},
 /turf/simulated/wall/shuttle/scc,
 /area/shuttle/orion_shuttle/portthrust)
+"dxt" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "dFW" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -1273,8 +1249,11 @@
 /obj/machinery/meter,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle/portthrust)
-"fma" = (
-/turf/simulated/wall/shuttle/scc,
+"flK" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor,
 /area/shuttle/orion_shuttle/portthrust)
 "fmY" = (
 /obj/machinery/photocopier,
@@ -1370,21 +1349,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/ship/orion/mainhall)
-"fOy" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/cockpit)
 "fUj" = (
 /turf/simulated/floor,
 /area/ship/orion/forehall)
-"fYz" = (
-/obj/machinery/atmospherics/binary/pump/high_power,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "gdY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -2125,9 +2092,9 @@
 "iEl" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/storage)
@@ -2219,6 +2186,13 @@
 /obj/structure/table/stone/marble,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"jhG" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "jiH" = (
 /obj/machinery/computer/ship/sensors,
 /obj/effect/decal/cleanable/dirt,
@@ -2638,6 +2612,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"lgC" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/starboardthrust)
 "lhJ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light{
@@ -3054,10 +3031,10 @@
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
+/area/shuttle/orion_shuttle/starboardthrust)
 "mME" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
@@ -3487,16 +3464,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
-"oyZ" = (
-/obj/machinery/door/airlock/hatch{
-	dir = 4;
-	name = "Port Thruster"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle/storage)
 "oAK" = (
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "orion_shuttle";
@@ -3523,6 +3490,20 @@
 /obj/item/stack/material/glass/full,
 /turf/simulated/floor,
 /area/ship/orion/engie)
+"oHZ" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/portables_connector{
+	layer = 2.8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "oIu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -4071,6 +4052,9 @@
 "qUy" = (
 /turf/simulated/wall/shuttle/scc,
 /area/shuttle/orion_shuttle/storage)
+"qVj" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/cockpit)
 "qXP" = (
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
@@ -4293,6 +4277,15 @@
 "rZA" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion/bridge)
+"scp" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "scs" = (
 /obj/effect/landmark/entry_point/west{
 	name = "starboard, engine compartment"
@@ -5047,7 +5040,7 @@
 "uzX" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
-	name = "Starboard Thruster"
+	name = "Port Thruster"
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5113,6 +5106,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
+"uYz" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "vcD" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5288,6 +5295,9 @@
 /obj/item/clothing/head/helmet/security,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
+"vBn" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/portthrust)
 "vBY" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -5410,11 +5420,6 @@
 /obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
-"vSk" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "vUr" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/light/small/emergency{
@@ -5489,6 +5494,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
+"wew" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4;
+	name = "Starboard Thruster"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/orion_shuttle/storage)
 "wia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
@@ -5836,20 +5851,6 @@
 /obj/structure/foamedmetal,
 /turf/simulated/floor,
 /area/ship/orion)
-"xtL" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/portables_connector{
-	layer = 2.8
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/high/north{
-	req_access = list(201)
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "xtN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -5914,13 +5915,6 @@
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
-"xEc" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk/indoor,
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "xFj" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5940,15 +5934,21 @@
 /obj/item/paper/business_card,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
+"xJc" = (
+/obj/machinery/atmospherics/binary/pump/high_power,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "xJk" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "aft, starboard side"
 	},
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion)
-"xJR" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/starboardthrust)
 "xPl" = (
 /obj/structure/bed/stool/chair/office/light{
 	dir = 8
@@ -6040,7 +6040,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
+/area/shuttle/orion_shuttle/starboardthrust)
 "yfU" = (
 /obj/machinery/appliance/cooker/fryer,
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -36499,8 +36499,8 @@ xRX
 xRX
 xRX
 dwE
-fma
-fma
+vBn
+vBn
 xRX
 xRX
 riA
@@ -36753,11 +36753,11 @@ xRX
 xRX
 xRX
 xRX
-fma
-fma
-fma
+vBn
+vBn
+vBn
 sqh
-yfz
+flK
 xRX
 riA
 riA
@@ -37011,7 +37011,7 @@ xRX
 xRX
 xRX
 mNJ
-vSk
+aYD
 nAQ
 ccK
 qMt
@@ -37267,11 +37267,11 @@ xRX
 xRX
 xRX
 iCX
-fma
-xtL
-mLK
+vBn
+oHZ
+xJc
 fkX
-yfz
+flK
 riA
 riA
 xsE
@@ -37513,10 +37513,10 @@ xRX
 xRX
 xRX
 xRX
-fOy
-fOy
-fOy
-fOy
+qVj
+qVj
+qVj
+qVj
 qUy
 qUy
 qUy
@@ -37526,7 +37526,7 @@ qUy
 qUy
 qUy
 qUy
-oyZ
+uzX
 qUy
 qUy
 wNT
@@ -38292,7 +38292,7 @@ qUy
 skU
 rdc
 biw
-iEl
+scp
 mzY
 biw
 aVM
@@ -38541,15 +38541,15 @@ xRX
 xRX
 xRX
 xRX
-fOy
+qVj
 vOd
 vPd
 dte
 qUy
 lZq
 lZq
-bnF
-cqM
+iEl
+uYz
 mzO
 rLo
 hlA
@@ -38798,7 +38798,7 @@ xRX
 xRX
 xRX
 xRX
-fOy
+qVj
 fdC
 gnR
 oey
@@ -39055,7 +39055,7 @@ xRX
 xRX
 xRX
 xRX
-fOy
+qVj
 fBW
 vRr
 kYI
@@ -39312,10 +39312,10 @@ xRX
 xRX
 xRX
 xRX
-fOy
-fOy
-fOy
-fOy
+qVj
+qVj
+qVj
+qVj
 qUy
 qUy
 qUy
@@ -39325,7 +39325,7 @@ qUy
 qUy
 qUy
 qUy
-uzX
+wew
 qUy
 qUy
 riA
@@ -39580,11 +39580,11 @@ xRX
 xRX
 xRX
 qkP
-xJR
+lgC
 mcN
-fYz
+mLK
 boM
-dwu
+yfz
 xRX
 oQa
 iCR
@@ -39838,9 +39838,9 @@ xRX
 xRX
 xRX
 uVR
-aYD
+dxt
 gjQ
-xEc
+jhG
 kOl
 xRX
 riA
@@ -40094,11 +40094,11 @@ xRX
 xRX
 xRX
 xRX
-xJR
-xJR
-xJR
+lgC
+lgC
+lgC
 oXn
-dwu
+yfz
 xRX
 xRX
 riA
@@ -40354,8 +40354,8 @@ xRX
 xRX
 xRX
 scs
-xJR
-xJR
+lgC
+lgC
 xRX
 xRX
 riA

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -248,7 +248,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
+/area/shuttle/orion_shuttle/portthrust)
 "aYE" = (
 /obj/effect/floor_decal/corner_wide/beige/full{
 	dir = 8
@@ -267,6 +267,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
+"aYK" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "bbM" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/vehicle/train/cargo/trolley,
@@ -561,6 +567,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"bWt" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/starboardthrust)
 "bWK" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -623,9 +632,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
+/area/shuttle/orion_shuttle/portthrust)
 "ceU" = (
 /obj/effect/map_effect/marker/airlock/docking{
 	master_tag = "orion_traveler_port";
@@ -933,6 +942,11 @@
 /obj/item/device/radio/off{
 	pixel_y = 3;
 	pixel_x = -9
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/cockpit)
@@ -1298,6 +1312,13 @@
 "fBW" = (
 /obj/structure/bed/stool/chair/shuttle,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/cockpit)
 "fJg" = (
@@ -1326,15 +1347,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/ship/orion/mainhall)
-"fNK" = (
-/obj/machinery/atmospherics/binary/pump/high_power,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "fUj" = (
 /turf/simulated/floor,
 /area/ship/orion/forehall)
@@ -1376,16 +1388,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"gim" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/starboardthrust)
 "gjQ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/east{
 	req_one_access = null;
 	req_access = list(201)
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle/starboardthrust)
 "gkw" = (
@@ -1409,6 +1417,10 @@
 	},
 /obj/item/pen{
 	pixel_x = -2
+	},
+/obj/item/device/flashlight/lamp{
+	pixel_x = -7;
+	pixel_y = 15
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle/cockpit)
@@ -1516,6 +1528,15 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
+"gEf" = (
+/obj/machinery/atmospherics/binary/pump/high_power,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "gGv" = (
 /obj/effect/floor_decal/corner_wide/beige{
 	dir = 6
@@ -2086,11 +2107,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/storage)
 "iGD" = (
@@ -2340,6 +2356,11 @@
 	},
 /obj/machinery/hologram/holopad/long_range,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle/cockpit)
 "jLO" = (
@@ -2443,12 +2464,6 @@
 "kog" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/pottedplant,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/west{
-	req_access = list(201)
-	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle/cockpit)
 "krv" = (
@@ -2583,6 +2598,11 @@
 	},
 /obj/structure/closet/crate/freezer/rations,
 /obj/effect/floor_decal/industrial/outline/service,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/cockpit)
 "laC" = (
@@ -2878,15 +2898,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/cargo)
-"mfX" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle/storage)
 "mgg" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -3000,15 +3011,6 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
-"mGg" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle/storage)
 "mGO" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
@@ -3069,6 +3071,15 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
+"mPc" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "mPM" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/window/reinforced{
@@ -3238,12 +3249,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle/storage)
 "nAQ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/west{
 	req_one_access = null;
 	req_access = list(201)
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle/portthrust)
 "nDV" = (
@@ -3443,12 +3453,22 @@
 	pixel_y = -3;
 	pixel_x = -6
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/cockpit)
 "ojl" = (
 /obj/structure/bookcase,
 /turf/simulated/floor,
 /area/ship/orion/atmos)
+"osx" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "ovT" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/captain)
@@ -3533,7 +3553,7 @@
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
-	icon_state = "2-8"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle/cockpit)
@@ -3579,7 +3599,7 @@
 	dir = 4;
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle/starboardthrust)
 "oZS" = (
@@ -3657,6 +3677,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"psm" = (
+/obj/machinery/door/airlock/hatch{
+	dir = 4;
+	name = "Starboard Thruster"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/orion_shuttle/storage)
 "ptP" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 4
@@ -3708,6 +3738,20 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/crew)
+"pEi" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle/storage)
 "pFY" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
@@ -3742,12 +3786,6 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster2)
-"pOG" = (
-/obj/machinery/atmospherics/unary/engine{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/starboardthrust)
 "pOK" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
 /area/ship/orion/captain)
@@ -4043,7 +4081,7 @@
 /area/ship/orion/bridge)
 "qUy" = (
 /turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/storage)
+/area/shuttle/orion_shuttle/cockpit)
 "qXP" = (
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
@@ -4065,11 +4103,6 @@
 	},
 /turf/simulated/floor/tiled/dark/airless,
 /area/ship/orion/thruster2)
-"rbj" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "rdc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -4418,6 +4451,13 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
+"spX" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/starboardthrust)
 "sqh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -4426,7 +4466,7 @@
 	dir = 8;
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle/portthrust)
 "ssp" = (
@@ -4439,6 +4479,9 @@
 /obj/structure/bed/stool/bar/padded/beige,
 /turf/simulated/floor/carpet,
 /area/ship/orion/crew)
+"syj" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/portthrust)
 "sys" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -5025,7 +5068,7 @@
 "uzX" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
-	name = "Maintenance"
+	name = "Port Thruster"
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5128,9 +5171,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
-"vgU" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/cockpit)
 "vhp" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -5373,6 +5413,11 @@
 	dir = 4;
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle/cockpit)
 "vRO" = (
@@ -5576,20 +5621,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
-"wzu" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/portables_connector{
-	layer = 2.8
-	},
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/high/north{
-	req_access = list(201)
-	},
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "wzK" = (
 /obj/effect/floor_decal/corner/dark_green/diagonal,
 /obj/machinery/door/window{
@@ -5629,9 +5660,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
-"wFa" = (
-/turf/simulated/wall/shuttle/scc,
-/area/shuttle/orion_shuttle/portthrust)
 "wFW" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid,
@@ -5820,13 +5848,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
-"xsv" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk,
-/turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
 "xsE" = (
 /obj/structure/foamedmetal,
 /turf/simulated/floor,
@@ -5914,6 +5935,20 @@
 /obj/item/paper/business_card,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
+"xGO" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/portables_connector{
+	layer = 2.8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/high/north{
+	req_access = list(201)
+	},
+/turf/simulated/floor,
+/area/shuttle/orion_shuttle/portthrust)
 "xJk" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "aft, starboard side"
@@ -5934,6 +5969,9 @@
 "xRX" = (
 /turf/template_noop,
 /area/space)
+"xSq" = (
+/turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle/storage)
 "xSA" = (
 /obj/item/trash/chips/dirtberry,
 /turf/simulated/floor,
@@ -6011,7 +6049,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/shuttle/orion_shuttle/portthrust)
+/area/shuttle/orion_shuttle/starboardthrust)
 "yfU" = (
 /obj/machinery/appliance/cooker/fryer,
 /obj/effect/floor_decal/corner/black/diagonal,
@@ -36470,8 +36508,8 @@ xRX
 xRX
 xRX
 dwE
-wFa
-wFa
+syj
+syj
 xRX
 xRX
 riA
@@ -36724,11 +36762,11 @@ xRX
 xRX
 xRX
 xRX
-wFa
-wFa
-wFa
+syj
+syj
+syj
 sqh
-yfz
+aYK
 xRX
 riA
 riA
@@ -36982,9 +37020,9 @@ xRX
 xRX
 xRX
 mNJ
-rbj
+aYD
 nAQ
-xsv
+ccK
 qMt
 xRX
 riA
@@ -37238,11 +37276,11 @@ xRX
 xRX
 xRX
 iCX
-wFa
-wzu
+syj
+xGO
 mLK
 fkX
-yfz
+aYK
 riA
 riA
 xsE
@@ -37484,22 +37522,22 @@ xRX
 xRX
 xRX
 xRX
-vgU
-vgU
-vgU
-vgU
 qUy
 qUy
 qUy
 qUy
-qUy
-qUy
-qUy
-qUy
-qUy
+xSq
+xSq
+xSq
+xSq
+xSq
+xSq
+xSq
+xSq
+xSq
 uzX
-qUy
-qUy
+xSq
+xSq
 wNT
 xsE
 xsE
@@ -37745,7 +37783,7 @@ wFW
 fau
 glh
 kog
-qUy
+xSq
 xTL
 ipM
 hld
@@ -37755,7 +37793,7 @@ sTK
 tRi
 qjk
 nzE
-qUy
+xSq
 soM
 haV
 haV
@@ -38010,10 +38048,10 @@ hvo
 mcD
 oIF
 jOD
-qUy
-qUy
-qUy
-qUy
+xSq
+xSq
+xSq
+xSq
 haV
 spv
 dGE
@@ -38259,11 +38297,11 @@ wFW
 jiH
 wkO
 jKa
-qUy
+xSq
 skU
 rdc
 biw
-mfX
+iEl
 mzY
 biw
 aVM
@@ -38512,15 +38550,15 @@ xRX
 xRX
 xRX
 xRX
-vgU
+qUy
 vOd
 vPd
 dte
-qUy
+xSq
 lZq
 lZq
-mGg
-iEl
+mPc
+pEi
 mzO
 rLo
 hlA
@@ -38769,11 +38807,11 @@ xRX
 xRX
 xRX
 xRX
-vgU
+qUy
 fdC
 gnR
 oey
-qUy
+xSq
 iPr
 nGq
 qQV
@@ -38781,9 +38819,9 @@ yaz
 eXD
 gdY
 lTO
-qUy
-qUy
-qUy
+xSq
+xSq
+xSq
 rrQ
 qBd
 qBd
@@ -39026,11 +39064,11 @@ xRX
 xRX
 xRX
 xRX
-vgU
+qUy
 fBW
 vRr
 kYI
-qUy
+xSq
 pdw
 rDS
 hNk
@@ -39040,7 +39078,7 @@ iOe
 kAZ
 ixH
 kcS
-qUy
+xSq
 efO
 bHV
 xzg
@@ -39283,22 +39321,22 @@ xRX
 xRX
 xRX
 xRX
-vgU
-vgU
-vgU
-vgU
 qUy
 qUy
 qUy
 qUy
-qUy
-qUy
-qUy
-qUy
-qUy
-uzX
-qUy
-qUy
+xSq
+xSq
+xSq
+xSq
+xSq
+xSq
+xSq
+xSq
+xSq
+psm
+xSq
+xSq
 riA
 oQa
 gMK
@@ -39551,11 +39589,11 @@ xRX
 xRX
 xRX
 qkP
-gim
+bWt
 mcN
-fNK
+gEf
 boM
-pOG
+yfz
 xRX
 oQa
 iCR
@@ -39809,9 +39847,9 @@ xRX
 xRX
 xRX
 uVR
-aYD
+osx
 gjQ
-ccK
+spX
 kOl
 xRX
 riA
@@ -40065,11 +40103,11 @@ xRX
 xRX
 xRX
 xRX
-gim
-gim
-gim
+bWt
+bWt
+bWt
 oXn
-pOG
+yfz
 xRX
 xRX
 riA
@@ -40325,8 +40363,8 @@ xRX
 xRX
 xRX
 scs
-gim
-gim
+bWt
+bWt
 xRX
 xRX
 riA

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -1187,7 +1187,10 @@
 "fdC" = (
 /obj/structure/bed/stool/chair/shuttle,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/alarm/north,
+/obj/machinery/alarm/north{
+	req_access = list(201);
+	req_one_access = null
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "feE" = (
@@ -1360,7 +1363,10 @@
 /area/ship/orion/forehall)
 "gjQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/alarm/east,
+/obj/machinery/alarm/east{
+	req_one_access = null;
+	req_access = list(201)
+	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)
@@ -2099,7 +2105,10 @@
 	layer = 2.71;
 	dir = 8
 	},
-/obj/machinery/alarm/north,
+/obj/machinery/alarm/north{
+	req_access = list(201);
+	req_one_access = null
+	},
 /obj/machinery/atmospherics/binary/passive_gate/on{
 	name = "Air to Distribution";
 	dir = 8
@@ -3117,7 +3126,10 @@
 /area/shuttle/orion_shuttle)
 "nAQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/alarm/west,
+/obj/machinery/alarm/west{
+	req_one_access = null;
+	req_access = list(201)
+	},
 /obj/structure/lattice/catwalk,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -130,31 +130,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/thruster2)
-"aGd" = (
-/obj/machinery/light{
-	dir = 8;
-	inserted_light = /obj/item/light/tube/colored/blue
-	},
-/obj/structure/table/steel,
-/obj/machinery/button/remote/blast_door{
-	name = "Safety Shutters";
-	id = "orion_shuttle_shutters";
-	dir = 1;
-	pixel_y = 8;
-	pixel_x = -8
-	},
-/obj/item/clothing/head/helmet/pilot{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/paper_bin{
-	pixel_x = 5
-	},
-/obj/item/pen{
-	pixel_x = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "aHs" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor,
@@ -332,10 +307,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
 "biw" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "bjg" = (
@@ -430,7 +407,8 @@
 	pixel_y = 11;
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "bvf" = (
 /obj/structure/cable/green{
@@ -446,6 +424,7 @@
 	shuttle_tag = "Orion Express Shuttle"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/green,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)
 "bAQ" = (
@@ -544,6 +523,7 @@
 	id_tag = "orion_traveler_n_out";
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 "bUj" = (
@@ -571,6 +551,16 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"bXa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/orion_shuttle)
 "bXG" = (
 /obj/structure/table/rack,
 /obj/item/stack/cable_coil{
@@ -842,6 +832,9 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"dho" = (
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "dhX" = (
 /obj/structure/table/rack,
 /obj/item/reagent_containers/toothbrush,
@@ -867,6 +860,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
+"dir" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "diy" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
@@ -1107,19 +1108,6 @@
 "etL" = (
 /turf/space/transit/north,
 /area/space)
-"evN" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 9
-	},
-/obj/structure/closet/walllocker/emerglocker/east,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/item/storage/bag/inflatable/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/suit/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "exg" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -1277,20 +1265,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/orion/thruster1)
-"frR" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	layer = 2.71
-	},
-/obj/structure/fuel_port/phoron{
-	pixel_x = -32
-	},
-/obj/effect/floor_decal/corner/dark_green,
-/obj/structure/bed/handrail{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "fuh" = (
 /obj/item/clothing/head/beret/janitor,
 /obj/structure/table/steel,
@@ -1309,9 +1283,22 @@
 /turf/simulated/floor,
 /area/ship/orion/engie)
 "fBW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/pottedplant,
-/turf/simulated/floor/tiled/dark/full,
+/obj/machinery/light{
+	dir = 8;
+	inserted_light = /obj/item/light/tube/colored/blue
+	},
+/obj/structure/table/steel,
+/obj/item/clothing/head/helmet/pilot{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/paper_bin{
+	pixel_x = -2
+	},
+/obj/item/pen{
+	pixel_x = -2
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "fJg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
@@ -1527,6 +1514,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
+"gJH" = (
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 9
+	},
+/obj/structure/closet/walllocker/emerglocker/east,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/item/storage/bag/inflatable/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/suit/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/obj/item/clothing/head/helmet/space/emergency,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "gJZ" = (
 /obj/machinery/vending/tool,
 /obj/machinery/light{
@@ -1586,6 +1586,7 @@
 	pixel_x = -40;
 	pixel_y = -1
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle)
 "gOp" = (
@@ -1791,14 +1792,21 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
+"hrA" = (
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 6
+	},
+/obj/structure/closet/walllocker/firecloset{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "htX" = (
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
 "hvo" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 2
 	},
@@ -1815,6 +1823,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
@@ -1876,13 +1889,13 @@
 /turf/simulated/floor,
 /area/ship/orion/engie)
 "hNk" = (
-/obj/structure/cable{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/smes/buildable/third_party_shuttle,
 /obj/structure/sign/electricshock{
 	pixel_x = 32
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
@@ -1961,7 +1974,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "ilT" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -1972,6 +1986,19 @@
 /obj/item/modular_computer/laptop,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
+"imN" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/orion_shuttle)
 "inj" = (
 /obj/machinery/door/airlock/glass{
 	name = "Commissary";
@@ -2012,12 +2039,9 @@
 /turf/simulated/floor,
 /area/ship/orion/atmos)
 "ixH" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/light{
-	dir = 4;
-	inserted_light = /obj/item/light/tube/colored/blue
-	},
-/turf/simulated/floor/carpet/rubber,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/pottedplant,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "iCR" = (
 /turf/simulated/wall/shuttle/scc_space_ship/cardinal,
@@ -2128,6 +2152,7 @@
 /area/ship/orion/forehall)
 "jiH" = (
 /obj/machinery/computer/ship/sensors,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "jmg" = (
@@ -2282,6 +2307,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad/long_range,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "jLO" = (
@@ -2351,7 +2378,6 @@
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 "kog" = (
-/obj/machinery/hologram/holopad/long_range,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "krv" = (
@@ -2394,15 +2420,11 @@
 /turf/simulated/floor,
 /area/ship/orion/cargo)
 "kAZ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	layer = 2.71
-	},
 /obj/effect/floor_decal/corner/dark_green{
-	dir = 10
+	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/bed/handrail{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
@@ -2431,10 +2453,10 @@
 /area/ship/orion/cargo)
 "kLL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc/west,
+/obj/structure/cable{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "kOl" = (
@@ -2482,6 +2504,7 @@
 	dir = 9
 	},
 /obj/structure/closet/crate/freezer/rations,
+/obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "laC" = (
@@ -2668,15 +2691,8 @@
 /turf/simulated/floor,
 /area/ship/orion/engie)
 "lZq" = (
-/obj/machinery/light{
-	dir = 1;
-	inserted_light = /obj/item/light/tube/colored/blue;
-	icon_state = "tube_empty"
-	},
+/obj/structure/bed/stool/chair/shuttle,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "maj" = (
@@ -2701,6 +2717,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 "maw" = (
@@ -2793,6 +2810,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
+"moh" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/alarm/north,
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "mpC" = (
 /obj/effect/floor_decal/corner/dark_green/diagonal,
 /obj/structure/cable/green{
@@ -2824,14 +2847,12 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
 "mzO" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	layer = 2.71;
-	dir = 1
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "mzY" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2867,11 +2888,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
-"mFR" = (
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "mGO" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
@@ -2956,7 +2975,9 @@
 	layer = 2.71;
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "mSy" = (
@@ -2972,7 +2993,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "mXd" = (
 /obj/structure/cable/green{
@@ -3237,14 +3258,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
-"nXs" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/sign/securearea{
-	pixel_x = -32
-	},
-/obj/structure/closet/crate,
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "nYY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -3282,6 +3295,10 @@
 	pixel_y = 9;
 	pixel_x = -3
 	},
+/obj/random/powercell{
+	pixel_y = -3;
+	pixel_x = -6
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "ojl" = (
@@ -3296,16 +3313,6 @@
 /obj/machinery/power/apc/high/south,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
-"oyE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/orion_shuttle)
 "oAK" = (
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "orion_shuttle";
@@ -3679,13 +3686,17 @@
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion)
 "qjk" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 6
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	layer = 2.71
 	},
-/obj/structure/closet/walllocker/firecloset{
+/obj/structure/fuel_port/phoron{
 	pixel_x = -32
 	},
-/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/effect/floor_decal/corner/dark_green,
+/obj/structure/bed/handrail{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "qkP" = (
@@ -3697,6 +3708,16 @@
 	dir = 1
 	},
 /turf/simulated/floor/airless,
+/area/shuttle/orion_shuttle)
+"qmf" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71;
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "qpS" = (
 /obj/structure/cable/green{
@@ -3736,9 +3757,7 @@
 	layer = 2.71;
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
 "qsf" = (
@@ -3900,9 +3919,6 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "rgL" = (
@@ -3917,10 +3933,6 @@
 "riA" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion)
-"rkQ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "rlw" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -3941,16 +3953,6 @@
 /obj/structure/closet/crate/loot,
 /turf/simulated/floor,
 /area/ship/orion/cargo)
-"rpe" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/vending/wallmed1{
-	req_access = null;
-	pixel_y = 30;
-	pixel_x = -6
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "rro" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -4037,12 +4039,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/bridge)
 "rDd" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/closet/secure_closet/package_courier{
 	req_access = list()
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "1-4";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
@@ -4143,12 +4148,12 @@
 /area/ship/orion/thruster1)
 "skU" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6;
-	pixel_y = 0
-	},
 /obj/structure/sign/flag/orion_express/large/north{
 	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
@@ -4423,9 +4428,6 @@
 /area/shuttle/orion_shuttle)
 "sTK" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "sXW" = (
@@ -4518,12 +4520,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
-"tiM" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/alarm/north,
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/orion_shuttle)
 "tlv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
@@ -4590,6 +4586,14 @@
 	},
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
+"tsK" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light{
+	dir = 4;
+	inserted_light = /obj/item/light/tube/colored/blue
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/orion_shuttle)
 "twl" = (
 /obj/effect/landmark/entry_point/starboard{
 	name = "port, engine entrance"
@@ -4617,6 +4621,7 @@
 	icon_state = "door_locked";
 	id_tag = "orion_traveler_n_out"
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 "tEO" = (
@@ -4846,7 +4851,7 @@
 	dir = 4;
 	name = "Maintenance"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle)
 "uGk" = (
 /obj/structure/table/wood,
@@ -4890,6 +4895,14 @@
 	name = "fore, starboard engines"
 	},
 /turf/simulated/wall/shuttle/scc,
+/area/shuttle/orion_shuttle)
+"uWs" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/securearea{
+	pixel_x = -32
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "uWQ" = (
 /obj/machinery/computer/ship/engines{
@@ -5154,6 +5167,18 @@
 "vOd" = (
 /obj/structure/bed/stool/chair/shuttle,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/vending/wallmed1{
+	req_access = null;
+	pixel_y = 30;
+	pixel_x = -7
+	},
+/obj/machinery/button/remote/blast_door{
+	name = "Safety Shutters";
+	id = "orion_shuttle_shutters";
+	dir = 1;
+	pixel_y = 27;
+	pixel_x = 7
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/orion_shuttle)
 "vPd" = (
@@ -5465,15 +5490,6 @@
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
-"wPg" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 8
-	},
-/obj/structure/bed/handrail{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/orion_shuttle)
 "wSv" = (
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -5761,12 +5777,14 @@
 /turf/simulated/floor,
 /area/ship/orion/cargo)
 "yaz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle)
@@ -37531,17 +37549,17 @@ xRX
 xRX
 wFW
 fau
-aGd
 fBW
+ixH
 qUy
 xTL
 ipM
-nXs
+uWs
 kLL
-rkQ
 sTK
-frR
+dir
 qjk
+hrA
 nzE
 qUy
 soM
@@ -38053,8 +38071,8 @@ rdc
 iEl
 biw
 mzY
-rkQ
-kAZ
+sTK
+imN
 ihA
 oAK
 gXD
@@ -38301,15 +38319,15 @@ xRX
 xRX
 xRX
 qUy
-rpe
+vOd
 vPd
 dte
 qUy
-lZq
+glh
 glh
 iEl
 biw
-mzY
+mzO
 rLo
 hlA
 buO
@@ -38558,17 +38576,17 @@ xRX
 xRX
 xRX
 qUy
-tiM
-mFR
+moh
+dho
 oey
 qUy
 iPr
 nGq
 qQV
 yaz
-oyE
+bXa
 gdY
-mzO
+qmf
 qUy
 qUy
 qUy
@@ -38815,8 +38833,8 @@ xRX
 xRX
 xRX
 qUy
-vOd
-ixH
+lZq
+tsK
 kYI
 qUy
 pdw
@@ -38825,8 +38843,8 @@ hNk
 rDd
 uWQ
 iOe
-wPg
-evN
+kAZ
+gJH
 kcS
 qUy
 efO

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -112,11 +112,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
 "aEq" = (
 /obj/machinery/atmospherics/unary/engine{
@@ -154,12 +153,11 @@
 /turf/simulated/floor/plating,
 /area/ship/orion/mainhall)
 "aMl" = (
-/obj/effect/floor_decal/corner_wide/beige{
-	dir = 9
-	},
-/obj/structure/bed/stool/chair,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/bed/stool/chair{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
@@ -178,6 +176,9 @@
 "aQB" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
@@ -250,9 +251,6 @@
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle/portthrust)
 "aYE" = (
-/obj/effect/floor_decal/corner_wide/beige/full{
-	dir = 8
-	},
 /obj/structure/bed/stool/chair,
 /obj/machinery/light{
 	dir = 8;
@@ -295,11 +293,12 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	pixel_y = 0
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
@@ -346,6 +345,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
@@ -443,10 +445,6 @@
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle/storage)
 "bAQ" = (
-/obj/effect/floor_decal/corner_wide/beige{
-	dir = 9
-	},
-/obj/structure/bed/stool/chair,
 /obj/structure/sign/poster{
 	icon_state = "poster7";
 	pixel_x = -32
@@ -454,6 +452,9 @@
 /obj/machinery/light{
 	dir = 8;
 	inserted_light = /obj/item/light/tube/colored/blue
+	},
+/obj/structure/bed/stool/chair{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
@@ -563,7 +564,9 @@
 /area/ship/orion/forehall)
 "bWK" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
 "bXG" = (
@@ -880,13 +883,14 @@
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle/portthrust)
 "dkq" = (
-/obj/effect/floor_decal/corner_wide/beige{
-	dir = 6
-	},
-/obj/structure/bed/stool/chair,
 /obj/machinery/light{
 	dir = 4;
 	inserted_light = /obj/item/light/tube/colored/blue
+	},
+/obj/structure/table/steel,
+/obj/item/trash/candybowl{
+	pixel_y = 5;
+	pixel_x = 3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
@@ -900,13 +904,11 @@
 /area/ship/orion/crew)
 "drF" = (
 /obj/machinery/vending/cola,
-/obj/effect/floor_decal/corner_wide/beige{
-	dir = 6
-	},
 /obj/machinery/light{
 	dir = 4;
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
+/obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "dte" = (
@@ -1028,16 +1030,13 @@
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/thruster2)
 "dNE" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
 /area/ship/orion/mainhall)
 "dYg" = (
 /obj/effect/floor_decal/corner_wide/beige{
@@ -1228,18 +1227,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "fkm" = (
-/obj/effect/floor_decal/corner_wide/beige{
-	dir = 5
-	},
 /obj/item/material/ashtray/glass{
-	pixel_x = -7
-	},
-/obj/item/material/ashtray/glass{
-	pixel_x = 6
+	pixel_x = -7;
+	pixel_y = -1
 	},
 /obj/structure/table/steel,
 /obj/structure/sign/flag/orion_express{
 	pixel_y = 32
+	},
+/obj/item/clothing/mask/smokable/cigarette/wulu{
+	pixel_y = 8;
+	pixel_x = -7
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
@@ -1298,11 +1296,15 @@
 /turf/simulated/floor,
 /area/ship/orion/forehall)
 "fva" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/light{
+	dir = 4;
+	inserted_light = /obj/item/light/tube/colored/blue
+	},
+/obj/structure/bed/stool/chair/sofa/left/brown{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/orion/shop)
+/area/ship/orion/mainhall)
 "fwA" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -1336,16 +1338,25 @@
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster2)
 "fJE" = (
-/obj/structure/bed/stool/chair,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
+/area/ship/orion/mainhall)
+"fLt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4;
+	icon_state = "map_scrubber_on"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "fUj" = (
 /turf/simulated/floor,
@@ -1519,6 +1530,7 @@
 	dir = 8;
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
 "gDc" = (
@@ -1725,8 +1737,7 @@
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
@@ -1830,6 +1841,7 @@
 	landmark_tag = "nav_orion_express_ship_3"
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 "htX" = (
@@ -1870,7 +1882,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	layer = 2.71;
@@ -1880,7 +1891,7 @@
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
 "hAw" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -1986,16 +1997,13 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/orion/forehall)
 "ifH" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/ship/orion/mainhall)
+/turf/simulated/floor/tiled/white,
+/area/ship/orion/forehall)
 "ihi" = (
 /obj/effect/floor_decal/industrial/hatch,
 /turf/simulated/floor/airless,
@@ -2272,7 +2280,6 @@
 /turf/simulated/floor/airless,
 /area/ship/orion/thruster1)
 "jvY" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/glass{
 	dir = 1;
@@ -2283,7 +2290,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "jwy" = (
 /turf/simulated/floor/wood,
@@ -2488,6 +2495,7 @@
 	pixel_y = 10;
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 "kxo" = (
@@ -2758,11 +2766,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 "lXU" = (
@@ -2831,14 +2839,14 @@
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 "maw" = (
-/obj/effect/floor_decal/corner_wide/beige{
-	dir = 6
-	},
 /obj/structure/sign/poster{
 	icon_state = "tcflposter2";
 	pixel_x = 29;
 	pixel_y = 7;
 	poster_type = "/datum/poster/bay_68"
+	},
+/obj/structure/bed/stool/chair/sofa/right/brown{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
@@ -2948,11 +2956,7 @@
 /turf/simulated/floor/wood,
 /area/ship/orion/crew)
 "myM" = (
-/obj/structure/bed/stool/bar/padded/beige,
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -3416,17 +3420,11 @@
 /turf/simulated/floor,
 /area/ship/orion/comms)
 "ode" = (
-/obj/structure/bed/stool/bar/padded/beige,
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4;
-	icon_state = "map_scrubber_on"
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/orion/forehall)
+/turf/simulated/floor/tiled/dark,
+/area/ship/orion/mainhall)
 "odB" = (
 /obj/structure/bed/stool/bar/padded/beige,
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -3564,10 +3562,10 @@
 /area/ship/orion/forehall)
 "oTa" = (
 /obj/machinery/vending/coffee,
-/obj/effect/floor_decal/corner_wide/beige/full,
 /obj/structure/sign/vacuum{
 	pixel_y = -32
 	},
+/obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "oVV" = (
@@ -3710,9 +3708,8 @@
 	name = "Primary Hall";
 	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "pDY" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
@@ -3948,9 +3945,6 @@
 /turf/simulated/floor,
 /area/ship/orion/engie)
 "qza" = (
-/obj/effect/floor_decal/corner_wide/beige/full{
-	dir = 1
-	},
 /obj/structure/closet/crate/bin{
 	name = "trashbin"
 	},
@@ -4612,8 +4606,8 @@
 /turf/simulated/floor,
 /area/ship/orion/cargo)
 "sYA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
@@ -4685,9 +4679,6 @@
 	dir = 8;
 	inserted_light = /obj/item/light/tube/colored/blue
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
@@ -4729,13 +4720,12 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "tnO" = (
 /obj/machinery/door/airlock/mining{
@@ -4758,8 +4748,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "trX" = (
 /obj/structure/cable/green{
@@ -4796,8 +4788,12 @@
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/atmos)
 "tAd" = (
-/obj/effect/floor_decal/corner_wide/beige{
-	dir = 10
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4;
+	icon_state = "map_scrubber_on"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
@@ -4834,10 +4830,18 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/orion_shuttle/cockpit)
 "tGB" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/ship/orion/mainhall)
 "tJl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4845,6 +4849,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
@@ -4993,13 +5000,15 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/ship/orion/mainhall)
@@ -5017,15 +5026,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/captain)
 "utt" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/ship/orion/forehall)
+/turf/simulated/wall/shuttle/scc_space_ship,
+/area/ship/orion/shop)
 "uty" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
@@ -5135,8 +5140,8 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/shop)
@@ -5175,6 +5180,7 @@
 	name = "exterior access button";
 	pixel_x = -32
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 "vhp" = (
@@ -5209,14 +5215,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
 "vtB" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/effect/floor_decal/corner/red{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
-/area/ship/orion/shop)
+/area/ship/orion/mainhall)
 "vtO" = (
 /obj/structure/sign/nosmoking_1{
 	pixel_x = 32
@@ -5534,12 +5537,10 @@
 /area/ship/orion/cargo)
 "wjI" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/floor_decal/corner_wide/beige{
-	dir = 9
-	},
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "wkF" = (
@@ -5573,20 +5574,24 @@
 /turf/simulated/floor/grass,
 /area/ship/orion/forehall)
 "wpP" = (
-/obj/structure/bed/stool/chair,
+/obj/effect/floor_decal/big/ox_full{
+	layer = 2.2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "wrd" = (
 /turf/simulated/wall/shuttle/scc_space_ship,
 /area/ship/orion/forehall)
 "wri" = (
-/obj/effect/floor_decal/corner_wide/beige{
-	dir = 9
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/machinery/alarm/west,
+/obj/structure/table/steel,
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/tcfl{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/trash/can{
+	pixel_x = -6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "wrk" = (
@@ -5744,12 +5749,10 @@
 /area/ship/orion/cargo)
 "wSM" = (
 /obj/machinery/vending/snack,
-/obj/effect/floor_decal/corner_wide/beige/full{
-	dir = 4
-	},
 /obj/structure/sign/directions/dock{
 	pixel_y = -32
 	},
+/obj/effect/floor_decal/industrial/hatch/grey,
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/mainhall)
 "wUT" = (
@@ -6120,6 +6123,7 @@
 	landmark_tag = "nav_orion_express_ship_3"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/ship/orion/mainhall)
 
@@ -36297,7 +36301,7 @@ deS
 lgk
 lMD
 odB
-jsi
+deS
 deS
 deS
 oVV
@@ -36550,11 +36554,11 @@ yfU
 lKs
 lKs
 wsA
-deS
-ode
+ifH
+lgk
 hlr
 odB
-pqv
+jsi
 odB
 odB
 qpX
@@ -36807,8 +36811,8 @@ wPe
 lKs
 lKs
 bCt
-deS
 myM
+lgk
 lMD
 odB
 pqv
@@ -37064,8 +37068,8 @@ sMg
 lKs
 lKs
 ian
-deS
-utt
+myM
+agB
 deS
 deS
 pqv
@@ -37837,12 +37841,12 @@ aYo
 qpX
 aYE
 bkP
-aev
+vtB
 aMl
 wri
 bAQ
-aev
-aev
+vtB
+vtB
 wjI
 oTa
 haV
@@ -38095,13 +38099,13 @@ qpX
 fkm
 tXC
 aev
+ode
+aev
 wpP
-sYA
-wpP
+ode
 aev
 aev
 aev
-tAd
 haV
 ppM
 gtw
@@ -38350,12 +38354,12 @@ aev
 vZZ
 pRV
 aev
-dNE
-tGB
+tXC
 aev
-sYA
+tAd
 aev
 aev
+fLt
 aev
 aev
 aev
@@ -38609,12 +38613,12 @@ tmL
 vcD
 vJO
 vcD
+tGB
 fJE
-ifH
 fJE
 ulP
 lXJ
-gYr
+dNE
 gYr
 hrj
 pMZ
@@ -38865,10 +38869,10 @@ ovT
 pOK
 qza
 tJl
-aev
+sYA
 dkq
 maw
-dkq
+fva
 aQB
 trH
 drF
@@ -39635,11 +39639,11 @@ aRB
 qeK
 pOK
 lXU
-fva
+jXl
 lym
 clk
 dhX
-vtB
+rxB
 ufB
 bXG
 ssp
@@ -39892,7 +39896,7 @@ xFA
 dYg
 pOK
 xnY
-jXl
+oMV
 tei
 oMV
 xrl
@@ -42207,7 +42211,7 @@ qBd
 xsE
 fsY
 qhi
-fsY
+utt
 xRX
 xRX
 xRX


### PR DESCRIPTION
A few very small changes and fixes to the OE ship, primarily focused on making the shuttle more functional.

The shuttle has been reworked to have functional power, a more interesting appearance, more resources available, and multiple areas. The intention is that a large volume of cargo can be easily loaded onto it. Previously, the cabling was broken in addition to all the flooring being shuttle floors, which cannot apparently be pried, so it was essentially impossible to fix.  Associated code could use a glance-over.

![image](https://github.com/Aurorastation/Aurora.3/assets/83198434/49a0db6c-6721-42ab-8e15-18750e0dabf4)

APCs throughout the ship have been set to OE ship access, so the crew can actually access them now.

