### PR TITLE
Fixes wallets being unable to hold boxes of cigarette components

### DIFF
--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -66,7 +66,7 @@
 		slot_l_hand_str = 'icons/mob/items/lefthand_cigs_lighters.dmi',
 		slot_r_hand_str = 'icons/mob/items/righthand_cigs_lighters.dmi',
 		)
-	w_class = ITEMSIZE_SMALL
+	w_class = ITEMSIZE_TINY
 	max_storage_space = 10
 	throwforce = 2
 	slot_flags = SLOT_BELT
@@ -94,7 +94,7 @@
 		slot_l_hand_str = 'icons/mob/items/lefthand_cigs_lighters.dmi',
 		slot_r_hand_str = 'icons/mob/items/righthand_cigs_lighters.dmi',
 		)
-	w_class = ITEMSIZE_SMALL
+	w_class = ITEMSIZE_TINY
 	starts_with = list(/obj/item/cigarette_filter = 10)
 	drop_sound = 'sound/items/drop/gloves.ogg'
 	pickup_sound = 'sound/items/pickup/gloves.ogg'
@@ -205,6 +205,7 @@
 		slot_l_hand_str = 'icons/mob/items/lefthand_cigs_lighters.dmi',
 		slot_r_hand_str = 'icons/mob/items/righthand_cigs_lighters.dmi',
 		)
+	w_class = ITEMSIZE_TINY
 	max_storage_space = 8
 	drop_sound = 'sound/items/drop/cardboardbox.ogg'
 	pickup_sound = 'sound/items/pickup/cardboardbox.ogg'

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/storage/wallet.dmi'
 	icon_state = "wallet_leather"
 	w_class = ITEMSIZE_SMALL
-	max_w_class = ITEMSIZE_NORMAL
+	max_w_class = ITEMSIZE_SMALL
 	can_hold = list(
 		/obj/item/spacecash,
 		/obj/item/card,

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/storage/wallet.dmi'
 	icon_state = "wallet_leather"
 	w_class = ITEMSIZE_SMALL
-	max_w_class = ITEMSIZE_SMALL
+	max_w_class = ITEMSIZE_NORMAL
 	can_hold = list(
 		/obj/item/spacecash,
 		/obj/item/card,

--- a/html/changelogs/llywelwyn-walletfix.yml
+++ b/html/changelogs/llywelwyn-walletfix.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Llywelwyn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Boxes of cigarette components are now tiny items, the same as boxes of cigarettes, rather than small items."
+  - bugfix: "Wallets can now hold the boxes for cigarette components as intended."


### PR DESCRIPTION
this pr made cigarette components able to placed into a wallet a while ago https://github.com/Aurorastation/Aurora.3/pull/17323, but it hasn't been working since storage items can't be placed into other storage items of the same size

regular cigarette packets are already ITEMCLASS_TINY, but for some reason all the components are ITEMCLASS_SMALL. this rectifies that by making all the components tiny too - which probably makes sense given they're all smaller than a packet of cigarettes is in the real world, and judging by matt's pr above they're clearly intended to be of a size that can fit into wallets

changes:
  - tweak: "Boxes of cigarette components are now tiny items, the same as boxes of cigarettes, rather than small items."
  - bugfix: "Wallets can now hold the boxes for cigarette components as intended."