### PR TITLE
Let detectives shut down drones, also drone conga line

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -59,8 +59,9 @@
 	var/list/pull_list = list(
 					/obj/structure/disposalconstruct,
 					/obj/item/pipe,
-					/obj/item/pipe_meter
-					)
+					/obj/item/pipe_meter,
+					/mob/living/silicon/robot/drone
+					) //Drone conga line, could give them a good robotic look as they march in unison to an objective, I dont know if this will work though
 	mob_bump_flag = SIMPLE_ANIMAL
 	holder_type = /obj/item/holder/drone
 
@@ -68,7 +69,7 @@
 
 	// ID and Access
 	law_update = FALSE
-	req_access = list(ACCESS_ENGINE, ACCESS_ROBOTICS)
+	req_access = list(ACCESS_ENGINE, ACCESS_ROBOTICS, ACCESS_FORENSICS_LOCKERS) //Should let detectives stop drones from cleaning their crimescenes
 	var/hacked = FALSE
 
 	// Laws

--- a/html/changelogs/Colfer1-PR-18341.yml
+++ b/html/changelogs/Colfer1-PR-18341.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Colfer
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Let maintenance drones conga."
+  - rscdel: "Made maintenance drones allergic to the detectives ID card."


### PR DESCRIPTION
The intent of these changes is to make maintenance drones make a little bit more sense, as well as adding new avenues of gameplay. Detectives being unable to stop a drone from cleaning a crimescene without beating it up has always confused me a little bit, even though they usually stop as soon as they see police tape. Also, I've always wanted to let drones conga-line their way to an atmospheric alarm as this promotes teamwork and looks realistic, think of it as their simplistic brains all coming to the same conclusion on which path to take, and marching in unison