### PR TITLE
Fixes Intern Investigator spawning with an extra set of regular security cadet gloves

### DIFF
--- a/code/game/jobs/faction/idris.dm
+++ b/code/game/jobs/faction/idris.dm
@@ -47,7 +47,7 @@
 	titles_to_loadout = list(
 		"Security Officer" = /datum/outfit/job/officer/idris,
 		"Warden" = /datum/outfit/job/warden/idris,
-		"Security Cadet" = /datum/outfit/job/intern_sec/idris,
+		"Security Cadet" = /datum/outfit/job/intern_sec/officer/idris,
 		"Investigator Intern" = /datum/outfit/job/intern_sec/forensics/idris,
 		"Investigator" =/datum/outfit/job/forensics/idris,
 		"Bartender" = /datum/outfit/job/bartender/idris,
@@ -101,7 +101,7 @@
 	dufflebag_faction = /obj/item/storage/backpack/duffel/idris
 	messengerbag_faction = /obj/item/storage/backpack/messenger/idris
 
-/datum/outfit/job/intern_sec/idris
+/datum/outfit/job/intern_sec/officer/idris
 	name = "Security Cadet - Idris"
 
 	uniform = /obj/item/clothing/under/rank/cadet/idris

--- a/code/game/jobs/faction/pmc.dm
+++ b/code/game/jobs/faction/pmc.dm
@@ -40,7 +40,7 @@
 	titles_to_loadout = list(
 		"Security Officer" = /datum/outfit/job/officer/pmc,
 		"Warden" = /datum/outfit/job/warden/pmc,
-		"Security Cadet" = /datum/outfit/job/intern_sec/pmc,
+		"Security Cadet" = /datum/outfit/job/intern_sec/officer/pmc,
 		"Investigator Intern" = /datum/outfit/job/intern_sec/forensics/pmc,
 		"Investigator" =/datum/outfit/job/forensics/pmc,
 		"Physician" = /datum/outfit/job/doctor/pmc,
@@ -80,7 +80,7 @@
 	dufflebag_faction = /obj/item/storage/backpack/duffel/pmcg
 	messengerbag_faction = /obj/item/storage/backpack/messenger/pmcg
 
-/datum/outfit/job/intern_sec/pmc
+/datum/outfit/job/intern_sec/officer/pmc
 	name = "Security Cadet - PMC"
 
 	uniform = /obj/item/clothing/under/rank/cadet/pmc

--- a/code/game/jobs/faction/zavodskoi.dm
+++ b/code/game/jobs/faction/zavodskoi.dm
@@ -49,7 +49,7 @@
 	titles_to_loadout = list(
 		"Security Officer" = /datum/outfit/job/officer/zavodskoi,
 		"Warden" = /datum/outfit/job/warden/zavodskoi,
-		"Security Cadet" = /datum/outfit/job/intern_sec/zavodskoi,
+		"Security Cadet" = /datum/outfit/job/intern_sec/officer/zavodskoi,
 		"Investigator Intern" = /datum/outfit/job/intern_sec/forensics/zavodskoi,
 		"Investigator" =/datum/outfit/job/forensics/zavodskoi,
 		"Scientist" = /datum/outfit/job/scientist/zavodskoi,
@@ -91,7 +91,7 @@
 	dufflebag_faction = /obj/item/storage/backpack/duffel/zavod
 	messengerbag_faction = /obj/item/storage/backpack/messenger/zavod
 
-/datum/outfit/job/intern_sec/zavodskoi
+/datum/outfit/job/intern_sec/officer/zavodskoi
 	name = "Security Cadet - Zavodskoi Interstellar"
 
 	uniform = /obj/item/clothing/under/rank/cadet/zavod

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -320,6 +320,5 @@
 	shoes = /obj/item/clothing/shoes/laceup
 
 /datum/outfit/job/intern_sec/forensics/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	. = ..()
 	H.equip_or_collect(new /obj/item/clothing/gloves/black/forensic(H), slot_gloves)
 

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -269,7 +269,7 @@
 	selection_color = "#991818"
 	access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_MAINT_TUNNELS)
 	minimal_access = list(ACCESS_SECURITY, ACCESS_SEC_DOORS)
-	outfit = /datum/outfit/job/intern_sec
+	outfit = /datum/outfit/job/intern_sec/officer
 	minimum_character_age = list(
 		SPECIES_HUMAN = 18,
 		SPECIES_SKRELL = 50,
@@ -285,7 +285,6 @@
 	uniform = /obj/item/clothing/under/rank/cadet
 	suit = /obj/item/clothing/suit/storage/hazardvest/security
 	head = /obj/item/clothing/head/beret/security
-	shoes = null
 
 	headset = /obj/item/device/radio/headset/headset_sec
 	bowman = /obj/item/device/radio/headset/headset_sec/alt
@@ -302,6 +301,15 @@
 	tablet = /obj/item/modular_computer/handheld/preset/security
 
 /datum/outfit/job/intern_sec/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+
+/datum/outfit/job/intern_sec/officer
+	name = "Security Cadet"
+	jobtype = /datum/job/intern_sec
+
+	shoes = null
+
+/datum/outfit/job/intern_sec/officer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 	if(istajara(H))
 		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots/toeless(H), slot_shoes)
@@ -320,5 +328,6 @@
 	shoes = /obj/item/clothing/shoes/laceup
 
 /datum/outfit/job/intern_sec/forensics/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
 	H.equip_or_collect(new /obj/item/clothing/gloves/black/forensic(H), slot_gloves)
 

--- a/html/changelogs/llywelwyn-internfix.yml
+++ b/html/changelogs/llywelwyn-internfix.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Fixes Intern Investigators spawning with two pairs of gloves."
+  - backend: "Slight refactor of how Security Cadet outfits are handled, so nobody inherits anything they shouldn't."

--- a/html/changelogs/llywelwyn-internfix.yml
+++ b/html/changelogs/llywelwyn-internfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Llywelwyn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes Intern Investigators spawning with two pairs of gloves."


### PR DESCRIPTION
regular security cadet has an empty shoe/glove slot, which then get replaced with species-specific items as appropriate

it's not needed for intern investigator because laceup shoes and forensic gloves work with all species

right now the intern investigator spawns with a pair of black leather gloves equipped (if they don't have any loadout gloves), and a pair of forensic gloves in their bag. this change makes them work how the actual investigator works - forensic gloves equipped (if they don't have loadout gloves), or placed in the bag otherwise

changes:
  - bugfix: "Fixes Intern Investigators spawning with two pairs of gloves."
  - backend: "Slight refactor of how Security Cadet outfits are handled, so nobody inherits anything they shouldn't."