### PR TITLE
password-locked ghostroles

### DIFF
--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -161,6 +161,11 @@ SUBSYSTEM_DEF(ghostroles)
 			if(cant_spawn)
 				to_chat(usr, "Unable to spawn: [cant_spawn]")
 				return
+			if(S.password)
+				var/password = input(usr, "Input Password:", "Ghost Spawner")
+				if(password != S.password)
+					to_chat(usr, SPAN_WARNING("Unable to spawn: Incorrect password"))
+					return
 			if(isnewplayer(usr))
 				var/mob/abstract/new_player/N = usr
 				N.close_spawn_windows()

--- a/code/controllers/subsystems/ghostroles.dm
+++ b/code/controllers/subsystems/ghostroles.dm
@@ -162,7 +162,7 @@ SUBSYSTEM_DEF(ghostroles)
 				to_chat(usr, "Unable to spawn: [cant_spawn]")
 				return
 			if(S.password)
-				var/password = input(usr, "Input Password:", "Ghost Spawner")
+				var/password = tgui_input_text(usr, "Input Password", "Ghost Spawner", multiline = FALSE)
 				if(password != S.password)
 					to_chat(usr, SPAN_WARNING("Unable to spawn: Incorrect password"))
 					return

--- a/code/modules/ghostroles/spawner/base.dm
+++ b/code/modules/ghostroles/spawner/base.dm
@@ -43,6 +43,9 @@
 	/// A lazylist of weakrefs to mobs this spawner has spawned
 	var/list/datum/weakref/spawned_mobs
 
+	/// Password required to spawn from this spawner. For event ghostroles.
+	var/password = null
+
 /datum/ghostspawner/New()
 	. = ..()
 	if(!jobban_job)

--- a/html/changelogs/RustingWithYou - ghostrolepassword.yml
+++ b/html/changelogs/RustingWithYou - ghostrolepassword.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Ghostroles can now be password-locked."


### PR DESCRIPTION
Ghostroles can now have a password set, which is required to join as them. This is largely intended for allowing event ghostroles to be restricted to volunteers as was done in the recent Exclusionist event.