### PR TITLE
PACHROM Water Barge Remap

### DIFF
--- a/html/changelogs/Lavillastrangiato - waterbarge.yml
+++ b/html/changelogs/Lavillastrangiato - waterbarge.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Lavillastrangiato
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Remaps the PACHROM water barge to add more facilities and make better use of space."

--- a/maps/away/ships/konyang/water_barge/water_barge.dmm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dmm
@@ -80,19 +80,6 @@
 "bf" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"bg" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "bl" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/railing/mapped,
@@ -384,6 +371,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"ea" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "eg" = (
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 6
@@ -404,10 +398,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
-"el" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/hangar)
 "et" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -557,6 +547,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"fp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
 "fB" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -603,6 +597,9 @@
 	},
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 2
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/engineering)
@@ -670,10 +667,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
-"gw" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "gz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -847,6 +840,10 @@
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"ix" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "iy" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -854,6 +851,15 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
+/area/water_barge)
+"iz" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/water_barge)
 "iA" = (
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
@@ -983,11 +989,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
-"jo" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/mainhallway)
 "jr" = (
 /obj/structure/bed/stool/chair{
 	dir = 1
@@ -1092,18 +1093,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
-"kp" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
-"kq" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/junk,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "ks" = (
 /obj/structure/bed/stool/bar/padded/red,
 /turf/simulated/floor/tiled/dark,
@@ -1232,6 +1221,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"ld" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
 "lj" = (
 /obj/machinery/door/window{
 	dir = 4
@@ -1304,10 +1302,6 @@
 "lL" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
-"lS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "lU" = (
 /obj/effect/floor_decal/corner/yellow/full{
 	dir = 1
@@ -1338,6 +1332,13 @@
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"mg" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "mj" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, starboard dock"
@@ -1376,6 +1377,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"mD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "mG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1605,6 +1610,20 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"oJ" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
+"oN" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "oQ" = (
 /obj/structure/bed/stool/chair/office/dark,
 /turf/simulated/floor/tiled/dark,
@@ -1653,6 +1672,15 @@
 "pk" = (
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"pw" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "pC" = (
 /obj/structure/bed/stool/chair{
 	dir = 1
@@ -1666,11 +1694,6 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
-"pL" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/effect/decal/cleanable/flour,
-/turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
 "pM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
@@ -1734,15 +1757,6 @@
 /obj/random/colored_jumpsuit,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
-"qI" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "qQ" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1869,6 +1883,10 @@
 "rO" = (
 /turf/simulated/floor/reinforced/hydrogen,
 /area/water_barge/fuelbay)
+"rT" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "rW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1893,21 +1911,18 @@
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"sw" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "sE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"sI" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "sK" = (
 /obj/effect/map_effect/marker/airlock/docking{
 	landmark_tag = "water_barge_dock";
@@ -1915,6 +1930,15 @@
 	name = "airlock_barge_portdock"
 	},
 /turf/simulated/floor/plating,
+/area/water_barge/dockingport/port)
+"sQ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
 "sT" = (
 /obj/structure/lattice/catwalk/indoor,
@@ -2142,10 +2166,6 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"vh" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport)
 "vl" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 2;
@@ -2292,10 +2312,6 @@
 /obj/machinery/portable_atmospherics/canister/hydrogen,
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
-"wo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
 "ws" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2325,6 +2341,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
+"wF" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "wJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -2358,6 +2378,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"wN" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/mainhallway)
 "wR" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -2494,17 +2523,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
+"xT" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "xW" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/engineering)
-"yl" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/mainhallway)
 "yo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
@@ -2563,15 +2588,12 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"yU" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"yZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "za" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/glass/reinforced/full,
@@ -2589,10 +2611,6 @@
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/airless,
 /area/water_barge/helm)
-"zl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/engineering)
 "zy" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -2652,12 +2670,6 @@
 /obj/machinery/shipsensors,
 /turf/simulated/floor/airless,
 /area/water_barge/helm)
-"At" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "Au" = (
 /obj/structure/reagent_dispensers/coolanttank,
 /obj/item/reagent_containers/glass/bucket,
@@ -2672,10 +2684,6 @@
 /area/water_barge/office)
 "AA" = (
 /turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/thrust)
-"AI" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/plating,
 /area/water_barge/thrust)
 "AN" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -2693,9 +2701,6 @@
 /obj/structure/bed/stool/chair/office/bridge/pilot,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"AX" = (
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "Bo" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -2716,6 +2721,17 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"Bq" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "Bv" = (
 /obj/structure/bed/roller,
 /obj/structure/curtain/open/medical,
@@ -2752,10 +2768,6 @@
 "BL" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/water_barge)
-"BO" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "BS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2796,6 +2808,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"Cn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
+"Cu" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "Cw" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -2844,6 +2867,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"CQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
 "CS" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/dockingport/port)
@@ -2863,9 +2890,6 @@
 /obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"CW" = (
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/thrust/port)
 "Dc" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/power/apc/super/east,
@@ -3105,13 +3129,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
-"Ff" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
 "Fh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3142,12 +3159,6 @@
 	dir = 4
 	},
 /area/water_barge/hangar)
-"Fv" = (
-/turf/simulated/wall/shuttle/space_ship{
-	can_open = 1;
-	color = "#DDDDD"
-	},
-/area/water_barge/breakroom)
 "FR" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -3503,6 +3514,12 @@
 /obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
+"JP" = (
+/turf/simulated/wall/shuttle/space_ship{
+	can_open = 1;
+	color = "#DDDDD"
+	},
+/area/water_barge/breakroom)
 "JQ" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/helm)
@@ -3664,6 +3681,10 @@
 	name = "airlock_barge_stbddock"
 	},
 /turf/simulated/floor/plating,
+/area/water_barge/dockingport)
+"La" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
 "Lb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -4005,6 +4026,10 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
+"Oi" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
 "Oj" = (
 /obj/effect/landmark/entry_point/port{
 	name = "port, office"
@@ -4012,11 +4037,16 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/office)
 "Ok" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
+"Os" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/effect/decal/cleanable/flour,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "Ou" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
@@ -4069,17 +4099,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
-"OS" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "OY" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -4140,7 +4159,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
 "PD" = (
@@ -4547,15 +4565,6 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
-"SH" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "SI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -4676,13 +4685,6 @@
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
-"TS" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "TU" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4724,6 +4726,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
 "Up" = (
@@ -4754,6 +4761,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/water_barge/bathroom)
+"Uy" = (
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "UA" = (
 /obj/machinery/sleeper,
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
@@ -4961,15 +4971,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"Vy" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "VF" = (
 /turf/unsimulated/wall/fakepdoor{
 	dir = 4
 	},
 /area/water_barge/hangar)
-"VI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
 "VO" = (
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 6
@@ -5100,12 +5112,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
-"Wt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "Wu" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5200,6 +5206,11 @@
 "WZ" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/medbay)
+"Xb" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
 "Xd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 8
@@ -5213,15 +5224,6 @@
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
-"Xo" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/water_barge/mainhallway)
 "Xr" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
@@ -5326,10 +5328,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
-"Yd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
 "Yf" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -5376,12 +5374,6 @@
 /obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
-"YB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "YJ" = (
 /turf/simulated/floor/beach/water/alt,
 /area/water_barge)
@@ -5417,6 +5409,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
+"YY" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "Zl" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/hangar)
@@ -5432,6 +5432,9 @@
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
+"Zo" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/thrust/port)
 "Zq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
 	dir = 8
@@ -15185,7 +15188,7 @@ NL
 NL
 AA
 pM
-Yd
+fp
 MR
 PY
 Vh
@@ -15509,16 +15512,16 @@ NL
 NL
 AA
 pM
-AI
+Oi
 MR
 HV
-kq
+oN
 TA
 JC
 Tj
 PG
 ar
-vh
+La
 PG
 bf
 bf
@@ -15999,7 +16002,7 @@ HB
 fU
 ws
 EA
-qI
+oJ
 EA
 iS
 PG
@@ -16322,7 +16325,7 @@ zY
 Hr
 MR
 HU
-lS
+ix
 vI
 aq
 Up
@@ -16485,7 +16488,7 @@ AA
 MR
 Og
 oZ
-sI
+pw
 oZ
 vp
 PG
@@ -16658,7 +16661,7 @@ xW
 Iw
 Iw
 Iw
-Fv
+JP
 Iw
 iR
 Yy
@@ -17142,7 +17145,7 @@ PI
 LC
 xW
 QM
-pL
+Os
 KD
 ks
 Il
@@ -17298,7 +17301,7 @@ xW
 xW
 NQ
 hV
-zl
+Cn
 zb
 af
 Ks
@@ -17957,35 +17960,35 @@ xs
 xs
 dq
 dE
-TS
+mg
 dp
 TK
 Yy
-Ff
+Cu
 Yy
 Yy
 Fh
 sT
-Ff
+Cu
 Yy
 Yy
-Ff
+Cu
 Yy
 Yy
 Cg
 Yy
 pc
-Ff
+Cu
 Yy
 Yy
-Ff
+Cu
 Yy
 Yy
 hG
 hU
 Yy
 Yy
-Ff
+Cu
 Yy
 TK
 dp
@@ -18102,9 +18105,9 @@ UY
 dO
 jL
 nl
-Xo
-Xo
-Xo
+ld
+ld
+ld
 AN
 fB
 Bo
@@ -18115,43 +18118,43 @@ GG
 Ex
 jc
 Rp
+wN
 PA
-yl
 uv
 re
-Um
-SH
+YY
+iz
 Zn
+YY
+YY
+YY
 Um
-Um
-Um
-bg
 qm
 dl
-SH
-Um
-Um
-Um
-Um
-Um
+iz
+YY
+YY
+YY
+YY
+YY
 dl
-Um
+YY
 nV
-OS
-Um
-Um
-Um
-Um
-Um
+Bq
+YY
+YY
+YY
+YY
+YY
 dl
 nV
-Um
-Um
-Um
-Um
+YY
+YY
+YY
+YY
 Zn
-Um
-Um
+YY
+YY
 me
 Vs
 Gw
@@ -18266,7 +18269,7 @@ KS
 rW
 Lf
 Lf
-jo
+Xb
 MJ
 qW
 Vr
@@ -18281,39 +18284,39 @@ SI
 By
 cS
 dE
-Ok
+Vy
 dp
 TK
 Yy
-kp
+ea
 He
 Dc
 hU
 sT
-kp
+ea
 Yy
 Yy
-kp
+ea
 Yy
 Yy
 qZ
 Yy
 Yh
-kp
+ea
 Yy
 Yy
-kp
+ea
 Yy
 Yy
 hG
 Fh
 Yy
 Yy
-kp
+ea
 Yy
 TK
 dp
-At
+Ok
 JQ
 IM
 Jm
@@ -18423,7 +18426,7 @@ BL
 BL
 BL
 Rt
-el
+wF
 bn
 dE
 lU
@@ -18914,7 +18917,7 @@ gG
 oa
 Ws
 cI
-VI
+mD
 cI
 cI
 yz
@@ -19719,10 +19722,10 @@ NL
 NL
 NL
 NL
-CW
-CW
-CW
-CW
+Zo
+Zo
+Zo
+Zo
 eQ
 eQ
 Jc
@@ -19730,7 +19733,7 @@ mn
 wn
 CS
 Ja
-yU
+sQ
 kj
 kV
 iV
@@ -19884,7 +19887,7 @@ NL
 Hc
 PO
 Gv
-CW
+Zo
 vu
 LP
 KI
@@ -20043,18 +20046,18 @@ NL
 NL
 NL
 NL
-CW
+Zo
 Nv
 PD
 Se
 fR
 wy
 Lb
-wo
+CQ
 Ed
 CS
 Ja
-yU
+sQ
 lL
 lL
 Em
@@ -20367,10 +20370,10 @@ NL
 NL
 NL
 NL
-CW
+Zo
 la
-YB
-CW
+sw
+Zo
 jD
 sc
 gC
@@ -20530,9 +20533,9 @@ NL
 NL
 NL
 kl
-gw
-AX
-CW
+xT
+Uy
+Zo
 nP
 QB
 nk
@@ -20691,10 +20694,10 @@ NL
 NL
 NL
 NL
-CW
+Zo
 la
-BO
-CW
+rT
+Zo
 CI
 UZ
 dP
@@ -20854,9 +20857,9 @@ NL
 NL
 NL
 Hc
-gw
-AX
-CW
+xT
+Uy
+Zo
 Mo
 KR
 dP
@@ -21015,10 +21018,10 @@ NL
 NL
 NL
 NL
-CW
+Zo
 la
-AX
-CW
+Uy
+Zo
 Mo
 NW
 dP
@@ -21178,9 +21181,9 @@ NL
 NL
 NL
 Hc
-Wt
-AX
-CW
+yZ
+Uy
+Zo
 dP
 dP
 dP
@@ -21339,10 +21342,10 @@ NL
 NL
 NL
 NL
-CW
-CW
-CW
-CW
+Zo
+Zo
+Zo
+Zo
 NL
 NL
 NL

--- a/maps/away/ships/konyang/water_barge/water_barge.dmm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dmm
@@ -44,6 +44,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"aR" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "aS" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -265,8 +271,6 @@
 /area/water_barge/bathroom)
 "dl" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -394,8 +398,6 @@
 /area/water_barge/toolstorage)
 "et" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
@@ -546,6 +548,8 @@
 "fB" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -685,6 +689,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
 "gR" = (
@@ -712,6 +717,15 @@
 /obj/effect/shuttle_landmark/water_barge_shuttle/transit,
 /turf/space,
 /area/space)
+"hs" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "hv" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/condiment/flour,
@@ -931,8 +945,6 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -988,6 +1000,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
+"jE" = (
+/turf/simulated/wall/shuttle/space_ship{
+	can_open = 1;
+	color = "#DDDDD"
+	},
+/area/water_barge/breakroom)
 "jL" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -1011,17 +1029,7 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
-"jS" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "jT" = (
-/obj/machinery/light/small/built{
-	dir = 1;
-	pixel_x = -1
-	},
 /obj/effect/floor_decal/corner_wide/dark_green/full{
 	dir = 1
 	},
@@ -1033,6 +1041,12 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/water_barge)
+"jX" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "kc" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -1205,6 +1219,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"lc" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/thrust/port)
 "lj" = (
 /obj/machinery/door/window{
 	dir = 4
@@ -1297,8 +1314,6 @@
 	name = "Bridge"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1312,6 +1327,9 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/dockingport)
+"ml" = (
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "mm" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -1351,6 +1369,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
+"mL" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "mM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
@@ -1366,9 +1391,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
 "mT" = (
-/obj/machinery/light/small/built{
-	dir = 4;
-	pixel_x = 14
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
@@ -1491,8 +1515,6 @@
 /area/water_barge/breakroom)
 "nV" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -1564,6 +1586,9 @@
 	pixel_y = 16
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/water_barge/breakroom)
 "oH" = (
@@ -1634,21 +1659,6 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
-"pJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "pM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
@@ -1689,8 +1699,6 @@
 /area/water_barge/toolstorage)
 "qm" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1739,16 +1747,13 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/light/small/built{
-	dir = 4;
-	pixel_x = 14
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
 "re" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1976,15 +1981,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"tP" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/water_barge/mainhallway)
 "ua" = (
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 1
@@ -2041,8 +2037,6 @@
 	dir = 10
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2388,6 +2382,9 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/air,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
 "xz" = (
@@ -2622,12 +2619,11 @@
 /obj/structure/bed/stool/chair/office/bridge/pilot,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"AX" = (
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/thrust/port)
 "Bo" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2686,6 +2682,19 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"Ce" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "Cf" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
@@ -2700,9 +2709,8 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/light/small/built{
-	dir = 8;
-	pixel_x = -13
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
@@ -2901,8 +2909,6 @@
 	dir = 9
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2965,8 +2971,6 @@
 "Ex" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3022,6 +3026,14 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"EP" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "ET" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3040,9 +3052,8 @@
 "Fi" = (
 /obj/machinery/appliance/cooker/stove,
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/machinery/light/small/built{
-	dir = 1;
-	pixel_x = -1
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/water_barge/breakroom)
@@ -3064,8 +3075,6 @@
 "FR" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3106,8 +3115,6 @@
 /area/water_barge/thrust/port)
 "Gw" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3136,12 +3143,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
-"GK" = (
-/turf/simulated/wall/shuttle/space_ship{
-	can_open = 1;
-	color = "#DDDDD"
-	},
-/area/water_barge/breakroom)
 "GS" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -3225,7 +3226,6 @@
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
 "HU" = (
-/obj/effect/large_stock_marker,
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
 	},
@@ -3258,9 +3258,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/breakroom)
-"Is" = (
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "It" = (
 /obj/effect/floor_decal/corner/yellow/full{
 	dir = 8
@@ -3276,6 +3273,10 @@
 "Iw" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/breakroom)
+"IA" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "IE" = (
 /obj/machinery/light{
 	dir = 8
@@ -3768,17 +3769,14 @@
 /turf/simulated/floor/plating,
 /area/water_barge)
 "MH" = (
-/obj/machinery/light/small/built{
-	dir = 8;
-	pixel_x = -14
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
 "MJ" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -3852,9 +3850,8 @@
 /turf/simulated/floor/plating,
 /area/water_barge/thrust/port)
 "Nz" = (
-/obj/machinery/light/small/built{
-	dir = 4;
-	pixel_x = 14
+/obj/machinery/light/small{
+	dir = 4
 	},
 /obj/structure/coatrack{
 	pixel_y = 16;
@@ -3927,8 +3924,13 @@
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/water_barge/fuelbay)
+"Oc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "Og" = (
-/obj/effect/large_stock_marker,
 /obj/effect/floor_decal/corner_wide/brown/full{
 	dir = 1
 	},
@@ -4054,10 +4056,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"Pz" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "PA" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4148,6 +4154,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"Ql" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "Qm" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/railing/mapped{
@@ -4299,8 +4312,6 @@
 "Rp" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
@@ -4309,8 +4320,6 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -4322,6 +4331,15 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/water_barge)
+"Ry" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
 "RK" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -4360,10 +4378,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
-"Sa" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "Sb" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
@@ -4607,6 +4621,8 @@
 /area/water_barge)
 "Ua" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -4661,9 +4677,8 @@
 	dir = 1;
 	pixel_y = -1
 	},
-/obj/machinery/light/small/built{
-	dir = 4;
-	pixel_x = 14
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/water_barge/bathroom)
@@ -4806,8 +4821,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4851,8 +4866,6 @@
 /area/water_barge/mainhallway)
 "Vs" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
@@ -4977,8 +4990,6 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5260,12 +5271,6 @@
 /obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"Yw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "Yy" = (
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
@@ -5319,8 +5324,6 @@
 	name = "Tanks"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5412,8 +5415,6 @@
 	dir = 9
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15252,11 +15253,11 @@ xb
 ZA
 nI
 PG
-bf
+Va
 bf
 PG
 bf
-bf
+ZR
 PG
 NL
 NL
@@ -15904,7 +15905,7 @@ bf
 bf
 bf
 tn
-ZR
+bf
 PG
 PG
 NL
@@ -16066,7 +16067,7 @@ bf
 tc
 ky
 bf
-bf
+ZR
 PG
 PG
 PG
@@ -16224,7 +16225,7 @@ vI
 aq
 Up
 PG
-bf
+Va
 tF
 tc
 bf
@@ -16382,7 +16383,7 @@ AA
 MR
 Og
 oZ
-oZ
+hs
 oZ
 vp
 PG
@@ -16555,7 +16556,7 @@ xW
 Iw
 Iw
 Iw
-GK
+jE
 Iw
 iR
 Yy
@@ -17854,28 +17855,28 @@ xs
 xs
 dq
 dE
-mG
+Pz
 dp
 TK
 Yy
-Gi
+Ql
 Yy
 Yy
 Fh
 sT
-Gi
+Ql
 Yy
 Yy
-Gi
+Ql
 Yy
 Yy
 Cg
 Yy
 pc
-Gi
+Ql
 Yy
 Yy
-Gi
+Ql
 Yy
 Yy
 hG
@@ -17999,9 +18000,9 @@ UY
 dO
 jL
 nl
-tP
-tP
-tP
+Ry
+Ry
+Ry
 AN
 fB
 Bo
@@ -18016,39 +18017,39 @@ PA
 PA
 uv
 re
-Um
-Um
+EP
+EP
 Zn
-Um
-Um
-Um
-pJ
+EP
+EP
+EP
+Ce
 qm
 dl
-Um
-Um
-Um
-Um
-Um
-Um
+EP
+EP
+EP
+EP
+EP
+EP
 dl
-Um
+EP
 nV
 Um
-Um
-Um
-Um
-Um
-Um
+EP
+EP
+EP
+EP
+EP
 dl
 nV
-Um
-Um
-Um
-Um
+EP
+EP
+EP
+EP
 Zn
-Um
-Um
+EP
+EP
 me
 Vs
 Gw
@@ -18178,28 +18179,28 @@ SI
 By
 cS
 dE
-Ok
+aR
 dp
 TK
 Yy
-kP
+mL
 He
 Dc
 hU
 sT
-kP
+mL
 Yy
 Yy
-kP
+mL
 Yy
 Yy
 qZ
 Yy
 Yh
-kP
+mL
 Yy
 Yy
-kP
+mL
 Yy
 Yy
 hG
@@ -19616,10 +19617,10 @@ NL
 NL
 NL
 NL
-AX
-AX
-AX
-AX
+lc
+lc
+lc
+lc
 eQ
 eQ
 Jc
@@ -19781,7 +19782,7 @@ NL
 Hc
 PO
 Gv
-AX
+lc
 vu
 LP
 KI
@@ -19940,7 +19941,7 @@ NL
 NL
 NL
 NL
-AX
+lc
 Nv
 PD
 Se
@@ -20264,10 +20265,10 @@ NL
 NL
 NL
 NL
-AX
+lc
 la
-jS
-AX
+jX
+lc
 jD
 sc
 gC
@@ -20427,9 +20428,9 @@ NL
 NL
 NL
 kl
-Sa
-Is
-AX
+IA
+ml
+lc
 nP
 QB
 nk
@@ -20588,10 +20589,10 @@ NL
 NL
 NL
 NL
-AX
+lc
 la
-Is
-AX
+ml
+lc
 CI
 UZ
 dP
@@ -20751,9 +20752,9 @@ NL
 NL
 NL
 Hc
-Sa
-Is
-AX
+IA
+ml
+lc
 Mo
 KR
 dP
@@ -20912,10 +20913,10 @@ NL
 NL
 NL
 NL
-AX
+lc
 la
-Is
-AX
+ml
+lc
 Mo
 NW
 dP
@@ -21075,9 +21076,9 @@ NL
 NL
 NL
 Hc
-Yw
-Is
-AX
+Oc
+ml
+lc
 dP
 dP
 dP
@@ -21236,10 +21237,10 @@ NL
 NL
 NL
 NL
-AX
-AX
-AX
-AX
+lc
+lc
+lc
+lc
 NL
 NL
 NL

--- a/maps/away/ships/konyang/water_barge/water_barge.dmm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dmm
@@ -12,12 +12,6 @@
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"ak" = (
-/turf/simulated/wall/shuttle/space_ship{
-	can_open = 1;
-	color = "#DDDDD"
-	},
-/area/water_barge/breakroom)
 "aq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -86,6 +80,19 @@
 "bf" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"bg" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "bl" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/railing/mapped,
@@ -158,12 +165,6 @@
 /obj/effect/floor_decal/corner/yellow/full,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
-"ci" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "cj" = (
 /obj/structure/closet/walllocker/medical{
 	name = "Blood Locker";
@@ -270,11 +271,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"df" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/effect/decal/cleanable/flour,
-/turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
 "di" = (
 /obj/effect/floor_decal/corner_wide/blue/diagonal,
 /obj/machinery/power/apc/low,
@@ -408,6 +404,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"el" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "et" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -557,10 +557,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"ft" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "fB" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -586,12 +582,6 @@
 /obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"fQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "fR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
@@ -680,6 +670,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"gw" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "gz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -989,6 +983,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"jo" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
 "jr" = (
 /obj/structure/bed/stool/chair{
 	dir = 1
@@ -1093,6 +1092,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
+"kp" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
+"kq" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "ks" = (
 /obj/structure/bed/stool/bar/padded/red,
 /turf/simulated/floor/tiled/dark,
@@ -1143,10 +1154,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
-"kK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/engineering)
 "kM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -1297,6 +1304,10 @@
 "lL" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"lS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "lU" = (
 /obj/effect/floor_decal/corner/yellow/full{
 	dir = 1
@@ -1395,18 +1406,10 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"na" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport)
 "nd" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
 /area/water_barge/office)
-"nf" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "ng" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
@@ -1444,13 +1447,6 @@
 /obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
-"no" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "np" = (
 /obj/machinery/telecomms/allinone/ship,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -1670,6 +1666,11 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
+"pL" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/effect/decal/cleanable/flour,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "pM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
@@ -1733,6 +1734,15 @@
 /obj/random/colored_jumpsuit,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"qI" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "qQ" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1809,17 +1819,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
-"rq" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
-"rs" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
 "rw" = (
 /obj/effect/landmark/entry_point/port{
 	name = "starboard"
@@ -1889,24 +1888,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
-"sh" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/mainhallway)
-"sr" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "su" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
@@ -1918,6 +1899,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"sI" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "sK" = (
 /obj/effect/map_effect/marker/airlock/docking{
 	landmark_tag = "water_barge_dock";
@@ -2016,15 +2006,6 @@
 /obj/structure/bookcase/libraryspawn/fiction,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
-"tN" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/water_barge/mainhallway)
 "tO" = (
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 8
@@ -2161,6 +2142,10 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"vh" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport)
 "vl" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 2;
@@ -2512,6 +2497,14 @@
 "xW" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/engineering)
+"yl" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/mainhallway)
 "yo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
@@ -2570,6 +2563,15 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"yU" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "za" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/glass/reinforced/full,
@@ -2587,6 +2589,10 @@
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/airless,
 /area/water_barge/helm)
+"zl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
 "zy" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -2646,8 +2652,15 @@
 /obj/machinery/shipsensors,
 /turf/simulated/floor/airless,
 /area/water_barge/helm)
+"At" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "Au" = (
-/obj/structure/lattice/catwalk/indoor,
+/obj/structure/reagent_dispensers/coolanttank,
+/obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
 "Aw" = (
@@ -2659,6 +2672,10 @@
 /area/water_barge/office)
 "AA" = (
 /turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/thrust)
+"AI" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
 /area/water_barge/thrust)
 "AN" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -2676,6 +2693,9 @@
 /obj/structure/bed/stool/chair/office/bridge/pilot,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"AX" = (
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "Bo" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -2732,6 +2752,10 @@
 "BL" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/water_barge)
+"BO" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "BS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2839,6 +2863,9 @@
 /obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"CW" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/thrust/port)
 "Dc" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/power/apc/super/east,
@@ -3078,6 +3105,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"Ff" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "Fh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3108,6 +3142,12 @@
 	dir = 4
 	},
 /area/water_barge/hangar)
+"Fv" = (
+/turf/simulated/wall/shuttle/space_ship{
+	can_open = 1;
+	color = "#DDDDD"
+	},
+/area/water_barge/breakroom)
 "FR" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -3281,10 +3321,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
-"Ia" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/hangar)
 "Id" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -3976,17 +4012,10 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/office)
 "Ok" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge)
-"Om" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
 /area/water_barge)
 "Ou" = (
 /obj/effect/floor_decal/corner/dark_green{
@@ -4007,27 +4036,6 @@
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
-"OE" = (
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
-"OG" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
-"OH" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/mainhallway)
 "OM" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
@@ -4132,6 +4140,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
 "PD" = (
@@ -4219,11 +4228,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"Ql" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/junk,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "Qm" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/railing/mapped{
@@ -4413,10 +4417,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
-"RS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
 "RX" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
@@ -4547,16 +4547,21 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
+"SH" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "SI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
-"SJ" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
 "SL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -4669,6 +4674,13 @@
 	name = "Tanks"
 	},
 /obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
+"TS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
 "TU" = (
@@ -4914,15 +4926,6 @@
 /obj/structure/closet/crate/loot,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
-"Vk" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "Vr" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4958,20 +4961,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
-"Vx" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "VF" = (
 /turf/unsimulated/wall/fakepdoor{
 	dir = 4
 	},
 /area/water_barge/hangar)
+"VI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "VO" = (
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 6
@@ -5063,12 +5061,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
-"Wn" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "Wq" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -5108,6 +5100,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"Wt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "Wu" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5215,6 +5213,15 @@
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
+"Xo" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
 "Xr" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
@@ -5225,15 +5232,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge)
-"Xt" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "Xv" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
@@ -5268,10 +5266,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
-"XE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "XI" = (
 /obj/structure/table/standard,
 /obj/item/paper_scanner,
@@ -5332,6 +5326,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
+"Yd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
 "Yf" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -5356,9 +5354,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
-"Yq" = (
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/thrust/port)
 "Yu" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -5381,6 +5376,12 @@
 /obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"YB" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "YJ" = (
 /turf/simulated/floor/beach/water/alt,
 /area/water_barge)
@@ -15184,7 +15185,7 @@ NL
 NL
 AA
 pM
-RS
+Yd
 MR
 PY
 Vh
@@ -15508,16 +15509,16 @@ NL
 NL
 AA
 pM
-SJ
+AI
 MR
 HV
-Ql
+kq
 TA
 JC
 Tj
 PG
 ar
-na
+vh
 PG
 bf
 bf
@@ -15998,7 +15999,7 @@ HB
 fU
 ws
 EA
-Vk
+qI
 EA
 iS
 PG
@@ -16321,7 +16322,7 @@ zY
 Hr
 MR
 HU
-XE
+lS
 vI
 aq
 Up
@@ -16484,7 +16485,7 @@ AA
 MR
 Og
 oZ
-Xt
+sI
 oZ
 vp
 PG
@@ -16657,7 +16658,7 @@ xW
 Iw
 Iw
 Iw
-ak
+Fv
 Iw
 iR
 Yy
@@ -17141,7 +17142,7 @@ PI
 LC
 xW
 QM
-df
+pL
 KD
 ks
 Il
@@ -17297,7 +17298,7 @@ xW
 xW
 NQ
 hV
-kK
+zl
 zb
 af
 Ks
@@ -17956,35 +17957,35 @@ xs
 xs
 dq
 dE
-no
+TS
 dp
 TK
 Yy
-Om
+Ff
 Yy
 Yy
 Fh
 sT
-Om
+Ff
 Yy
 Yy
-Om
+Ff
 Yy
 Yy
 Cg
 Yy
 pc
-Om
+Ff
 Yy
 Yy
-Om
+Ff
 Yy
 Yy
 hG
 hU
 Yy
 Yy
-Om
+Ff
 Yy
 TK
 dp
@@ -18101,9 +18102,9 @@ UY
 dO
 jL
 nl
-tN
-tN
-tN
+Xo
+Xo
+Xo
 AN
 fB
 Bo
@@ -18114,20 +18115,20 @@ GG
 Ex
 jc
 Rp
-OH
 PA
+yl
 uv
 re
 Um
-Vx
+SH
 Zn
 Um
 Um
 Um
-sr
+bg
 qm
 dl
-Vx
+SH
 Um
 Um
 Um
@@ -18265,7 +18266,7 @@ KS
 rW
 Lf
 Lf
-sh
+jo
 MJ
 qW
 Vr
@@ -18280,39 +18281,39 @@ SI
 By
 cS
 dE
-Wn
+Ok
 dp
 TK
 Yy
-rq
+kp
 He
 Dc
 hU
 sT
-rq
+kp
 Yy
 Yy
-rq
+kp
 Yy
 Yy
 qZ
 Yy
 Yh
-rq
+kp
 Yy
 Yy
-rq
+kp
 Yy
 Yy
 hG
 Fh
 Yy
 Yy
-rq
+kp
 Yy
 TK
 dp
-Ok
+At
 JQ
 IM
 Jm
@@ -18422,7 +18423,7 @@ BL
 BL
 BL
 Rt
-Ia
+el
 bn
 dE
 lU
@@ -18913,7 +18914,7 @@ gG
 oa
 Ws
 cI
-rs
+VI
 cI
 cI
 yz
@@ -19718,10 +19719,10 @@ NL
 NL
 NL
 NL
-Yq
-Yq
-Yq
-Yq
+CW
+CW
+CW
+CW
 eQ
 eQ
 Jc
@@ -19729,7 +19730,7 @@ mn
 wn
 CS
 Ja
-OG
+yU
 kj
 kV
 iV
@@ -19883,7 +19884,7 @@ NL
 Hc
 PO
 Gv
-Yq
+CW
 vu
 LP
 KI
@@ -20042,7 +20043,7 @@ NL
 NL
 NL
 NL
-Yq
+CW
 Nv
 PD
 Se
@@ -20053,7 +20054,7 @@ wo
 Ed
 CS
 Ja
-OG
+yU
 lL
 lL
 Em
@@ -20366,10 +20367,10 @@ NL
 NL
 NL
 NL
-Yq
+CW
 la
-fQ
-Yq
+YB
+CW
 jD
 sc
 gC
@@ -20529,9 +20530,9 @@ NL
 NL
 NL
 kl
-nf
-OE
-Yq
+gw
+AX
+CW
 nP
 QB
 nk
@@ -20690,10 +20691,10 @@ NL
 NL
 NL
 NL
-Yq
+CW
 la
-ft
-Yq
+BO
+CW
 CI
 UZ
 dP
@@ -20853,9 +20854,9 @@ NL
 NL
 NL
 Hc
-nf
-OE
-Yq
+gw
+AX
+CW
 Mo
 KR
 dP
@@ -21014,10 +21015,10 @@ NL
 NL
 NL
 NL
-Yq
+CW
 la
-OE
-Yq
+AX
+CW
 Mo
 NW
 dP
@@ -21177,9 +21178,9 @@ NL
 NL
 NL
 Hc
-ci
-OE
-Yq
+Wt
+AX
+CW
 dP
 dP
 dP
@@ -21338,10 +21339,10 @@ NL
 NL
 NL
 NL
-Yq
-Yq
-Yq
-Yq
+CW
+CW
+CW
+CW
 NL
 NL
 NL

--- a/maps/away/ships/konyang/water_barge/water_barge.dmm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dmm
@@ -1,41 +1,32 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "af" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/blue{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
-/area/water_barge)
+/area/water_barge/engineering)
 "aj" = (
 /obj/machinery/atmospherics/binary/passive_gate/on{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"ap" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
-	},
+/area/water_barge/engineering)
+"aq" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/fuelbay)
+"ar" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/north,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport)
 "as" = (
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"aE" = (
-/obj/machinery/atmospherics/pipe/tank{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/area/water_barge/fuelbay)
 "aP" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
@@ -54,18 +45,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
 "aS" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "aY" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -90,30 +79,40 @@
 "bf" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"bi" = (
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/engineering)
+"bl" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/structure/railing/mapped,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
+"bn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "bw" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/air_sensor{
+	frequency = 0989;
+	id_tag = "h2_sensor"
 	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
 	},
-/obj/machinery/recharge_station,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/turf/simulated/floor/reinforced/hydrogen,
+/area/water_barge/fuelbay)
 "bF" = (
 /obj/effect/shuttle_landmark/water_barge/nav1,
 /turf/template_noop,
 /area/space)
 "bK" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/thrust)
+/area/water_barge/engineering)
 "bL" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8;
@@ -122,76 +121,46 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
 "bN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/radiation{
+	pixel_y = 3;
+	pixel_x = -4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport)
-"bP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/item/storage/firstaid{
+	pixel_x = -4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/item/storage/firstaid/toxin{
+	pixel_y = 4;
+	pixel_x = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
+/obj/item/storage/firstaid/o2{
+	pixel_x = 5
+	},
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "bS" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/turf/simulated/wall/shuttle/space_ship,
+/area/space)
 "bW" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
 "cb" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"cc" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/high/east{
-	req_access = null
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/engineering)
-"cj" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
-	},
+/obj/effect/floor_decal/corner/yellow/full,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"cj" = (
+/obj/structure/closet/walllocker/medical{
+	name = "Blood Locker";
+	pixel_y = 32
+	},
+/obj/structure/table/standard,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "cp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -202,24 +171,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "ct" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+/obj/machinery/light/small/emergency{
 	dir = 1
 	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
-"cv" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/helm)
 "cx" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/fore{
@@ -244,6 +203,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"cC" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "cI" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
@@ -253,10 +218,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"cM" = (
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "cP" = (
 /obj/effect/shuttle_landmark/water_barge/nav3,
 /turf/template_noop,
 /area/space)
+"cS" = (
+/obj/effect/floor_decal/corner_wide/green{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
 "dd" = (
 /obj/machinery/light{
 	dir = 4
@@ -269,16 +250,34 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"dp" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/railing/mapped{
-	dir = 4
+"di" = (
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/obj/machinery/power/apc/low,
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/white,
+/area/space)
+"dl" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/turf/simulated/floor/beach/water/alt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/turf/simulated/floor/tiled/dark,
 /area/water_barge)
+"dp" = (
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
+"dq" = (
+/obj/effect/floor_decal/corner_wide/dark_green/full,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"dt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "dx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -294,9 +293,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/airlock/engineering{
 	dir = 4;
-	name = "Starboard Propulsion"
+	name = "Engineering";
+	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
@@ -315,43 +315,15 @@
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
-"dB" = (
-/obj/effect/floor_decal/corner/yellow{
+"dM" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/structure/closet/secure_closet/engineering_electrical{
-	req_access = null
-	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
-"dC" = (
-/obj/effect/landmark/entry_point/port{
-	name = "port, main hold"
-	},
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge)
-"dM" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/airlock/engineering{
-	dir = 4;
-	name = "Engineering"
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/breakroom)
+/area/water_barge/dockingport/port)
 "dO" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
@@ -359,47 +331,118 @@
 "dP" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/fuelbay)
+"dW" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plating,
+/area/water_barge)
 "dY" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"et" = (
-/obj/structure/railing/mapped{
+"eg" = (
+/obj/effect/floor_decal/corner_wide/green{
+	dir = 6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"ek" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
-"eu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"ew" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
-"eO" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"et" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
+"eu" = (
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
+"ex" = (
+/obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
+/obj/effect/floor_decal/corner_wide/brown/full,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
+"eA" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
+"eJ" = (
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"eO" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/obj/machinery/light/small/built{
+	dir = 1;
+	pixel_x = -1
+	},
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/space)
 "eP" = (
 /obj/machinery/light{
 	dir = 8
@@ -412,10 +455,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
 "eQ" = (
-/obj/structure/table/steel,
-/obj/random/tool,
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
+"eW" = (
+/obj/structure/bed/stool/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/dockingport/port)
 "eY" = (
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, crew quarters"
@@ -423,63 +481,60 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/cryo)
 "fd" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/hatch{
-	name = "Main Hold"
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
+"ff" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge)
-"ff" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/area/water_barge/breakroom)
+"fh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"fh" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
 "fi" = (
-/obj/structure/lattice/catwalk/indoor,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport)
+"fB" = (
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/water_barge)
-"fr" = (
-/obj/effect/landmark/entry_point/starboard{
-	name = "starboard, thrusters"
-	},
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/thrust)
+/area/water_barge/toolstorage)
 "fF" = (
+/obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
 "fO" = (
@@ -487,25 +542,21 @@
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
 "fR" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
 "fV" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Engineering"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/engineering)
+"gc" = (
 /obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light,
+/obj/machinery/door/airlock/multi_tile/glass,
 /turf/simulated/floor/plating,
 /area/water_barge)
-"fW" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 5
-	},
-/obj/structure/table/steel,
-/obj/random/toolbox,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
 "gd" = (
 /obj/machinery/light{
 	dir = 4;
@@ -518,6 +569,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
+"ge" = (
+/obj/structure/bed/stool/bar/padded/red,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
 "gm" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -529,6 +587,7 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Port Docking Bay"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
 "gp" = (
@@ -547,62 +606,89 @@
 /turf/template_noop,
 /area/water_barge/helm)
 "gs" = (
-/obj/machinery/light{
-	dir = 4
+/turf/simulated/wall/shuttle/space_ship{
+	can_open = 1
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/engineering)
-"gE" = (
-/obj/structure/lattice/catwalk/indoor,
+/area/space)
+"gt" = (
 /obj/machinery/light,
-/obj/machinery/light{
-	dir = 1
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
+"gz" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"gC" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/water_barge)
+/area/water_barge/fuelbay)
 "gG" = (
-/obj/machinery/light,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/floodlight,
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
 "gK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8;
-	icon_state = "map"
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
 	},
-/obj/machinery/access_button{
-	pixel_x = -28;
-	pixel_y = 12;
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/external,
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/docking{
-	landmark_tag = "water_barge_dock_s";
-	master_tag = "airlock_barge_stbddock";
-	name = "airlock_barge_stbddock"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/dockingport)
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
 "gR" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/breakroom)
+"hg" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "hl" = (
 /obj/effect/shuttle_landmark/water_barge_shuttle/transit,
 /turf/space,
 /area/space)
 "hv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport)
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/drinks/carton/soymilk,
+/obj/item/reagent_containers/food/drinks/carton/soymilk,
+/obj/item/storage/box/fancy/egg_box,
+/obj/item/storage/box/fancy/egg_box,
+/obj/item/reagent_containers/food/drinks/carton/milk,
+/obj/item/reagent_containers/food/drinks/carton/milk,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/storage/box/produce,
+/obj/item/storage/box/produce,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "hz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
@@ -615,16 +701,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"hE" = (
+"hG" = (
 /obj/structure/lattice/catwalk/indoor,
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
@@ -636,6 +716,12 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/reinforced,
 /area/water_barge/engineering)
+"hJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "hP" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -649,21 +735,22 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/cryo)
 "hT" = (
-/obj/machinery/light{
+/obj/structure/lattice/catwalk/indoor,
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
-	},
-/obj/machinery/photocopier,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/office)
+/turf/simulated/floor/plating,
+/area/water_barge)
 "hU" = (
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/atmos)
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "hV" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -681,42 +768,39 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"hW" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
 "hX" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Cafeteria"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/water_barge/breakroom)
 "ic" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"iA" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+"iy" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/hydrogen,
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge)
+"iA" = (
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/structure/sign/nosmoking_2{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "iB" = (
 /obj/machinery/computer/ship/sensors,
 /obj/effect/floor_decal/corner/dark_blue{
@@ -724,15 +808,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"iH" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 8;
-	layer = 2.8;
-	name = "CO2 to Thrusters"
-	},
-/obj/effect/floor_decal/industrial/warning/full,
+"iF" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/hangar)
+"iH" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport)
 "iL" = (
 /obj/structure/cable,
 /obj/machinery/power/smes/buildable/horizon_shuttle,
@@ -747,6 +833,36 @@
 "iR" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge)
+"iS" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
+"iV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "iW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 4
@@ -764,6 +880,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"jc" = (
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"jd" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "je" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	dir = 1;
@@ -771,6 +906,7 @@
 	id_tag = "water_barge_hangar";
 	frequency = 1380
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
 "jj" = (
@@ -794,12 +930,18 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"jD" = (
+/obj/machinery/power/apc/north,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
 "jL" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -817,13 +959,19 @@
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
 "jR" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cryo)
+/obj/structure/lattice/catwalk/indoor,
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "jT" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 5
+/obj/machinery/light/small/built{
+	dir = 1;
+	pixel_x = -1
+	},
+/obj/effect/floor_decal/corner_wide/dark_green/full{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/breakroom)
@@ -833,11 +981,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/water_barge)
-"ki" = (
-/turf/simulated/wall/shuttle/space_ship{
-	can_open = 1
-	},
-/area/water_barge/dockingport/port)
 "kj" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
@@ -865,7 +1008,7 @@
 	name = "aft, port thruster"
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/area/water_barge/fuelbay)
 "kn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -885,24 +1028,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"kw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
 "ky" = (
 /obj/structure/table/steel,
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
 "kz" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/portable_atmospherics/canister/empty{
+	name = "waste canister"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 4
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
 	},
+/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/engineering)
 "kF" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -919,6 +1066,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
+"kM" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
+"kP" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small/built{
+	dir = 4;
+	pixel_x = 14
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
+"kQ" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/obj/machinery/light/small/built,
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/obj/machinery/alarm/south{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
 "kR" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -947,27 +1121,15 @@
 /obj/effect/floor_decal/corner/brown,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"kY" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
 "la" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
 	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/area/water_barge/fuelbay)
 "lb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -982,36 +1144,64 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"li" = (
-/obj/structure/closet/firecloset/full,
-/obj/effect/floor_decal/industrial/outline/firefighting_closet,
-/obj/effect/floor_decal/corner/dark_blue{
+"lj" = (
+/obj/machinery/door/window{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
+"lq" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
+"ly" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
+"lB" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
+"lH" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
+"lJ" = (
+/obj/effect/floor_decal/corner_wide/green{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/helm)
-"lj" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
-"lq" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
-"lJ" = (
-/obj/structure/bed/stool/chair/office/dark{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/breakroom)
 "lK" = (
 /obj/machinery/alarm/east{
 	req_one_access = null
@@ -1024,23 +1214,36 @@
 "lL" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"lU" = (
+/obj/effect/floor_decal/corner/yellow/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "lX" = (
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
-"lY" = (
-/obj/effect/landmark/entry_point/port{
-	name = "port, docking bay"
-	},
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/dockingport/port)
 "md" = (
 /obj/machinery/hologram/holopad/long_range,
 /obj/effect/overmap/visitable/ship/landable/water_barge_shuttle,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"me" = (
+/obj/machinery/door/airlock/glass_command{
+	name = "Bridge"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/helm)
 "mj" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, starboard dock"
@@ -1048,25 +1251,28 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/dockingport)
 "mm" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/canister/empty/hydrogen,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "mn" = (
-/obj/machinery/light{
-	dir = 1
+/obj/item/tank/hydrogen/shuttle,
+/obj/item/tank/hydrogen/shuttle,
+/obj/item/tank/hydrogen/shuttle,
+/obj/item/tank/hydrogen/shuttle,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
+"mp" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 5
-	},
-/obj/structure/sink{
-	pixel_y = 25
+/obj/machinery/alarm/north{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/dockingport)
 "mv" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -1076,97 +1282,169 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"mM" = (
-/obj/structure/railing/mapped{
-	dir = 8
+"mG" = (
+/obj/machinery/light/small/built{
+	dir = 8;
+	pixel_x = -13
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/beach/water/alt,
+/turf/simulated/floor/tiled/dark,
 /area/water_barge)
-"mN" = (
+"mM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"na" = (
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/tiled/dark,
 /area/water_barge/engineering)
+"mP" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
+	},
+/obj/machinery/power/apc/east,
+/obj/structure/cable/green{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"mT" = (
+/obj/machinery/light/small/built{
+	dir = 4;
+	pixel_x = 14
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
+"mY" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport)
 "nd" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
 /area/water_barge/office)
 "ng" = (
-/obj/structure/lattice/catwalk/indoor,
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 5
+	},
+/obj/structure/closet,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/toy/plushie/ipc,
+/obj/item/clothing/head/beanie/random,
+/obj/random/colored_jumpsuit,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cryo)
 "nh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"nl" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/water_barge/breakroom)
-"np" = (
-/obj/structure/railing/mapped,
+"nk" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
+"nl" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Hangar"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/space)
+"np" = (
+/obj/machinery/telecomms/allinone/ship,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/bluegrid/cooled,
+/area/water_barge/engineering)
 "nq" = (
 /obj/effect/shuttle_landmark/water_barge/nav2,
 /turf/template_noop,
 /area/space)
 "nt" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
 	},
-/obj/machinery/light{
+/obj/machinery/photocopier,
+/obj/machinery/light/small/built,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/office)
+"nz" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
+"nF" = (
+/obj/machinery/atmospherics/pipe/tank{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
+"nI" = (
+/obj/structure/closet/crate/loot,
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
+"nP" = (
+/obj/machinery/computer/general_air_control/large_tank_control{
+	frequency = 0989;
+	input_tag = "co2_in";
+	name = "Carbon Dioxide Supply Monitor";
+	output_tag = "co2_out";
+	sensors = list("co2_sensor"="Tank");
 	dir = 8
 	},
 /turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
+"nS" = (
+/obj/item/reagent_containers/cooking_container/board,
+/obj/structure/table/stone/marble,
+/obj/item/material/kitchen/rollingpin{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/material/knife{
+	layer = 2.99;
+	pixel_x = -9
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
+"nV" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
 /area/water_barge)
-"nF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+"nX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
-"nS" = (
-/obj/structure/railing/mapped,
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
-"nV" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/hangar)
 "oa" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/toolstorage)
@@ -1177,12 +1455,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
 "od" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 9
-	},
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/snack/konyang,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/dockingport)
 "og" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -1198,71 +1473,43 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "om" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/engineering)
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/machinery/power/apc/east,
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "on" = (
-/obj/machinery/computer/general_air_control/large_tank_control{
-	frequency = 0989;
-	input_tag = "h2_in";
-	name = "Hydrogen Supply Monitor";
-	output_tag = "h2_out";
-	sensors = list("h2_sensor"="Tank");
-	dir = 8
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/obj/item/folder/yellow{
+	pixel_x = 8
+	},
+/obj/item/folder/red,
+/obj/item/stamp,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/helm)
 "ov" = (
 /obj/machinery/computer/ship/helm,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"oy" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
 "oC" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
+/obj/structure/table/stone/marble,
+/obj/machinery/reagentgrinder{
+	pixel_x = 4;
+	pixel_y = 16
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "oH" = (
-/obj/structure/cable/green{
-	icon_state = "0-2"
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
 	},
-/obj/machinery/power/apc/high/west{
-	req_access = null
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/helm)
 "oQ" = (
 /obj/structure/bed/stool/chair/office/dark,
 /turf/simulated/floor/tiled/dark,
@@ -1276,8 +1523,17 @@
 /obj/machinery/alarm/south{
 	req_one_access = null
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"oZ" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
 "pa" = (
 /obj/machinery/computer/ship/engines,
 /obj/effect/floor_decal/corner/dark_blue{
@@ -1285,46 +1541,61 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"pd" = (
-/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+"pc" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge)
 "pg" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
 "pk" = (
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
-"pz" = (
-/obj/effect/landmark/entry_point/starboard{
-	name = "starboard, main hold"
+"pC" = (
+/obj/structure/bed/stool/chair{
+	dir = 1
 	},
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
+"pI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor/plating,
+/area/water_barge/toolstorage)
 "pM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
 	},
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
 "pU" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/hangar)
-"qc" = (
-/obj/structure/bed/stool/bar/padded/red,
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
+/obj/machinery/vending/cola/konyang,
 /turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport)
+"qc" = (
+/obj/structure/table/stone/marble,
+/obj/item/reagent_containers/cooking_container/board/bowl,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_y = 8
+	},
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/water_barge/breakroom)
 "qd" = (
 /obj/structure/table/standard,
@@ -1332,19 +1603,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "qi" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 2;
-	name = "scrubbers to waste"
+/obj/structure/reagent_dispensers/extinguisher,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
 	},
-/obj/effect/floor_decal/industrial/warning/full,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"qk" = (
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, engineering"
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"qm" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/engineering)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "qn" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/aft{
@@ -1352,61 +1626,54 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
-"qD" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
 "qE" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
 	},
 /obj/structure/closet,
+/obj/item/toy/plushie/squid,
+/obj/item/storage/wallet/random,
+/obj/random/colored_jumpsuit,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
-"qO" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/water_barge/breakroom)
-"qS" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor/plating,
-/area/water_barge/hangar)
-"rd" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
-"re" = (
+"qQ" = (
 /obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
+"qW" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/toolstorage)
+"qZ" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light/small/built{
+	dir = 4;
+	pixel_x = 14
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
+"re" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/service{
+	name = "Main Hallway"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
 "rf" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, port dock"
@@ -1416,25 +1683,40 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/dockingport/port)
-"rk" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Starboard Docking Bay";
+"ri" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
-"rx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10
-	},
-/obj/machinery/alarm/north{
-	req_one_access = null
-	},
+"rk" = (
+/obj/machinery/recharge_station,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/obj/effect/floor_decal/corner_wide/dark_green/full{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"ry" = (
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
 "rz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1449,23 +1731,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"rA" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
 "rB" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -1473,60 +1738,40 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
 "rK" = (
-/obj/structure/table/steel,
-/obj/random/junk,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
-"rO" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	frequency = 0989;
+	id_tag = "h2_out";
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
+/turf/simulated/floor/reinforced/hydrogen,
+/area/water_barge/fuelbay)
+"rO" = (
+/turf/simulated/floor/reinforced/hydrogen,
+/area/water_barge/fuelbay)
 "rW" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
-/area/water_barge/breakroom)
-"rY" = (
+/area/water_barge/toolstorage)
+"rX" = (
 /obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
+"sc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
 "su" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"sD" = (
-/obj/structure/cable/green,
-/obj/machinery/power/apc/high/west{
-	req_access = null
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
 "sE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 4
@@ -1541,37 +1786,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
+"sT" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "sV" = (
-/obj/machinery/light,
-/obj/structure/bed/stool/bar/padded/red,
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
 	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/toolstorage)
 "sZ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light/spot{
+	dir = 4;
+	must_start_working = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/airlock/hatch{
-	name = "Shuttle Hangar"
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/hangar)
+/turf/simulated/floor/beach/water/alt,
+/area/water_barge)
 "ta" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/canister/empty/air,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"tb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
+/obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
 "tc" = (
@@ -1579,16 +1817,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
 "th" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
 "tk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light/spot{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/engineering)
+/area/water_barge/hangar)
 "tn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -1601,13 +1838,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
-"tt" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 9
-	},
-/obj/machinery/vending/cola/konyang,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
 "tz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -1615,19 +1845,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
 "tC" = (
-/obj/machinery/alarm/east{
-	req_one_access = null
+/obj/structure/table/standard,
+/obj/item/roller,
+/obj/item/stack/nanopaste{
+	pixel_y = 7
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "tF" = (
 /obj/structure/bed/stool/chair/office/dark,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
 "tH" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/table/steel,
 /obj/item/paper_bin,
 /obj/item/pen/black,
@@ -1643,6 +1873,7 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
 	},
+/obj/structure/bookcase/libraryspawn/fiction,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "tO" = (
@@ -1651,42 +1882,44 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"tZ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
 "ua" = (
+/obj/effect/floor_decal/corner/brown/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/office)
+"uc" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"uk" = (
+/obj/machinery/vending/cigarette,
+/obj/machinery/light,
+/obj/effect/floor_decal/corner_wide/green/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"un" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
 /area/water_barge/fuelbay)
-"uc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/airlock/hatch{
-	name = "Main Hold"
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
-"uk" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
-"un" = (
-/obj/machinery/telecomms/allinone/ship,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark/cooled,
-/area/water_barge/engineering)
 "uu" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock/docking{
@@ -1700,50 +1933,78 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
-"uF" = (
-/obj/structure/lattice/catwalk/indoor,
+"uv" = (
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"uy" = (
+/obj/structure/closet/firecloset/full,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/plating,
-/area/water_barge)
-"uQ" = (
-/obj/machinery/door/airlock/hatch{
-	dir = 4;
-	name = "Port Docking Bay"
+/area/water_barge/hangar)
+"uF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/water_barge)
-"uR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
+"uW" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
-"uU" = (
-/obj/structure/table/steel,
-/obj/random/tech_supply,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/breakroom)
 "uX" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 10
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock_s";
+	master_tag = "airlock_barge_stbddock";
+	name = "airlock_barge_stbddock"
 	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/office)
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport)
 "uY" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
+/obj/machinery/portable_atmospherics/canister/empty{
+	name = "waste canister"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/shuttle/water_barge)
 "vg" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -1753,11 +2014,13 @@
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
 "vl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/machinery/atmospherics/binary/pump{
+	dir = 2;
+	name = "scrubbers to waste"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
 "vm" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
@@ -1767,6 +2030,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"vp" = (
+/obj/effect/floor_decal/corner_wide/brown/full{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
 "vq" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
@@ -1780,11 +2063,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "vu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport)
+/obj/machinery/alarm/north{
+	req_one_access = null
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
 "vz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark,
@@ -1796,45 +2082,34 @@
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
 "vI" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/cooled,
-/area/water_barge/engineering)
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
 "vO" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/area/water_barge/fuelbay)
 "vQ" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"vV" = (
-/obj/machinery/light{
-	dir = 8
-	},
+"vU" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/plating,
-/area/water_barge/engineering)
-"vW" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
-	},
-/obj/machinery/vending/snack/konyang,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/hangar)
 "vZ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/contraband,
 /turf/simulated/floor/plating,
-/area/water_barge/breakroom)
+/area/water_barge/dockingport)
 "wc" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -1874,6 +2149,29 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"wn" = (
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/hydrogen,
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
+"ws" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
 "wu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -1883,6 +2181,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"wy" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
 "wJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -1927,16 +2229,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
 "xb" = (
-/turf/simulated/floor/reinforced/carbon_dioxide,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
 /area/water_barge/fuelbay)
 "xh" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
 /obj/structure/closet,
+/obj/item/clothing/suit/storage/toggle/trench/colorable/random,
+/obj/random/colored_jumpsuit,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "xr" = (
@@ -1946,27 +2248,42 @@
 /obj/machinery/vending/engineering{
 	req_access = null
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
 "xs" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/hatch{
-	name = "Starboard Docking Bay"
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"xu" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/dockingport)
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/space)
 "xw" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"xx" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/empty/air,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
 "xz" = (
 /obj/machinery/alarm/north{
 	req_one_access = null
@@ -1989,56 +2306,54 @@
 /turf/simulated/floor/reinforced,
 /area/water_barge/engineering)
 "xG" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plating,
-/area/water_barge)
-"xI" = (
-/obj/structure/railing/mapped,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
-"xM" = (
-/turf/simulated/wall/r_wall,
-/area/water_barge)
-"xN" = (
-/obj/structure/cable/green,
-/obj/machinery/power/apc/high/south{
+/obj/machinery/suit_cycler/engineering{
 	req_access = null
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"xI" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
 /area/water_barge/breakroom)
-"xW" = (
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/engineering)
-"xZ" = (
-/obj/structure/lattice/catwalk/indoor,
+"xJ" = (
+/obj/effect/floor_decal/corner_wide/green/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"xM" = (
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/dockingport/port)
+"xN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
-/area/water_barge)
+/area/water_barge/fuelbay)
+"xW" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/engineering)
 "yo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
@@ -2049,31 +2364,32 @@
 /obj/machinery/computer/shuttle_control/explore/water_barge_shuttle,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"yv" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
+"yy" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor/plating,
+/area/water_barge)
+"yz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/machinery/vending/tool,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
 "yB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/rack,
+/obj/item/stack/material/steel/full,
+/obj/item/stack/rods/full,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/engineering)
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "yI" = (
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
@@ -2093,15 +2409,18 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
 "za" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/structure/table/rack,
+/obj/item/stack/material/glass/reinforced/full,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
 	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/dark/cooled,
-/area/water_barge/engineering)
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "zb" = (
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
@@ -2110,14 +2429,6 @@
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/airless,
 /area/water_barge/helm)
-"zx" = (
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
-	frequency = 0989;
-	id_tag = "co2_out";
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/carbon_dioxide,
-/area/water_barge/fuelbay)
 "zy" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -2166,13 +2477,19 @@
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
 "An" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/power/portgen,
 /turf/simulated/floor/plating,
-/area/water_barge/dockingport/port)
+/area/water_barge/hangar)
 "Ar" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/shipsensors,
 /turf/simulated/floor/airless,
 /area/water_barge/helm)
+"Au" = (
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
 "Aw" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -2183,56 +2500,70 @@
 "AA" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/thrust)
+"AN" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/toolstorage)
 "AT" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"Ba" = (
-/obj/effect/floor_decal/industrial/warning{
+"Bo" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/cooled,
-/area/water_barge/engineering)
-"Bd" = (
-/obj/effect/floor_decal/industrial/warning/full,
-/obj/machinery/mech_recharger,
-/mob/living/heavy_vehicle/premade/ripley/loader,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
-"Bs" = (
-/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
-"Bv" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/yellow{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/water_barge/toolstorage)
+"Bp" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
+"Bv" = (
+/obj/structure/bed/roller,
+/obj/structure/curtain/open/medical,
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "By" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/breakroom)
-"BB" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
 "BE" = (
-/obj/machinery/alarm/south{
-	req_one_access = null
+/obj/structure/table/standard,
+/obj/structure/bedsheetbin{
+	pixel_y = 7
 	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/item/storage/box/masks{
+	pixel_x = 9;
+	pixel_y = 5
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = 8
+	},
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/water_barge/breakroom)
 "BH" = (
 /obj/effect/landmark/entry_point/port{
@@ -2243,19 +2574,11 @@
 "BL" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/water_barge)
-"BN" = (
-/obj/random/contraband,
-/obj/random/contraband,
-/obj/item/ipc_overloader/tranquil,
-/turf/simulated/floor/plating,
-/area/water_barge/dockingport/port)
 "BS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
 "Cf" = (
@@ -2267,6 +2590,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"Cg" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light/small/built{
+	dir = 8;
+	pixel_x = -13
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "Ck" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2275,17 +2609,12 @@
 /turf/simulated/floor/reinforced,
 /area/water_barge/engineering)
 "Cl" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
 	},
-/obj/machinery/power/apc/high/north{
-	req_access = null
-	},
-/obj/machinery/light,
-/turf/simulated/floor/plating,
-/area/water_barge)
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "Cw" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -2298,32 +2627,42 @@
 	dir = 10
 	},
 /obj/structure/closet,
+/obj/random/colored_jumpsuit,
+/obj/item/clothing/accessory/silversun/random,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "Cz" = (
-/obj/structure/cable/green{
-	icon_state = "0-2"
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
 	},
-/obj/machinery/power/apc/high/east{
-	req_access = null
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 9
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
-"CI" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 6
-	},
-/obj/structure/closet/secure_closet/engineering_welding{
-	req_access = null
-	},
+/obj/structure/closet/crate/bin,
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/dom,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/helm)
+"CI" = (
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
 "CJ" = (
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"CO" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "CS" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/dockingport/port)
@@ -2343,28 +2682,38 @@
 /obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"CZ" = (
-/obj/structure/table/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/void/engineering,
-/obj/item/clothing/head/helmet/space/void/engineering,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/engineering)
+"Dc" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/power/apc/super/east,
+/turf/simulated/floor/plating,
+/area/water_barge)
 "Df" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
 "Dn" = (
-/obj/machinery/air_sensor{
-	frequency = 0989;
-	id_tag = "co2_sensor"
+/obj/effect/floor_decal/corner/dark_green/full,
+/obj/machinery/media/jukebox/audioconsole/wall{
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"Dr" = (
+/obj/effect/floor_decal/corner_wide/dark_green/full{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/carbon_dioxide,
-/area/water_barge/fuelbay)
+/obj/structure/cable/green{
+	icon_state = "0-2";
+	dir = 1
+	},
+/obj/machinery/power/apc,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
 "Dv" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -2378,7 +2727,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
 "DB" = (
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/shuttle_landmark/water_barge_shuttle/hangar,
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
@@ -2400,67 +2748,89 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
-"DL" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+"DI" = (
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/cooled,
-/area/water_barge/engineering)
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"DL" = (
+/obj/machinery/power/apc/north,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
 "DN" = (
 /obj/machinery/computer/ship/engines{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"DQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
+"DR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport)
 "DS" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
 "DT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport)
-"DX" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/table/steel,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
-"Em" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 6
-	},
-/obj/structure/closet/crate/freezer/rations,
-/obj/random/mre,
-/obj/random/mre,
-/obj/random/mre,
-/obj/random/mre,
-/obj/random/mre,
-/obj/random/mre,
-/obj/item/reagent_containers/food/drinks/waterbottle/large,
-/obj/item/reagent_containers/food/drinks/waterbottle/large,
-/obj/item/reagent_containers/food/drinks/waterbottle/large,
-/obj/item/reagent_containers/food/drinks/waterbottle/large,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/recharge_station,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/water_barge/breakroom)
-"Eo" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 10
-	},
+"DU" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"DX" = (
+/obj/machinery/door/airlock{
+	dir = 1;
+	id_tag = "central_stall_2";
+	name = "Stall 2"
+	},
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/dockingport/port)
+"Ed" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
+"Em" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
+"Eo" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
+	},
+/obj/structure/table/steel,
+/obj/item/storage/bag/inflatable,
+/obj/item/storage/bag/inflatable,
+/obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
 "Eu" = (
@@ -2485,69 +2855,92 @@
 /turf/simulated/floor/reinforced,
 /area/water_barge/engineering)
 "Ex" = (
-/obj/structure/lattice/catwalk/indoor,
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Main Hallway"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plating,
+/area/space)
+"Ez" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
+"EA" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
 "ED" = (
-/obj/structure/table/standard,
-/obj/item/stamp,
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/helm)
+/obj/structure/lattice/catwalk/indoor,
+/obj/structure/railing/mapped,
+/turf/simulated/floor/plating,
+/area/water_barge)
 "EM" = (
-/obj/structure/closet/emcloset,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Engineering Supplies"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/helm)
+/area/water_barge/dockingport/port)
 "EN" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"Fh" = (
+"ET" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 8;
+	icon_state = "1-8"
 	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
+"Fh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 5
-	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
-/area/water_barge/engineering)
+/area/water_barge)
 "Fi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/red{
+/obj/machinery/appliance/cooker/stove,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/light/small/built{
+	dir = 1;
+	pixel_x = -1
+	},
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
+"Fj" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/structure/railing/mapped{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"Fj" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cryo)
+/area/water_barge)
 "Fp" = (
 /obj/effect/landmark/entry_point/aft{
 	name = "aft, hangar"
@@ -2556,42 +2949,21 @@
 	dir = 4
 	},
 /area/water_barge/hangar)
-"FQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
 "FR" = (
-/obj/structure/bed/stool/bar/padded/red,
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 6
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
-"FW" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/docking{
-	landmark_tag = "water_barge_dock_s";
-	master_tag = "airlock_barge_stbddock";
-	name = "airlock_barge_stbddock"
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/dockingport)
-"FX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/toolstorage)
 "Ge" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -2605,10 +2977,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
-"Gh" = (
-/obj/random/contraband,
+"Gi" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small/built{
+	dir = 8;
+	pixel_x = -13
+	},
 /turf/simulated/floor/plating,
-/area/water_barge/dockingport/port)
+/area/water_barge)
+"Gv" = (
+/obj/machinery/power/apc/high/west,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
 "Gw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2620,12 +3003,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
 "GE" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/cooled,
-/area/water_barge/engineering)
+/obj/item/ipc_overloader/tranquil,
+/obj/random/contraband,
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport)
 "GF" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot{
 	dir = 8
@@ -2633,22 +3014,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
 "GG" = (
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/water_barge/breakroom)
-"GO" = (
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/engineering)
+/area/water_barge/toolstorage)
 "GS" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -2663,7 +3038,12 @@
 /obj/structure/window/borosilicate/reinforced,
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/area/water_barge/fuelbay)
+"He" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/alarm/east,
+/turf/simulated/floor/plating,
+/area/water_barge)
 "Hi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/light{
@@ -2678,18 +3058,35 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
 "Hr" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/power/apc/high/east{
+	req_access = null
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
+"HB" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
 "HE" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/shower{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 6
+/obj/structure/curtain/open/shower,
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Shower"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/turf/simulated/floor/tiled/white,
+/area/space)
 "HF" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/shipsensors/weak,
@@ -2698,49 +3095,72 @@
 "HG" = (
 /turf/space,
 /area/space)
-"HN" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+"HL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/bed/stool/bar/padded/red,
-/turf/simulated/floor/plating,
-/area/water_barge/breakroom)
-"HV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"Il" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/area/water_barge/engineering)
+"HU" = (
+/obj/effect/large_stock_marker,
+/obj/effect/floor_decal/corner/brown{
 	dir = 5
 	},
-/turf/simulated/floor/plating,
-/area/water_barge)
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
+"HV" = (
+/obj/machinery/alarm/north{
+	req_one_access = null
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
+"Id" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
+	},
+/obj/machinery/alarm/east,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"Il" = (
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"It" = (
+/obj/effect/floor_decal/corner/yellow/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "Iu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"Iv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
 "Iw" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/breakroom)
 "IE" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
 "IH" = (
 /obj/machinery/light{
 	dir = 4;
@@ -2762,63 +3182,49 @@
 /turf/simulated/floor/reinforced,
 /area/water_barge/engineering)
 "IL" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/closet/firecloset/full,
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/airlock/engineering{
-	dir = 4;
-	name = "Equipment Storage"
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/breakroom)
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/helm)
 "IM" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"IO" = (
-/obj/structure/bed/stool/bar/padded/red,
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
-"IT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport)
-"Jc" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/cooled,
-/area/water_barge/engineering)
-"Jf" = (
-/obj/machinery/light{
-	dir = 1
+"IR" = (
+/obj/structure/closet/crate,
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
+"Ja" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
+"Jc" = (
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/area/water_barge/fuelbay)
+"Jf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "Ji" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
@@ -2851,50 +3257,38 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"Jt" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/high/north{
-	req_access = null
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport)
 "Jw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/structure/bed/stool/chair{
+	dir = 8
+	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "JB" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/cryo)
 "JC" = (
-/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
-	frequency = 0989;
-	id_tag = "h2_out";
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/hydrogen,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/dark,
 /area/water_barge/fuelbay)
 "JK" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
 /obj/structure/closet,
+/obj/item/clothing/head/softcap/colorable/random,
+/obj/item/clothing/suit/storage/hooded/wintercoat/hoodie/random,
+/obj/random/colored_jumpsuit,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "JM" = (
@@ -2940,41 +3334,28 @@
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
 "Ke" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"Kh" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
-"Ko" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/area/water_barge/fuelbay)
+"Ko" = (
+/obj/structure/railing/mapped,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor/plating,
+/area/water_barge)
 "Kp" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/table/rack,
+/obj/item/stack/material/plasteel/full,
+/obj/effect/floor_decal/corner/yellow/full{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport)
+/area/water_barge/toolstorage)
 "Kr" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2987,39 +3368,39 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
 "Ks" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/light/small/built,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
+"Kt" = (
+/obj/machinery/vending/coffee,
+/obj/effect/floor_decal/corner_wide/green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"Ku" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"Kt" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"Ku" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "KB" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/cooled,
+/turf/simulated/floor/plating,
 /area/water_barge/engineering)
 "KC" = (
 /obj/effect/floor_decal/corner/dark_green{
@@ -3031,14 +3412,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "KD" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
+/obj/structure/table/stone/marble,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "KH" = (
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 4
@@ -3050,18 +3427,31 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"KR" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/area/water_barge/fuelbay)
+"KN" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
-"KS" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+"KR" = (
+/obj/machinery/air_sensor{
+	frequency = 0989;
+	id_tag = "co2_sensor"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced/carbon_dioxide,
+/area/water_barge/fuelbay)
+"KS" = (
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
 "KW" = (
@@ -3080,12 +3470,11 @@
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
 "Lb" = (
-/obj/machinery/suit_cycler/engineering{
-	req_access = null
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/engineering)
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
 "Lc" = (
 /obj/machinery/light{
 	dir = 1
@@ -3096,43 +3485,55 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
 "Lf" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
-/area/water_barge)
+/area/water_barge/toolstorage)
+"Lh" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
+	},
+/obj/structure/sign/radiation{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "Ll" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},
+/obj/machinery/power/apc/high,
+/obj/structure/cable/green{
+	icon_state = "0-2";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
-"Ls" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 5
+"Ln" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/structure/sink{
-	pixel_y = 25
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
+"Ly" = (
+/obj/structure/bed/stool/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/dockingport/port)
 "LC" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/railing/mapped,
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
 "LP" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
 "LS" = (
 /obj/machinery/light{
 	dir = 8
@@ -3148,21 +3549,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
-"LT" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
 "LU" = (
 /obj/machinery/computer/ship/navigation{
 	dir = 8
@@ -3173,23 +3559,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
 "LW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1
 	},
-/obj/machinery/door/airlock/external,
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/docking{
-	landmark_tag = "water_barge_dock_s";
-	master_tag = "airlock_barge_stbddock";
-	name = "airlock_barge_stbddock"
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/dockingport)
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "LX" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/helm)
 "Ma" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
@@ -3212,59 +3594,31 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
 "Me" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/cable/green{
-	icon_state = "1-8"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/water_barge)
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport)
 "Mi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"Mm" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "Mo" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"Mp" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/engineering)
+/turf/simulated/floor/reinforced/carbon_dioxide,
+/area/water_barge/fuelbay)
 "Mr" = (
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"My" = (
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
 "Mz" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
@@ -3279,6 +3633,47 @@
 /obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
+"MG" = (
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor/plating,
+/area/water_barge)
+"MH" = (
+/obj/machinery/light/small/built{
+	dir = 8;
+	pixel_x = -14
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
+"MJ" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/toolstorage)
+"MK" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "MO" = (
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
@@ -3297,42 +3692,58 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"MT" = (
-/obj/effect/landmark/entry_point/port{
-	name = "port, atmospherics"
-	},
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/atmos)
 "Nb" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 5
-	},
-/obj/machinery/recharge_station,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/bed/stool/chair,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/cryo)
 "Nc" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/water_barge)
-"Nl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = 12;
+	dir = 1
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock_s";
+	master_tag = "airlock_barge_stbddock";
+	name = "airlock_barge_stbddock"
+	},
+/turf/simulated/floor/plating,
 /area/water_barge/dockingport)
 "Nv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
 	},
-/obj/machinery/light{
+/obj/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/area/water_barge/fuelbay)
+"Nz" = (
+/obj/machinery/light/small/built{
+	dir = 4;
+	pixel_x = 14
+	},
+/obj/structure/coatrack{
+	pixel_y = 16;
+	pixel_x = 8
+	},
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/dockingport/port)
+"NB" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plating,
+/area/water_barge)
 "ND" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
@@ -3343,11 +3754,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
 "NG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/blue{
-	dir = 6
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/area/water_barge/fuelbay)
 "NL" = (
 /turf/template_noop,
 /area/space)
@@ -3355,51 +3773,54 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/lattice/catwalk/indoor,
+/obj/item/stack/material/tritium/full,
+/obj/item/stack/material/tritium/full,
+/obj/structure/closet/walllocker{
+	name = "radiation gear locker";
+	pixel_y = 32
+	},
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/glasses/safety/goggles,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
 "NS" = (
-/obj/machinery/atmospherics/pipe/tank/air{
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/effect/floor_decal/corner/yellow/full,
+/mob/living/heavy_vehicle/premade/ripley/loader,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"NW" = (
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	frequency = 0989;
+	id_tag = "co2_out";
+	dir = 8
+	},
+/turf/simulated/floor/reinforced/carbon_dioxide,
+/area/water_barge/fuelbay)
+"Og" = (
+/obj/effect/large_stock_marker,
+/obj/effect/floor_decal/corner_wide/brown/full{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"NW" = (
-/obj/machinery/alarm/west{
-	req_one_access = null
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"NZ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"Og" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/engineering)
+/area/water_barge/fuelbay)
 "Oj" = (
 /obj/effect/landmark/entry_point/port{
 	name = "port, office"
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/office)
-"Ol" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+"Ok" = (
+/obj/machinery/light/small/built{
+	dir = 4;
+	pixel_x = 14
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "Ou" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
@@ -3416,16 +3837,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "Ox" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "OM" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
@@ -3439,136 +3853,144 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
 "OO" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/portables_connector{
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"OY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
+/area/water_barge/fuelbay)
+"OP" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
-"Pc" = (
-/obj/effect/landmark/entry_point/starboard{
-	name = "starboard, fuel bay"
+/area/water_barge/toolstorage)
+"OY" = (
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 9
 	},
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/fuelbay)
+/obj/structure/bed/stool/bar/padded/red,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"Pc" = (
+/obj/effect/floor_decal/corner/yellow/full{
+	dir = 8
+	},
+/obj/machinery/vending/tool,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "Pd" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
 	},
+/obj/structure/table/rack/no_cargo,
+/obj/item/towel/random,
+/obj/item/towel/random,
+/obj/item/towel/random,
+/obj/item/towel/random,
+/obj/item/reagent_containers/toothbrush,
+/obj/item/reagent_containers/toothbrush/green,
+/obj/item/reagent_containers/toothbrush/red,
+/obj/item/reagent_containers/toothpaste,
+/obj/item/reagent_containers/toothpaste,
+/obj/item/reagent_containers/toothpaste,
+/obj/random/soap,
+/obj/random/soap,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "Pf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"Pj" = (
-/obj/machinery/atmospherics/binary/pump/fuel{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/full,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
-"Pk" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/loot,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
 "Pm" = (
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
 "Pu" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
+/obj/structure/filingcabinet,
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/office)
+"PA" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"PD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
+"PG" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/dockingport)
+"PI" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/blue{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
+"PL" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"PO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
+	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/thrust)
-"Pz" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
-"PD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"PG" = (
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/dockingport)
-"PI" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/structure/railing/mapped,
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
-"PL" = (
-/obj/machinery/atmospherics/portables_connector/fuel{
+/area/water_barge/fuelbay)
+"PS" = (
+/obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
-"PO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"PS" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/engineering)
-"PT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
-"PU" = (
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 9
-	},
-/obj/machinery/vending/cigarette,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/shuttle/water_barge)
+"PU" = (
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/space)
 "PV" = (
 /obj/machinery/computer/ship/navigation{
 	dir = 4
@@ -3579,7 +4001,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
 "PY" = (
-/turf/simulated/floor/reinforced/hydrogen,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
 /area/water_barge/fuelbay)
 "PZ" = (
 /obj/structure/table/standard,
@@ -3594,65 +4021,82 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"Ql" = (
-/obj/item/tank/hydrogen/shuttle,
-/obj/item/tank/hydrogen/shuttle,
-/obj/item/tank/hydrogen/shuttle,
-/obj/item/tank/hydrogen/shuttle,
-/obj/structure/closet/crate,
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
 "Qm" = (
 /obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/light{
+/obj/structure/railing/mapped{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
-"Qv" = (
+"Qr" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/simulated/floor/plating,
+/area/water_barge)
+"Qs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
+"Qu" = (
+/obj/machinery/computer/general_air_control/large_tank_control{
+	frequency = 0989;
+	input_tag = "h2_in";
+	name = "Hydrogen Supply Monitor";
+	output_tag = "h2_out";
+	sensors = list("h2_sensor"="Tank");
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
+"Qy" = (
+/obj/structure/closet/secure_closet/engineering_electrical{
+	req_access = null
+	},
+/obj/effect/floor_decal/corner/yellow/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"QB" = (
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8;
+	layer = 2.8;
+	name = "CO2 to Thrusters"
+	},
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
+"QD" = (
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/void/engineering,
+/obj/item/clothing/head/helmet/space/void/engineering,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"QI" = (
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/engineering)
-"Qy" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/obj/structure/table/steel,
-/obj/random/tool,
-/obj/random/tech_supply,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
-"QC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
-"QD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
+/turf/simulated/floor/tiled/white,
+/area/water_barge/dockingport/port)
 "QJ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3663,11 +4107,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
 "QK" = (
-/obj/structure/table/steel,
-/obj/item/paper_bin,
-/obj/item/pen/black,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/obj/machinery/appliance/cooker/oven,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "QL" = (
 /obj/structure/cable{
 	dir = 1
@@ -3684,38 +4127,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
 "QM" = (
-/obj/structure/railing/mapped{
-	dir = 4
+/obj/structure/sink/kitchen{
+	pixel_y = 14
 	},
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
-"QN" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 5
-	},
-/obj/structure/filingcabinet{
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/office)
-"QO" = (
-/obj/machinery/power/apc/high/north{
-	req_access = null
-	},
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/obj/effect/floor_decal/corner/grey/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "QX" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/light{
+/obj/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/reinforced,
@@ -3742,9 +4164,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
 "Rp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
 "Rt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
@@ -3761,11 +4199,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "RQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2;
+	name = "Medical"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
+/turf/space,
+/area/water_barge/breakroom)
 "RX" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
@@ -3786,19 +4225,28 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "Sb" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking{
+	landmark_tag = "water_barge_dock_s";
+	master_tag = "airlock_barge_stbddock";
+	name = "airlock_barge_stbddock"
+	},
+/obj/effect/shuttle_landmark/scc_scout_ship/catwalk/fore_starboard{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport)
+"Sd" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
 "Se" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/door/airlock/multi_tile{
@@ -3813,39 +4261,29 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
 /area/water_barge/engineering)
-"Sn" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/airlock/hatch{
-	dir = 4;
-	name = "Atmospherics & Port Propulsion"
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
 "So" = (
 /obj/structure/table/steel,
 /obj/random/tool,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
 "Ss" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table/standard,
+/obj/machinery/chemical_dispenser/coffeemaster/full{
+	pixel_y = 16
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal/coc{
+	pixel_x = 10;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/glass{
+	pixel_y = -1;
+	pixel_x = -7
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/helm)
 "Sv" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
@@ -3865,6 +4303,18 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/dockingport)
+"Sx" = (
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 10
+	},
+/obj/machinery/alarm/south{
+	req_one_access = null
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
 "SF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8;
@@ -3884,16 +4334,27 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
-"SG" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
+"SI" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
 "SL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"SO" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "SU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
@@ -3915,33 +4376,41 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"Tf" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
 "Tg" = (
 /obj/machinery/computer/ship/sensors,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
 "Ti" = (
-/obj/structure/lattice/catwalk/indoor,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/water_barge)
-"Tj" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge)
+/area/water_barge/engineering)
+"Tj" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
 "Tr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -3949,51 +4418,73 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
 "TA" = (
-/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/loot,
+/turf/simulated/floor/tiled/dark,
 /area/water_barge/fuelbay)
 "TD" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/office)
-"TH" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"TG" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/water_barge)
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "TJ" = (
+/obj/structure/bed/stool/chair{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
+"TK" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Tanks"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
+"TU" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
-"TK" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/blue,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"TL" = (
-/obj/machinery/atmospherics/portables_connector/fuel{
-	dir = 4
+"Ua" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/toolstorage)
 "Ud" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -4004,63 +4495,44 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 6
-	},
-/obj/machinery/alarm/west{
-	req_one_access = null
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
-"Ut" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/floor_decal/corner/dark_green{
-	dir = 5
+/area/water_barge)
+"Up" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/breakroom)
-"Uv" = (
-/obj/structure/lattice/catwalk/indoor,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
-/obj/machinery/alarm/north{
-	req_one_access = null
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
-"UA" = (
-/obj/structure/railing/mapped{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
 	},
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
+"Uv" = (
+/obj/structure/toilet{
+	dir = 1;
+	pixel_y = -1
+	},
+/obj/machinery/light/small/built{
+	dir = 4;
+	pixel_x = 14
+	},
+/turf/simulated/floor/tiled/white,
+/area/water_barge/dockingport/port)
+"UA" = (
+/obj/machinery/sleeper,
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "UD" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4083,19 +4555,11 @@
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
 "UE" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
+/obj/machinery/light,
+/obj/machinery/iv_drip,
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "UF" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot{
 	dir = 1
@@ -4103,11 +4567,33 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
 "UG" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/door/airlock/engineering{
+	dir = 4;
+	name = "Equipment Storage"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/dockingport/port)
 "UV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4124,7 +4610,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
 "UW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
 "UY" = (
@@ -4154,9 +4642,12 @@
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
 "UZ" = (
-/obj/machinery/light,
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/area/water_barge/fuelbay)
 "Va" = (
 /obj/machinery/light{
 	dir = 1
@@ -4164,9 +4655,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
 "Vd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 1;
+	name = "Engineering Supplies"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "Vg" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4182,21 +4687,23 @@
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
 "Vh" = (
-/obj/machinery/air_sensor{
-	frequency = 0989;
-	id_tag = "h2_sensor"
+/obj/effect/floor_decal/corner/brown{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
-	},
-/turf/simulated/floor/reinforced/hydrogen,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/crate/loot,
+/turf/simulated/floor/tiled/dark,
 /area/water_barge/fuelbay)
 "Vr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/cooled,
-/area/water_barge/engineering)
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/toolstorage)
 "Vs" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4216,21 +4723,36 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
 "Vw" = (
-/obj/machinery/computer/general_air_control/large_tank_control{
-	frequency = 0989;
-	input_tag = "co2_in";
-	name = "Carbon Dioxide Supply Monitor";
-	output_tag = "co2_out";
-	sensors = list("co2_sensor"="Tank");
-	dir = 8
+/obj/structure/closet/secure_closet/engineering_electrical{
+	req_access = null
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/obj/effect/floor_decal/corner/yellow{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "VF" = (
 /turf/unsimulated/wall/fakepdoor{
 	dir = 4
 	},
 /area/water_barge/hangar)
+"VO" = (
+/obj/effect/floor_decal/corner_wide/green{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
 "VS" = (
 /obj/machinery/computer/ship/helm,
 /obj/effect/floor_decal/corner/dark_blue{
@@ -4248,14 +4770,42 @@
 /obj/structure/bed/stool/chair/office/dark,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"VW" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "VZ" = (
 /obj/structure/bed/stool/chair/office/dark,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"Wa" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/glass_mining{
+	name = "Warehouse";
+	req_one_access = list(26,29,31,48,67,70)
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport)
 "Wc" = (
-/obj/structure/dispenser/oxygen,
+/obj/machinery/power/apc/north,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/engineering)
+/area/water_barge/dockingport/port)
 "We" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -4277,29 +4827,38 @@
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
 "Wq" = (
-/obj/structure/cable/green{
-	icon_state = "0-4"
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
 	},
-/obj/machinery/power/apc/high/north{
-	req_access = null
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
-"Wr" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"Wr" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
+/obj/machinery/light/small/built{
+	dir = 1;
+	pixel_x = -1
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/high/east,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
 "Ws" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
@@ -4319,12 +4878,11 @@
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
 "Wv" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/table/steel,
-/obj/item/paper_bin,
-/obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
 "Wz" = (
@@ -4354,6 +4912,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"WD" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/dark_green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/breakroom)
 "WL" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
@@ -4379,15 +4954,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"Xb" = (
-/obj/machinery/portable_atmospherics/canister/empty{
-	name = "waste canister"
-	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
+"WY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/fuelbay)
 "Xd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 8
@@ -4396,24 +4966,33 @@
 /area/shuttle/water_barge)
 "Xg" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/obj/effect/floor_decal/corner_wide/lime/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "Xr" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
 /area/water_barge/helm)
 "Xv" = (
-/obj/structure/table/steel,
+/obj/structure/table/standard,
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/pen/black,
+/obj/item/toy/figure/qm{
+	pixel_y = 2;
+	pixel_x = 8
+	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
-"Xz" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/area/water_barge/office)
+"XA" = (
+/obj/machinery/light/spot{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/beach/water/alt,
 /area/water_barge)
 "XB" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -4435,19 +5014,28 @@
 /obj/item/paper_scanner,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"XO" = (
+"XL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
+"XN" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
+"XO" = (
+/obj/structure/dispenser/oxygen,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/engineering)
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "XQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -4458,35 +5046,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
 "XW" = (
-/obj/structure/table/standard,
-/obj/machinery/chemical_dispenser/coffeemaster/full,
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
+/obj/machinery/door/airlock/service{
+	name = "Bathroom"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/helm)
-"XY" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner_wide/blue/diagonal,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
+/turf/simulated/floor/tiled/white,
+/area/space)
 "Ya" = (
 /obj/machinery/atmospherics/unary/engine,
 /obj/structure/window/borosilicate/reinforced,
@@ -4504,18 +5076,22 @@
 	dir = 9
 	},
 /obj/structure/closet,
+/obj/random/colored_jumpsuit,
+/obj/random/hardhat,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"Yh" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "Yk" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
-"Yn" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate,
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
 "Yu" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -4528,34 +5104,25 @@
 /obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"Yw" = (
-/obj/machinery/portable_atmospherics/canister/empty{
-	name = "waste canister"
-	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/water_barge)
 "Yy" = (
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge)
-"YH" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 10
-	},
+"YA" = (
+/obj/structure/table/steel,
+/obj/item/paper_bin,
+/obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/office)
+/area/water_barge/dockingport/port)
 "YJ" = (
 /turf/simulated/floor/beach/water/alt,
 /area/water_barge)
+"YL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "YN" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -4582,42 +5149,43 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
-"YY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/atmos)
-"Zc" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/plating,
-/area/water_barge/breakroom)
 "Zl" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/hangar)
+"Zn" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Tanks"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "Zq" = (
-/obj/structure/railing/mapped{
+/obj/machinery/atmospherics/pipe/manifold/hidden/red{
 	dir = 8
 	},
-/obj/structure/railing/mapped,
-/turf/simulated/floor/beach/water/alt,
-/area/water_barge)
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
 "Zt" = (
 /obj/structure/bed/stool/chair,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"Zu" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "Zv" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/fore{
@@ -4625,20 +5193,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/helm)
-"Zx" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/warning/full,
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
 "ZA" = (
-/obj/machinery/alarm/north{
-	req_one_access = null
-	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/empty/air,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport)
+/area/water_barge/fuelbay)
 "ZD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -4650,6 +5209,14 @@
 /obj/effect/overmap/visitable/ship/water_barge,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"ZF" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4;
+	icon_state = "map_scrubber_on"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "ZI" = (
 /obj/item/modular_computer/console/preset/civilian,
 /turf/simulated/floor/tiled/dark,
@@ -4671,10 +5238,64 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
+"ZL" = (
+/obj/effect/floor_decal/corner/yellow/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"ZN" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"ZQ" = (
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/suit/space/void/engineering,
+/obj/item/clothing/head/helmet/space/void/engineering,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "ZR" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"ZT" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
 "ZV" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -12200,13 +12821,13 @@ NL
 NL
 NL
 NL
-PG
-PG
-PG
-PG
-PG
-PG
-PG
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 NL
 NL
 NL
@@ -12362,13 +12983,13 @@ NL
 NL
 NL
 NL
-PG
-bf
-DT
-gK
-XB
-Wm
-KW
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 NL
 NL
 NL
@@ -12507,10 +13128,12 @@ NL
 NL
 NL
 NL
-AA
-AA
-AA
-AA
+NL
+NL
+NL
+NL
+NL
+NL
 NL
 NL
 NL
@@ -12525,14 +13148,12 @@ NL
 NL
 NL
 PG
-Va
-Nl
-LW
-Eu
-gd
-FW
-NL
-NL
+PG
+PG
+PG
+PG
+PG
+PG
 NL
 NL
 NL
@@ -12669,13 +13290,15 @@ NL
 NL
 NL
 NL
-AA
-Pm
-Pm
-AA
-fr
-AA
-AA
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 NL
 NL
 NL
@@ -12687,14 +13310,12 @@ NL
 NL
 NL
 PG
+wc
 bf
-Nl
-PG
-PG
-PG
-PG
-NL
-NL
+Nc
+XB
+Wm
+KW
 NL
 NL
 NL
@@ -12831,16 +13452,18 @@ NL
 NL
 NL
 NL
-vC
-SU
-Pm
-Pm
-bK
-Pm
-AA
-dP
-dP
-dP
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 NL
 NL
 NL
@@ -12849,14 +13472,12 @@ NL
 NL
 NL
 PG
-bf
-Nl
-PG
-NL
-NL
-NL
-NL
-NL
+Me
+nh
+uX
+Eu
+gd
+Sb
 NL
 NL
 NL
@@ -12993,32 +13614,32 @@ NL
 NL
 NL
 NL
-AA
-pM
-Pm
-Pm
-Pm
-Pm
-Pm
-dP
-TL
-dP
-Pc
-dP
-dP
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 NL
 NL
 NL
 NL
 PG
 bf
-Nl
-mj
-NL
-NL
-NL
-NL
-NL
+bf
+PG
+PG
+PG
+PG
 NL
 NL
 NL
@@ -13155,29 +13776,29 @@ NL
 NL
 NL
 NL
-vC
-kn
-Pm
-Pm
-Pm
-Pm
-Pm
-dP
-UG
-TL
-PL
-Ql
-dP
-PG
-PG
-Sw
-PG
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 PG
 bf
-Nl
+bf
 PG
-NL
-NL
 NL
 NL
 NL
@@ -13317,29 +13938,29 @@ NL
 NL
 NL
 NL
-AA
-pM
-Pm
-Pm
-Pm
-Pm
-Pm
-dP
-rx
-fR
-uR
-My
-iA
-PG
-su
-ic
-wc
-PG
-Va
-hv
-PG
 NL
 NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+PG
+bf
+bf
+PG
 NL
 NL
 NL
@@ -13479,29 +14100,29 @@ NL
 NL
 NL
 NL
-Ya
-II
-Pm
-Pm
-Pm
-Pm
-Pm
-dP
-QO
-Pj
-My
-My
-Zx
-PG
-Va
-bf
-Nl
-PG
-bf
-Nl
-PG
 NL
 NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+PG
+bf
+ZR
+PG
 NL
 NL
 NL
@@ -13641,29 +14262,29 @@ NL
 NL
 NL
 NL
-AA
-ct
-UW
-UW
-UW
-UW
-QD
-Se
-ua
-Ol
-Xg
-My
-FX
-PG
-bf
-SL
-Nl
-PG
-bf
-Nl
-PG
 NL
 NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+PG
+bf
+bf
+PG
 NL
 NL
 NL
@@ -13803,29 +14424,29 @@ NL
 NL
 NL
 NL
-vC
-II
-Pm
-Pm
-Pm
-Pm
-hW
-Wu
-aS
-oy
-bS
-Wu
-kz
-xs
-bN
-WP
-vu
-nh
-nh
-IT
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 PG
-NL
-NL
+bf
+bf
+PG
 NL
 NL
 NL
@@ -13965,29 +14586,29 @@ NL
 NL
 NL
 NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 AA
-pM
-Pm
-Pm
-Pm
-Pm
-Pz
+AA
+AA
 dP
-Vw
-iH
-PT
-on
-FX
-PG
-Kp
-tn
-bf
-bf
-bf
-bf
-PG
 NL
 NL
+NL
+NL
+NL
+NL
+NL
+NL
+PG
+bf
+bf
+mj
 NL
 NL
 NL
@@ -14127,29 +14748,29 @@ NL
 NL
 NL
 NL
-vC
-zY
-Pm
-Pm
-Pm
-Df
-Pu
-dP
-Bs
-pd
-dP
-Bs
-TA
-PG
-Jt
-bf
-bf
-bf
-bf
-ZR
-PG
-PG
 NL
+NL
+NL
+NL
+NL
+NL
+NL
+vC
+SU
+Pm
+dP
+dP
+dP
+dP
+dP
+dP
+PG
+Sw
+PG
+PG
+Va
+bf
+PG
 NL
 NL
 NL
@@ -14289,28 +14910,28 @@ NL
 NL
 NL
 NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 AA
+pM
 Pm
-Pm
-Pm
-Pm
-Hr
-kY
-dP
-xb
-Dn
 dP
 PY
 Vh
+xx
+lH
+ex
 PG
-ZA
-tc
-ky
-bf
-bf
-bf
+su
+ic
 PG
-PG
+bf
+iH
 PG
 NL
 NL
@@ -14451,29 +15072,28 @@ NL
 NL
 NL
 NL
-AA
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+vC
+kn
 Pm
-Pm
-Ss
-tC
-Cz
-XY
-dP
-xb
-zx
 dP
 PY
 JC
+xb
+ZA
+nI
 PG
 bf
-tF
-tc
-bf
-bf
 bf
 PG
-yI
-PG
+bf
+bf
 PG
 NL
 NL
@@ -14483,6 +15103,14 @@ NL
 NL
 NL
 NL
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 NL
 NL
 NL
@@ -14492,21 +15120,14 @@ NL
 NL
 NL
 NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 NL
 NL
 NL
@@ -14613,30 +15234,28 @@ NL
 NL
 NL
 NL
-xW
-xW
-xW
-xW
-xW
-xW
-dx
-xW
-xW
-xW
-xW
-xW
-xW
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+AA
+pM
+Pm
+dP
+HV
+xb
+TA
+JC
+Tj
+PG
+ar
+bf
 PG
 bf
 bf
-tH
-bf
-bf
-bf
-PG
-yI
-yI
-PG
 PG
 NL
 NL
@@ -14645,6 +15264,16 @@ NL
 NL
 NL
 NL
+iR
+iR
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+iR
+iR
 NL
 NL
 NL
@@ -14652,24 +15281,16 @@ NL
 NL
 NL
 NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
+iR
+iR
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+iR
+iR
 NL
 NL
 NL
@@ -14775,64 +15396,64 @@ NL
 NL
 NL
 NL
-xW
-xD
-hP
-Sg
-IK
-zb
-hV
-vV
-zb
-xW
-KB
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+Ya
+II
+UW
+dP
 DL
-za
-iR
-iR
-iR
-iR
-iR
-iR
-rk
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-pz
-iR
-iR
-iR
-iR
-iR
-iR
-JB
-JB
-JB
+TA
+xb
+xb
+IR
+PG
+mp
+bf
+bf
+SL
+bf
+PG
 NL
 NL
 NL
 NL
 NL
 NL
+iR
+iR
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+iR
+iR
 NL
 NL
 NL
+NL
+NL
+iR
+iR
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+iR
+iR
 NL
 NL
 NL
@@ -14937,72 +15558,72 @@ NL
 NL
 NL
 NL
-qk
-QX
-hI
-Ck
-Jj
-pg
-hV
-zb
-zb
-fO
-Vr
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+AA
+ct
+XL
+Se
 un
-vI
+WY
+WY
+WY
+nz
+Wa
+fi
+DR
+DR
+WP
+bf
+PG
+NL
+NL
+NL
+NL
+NL
 iR
-fV
-xM
-mM
-UA
-Zq
-LC
-UA
-UA
-lj
-xM
-gE
-xM
-mM
-UA
-Zq
-LC
-UA
-UA
-lj
-xM
-gE
-xM
-mM
-UA
-Zq
-LC
-UA
-UA
-lj
-xM
-Yy
 iR
+XA
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+XA
+iR
+iR
+NL
+NL
+NL
+iR
+iR
+XA
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+XA
+iR
+iR
+NL
+JB
 JB
 JB
 JB
 eY
 JB
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -15099,52 +15720,67 @@ NL
 NL
 NL
 NL
-xW
-YN
-Ew
-JX
-IK
-NQ
-hV
-zb
-zb
-xW
-Jc
-Ba
-GE
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+vC
+II
+HB
+Wu
+ws
+EA
+EA
+EA
+iS
+PG
+bf
+bf
+bf
+tn
+ZR
+PG
+PG
+NL
+NL
+NL
+NL
 iR
-Yy
-et
-YJ
-YJ
-nS
-LC
 YJ
 YJ
 YJ
-xI
-Yy
-et
 YJ
 YJ
-nS
-LC
+Qm
+ED
 YJ
 YJ
 YJ
-xI
-Yy
-et
 YJ
 YJ
-nS
-LC
-YJ
-YJ
-YJ
-xI
-Yy
 iR
+NL
+NL
+NL
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+NL
+JB
 vq
 LS
 RK
@@ -15152,21 +15788,6 @@ ZV
 JB
 JB
 JB
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -15261,52 +15882,67 @@ NL
 NL
 NL
 NL
-xW
-xW
-xW
-xW
-xW
-NQ
-hV
-zb
-zb
-xW
-xW
-xW
-xW
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+AA
+pM
+Df
+dP
+HU
+vI
+vI
+Tf
+gK
+PG
+bf
+tc
+ky
+bf
+bf
+PG
+PG
+PG
+bS
+NL
 iR
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
 iR
+YJ
+YJ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+iR
+NL
+iR
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+iR
+JB
 vm
 RX
 RX
@@ -15315,21 +15951,6 @@ Pd
 tK
 JB
 JB
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -15423,53 +16044,68 @@ NL
 NL
 NL
 NL
-xW
-vg
-yQ
-BS
-tk
-EN
-hV
-zb
-zb
-Wc
-Lb
-Og
-CZ
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+vC
+zY
+Hr
+dP
+HU
+vI
+vI
+aq
+Up
+PG
+bf
+tF
+tc
+bf
+pU
+PG
+GE
+vZ
+PG
+PG
 iR
-Yy
-uk
-YJ
-YJ
-nS
-LC
 YJ
 YJ
 YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
 YJ
 YJ
 YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
+Qm
+ED
 YJ
 YJ
 YJ
-nS
-Yy
+YJ
+YJ
+YJ
 iR
-JK
+NL
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+JB
+ng
 RX
 RX
 RX
@@ -15477,21 +16113,6 @@ RX
 cK
 Yf
 JB
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -15582,78 +16203,78 @@ NL
 NL
 NL
 NL
-Zl
-Zl
-Zl
-xW
-Wr
-kv
-kv
-kv
-kv
-Mp
-yB
-XO
-Fh
-bi
-bi
-CZ
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+AA
+AA
+AA
+dP
+Og
+oZ
+oZ
+oZ
+vp
+PG
+bf
+mY
+tH
+bf
+od
+PG
+vZ
+yI
+PG
 iR
-Yy
-dp
-dp
-dp
-dp
-ng
-dp
-dp
-dp
-dp
-Yy
-dp
-dp
-dp
-dp
-ng
-dp
-dp
-dp
-dp
-Yy
-dp
-dp
-dp
-dp
-ng
-dp
-dp
-dp
-dp
-Yy
 iR
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+iR
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+JB
 KC
+RX
 Zt
-Fj
 Yk
 jr
 RX
 Ge
 JB
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -15742,80 +16363,80 @@ NL
 NL
 NL
 NL
-Zl
-Zl
-Zl
-pk
-pk
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 xW
-ff
-zb
-zb
-zb
-zb
-PS
-Qv
-zb
-hV
-bi
-bi
-CZ
+xW
+xW
+xW
+xW
+xW
+dx
+xW
+xW
+xW
+xW
+xW
+Iw
+Iw
+Iw
+Iw
+Iw
 iR
 Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-iR
-xh
-Zt
 Fj
+Fj
+Fj
+Fj
+Fj
+Fj
+pc
+rX
+Fj
+Fj
+Fj
+Fj
+Fj
+Fj
+gc
+Gi
+gc
+Fj
+Fj
+Fj
+Fj
+Fj
+Fj
+rX
+ZF
+Fj
+Fj
+Fj
+Fj
+Fj
+Fj
+Yy
+JB
+xh
+RX
+Zt
 qd
 jr
 RX
 Cx
 hS
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -15902,82 +16523,82 @@ NL
 NL
 NL
 NL
+NL
+NL
+NL
+NL
+NL
+NL
 Zl
 Zl
 Zl
-pk
-nV
-pk
-gG
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 xW
-cc
-GO
-zb
-gs
-zb
-zb
-zb
-zb
+xD
+hP
+Sg
+IK
+Au
 hV
-na
-om
-CZ
+zb
+IE
+fO
+np
+xW
+Fi
+mm
+nS
+OY
+Dn
 iR
 Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-iR
-KC
-Zt
 jR
+jR
+jR
+jR
+jR
+jR
+dW
+NB
+jR
+jR
+jR
+jR
+jR
+jR
+Yy
+Yy
+Yy
+jR
+jR
+jR
+jR
+jR
+jR
+iy
+Qr
+jR
+jR
+jR
+jR
+jR
+jR
+Yy
+JB
+KC
+RX
+Nb
 og
 SY
 RX
 Ge
 JB
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -16062,6 +16683,12 @@ NL
 NL
 NL
 NL
+NL
+NL
+NL
+NL
+Zl
+Zl
 Zl
 Zl
 Zl
@@ -16071,52 +16698,61 @@ pk
 pk
 pk
 pk
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Zl
-Iw
-dM
-Iw
-Iw
-Iw
+pk
+MH
+An
+xW
+QX
+hI
+Ck
+Jj
+pg
+hV
+zb
+zb
+xW
+xW
+xW
+QK
+mm
+qc
+ks
+gR
 iR
-Yy
-lq
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-np
-Yy
-lq
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-np
-Yy
 iR
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+MG
+bl
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+iR
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+hT
+Ko
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+JB
 JK
 RX
 RX
@@ -16126,21 +16762,6 @@ RX
 qE
 JB
 JQ
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -16224,61 +16845,76 @@ NL
 NL
 NL
 NL
-VF
-pk
-nV
-pk
-pk
-pk
-pk
-pk
-pk
-pk
-pk
-nV
-pk
-pk
-pk
-pk
+NL
+NL
 Zl
-PU
-rW
-tt
-od
-vW
+Zl
+Zl
+tk
+pk
+pk
+pk
+pk
+pk
+pk
+pk
+pk
+pk
+pk
+pk
+Mm
+xW
+YN
+Ew
+JX
+IK
+kw
+lB
+fh
+aj
+PI
+LC
+xW
+QM
+mm
+KD
+ks
+Il
+Iw
 iR
-fV
-xM
-fh
-QM
-PI
-LC
-QM
-QM
-Ku
-xM
-Qm
-xM
-fh
-QM
-PI
-LC
-QM
-QM
-Ku
-xM
-Qm
-xM
-fh
-QM
-PI
-LC
-QM
-QM
-Ku
-xM
-Kh
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+MG
+bl
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
 iR
+NL
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+hT
+Ko
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+JB
 Ou
 jj
 zy
@@ -16288,21 +16924,6 @@ jj
 RY
 JB
 Ar
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -16386,6 +17007,8 @@ NL
 NL
 NL
 NL
+NL
+NL
 VF
 pk
 pk
@@ -16401,46 +17024,59 @@ BL
 BL
 pk
 pk
-gG
-Zl
-Nb
-rW
-By
-By
+iF
+xW
+xW
+xW
+xW
+xW
+NQ
+hV
+zb
+zb
+af
+Ks
+xW
+hv
+mm
+KD
+ks
 gR
+Iw
 iR
-rY
-re
-af
-af
-af
-af
-af
-af
-af
-KD
-xZ
-KD
-af
-af
-af
-af
-af
-af
-af
-nt
-xZ
-nt
-af
-af
-af
-af
-af
-af
-af
-ew
-Il
 iR
+YJ
+YJ
+YJ
+YJ
+YJ
+MG
+bl
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+iR
+NL
+iR
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+hT
+Ko
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+iR
+JB
 JB
 JB
 JB
@@ -16450,21 +17086,6 @@ JB
 JB
 JB
 JQ
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -16548,6 +17169,8 @@ NL
 NL
 NL
 NL
+NL
+NL
 VF
 pk
 pk
@@ -16562,48 +17185,61 @@ DN
 Mi
 wK
 pk
-pk
+ly
 GS
-Zl
-bw
-qO
-hX
-hX
-xN
+xW
+vg
+yQ
+BS
+BS
+EN
+ZT
+mM
+vl
+Zq
+kz
+xW
+oC
+lj
+KD
+ge
+Sx
+Iw
+NL
 iR
-TJ
-xM
-mM
-UA
-Zq
-LC
-UA
-UA
-lj
-xM
-Ox
-xM
-mM
-UA
-Zq
-LC
-UA
-UA
-lj
-xM
-Ox
-xM
-mM
-UA
-Zq
-LC
-UA
-UA
-lj
-xM
-rO
+YJ
+YJ
+YJ
+YJ
+YJ
+MG
+bl
+YJ
+YJ
+YJ
+YJ
+YJ
 iR
-cv
+NL
+NL
+NL
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+hT
+Ko
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+NL
+JQ
+Cz
 dY
 dY
 cA
@@ -16612,21 +17248,6 @@ WL
 PZ
 Xr
 gq
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -16710,84 +17331,84 @@ NL
 NL
 NL
 NL
+NL
+NL
 VF
 pk
 HF
 BL
 BL
 BL
-Nc
-Yw
 fF
+uY
+PS
 Mi
 Hi
 sE
 wK
 pk
-pk
+Jf
 oR
-Zl
-Ut
-Zc
-vZ
-By
-BE
+xW
+Wr
+kv
+kv
+kv
+HL
+et
+KB
+zb
+bK
+nF
+xW
+jT
+ff
+xI
+uW
+Dr
+Iw
+NL
 iR
-TJ
-et
 YJ
-YJ
-nS
-LC
+sZ
 YJ
 YJ
 YJ
-xI
-Yy
-et
-YJ
-YJ
-nS
-LC
+MG
+bl
 YJ
 YJ
 YJ
-xI
-Yy
-et
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-xI
-Xz
+sZ
 iR
-XW
+iR
+NL
+NL
+NL
+iR
+YJ
+sZ
+YJ
+YJ
+YJ
+hT
+Ko
+YJ
+YJ
+YJ
+sZ
+iR
+iR
+NL
+JQ
+Ss
 Jm
 Jm
 lb
 GF
 Jm
-Cw
+oH
 Xr
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -16872,6 +17493,8 @@ NL
 NL
 NL
 NL
+NL
+NL
 VF
 pk
 BL
@@ -16886,47 +17509,60 @@ BL
 BL
 BL
 BL
-pk
+fd
 Tb
-qS
-jT
-rW
-By
-By
-gR
+xW
+xW
+xW
+xW
+xW
+xW
+Ti
+fV
+xW
+xW
+xW
+xW
+Iw
+PL
+hX
+Iw
+Iw
+Iw
 iR
-TJ
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Xz
 iR
+iR
+iR
+iR
+iR
+iR
+TU
+Ez
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+hG
+ri
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+JQ
 aY
 Jm
 Jm
@@ -16935,21 +17571,6 @@ Jm
 Jm
 wL
 Xr
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -17034,6 +17655,8 @@ NL
 NL
 NL
 NL
+NL
+NL
 VF
 pk
 DS
@@ -17050,68 +17673,66 @@ JM
 BL
 DB
 jA
-qS
-jT
-rW
-By
-By
-gR
-Tj
-TJ
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
+oa
+It
+SO
+tp
+tp
+Lh
+MK
+DU
+tp
+SO
+cb
+oa
+rk
+WD
+xs
+xs
+dq
+Iw
+mG
+dp
+TK
 Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
+Gi
 Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Xz
-Tj
+Yy
+Fh
+sT
+Gi
+Yy
+Yy
+Gi
+Yy
+Yy
+Cg
+Yy
+pc
+Gi
+Yy
+Yy
+Gi
+Yy
+Yy
+hG
+hU
+Yy
+Yy
+Gi
+Yy
+TK
+dp
+mG
+JQ
 Kr
 Jm
 Jm
 lb
 Tr
-Jm
+AT
 iB
 Xr
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -17196,7 +17817,9 @@ NL
 NL
 NL
 NL
-Fp
+NL
+NL
+VF
 pk
 qn
 ov
@@ -17212,45 +17835,58 @@ kF
 UY
 dO
 jL
-sZ
-GG
 nl
 GG
 GG
 GG
-uc
-Lf
-dp
-dp
-dp
-dp
-ng
-dp
-dp
-dp
-dp
-Yy
-dp
-dp
-dp
-dp
-ng
-dp
-dp
-dp
-dp
-Yy
-dp
-dp
-dp
-dp
-ng
-dp
-dp
-dp
-dp
-hE
-fd
+AN
+fB
+Bo
+Ua
+GG
+GG
+GG
+Ex
+jc
+Rp
+PA
+PA
+uv
+re
+Um
+Um
+Zn
+Um
+Um
+Um
+Um
+qm
+dl
+Um
+Um
+Um
+Um
+Um
+Um
+dl
+Um
+nV
+Um
+Um
+Um
+Um
+Um
+Um
+dl
+nV
+Um
+Um
+Um
+Um
+Zn
+Um
+Um
+me
 Vs
 Gw
 Gw
@@ -17259,21 +17895,6 @@ ZD
 AT
 VS
 Zv
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -17358,7 +17979,9 @@ NL
 NL
 NL
 NL
-VF
+NL
+NL
+Fp
 pk
 DS
 Tg
@@ -17374,68 +17997,66 @@ Mz
 Rt
 dO
 KS
-qS
-jT
 rW
+Lf
+Lf
+Lf
+MJ
+qW
+Vr
+FR
+Lf
+Lf
+Lf
+pI
+lJ
+uc
+SI
 By
-By
-gR
-Tj
-TH
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
+cS
+Iw
+Ok
+dp
+TK
 Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
+kP
+He
+Dc
+hU
+sT
+kP
 Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-BB
-Tj
+Yy
+kP
+Yy
+Yy
+qZ
+Yy
+Yh
+kP
+Yy
+Yy
+kP
+Yy
+Yy
+hG
+Fh
+Yy
+Yy
+kP
+Yy
+TK
+dp
+Ok
+JQ
 IM
 Jm
 Jm
 Jq
 hC
-Jm
+AT
 pa
 Xr
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -17520,6 +18141,8 @@ NL
 NL
 NL
 NL
+NL
+NL
 VF
 pk
 BL
@@ -17535,69 +18158,67 @@ BL
 BL
 Rt
 pk
-pk
-qS
-jT
-rW
-By
-By
-gR
+bn
+oa
+lU
+DI
+bd
+mP
+Id
+TG
+Wq
+bd
+DI
+ZL
+oa
+xJ
+VO
+eg
+Kt
+uk
+Iw
 iR
-TH
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-BB
 iR
+iR
+iR
+iR
+iR
+iR
+hU
+Ez
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+hG
+ri
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+JQ
 xz
 Jm
 Jm
 Jq
 Jm
 Jm
-ED
+on
 Xr
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -17682,6 +18303,8 @@ NL
 NL
 NL
 NL
+NL
+NL
 VF
 pk
 bW
@@ -17696,48 +18319,61 @@ MS
 Xd
 wK
 kR
-pk
+YL
 je
-Zl
-Ut
-Zc
-HN
-Xv
-qc
+oa
+oa
+oa
+oa
+oa
+oa
+hJ
+Vd
+oa
+oa
+oa
+oa
+Iw
+Qs
+RQ
+Iw
+Iw
+Iw
+NL
 iR
-TH
-lq
 YJ
-YJ
-nS
-LC
+XA
 YJ
 YJ
 YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
+MG
+bl
 YJ
 YJ
 YJ
-np
-Yy
-lq
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-np
-BB
+XA
 iR
-EM
+iR
+NL
+NL
+NL
+iR
+YJ
+XA
+YJ
+YJ
+YJ
+hT
+Ko
+YJ
+YJ
+YJ
+XA
+iR
+iR
+NL
+JQ
+LX
 Jm
 Jm
 Jq
@@ -17745,21 +18381,6 @@ vQ
 Jm
 Cw
 Xr
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -17844,6 +18465,8 @@ NL
 NL
 NL
 NL
+NL
+NL
 VF
 pk
 pk
@@ -17858,48 +18481,61 @@ Wz
 Iu
 wK
 pk
-pk
-pk
-Zl
-mn
-rW
-ks
-Xv
+bn
+Ln
+oa
+Pc
+tp
 sV
-iR
+XO
 xG
-xM
-fh
-QM
-PI
-LC
-QM
-QM
+KN
+ZN
+Cl
+qi
+NS
+oa
+cj
 Ku
-xM
-Qm
-xM
-fh
-QM
-PI
-LC
-QM
-QM
-Ku
-xM
-Qm
-xM
-fh
-QM
-PI
-LC
-QM
-QM
-Ku
-xM
-LT
+Xg
+eu
+Bv
+Iw
+NL
 iR
-li
+YJ
+YJ
+YJ
+YJ
+YJ
+MG
+bl
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+NL
+NL
+NL
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+hT
+Ko
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+NL
+JQ
+IL
 xw
 xw
 Jq
@@ -17908,21 +18544,6 @@ OM
 Sv
 Xr
 gq
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -18006,6 +18627,8 @@ NL
 NL
 NL
 NL
+NL
+NL
 VF
 pk
 pk
@@ -18020,47 +18643,60 @@ BL
 BL
 BL
 pk
-pk
+Ln
 gG
-Zl
-Ls
-rW
-ks
-Xv
-qc
-iR
-Uv
-fi
+oa
+Ws
+cI
+cI
+cI
+cI
+yz
+eJ
+CO
+ek
+Ll
+oa
+BE
 uF
-uF
-uF
-uF
-uF
-uF
-uF
+Ox
+Ox
 UE
-Ex
-UE
-uF
-uF
-uF
-uF
-uF
-uF
-uF
-Ti
-Ex
-Ti
-uF
-uF
-uF
-uF
-uF
-uF
-uF
-QC
-Me
+Iw
 iR
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+MG
+bl
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+iR
+NL
+iR
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+hT
+Ko
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+iR
+TD
 TD
 TD
 TD
@@ -18070,21 +18706,6 @@ TD
 TD
 TD
 JQ
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -18168,85 +18789,85 @@ NL
 NL
 NL
 NL
-VF
-pk
-pU
-pk
-pk
-pk
-pk
-pk
-pk
-pk
-pk
-pU
-pk
-pk
-pk
-pk
+NL
+NL
 Zl
-Em
-rW
-IO
-rd
-FR
-iR
-Cl
-xM
-mM
+Zl
+Zl
+jd
+pk
+pk
+pk
+pk
+pk
+pk
+pk
+pk
+pk
+pk
+pk
+uy
+oa
+xr
+cI
+cI
+cI
+cI
+gz
+cC
+hJ
+OP
+za
+oa
 UA
-Zq
-LC
-UA
-UA
-lj
-xM
+uF
 Ox
-xM
-mM
-UA
-Zq
-LC
-UA
-UA
-lj
-xM
 Ox
-xM
-mM
-UA
-Zq
-LC
-UA
-UA
-lj
-xM
-Kh
+bN
+Iw
 iR
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+MG
+bl
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+NL
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+hT
+Ko
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+TD
 Cf
 eP
 Dv
 rz
 gp
 XQ
-YH
+Pu
 TD
 zd
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -18330,85 +18951,85 @@ NL
 NL
 NL
 NL
+NL
+NL
+NL
+NL
 Zl
 Zl
 Zl
+Zl
+Zl
 pk
 pk
 pk
 pk
 pk
 pk
+pk
+mT
+vU
 oa
+Vw
+cI
+cI
+cI
+cI
+cI
+cI
+hJ
+OP
+yB
 oa
-oa
-oa
-oa
-oa
-oa
-oa
-Iw
-IL
-Iw
-Iw
-Iw
+iA
+uF
+Ox
+Ox
+tC
 iR
-Yy
-et
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-xI
-Yy
-et
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-xI
-Yy
-et
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-xI
-Yy
 iR
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+MG
+bl
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+iR
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+hT
+Ko
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+TD
 Aw
 ZI
 zF
 VV
 ZI
 zF
-uX
+nt
 TD
 JQ
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -18494,59 +19115,74 @@ NL
 NL
 NL
 NL
+NL
+NL
+NL
+NL
+NL
+NL
 Zl
 Zl
 Zl
-pk
-pU
-pk
-gG
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
+Zl
 oa
-yv
-tp
-eO
-Bd
-uY
-oH
-Um
-Sb
-rA
 Qy
-tp
+bd
 Eo
+QD
+ZQ
+QD
+QD
+TG
+aS
+Kp
+oa
+cM
+Jw
+TJ
+om
+DT
 iR
 Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
+Fj
+Fj
+Fj
+Fj
+Fj
+Fj
+yy
+NB
+Fj
+Fj
+Fj
+Fj
+Fj
+Fj
+gc
 Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
+gc
+Fj
+Fj
+Fj
+Fj
+Fj
+Fj
+iy
+Qr
+Fj
+Fj
+Fj
+Fj
+Fj
+Fj
 Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-iR
+TD
 iQ
 ND
 Ud
@@ -18555,21 +19191,6 @@ CT
 zF
 rB
 nd
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -18658,57 +19279,72 @@ NL
 NL
 NL
 NL
-Zl
-Zl
-Zl
-pk
-pk
-oa
-Ws
-cI
-cI
-cI
-cI
-cI
-cj
-cI
-cI
-uU
-lJ
-Bv
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+dP
+dP
+dP
+dP
+dP
+dP
+dP
+CS
+Ja
+EM
+CS
+CS
+UG
+gs
+bS
+bS
+bS
 iR
 Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
+jR
+jR
+jR
+jR
+jR
+jR
+Yh
+qQ
+jR
+jR
+jR
+jR
+jR
+jR
 Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
+kP
 Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
+jR
+jR
+jR
+jR
+jR
+jR
+qQ
+Yh
+jR
+jR
+jR
+jR
+jR
+jR
 Yy
-iR
+TD
 Lc
 zF
 zF
@@ -18717,21 +19353,6 @@ zF
 zF
 rB
 cx
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -18822,55 +19443,70 @@ NL
 NL
 NL
 NL
-Zl
-Zl
-Zl
-oa
-xr
-cI
-cI
-cI
-cI
-tZ
-ap
-KR
-cI
-QK
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+dP
+dP
+dP
+dP
 eQ
-Ll
+eQ
+Jc
+mn
+wn
+CS
+Ja
+Wv
+kj
+kV
+iV
+gs
+eO
+xu
+kQ
 iR
-Yy
-dp
-dp
-dp
-dp
-ng
-dp
-dp
-dp
-dp
-Yy
-dp
-dp
-dp
-dp
-ng
-dp
-dp
-dp
-dp
-Yy
-dp
-dp
-dp
-dp
-ng
-dp
-dp
-dp
-dp
-Yy
 iR
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+iR
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+TD
 iQ
 XI
 zF
@@ -18879,21 +19515,6 @@ XI
 zF
 rB
 nd
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -18987,52 +19608,67 @@ NL
 NL
 NL
 NL
-oa
-fW
-bd
-HE
-dB
-CI
-bd
-cj
-bd
-bd
-HE
-bd
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+Hc
+PO
+Gv
+dP
+vu
 LP
+KI
+as
+Ed
+CS
+nX
+VW
+XN
+XN
+eA
+XW
+ry
+PU
+di
+CS
 iR
-Yy
-uk
-YJ
-YJ
-nS
-LC
 YJ
 YJ
 YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
 YJ
 YJ
 YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
+Qm
+ED
 YJ
 YJ
 YJ
-nS
-Yy
+YJ
+YJ
+YJ
 iR
+NL
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+TD
 Aw
 ZI
 zF
@@ -19041,21 +19677,6 @@ ZI
 kX
 mv
 nd
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -19149,75 +19770,75 @@ NL
 NL
 NL
 NL
-hU
-hU
-hU
-hU
-hU
-hU
-hU
-Sn
-hU
-hU
-hU
-hU
-hU
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+dP
+Nv
+PD
+Se
+fR
+wy
+Lb
+as
+Ed
+CS
+Ja
+Wv
+lL
+lL
+Em
+CS
+QI
+CS
+CS
+bS
 iR
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
 iR
+YJ
+YJ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+iR
+NL
+iR
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+iR
+TD
 iQ
-ND
+Xv
 zF
 kX
 Yu
 dd
 TD
 TD
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -19311,74 +19932,74 @@ NL
 NL
 NL
 NL
-hU
-ta
-LX
-mm
-ta
-LX
-as
-oC
-sD
-NW
-vO
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+Hc
+Pf
+Sd
+Wu
 NG
 OO
-iR
-Yy
+xN
+vO
 lq
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-nS
-Yy
-uk
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-np
-Yy
-lq
-YJ
-YJ
-nS
-LC
-YJ
-YJ
-YJ
-np
-Yy
+gm
+Zu
+hg
+dt
+dt
+pC
+CS
+xM
+DX
+Uv
+bS
+NL
 iR
-iQ
-kX
+YJ
+YJ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+NL
+NL
+NL
+iR
+YJ
+YJ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+YJ
+YJ
+iR
+NL
+TD
+ua
+We
 We
 mv
 TD
 TD
 TD
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -19473,72 +20094,72 @@ NL
 NL
 NL
 NL
-hU
-Pk
-ta
-Yn
-LX
-qD
-SG
-Ks
-Rp
-DQ
-aj
-TK
-NS
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+dP
+la
+gC
+dP
+jD
+sc
+gC
+as
+Ed
+CS
+lX
+Wv
+lL
+kM
+eW
+CS
+xM
+CS
+bS
+bS
+NL
 iR
-fV
-xM
-fh
-QM
-PI
-LC
-QM
-QM
-Ku
-xM
-gE
-xM
-fh
-QM
-PI
-LC
-QM
-QM
-Ku
-xM
-gE
-xM
-fh
-QM
-PI
-LC
-QM
-QM
-Ku
-xM
-Kh
 iR
-QN
-hT
+sZ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+sZ
+iR
+iR
+NL
+NL
+NL
+iR
+iR
+sZ
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+sZ
+iR
+iR
+NL
+TD
+TD
+TD
 TD
 Oj
 TD
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
 NL
 NL
 NL
@@ -19635,64 +20256,64 @@ NL
 NL
 NL
 NL
-hU
-Jf
-qD
-qD
-qD
-qD
-Kt
-NZ
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+kl
+wy
 as
-as
-as
-eu
-OO
+dP
+nP
+QB
+nk
+Qu
+QB
+CS
+Wc
+ET
+lL
+Bp
+Ly
+CS
+Nz
+HE
+bS
+NL
+NL
+NL
 iR
 iR
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
 iR
 iR
-iR
-iR
-uQ
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-iR
-dC
-iR
-iR
-iR
-iR
-iR
-iR
-TD
-TD
-TD
 NL
 NL
 NL
 NL
 NL
-NL
-NL
-NL
-NL
+iR
+iR
+YJ
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+YJ
+iR
+iR
 NL
 NL
 NL
@@ -19797,31 +20418,46 @@ NL
 NL
 NL
 NL
-hU
-LX
-Pk
-LX
-Yn
-ta
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+dP
+la
 as
-Ko
-as
-as
-as
-as
+dP
+CI
 UZ
+dP
+CI
+Ke
 CS
 lL
+ta
+ta
 lL
-Wv
 lL
-lL
-lL
-ki
-An
-Gh
 CS
-CS
+bS
+bS
+bS
+NL
+NL
+NL
+NL
+iR
+iR
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+iR
+iR
 NL
 NL
 NL
@@ -19829,31 +20465,16 @@ NL
 NL
 NL
 NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
+iR
+iR
+YJ
+YJ
+Qm
+ED
+YJ
+YJ
+iR
+iR
 NL
 NL
 NL
@@ -19959,29 +20580,28 @@ NL
 NL
 NL
 NL
-hU
-Yn
-ta
-qD
-qD
-qD
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+Hc
+wy
 as
-Ko
-as
-as
-as
-as
-as
+dP
+Mo
+KR
+dP
+rO
+bw
 CS
 Hq
 VZ
-So
+YA
 lL
 lL
-IE
-CS
-BN
-CS
 CS
 NL
 NL
@@ -19991,6 +20611,14 @@ NL
 NL
 NL
 NL
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 NL
 NL
 NL
@@ -20000,21 +20628,14 @@ NL
 NL
 NL
 NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
-NL
+iR
+iR
+iR
+iR
+iR
+iR
+iR
+iR
 NL
 NL
 NL
@@ -20121,28 +20742,28 @@ NL
 NL
 NL
 NL
-hU
-qD
-qD
-qD
-qD
-qD
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+dP
+la
 as
-Ko
-as
-as
-as
-as
-as
-CS
-Wq
+dP
+Mo
+NW
+dP
+rO
 rK
-DX
-lL
-lL
-lL
 CS
-CS
+lL
+th
+So
+lL
+lL
 CS
 NL
 NL
@@ -20283,29 +20904,29 @@ NL
 NL
 NL
 NL
-Hc
-PO
-PD
-PD
-PD
-PD
-PD
-Jw
-Mo
-Mo
-Mo
-Mo
-Mo
-gm
-FQ
-th
-bP
-lL
-lL
-lL
-CS
-CS
 NL
+NL
+NL
+NL
+NL
+NL
+NL
+Hc
+KI
+as
+dP
+dP
+dP
+dP
+dP
+dP
+CS
+CS
+CS
+CS
+lL
+LW
+CS
 NL
 NL
 NL
@@ -20445,29 +21066,29 @@ NL
 NL
 NL
 NL
-hU
-Nv
-as
-as
-as
-as
-as
-HV
-as
-as
-as
-as
-as
-CS
-lX
-lL
-RQ
-lL
-lL
-lL
-CS
 NL
 NL
+NL
+NL
+NL
+NL
+NL
+dP
+dP
+dP
+dP
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+CS
+Hq
+lL
+CS
 NL
 NL
 NL
@@ -20607,29 +21228,29 @@ NL
 NL
 NL
 NL
-Hc
-Pf
-as
-as
-as
-as
-as
-YY
-Vd
-mN
-qi
-Fi
-Xb
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 CS
 lL
 lL
-OY
-vz
-vz
-tb
 CS
-NL
-NL
 NL
 NL
 NL
@@ -20769,29 +21390,29 @@ NL
 NL
 NL
 NL
-hU
-la
-as
-as
-as
-as
-as
-as
-as
-as
-as
-Ke
-aE
-CS
-Hq
-lL
-nF
-CS
-lL
-nF
-CS
 NL
 NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+CS
+lL
+lL
+CS
 NL
 NL
 NL
@@ -20931,29 +21552,29 @@ NL
 NL
 NL
 NL
-kl
-Pf
-as
-as
-as
-as
-as
-as
-as
-as
-as
-as
-UZ
-CS
-lL
-lL
-nF
-CS
-lL
-nF
-CS
 NL
 NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+CS
+lL
+lL
+CS
 NL
 NL
 NL
@@ -21093,29 +21714,29 @@ NL
 NL
 NL
 NL
-hU
-Nv
-as
-as
-as
-as
-as
-as
-as
-as
-as
-as
-as
-CS
-lL
-lL
-nF
-CS
-Hq
-Iv
-CS
 NL
 NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+CS
+lL
+gt
+rf
 NL
 NL
 NL
@@ -21255,29 +21876,29 @@ NL
 NL
 NL
 NL
-Hc
-Pf
-as
-as
-as
-as
-as
-as
-as
-cb
-as
-as
-hU
-CS
-kj
-kV
-aP
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 CS
 lL
-nF
-rf
-NL
-NL
+lL
+CS
 NL
 NL
 NL
@@ -21417,29 +22038,29 @@ NL
 NL
 NL
 NL
-hU
-la
-as
-as
-as
-as
-as
-cb
-as
-hU
-hU
-hU
-hU
-CS
-CS
-lY
-CS
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 CS
 lL
-nF
+lL
 CS
-NL
-NL
 NL
 NL
 NL
@@ -21579,16 +22200,18 @@ NL
 NL
 NL
 NL
-Hc
-KI
-as
-as
-cb
-as
-hU
-hU
-MT
-hU
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 NL
 NL
 NL
@@ -21598,13 +22221,11 @@ NL
 NL
 CS
 lL
-nF
+lL
 CS
-NL
-NL
-NL
-NL
-NL
+CS
+CS
+CS
 NL
 NL
 NL
@@ -21741,13 +22362,15 @@ NL
 NL
 NL
 NL
-hU
-as
-as
-hU
-hU
-hU
-hU
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 NL
 NL
 NL
@@ -21759,14 +22382,12 @@ NL
 NL
 NL
 CS
-lL
-nF
-CS
-CS
-CS
-CS
-NL
-NL
+dM
+vz
+SF
+zM
+sK
+dA
 NL
 NL
 NL
@@ -21903,10 +22524,12 @@ NL
 NL
 NL
 NL
-hU
-hU
-hU
-hU
+NL
+NL
+NL
+NL
+NL
+NL
 NL
 NL
 NL
@@ -21921,14 +22544,12 @@ NL
 NL
 NL
 CS
-Hq
-vl
-SF
-zM
-sK
-dA
-NL
-NL
+aP
+lL
+wJ
+Kd
+IH
+uu
 NL
 NL
 NL
@@ -22082,15 +22703,15 @@ NL
 NL
 NL
 NL
+NL
+NL
 CS
-lL
-lL
-wJ
-Kd
-IH
-uu
-NL
-NL
+CS
+CS
+CS
+CS
+CS
+CS
 NL
 NL
 NL
@@ -22244,13 +22865,13 @@ NL
 NL
 NL
 NL
-CS
-CS
-CS
-CS
-CS
-CS
-CS
+NL
+NL
+NL
+NL
+NL
+NL
+NL
 NL
 NL
 NL

--- a/maps/away/ships/konyang/water_barge/water_barge.dmm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dmm
@@ -27,15 +27,6 @@
 "as" = (
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
-"aG" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/water_barge/mainhallway)
 "aP" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
@@ -101,6 +92,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"bq" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/mainhallway)
 "bw" = (
 /obj/machinery/air_sensor{
 	frequency = 0989;
@@ -111,15 +111,6 @@
 	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/water_barge/fuelbay)
-"by" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
 "bF" = (
 /obj/effect/shuttle_landmark/water_barge/nav1,
 /turf/template_noop,
@@ -168,19 +159,6 @@
 /obj/effect/floor_decal/corner/yellow/full,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
-"ch" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "cj" = (
 /obj/structure/closet/walllocker/medical{
 	name = "Blood Locker";
@@ -367,6 +345,12 @@
 "dE" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/mainhallway)
+"dG" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "dM" = (
 /obj/machinery/light{
 	dir = 1
@@ -405,6 +389,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"ee" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "eg" = (
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 6
@@ -593,6 +584,11 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"fN" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/effect/decal/cleanable/flour,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "fO" = (
 /obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/plating,
@@ -859,6 +855,9 @@
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"if" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/thrust/port)
 "iy" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -933,10 +932,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
-"iT" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
 "iV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -1005,6 +1000,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"jw" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport)
 "jA" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1016,6 +1015,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"jC" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
 "jD" = (
 /obj/machinery/power/apc/north,
 /obj/structure/cable/green{
@@ -1153,6 +1157,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
+"kH" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "kM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -1208,6 +1221,10 @@
 /obj/effect/floor_decal/corner/brown,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"kY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "la" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
@@ -1252,6 +1269,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
+"lv" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "bar_shutter";
+	name = "Desk Shutters";
+	pixel_x = 20;
+	req_access = list(25);
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/office)
 "ly" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1371,14 +1405,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"mE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
 "mG" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
 "mM" = (
@@ -1401,6 +1432,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"mV" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "mY" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
@@ -1414,6 +1449,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/office)
+"nf" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "ng" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
@@ -1451,6 +1493,15 @@
 /obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
+"nn" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
 "np" = (
 /obj/machinery/telecomms/allinone/ship,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -1483,6 +1534,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
+"nB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
 "nF" = (
 /obj/machinery/atmospherics/pipe/tank{
 	dir = 1
@@ -1531,6 +1586,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
+"nW" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "nX" = (
 /obj/machinery/light{
 	dir = 1
@@ -1600,16 +1661,28 @@
 /area/shuttle/water_barge)
 "oC" = (
 /obj/structure/table/stone/marble,
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/vending/dinnerware{
+	pixel_y = 23
+	},
 /obj/machinery/reagentgrinder{
 	pixel_x = 4;
-	pixel_y = 16
+	pixel_y = 10
 	},
-/obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/water_barge/breakroom)
+"oF" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "oH" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -1635,11 +1708,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
-"oT" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/junk,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "oZ" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -1678,13 +1746,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
-"pD" = (
-/obj/random/contraband,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/dockingport)
 "pI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -1721,6 +1782,12 @@
 /obj/item/deck/cards,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"qe" = (
+/turf/simulated/wall/shuttle/space_ship{
+	can_open = 1;
+	color = "#DDDDD"
+	},
+/area/water_barge/breakroom)
 "qi" = (
 /obj/structure/reagent_dispensers/extinguisher,
 /obj/effect/floor_decal/corner/yellow{
@@ -1766,6 +1833,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
+"qS" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "qW" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1784,6 +1858,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
+"rb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "re" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -1969,13 +2047,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
-"ty" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
 "tz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -2199,6 +2270,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"vr" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "vu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
@@ -2247,10 +2327,6 @@
 /obj/random/contraband,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
-"wb" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "wc" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -2537,15 +2613,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
-"yH" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/mainhallway)
 "yI" = (
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
@@ -2585,19 +2652,6 @@
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/airless,
 /area/water_barge/helm)
-"zg" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
-"zr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "zy" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -2652,10 +2706,6 @@
 /obj/machinery/power/portgen,
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
-"Aq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "Ar" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/shipsensors,
@@ -2666,6 +2716,17 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"Av" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "Aw" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -2676,6 +2737,12 @@
 "AA" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/thrust)
+"AH" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "AN" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -2712,6 +2779,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"Bs" = (
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "Bv" = (
 /obj/structure/bed/roller,
 /obj/structure/curtain/open/medical,
@@ -2755,10 +2825,6 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"BT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
 "Cf" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
@@ -2819,10 +2885,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/dom,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"CA" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport)
 "CI" = (
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
 /turf/simulated/floor/plating,
@@ -3090,10 +3152,10 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"EQ" = (
+"EP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/water_barge/hangar)
+/area/water_barge/fuelbay)
 "ET" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3132,6 +3194,10 @@
 	dir = 4
 	},
 /area/water_barge/hangar)
+"FP" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "FR" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -3166,15 +3232,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
-"Gk" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "Gv" = (
 /obj/machinery/power/apc/high/west,
 /obj/structure/cable/green{
@@ -3222,6 +3279,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"GX" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
 "Hc" = (
 /obj/machinery/atmospherics/unary/engine,
 /obj/structure/window/borosilicate/reinforced,
@@ -3255,6 +3316,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
+"Ht" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "HB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3314,23 +3379,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
-"HW" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 10
+"HX" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 4;
-	id = "bar_shutter";
-	name = "Desk Shutters";
-	pixel_x = 20;
-	req_access = list(25);
-	pixel_y = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/office)
+/area/water_barge/cargo)
 "Id" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -3523,6 +3580,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
 /area/water_barge/engineering)
+"Ka" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "Kd" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
@@ -3634,10 +3697,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
-"KK" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "KN" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -3647,6 +3706,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"KO" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "KR" = (
 /obj/machinery/air_sensor{
 	frequency = 0989;
@@ -3698,6 +3770,10 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
+"Lg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
 "Lh" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -3721,13 +3797,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
-"Lo" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "Ly" = (
 /obj/structure/bed/stool/chair{
 	dir = 1
@@ -3744,11 +3813,6 @@
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"LM" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/mainhallway)
 "LP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
 /turf/simulated/floor/plating,
@@ -3794,10 +3858,6 @@
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"LY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/engineering)
 "Ma" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
@@ -3918,9 +3978,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"MX" = (
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "Nb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/bed/stool/chair,
@@ -3944,12 +4001,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
-"No" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "Nv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
@@ -4068,17 +4119,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
-"Ov" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "Ox" = (
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -4114,15 +4154,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
-"OR" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "OY" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -4251,15 +4282,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"PW" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "PY" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/reagent_dispensers/watertank,
@@ -4310,6 +4332,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
+"Qt" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "Qu" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 0989;
@@ -4412,10 +4440,6 @@
 /obj/effect/step_trigger/teleporter,
 /turf/space,
 /area/space)
-"Rj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
 "Rl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
@@ -4455,11 +4479,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/water_barge)
-"RE" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/effect/decal/cleanable/flour,
-/turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
 "RK" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -4630,12 +4649,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
-"SR" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
 "SU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
@@ -5082,12 +5095,6 @@
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
-"Wb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "Wc" = (
 /obj/machinery/power/apc/north,
 /obj/structure/cable/green{
@@ -5166,6 +5173,8 @@
 /area/water_barge/thrust/port)
 "Wv" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -5260,15 +5269,13 @@
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
-"Xm" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"Xk" = (
+/obj/random/contraband,
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/hangar)
+/area/water_barge/dockingport)
 "Xr" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/shutters/open{
@@ -5297,9 +5304,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"Xz" = (
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/thrust/port)
 "XA" = (
 /obj/machinery/light/spot{
 	dir = 8
@@ -5405,12 +5409,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
-"Ym" = (
-/turf/simulated/wall/shuttle/space_ship{
-	can_open = 1;
-	color = "#DDDDD"
-	},
-/area/water_barge/breakroom)
 "Yu" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -5433,6 +5431,11 @@
 /obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"YB" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "YJ" = (
 /turf/simulated/floor/beach/water/alt,
 /area/water_barge)
@@ -15241,7 +15244,7 @@ NL
 NL
 AA
 pM
-Rj
+nB
 MR
 PY
 Vh
@@ -15565,16 +15568,16 @@ NL
 NL
 AA
 pM
-iT
+GX
 MR
 HV
-oT
+YB
 TA
 JC
 Tj
 PG
 ar
-CA
+jw
 PG
 bf
 bf
@@ -16055,7 +16058,7 @@ HB
 fU
 ws
 EA
-PW
+HX
 EA
 iS
 PG
@@ -16378,7 +16381,7 @@ zY
 Hr
 MR
 HU
-Aq
+Ht
 vI
 aq
 Up
@@ -16390,7 +16393,7 @@ bf
 pU
 PG
 GE
-pD
+Xk
 PG
 PG
 iR
@@ -16541,7 +16544,7 @@ AA
 MR
 Og
 oZ
-Gk
+kH
 oZ
 vp
 PG
@@ -16714,7 +16717,7 @@ xW
 Iw
 Iw
 Iw
-Ym
+qe
 Iw
 iR
 Yy
@@ -17198,7 +17201,7 @@ PI
 LC
 xW
 QM
-RE
+fN
 KD
 ks
 Il
@@ -17354,7 +17357,7 @@ xW
 xW
 NQ
 hV
-LY
+Lg
 zb
 af
 Ks
@@ -18013,39 +18016,39 @@ xs
 xs
 dq
 dE
-Lo
+mG
 dp
 TK
 Yy
-zg
+nf
 Yy
 Yy
 Fh
 sT
-zg
+nf
 Yy
 Yy
-zg
+nf
 Yy
 Yy
 Cg
 Yy
 pc
-zg
+nf
 Yy
 Yy
-zg
+nf
 Yy
 Yy
 hG
 hU
 Yy
 Yy
-zg
+nf
 Yy
 TK
 dp
-mG
+AH
 JQ
 Kr
 Jm
@@ -18155,12 +18158,12 @@ UD
 Vg
 kF
 UY
-Xm
+oF
 jL
 nl
-aG
-aG
-aG
+nn
+nn
+nn
 AN
 fB
 Bo
@@ -18171,20 +18174,20 @@ GG
 Ex
 jc
 Rp
-yH
+bq
 PA
 uv
 re
 Um
-OR
+vr
 Zn
 Um
 Um
 Um
-ch
+KO
 qm
 dl
-OR
+vr
 Um
 Um
 Um
@@ -18193,7 +18196,7 @@ Um
 dl
 Um
 nV
-Ov
+Av
 Um
 Um
 Um
@@ -18322,7 +18325,7 @@ KS
 rW
 Lf
 Lf
-LM
+jC
 MJ
 qW
 Vr
@@ -18341,35 +18344,35 @@ Ok
 dp
 TK
 Yy
-ty
+qS
 He
 Dc
 hU
 sT
-ty
+qS
 Yy
 Yy
-ty
+qS
 Yy
 Yy
 qZ
 Yy
 Yh
-ty
+qS
 Yy
 Yy
-ty
+qS
 Yy
 Yy
 hG
 Fh
 Yy
 Yy
-ty
+qS
 Yy
 TK
 dp
-No
+dG
 JQ
 IM
 Jm
@@ -18479,7 +18482,7 @@ BL
 BL
 BL
 Rt
-EQ
+rb
 bn
 dE
 lU
@@ -18970,7 +18973,7 @@ gG
 oa
 Ws
 cI
-mE
+kY
 cI
 cI
 yz
@@ -19775,10 +19778,10 @@ NL
 NL
 NL
 NL
-Xz
-Xz
-Xz
-Xz
+if
+if
+if
+if
 eQ
 eQ
 Jc
@@ -19786,7 +19789,7 @@ mn
 wn
 CS
 Ja
-Wv
+ee
 kj
 kV
 iV
@@ -19940,7 +19943,7 @@ NL
 Hc
 PO
 Gv
-Xz
+if
 vu
 LP
 KI
@@ -19997,7 +20000,7 @@ zF
 oQ
 ZI
 kX
-HW
+lv
 nd
 NL
 NL
@@ -20099,18 +20102,18 @@ NL
 NL
 NL
 NL
-Xz
+if
 Nv
 PD
 Se
 fR
 wy
 Lb
-BT
+EP
 Ed
 CS
 Ja
-by
+Wv
 lL
 lL
 Em
@@ -20423,10 +20426,10 @@ NL
 NL
 NL
 NL
-Xz
+if
 la
-Wb
-Xz
+Qt
+if
 jD
 sc
 gC
@@ -20434,7 +20437,7 @@ as
 Ed
 CS
 lX
-SR
+nW
 lL
 kM
 eW
@@ -20586,9 +20589,9 @@ NL
 NL
 NL
 kl
-KK
-MX
-Xz
+mV
+Bs
+if
 nP
 QB
 nk
@@ -20747,10 +20750,10 @@ NL
 NL
 NL
 NL
-Xz
+if
 la
-wb
-Xz
+FP
+if
 CI
 UZ
 dP
@@ -20910,9 +20913,9 @@ NL
 NL
 NL
 Hc
-KK
-MX
-Xz
+mV
+Bs
+if
 Mo
 KR
 dP
@@ -21071,10 +21074,10 @@ NL
 NL
 NL
 NL
-Xz
+if
 la
-MX
-Xz
+Bs
+if
 Mo
 NW
 dP
@@ -21234,9 +21237,9 @@ NL
 NL
 NL
 Hc
-zr
-MX
-Xz
+Ka
+Bs
+if
 dP
 dP
 dP
@@ -21395,10 +21398,10 @@ NL
 NL
 NL
 NL
-Xz
-Xz
-Xz
-Xz
+if
+if
+if
+if
 NL
 NL
 NL

--- a/maps/away/ships/konyang/water_barge/water_barge.dmm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dmm
@@ -27,6 +27,18 @@
 "as" = (
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
+"aF" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
+"aG" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
 "aP" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
@@ -78,6 +90,14 @@
 "bf" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"bj" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "bl" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/railing/mapped,
@@ -102,16 +122,10 @@
 	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/water_barge/fuelbay)
-"by" = (
-/obj/effect/decal/cleanable/dirt,
+"bz" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /turf/simulated/floor/plating,
-/area/water_barge/thrust)
-"bE" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
+/area/water_barge/thrust/port)
 "bF" = (
 /obj/effect/shuttle_landmark/water_barge/nav1,
 /turf/template_noop,
@@ -196,12 +210,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/office)
-"cz" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
 "cA" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -403,6 +411,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"es" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/effect/decal/cleanable/flour,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "et" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -552,6 +565,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"fm" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/mainhallway)
 "fB" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -685,10 +707,6 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
-"gI" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
 "gK" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -712,6 +730,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/breakroom)
+"gS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "hg" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -725,12 +750,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
-"hh" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "hl" = (
 /obj/effect/shuttle_landmark/water_barge_shuttle/transit,
 /turf/space,
@@ -849,6 +868,15 @@
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"ij" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "iy" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -1123,12 +1151,6 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"kD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "kF" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -1244,10 +1266,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
-"lt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/engineering)
 "ly" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1272,10 +1290,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"lE" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport)
 "lH" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
@@ -1284,6 +1298,10 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
+"lI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
 "lJ" = (
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 5
@@ -1372,10 +1390,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
 "mG" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
 "mM" = (
@@ -1398,6 +1415,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"mV" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "mY" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
@@ -1460,6 +1484,12 @@
 /obj/machinery/light/small/built,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"ny" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "nz" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -1501,15 +1531,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
-"nQ" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "nS" = (
 /obj/item/reagent_containers/cooking_container/board,
 /obj/structure/table/stone/marble,
@@ -1591,10 +1612,6 @@
 /obj/machinery/computer/ship/helm,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"oA" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "oC" = (
 /obj/structure/table/stone/marble,
 /obj/machinery/reagentgrinder{
@@ -1738,6 +1755,10 @@
 /obj/random/colored_jumpsuit,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"qK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "qQ" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1751,6 +1772,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
+"qU" = (
+/turf/simulated/wall/shuttle/space_ship{
+	can_open = 1;
+	color = "#DDDDD"
+	},
+/area/water_barge/breakroom)
 "qW" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1847,6 +1874,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"rA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
 "rB" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -1883,9 +1914,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
-"sg" = (
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/thrust/port)
 "su" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
@@ -1931,34 +1959,10 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
-"tb" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "tc" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"tf" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "th" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
@@ -2025,19 +2029,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"tQ" = (
+"tX" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
-"tU" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/mainhallway)
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
 "ua" = (
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 1
@@ -2058,19 +2053,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
-"ud" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/hangar)
-"uf" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "uk" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light,
@@ -2119,6 +2101,13 @@
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"uz" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "uF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2181,13 +2170,6 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"vh" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
 "vl" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 2;
@@ -2285,6 +2267,19 @@
 /obj/random/contraband,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
+"wb" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "wc" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -2302,10 +2297,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"wd" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "we" = (
 /obj/effect/shuttle_landmark/water_barge/nav4,
 /turf/template_noop,
@@ -2597,6 +2588,15 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"yV" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "za" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/glass/reinforced/full,
@@ -2655,9 +2655,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
-"zR" = (
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "zY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
@@ -2691,6 +2688,15 @@
 "AA" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/thrust)
+"AM" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "AN" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -2703,6 +2709,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
+"AS" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "AT" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot,
 /turf/simulated/floor/tiled/dark,
@@ -2763,6 +2773,15 @@
 "BL" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/water_barge)
+"BP" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
 "BS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2889,10 +2908,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/breakroom)
-"Dq" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
 "Dr" = (
 /obj/effect/floor_decal/corner_wide/dark_green/full{
 	dir = 4
@@ -2941,15 +2956,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
-"DG" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/water_barge/mainhallway)
 "DI" = (
 /obj/machinery/light{
 	dir = 4
@@ -2969,6 +2975,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
+"DM" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "DN" = (
 /obj/machinery/computer/ship/engines{
 	dir = 4
@@ -3707,12 +3717,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
-"Lw" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "Ly" = (
 /obj/structure/bed/stool/chair{
 	dir = 1
@@ -3804,21 +3808,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"Mf" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/hangar)
 "Mi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"Mk" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "Mm" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -3926,6 +3926,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
+"Ns" = (
+/obj/random/contraband,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport)
+"Nu" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
 "Nv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
@@ -3995,13 +4006,6 @@
 /obj/item/clothing/glasses/safety/goggles,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"NR" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
 "NS" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/warning/full,
@@ -4124,6 +4128,12 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/water_barge/thrust/port)
+"Pi" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "Pm" = (
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
@@ -4275,12 +4285,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
-"Qv" = (
-/turf/simulated/wall/shuttle/space_ship{
-	can_open = 1;
-	color = "#DDDDD"
-	},
-/area/water_barge/breakroom)
 "Qy" = (
 /obj/structure/closet/secure_closet/engineering_electrical{
 	req_access = null
@@ -4372,11 +4376,6 @@
 /obj/effect/step_trigger/teleporter,
 /turf/space,
 /area/space)
-"Rk" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/mainhallway)
 "Rl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
@@ -4577,15 +4576,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"SM" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "SO" = (
 /obj/machinery/light{
 	dir = 8
@@ -4651,10 +4641,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
-"To" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "Tr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -4669,13 +4655,9 @@
 "TD" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/office)
-"TE" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
+"TF" = (
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "TG" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -4715,6 +4697,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
+"TX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "Ua" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4742,10 +4728,13 @@
 /area/water_barge/office)
 "Um" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
 "Up" = (
@@ -5015,6 +5004,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"VU" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/thrust/port)
 "VV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -5137,11 +5129,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
-"Wx" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/effect/decal/cleanable/flour,
-/turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
 "Wz" = (
 /obj/machinery/computer/ship/engines{
 	dir = 8
@@ -5335,6 +5322,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
+"Yc" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "Yf" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -5371,6 +5367,12 @@
 /obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"Yx" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "Yy" = (
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
@@ -5416,11 +5418,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
+"YR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "YZ" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/junk,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
+/area/water_barge/dockingport)
 "Zl" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/hangar)
@@ -15189,7 +15196,7 @@ NL
 NL
 AA
 pM
-by
+tX
 MR
 PY
 Vh
@@ -15513,16 +15520,16 @@ NL
 NL
 AA
 pM
-gI
+Nu
 MR
 HV
-YZ
+Mk
 TA
 JC
 Tj
 PG
 ar
-lE
+YZ
 PG
 bf
 bf
@@ -16003,7 +16010,7 @@ HB
 fU
 ws
 EA
-SM
+Yc
 EA
 iS
 PG
@@ -16326,7 +16333,7 @@ zY
 Hr
 MR
 HU
-oA
+qK
 vI
 aq
 Up
@@ -16338,7 +16345,7 @@ bf
 pU
 PG
 GE
-vZ
+Ns
 PG
 PG
 iR
@@ -16489,7 +16496,7 @@ AA
 MR
 Og
 oZ
-nQ
+yV
 oZ
 vp
 PG
@@ -16662,7 +16669,7 @@ xW
 Iw
 Iw
 Iw
-Qv
+qU
 Iw
 iR
 Yy
@@ -17146,7 +17153,7 @@ PI
 LC
 xW
 QM
-Wx
+es
 KD
 ks
 Il
@@ -17302,7 +17309,7 @@ xW
 xW
 NQ
 hV
-lt
+rA
 zb
 af
 Ks
@@ -17961,39 +17968,39 @@ xs
 xs
 dq
 dE
-mG
+gS
 dp
 TK
 Yy
-NR
+aF
 Yy
 Yy
 Fh
 sT
-NR
+aF
 Yy
 Yy
-NR
+aF
 Yy
 Yy
 Cg
 Yy
 pc
-NR
+aF
 Yy
 Yy
-NR
+aF
 Yy
 Yy
 hG
 hU
 Yy
 Yy
-NR
+aF
 Yy
 TK
 dp
-Lw
+mG
 JQ
 Kr
 Jm
@@ -18103,12 +18110,12 @@ UD
 Vg
 kF
 UY
-Mf
+ij
 jL
 nl
-DG
-DG
-DG
+BP
+BP
+BP
 AN
 fB
 Bo
@@ -18119,43 +18126,43 @@ GG
 Ex
 jc
 Rp
-tU
+fm
 PA
 uv
 re
-Um
-uf
+bj
+AM
 Zn
-Um
-Um
-Um
-tb
+bj
+bj
+bj
+wb
 qm
 dl
-uf
-Um
-Um
-Um
-Um
-Um
+AM
+bj
+bj
+bj
+bj
+bj
 dl
-Um
-nV
-tf
-Um
-Um
-Um
-Um
-Um
-dl
+bj
 nV
 Um
-Um
-Um
-Um
+bj
+bj
+bj
+bj
+bj
+dl
+nV
+bj
+bj
+bj
+bj
 Zn
-Um
-Um
+bj
+bj
 me
 Vs
 Gw
@@ -18270,7 +18277,7 @@ KS
 rW
 Lf
 Lf
-Rk
+aG
 MJ
 qW
 Vr
@@ -18285,35 +18292,35 @@ SI
 By
 cS
 dE
-bE
+ny
 dp
 TK
 Yy
-vh
+mV
 He
 Dc
 hU
 sT
-vh
+mV
 Yy
 Yy
-vh
+mV
 Yy
 Yy
 qZ
 Yy
 Yh
-vh
+mV
 Yy
 Yy
-vh
+mV
 Yy
 Yy
 hG
 Fh
 Yy
 Yy
-vh
+mV
 Yy
 TK
 dp
@@ -18427,7 +18434,7 @@ BL
 BL
 BL
 Rt
-ud
+TX
 bn
 dE
 lU
@@ -18918,7 +18925,7 @@ gG
 oa
 Ws
 cI
-tQ
+DM
 cI
 cI
 yz
@@ -19723,10 +19730,10 @@ NL
 NL
 NL
 NL
-sg
-sg
-sg
-sg
+VU
+VU
+VU
+VU
 eQ
 eQ
 Jc
@@ -19734,7 +19741,7 @@ mn
 wn
 CS
 Ja
-TE
+uz
 kj
 kV
 iV
@@ -19888,7 +19895,7 @@ NL
 Hc
 PO
 Gv
-sg
+VU
 vu
 LP
 KI
@@ -20047,14 +20054,14 @@ NL
 NL
 NL
 NL
-sg
+VU
 Nv
 PD
 Se
 fR
 wy
 Lb
-Dq
+lI
 Ed
 CS
 Ja
@@ -20371,10 +20378,10 @@ NL
 NL
 NL
 NL
-sg
+VU
 la
-hh
-sg
+Yx
+VU
 jD
 sc
 gC
@@ -20382,7 +20389,7 @@ as
 Ed
 CS
 lX
-cz
+Pi
 lL
 kM
 eW
@@ -20534,9 +20541,9 @@ NL
 NL
 NL
 kl
-wd
-zR
-sg
+bz
+TF
+VU
 nP
 QB
 nk
@@ -20695,10 +20702,10 @@ NL
 NL
 NL
 NL
-sg
+VU
 la
-To
-sg
+AS
+VU
 CI
 UZ
 dP
@@ -20858,9 +20865,9 @@ NL
 NL
 NL
 Hc
-wd
-zR
-sg
+bz
+TF
+VU
 Mo
 KR
 dP
@@ -21019,10 +21026,10 @@ NL
 NL
 NL
 NL
-sg
+VU
 la
-zR
-sg
+TF
+VU
 Mo
 NW
 dP
@@ -21182,9 +21189,9 @@ NL
 NL
 NL
 Hc
-kD
-zR
-sg
+YR
+TF
+VU
 dP
 dP
 dP
@@ -21343,10 +21350,10 @@ NL
 NL
 NL
 NL
-sg
-sg
-sg
-sg
+VU
+VU
+VU
+VU
 NL
 NL
 NL

--- a/maps/away/ships/konyang/water_barge/water_barge.dmm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dmm
@@ -74,6 +74,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
+/obj/machinery/alarm/east,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
 "bf" = (
@@ -545,8 +546,6 @@
 "fB" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1012,6 +1011,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
+"jS" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "jT" = (
 /obj/machinery/light/small/built{
 	dir = 1;
@@ -1356,7 +1361,7 @@
 	},
 /obj/machinery/power/apc/east,
 /obj/structure/cable/green{
-	dir = 4
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
@@ -1629,6 +1634,21 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
+"pJ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "pM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
@@ -1937,12 +1957,6 @@
 /obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"tJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "tK" = (
 /obj/machinery/light{
 	dir = 8
@@ -1962,6 +1976,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"tP" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
 "ua" = (
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 1
@@ -2046,12 +2069,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
-"uI" = (
-/turf/simulated/wall/shuttle/space_ship{
-	can_open = 1;
-	color = "#DDDDD"
-	},
-/area/water_barge/breakroom)
 "uW" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -2518,12 +2535,6 @@
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/airless,
 /area/water_barge/helm)
-"zn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "zy" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -2598,8 +2609,6 @@
 "AN" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2613,11 +2622,12 @@
 /obj/structure/bed/stool/chair/office/bridge/pilot,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"AX" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/thrust/port)
 "Bo" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2780,6 +2790,9 @@
 "Dc" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/power/apc/super/east,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/water_barge)
 "Df" = (
@@ -2799,10 +2812,7 @@
 /obj/effect/floor_decal/corner_wide/dark_green/full{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2";
-	dir = 1
-	},
+/obj/structure/cable/green,
 /obj/machinery/power/apc,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -3126,6 +3136,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
+"GK" = (
+/turf/simulated/wall/shuttle/space_ship{
+	can_open = 1;
+	color = "#DDDDD"
+	},
+/area/water_barge/breakroom)
 "GS" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -3228,10 +3244,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
-"HW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "Id" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -3239,9 +3251,6 @@
 /obj/machinery/alarm/east,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
-"Ii" = (
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "Il" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -3249,6 +3258,9 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/breakroom)
+"Is" = (
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "It" = (
 /obj/effect/floor_decal/corner/yellow/full{
 	dir = 8
@@ -3720,9 +3732,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"Ml" = (
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/thrust/port)
 "Mm" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -4166,7 +4175,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
 "Qu" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
@@ -4330,7 +4339,7 @@
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 2
 	},
-/turf/space,
+/turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
 "RX" = (
 /turf/simulated/floor/tiled/dark,
@@ -4351,6 +4360,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"Sa" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "Sb" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
@@ -4572,6 +4585,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/alarm/east,
 /turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
 "TK" = (
@@ -4593,8 +4607,6 @@
 /area/water_barge)
 "Ua" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -4602,8 +4614,6 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
@@ -5250,6 +5260,12 @@
 /obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"Yw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "Yy" = (
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
@@ -16539,7 +16555,7 @@ xW
 Iw
 Iw
 Iw
-uI
+GK
 Iw
 iR
 Yy
@@ -17983,9 +17999,9 @@ UY
 dO
 jL
 nl
-GG
-GG
-GG
+tP
+tP
+tP
 AN
 fB
 Bo
@@ -18006,7 +18022,7 @@ Zn
 Um
 Um
 Um
-Um
+pJ
 qm
 dl
 Um
@@ -19600,10 +19616,10 @@ NL
 NL
 NL
 NL
-Ml
-Ml
-Ml
-Ml
+AX
+AX
+AX
+AX
 eQ
 eQ
 Jc
@@ -19765,7 +19781,7 @@ NL
 Hc
 PO
 Gv
-Ml
+AX
 vu
 LP
 KI
@@ -19924,7 +19940,7 @@ NL
 NL
 NL
 NL
-Ml
+AX
 Nv
 PD
 Se
@@ -20248,10 +20264,10 @@ NL
 NL
 NL
 NL
-Ml
+AX
 la
-zn
-Ml
+jS
+AX
 jD
 sc
 gC
@@ -20411,9 +20427,9 @@ NL
 NL
 NL
 kl
-HW
-Ii
-Ml
+Sa
+Is
+AX
 nP
 QB
 nk
@@ -20572,10 +20588,10 @@ NL
 NL
 NL
 NL
-Ml
+AX
 la
-Ii
-Ml
+Is
+AX
 CI
 UZ
 dP
@@ -20735,9 +20751,9 @@ NL
 NL
 NL
 Hc
-HW
-Ii
-Ml
+Sa
+Is
+AX
 Mo
 KR
 dP
@@ -20896,10 +20912,10 @@ NL
 NL
 NL
 NL
-Ml
+AX
 la
-Ii
-Ml
+Is
+AX
 Mo
 NW
 dP
@@ -21059,9 +21075,9 @@ NL
 NL
 NL
 Hc
-tJ
-Ii
-Ml
+Yw
+Is
+AX
 dP
 dP
 dP
@@ -21220,10 +21236,10 @@ NL
 NL
 NL
 NL
-Ml
-Ml
-Ml
-Ml
+AX
+AX
+AX
+AX
 NL
 NL
 NL

--- a/maps/away/ships/konyang/water_barge/water_barge.dmm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dmm
@@ -12,6 +12,12 @@
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"ak" = (
+/turf/simulated/wall/shuttle/space_ship{
+	can_open = 1;
+	color = "#DDDDD"
+	},
+/area/water_barge/breakroom)
 "aq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -44,12 +50,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
-"aR" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "aS" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -158,6 +158,12 @@
 /obj/effect/floor_decal/corner/yellow/full,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
+"ci" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "cj" = (
 /obj/structure/closet/walllocker/medical{
 	name = "Blood Locker";
@@ -249,6 +255,7 @@
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
 "dd" = (
@@ -263,6 +270,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"df" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/effect/decal/cleanable/flour,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "di" = (
 /obj/effect/floor_decal/corner_wide/blue/diagonal,
 /obj/machinery/power/apc/low,
@@ -545,6 +557,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"ft" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "fB" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -570,6 +586,12 @@
 /obj/structure/plasticflaps/airtight,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"fQ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "fR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
@@ -717,15 +739,6 @@
 /obj/effect/shuttle_landmark/water_barge_shuttle/transit,
 /turf/space,
 /area/space)
-"hs" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "hv" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/condiment/flour,
@@ -998,14 +1011,9 @@
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
-"jE" = (
-/turf/simulated/wall/shuttle/space_ship{
-	can_open = 1;
-	color = "#DDDDD"
-	},
-/area/water_barge/breakroom)
 "jL" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -1041,12 +1049,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/water_barge)
-"jX" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "kc" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -1141,6 +1143,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
+"kK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
 "kM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -1219,9 +1225,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"lc" = (
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/thrust/port)
 "lj" = (
 /obj/machinery/door/window{
 	dir = 4
@@ -1264,6 +1267,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
 "lH" = (
@@ -1278,6 +1282,7 @@
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
 "lK" = (
@@ -1296,6 +1301,7 @@
 /obj/effect/floor_decal/corner/yellow/full{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
 "lX" = (
@@ -1327,9 +1333,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/dockingport)
-"ml" = (
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "mm" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -1363,18 +1366,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
 "mG" = (
-/obj/machinery/light/small/built{
-	dir = 8;
-	pixel_x = -13
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge)
-"mL" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
 /area/water_barge)
 "mM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -1400,10 +1395,18 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"na" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport)
 "nd" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
 /area/water_barge/office)
+"nf" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "ng" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
@@ -1441,6 +1444,13 @@
 /obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
+"no" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "np" = (
 /obj/machinery/telecomms/allinone/ship,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -1528,6 +1538,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
 "oa" = (
@@ -1740,6 +1751,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
 "qZ" = (
@@ -1797,6 +1809,17 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
+"rq" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
+"rs" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "rw" = (
 /obj/effect/landmark/entry_point/port{
 	name = "starboard"
@@ -1866,6 +1889,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
+"sh" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
+"sr" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "su" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
@@ -1975,6 +2016,15 @@
 /obj/structure/bookcase/libraryspawn/fiction,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"tN" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
 "tO" = (
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 8
@@ -2041,6 +2091,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
 "uy" = (
@@ -2254,6 +2305,10 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/hydrogen,
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
+"wo" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
 "ws" = (
@@ -2577,6 +2632,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
 	},
+/obj/machinery/alarm/east,
+/obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
 "An" = (
@@ -2682,19 +2739,6 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"Ce" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "Cf" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
@@ -3026,14 +3070,6 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"EP" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "ET" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3124,6 +3160,7 @@
 "GE" = (
 /obj/item/ipc_overloader/tranquil,
 /obj/random/contraband,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
 "GF" = (
@@ -3244,6 +3281,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
+"Ia" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "Id" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -3273,10 +3314,6 @@
 "Iw" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/breakroom)
-"IA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "IE" = (
 /obj/machinery/light{
 	dir = 8
@@ -3522,6 +3559,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
 "KC" = (
@@ -3924,12 +3962,6 @@
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/water_barge/fuelbay)
-"Oc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "Og" = (
 /obj/effect/floor_decal/corner_wide/brown/full{
 	dir = 1
@@ -3944,11 +3976,17 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/office)
 "Ok" = (
-/obj/machinery/light/small/built{
-	dir = 4;
-	pixel_x = 14
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
+/area/water_barge)
+"Om" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/water_barge)
 "Ou" = (
 /obj/effect/floor_decal/corner/dark_green{
@@ -3969,6 +4007,27 @@
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
+"OE" = (
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
+"OG" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
+"OH" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/mainhallway)
 "OM" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
@@ -4002,6 +4061,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"OS" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "OY" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -4056,12 +4126,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"Pz" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "PA" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4102,6 +4166,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
 	},
+/obj/machinery/alarm/west,
 /turf/simulated/floor/plating,
 /area/water_barge/thrust/port)
 "PS" = (
@@ -4155,12 +4220,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
 "Ql" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "Qm" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/railing/mapped{
@@ -4331,15 +4394,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/water_barge)
-"Ry" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/water_barge/mainhallway)
 "RK" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -4359,6 +4413,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
+"RS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
 "RX" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
@@ -4495,6 +4553,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
+"SJ" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
 "SL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -4646,8 +4708,6 @@
 /area/water_barge/office)
 "Um" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4854,6 +4914,15 @@
 /obj/structure/closet/crate/loot,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
+"Vk" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "Vr" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4889,6 +4958,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"Vx" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "VF" = (
 /turf/unsimulated/wall/fakepdoor{
 	dir = 4
@@ -4985,6 +5063,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
+"Wn" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "Wq" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -5141,6 +5225,15 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge)
+"Xt" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "Xv" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
@@ -5175,6 +5268,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
+"XE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "XI" = (
 /obj/structure/table/standard,
 /obj/item/paper_scanner,
@@ -5259,6 +5356,9 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"Yq" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/thrust/port)
 "Yu" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -5458,6 +5558,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
 "ZV" = (
@@ -15083,7 +15184,7 @@ NL
 NL
 AA
 pM
-Pm
+RS
 MR
 PY
 Vh
@@ -15407,16 +15508,16 @@ NL
 NL
 AA
 pM
-Pm
+SJ
 MR
 HV
-xb
+Ql
 TA
 JC
 Tj
 PG
 ar
-bf
+na
 PG
 bf
 bf
@@ -15897,7 +15998,7 @@ HB
 fU
 ws
 EA
-EA
+Vk
 EA
 iS
 PG
@@ -16220,7 +16321,7 @@ zY
 Hr
 MR
 HU
-vI
+XE
 vI
 aq
 Up
@@ -16383,7 +16484,7 @@ AA
 MR
 Og
 oZ
-hs
+Xt
 oZ
 vp
 PG
@@ -16556,7 +16657,7 @@ xW
 Iw
 Iw
 Iw
-jE
+ak
 Iw
 iR
 Yy
@@ -17040,7 +17141,7 @@ PI
 LC
 xW
 QM
-mm
+df
 KD
 ks
 Il
@@ -17196,7 +17297,7 @@ xW
 xW
 NQ
 hV
-zb
+kK
 zb
 af
 Ks
@@ -17855,35 +17956,35 @@ xs
 xs
 dq
 dE
-Pz
+no
 dp
 TK
 Yy
-Ql
+Om
 Yy
 Yy
 Fh
 sT
-Ql
+Om
 Yy
 Yy
-Ql
+Om
 Yy
 Yy
 Cg
 Yy
 pc
-Ql
+Om
 Yy
 Yy
-Ql
+Om
 Yy
 Yy
 hG
 hU
 Yy
 Yy
-Gi
+Om
 Yy
 TK
 dp
@@ -18000,9 +18101,9 @@ UY
 dO
 jL
 nl
-Ry
-Ry
-Ry
+tN
+tN
+tN
 AN
 fB
 Bo
@@ -18013,43 +18114,43 @@ GG
 Ex
 jc
 Rp
-PA
+OH
 PA
 uv
 re
-EP
-EP
+Um
+Vx
 Zn
-EP
-EP
-EP
-Ce
+Um
+Um
+Um
+sr
 qm
 dl
-EP
-EP
-EP
-EP
-EP
-EP
+Vx
+Um
+Um
+Um
+Um
+Um
 dl
-EP
+Um
+nV
+OS
+Um
+Um
+Um
+Um
+Um
+dl
 nV
 Um
-EP
-EP
-EP
-EP
-EP
-dl
-nV
-EP
-EP
-EP
-EP
+Um
+Um
+Um
 Zn
-EP
-EP
+Um
+Um
 me
 Vs
 Gw
@@ -18164,7 +18265,7 @@ KS
 rW
 Lf
 Lf
-Lf
+sh
 MJ
 qW
 Vr
@@ -18179,35 +18280,35 @@ SI
 By
 cS
 dE
-aR
+Wn
 dp
 TK
 Yy
-mL
+rq
 He
 Dc
 hU
 sT
-mL
+rq
 Yy
 Yy
-mL
+rq
 Yy
 Yy
 qZ
 Yy
 Yh
-mL
+rq
 Yy
 Yy
-mL
+rq
 Yy
 Yy
 hG
 Fh
 Yy
 Yy
-kP
+rq
 Yy
 TK
 dp
@@ -18321,7 +18422,7 @@ BL
 BL
 BL
 Rt
-pk
+Ia
 bn
 dE
 lU
@@ -18812,7 +18913,7 @@ gG
 oa
 Ws
 cI
-cI
+rs
 cI
 cI
 yz
@@ -19617,10 +19718,10 @@ NL
 NL
 NL
 NL
-lc
-lc
-lc
-lc
+Yq
+Yq
+Yq
+Yq
 eQ
 eQ
 Jc
@@ -19628,7 +19729,7 @@ mn
 wn
 CS
 Ja
-Wv
+OG
 kj
 kV
 iV
@@ -19782,7 +19883,7 @@ NL
 Hc
 PO
 Gv
-lc
+Yq
 vu
 LP
 KI
@@ -19941,18 +20042,18 @@ NL
 NL
 NL
 NL
-lc
+Yq
 Nv
 PD
 Se
 fR
 wy
 Lb
-as
+wo
 Ed
 CS
 Ja
-Wv
+OG
 lL
 lL
 Em
@@ -20265,10 +20366,10 @@ NL
 NL
 NL
 NL
-lc
+Yq
 la
-jX
-lc
+fQ
+Yq
 jD
 sc
 gC
@@ -20428,9 +20529,9 @@ NL
 NL
 NL
 kl
-IA
-ml
-lc
+nf
+OE
+Yq
 nP
 QB
 nk
@@ -20589,10 +20690,10 @@ NL
 NL
 NL
 NL
-lc
+Yq
 la
-ml
-lc
+ft
+Yq
 CI
 UZ
 dP
@@ -20752,9 +20853,9 @@ NL
 NL
 NL
 Hc
-IA
-ml
-lc
+nf
+OE
+Yq
 Mo
 KR
 dP
@@ -20913,10 +21014,10 @@ NL
 NL
 NL
 NL
-lc
+Yq
 la
-ml
-lc
+OE
+Yq
 Mo
 NW
 dP
@@ -21076,9 +21177,9 @@ NL
 NL
 NL
 Hc
-Oc
-ml
-lc
+ci
+OE
+Yq
 dP
 dP
 dP
@@ -21237,10 +21338,10 @@ NL
 NL
 NL
 NL
-lc
-lc
-lc
-lc
+Yq
+Yq
+Yq
+Yq
 NL
 NL
 NL

--- a/maps/away/ships/konyang/water_barge/water_barge.dmm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dmm
@@ -704,6 +704,10 @@
 /obj/effect/shuttle_landmark/water_barge_shuttle/transit,
 /turf/space,
 /area/space)
+"hq" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "hv" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/condiment/flour,
@@ -1049,7 +1053,7 @@
 	name = "aft, port thruster"
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/thrust/port)
 "kn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -1107,6 +1111,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
+"kG" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "kM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -1170,7 +1180,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/thrust/port)
 "lb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1897,6 +1907,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"tB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "tC" = (
 /obj/structure/table/standard,
 /obj/item/roller,
@@ -1955,6 +1971,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
+"uh" = (
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "uk" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light,
@@ -3044,7 +3063,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/thrust/port)
 "Gw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3091,7 +3110,7 @@
 /obj/structure/window/borosilicate/reinforced,
 /obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/thrust/port)
 "He" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/alarm/east,
@@ -3779,7 +3798,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/thrust/port)
 "Nz" = (
 /obj/machinery/light/small/built{
 	dir = 4;
@@ -3966,7 +3985,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/thrust/port)
 "Pm" = (
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
@@ -3999,7 +4018,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/thrust/port)
 "PG" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/dockingport)
@@ -4026,7 +4045,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/thrust/port)
 "PS" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -4308,14 +4327,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/thrust/port)
 "Se" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/door/airlock/multi_tile{
 	name = "Fuel Bay"
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/thrust/port)
 "Sg" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -4396,6 +4415,9 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
+"SH" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/thrust/port)
 "SI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -4938,7 +4960,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
+/area/water_barge/thrust/port)
 "Wv" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19524,10 +19546,10 @@ NL
 NL
 NL
 NL
-dP
-dP
-dP
-dP
+SH
+SH
+SH
+SH
 eQ
 eQ
 Jc
@@ -19689,7 +19711,7 @@ NL
 Hc
 PO
 Gv
-dP
+SH
 vu
 LP
 KI
@@ -19848,7 +19870,7 @@ NL
 NL
 NL
 NL
-dP
+SH
 Nv
 PD
 Se
@@ -20172,10 +20194,10 @@ NL
 NL
 NL
 NL
-dP
+SH
 la
-gC
-dP
+kG
+SH
 jD
 sc
 gC
@@ -20335,9 +20357,9 @@ NL
 NL
 NL
 kl
-wy
-as
-dP
+hq
+uh
+SH
 nP
 QB
 nk
@@ -20496,10 +20518,10 @@ NL
 NL
 NL
 NL
-dP
+SH
 la
-as
-dP
+uh
+SH
 CI
 UZ
 dP
@@ -20659,9 +20681,9 @@ NL
 NL
 NL
 Hc
-wy
-as
-dP
+hq
+uh
+SH
 Mo
 KR
 dP
@@ -20820,10 +20842,10 @@ NL
 NL
 NL
 NL
-dP
+SH
 la
-as
-dP
+uh
+SH
 Mo
 NW
 dP
@@ -20983,9 +21005,9 @@ NL
 NL
 NL
 Hc
-KI
-as
-dP
+tB
+uh
+SH
 dP
 dP
 dP
@@ -21144,10 +21166,10 @@ NL
 NL
 NL
 NL
-dP
-dP
-dP
-dP
+SH
+SH
+SH
+SH
 NL
 NL
 NL

--- a/maps/away/ships/konyang/water_barge/water_barge.dmm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dmm
@@ -15,7 +15,7 @@
 "aq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "ar" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -138,10 +138,10 @@
 	},
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "bS" = (
 /turf/simulated/wall/shuttle/space_ship,
-/area/space)
+/area/water_barge/bathroom)
 "bW" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/iff_beacon/name_change,
@@ -150,7 +150,7 @@
 "cb" = (
 /obj/effect/floor_decal/corner/yellow/full,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "cj" = (
 /obj/structure/closet/walllocker/medical{
 	name = "Blood Locker";
@@ -160,7 +160,7 @@
 /obj/item/reagent_containers/blood/OMinus,
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "cp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -212,6 +212,12 @@
 "cI" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"cJ" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/mainhallway)
 "cK" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 8
@@ -227,7 +233,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "cP" = (
 /obj/effect/shuttle_landmark/water_barge/nav3,
 /turf/template_noop,
@@ -237,7 +243,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "dd" = (
 /obj/machinery/light{
 	dir = 4
@@ -255,7 +261,7 @@
 /obj/machinery/power/apc/low,
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
-/area/space)
+/area/water_barge/bathroom)
 "dl" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -266,13 +272,19 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
+"dm" = (
+/obj/effect/landmark/entry_point/starboard{
+	name = "starboard, docking bay"
+	},
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/thrust)
 "dp" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
 "dq" = (
 /obj/effect/floor_decal/corner_wide/dark_green/full,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "dt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -315,6 +327,9 @@
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
+"dE" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/mainhallway)
 "dM" = (
 /obj/machinery/light{
 	dir = 1
@@ -331,6 +346,13 @@
 "dP" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/fuelbay)
+"dS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/door/airlock/multi_tile{
+	name = "Fuel Bay"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/cargo)
 "dW" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -353,7 +375,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "ek" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -394,13 +416,13 @@
 	pixel_x = -12
 	},
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "ex" = (
 /obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
 /obj/effect/floor_decal/corner_wide/brown/full,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "eA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -442,7 +464,7 @@
 	},
 /obj/effect/floor_decal/corner_wide/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/space)
+/area/water_barge/bathroom)
 "eP" = (
 /obj/machinery/light{
 	dir = 8
@@ -528,7 +550,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "fF" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/portables_connector{
@@ -545,6 +567,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
+"fU" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/water_barge/cargo)
 "fV" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 1;
@@ -609,7 +641,7 @@
 /turf/simulated/wall/shuttle/space_ship{
 	can_open = 1
 	},
-/area/space)
+/area/water_barge/bathroom)
 "gt" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
@@ -646,7 +678,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "gR" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -800,7 +832,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "iB" = (
 /obj/machinery/computer/ship/sensors,
 /obj/effect/floor_decal/corner/dark_blue{
@@ -853,7 +885,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "iV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -892,7 +924,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "jd" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -981,6 +1013,15 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/water_barge)
+"kc" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/mainhallway)
 "kj" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
@@ -1092,7 +1133,7 @@
 	req_one_access = null
 	},
 /turf/simulated/floor/tiled/white,
-/area/space)
+/area/water_barge/bathroom)
 "kR" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -1195,13 +1236,13 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "lJ" = (
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "lK" = (
 /obj/machinery/alarm/east{
 	req_one_access = null
@@ -1219,7 +1260,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "lX" = (
 /obj/machinery/alarm/north{
 	req_one_access = null
@@ -1302,7 +1343,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "mT" = (
 /obj/machinery/light/small/built{
 	dir = 4;
@@ -1353,7 +1394,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/space)
+/area/water_barge/mainhallway)
 "np" = (
 /obj/machinery/telecomms/allinone/ship,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -1385,7 +1426,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "nF" = (
 /obj/machinery/atmospherics/pipe/tank{
 	dir = 1
@@ -1400,7 +1441,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "nP" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 0989;
@@ -1477,7 +1518,7 @@
 /obj/machinery/power/apc/east,
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "on" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/dark_blue{
@@ -1533,7 +1574,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "pa" = (
 /obj/machinery/computer/ship/engines,
 /obj/effect/floor_decal/corner/dark_blue{
@@ -1570,7 +1611,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "pM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
@@ -1643,13 +1684,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
+"qR" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/mainhallway)
 "qW" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "qZ" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1673,7 +1720,7 @@
 	name = "Main Hallway"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "rf" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, port dock"
@@ -1703,7 +1750,13 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
+"rw" = (
+/obj/effect/landmark/entry_point/port{
+	name = "starboard"
+	},
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/fuelbay)
 "ry" = (
 /obj/effect/floor_decal/corner_wide/blue/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1716,7 +1769,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/space)
+/area/water_barge/bathroom)
 "rz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1753,7 +1806,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "rX" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1852,7 +1905,7 @@
 	},
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "tF" = (
 /obj/structure/bed/stool/chair/office/dark,
 /turf/simulated/floor/tiled/dark,
@@ -1901,7 +1954,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "uk" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light,
@@ -1909,7 +1962,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "un" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/cable/green{
@@ -1919,7 +1972,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "uu" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock/docking{
@@ -1945,7 +1998,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "uy" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
@@ -1965,7 +2018,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "uW" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -2049,7 +2102,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "vq" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
@@ -2083,7 +2136,7 @@
 /area/water_barge/thrust)
 "vI" = (
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "vO" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2171,7 +2224,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "wu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -2231,7 +2284,7 @@
 "xb" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "xh" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
@@ -2258,7 +2311,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "xu" = (
 /obj/structure/sink{
 	dir = 8;
@@ -2269,7 +2322,7 @@
 	},
 /obj/effect/floor_decal/corner_wide/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/space)
+/area/water_barge/bathroom)
 "xw" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 6
@@ -2283,7 +2336,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/air,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "xz" = (
 /obj/machinery/alarm/north{
 	req_one_access = null
@@ -2331,11 +2384,11 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "xM" = (
 /obj/effect/floor_decal/corner_wide/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/water_barge/dockingport/port)
+/area/water_barge/bathroom)
 "xN" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2513,7 +2566,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "AT" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot,
 /turf/simulated/floor/tiled/dark,
@@ -2533,7 +2586,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "Bp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
@@ -2543,10 +2596,10 @@
 /obj/structure/curtain/open/medical,
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "By" = (
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "BE" = (
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin{
@@ -2564,7 +2617,7 @@
 	},
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "BH" = (
 /obj/effect/landmark/entry_point/port{
 	name = "starboard"
@@ -2756,7 +2809,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "DL" = (
 /obj/machinery/power/apc/north,
 /obj/structure/cable/green{
@@ -2766,7 +2819,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "DN" = (
 /obj/machinery/computer/ship/engines{
 	dir = 4
@@ -2787,7 +2840,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "DU" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -2798,7 +2851,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "DX" = (
 /obj/machinery/door/airlock{
 	dir = 1;
@@ -2807,7 +2860,7 @@
 	},
 /obj/effect/floor_decal/corner_wide/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/water_barge/dockingport/port)
+/area/water_barge/bathroom)
 "Ed" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
@@ -2867,7 +2920,7 @@
 	name = "Main Hallway"
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/water_barge/mainhallway)
 "Ez" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -2885,7 +2938,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "ED" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/railing/mapped,
@@ -2963,7 +3016,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "Ge" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -3023,7 +3076,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "GS" = (
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -3086,7 +3139,7 @@
 	name = "Shower"
 	},
 /turf/simulated/floor/tiled/white,
-/area/space)
+/area/water_barge/bathroom)
 "HF" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/shipsensors/weak,
@@ -3113,7 +3166,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "HV" = (
 /obj/machinery/alarm/north{
 	req_one_access = null
@@ -3125,14 +3178,14 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "Id" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
 /obj/machinery/alarm/east,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "Il" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -3145,7 +3198,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "Iu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
@@ -3202,7 +3255,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "Ja" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
@@ -3272,7 +3325,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "JB" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/cryo)
@@ -3280,7 +3333,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "JK" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
@@ -3382,7 +3435,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "Ku" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3395,7 +3448,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "KB" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -3487,7 +3540,7 @@
 "Lf" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "Lh" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -3496,7 +3549,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "Ll" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
@@ -3658,7 +3711,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "MK" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -3673,7 +3726,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "MO" = (
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
@@ -3683,6 +3736,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"MR" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/cargo)
 "MS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 1
@@ -3735,7 +3791,7 @@
 	},
 /obj/effect/floor_decal/corner_wide/blue/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/water_barge/dockingport/port)
+/area/water_barge/bathroom)
 "NB" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -3807,7 +3863,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "Oj" = (
 /obj/effect/landmark/entry_point/port{
 	name = "port, office"
@@ -3839,7 +3895,7 @@
 "Ox" = (
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "OM" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
@@ -3936,7 +3992,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "PD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/cable/green{
@@ -3990,7 +4046,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/space)
+/area/water_barge/bathroom)
 "PV" = (
 /obj/machinery/computer/ship/navigation{
 	dir = 4
@@ -4007,7 +4063,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "PZ" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
@@ -4049,7 +4105,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "Qu" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 0989;
@@ -4096,7 +4152,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/water_barge/dockingport/port)
+/area/water_barge/bathroom)
 "QJ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4142,6 +4198,12 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/water_barge/engineering)
+"Rd" = (
+/obj/effect/landmark/entry_point/starboard{
+	name = "starboard, docking bay"
+	},
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge)
 "Ri" = (
 /obj/effect/step_trigger/teleporter,
 /turf/space,
@@ -4182,7 +4244,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "Rt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
@@ -4204,7 +4266,7 @@
 	name = "Medical"
 	},
 /turf/space,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "RX" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
@@ -4339,7 +4401,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "SL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -4354,7 +4416,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "SU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
@@ -4382,7 +4444,7 @@
 "Tf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "Tg" = (
 /obj/machinery/computer/ship/sensors,
 /turf/simulated/floor/tiled/dark,
@@ -4410,7 +4472,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "Tr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -4421,7 +4483,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate/loot,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "TD" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/office)
@@ -4445,7 +4507,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "TK" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Tanks"
@@ -4484,7 +4546,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "Ud" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -4516,7 +4578,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "Uv" = (
 /obj/structure/toilet{
 	dir = 1;
@@ -4527,12 +4589,12 @@
 	pixel_x = 14
 	},
 /turf/simulated/floor/tiled/white,
-/area/water_barge/dockingport/port)
+/area/water_barge/bathroom)
 "UA" = (
 /obj/machinery/sleeper,
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "UD" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4559,7 +4621,7 @@
 /obj/machinery/iv_drip,
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "UF" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot{
 	dir = 1
@@ -4693,7 +4755,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate/loot,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "Vr" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4703,7 +4765,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "Vs" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4752,7 +4814,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "VS" = (
 /obj/machinery/computer/ship/helm,
 /obj/effect/floor_decal/corner/dark_blue{
@@ -4842,7 +4904,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "Wr" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -4928,7 +4990,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/breakroom)
+/area/water_barge/mainhallway)
 "WL" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
@@ -4957,7 +5019,10 @@
 "WY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
+"WZ" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/medbay)
 "Xd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 8
@@ -4970,11 +5035,17 @@
 	},
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
+/area/water_barge/medbay)
 "Xr" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
 /area/water_barge/helm)
+"Xs" = (
+/obj/effect/landmark/entry_point/port{
+	name = "starboard"
+	},
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge)
 "Xv" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin{
@@ -5058,7 +5129,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/space)
+/area/water_barge/bathroom)
 "Ya" = (
 /obj/machinery/atmospherics/unary/engine,
 /obj/structure/window/borosilicate/reinforced,
@@ -5197,7 +5268,7 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/air,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/fuelbay)
+/area/water_barge/cargo)
 "ZD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -5243,7 +5314,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
+/area/water_barge/mainhallway)
 "ZN" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -14594,9 +14665,9 @@ NL
 NL
 NL
 AA
+dm
 AA
-AA
-dP
+MR
 NL
 NL
 NL
@@ -14758,12 +14829,12 @@ NL
 vC
 SU
 Pm
-dP
-dP
-dP
-dP
-dP
-dP
+MR
+MR
+MR
+MR
+MR
+MR
 PG
 Sw
 PG
@@ -14920,7 +14991,7 @@ NL
 AA
 pM
 Pm
-dP
+MR
 PY
 Vh
 xx
@@ -15082,7 +15153,7 @@ NL
 vC
 kn
 Pm
-dP
+MR
 PY
 JC
 xb
@@ -15107,10 +15178,10 @@ iR
 iR
 iR
 iR
+Rd
 iR
 iR
 iR
-iR
 NL
 NL
 NL
@@ -15120,7 +15191,7 @@ NL
 NL
 NL
 NL
-iR
+Rd
 iR
 iR
 iR
@@ -15244,7 +15315,7 @@ NL
 AA
 pM
 Pm
-dP
+MR
 HV
 xb
 TA
@@ -15406,7 +15477,7 @@ NL
 Ya
 II
 UW
-dP
+MR
 DL
 TA
 xb
@@ -15568,7 +15639,7 @@ NL
 AA
 ct
 XL
-Se
+dS
 un
 WY
 WY
@@ -15730,7 +15801,7 @@ NL
 vC
 II
 HB
-Wu
+fU
 ws
 EA
 EA
@@ -15892,7 +15963,7 @@ NL
 AA
 pM
 Df
-dP
+MR
 HU
 vI
 vI
@@ -15907,7 +15978,7 @@ bf
 PG
 PG
 PG
-bS
+PG
 NL
 iR
 iR
@@ -16054,7 +16125,7 @@ NL
 vC
 zY
 Hr
-dP
+MR
 HU
 vI
 vI
@@ -16216,7 +16287,7 @@ NL
 AA
 AA
 AA
-dP
+MR
 Og
 oZ
 oZ
@@ -17673,24 +17744,24 @@ JM
 BL
 DB
 jA
-oa
+dE
 It
 SO
-tp
-tp
+cJ
+cJ
 Lh
 MK
 DU
-tp
+cJ
 SO
 cb
-oa
+dE
 rk
 WD
 xs
 xs
 dq
-Iw
+dE
 mG
 dp
 TK
@@ -18014,7 +18085,7 @@ uc
 SI
 By
 cS
-Iw
+dE
 Ok
 dp
 TK
@@ -18159,24 +18230,24 @@ BL
 Rt
 pk
 bn
-oa
+dE
 lU
 DI
-bd
+qR
 mP
 Id
-TG
+kc
 Wq
-bd
+qR
 DI
 ZL
-oa
+dE
 xJ
 VO
 eg
 Kt
 uk
-Iw
+dE
 iR
 iR
 iR
@@ -18333,12 +18404,12 @@ oa
 oa
 oa
 oa
-Iw
+WZ
 Qs
 RQ
-Iw
-Iw
-Iw
+WZ
+WZ
+WZ
 NL
 iR
 YJ
@@ -18500,7 +18571,7 @@ Ku
 Xg
 eu
 Bv
-Iw
+WZ
 NL
 iR
 YJ
@@ -18662,7 +18733,7 @@ uF
 Ox
 Ox
 UE
-Iw
+WZ
 iR
 iR
 YJ
@@ -18824,7 +18895,7 @@ uF
 Ox
 Ox
 bN
-Iw
+WZ
 iR
 YJ
 YJ
@@ -19634,7 +19705,7 @@ XW
 ry
 PU
 di
-CS
+bS
 iR
 YJ
 YJ
@@ -19792,10 +19863,10 @@ Wv
 lL
 lL
 Em
-CS
+bS
 QI
-CS
-CS
+bS
+bS
 bS
 iR
 iR
@@ -19954,7 +20025,7 @@ hg
 dt
 dt
 pC
-CS
+bS
 xM
 DX
 Uv
@@ -20116,9 +20187,9 @@ Wv
 lL
 kM
 eW
-CS
+bS
 xM
-CS
+bS
 bS
 bS
 NL
@@ -20278,7 +20349,7 @@ ET
 lL
 Bp
 Ly
-CS
+bS
 Nz
 HE
 bS
@@ -20440,7 +20511,7 @@ ta
 ta
 lL
 lL
-CS
+bS
 bS
 bS
 bS
@@ -20474,7 +20545,7 @@ ED
 YJ
 YJ
 iR
-iR
+Xs
 NL
 NL
 NL
@@ -20612,7 +20683,7 @@ NL
 NL
 NL
 iR
-iR
+Xs
 iR
 iR
 iR
@@ -20918,7 +20989,7 @@ dP
 dP
 dP
 dP
-dP
+rw
 dP
 CS
 CS

--- a/maps/away/ships/konyang/water_barge/water_barge.dmm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dmm
@@ -310,6 +310,9 @@
 	name = "Engineering";
 	req_one_access = list(11,24)
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
 "dA" = (
@@ -351,6 +354,7 @@
 /obj/machinery/door/airlock/multi_tile{
 	name = "Fuel Bay"
 	},
+/obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/plating,
 /area/water_barge/cargo)
 "dW" = (
@@ -582,11 +586,15 @@
 	dir = 1;
 	name = "Engineering"
 	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/engineering)
 "gc" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/plating,
 /area/water_barge)
 "gd" = (
@@ -620,6 +628,7 @@
 	name = "Port Docking Bay"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
 "gp" = (
@@ -704,10 +713,6 @@
 /obj/effect/shuttle_landmark/water_barge_shuttle/transit,
 /turf/space,
 /area/space)
-"hq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "hv" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/condiment/flour,
@@ -812,6 +817,9 @@
 	dir = 1;
 	name = "Cafeteria"
 	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/breakroom)
 "ic" = (
@@ -852,6 +860,9 @@
 "iH" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 1
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 2
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
@@ -1111,12 +1122,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
-"kG" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "kM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -1293,6 +1298,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
 "mj" = (
@@ -1403,6 +1409,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
 "np" = (
@@ -1729,6 +1736,7 @@
 /obj/machinery/door/airlock/service{
 	name = "Main Hallway"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
 "rf" = (
@@ -1747,6 +1755,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 2
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
@@ -1907,12 +1918,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"tB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "tC" = (
 /obj/structure/table/standard,
 /obj/item/roller,
@@ -1932,6 +1937,12 @@
 /obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"tJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "tK" = (
 /obj/machinery/light{
 	dir = 8
@@ -1971,9 +1982,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
-"uh" = (
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "uk" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light,
@@ -2038,6 +2046,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
+"uI" = (
+/turf/simulated/wall/shuttle/space_ship{
+	can_open = 1;
+	color = "#DDDDD"
+	},
+/area/water_barge/breakroom)
 "uW" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -2218,6 +2232,9 @@
 /obj/machinery/door/airlock/mining{
 	dir = 8;
 	name = "Office"
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
@@ -2501,6 +2518,12 @@
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/airless,
 /area/water_barge/helm)
+"zn" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "zy" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -2818,6 +2841,9 @@
 	name = "Crew Compartment";
 	dir = 4
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
 "DI" = (
@@ -2938,6 +2964,7 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Main Hallway"
 	},
+/obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
 "Ez" = (
@@ -2947,6 +2974,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 2
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
@@ -3198,6 +3228,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
+"HW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "Id" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -3205,6 +3239,9 @@
 /obj/machinery/alarm/east,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
+"Ii" = (
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "Il" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -3634,6 +3671,9 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
 "LX" = (
@@ -3680,6 +3720,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"Ml" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/thrust/port)
 "Mm" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -4284,6 +4327,9 @@
 	dir = 2;
 	name = "Medical"
 	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 2
+	},
 /turf/space,
 /area/water_barge/medbay)
 "RX" = (
@@ -4333,6 +4379,7 @@
 /obj/machinery/door/airlock/multi_tile{
 	name = "Fuel Bay"
 	},
+/obj/machinery/door/firedoor/multi_tile,
 /turf/simulated/floor/plating,
 /area/water_barge/thrust/port)
 "Sg" = (
@@ -4415,9 +4462,6 @@
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
-"SH" = (
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/thrust/port)
 "SI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -4534,6 +4578,7 @@
 /obj/machinery/door/airlock/atmos{
 	name = "Tanks"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
 "TU" = (
@@ -4666,15 +4711,18 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/door/airlock/medical{
 	dir = 4;
-	name = "Equipment Storage"
+	name = "Medical"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
@@ -4753,6 +4801,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/multi_tile{
+	dir = 2
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
@@ -4881,6 +4932,7 @@
 	name = "Warehouse";
 	req_one_access = list(26,29,31,48,67,70)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
 "Wc" = (
@@ -5150,6 +5202,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/white,
 /area/water_barge/bathroom)
 "Ya" = (
@@ -5256,6 +5309,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
 "Zq" = (
@@ -16485,7 +16539,7 @@ xW
 Iw
 Iw
 Iw
-Iw
+uI
 Iw
 iR
 Yy
@@ -19546,10 +19600,10 @@ NL
 NL
 NL
 NL
-SH
-SH
-SH
-SH
+Ml
+Ml
+Ml
+Ml
 eQ
 eQ
 Jc
@@ -19711,7 +19765,7 @@ NL
 Hc
 PO
 Gv
-SH
+Ml
 vu
 LP
 KI
@@ -19870,7 +19924,7 @@ NL
 NL
 NL
 NL
-SH
+Ml
 Nv
 PD
 Se
@@ -20194,10 +20248,10 @@ NL
 NL
 NL
 NL
-SH
+Ml
 la
-kG
-SH
+zn
+Ml
 jD
 sc
 gC
@@ -20357,9 +20411,9 @@ NL
 NL
 NL
 kl
-hq
-uh
-SH
+HW
+Ii
+Ml
 nP
 QB
 nk
@@ -20518,10 +20572,10 @@ NL
 NL
 NL
 NL
-SH
+Ml
 la
-uh
-SH
+Ii
+Ml
 CI
 UZ
 dP
@@ -20681,9 +20735,9 @@ NL
 NL
 NL
 Hc
-hq
-uh
-SH
+HW
+Ii
+Ml
 Mo
 KR
 dP
@@ -20842,10 +20896,10 @@ NL
 NL
 NL
 NL
-SH
+Ml
 la
-uh
-SH
+Ii
+Ml
 Mo
 NW
 dP
@@ -21005,9 +21059,9 @@ NL
 NL
 NL
 Hc
-tB
-uh
-SH
+tJ
+Ii
+Ml
 dP
 dP
 dP
@@ -21166,10 +21220,10 @@ NL
 NL
 NL
 NL
-SH
-SH
-SH
-SH
+Ml
+Ml
+Ml
+Ml
 NL
 NL
 NL

--- a/maps/away/ships/konyang/water_barge/water_barge.dmm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dmm
@@ -27,16 +27,13 @@
 "as" = (
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
-"aF" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
 "aG" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
 "aP" = (
@@ -90,14 +87,6 @@
 "bf" = (
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"bj" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "bl" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/structure/railing/mapped,
@@ -122,10 +111,15 @@
 	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/water_barge/fuelbay)
-"bz" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
+"by" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "bF" = (
 /obj/effect/shuttle_landmark/water_barge/nav1,
 /turf/template_noop,
@@ -174,6 +168,19 @@
 /obj/effect/floor_decal/corner/yellow/full,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
+"ch" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "cj" = (
 /obj/structure/closet/walllocker/medical{
 	name = "Blood Locker";
@@ -207,6 +214,11 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, office"
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "bar_viewing_shutters";
+	name = "Bar Viewing Shutters"
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/office)
@@ -411,11 +423,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
-"es" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/effect/decal/cleanable/flour,
-/turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
 "et" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -565,15 +572,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"fm" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/mainhallway)
 "fB" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -730,13 +728,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/breakroom)
-"gS" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "hg" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -868,15 +859,6 @@
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"ij" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/hangar)
 "iy" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -951,6 +933,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
+"iT" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
 "iV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -1298,10 +1284,6 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
-"lI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
 "lJ" = (
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 5
@@ -1389,6 +1371,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"mE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
 "mG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1415,19 +1401,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
-"mV" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
 "mY" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
 "nd" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "bar_viewing_shutters";
+	name = "Bar Viewing Shutters"
+	},
 /turf/simulated/floor/plating,
 /area/water_barge/office)
 "ng" = (
@@ -1484,12 +1468,6 @@
 /obj/machinery/light/small/built,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"ny" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "nz" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -1606,6 +1584,14 @@
 	},
 /obj/item/folder/red,
 /obj/item/stamp,
+/obj/machinery/button/remote/blast_door{
+	dir = 9;
+	id = "bar_shutter";
+	name = "Desk Shutters";
+	pixel_x = -5;
+	req_access = list(25);
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
 "ov" = (
@@ -1649,6 +1635,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"oT" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "oZ" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -1687,6 +1678,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"pD" = (
+/obj/random/contraband,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/dockingport)
 "pI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -1755,10 +1753,6 @@
 /obj/random/colored_jumpsuit,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
-"qK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "qQ" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1772,12 +1766,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
-"qU" = (
-/turf/simulated/wall/shuttle/space_ship{
-	can_open = 1;
-	color = "#DDDDD"
-	},
-/area/water_barge/breakroom)
 "qW" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1874,10 +1862,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"rA" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/engineering)
 "rB" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -1985,6 +1969,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"ty" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "tz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -2029,10 +2020,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"tX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
 "ua" = (
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 1
@@ -2101,13 +2088,6 @@
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
-"uz" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
 "uF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2268,18 +2248,9 @@
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
 "wb" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "wc" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -2566,6 +2537,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"yH" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/mainhallway)
 "yI" = (
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
@@ -2588,15 +2568,6 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"yV" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "za" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/glass/reinforced/full,
@@ -2614,6 +2585,19 @@
 /obj/machinery/iff_beacon/name_change,
 /turf/simulated/floor/airless,
 /area/water_barge/helm)
+"zg" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
+"zr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "zy" = (
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -2668,6 +2652,10 @@
 /obj/machinery/power/portgen,
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"Aq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "Ar" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/shipsensors,
@@ -2688,15 +2676,6 @@
 "AA" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/thrust)
-"AM" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "AN" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -2709,10 +2688,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/mainhallway)
-"AS" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "AT" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot,
 /turf/simulated/floor/tiled/dark,
@@ -2773,15 +2748,6 @@
 "BL" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/water_barge)
-"BP" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/water_barge/mainhallway)
 "BS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2789,6 +2755,10 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"BT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
 "Cf" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
@@ -2849,6 +2819,10 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/dom,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"CA" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport)
 "CI" = (
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
 /turf/simulated/floor/plating,
@@ -2975,10 +2949,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
-"DM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
 "DN" = (
 /obj/machinery/computer/ship/engines{
 	dir = 4
@@ -3120,6 +3090,10 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"EQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "ET" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3192,6 +3166,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
+"Gk" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "Gv" = (
 /obj/machinery/power/apc/high/west,
 /obj/structure/cable/green{
@@ -3331,6 +3314,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
+"HW" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "bar_shutter";
+	name = "Desk Shutters";
+	pixel_x = 20;
+	req_access = list(25);
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/office)
 "Id" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -3634,6 +3634,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
+"KK" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "KN" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -3717,6 +3721,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"Lo" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "Ly" = (
 /obj/structure/bed/stool/chair{
 	dir = 1
@@ -3733,6 +3744,11 @@
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"LM" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
 "LP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/fuel,
 /turf/simulated/floor/plating,
@@ -3778,6 +3794,10 @@
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"LY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
 "Ma" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
@@ -3814,11 +3834,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
-"Mk" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/junk,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "Mm" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -3903,6 +3918,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"MX" = (
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "Nb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/bed/stool/chair,
@@ -3926,17 +3944,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
-"Ns" = (
-/obj/random/contraband,
+"No" = (
 /obj/machinery/light/small{
-	dir = 8
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/water_barge/dockingport)
-"Nu" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "Nv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
@@ -4035,7 +4048,7 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/office)
 "Ok" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4055,6 +4068,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"Ov" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "Ox" = (
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -4090,6 +4114,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
+"OR" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "OY" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -4128,12 +4161,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/water_barge/thrust/port)
-"Pi" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport/port)
 "Pm" = (
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
@@ -4224,6 +4251,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
+"PW" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "PY" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/reagent_dispensers/watertank,
@@ -4376,6 +4412,10 @@
 /obj/effect/step_trigger/teleporter,
 /turf/space,
 /area/space)
+"Rj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
 "Rl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
@@ -4415,6 +4455,11 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/water_barge)
+"RE" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/effect/decal/cleanable/flour,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "RK" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 9
@@ -4585,6 +4630,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
+"SR" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "SU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
@@ -4655,9 +4706,6 @@
 "TD" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/office)
-"TF" = (
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "TG" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -4697,10 +4745,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge)
-"TX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/hangar)
 "Ua" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4728,13 +4772,10 @@
 /area/water_barge/office)
 "Um" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
 "Up" = (
@@ -5004,9 +5045,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"VU" = (
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/thrust/port)
 "VV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -5044,6 +5082,12 @@
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
+"Wb" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "Wc" = (
 /obj/machinery/power/apc/north,
 /obj/structure/cable/green{
@@ -5122,8 +5166,6 @@
 /area/water_barge/thrust/port)
 "Wv" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -5218,8 +5260,22 @@
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
+"Xm" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "Xr" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "bar_viewing_shutters";
+	name = "Bar Viewing Shutters"
+	},
 /turf/simulated/floor/plating,
 /area/water_barge/helm)
 "Xs" = (
@@ -5241,6 +5297,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
+"Xz" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/thrust/port)
 "XA" = (
 /obj/machinery/light/spot{
 	dir = 8
@@ -5322,15 +5381,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/thrust)
-"Yc" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "Yf" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
@@ -5355,6 +5405,12 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"Ym" = (
+/turf/simulated/wall/shuttle/space_ship{
+	can_open = 1;
+	color = "#DDDDD"
+	},
+/area/water_barge/breakroom)
 "Yu" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -5367,12 +5423,6 @@
 /obj/item/pen/black,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"Yx" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "Yy" = (
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
@@ -5418,16 +5468,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
-"YR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
-"YZ" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport)
 "Zl" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/hangar)
@@ -5468,6 +5508,11 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, bridge"
+	},
+/obj/machinery/door/blast/shutters/open{
+	dir = 2;
+	id = "bar_viewing_shutters";
+	name = "Bar Viewing Shutters"
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/helm)
@@ -15196,7 +15241,7 @@ NL
 NL
 AA
 pM
-tX
+Rj
 MR
 PY
 Vh
@@ -15520,16 +15565,16 @@ NL
 NL
 AA
 pM
-Nu
+iT
 MR
 HV
-Mk
+oT
 TA
 JC
 Tj
 PG
 ar
-YZ
+CA
 PG
 bf
 bf
@@ -16010,7 +16055,7 @@ HB
 fU
 ws
 EA
-Yc
+PW
 EA
 iS
 PG
@@ -16333,7 +16378,7 @@ zY
 Hr
 MR
 HU
-qK
+Aq
 vI
 aq
 Up
@@ -16345,7 +16390,7 @@ bf
 pU
 PG
 GE
-Ns
+pD
 PG
 PG
 iR
@@ -16496,7 +16541,7 @@ AA
 MR
 Og
 oZ
-yV
+Gk
 oZ
 vp
 PG
@@ -16669,7 +16714,7 @@ xW
 Iw
 Iw
 Iw
-qU
+Ym
 Iw
 iR
 Yy
@@ -17153,7 +17198,7 @@ PI
 LC
 xW
 QM
-es
+RE
 KD
 ks
 Il
@@ -17309,7 +17354,7 @@ xW
 xW
 NQ
 hV
-rA
+LY
 zb
 af
 Ks
@@ -17968,35 +18013,35 @@ xs
 xs
 dq
 dE
-gS
+Lo
 dp
 TK
 Yy
-aF
+zg
 Yy
 Yy
 Fh
 sT
-aF
+zg
 Yy
 Yy
-aF
+zg
 Yy
 Yy
 Cg
 Yy
 pc
-aF
+zg
 Yy
 Yy
-aF
+zg
 Yy
 Yy
 hG
 hU
 Yy
 Yy
-aF
+zg
 Yy
 TK
 dp
@@ -18110,12 +18155,12 @@ UD
 Vg
 kF
 UY
-ij
+Xm
 jL
 nl
-BP
-BP
-BP
+aG
+aG
+aG
 AN
 fB
 Bo
@@ -18126,43 +18171,43 @@ GG
 Ex
 jc
 Rp
-fm
+yH
 PA
 uv
 re
-bj
-AM
+Um
+OR
 Zn
-bj
-bj
-bj
-wb
+Um
+Um
+Um
+ch
 qm
 dl
-AM
-bj
-bj
-bj
-bj
-bj
+OR
+Um
+Um
+Um
+Um
+Um
 dl
-bj
+Um
+nV
+Ov
+Um
+Um
+Um
+Um
+Um
+dl
 nV
 Um
-bj
-bj
-bj
-bj
-bj
-dl
-nV
-bj
-bj
-bj
-bj
+Um
+Um
+Um
 Zn
-bj
-bj
+Um
+Um
 me
 Vs
 Gw
@@ -18277,7 +18322,7 @@ KS
 rW
 Lf
 Lf
-aG
+LM
 MJ
 qW
 Vr
@@ -18292,39 +18337,39 @@ SI
 By
 cS
 dE
-ny
+Ok
 dp
 TK
 Yy
-mV
+ty
 He
 Dc
 hU
 sT
-mV
+ty
 Yy
 Yy
-mV
+ty
 Yy
 Yy
 qZ
 Yy
 Yh
-mV
+ty
 Yy
 Yy
-mV
+ty
 Yy
 Yy
 hG
 Fh
 Yy
 Yy
-mV
+ty
 Yy
 TK
 dp
-Ok
+No
 JQ
 IM
 Jm
@@ -18434,7 +18479,7 @@ BL
 BL
 BL
 Rt
-TX
+EQ
 bn
 dE
 lU
@@ -18925,7 +18970,7 @@ gG
 oa
 Ws
 cI
-DM
+mE
 cI
 cI
 yz
@@ -19730,10 +19775,10 @@ NL
 NL
 NL
 NL
-VU
-VU
-VU
-VU
+Xz
+Xz
+Xz
+Xz
 eQ
 eQ
 Jc
@@ -19741,7 +19786,7 @@ mn
 wn
 CS
 Ja
-uz
+Wv
 kj
 kV
 iV
@@ -19895,7 +19940,7 @@ NL
 Hc
 PO
 Gv
-VU
+Xz
 vu
 LP
 KI
@@ -19952,7 +19997,7 @@ zF
 oQ
 ZI
 kX
-mv
+HW
 nd
 NL
 NL
@@ -20054,18 +20099,18 @@ NL
 NL
 NL
 NL
-VU
+Xz
 Nv
 PD
 Se
 fR
 wy
 Lb
-lI
+BT
 Ed
 CS
 Ja
-Wv
+by
 lL
 lL
 Em
@@ -20378,10 +20423,10 @@ NL
 NL
 NL
 NL
-VU
+Xz
 la
-Yx
-VU
+Wb
+Xz
 jD
 sc
 gC
@@ -20389,7 +20434,7 @@ as
 Ed
 CS
 lX
-Pi
+SR
 lL
 kM
 eW
@@ -20541,9 +20586,9 @@ NL
 NL
 NL
 kl
-bz
-TF
-VU
+KK
+MX
+Xz
 nP
 QB
 nk
@@ -20702,10 +20747,10 @@ NL
 NL
 NL
 NL
-VU
+Xz
 la
-AS
-VU
+wb
+Xz
 CI
 UZ
 dP
@@ -20865,9 +20910,9 @@ NL
 NL
 NL
 Hc
-bz
-TF
-VU
+KK
+MX
+Xz
 Mo
 KR
 dP
@@ -21026,10 +21071,10 @@ NL
 NL
 NL
 NL
-VU
+Xz
 la
-TF
-VU
+MX
+Xz
 Mo
 NW
 dP
@@ -21189,9 +21234,9 @@ NL
 NL
 NL
 Hc
-YR
-TF
-VU
+zr
+MX
+Xz
 dP
 dP
 dP
@@ -21350,10 +21395,10 @@ NL
 NL
 NL
 NL
-VU
-VU
-VU
-VU
+Xz
+Xz
+Xz
+Xz
 NL
 NL
 NL

--- a/maps/away/ships/konyang/water_barge/water_barge.dmm
+++ b/maps/away/ships/konyang/water_barge/water_barge.dmm
@@ -49,8 +49,6 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -104,6 +102,16 @@
 	},
 /turf/simulated/floor/reinforced/hydrogen,
 /area/water_barge/fuelbay)
+"by" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
+"bE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "bF" = (
 /obj/effect/shuttle_landmark/water_barge/nav1,
 /turf/template_noop,
@@ -160,6 +168,7 @@
 /obj/structure/table/standard,
 /obj/item/reagent_containers/blood/OMinus,
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/water_barge/medbay)
 "cp" = (
@@ -187,6 +196,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/office)
+"cz" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "cA" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -307,8 +322,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
-	name = "Engineering";
-	req_one_access = list(11,24)
+	name = "Engineering"
 	},
 /obj/machinery/door/firedoor/noid{
 	dir = 8
@@ -371,13 +385,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"ea" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
 "eg" = (
 /obj/effect/floor_decal/corner_wide/green{
 	dir = 6
@@ -389,8 +396,6 @@
 /area/water_barge/mainhallway)
 "ek" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
@@ -547,10 +552,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"fp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
 "fB" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
@@ -684,6 +685,10 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"gI" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust)
 "gK" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -709,8 +714,6 @@
 /area/water_barge/breakroom)
 "hg" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
@@ -722,6 +725,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"hh" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "hl" = (
 /obj/effect/shuttle_landmark/water_barge_shuttle/transit,
 /turf/space,
@@ -840,10 +849,6 @@
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"ix" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "iy" = (
 /obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -851,15 +856,6 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/water_barge)
-"iz" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
 /area/water_barge)
 "iA" = (
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
@@ -1127,6 +1123,12 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"kD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "kF" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -1221,15 +1223,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"ld" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/water_barge/mainhallway)
 "lj" = (
 /obj/machinery/door/window{
 	dir = 4
@@ -1251,6 +1244,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
+"lt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/engineering)
 "ly" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1275,6 +1272,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"lE" = (
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport)
 "lH" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
@@ -1332,13 +1333,6 @@
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"mg" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "mj" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, starboard dock"
@@ -1377,14 +1371,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/office)
-"mD" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/toolstorage)
 "mG" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
 "mM" = (
@@ -1510,6 +1501,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
+"nQ" = (
+/obj/effect/floor_decal/corner/brown{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "nS" = (
 /obj/item/reagent_containers/cooking_container/board,
 /obj/structure/table/stone/marble,
@@ -1591,6 +1591,10 @@
 /obj/machinery/computer/ship/helm,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"oA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "oC" = (
 /obj/structure/table/stone/marble,
 /obj/machinery/reagentgrinder{
@@ -1610,20 +1614,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"oJ" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
-"oN" = (
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/random/junk,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "oQ" = (
 /obj/structure/bed/stool/chair/office/dark,
 /turf/simulated/floor/tiled/dark,
@@ -1672,15 +1662,6 @@
 "pk" = (
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
-"pw" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/cargo)
 "pC" = (
 /obj/structure/bed/stool/chair{
 	dir = 1
@@ -1883,10 +1864,6 @@
 "rO" = (
 /turf/simulated/floor/reinforced/hydrogen,
 /area/water_barge/fuelbay)
-"rT" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "rW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1906,17 +1883,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
+"sg" = (
+/turf/simulated/wall/shuttle/space_ship,
+/area/water_barge/thrust/port)
 "su" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
-"sw" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "sE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 4
@@ -1930,15 +1904,6 @@
 	name = "airlock_barge_portdock"
 	},
 /turf/simulated/floor/plating,
-/area/water_barge/dockingport/port)
-"sQ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
 "sT" = (
 /obj/structure/lattice/catwalk/indoor,
@@ -1966,10 +1931,34 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"tb" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "tc" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"tf" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "th" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
@@ -2036,6 +2025,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/water_barge)
+"tQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/toolstorage)
+"tU" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/mainhallway)
 "ua" = (
 /obj/effect/floor_decal/corner/brown/full{
 	dir = 1
@@ -2056,6 +2058,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/mainhallway)
+"ud" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
+"uf" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "uk" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light,
@@ -2166,6 +2181,13 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"vh" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "vl" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 2;
@@ -2280,6 +2302,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"wd" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "we" = (
 /obj/effect/shuttle_landmark/water_barge/nav4,
 /turf/template_noop,
@@ -2341,10 +2367,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
-"wF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/hangar)
 "wJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -2378,15 +2400,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/helm)
-"wN" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/mainhallway)
 "wR" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -2523,10 +2536,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
-"xT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "xW" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/engineering)
@@ -2588,12 +2597,6 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
-"yZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "za" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/glass/reinforced/full,
@@ -2652,6 +2655,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport/port)
+"zR" = (
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "zY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
@@ -2721,17 +2727,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
-"Bq" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "Bv" = (
 /obj/structure/bed/roller,
 /obj/structure/curtain/open/medical,
@@ -2808,17 +2803,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
-"Cn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/engineering)
-"Cu" = (
-/obj/structure/lattice/catwalk/indoor,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/water_barge)
 "Cw" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -2858,8 +2842,6 @@
 /area/shuttle/water_barge)
 "CO" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -2867,10 +2849,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
-"CQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/fuelbay)
 "CS" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/dockingport/port)
@@ -2911,6 +2889,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/breakroom)
+"Dq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/fuelbay)
 "Dr" = (
 /obj/effect/floor_decal/corner_wide/dark_green/full{
 	dir = 4
@@ -2959,6 +2941,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cryo)
+"DG" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
 "DI" = (
 /obj/machinery/light{
 	dir = 4
@@ -3108,8 +3099,6 @@
 	name = "Engineering Supplies"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3514,12 +3503,6 @@
 /obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
-"JP" = (
-/turf/simulated/wall/shuttle/space_ship{
-	can_open = 1;
-	color = "#DDDDD"
-	},
-/area/water_barge/breakroom)
 "JQ" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/helm)
@@ -3682,10 +3665,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/dockingport)
-"La" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/dark,
-/area/water_barge/dockingport)
 "Lb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -3719,10 +3698,7 @@
 	dir = 10
 	},
 /obj/machinery/power/apc/high,
-/obj/structure/cable/green{
-	icon_state = "0-2";
-	dir = 1
-	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
 "Ln" = (
@@ -3731,6 +3707,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/hangar)
+"Lw" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/water_barge)
 "Ly" = (
 /obj/structure/bed/stool/chair{
 	dir = 1
@@ -3822,6 +3804,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"Mf" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/water_barge/hangar)
 "Mi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
@@ -4004,6 +3995,13 @@
 /obj/item/clothing/glasses/safety/goggles,
 /turf/simulated/floor/plating,
 /area/water_barge/engineering)
+"NR" = (
+/obj/structure/lattice/catwalk/indoor,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/water_barge)
 "NS" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/warning/full,
@@ -4026,10 +4024,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
-"Oi" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/plating,
-/area/water_barge/thrust)
 "Oj" = (
 /obj/effect/landmark/entry_point/port{
 	name = "port, office"
@@ -4042,11 +4036,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
-"Os" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/effect/decal/cleanable/flour,
-/turf/simulated/floor/tiled/white,
-/area/water_barge/breakroom)
 "Ou" = (
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
@@ -4093,8 +4082,6 @@
 /area/water_barge/fuelbay)
 "OP" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4183,9 +4170,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/breakroom)
@@ -4286,6 +4275,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/water_barge/fuelbay)
+"Qv" = (
+/turf/simulated/wall/shuttle/space_ship{
+	can_open = 1;
+	color = "#DDDDD"
+	},
+/area/water_barge/breakroom)
 "Qy" = (
 /obj/structure/closet/secure_closet/engineering_electrical{
 	req_access = null
@@ -4377,6 +4372,11 @@
 /obj/effect/step_trigger/teleporter,
 /turf/space,
 /area/space)
+"Rk" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/water_barge/mainhallway)
 "Rl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
@@ -4577,6 +4577,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport)
+"SM" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/cargo)
 "SO" = (
 /obj/machinery/light{
 	dir = 8
@@ -4642,6 +4651,10 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/cargo)
+"To" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/water_barge/thrust/port)
 "Tr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -4656,6 +4669,13 @@
 "TD" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/office)
+"TE" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/water_barge/dockingport/port)
 "TG" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -4726,11 +4746,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
 "Up" = (
@@ -4761,9 +4776,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/water_barge/bathroom)
-"Uy" = (
-/turf/simulated/floor/plating,
-/area/water_barge/thrust/port)
 "UA" = (
 /obj/machinery/sleeper,
 /obj/effect/floor_decal/corner_wide/lime/diagonal,
@@ -4912,6 +4924,9 @@
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
 "Vg" = (
@@ -4971,12 +4986,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/toolstorage)
-"Vy" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/water_barge)
 "VF" = (
 /turf/unsimulated/wall/fakepdoor{
 	dir = 4
@@ -5018,8 +5027,6 @@
 /area/water_barge/office)
 "VW" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
@@ -5040,8 +5047,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/glass_mining{
-	name = "Warehouse";
-	req_one_access = list(26,29,31,48,67,70)
+	name = "Warehouse"
 	},
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/plating,
@@ -5128,8 +5134,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge/dockingport/port)
+"Wx" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/effect/decal/cleanable/flour,
+/turf/simulated/floor/tiled/white,
+/area/water_barge/breakroom)
 "Wz" = (
 /obj/machinery/computer/ship/engines{
 	dir = 8
@@ -5206,11 +5218,6 @@
 "WZ" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/medbay)
-"Xb" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/water_barge/mainhallway)
 "Xd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 8
@@ -5409,14 +5416,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/water_barge)
-"YY" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+"YZ" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/junk,
 /turf/simulated/floor/tiled/dark,
-/area/water_barge)
+/area/water_barge/cargo)
 "Zl" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/water_barge/hangar)
@@ -5432,9 +5436,6 @@
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/water_barge)
-"Zo" = (
-/turf/simulated/wall/shuttle/space_ship,
-/area/water_barge/thrust/port)
 "Zq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
 	dir = 8
@@ -15188,7 +15189,7 @@ NL
 NL
 AA
 pM
-fp
+by
 MR
 PY
 Vh
@@ -15512,16 +15513,16 @@ NL
 NL
 AA
 pM
-Oi
+gI
 MR
 HV
-oN
+YZ
 TA
 JC
 Tj
 PG
 ar
-La
+lE
 PG
 bf
 bf
@@ -16002,7 +16003,7 @@ HB
 fU
 ws
 EA
-oJ
+SM
 EA
 iS
 PG
@@ -16325,7 +16326,7 @@ zY
 Hr
 MR
 HU
-ix
+oA
 vI
 aq
 Up
@@ -16488,7 +16489,7 @@ AA
 MR
 Og
 oZ
-pw
+nQ
 oZ
 vp
 PG
@@ -16661,7 +16662,7 @@ xW
 Iw
 Iw
 Iw
-JP
+Qv
 Iw
 iR
 Yy
@@ -17145,7 +17146,7 @@ PI
 LC
 xW
 QM
-Os
+Wx
 KD
 ks
 Il
@@ -17301,7 +17302,7 @@ xW
 xW
 NQ
 hV
-Cn
+lt
 zb
 af
 Ks
@@ -17960,39 +17961,39 @@ xs
 xs
 dq
 dE
-mg
+mG
 dp
 TK
 Yy
-Cu
+NR
 Yy
 Yy
 Fh
 sT
-Cu
+NR
 Yy
 Yy
-Cu
+NR
 Yy
 Yy
 Cg
 Yy
 pc
-Cu
+NR
 Yy
 Yy
-Cu
+NR
 Yy
 Yy
 hG
 hU
 Yy
 Yy
-Cu
+NR
 Yy
 TK
 dp
-mG
+Lw
 JQ
 Kr
 Jm
@@ -18102,12 +18103,12 @@ UD
 Vg
 kF
 UY
-dO
+Mf
 jL
 nl
-ld
-ld
-ld
+DG
+DG
+DG
 AN
 fB
 Bo
@@ -18118,43 +18119,43 @@ GG
 Ex
 jc
 Rp
-wN
+tU
 PA
 uv
 re
-YY
-iz
-Zn
-YY
-YY
-YY
 Um
+uf
+Zn
+Um
+Um
+Um
+tb
 qm
 dl
-iz
-YY
-YY
-YY
-YY
-YY
+uf
+Um
+Um
+Um
+Um
+Um
 dl
-YY
+Um
 nV
-Bq
-YY
-YY
-YY
-YY
-YY
+tf
+Um
+Um
+Um
+Um
+Um
 dl
 nV
-YY
-YY
-YY
-YY
+Um
+Um
+Um
+Um
 Zn
-YY
-YY
+Um
+Um
 me
 Vs
 Gw
@@ -18269,7 +18270,7 @@ KS
 rW
 Lf
 Lf
-Xb
+Rk
 MJ
 qW
 Vr
@@ -18284,35 +18285,35 @@ SI
 By
 cS
 dE
-Vy
+bE
 dp
 TK
 Yy
-ea
+vh
 He
 Dc
 hU
 sT
-ea
+vh
 Yy
 Yy
-ea
+vh
 Yy
 Yy
 qZ
 Yy
 Yh
-ea
+vh
 Yy
 Yy
-ea
+vh
 Yy
 Yy
 hG
 Fh
 Yy
 Yy
-ea
+vh
 Yy
 TK
 dp
@@ -18426,7 +18427,7 @@ BL
 BL
 BL
 Rt
-wF
+ud
 bn
 dE
 lU
@@ -18917,7 +18918,7 @@ gG
 oa
 Ws
 cI
-mD
+tQ
 cI
 cI
 yz
@@ -19722,10 +19723,10 @@ NL
 NL
 NL
 NL
-Zo
-Zo
-Zo
-Zo
+sg
+sg
+sg
+sg
 eQ
 eQ
 Jc
@@ -19733,7 +19734,7 @@ mn
 wn
 CS
 Ja
-sQ
+TE
 kj
 kV
 iV
@@ -19887,7 +19888,7 @@ NL
 Hc
 PO
 Gv
-Zo
+sg
 vu
 LP
 KI
@@ -20046,18 +20047,18 @@ NL
 NL
 NL
 NL
-Zo
+sg
 Nv
 PD
 Se
 fR
 wy
 Lb
-CQ
+Dq
 Ed
 CS
 Ja
-sQ
+Wv
 lL
 lL
 Em
@@ -20370,10 +20371,10 @@ NL
 NL
 NL
 NL
-Zo
+sg
 la
-sw
-Zo
+hh
+sg
 jD
 sc
 gC
@@ -20381,7 +20382,7 @@ as
 Ed
 CS
 lX
-Wv
+cz
 lL
 kM
 eW
@@ -20533,9 +20534,9 @@ NL
 NL
 NL
 kl
-xT
-Uy
-Zo
+wd
+zR
+sg
 nP
 QB
 nk
@@ -20694,10 +20695,10 @@ NL
 NL
 NL
 NL
-Zo
+sg
 la
-rT
-Zo
+To
+sg
 CI
 UZ
 dP
@@ -20857,9 +20858,9 @@ NL
 NL
 NL
 Hc
-xT
-Uy
-Zo
+wd
+zR
+sg
 Mo
 KR
 dP
@@ -21018,10 +21019,10 @@ NL
 NL
 NL
 NL
-Zo
+sg
 la
-Uy
-Zo
+zR
+sg
 Mo
 NW
 dP
@@ -21181,9 +21182,9 @@ NL
 NL
 NL
 Hc
-yZ
-Uy
-Zo
+kD
+zR
+sg
 dP
 dP
 dP
@@ -21342,10 +21343,10 @@ NL
 NL
 NL
 NL
-Zo
-Zo
-Zo
-Zo
+sg
+sg
+sg
+sg
 NL
 NL
 NL

--- a/maps/away/ships/konyang/water_barge/water_barge_areas.dm
+++ b/maps/away/ships/konyang/water_barge/water_barge_areas.dm
@@ -15,13 +15,17 @@
 	name = "Water Barge - Hangar"
 	icon_state = "exit"
 
+/area/water_barge/mainhallway
+	name = "Water Barge - Main Hallway"
+	icon_state = "exit"
+
+/area/water_barge/medbay
+	name = "Water Barge - Clinic"
+	icon_state = "medbay"
+
 /area/water_barge/engineering
 	name = "Water Barge - Engineering"
 	icon_state = "engineering"
-
-/area/water_barge/atmos
-	name = "Water Barge - Atmospherics"
-	icon_state = "atmos"
 
 /area/water_barge/fuelbay
 	name = "Water Barge - Fuel Bay"
@@ -30,6 +34,10 @@
 /area/water_barge/toolstorage
 	name = "Water Barge - Tool Storage"
 	icon_state = "engineering_storage"
+
+/area/water_barge/cargo
+	name = "Water Barge - Cargo"
+	icon_state = "outpost_mine_main"
 
 /area/water_barge/dockingport
 	name = "Water Barge - Starboard Docking Bay"
@@ -46,12 +54,19 @@
 	name = "Water Barge - Break Room"
 	icon_state = "cafeteria"
 
+/area/water_barge/bathroom
+	name = "Water Barge - Bathroom"
+	icon_state = "washroom"
 /area/water_barge/cryo
 	name = "Water Barge - Cryogenics"
 	icon_state = "cryo"
 
 /area/water_barge/thrust
 	name = "Water Barge - Starboard Thruster"
+	icon_state = "engine"
+
+/area/water_barge/thrust/port
+	name = "Water Barge - Port Thruster"
 	icon_state = "engine"
 
 /area/water_barge/quarters


### PR DESCRIPTION
Ensoullifes the Water Barge.

- Makes the water tanks more tank-like. Also fixes the thing where water would flow over the tanks.
- Adds a bathroom, a small kitchen, and a cargo bay.
- Smashes some rooms together.
- Adds tritium ingots and a coolant tank to the reactor room.
- Adds some more engineering equipment so the barge can do engineering things if they want.

![image](https://github.com/Aurorastation/Aurora.3/assets/63124803/b2cc083e-9539-4119-90dc-f78cd2c4f223)
