### PR TITLE
ECD layering tweak

### DIFF
--- a/code/game/objects/structures/ECD.dm
+++ b/code/game/objects/structures/ECD.dm
@@ -11,6 +11,7 @@
 	density = TRUE
 	var/state = ECD_WELDED
 	slowdown = 10
+	layer = ABOVE_ALL_MOB_LAYER
 
 /obj/structure/ecd/examine(mob/living/user, distance)
 	. = ..()

--- a/html/changelogs/RustingWithYou - ecdlayering.yml
+++ b/html/changelogs/RustingWithYou - ecdlayering.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Changes the ECD sprite layer to prevent weird-looking layering errors."


### PR DESCRIPTION
Moves the ECD sprite layer to ABOVE_ALL_MOB_LAYER as I noticed that the top layer will be underneath windows, mobs, and various effects which all look very weird.