### PR TITLE
Adds the ability for revived IPCs to choose their pronouns, accent and languages.

### DIFF
--- a/code/modules/mob/living/silicon/robot/items/robot_parts.dm
+++ b/code/modules/mob/living/silicon/robot/items/robot_parts.dm
@@ -270,7 +270,7 @@
 				new_shell.name = new_shell.real_name
 				var/obj/item/organ/internal/mmi_holder/posibrain/P = new_shell.internal_organs_by_name[BP_BRAIN]
 				P.setup_brain()
-				new_shell.change_appearance(APPEARANCE_ALL_HAIR | APPEARANCE_SKIN | APPEARANCE_EYE_COLOR, new_shell)
+				new_shell.change_appearance(APPEARANCE_PLASTICSURGERY, new_shell)
 				qdel(src)
 				return
 

--- a/html/changelogs/Snowy1237-IPCRevivalTweaks.yml
+++ b/html/changelogs/Snowy1237-IPCRevivalTweaks.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: Snowy1237
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/Snowy1237-IPCRevivalTweaks.yml
+++ b/html/changelogs/Snowy1237-IPCRevivalTweaks.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added the ability for revived IPCs to choose their pronouns, accent and languages."


### PR DESCRIPTION
See title.

(SleepyGemmy) context: this is required as revived IPCs don't retain their previous pronouns, accent, and languages. this is a easy solution to let them reselect what they had previously.