### PR TITLE
All IPC types can now be any gender.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
@@ -11,7 +11,7 @@
 	age_max = 60
 	economic_modifier = 3
 	default_genders = list(NEUTER)
-	selectable_pronouns = list(NEUTER, PLURAL)
+	selectable_pronouns = list(MALE, FEMALE, PLURAL, NEUTER)
 
 	blurb = "IPCs are, quite simply, \"Integrated Positronic Chassis.\" In this scenario, 'positronic' implies that the chassis possesses a positronic processing core (or positronic brain), meaning that an IPC must be positronic to be considered an IPC. The Baseline model is more of a category - the long of the short is that they represent all unbound synthetic units. Baseline models cover anything that is not an Industrial chassis or a Shell chassis. They can be custom made or assembly made. The most common feature of the Baseline model is a simple design, skeletal or semi-humanoid, and ordinary atmospheric diffusion cooling systems."
 

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -8,7 +8,6 @@
 	height_min = 140
 	height_max = 230
 	default_genders = list(MALE, FEMALE)
-	selectable_pronouns = list(MALE, FEMALE, PLURAL, NEUTER)
 
 	burn_mod = 1.2
 	grab_mod = 1

--- a/html/changelogs/sniblet-ipc-any-gender-82.yml
+++ b/html/changelogs/sniblet-ipc-any-gender-82.yml
@@ -1,0 +1,6 @@
+author: Sniblet
+
+delete-after: True
+
+changes:
+  - tweak: "All IPC types can now be any gender."


### PR DESCRIPTION
They're made by a species that cares a lot about gender, and their whole thing is trying to adapt into that species.
-Skrell can be anything they want but they have no sexual dimorphism.
-IPCs can only be plural or neuter, unless they wear skin. There's still nothing stopping them from being as visibly, audibly, superficially, mentally masculine or feminine as they or their manufacturer want, but unless they wear skin, this won't be reflected automatically.

Illustrative example:
Imagine a Bishop frame. It wears a woman's face in its holodisplay, bangs and all. It has paid financially and in function to have its chassis shaped to have a thinner waist. It speaks in a feminine timbre. It wears a bow on its head and tries to act like a proper lady in all situations. The game calls it an it.
Imagine a skrell. He has headtails. His player has not decided how he prefers to use them reproductively. He is shaped like a skrell and talks like a skrell and acts like an oqi even though he is an ix. He spoke to a human once about gender and went, "I guessch if I had to choosche one, I'd be male." The game calls him a he.