### PR TITLE
Disables Point Verdant

### DIFF
--- a/html/changelogs/DreamySkrell-pv-temp-disable.yml
+++ b/html/changelogs/DreamySkrell-pv-temp-disable.yml
@@ -1,0 +1,7 @@
+
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - tweak: "Disables Point Verdant."

--- a/maps/away/away_site/konyang/point_verdant/point_verdant.dm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant.dm
@@ -2,11 +2,11 @@
 	name = "Konyang - Point Verdant Spaceport"
 	id = "point_verdant"
 	description = "A landing zone designated by local authorities within an SCC-affiliated spaceport. Accommodations have been made to ensure full visitation of any open facilities present."
-	sectors = list(SECTOR_HANEUNIM)
+	sectors = list() //list(SECTOR_HANEUNIM)
 	suffixes = list("away_site/konyang/point_verdant/point_verdant-1.dmm","away_site/konyang/point_verdant/point_verdant-2.dmm","away_site/konyang/point_verdant/point_verdant-3.dmm")
 	spawn_weight = 1
 	spawn_cost = 1
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
+	//template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 	unit_test_groups = list(2)
 


### PR DESCRIPTION
As announced on discord:

> Yo. Currently some bug fixes and final touches are being placed on the Point Verdant map to ensure it doesn't go through the same unfortunate lag process it went through last time. We will be officially introducing Point Verdant Saturday, February 24th. Everyone will be off-duty and get a chill round to enjoy the map fully.

> In the meantime, as dictated by synthetic lore, we are working on swapping the sector to Haneunim and disabling Point Verdant from spawning so we can enjoy the rest of Konyang's away sites and ghost roles before Point Verdant's official introduction. For the rest of Silicon Nightmares after the 24th, Point Verdant will be available as a location on Konyang.