### PR TITLE
Adds visible messages when someone operates a recorder, like happens with PDAs, and some other tweaks

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -92,6 +92,7 @@
 
 	if(use_check_and_message(usr))
 		return
+	usr.visible_message("[SPAN_BOLD("\The [usr]")] presses a button on \the [src].")
 	if(emagged)
 		to_chat(usr, SPAN_WARNING("The tape recorder makes a scratchy noise."))
 		return
@@ -119,6 +120,7 @@
 
 	if(use_check_and_message(usr))
 		return
+	usr.visible_message("[SPAN_BOLD("\The [usr]")] presses a button on \the [src].")
 	if(emagged)
 		to_chat(usr, SPAN_WARNING("The tape recorder makes a scratchy noise."))
 		return
@@ -143,6 +145,7 @@
 
 	if(use_check_and_message(usr))
 		return
+	usr.visible_message("[SPAN_BOLD("\The [usr]")] presses a button on \the [src].")
 	if(emagged)
 		to_chat(usr, SPAN_WARNING("The tape recorder makes a scratchy noise."))
 		return
@@ -216,6 +219,7 @@
 
 	if(use_check_and_message(usr))
 		return
+	usr.visible_message("[SPAN_BOLD("\The [usr]")] presses a button on \the [src].")
 	if(emagged)
 		to_chat(usr, SPAN_WARNING("The tape recorder makes a scratchy noise."))
 		return
@@ -276,6 +280,7 @@
 	if(!recording && !playing)
 		if(use_check_and_message(usr))
 			return
+		usr.visible_message("[SPAN_BOLD("\The [usr]")] presses a button on \the [src].")
 		if(emagged)
 			to_chat(usr, SPAN_WARNING("The tape recorder makes a scratchy noise."))
 			return
@@ -298,6 +303,7 @@
 	else
 		if(use_check_and_message(usr))
 			return
+		usr.visible_message("[SPAN_BOLD("\The [usr]")] presses a button on \the [src].")
 		if(recording)
 			recording = FALSE
 			timestamp += time_recorded

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -94,7 +94,7 @@
 		return
 	usr.visible_message("[SPAN_BOLD("\The [usr]")] presses a button on \the [src].")
 	if(emagged)
-		to_chat(usr, SPAN_WARNING("The tape recorder makes a scratchy noise."))
+		src.audible_message(SPAN_WARNING("The tape recorder makes a scratchy noise."), hearing_distance = 3)
 		return
 	icon_state = "taperecorderrecording"
 	if(time_recorded < 3600 && !playing)
@@ -122,9 +122,8 @@
 		return
 	usr.visible_message("[SPAN_BOLD("\The [usr]")] presses a button on \the [src].")
 	if(emagged)
-		to_chat(usr, SPAN_WARNING("The tape recorder makes a scratchy noise."))
+		src.audible_message(SPAN_WARNING("\The [src] makes a scratchy noise."), hearing_distance = 3)
 		return
-
 	if(recording)
 		recording = FALSE
 		timestamp += time_recorded
@@ -147,7 +146,7 @@
 		return
 	usr.visible_message("[SPAN_BOLD("\The [usr]")] presses a button on \the [src].")
 	if(emagged)
-		to_chat(usr, SPAN_WARNING("The tape recorder makes a scratchy noise."))
+		src.audible_message(SPAN_WARNING("\The [src] makes a scratchy noise."), hearing_distance = 3)
 		return
 	if(recording || playing)
 		to_chat(usr, SPAN_WARNING("You can't clear the memory while playing or recording!"))
@@ -221,7 +220,7 @@
 		return
 	usr.visible_message("[SPAN_BOLD("\The [usr]")] presses a button on \the [src].")
 	if(emagged)
-		to_chat(usr, SPAN_WARNING("The tape recorder makes a scratchy noise."))
+		src.audible_message(SPAN_WARNING("\The [src] makes a scratchy noise."), hearing_distance = 3)
 		return
 	if(!can_print)
 		to_chat(usr, SPAN_WARNING("The recorder can't print that fast!"))
@@ -282,7 +281,7 @@
 			return
 		usr.visible_message("[SPAN_BOLD("\The [usr]")] presses a button on \the [src].")
 		if(emagged)
-			to_chat(usr, SPAN_WARNING("The tape recorder makes a scratchy noise."))
+			src.audible_message(SPAN_WARNING("\The [src] makes a scratchy noise."), hearing_distance = 3)
 			return
 		icon_state = "taperecorderrecording"
 		if(time_recorded < 3600 && !playing)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -94,7 +94,7 @@
 		return
 	usr.visible_message("[SPAN_BOLD("\The [usr]")] presses a button on \the [src].")
 	if(emagged)
-		src.audible_message(SPAN_WARNING("The tape recorder makes a scratchy noise."), hearing_distance = 3)
+		src.audible_message(SPAN_WARNING("\The [src] makes a scratchy noise."), hearing_distance = 3)
 		return
 	icon_state = "taperecorderrecording"
 	if(time_recorded < 3600 && !playing)
@@ -223,7 +223,7 @@
 		src.audible_message(SPAN_WARNING("\The [src] makes a scratchy noise."), hearing_distance = 3)
 		return
 	if(!can_print)
-		to_chat(usr, SPAN_WARNING("The recorder can't print that fast!"))
+		to_chat(usr, SPAN_WARNING("\The [src] can't print that fast!"))
 		return
 	if(recording || playing)
 		to_chat(usr, SPAN_WARNING("You can't print the transcript while playing or recording!"))
@@ -298,7 +298,7 @@
 			icon_state = "taperecorderidle"
 			return
 		else
-			to_chat(usr, SPAN_WARNING("Either your tape recorder's memory is full, or it is currently playing back its memory."))
+			to_chat(usr, SPAN_WARNING("Either \the [src]'s memory is full, or it is currently playing back its memory."))
 	else
 		if(use_check_and_message(usr))
 			return
@@ -311,7 +311,7 @@
 			icon_state = "taperecorderidle"
 			return
 		else if(emagged)
-			to_chat(usr, SPAN_WARNING("The tape recorder's buttons doesn't react!"))
+			to_chat(usr, SPAN_WARNING("\The [src]'s buttons doesn't react!"))
 			return
 		else if(playing)
 			playing = FALSE

--- a/html/changelogs/llywelwyn-recorder.yml
+++ b/html/changelogs/llywelwyn-recorder.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Llywelwyn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a visible message for when someone interacts with a universal recorder."
+  - tweak: "Changed the local chat message for e-magged universal recorders to an audible message."


### PR DESCRIPTION
changes:
  - rscadd: "Added a visible message for when someone interacts with a universal recorder."
  - tweak: "Changed the local chat message for e-magged universal recorders to an audible message."

also replaced some "the tape recorder" messages with "\the [src]" where appropriate

![image](https://github.com/Aurorastation/Aurora.3/assets/82828093/1320e658-e2d7-4612-920c-d1c72526e216)
