### PR TITLE
Various Melee Tweaks

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -244,8 +244,8 @@
 	edge = TRUE
 	shield_power = 75
 	can_block_bullets = TRUE
-	base_reflectchance = 60
-	base_block_chance = 60
+	base_reflectchance = 30
+	base_block_chance = 30
 	var/blade_color
 
 /obj/item/melee/energy/sword/New()
@@ -312,6 +312,8 @@
 	icon_state = "cutlass0"
 
 	slot_flags = SLOT_BELT
+	base_reflectchance = 60
+	base_block_chance = 60
 
 /obj/item/melee/energy/sword/pirate/activate(mob/living/user)
 	..()

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -242,8 +242,11 @@
 	origin_tech = list(TECH_MAGNET = 3, TECH_ILLEGAL = 4)
 	sharp = 1
 	edge = TRUE
-	var/blade_color
 	shield_power = 75
+	can_block_bullets = TRUE
+	base_reflectchance = 60
+	base_block_chance = 60
+	var/blade_color
 
 /obj/item/melee/energy/sword/New()
 	blade_color = pick("red","blue","green","purple")
@@ -274,15 +277,41 @@
 	attack_verb = list()
 	icon_state = initial(icon_state)
 
+/obj/item/melee/energy/sword/perform_technique(mob/living/carbon/human/target, mob/living/carbon/human/user, target_zone)
+	. = ..()
+	var/armor_reduction = target.get_blocked_ratio(target_zone, DAMAGE_BRUTE, DAMAGE_FLAG_EDGE|DAMAGE_FLAG_SHARP, damage = force)*100
+	var/obj/item/organ/external/affecting = target.get_organ(target_zone)
+	if(!affecting)
+		return
+	user.do_attack_animation(target)
+
+	if(target_zone == BP_HEAD || target_zone == BP_EYES || target_zone == BP_MOUTH)
+		if(prob(70 - armor_reduction))
+			target.eye_blurry += 5
+			target.confused += 10
+			return TRUE
+
+	if(target_zone == BP_R_ARM || target_zone == BP_L_ARM || target_zone == BP_R_HAND || target_zone == BP_L_HAND)
+		if(prob(80 - armor_reduction))
+			if(target_zone == BP_R_ARM || target_zone == BP_R_HAND)
+				target.drop_r_hand()
+			else
+				target.drop_l_hand()
+			return TRUE
+
+	if(target_zone == BP_R_FOOT || target_zone == BP_R_FOOT || target_zone == BP_R_LEG || target_zone == BP_L_LEG)
+		if(prob(60 - armor_reduction))
+			target.Weaken(5)
+			return TRUE
+
+	return FALSE
+
 /obj/item/melee/energy/sword/pirate
 	name = "energy cutlass"
 	desc = "Arrrr matey."
 	icon_state = "cutlass0"
 
 	slot_flags = SLOT_BELT
-
-	base_reflectchance = 60
-	base_block_chance = 60
 
 /obj/item/melee/energy/sword/pirate/activate(mob/living/user)
 	..()

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -251,11 +251,12 @@
 	name = "hegemony barrier"
 	desc = "A Zkrehk-Guild manufactured energy shield capable of protecting the wielder from both material and energy attack."
 	icon_state = "hegemony-eshield0"
+	base_block_chance = 60
 
 /obj/item/shield/energy/hegemony/update_icon()
 	icon_state = "hegemony-eshield[active]"
 	if(active)
-		set_light(1.5, 1.5, "e68917")
+		set_light(1.5, 1.5, "#e68917")
 	else
 		set_light(0)
 
@@ -263,6 +264,7 @@
 	name = "kataphract barrier"
 	desc = "A hardlight kite shield capable of protecting the wielder from both material and energy attack."
 	icon_state = "kataphract-eshield0"
+	base_block_chance = 65
 
 /obj/item/shield/energy/hegemony/kataphract/update_icon()
 	icon_state = "kataphract-eshield[active]"
@@ -275,6 +277,7 @@
 	name = "energy barrier"
 	desc = "A large deployable energy shield meant to provide excellent protection against ranged attacks."
 	icon_state = "ebarrier0"
+	base_block_chance = 55
 
 /obj/item/shield/energy/legion/update_icon()
 	icon_state = "ebarrier[active]"
@@ -287,6 +290,7 @@
 	name = "dominian energy barrier"
 	desc = "A hardlight energy shield meant to provide excellent protection in melee engagements."
 	icon_state = "dominian-eshield0"
+	base_block_chance = 60
 
 /obj/item/shield/energy/dominia/update_icon()
 	icon_state = "dominian-eshield[active]"

--- a/code/modules/martial_arts/swordsmanship.dm
+++ b/code/modules/martial_arts/swordsmanship.dm
@@ -1,6 +1,6 @@
 /datum/martial_art/swordsmanship
 	name = "Swordsmanship"
-	weapon_affinity = list(/obj/item/material/sword)
+	weapon_affinity = list(/obj/item/material/sword, /obj/item/melee/energy/sword)
 	parry_multiplier = 2
 	possible_weapons = list(/obj/item/material/sword, /obj/item/material/sword/katana, /obj/item/material/sword/rapier)
 

--- a/html/changelogs/RustingWithYou - sovlenhancement.yml
+++ b/html/changelogs/RustingWithYou - sovlenhancement.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Energy swords now work with the swordsmanship martial art."
+  - tweak: "Raises the chance for energy swords to block or deflect projectiles."
+  - tweak: "Increases the block chance on the various military-grade energy shields."


### PR DESCRIPTION
Some tweaks to energy swords and shields to make them more viable when compared to Shoot With Gun.
Energy swords now have a slightly higher base block chance and can block bullets as opposed to just lasers.

Energy shields associated with military forces now have a higher block rate - the TCFL one has been increased to 55 from 50, the Hegemony and Dominian ones have been increased to 60, and the Kataphract one has been increased to 65 as they're supposed to be the most melee-focused of these groups.

Energy swords are now compatible with the Swordsmanship martial art, and will work the same as normal swords for it. I honestly thought this was already in.