### PR TITLE
Fixes Gas Pump for thrusters for Golden Deep ship

### DIFF
--- a/html/changelogs/Ben10083-Golden.yml
+++ b/html/changelogs/Ben10083-Golden.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "The Golden Deep Ships no longer have their gas pump to thrusters the wrong way around."

--- a/maps/away/ships/golden_deep/golden_deep_merchant.dmm
+++ b/maps/away/ships/golden_deep/golden_deep_merchant.dmm
@@ -43,7 +43,8 @@
 /area/golden_deep/hangar)
 "aK" = (
 /obj/machinery/atmospherics/binary/pump/fuel{
-	name = "canister to thrusters"
+	name = "canister to thrusters";
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
@@ -349,7 +350,8 @@
 /area/golden_deep/bridge)
 "dK" = (
 /obj/machinery/atmospherics/binary/pump/fuel{
-	name = "canister to thrusters"
+	name = "canister to thrusters";
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,

--- a/maps/away/ships/golden_deep/golden_deep_merchant.dmm
+++ b/maps/away/ships/golden_deep/golden_deep_merchant.dmm
@@ -43,8 +43,7 @@
 /area/golden_deep/hangar)
 "aK" = (
 /obj/machinery/atmospherics/binary/pump/fuel{
-	name = "canister to thrusters";
-	dir = 1
+	name = "canister to thrusters"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,


### PR DESCRIPTION
The gas pump for the Golden Deep ship was the wrong way around, it is now flipped, making it pump gas _out_ of the canisters.