### PR TITLE
Fixes health scanner augment, so it doesn't visibly message, and can no longer "hit the floor" if dizzy

### DIFF
--- a/code/modules/organs/subtypes/augment.dm
+++ b/code/modules/organs/subtypes/augment.dm
@@ -212,7 +212,7 @@
 	if(!.)
 		return FALSE
 
-	health_scan_mob(owner, owner)
+	health_scan_mob(owner, owner, TRUE, TRUE)
 
 /obj/item/organ/internal/augment/tesla
 	name = "tesla spine"

--- a/html/changelogs/llywelwyn-healthscanner.yml
+++ b/html/changelogs/llywelwyn-healthscanner.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Llywelwyn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Integrated Health Scanner no longer broadcasts a visible message, and can't miss and hit the floor if dizzy, etc."


### PR DESCRIPTION
changes:
  - bugfix: "Integrated Health Scanner no longer broadcasts a visible message, and can't miss and hit the floor if dizzy, etc."

var/just_scan wasn't enabled, so it was behaving like a scanner held in the hands. if incapacitated in some way, like being dumb or dizzy, it could miss and broadcast a msg saying the user hits the floor with the scanner, etc. had a look and just_scan appears to be true for every other sort of internal scanner or similar

fixes https://github.com/Aurorastation/Aurora.3/issues/18347