### PR TITLE
Point Verdant Access Fixes & Lighting

### DIFF
--- a/code/modules/vehicles/bike.dm
+++ b/code/modules/vehicles/bike.dm
@@ -438,6 +438,13 @@
 	can_hover = FALSE
 	key_type = /obj/item/key/bike/sport
 
+/obj/vehicle/bike/motor/check_destination(turf/destination)
+	var/static/list/types = typecacheof(list(/turf/space, /turf/simulated/floor/exoplanet/water))
+	if(is_type_in_typecache(destination,types) || pulledby)
+		return TRUE
+	else
+		return FALSE
+
 /obj/vehicle/bike/motor/generate_registration_plate()
 	registration_plate = "[rand(10,99)]S-[rand(1000,9999)]"
 

--- a/html/changelogs/RustingWithYou - verdantfixes.yml
+++ b/html/changelogs/RustingWithYou - verdantfixes.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes incorrect accesses on Point Verdant"
+  - maptweak: "Point Verdant exterior areas will now be automatically lit."

--- a/html/changelogs/RustingWithYou - verdantfixes.yml
+++ b/html/changelogs/RustingWithYou - verdantfixes.yml
@@ -39,4 +39,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Fixes incorrect accesses on Point Verdant"
+  - bugfix: "Fixes motorbikes being unable to go upstairs."
   - maptweak: "Point Verdant exterior areas will now be automatically lit."

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
@@ -743,10 +743,6 @@
 /area/point_verdant/interior)
 "cf" = (
 /obj/structure/weightlifter,
-/obj/effect/ghostspawpoint{
-	name = "igs - konyang_goon_boss";
-	identifier = "konyang_goon_boss"
-	},
 /turf/simulated/floor/lino,
 /area/point_verdant/interior/decrepit)
 "cg" = (
@@ -1936,6 +1932,8 @@
 /obj/item/storage/bag/trash,
 /obj/item/hammer,
 /obj/random/dirt_75,
+/obj/random/civgun,
+/obj/random/civgun,
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/streetvendor)
 "fK" = (
@@ -2663,7 +2661,7 @@
 /area/point_verdant/interior)
 "hW" = (
 /obj/structure/closet/secure_closet/guncabinet{
-	req_access = list(217)
+	req_access = list(218)
 	},
 /obj/item/ammo_magazine/c45/revolver,
 /obj/item/ammo_magazine/c45/revolver,
@@ -4498,10 +4496,6 @@
 /obj/structure/bed/stool/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/ghostspawpoint{
-	name = "igs - konyang_goon";
-	identifier = "konyang_goon"
-	},
 /turf/simulated/floor/lino,
 /area/point_verdant/interior/decrepit)
 "ni" = (
@@ -5388,7 +5382,7 @@
 /area/point_verdant/outdoors)
 "qa" = (
 /obj/structure/closet/secure_closet{
-	req_access = list(217)
+	req_access = list(218)
 	},
 /obj/item/device/flashlight/maglight,
 /obj/item/device/flashlight/maglight,
@@ -6719,7 +6713,7 @@
 /area/point_verdant/interior)
 "tS" = (
 /obj/structure/closet/secure_closet/guncabinet{
-	req_access = list(217)
+	req_access = list(218)
 	},
 /obj/random/dirt_75,
 /obj/item/gun/projectile/revolver/konyang/police,
@@ -6900,10 +6894,6 @@
 "uy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/stool/chair/office/dark,
-/obj/effect/ghostspawpoint{
-	name = "igs - konyang_goon";
-	identifier = "konyang_goon"
-	},
 /turf/simulated/floor/lino,
 /area/point_verdant/interior/decrepit)
 "uz" = (
@@ -7837,10 +7827,6 @@
 /obj/machinery/light/colored/decayed{
 	dir = 8;
 	pixel_x = -10
-	},
-/obj/effect/ghostspawpoint{
-	name = "igs - konyang_goon";
-	identifier = "konyang_goon"
 	},
 /turf/simulated/floor/lino,
 /area/point_verdant/interior/decrepit)
@@ -10511,7 +10497,7 @@
 /area/point_verdant/interior)
 "FD" = (
 /obj/structure/closet/secure_closet{
-	req_access = list(217)
+	req_access = list(218)
 	},
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/shoes/jackboots,
@@ -10522,10 +10508,9 @@
 /obj/item/clothing/under/rank/konyang/police,
 /obj/item/clothing/under/rank/konyang/police,
 /obj/item/clothing/under/rank/konyang/police,
-/obj/item/clothing/suit/armor/carrier/generic,
-/obj/item/clothing/suit/armor/carrier/generic,
-/obj/item/clothing/suit/armor/carrier/generic,
-/obj/item/clothing/suit/armor/carrier/generic,
+/obj/item/clothing/suit/storage/vest/konyang,
+/obj/item/clothing/suit/storage/vest/konyang,
+/obj/item/clothing/suit/storage/vest/konyang,
 /turf/simulated/floor/tiled/dark,
 /area/point_verdant/interior/police)
 "FE" = (
@@ -11492,7 +11477,7 @@
 /area/point_verdant/interior/offices/kaf)
 "Ib" = (
 /obj/structure/closet/secure_closet{
-	req_access = list(217)
+	req_access = list(218)
 	},
 /obj/item/melee/baton/loaded,
 /obj/item/melee/baton/loaded,
@@ -11885,8 +11870,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb2,
-/obj/random/civgun,
-/obj/random/civgun,
 /turf/simulated/floor/lino,
 /area/point_verdant/interior/decrepit)
 "Jj" = (

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-2.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-2.dmm
@@ -1926,6 +1926,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/offices)
+"fp" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/random/dirt_75,
+/obj/effect/ghostspawpoint{
+	name = "igs - konyang_gwok";
+	identifier = "konyang_gwok"
+	},
+/turf/simulated/floor/tiled/white,
+/area/point_verdant/interior/restaurant)
 "fr" = (
 /obj/machinery/door/window/eastleft,
 /turf/simulated/floor/tiled/white,
@@ -10559,6 +10568,10 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
+/obj/effect/ghostspawpoint{
+	name = "igs - konyang_goon";
+	identifier = "konyang_goon"
+	},
 /turf/simulated/floor/lino/diamond,
 /area/point_verdant/interior/streetvendor)
 "Bk" = (
@@ -16449,6 +16462,17 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/lino/diamond,
 /area/point_verdant/interior/restaurant)
+"Qk" = (
+/obj/structure/ledge/quarter{
+	dir = 1
+	},
+/obj/random/dirt_75,
+/obj/effect/ghostspawpoint{
+	name = "igs - konyang_goon";
+	identifier = "konyang_goon"
+	},
+/turf/simulated/floor/lino/diamond,
+/area/point_verdant/interior/streetvendor)
 "Ql" = (
 /obj/effect/decal/curb/corner{
 	dir = 1
@@ -17449,6 +17473,10 @@
 	pixel_y = 26;
 	pixel_x = -21
 	},
+/obj/effect/ghostspawpoint{
+	name = "igs - konyang_goon_boss";
+	identifier = "konyang_goon_boss"
+	},
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/streetvendor)
 "ST" = (
@@ -18034,6 +18062,10 @@
 "Uu" = (
 /obj/structure/rod_railing{
 	dir = 8
+	},
+/obj/effect/ghostspawpoint{
+	name = "igs - konyang_goon";
+	identifier = "konyang_goon"
 	},
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/streetvendor)
@@ -18643,6 +18675,14 @@
 	},
 /turf/simulated/floor/asphalt,
 /area/point_verdant/outdoors)
+"Wb" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/effect/ghostspawpoint{
+	name = "igs - konyang_gwok";
+	identifier = "konyang_gwok"
+	},
+/turf/simulated/floor/tiled/white,
+/area/point_verdant/interior/restaurant)
 "Wc" = (
 /obj/structure/flora/rock/konyang/water,
 /obj/structure/flora/bush/konyang_reeds/water,
@@ -48791,7 +48831,7 @@ zk
 zk
 BE
 BE
-BE
+Wb
 la
 YS
 Sw
@@ -50331,7 +50371,7 @@ xn
 dm
 zk
 zk
-zk
+fp
 zk
 Qy
 Gf
@@ -54482,7 +54522,7 @@ gU
 tQ
 KL
 aM
-XR
+Qk
 Lr
 uu
 xb

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-3.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-3.dmm
@@ -94,7 +94,9 @@
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/minimart)
 "aE" = (
-/obj/machinery/mecha_part_fabricator,
+/obj/machinery/mecha_part_fabricator{
+	req_access = list(219)
+	},
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/robotics)
@@ -3382,7 +3384,9 @@
 /turf/simulated/floor/roofing_tiles,
 /area/point_verdant/outdoors)
 "Bf" = (
-/obj/machinery/mecha_part_fabricator,
+/obj/machinery/mecha_part_fabricator{
+	req_access = list(219)
+	},
 /obj/machinery/light{
 	dir = 8
 	},

--- a/maps/away/away_site/konyang/point_verdant/point_verdant_areas.dm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant_areas.dm
@@ -6,21 +6,31 @@
 	base_turf = /turf/simulated/floor/exoplanet/dirt_konyang
 	ambience = AMBIENCE_KONYANG_TRAFFIC
 	sound_env = CITY
+	var/lighting = FALSE //Is this area automatically lit?
+
+/area/point_verdant/Initialize()
+	. = ..()
+	if(lighting)
+		for(var/turf/T in src)
+			T.set_light(MINIMUM_USEFUL_LIGHT_RANGE, 50, COLOR_WHITE) //Same light level as Konyang proper
 
 /area/point_verdant/outer
 	name = "Point Verdant - Outskirts"
 	sound_env = FOREST
+	lighting = TRUE
 
 /area/point_verdant/coast
 	name = "Point Verdant - Waterside"
 	ambience = AMBIENCE_KONYANG_WATER
 	area_blurb = "The crashing sounds of waves on the shore punctuates the air. The vast ocean spreads out as far as the eye can see, looking almost flat."
 	area_blurb_category = "verdant_shore"
+	lighting = TRUE
 
 /area/point_verdant/reservoir
 	name = "Point Verdant - Reservoir"
 	sound_env = PLAIN
 	ambience = AMBIENCE_KONYANG_WATER
+	lighting = TRUE
 
 /area/point_verdant/sewer
 	name = "Point Verdant - Sewers"
@@ -119,10 +129,13 @@
 	name = "Point Verdant - Outdoors"
 	area_blurb = "The sounds and smells of Point Verdant bombard you from all directions. Skyscrapers tower up further into the city."
 	area_blurb_category = "verdant_outdoors"
+	lighting = TRUE
 
 /area/point_verdant/water
 	name = "Point Verdant - Open Water"
 	icon_state = "fitness_pool"
+	lighting = TRUE
 
 /area/point_verdant/water/deep // also used for waterdock landing area
 	name = "Point Verdant - Deep Water"
+	lighting = TRUE

--- a/maps/away/away_site/konyang/point_verdant/point_verdant_ghostroles.dm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant_ghostroles.dm
@@ -11,11 +11,12 @@
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 	assigned_role = "Zeng-Hu Pharmaceuticals Corporate Personnel"
 	special_role = "Zeng-Hu Pharmaceuticals Corporate Personnel"
+	respawn_flag = null
 
 /datum/outfit/admin/konyang_zh
 	name = "Zeng-Hu Pharmaceuticals Employee"
-	uniform = /obj/item/clothing/under/rank/scientist/zeng
-	shoes = /obj/item/clothing/shoes/sneakers
+	uniform = /obj/item/clothing/under/rank/liaison/zeng
+	shoes = /obj/item/clothing/shoes/laceup
 	id = /obj/item/card/id/zeng_hu
 	back = /obj/item/storage/backpack/satchel/zeng
 	head = /obj/item/clothing/head/beret/corporate/zeng
@@ -37,11 +38,12 @@
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 	assigned_role = "Einstein Engines Corporate Personnel"
 	special_role = "Einstein Engines Corporate Personnel"
+	respawn_flag = null
 
 /datum/outfit/admin/konyang_ee
 	name = "Einstein Engines Employee"
-	uniform = /obj/item/clothing/under/rank/einstein
-	shoes = /obj/item/clothing/shoes/sneakers/black
+	uniform = /obj/item/clothing/under/rank/liaison/einstein
+	shoes = /obj/item/clothing/shoes/laceup
 	id = /obj/item/card/id/einstein
 	back = /obj/item/storage/backpack/satchel
 	r_pocket = /obj/item/storage/wallet/random
@@ -62,6 +64,7 @@
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 	assigned_role = "Konyang National Police Patrolman"
 	special_role = "Konyang National Police Patrolman"
+	respawn_flag = null
 
 /datum/outfit/admin/konyang_cop
 	name = "Konyang Police Officer"
@@ -114,6 +117,7 @@
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 	assigned_role = "5-Cheung Thug"
 	special_role = "5-Cheung Thug"
+	respawn_flag = null
 
 /datum/outfit/admin/konyang_goon
 	name = "5-Cheung Thug"
@@ -133,6 +137,7 @@
 	outfit = /datum/outfit/admin/konyang_mob_boss
 	assigned_role = "5-Cheung Boss"
 	special_role = "5-Cheung Boss"
+	respawn_flag = null
 
 /datum/outfit/admin/konyang_mob_boss
 	name = "5-Cheung Boss"
@@ -156,6 +161,7 @@
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 	assigned_role = "Point Verdant Vendor"
 	special_role = "Point Verdant Vendor"
+	respawn_flag = null
 
 /datum/outfit/admin/konyang_vendor
 	name = "Konyang Vendor"
@@ -181,6 +187,7 @@
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 	assigned_role = "Konyang Robotics Company Doctor"
 	special_role = "Konyang Robotics Company Doctor"
+	respawn_flag = null
 
 /datum/outfit/admin/konyang_clinic
 	name = "KRC Doctor"
@@ -205,6 +212,7 @@
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 	assigned_role = "Pharmacist"
 	special_role = "Pharmacist"
+	respawn_flag = null
 
 /datum/outfit/admin/konyang_pharm
 	name = "Konyang Pharmacist"
@@ -229,6 +237,7 @@
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 	assigned_role = "Bartender"
 	special_role = "Bartender"
+	respawn_flag = null
 
 /datum/outfit/admin/konyang_bar
 	name = "Konyang Bartender"
@@ -250,6 +259,7 @@
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 	assigned_role = "Point Verdant Utility Worker"
 	special_role = "Point Verdant Utility Worker"
+	respawn_flag = null
 
 /datum/outfit/admin/konyang_utility
 	name = "Point Verdant Utility Worker"
@@ -274,6 +284,7 @@
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 	assigned_role = "UP! Burger Employee"
 	special_role = "UP! Burger Employee"
+	respawn_flag = null
 
 /datum/outfit/admin/konyang_gwok
 	name = "UP! Burger Employee"


### PR DESCRIPTION
The police lockers are no longer owned by the Golden Deep, as funny as that is.
The mech fabricators in the robotics clinic are now accessible by the clinic workers.
Point Verdant exteriors now have lighting so you can actually see the cool ocean.
Point Verdant ghostroles no longer require a 20 minute wait to join.
Motorbikes can now go up Z-levels