### PR TITLE
Psi Points on Species Change

### DIFF
--- a/code/modules/ghostroles/spawner/human/human.dm
+++ b/code/modules/ghostroles/spawner/human/human.dm
@@ -104,9 +104,6 @@
 
 	M.set_species(picked_species)
 
-	if(M.species.character_creation_psi_points && M.has_psionics)
-		M.psi.psi_points = M.species.character_creation_psi_points
-
 	//Prepare the mob
 	M.check_dna(M)
 	M.dna.ready_dna(M)

--- a/code/modules/ghostroles/spawner/human/human.dm
+++ b/code/modules/ghostroles/spawner/human/human.dm
@@ -104,6 +104,9 @@
 
 	M.set_species(picked_species)
 
+	if(M.species.character_creation_psi_points && M.has_psionics)
+		M.psi.psi_points = M.species.character_creation_psi_points
+
 	//Prepare the mob
 	M.check_dna(M)
 	M.dna.ready_dna(M)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1506,6 +1506,9 @@
 	else if(HAS_TRAIT(src, TRAIT_PSIONICALLY_DEAF))
 		REMOVE_TRAIT(src, TRAIT_PSIONICALLY_DEAF, INNATE_TRAIT)
 
+	if(species.character_creation_psi_points && species.has_psionics)
+		psi.psi_points = max(species.character_creation_psi_points - psi.spent_psi_points, 0) //to prevent species-switching for more points
+
 	if(client)
 		client.init_verbs()
 

--- a/html/changelogs/RustingWithYou - skrostroles.yml
+++ b/html/changelogs/RustingWithYou - skrostroles.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Ghostspawners for psionic species will now give psi points on spawning."


### PR DESCRIPTION
If you change species to Skrell (or any theoretical other psionic species), whether by spawning as one in a ghostrole or switching to one in an appearance changer, you will now gain the psi points that you would have in normal character creation.