### PR TITLE
Prevents ghosts from calling elevators

### DIFF
--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -72,8 +72,6 @@
 	light_up = FALSE
 	update_icon()
 
-// Prevents ghosts from calling the lift unless they are an admin.
-
 /obj/structure/lift/button/attack_ghost(var/mob/user)
 	if(check_rights(R_ADMIN))
 		return ui_interact(user)

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -73,7 +73,7 @@
 	update_icon()
 
 /obj/structure/lift/button/attack_ghost(var/mob/user)
-	if(check_rights(R_ADMIN))
+	if(check_rights(R_ADMIN, FALSE, user))
 		return ui_interact(user)
 
 /obj/structure/lift/button/ui_interact(var/mob/user)

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -75,7 +75,7 @@
 // Prevents ghosts from calling the lift.
 
 /obj/structure/lift/button/attack_ghost(var/mob/user)
-    return
+	return
 
 /obj/structure/lift/button/ui_interact(var/mob/user)
 	if(!..())

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -72,6 +72,10 @@
 	light_up = FALSE
 	update_icon()
 
+// Prevents ghosts from calling the lift.
+/obj/structure/lift/button/attack_ghost(var/mob/user)
+    return
+
 /obj/structure/lift/button/ui_interact(var/mob/user)
 	if(!..())
 		return

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -77,8 +77,6 @@
 /obj/structure/lift/button/attack_ghost(var/mob/user)
 	if(check_rights(R_ADMIN))
 		return ui_interact(user)
-	else
-		return
 
 /obj/structure/lift/button/ui_interact(var/mob/user)
 	if(!..())

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -72,10 +72,13 @@
 	light_up = FALSE
 	update_icon()
 
-// Prevents ghosts from calling the lift.
+// Prevents ghosts from calling the lift unless they are an admin.
 
 /obj/structure/lift/button/attack_ghost(var/mob/user)
-	return
+	if(check_rights(R_ADMIN))
+		return ui_interact(user)
+	else
+		return
 
 /obj/structure/lift/button/ui_interact(var/mob/user)
 	if(!..())

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -73,6 +73,7 @@
 	update_icon()
 
 // Prevents ghosts from calling the lift.
+
 /obj/structure/lift/button/attack_ghost(var/mob/user)
     return
 

--- a/html/changelogs/hazelmouse - elevator_exorcism.yml
+++ b/html/changelogs/hazelmouse - elevator_exorcism.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Ghosts can no longer call the elevator with elevator buttons."


### PR DESCRIPTION
Prevents ghosts from calling elevators using elevator buttons.

I assume there's way better ways to handle this. Notably, this prevents admin ghosts from using elevator buttons as well as regular ghosts. Elevator panels, like the ones in operations, have a TGUI interface that can't be opened by ghosts at all, but can be used with full functionality by admin ghosts.

Resolves https://github.com/Aurorastation/Aurora.3/issues/18330