### PR TITLE
Genericizes the konyang tribute ruin

### DIFF
--- a/html/changelogs/DreamySkrell-generic-tribute-ruin.yml
+++ b/html/changelogs/DreamySkrell-generic-tribute-ruin.yml
@@ -4,4 +4,4 @@ author: DreamySkrell
 delete-after: True
 
 changes:
-  - maptweak: "Genericizes one konyang tribue ruin."
+  - maptweak: "Genericizes the konyang tribute ruin."

--- a/html/changelogs/DreamySkrell-generic-tribute-ruin.yml
+++ b/html/changelogs/DreamySkrell-generic-tribute-ruin.yml
@@ -1,0 +1,7 @@
+
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - maptweak: "Genericizes one konyang tribue ruin."

--- a/maps/random_ruins/exoplanets/konyang/tribute.dmm
+++ b/maps/random_ruins/exoplanets/konyang/tribute.dmm
@@ -956,8 +956,8 @@
 /obj/structure/sign/painting_frame/martyr{
 	pixel_y = 9;
 	pixel_x = -16;
-	name = "photo of a martyr";
-	desc = "a small portrait, with a plate reading 'Rest in Peace Kei Nakai' on the bottom of the frame.";
+	name = "photo of a person";
+	desc = "a small portrait, with a plate reading 'Rest in Peace' on the bottom of the frame.";
 	desc_extended = null
 	},
 /obj/item/flag/trinaryperfection{


### PR DESCRIPTION
It was added in a PR that did not mention this (in changelog or description) so there was no way to see this without checking the thousands of changed lines, one by one. So this was effectively sneaked in, in a PR that added some random generic ruins like swamps or villages.

I don't think it is fitting the server at all to have people adding personal ruins/sites/whatever for their (or other people's) characters. 

And even then still, another thing is that it's a random ruin and supposedly we are landing in a different place on konyang every round. Why are random konyangers making a shrine to one specific person, all over konyang? Ruins should be as generic as possible.