### PR TITLE
Infected IPC Balance Tweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ipc_zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ipc_zombie.dm
@@ -9,7 +9,7 @@
 	maxHealth = 100
 	melee_damage_lower = 15
 	melee_damage_upper = 20
-	armor_penetration = 10
+	armor_penetration = 20
 	attack_sound = 'sound/weapons/smash.ogg'
 	attacktext = "smashed"
 	faction = "hivebot"

--- a/code/modules/mob/living/simple_animal/hostile/ipc_zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ipc_zombie.dm
@@ -7,9 +7,9 @@
 	blood_type = COLOR_OIL
 	health = 100
 	maxHealth = 100
-	melee_damage_lower = 20
+	melee_damage_lower = 15
 	melee_damage_upper = 20
-	armor_penetration = 40
+	armor_penetration = 10
 	attack_sound = 'sound/weapons/smash.ogg'
 	attacktext = "smashed"
 	faction = "hivebot"

--- a/html/changelogs/RustingWithYou - zombienerf.yml
+++ b/html/changelogs/RustingWithYou - zombienerf.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Nerfs IPC zombie damage and armor penetration."

--- a/html/changelogs/RustingWithYou - zombienerf.yml
+++ b/html/changelogs/RustingWithYou - zombienerf.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Nerfs IPC zombie damage and armor penetration."
+  - tweak: "Nerfs infected IPC damage and armor penetration."


### PR DESCRIPTION
Lowers the damage and armor penetration on infected IPC attacks, as they seem to be too deadly for the large numbers they frequently spawn in.