### PR TITLE
Point Verdant now takes cargo packages + some bug fixes

### DIFF
--- a/html/changelogs/Ben10083 - PV Cargo.yml
+++ b/html/changelogs/Ben10083 - PV Cargo.yml
@@ -40,3 +40,4 @@ delete-after: True
 changes:
   - rscadd: "Point Verdant Sakae Tower now takes cargo packages."
   - bugfix: "Cryo Computers added to Point Verdant at most areas with a cryopod"
+  - bugfix: "Konyang Police lockers now have proper access"

--- a/html/changelogs/Ben10083 - PV Cargo.yml
+++ b/html/changelogs/Ben10083 - PV Cargo.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Point Verdant Sakae Tower now takes cargo packages."

--- a/html/changelogs/Ben10083 - PV Cargo.yml
+++ b/html/changelogs/Ben10083 - PV Cargo.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Point Verdant Sakae Tower now takes cargo packages."
+  - bugfix: "Cryo Computers added to Point Verdant at most areas with a cryopod"

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
@@ -5388,7 +5388,7 @@
 /area/point_verdant/outdoors)
 "qa" = (
 /obj/structure/closet/secure_closet{
-	req_access = list(217)
+	req_access = list(218)
 	},
 /obj/item/device/flashlight/maglight,
 /obj/item/device/flashlight/maglight,
@@ -6719,7 +6719,7 @@
 /area/point_verdant/interior)
 "tS" = (
 /obj/structure/closet/secure_closet/guncabinet{
-	req_access = list(217)
+	req_access = list(218)
 	},
 /obj/random/dirt_75,
 /obj/item/gun/projectile/revolver/konyang/police,
@@ -10511,7 +10511,7 @@
 /area/point_verdant/interior)
 "FD" = (
 /obj/structure/closet/secure_closet{
-	req_access = list(217)
+	req_access = list(218)
 	},
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/shoes/jackboots,
@@ -11492,7 +11492,7 @@
 /area/point_verdant/interior/offices/kaf)
 "Ib" = (
 /obj/structure/closet/secure_closet{
-	req_access = list(217)
+	req_access = list(218)
 	},
 /obj/item/melee/baton/loaded,
 /obj/item/melee/baton/loaded,

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
@@ -5718,6 +5718,11 @@
 /obj/structure/closet/crate/bin/filled,
 /obj/item/trash/cigbutt,
 /obj/item/trash/cigbutt,
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = 22;
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/police)
 "qV" = (

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
@@ -12559,6 +12559,9 @@
 "Lt" = (
 /obj/random/dirt_75,
 /obj/random/dirt_75,
+/obj/machinery/computer/cryopod{
+	pixel_y = 30
+	},
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/hotel)
 "Lu" = (

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-2.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-2.dmm
@@ -5859,6 +5859,9 @@
 /obj/machinery/cryopod{
 	dir = 4
 	},
+/obj/machinery/computer/cryopod{
+	pixel_y = 30
+	},
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/bar)
 "pq" = (

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-3.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-3.dmm
@@ -3144,6 +3144,10 @@
 	},
 /turf/simulated/floor/asphalt,
 /area/point_verdant/interior/shallow)
+"zd" = (
+/obj/structure/cargo_receptacle,
+/turf/simulated/floor/wood,
+/area/point_verdant/interior/offices)
 "zi" = (
 /obj/effect/decal/curb/corner,
 /obj/effect/decal/curb{
@@ -17884,7 +17888,7 @@ Zq
 Jy
 Hc
 bf
-HS
+zd
 HS
 HS
 HS


### PR DESCRIPTION
Adds a cargo receptacle to Sakae Towers, PV, to encourage deliveries to the area. May consider adding more in the future

Adds missing cryo computers to two different locations in PV (metro lifts wont have one)

Konyang Police Access now set to police instead of Golden Deep (They can't keep getting away with this)