### PR TITLE
Minor playable grem fixes, minor refactors

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -721,9 +721,15 @@
 /atom/movable/onDropInto(var/atom/movable/AM)
 	return loc // If onDropInto returns something, then dropInto will attempt to drop AM there.
 
-// This proc is used by ghost spawners to assign a player to a specific atom.
-// It receives the current mob of the player's argument and MUST return the mob the player has been assigned.
-/atom/proc/assign_player(var/mob/user)
+/**
+ * This proc is used by ghost spawners to assign a player to a specific atom
+ *
+ * It receives the current mob of the player's argument and MUST return the mob the player has been assigned
+ *
+ * Returns the `/mob` the player was assigned to
+ */
+/atom/proc/assign_player(mob/user)
+	RETURN_TYPE(/mob)
 	return
 
 /atom/proc/get_contained_external_atoms()

--- a/code/modules/ghostroles/spawner/atom/greimorian_servant.dm
+++ b/code/modules/ghostroles/spawner/atom/greimorian_servant.dm
@@ -10,3 +10,14 @@
 	atom_add_message = "A Greimorian queen has birthed a Greimorian servant!"
 
 	spawn_mob = /mob/living/simple_animal/hostile/giant_spider/nurse/servant
+
+/datum/ghostspawner/servant/spawn_mob(mob/user)
+	. = ..()
+
+	//Basically, we don't want the mob AI to keep running if a player is assigned to it
+	//ideally there should also be an handling to resume thinking if the player ghosts
+	//but that would probably need a signal that we don't currently have, hence
+	//something for another time
+	var/mob/our_new_mob = . //This cast is needed, sorry
+	if(istype(our_new_mob) && !QDELETED(our_new_mob))
+		MOB_STOP_THINKING(our_new_mob)

--- a/code/modules/ghostroles/spawner/base.dm
+++ b/code/modules/ghostroles/spawner/base.dm
@@ -155,9 +155,19 @@
 		spawn_atoms -= A
 	return A
 
-//The proc to actually spawn in the user
+/**
+ * The proc to actually spawn in the user
+ *
+ * OVERWRITE THIS IN THE CHILD IMPLEMENTATIONS to return the spawned in mob !!!
+ *
+ * This is a basic proc for atom based spawners
+ *
+ * * user - A `/mob` to assign the current owner (client) of, to the new ghost spawn
+ *
+ * Returns a `/mob` which is the spawned mob, or `null` in case of error/unavailability
+ */
 /datum/ghostspawner/proc/spawn_mob(mob/user)
-	//OVERWRITE THIS IN THE CHILD IMPLEMENTATIONS to return the spawned in mob !!!
+	RETURN_TYPE(/mob)
 
 	//This is a basic proc for atom based spawners.
 	//  Location based spawners usually need a bit more logic

--- a/code/modules/ghostroles/spawner/simplemob/spider_queen.dm
+++ b/code/modules/ghostroles/spawner/simplemob/spider_queen.dm
@@ -13,3 +13,14 @@
 	respawn_flag = null
 
 	spawn_mob = /mob/living/simple_animal/hostile/giant_spider/nurse/spider_queen
+
+/datum/ghostspawner/simplemob/spider_queen/spawn_mob(mob/user)
+	. = ..()
+
+	//Basically, we don't want the mob AI to keep running if a player is assigned to it
+	//ideally there should also be an handling to resume thinking if the player ghosts
+	//but that would probably need a signal that we don't currently have, hence
+	//something for another time
+	var/mob/our_new_mob = . //This cast is needed, sorry
+	if(istype(our_new_mob) && !QDELETED(our_new_mob))
+		MOB_STOP_THINKING(our_new_mob)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -49,28 +49,67 @@
 	if(halloss) apply_damage(halloss, DAMAGE_PAIN, def_zone, blocked)
 	return TRUE
 
-/mob/living/proc/apply_effect(var/effect = 0,var/effecttype = STUN, var/blocked = 0)
-	if(!effect || (blocked >= 100))	return 0
-	switch(effecttype)
+/**
+ * Apply an effect to the mob
+ *
+ * * effect - The amount of effect to apply, a number
+ * * effect_type - An effect eg. `STUN`, `WEAKEN`; see `code\__DEFINES\damage_organs.dm` for relative defines
+ * * blocked - The amount of effect that was blocked, eg. by armor, a number, percentage
+ *
+ * Returns `TRUE` if the effect was applied, `FALSE` otherwise
+ */
+/mob/living/proc/apply_effect(effect = 0, effect_type = STUN, blocked = 0)
+	SHOULD_NOT_SLEEP(TRUE)
+
+	//Check that noone fucked up the vars
+	if(!isnum(effect))
+		stack_trace("Passed a wrong value in the proc for the effect var, it must be a number!")
+		return FALSE
+
+	if(!isnum(blocked))
+		stack_trace("Passed a wrong value in the proc for the blocked var, it must be a number!")
+		blocked = 0
+
+	if(!istext(effect_type))
+		stack_trace("Passed a wrong value in the proc for the effect_type var, it must be an effect!")
+		return FALSE
+
+	//If the armor blocked it all, no effect is to be applied
+	if(blocked >= 100)
+		return FALSE
+
+	//Apply the effect based on type, accounting for the blocked percentage
+	switch(effect_type)
+
 		if(STUN)
 			Stun(effect * BLOCKED_MULT(blocked))
+
 		if(WEAKEN)
 			Weaken(effect * BLOCKED_MULT(blocked))
+
 		if(PARALYZE)
 			Paralyse(effect * BLOCKED_MULT(blocked))
+
 		if(DAMAGE_PAIN)
 			adjustHalLoss(effect * BLOCKED_MULT(blocked)) //Changed this to use the wrapper function, it shouldn't directly alter the value
+
 		if(STUTTER)
 			if(status_flags & CANSTUN) // stun is usually associated with stutter
 				stuttering = max(stuttering, effect * BLOCKED_MULT(blocked))
+
 		if(EYE_BLUR)
 			eye_blurry = max(eye_blurry, effect * BLOCKED_MULT(blocked))
+
 		if(DROWSY)
 			drowsiness = max(drowsiness, effect * BLOCKED_MULT(blocked))
+
 		if(INCINERATE)
 			IgniteMob(effect * BLOCKED_MULT(blocked))
+
+	//Update health for the mob
 	updatehealth()
-	return 1
+
+	return TRUE
 
 
 /mob/living/proc/apply_effects(var/stun = 0, var/weaken = 0, var/paralyze = 0, var/irradiate = 0, var/stutter = 0, var/eyeblur = 0, var/drowsy = 0, var/agony = 0, var/incinerate = 0, var/blocked = 0)

--- a/code/modules/mob/living/simple_animal/hostile/spider_queen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/spider_queen.dm
@@ -122,7 +122,7 @@
 		for(var/mob/living/M in target_turf)
 			if(M != src)
 				M.apply_damage(50, DAMAGE_BRUTE)
-				M.apply_effect(6, STUN, blocked)
+				M.apply_effect(6, STUN)
 	return TRUE
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/spider_queen/Life()

--- a/html/changelogs/fluffyghost-fixplayablegrems.yml
+++ b/html/changelogs/fluffyghost-fixplayablegrems.yml
@@ -1,0 +1,45 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Spider queens and servants now stop thinking as mobs when a player is assigned to it."
+  - bugfix: "Resolved a runtime of effect application when the spider lands."
+  - backend: "Refactored apply_effect proc, DMdoc, check that the parameters are the correct type."
+  - backend: "DMDoc'd spawn_mob, set SDMM return type."
+  - backend: "DMDoc'd assign_player, set SDMM return type."


### PR DESCRIPTION
Spider queens and servants now stop thinking as mobs when a player is assigned to it.
Resolved a runtime of effect application when the spider lands.
Refactored apply_effect proc, DMdoc, check that the parameters are the correct type.
DMDoc'd spawn_mob, set SDMM return type.
DMDoc'd assign_player, set SDMM return type.