### PR TITLE
Ling accent, skin tone, hair gradient, and organ failure fixes

### DIFF
--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -145,7 +145,7 @@
 		H.b_eyes   = dna.GetUIValueRange(DNA_UI_EYES_B,    255)
 		H.update_eyes()
 
-		H.s_tone   = 35 - dna.GetUIValueRange(DNA_UI_SKIN_TONE, 220) // Value can be negative.
+		H.s_tone   = dna.GetUIValueRange(DNA_UI_SKIN_TONE, 220)
 
 		if (dna.GetUIState(DNA_UI_GENDER))
 			H.gender = FEMALE

--- a/code/game/gamemodes/changeling/helpers/_framework.dm
+++ b/code/game/gamemodes/changeling/helpers/_framework.dm
@@ -205,16 +205,16 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 //DNA related datums
 
 /datum/hair_gradient
-    var/style
-    var/red
-    var/green
-    var/blue
+	var/style
+	var/red
+	var/green
+	var/blue
 
 /datum/hair_gradient/New(var/newStyle, var/newRed, var/newGreen, var/newBlue)
-    style = newStyle
-    red = newRed
-    green = newGreen
-    blue = newBlue
+	style = newStyle
+	red = newRed
+	green = newGreen
+	blue = newBlue
 
 /datum/absorbed_dna
 	var/name

--- a/code/game/gamemodes/changeling/helpers/_framework.dm
+++ b/code/game/gamemodes/changeling/helpers/_framework.dm
@@ -97,7 +97,8 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 
 	var/mob/living/carbon/human/H = src
 	if(istype(H))
-		var/datum/absorbed_dna/newDNA = new(H.real_name, H.dna, H.species.get_cloning_variant(), H.languages, H.height, H.gender, H.pronouns, H.accent)
+		var/datum/hair_gradient/newGradient = new(H.g_style, H.r_grad, H.g_grad, H.b_grad)
+		var/datum/absorbed_dna/newDNA = new(H.real_name, H.dna, H.species.get_cloning_variant(), H.languages, H.height, H.gender, H.pronouns, H.accent, newGradient)
 		absorbDNA(newDNA)
 		changeling.mimiced_accent = H.accent
 
@@ -203,6 +204,18 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 
 //DNA related datums
 
+/datum/hair_gradient
+    var/style
+    var/red
+    var/green
+    var/blue
+
+/datum/hair_gradient/New(var/newStyle, var/newRed, var/newGreen, var/newBlue)
+    style = newStyle
+    red = newRed
+    green = newGreen
+    blue = newBlue
+
 /datum/absorbed_dna
 	var/name
 	var/datum/dna/dna
@@ -212,8 +225,9 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	var/gender
 	var/pronouns
 	var/accent
+	var/datum/hair_gradient/hairGradient
 
-/datum/absorbed_dna/New(var/newName, var/newDNA, var/newSpecies, var/newLanguages, var/newHeight, var/newGender, var/newPronouns, var/newAccent)
+/datum/absorbed_dna/New(var/newName, var/newDNA, var/newSpecies, var/newLanguages, var/newHeight, var/newGender, var/newPronouns, var/newAccent, var/newGradient)
 	..()
 	name = newName
 	dna = newDNA
@@ -223,7 +237,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 	gender = newGender
 	pronouns = newPronouns
 	accent = newAccent
-
+	hairGradient = newGradient
 //Helper for stingcode
 
 /mob/proc/sting_can_reach(mob/M as mob, sting_range = 1)

--- a/code/game/gamemodes/changeling/implements/powers/body.dm
+++ b/code/game/gamemodes/changeling/implements/powers/body.dm
@@ -40,12 +40,14 @@
 
 /mob/proc/handle_changeling_transform(var/datum/absorbed_dna/chosen_dna)
 	if(ishuman(src))
-		src.visible_message("<span class='warning'>[src] transforms!</span>")
 		var/mob/living/carbon/human/H = src
-		var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
+		H.visible_message("<span class='warning'>[H] transforms!</span>")
 		var/newSpecies = chosen_dna.speciesName
 		H.set_species(newSpecies, 1)
-
+		if(mind) //likely transfomration sting on ghosted corpse if no mind
+			var/datum/changeling/changeling = mind.antag_datums[MODE_CHANGELING]
+			if(changeling && !changeling.mimicing)
+				changeling.mimiced_accent = chosen_dna.accent
 		H.dna = chosen_dna.dna
 		H.real_name = chosen_dna.name
 		H.sync_organ_dna()
@@ -53,8 +55,10 @@
 		H.height = chosen_dna.height
 		H.gender = chosen_dna.gender
 		H.pronouns = chosen_dna.pronouns
-		if(!changeling.mimicing)
-			changeling.mimiced_accent = chosen_dna.accent
+		H.g_style = chosen_dna.hairGradient.style
+		H.r_grad = chosen_dna.hairGradient.red
+		H.g_grad = chosen_dna.hairGradient.green
+		H.b_grad = chosen_dna.hairGradient.blue
 		domutcheck(H, null) //donut check heh heh heh - Geeves
 		H.UpdateAppearance()
 
@@ -283,7 +287,7 @@
 	if(!head)
 		return
 
-	var/datum/absorbed_dna/DNA = changeling.absorbed_dna[1]
+	var/datum/absorbed_dna/DNA = changeling.GetDNA(H.real_name)
 	var/datum/dna/chosen_dna = DNA.dna
 	if(!chosen_dna)
 		return
@@ -304,17 +308,10 @@
 	var/mob/living/simple_animal/hostile/lesser_changeling/revive/ling = new(get_turf(H))
 
 	var/mob/living/carbon/human/O = new /mob/living/carbon/human(ling)
-	if(chosen_dna.GetUIState(DNA_UI_GENDER))
-		O.gender = FEMALE
-	else
-		O.gender = MALE
-	O.set_species(chosen_dna.species)
-	O.dna = chosen_dna.Clone()
-	O.real_name = chosen_dna.real_name
-	O.UpdateAppearance()
-	domutcheck(O, null)
 	O.make_changeling(H.mind)
 	O.changeling_update_languages(changeling.absorbed_languages)
+	O.accent = DNA.accent
+	O.handle_changeling_transform(DNA)
 	O.status_flags |= GODMODE
 
 	if(H.mind)

--- a/code/game/gamemodes/changeling/implements/powers/stings.dm
+++ b/code/game/gamemodes/changeling/implements/powers/stings.dm
@@ -251,7 +251,8 @@
 
 /datum/changeling_sting/dna_extract/do_sting(mob/living/carbon/human/target)
 	..()
-	var/datum/absorbed_dna/newDNA = new(target.real_name, target.dna, target.species.get_cloning_variant(), target.languages, target.height, target.gender, target.pronouns, target.accent)
+	var/datum/hair_gradient/newGradient = new(target.g_style, target.r_grad, target.g_grad, target.b_grad)
+	var/datum/absorbed_dna/newDNA = new(target.real_name, target.dna, target.species.get_cloning_variant(), target.languages, target.height, target.gender, target.pronouns, target.accent, newGradient)
 	owner.absorbDNA(newDNA)
 
 //Boosts the range of your next sting attack by 1

--- a/code/game/gamemodes/changeling/implements/powers/suck.dm
+++ b/code/game/gamemodes/changeling/implements/powers/suck.dm
@@ -77,7 +77,8 @@
 
 	changeling_update_languages(changeling.absorbed_languages)
 
-	var/datum/absorbed_dna/newDNA = new(T.real_name, T.dna, T.species.get_cloning_variant(), T.languages, T.height, T.gender, T.pronouns, T.accent)
+	var/datum/hair_gradient/newGradient = new(T.g_style, T.r_grad, T.g_grad, T.b_grad)
+	var/datum/absorbed_dna/newDNA = new(T.real_name, T.dna, T.species.get_cloning_variant(), T.languages, T.height, T.gender, T.pronouns, T.accent, newGradient)
 	absorbDNA(newDNA)
 
 	var/datum/changeling/changeling_check = T.get_antag_datum(MODE_CHANGELING)

--- a/html/changelogs/AlaunusLux-ling-fixes.yml
+++ b/html/changelogs/AlaunusLux-ling-fixes.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: AlaunusLux
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Changeling emergency transform ability gives you the correct accent and no longer causes organ failure."
+  - bugfix: "Changeling transform now retains hair gradients and skin tone."
+  - bugfix: "Transformation sting now works on ghosted corpses."
+  - tweak: "After emergency transform, changelings will return to the form they had last."


### PR DESCRIPTION
Reworked emergency transform to revert to your chosen form at the time of ejection, fixed the accent and skin tone changing, as well as organ failure. 
Separately, added a datum to track gradients because absorbDNA's proc call was getting too long. Maybe get_gradient() would be better.

Pretty concerned about ripple effects due to the change in the dna file. I will look into it more later, but I am assuming that either this function isn't used in login or character creation, or the value gets skewed somehow as ling. Will look into a different fix, but hoped someone could shed some light on that.

Fixes #18338