### PR TITLE
Dominian Ship Spawn Tweaks

### DIFF
--- a/html/changelogs/RustingWithYou - impsgtfo.yml
+++ b/html/changelogs/RustingWithYou - impsgtfo.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "The Dominian science ship can now spawn in Haneunim, and the Dominian privateer ship can now spawn in the Weeping Stars."

--- a/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dm
+++ b/maps/away/ships/dominia/dominian_science_vessel/dominian_science_vessel.dm
@@ -3,6 +3,7 @@
 	description = "Based on the Lammergeier-class corvette, this vessel has been repurposed by House Volvalaad for long range survey and scientific tasks. Due to its repurposement, the vessel features an enlarged hangar and shuttle, as well as scientific labs and a smaller defensive armament."
 	suffixes = list("ships/dominia/dominian_science_vessel/dominian_science_vessel.dmm")
 	sectors = list(ALL_TAU_CETI_SECTORS, ALL_COALITION_SECTORS, SECTOR_BADLANDS)
+	sectors_blacklist = list(SECTOR_HANEUNIM)
 	spawn_weight = 1
 	ship_cost = 1
 	id = "dominian_science_vessel"

--- a/maps/away/ships/dominia/dominian_unathi_privateer/dominian_unathi_privateer.dm
+++ b/maps/away/ships/dominia/dominian_unathi_privateer/dominian_unathi_privateer.dm
@@ -2,7 +2,7 @@
 	name = "Kazhkz Privateer Ship"
 	description = "Dominian Unathi pirates"
 	suffixes = list("ships/dominia/dominian_unathi_privateer/dominian_unathi_privateer.dmm")
-	sectors = list(SECTOR_BADLANDS)
+	sectors = list(SECTOR_BADLANDS, SECTOR_WEEPING_STARS)
 	spawn_weight = 1
 	ship_cost = 1
 	id = "dominian_unathi"


### PR DESCRIPTION
The House Volvalaad Science Ship will no longer spawn in Haneunim.
The House Kazhkz Privateer Ship will now spawn in the Weeping Stars.