### PR TITLE
Miscellaneous bugfixes

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -595,7 +595,13 @@
 		if(toxvomit)
 			this.icon_state = "vomittox_[pick(1,4)]"
 
-/mob/living/proc/handle_additional_vomit_reagents(var/obj/effect/decal/cleanable/vomit/vomit)
+/mob/living/proc/handle_additional_vomit_reagents(obj/effect/decal/cleanable/vomit/vomit)
+	SHOULD_NOT_SLEEP(TRUE)
+	SHOULD_CALL_PARENT(TRUE)
+
+	if(!istype(vomit))
+		return
+
 	vomit.reagents.add_reagent(/singleton/reagent/acid/stomach, 5)
 
 /atom/proc/clean_blood()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -509,7 +509,7 @@
 	set_opacity(0)
 	operating = FALSE
 
-	if(autoclose)
+	if(autoclose && !QDELETED(src))
 		close_door_in(next_close_time())
 
 	return 1

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -28,9 +28,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/cmd_admin_delete,		/*delete an instance/object/mob/etc*/
 	/client/proc/cmd_admin_check_contents,	/*displays the contents of an instance*/
 	/datum/admins/proc/access_news_network,	/*allows access of newscasters*/
-	/client/proc/giveruntimelog,		/*allows us to give access to runtime logs to somebody*/
 	/client/proc/getserverlog,			/*allows us to fetch server logs (diary) for other days*/
-	/client/proc/view_signal_log,		/*allows admins to check the log of signaler uses*/
 	/client/proc/jumptocoord,			/*we ghost and jump to a coordinate*/
 	/client/proc/jumptozlevel,
 	/client/proc/jumptoshuttle,
@@ -393,7 +391,6 @@ var/list/admin_verbs_hideable = list(
 	/datum/admins/proc/ccannoucment,
 	/client/proc/cmd_display_init_log,
 	/client/proc/getruntimelog,
-	/client/proc/giveruntimelog,
 	/client/proc/toggledebuglogs,
 	/client/proc/getserverlog,
 	/client/proc/view_chemical_reaction_logs,
@@ -467,7 +464,6 @@ var/list/admin_verbs_dev = list( //will need to be altered - Ryan784
 	/client/proc/debug_variables,
 	/client/proc/dsay,
 	/client/proc/getruntimelog,
-	/client/proc/giveruntimelog,
 	/client/proc/hide_most_verbs,
 	/client/proc/kill_air,
 	/client/proc/kill_airgroup,

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -13,40 +13,15 @@
 	codebase for the entire /TG/station commuity a TONNE easier :3 Thanks for your help!
 */
 
-
-//This proc allows Game Masters to grant a client access to the .getruntimelog verb
-//Permissions expire at the end of each round.
-//Runtimes can be used to meta or spot game-crashing exploits so it's advised to only grant coders that
-//you trust access. Also, it may be wise to ensure that they are not going to play in the current round.
-/client/proc/giveruntimelog()
-	set name = ".giveruntimelog"
-	set desc = "Give somebody access to any session logfiles saved to the /log/runtime/ folder."
-	set category = null
-
-	if(!src.holder)
-		to_chat(src, "<span class='warning'>Only Admins may use this command.</span>")
-		return
-
-	var/client/target = input(src,"Choose somebody to grant access to the server's runtime logs (permissions expire at the end of each round):","Grant Permissions",null) as null|anything in GLOB.clients
-	if(!istype(target,/client))
-		to_chat(src, "<span class='warning'>Error: giveruntimelog(): Client not found.</span>")
-		return
-
-	add_verb(target, /client/proc/getruntimelog)
-	to_chat(target, "<span class='warning'>You have been granted access to runtime logs. Please use them responsibly or risk being banned.</span>")
-	return
-
-
-//This proc allows download of runtime logs saved within the data/logs/ folder by dreamdeamon.
-//It works similarly to show-server-log.
+/**
+ * Allows a client that has this proc to download the runtime logs of the current round
+ */
 /client/proc/getruntimelog()
 	set name = ".getruntimelog"
 	set desc = "Retrieve any session logfiles saved by dreamdeamon."
 	set category = null
 
-	var/path = browse_files("data/logs/_runtime/")
-	if(!path)
-		return
+	var/path = LOGPATH(GLOB.config.logfiles["world_runtime_log"])
 
 	if(file_spam_check())
 		return
@@ -54,17 +29,21 @@
 	message_admins("[key_name_admin(src)] accessed file: [path]")
 	src << run( file(path) )
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
-	return
 
 
 //This proc allows download of past server logs saved within the data/logs/ folder.
 //It works similarly to show-server-log.
+/**
+ * Allows a client that has this proc the download of a log file of the active round
+ *
+ * Assigned only to admins currently
+ */
 /client/proc/getserverlog()
 	set name = ".getserverlog"
 	set desc = "Fetch logfiles from data/logs"
 	set category = null
 
-	var/path = browse_files("data/logs/")
+	var/path = browse_files(LOGPATH("")) //Prompt for which file to download, understands subfolders from files
 	if(!path)
 		return
 
@@ -74,20 +53,3 @@
 	message_admins("[key_name_admin(src)] accessed file: [path]")
 	src << run( file(path) )
 	to_chat(src, "Attempting to send file, this may take a fair few minutes if the file is very large.")
-	return
-
-
-//Other log stuff put here for the sake of organisation
-
-/client/proc/view_signal_log()
-	set name = "View Signaler Log"
-	set desc = "Use this to view who sent signaler signals to things."
-	set category = "Admin"
-
-	var/text_signal_log = ""
-	for(var/log in GLOB.signal_log)
-		text_signal_log += "[log]<br>"
-
-	var/datum/browser/signal_win = new(usr, "signallog", "Signal Log", 550, 500)
-	signal_win.set_content(text_signal_log)
-	signal_win.open()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -957,16 +957,17 @@
 			if((species.gluttonous & GLUT_PROJECTILE_VOMIT) && !vomitReceptacle)
 				M.throw_at(get_edge_target_turf(src,dir),7,7,src)
 
-	if(stomach.ingested.total_volume)
-		stomach.ingested.trans_to_obj(splat, min(15, stomach.ingested.total_volume))
-	for(var/obj/item/organ/internal/parasite/P in src.internal_organs)
-		if(P)
-			if(P.egg && (P.stage == P.max_stage))
-				splat.reagents.add_reagent(P.egg, 2)
-	handle_additional_vomit_reagents(splat)
-	splat.update_icon()
+	if(istype(splat))
+		if(stomach.ingested.total_volume)
+			stomach.ingested.trans_to_obj(splat, min(15, stomach.ingested.total_volume))
+		for(var/obj/item/organ/internal/parasite/P in src.internal_organs)
+			if(P)
+				if(P.egg && (P.stage == P.max_stage))
+					splat.reagents.add_reagent(P.egg, 2)
+		handle_additional_vomit_reagents(splat)
+		splat.update_icon()
 
-	playsound(get_turf(src), 'sound/effects/splat.ogg', 50, 1)
+		playsound(get_turf(src), 'sound/effects/splat.ogg', 50, 1)
 
 /mob/living/carbon/human/proc/vomit(var/timevomit = 1, var/level = 3, var/deliberate = FALSE)
 
@@ -1003,7 +1004,7 @@
 	lastpuke = FALSE
 
 // A damaged stomach can put blood in your vomit.
-/mob/living/carbon/human/handle_additional_vomit_reagents(var/obj/effect/decal/cleanable/vomit/vomit)
+/mob/living/carbon/human/handle_additional_vomit_reagents(obj/effect/decal/cleanable/vomit/vomit)
 	..()
 	if(should_have_organ(BP_STOMACH))
 		var/obj/item/organ/internal/stomach/stomach = internal_organs_by_name[BP_STOMACH]

--- a/html/changelogs/fluffyghost-bugfixes.yml
+++ b/html/changelogs/fluffyghost-bugfixes.yml
@@ -1,0 +1,46 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Resolved a runtime on QDEL'd doors that tries to register a closing timer."
+  - bugfix: "Resolved a runtime on vomit decal ending on space atoms and having access to the reagents attempted."
+  - backend: "SDMM markings on handle_additional_vomit_reagents proc."
+  - bugfix: "Fixed log grabbing procs for the relevant clients."
+  - rscdel: "Removed runtime log access granting proc, noone uses it."
+  - rscdel: "Removed signals log browser proc, noone used it ever."


### PR DESCRIPTION
Resolved a runtime on QDEL'd doors that tries to register a closing timer.
Resolved a runtime on vomit decal ending on space atoms and having access to the reagents attempted.
SDMM markings on handle_additional_vomit_reagents proc.
Fixed log grabbing procs for the relevant clients.
Removed runtime log access granting proc, noone uses it.
Removed signals log browser proc, noone used it ever.