### PR TITLE
Fixes shuttle window transparency

### DIFF
--- a/code/game/turfs/simulated/shuttle_turfs.dm
+++ b/code/game/turfs/simulated/shuttle_turfs.dm
@@ -190,6 +190,7 @@
 	icon_state = "wall2"
 	health = 500
 	maxhealth = 500
+	alpha = 255
 	smoothing_flags = null
 	canSmoothWith = null
 	can_be_unanchored = FALSE

--- a/html/changelogs/kyres1-shuttle_cockpit_fix.yml
+++ b/html/changelogs/kyres1-shuttle_cockpit_fix.yml
@@ -1,0 +1,6 @@
+author: kyres1
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed incorrect transparency on shuttle cockpits."


### PR DESCRIPTION
Makes the unique shuttle windows have max alpha, since they're meant to be manually given transparency in the icon itself. It'll fix the transparency issues on the Canary, Intrepid and Spark.
