### PR TITLE
nerfs and reflavours cocaine od's cardiac damage

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
@@ -577,9 +577,13 @@
 	M.apply_effect(1, STUTTER)
 	M.make_jittery(power - 6)
 	M.add_chemical_effect(CE_NEUROTOXIC, removed / 3)
-	M.add_chemical_effect(CE_CARDIOTOXIC, removed * 2)
-	if(prob(10))
-		M.add_chemical_effect(CE_NOPULSE, power)
+	M.add_chemical_effect(CE_CARDIOTOXIC, removed / 2) //Tolerable damage, unless your heart can't regenerate...
+	if(prob(7))
+		var/obj/item/organ/internal/heart/H = M.internal_organs_by_name[BP_HEART]
+		if(istype(H) && !BP_IS_ROBOTIC(H)) //But at least a robot heart can keep working at all!
+			to_chat(M, SPAN_WARNING(pick("You feel a cramp in your chest!", "Something tingles inside your chest.", "You feel lightheaded.", "Your vision tunnels.", "You can't feel your fingers.", "Maybe you should slow down?")))
+			if(prob(20))
+				M.add_chemical_effect(CE_NOPULSE, power)
 
 /singleton/reagent/drugs/cocaine/contemplus
 	name = "Contemplus"

--- a/html/changelogs/sniblet-slowdowncokeboy.yml
+++ b/html/changelogs/sniblet-slowdowncokeboy.yml
@@ -1,0 +1,6 @@
+author: Sniblet
+
+delete-after: True
+
+changes:
+  - tweak: "Nerfed and reflavoured the cocaine overdose's effect on the heart."


### PR DESCRIPTION
Quarters direct heart damage, decimates the chance of going straight to NOPULSE, and lets you know with custom warnings when the last tick almost NOPULSED you. It's kind of ludicrous right now - on cyanide's level, with no warning or transition between "you feel really good!" and **Your heart has stopped!**
Cocaine is dangerous and overdoses are worse, but people must be able to survive them, otherwise we'd be out of Cythereans.