### PR TITLE
Law Manager Fix

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -95,7 +95,7 @@ var/list/reverseradiochannels = list(
 
 // The assoc variants are separate lists because they need the keys to be strings, but some code expects numbers.
 
-// central command channels, i.e deathsquid & response teams
+/// central command channels, i.e deathsquid & response teams
 var/list/CENT_FREQS = list(
 	ERT_FREQ,
 	DTH_FREQ
@@ -106,7 +106,7 @@ var/list/CENT_FREQS_ASSOC = list(
 	"[DTH_FREQ]" = TRUE
 )
 
-// Antag channels, i.e. Syndicate
+/// Antag channels, i.e. Syndicate
 var/list/ANTAG_FREQS = list(
 	SYND_FREQ,
 	RAID_FREQ,
@@ -123,7 +123,7 @@ var/list/ANTAG_FREQS_ASSOC = list(
 	"[BLSP_FREQ]" = TRUE
 )
 
-//Department channels, arranged lexically
+/// Department channels, arranged lexically
 var/list/DEPT_FREQS = list(
 	AI_FREQ,
 	COMM_FREQ,
@@ -148,10 +148,14 @@ var/list/DEPT_FREQS_ASSOC = list(
 	"[ENT_FREQ]" = TRUE
 )
 
-#define TRANSMISSION_WIRE        0 // Wired transmission, unused at the moment
-#define TRANSMISSION_RADIO       1 // Default radiowave transmission
-#define TRANSMISSION_SUBSPACE    2 // Subspace transmission (headsets)
-#define TRANSMISSION_SUPERSPACE  3 // Independent / CentCom radios only
+/// Wired transmission, unused at the moment
+#define TRANSMISSION_WIRE        0
+/// Default radiowave transmission
+#define TRANSMISSION_RADIO       1
+/// Subspace transmission (headsets)
+#define TRANSMISSION_SUBSPACE    2
+/// Independent / CentCom radios only
+#define TRANSMISSION_SUPERSPACE  3
 
 #define RADIO_NO_Z_LEVEL_RESTRICTION 0
 
@@ -160,11 +164,12 @@ var/list/DEPT_FREQS_ASSOC = list(
 //Other devices can then choose to send signals to only those devices that belong to a particular filter.
 //This is done for performance, so we don't send signals to lots of machines unnecessarily.
 
-//This filter is special because devices belonging to default also receive signals sent to any other filter.
+/// This filter is special because devices belonging to default also receive signals sent to any other filter.
 #define RADIO_DEFAULT "radio_default"
-
-#define RADIO_TO_AIRALARM "radio_airalarm" //air alarms
-#define RADIO_FROM_AIRALARM "radio_airalarm_rcvr" //devices interested in recieving signals from air alarms
+/// air alarms
+#define RADIO_TO_AIRALARM "radio_airalarm"
+/// devices interested in recieving signals from air alarms
+#define RADIO_FROM_AIRALARM "radio_airalarm_rcvr"
 #define RADIO_CHAT "radio_telecoms"
 #define RADIO_ATMOSIA "radio_atmos"
 #define RADIO_NAVBEACONS "radio_navbeacon"
@@ -173,7 +178,9 @@ var/list/DEPT_FREQS_ASSOC = list(
 #define RADIO_ARRIVALS "radio_arrvl"
 
 #define JAMMER_OFF -1
-#define JAMMER_ALL 1 // affects ALL wireless streams
-#define JAMMER_SYNTHETIC 2 // affects only synthetic wireless connections (attack_ai)
+///// affects ALL wireless streams
+#define JAMMER_ALL 1
+/// affects only synthetic wireless connections (attack_ai)
+#define JAMMER_SYNTHETIC 2
 
 #define DEFAULT_LAW_CHANNEL "Main Frequency"

--- a/code/modules/modular_computers/computers/subtypes/dev_silicon.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_silicon.dm
@@ -12,18 +12,19 @@
 	max_damage = 50
 	w_class = ITEMSIZE_NORMAL
 	enrolled = DEVICE_PRIVATE
-	var/mob/living/silicon/computer_host		// Thing that contains this computer. Used for silicon computers
+	/// Thing that contains this computer. Used for silicon computers
+	var/mob/living/silicon/computer_host
 	looping_sound = FALSE
 
 /obj/item/modular_computer/silicon/ui_host()
 	. = computer_host
 
 /obj/item/modular_computer/silicon/Initialize(mapload)
-	. = ..()
-	if(istype(loc, /mob/living/silicon))
-		computer_host = loc
-	else
-		return INITIALIZE_HINT_QDEL
+    if(istype(loc, /mob/living/silicon))
+        computer_host = loc
+    else
+        return INITIALIZE_HINT_QDEL
+    . = ..()
 
 /obj/item/modular_computer/silicon/Destroy()
 	computer_host = null
@@ -31,7 +32,7 @@
 	GC_TEMPORARY_HARDDEL
 
 /obj/item/modular_computer/silicon/computer_use_power(power_usage)
-	// If we have host like AI, borg or pAI we handle there power
+	// If we have host like AI, borg or pAI we handle their power
 	if(computer_host)
 		// If host is borg, we use power from it's cell, like anyone other module
 		if(istype(computer_host, /mob/living/silicon/robot))

--- a/html/changelogs/Ben10083 - LawManager Fix.yml
+++ b/html/changelogs/Ben10083 - LawManager Fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Law Manager software has been fixed."


### PR DESCRIPTION
Fixes the initialization of the silicon internal computer to allow programs such as Law Manager to work again
Fixes https://github.com/Aurorastation/Aurora.3/issues/18206

Also touched the documentation of radio.dm a bit (added some /// to the lists)