### PR TITLE
Ghost spawner UI improvements

### DIFF
--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -119,13 +119,24 @@ SUBSYSTEM_DEF(ghostroles)
 		var/datum/ghostspawner/G = spawners[s]
 		if(G.cant_see(user))
 			continue
+
 		var/cant_spawn = G.cant_spawn(user)
+
 		var/list/manifest = list()
 		if(LAZYLEN(G.spawned_mobs))
 			for(var/datum/weakref/mob_ref in G.spawned_mobs)
 				var/mob/spawned_mob = mob_ref.resolve()
 				if(spawned_mob)
 					manifest += spawned_mob.real_name
+
+		var/atom/spawn_overmap_location = null
+		if(SSatlas.current_map.use_overmap)
+			var/atom/spawner = G.select_spawnlocation(FALSE)
+			if(istype(spawner))
+				var/obj/effect/overmap/visitable/sector = GLOB.map_sectors["[spawner.z]"]
+				if(istype(sector))
+					spawn_overmap_location = sector.name
+
 		var/list/spawner = list(
 			"short_name" = G.short_name,
 			"name" = G.name,
@@ -137,6 +148,7 @@ SUBSYSTEM_DEF(ghostroles)
 			"enabled" = G.enabled,
 			"count" = G.count,
 			"spawn_atoms" = length(G.spawn_atoms),
+			"spawn_overmap_location" = spawn_overmap_location,
 			"max_count" = G.max_count,
 			"tags" = G.tags,
 			"spawnpoints" = G.spawnpoints,

--- a/code/modules/ghostroles/spawner/base.dm
+++ b/code/modules/ghostroles/spawner/base.dm
@@ -61,9 +61,6 @@
 	if(!enabled && !can_edit(user)) //If its not enabled and the user cant edit it, dont show it
 		return "Currently Disabled"
 
-	if(loc_type == GS_LOC_ATOM && !length(spawn_atoms))
-		return "No spawn atoms available"
-
 	var/ban_reason = jobban_isbanned(user,jobban_job)
 	if(jobban_job && ban_reason)
 		return "[ban_reason]"

--- a/html/changelogs/DreamySkrell-spawner-color-loc.yml
+++ b/html/changelogs/DreamySkrell-spawner-color-loc.yml
@@ -1,0 +1,8 @@
+
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - rscadd: "Ghost spawners show the location of the spawner (ship, station, etc)."
+  - tweak: "Ghost spawners are shown in the list even if full."

--- a/html/changelogs/DreamySkrell-spawner-color-loc.yml
+++ b/html/changelogs/DreamySkrell-spawner-color-loc.yml
@@ -4,5 +4,6 @@ author: DreamySkrell
 delete-after: True
 
 changes:
-  - rscadd: "Ghost spawners show the location of the spawner (ship, station, etc)."
+  - rscadd: "Ghost spawners show the location of the spawner."
   - tweak: "Ghost spawners are shown in the list even if full."
+  - tweak: "Ghost spawners are grayed out if visible, but cannot use them for whatever reason."

--- a/tgui/packages/tgui/interfaces/GhostSpawner.tsx
+++ b/tgui/packages/tgui/interfaces/GhostSpawner.tsx
@@ -158,7 +158,10 @@ export const GhostSpawner = (props, context) => {
             {spawners.map(
               (spawner) =>
                 (spawner.tags.indexOf(tab) > -1 || tab === 'All') && (
-                  <Table.Row key={spawner.short_name} className="candystripe">
+                  <Table.Row
+                    key={spawner.short_name}
+                    className="candystripe"
+                    color={spawner.cant_spawn ? 'gray' : null}>
                     <Table.Cell>{spawner.name}</Table.Cell>
                     <Table.Cell
                       color={loc_to_color[spawner.spawn_overmap_location]}>

--- a/tgui/packages/tgui/interfaces/GhostSpawner.tsx
+++ b/tgui/packages/tgui/interfaces/GhostSpawner.tsx
@@ -22,6 +22,7 @@ type Spawner = {
   count: number;
   max_count: number;
   spawn_atoms: any;
+  spawn_overmap_location: string;
   tags: string[];
   spawnpoints: string[];
   manifest: string[];
@@ -78,12 +79,43 @@ const ManifestTable = function (act, spawner: Spawner) {
 
 export const GhostSpawner = (props, context) => {
   const { act, data } = useBackend<SpawnerData>(context);
+
   const [tab, setTab] = useLocalState(context, 'tab', 'All');
   const [searchTerm, setSearchTerm] = useLocalState<string>(
     context,
     `searchTerm`,
     ``
   );
+
+  const spawners = data.spawners.filter(
+    (S) => S.name.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1
+  );
+
+  const colors = [
+    'blue',
+    'purple',
+    'maroon',
+    'olive',
+    'orange',
+    'cyan',
+    'red',
+    'green',
+    'yellow',
+    'white',
+  ];
+
+  let loc_to_color: Map<string, string> = new Map();
+
+  paginate(
+    Array.from(
+      new Set(
+        spawners
+          .filter((s) => s.spawn_overmap_location)
+          .map((s) => s.spawn_overmap_location)
+      )
+    ),
+    colors.length
+  ).map((p) => p.map((l, i) => (loc_to_color[l] = colors[i % colors.length])));
 
   return (
     <Window resizable width={1000} height={700}>
@@ -119,93 +151,93 @@ export const GhostSpawner = (props, context) => {
           <Table preserveWhitespace>
             <Table.Row header>
               <Table.Cell>Name</Table.Cell>
+              <Table.Cell>Location</Table.Cell>
               <Table.Cell>Description</Table.Cell>
               <Table.Cell>Available Slots</Table.Cell>
               <Table.Cell>Actions</Table.Cell>
             </Table.Row>
-            {data.spawners
-              .filter(
-                (S) =>
-                  S.name.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1
-              )
-              .map(
-                (spawner) =>
-                  (spawner.tags.indexOf(tab) > -1 || tab === 'All') && (
-                    <Table.Row key={spawner.short_name} className="candystripe">
-                      <Table.Cell>{spawner.name}</Table.Cell>
-                      <Table.Cell>
-                        <Box pb={2} pt={2}>
-                          {spawner.desc}
-                          {spawner.manifest.length > 0 ? (
-                            <Box
-                              style={{
-                                'background-color': 'rgba(0, 0, 0, 0.25)',
-                                'border': '1px solid rgba(0, 0, 0, 0.5)',
-                              }}
-                              mt={2}
-                              pb={1}
-                              pt={1}
-                              pl={1}>
-                              <Box fontSize="1.2rem" textAlign="center">
-                                Manifest
-                              </Box>
-                              {ManifestTable(act, spawner)}
+            {spawners.map(
+              (spawner) =>
+                (spawner.tags.indexOf(tab) > -1 || tab === 'All') && (
+                  <Table.Row key={spawner.short_name} className="candystripe">
+                    <Table.Cell>{spawner.name}</Table.Cell>
+                    <Table.Cell
+                      color={loc_to_color[spawner.spawn_overmap_location]}>
+                      {spawner.spawn_overmap_location}
+                    </Table.Cell>
+                    <Table.Cell>
+                      <Box pb={2} pt={2}>
+                        {spawner.desc}
+                        {spawner.manifest.length > 0 ? (
+                          <Box
+                            style={{
+                              'background-color': 'rgba(0, 0, 0, 0.25)',
+                              'border': '1px solid rgba(0, 0, 0, 0.5)',
+                            }}
+                            mt={2}
+                            pb={1}
+                            pt={1}
+                            pl={1}>
+                            <Box fontSize="1.2rem" textAlign="center">
+                              Manifest
                             </Box>
-                          ) : null}
-                        </Box>
-                      </Table.Cell>
-                      <Table.Cell>
-                        {spawner.max_count > 0
-                          ? spawner.max_count -
-                          spawner.count +
-                          ' / ' +
-                          spawner.max_count
-                          : spawner.spawn_atoms}
-                      </Table.Cell>
-                      <Table.Cell inline nowrap>
+                            {ManifestTable(act, spawner)}
+                          </Box>
+                        ) : null}
+                      </Box>
+                    </Table.Cell>
+                    <Table.Cell>
+                      {spawner.max_count > 0
+                        ? spawner.max_count -
+                        spawner.count +
+                        ' / ' +
+                        spawner.max_count
+                        : spawner.spawn_atoms}
+                    </Table.Cell>
+                    <Table.Cell inline nowrap>
+                      <Button
+                        content="Spawn"
+                        color="good"
+                        icon="star"
+                        disabled={spawner.cant_spawn}
+                        onClick={() =>
+                          act('spawn', { spawn: spawner.short_name })
+                        }
+                      />
+                      {spawner.can_jump_to ? (
                         <Button
-                          content="Spawn"
-                          color="good"
-                          icon="star"
-                          disabled={spawner.cant_spawn}
+                          content="J"
                           onClick={() =>
-                            act('spawn', { spawn: spawner.short_name })
+                            act('jump_to', { spawner_id: spawner.short_name })
                           }
                         />
-                        {spawner.can_jump_to ? (
+                      ) : (
+                        ''
+                      )}
+                      {spawner.can_edit ? (
+                        <>
                           <Button
-                            content="J"
+                            content="E"
+                            disabled={spawner.enabled}
                             onClick={() =>
-                              act('jump_to', { spawner_id: spawner.short_name })
+                              act('enable', { enable: spawner.short_name })
                             }
                           />
-                        ) : (
-                          ''
-                        )}
-                        {spawner.can_edit ? (
-                          <>
-                            <Button
-                              content="E"
-                              disabled={spawner.enabled}
-                              onClick={() =>
-                                act('enable', { enable: spawner.short_name })
-                              }
-                            />
-                            <Button
-                              content="D"
-                              disabled={!spawner.enabled}
-                              onClick={() =>
-                                act('disable', { disable: spawner.short_name })
-                              }
-                            />
-                          </>
-                        ) : (
-                          ' '
-                        )}
-                      </Table.Cell>
-                    </Table.Row>
-                  )
-              )}
+                          <Button
+                            content="D"
+                            disabled={!spawner.enabled}
+                            onClick={() =>
+                              act('disable', { disable: spawner.short_name })
+                            }
+                          />
+                        </>
+                      ) : (
+                        ' '
+                      )}
+                    </Table.Cell>
+                  </Table.Row>
+                )
+            )}
           </Table>
         </Section>
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/GhostSpawner.tsx
+++ b/tgui/packages/tgui/interfaces/GhostSpawner.tsx
@@ -101,7 +101,6 @@ export const GhostSpawner = (props, context) => {
     'red',
     'green',
     'yellow',
-    'white',
   ];
 
   let loc_to_color: Map<string, string> = new Map();


### PR DESCRIPTION
![image](https://github.com/Aurorastation/Aurora.3/assets/107256943/27dad929-c8fc-4437-9d6c-1c556cbd8f0e)

changes:
  - rscadd: "Ghost spawners show the location of the spawner."
  - tweak: "Ghost spawners are shown in the list even if full."
  - tweak: "Ghost spawners are grayed out if visible, but cannot use them for whatever reason."
