### PR TITLE
Point Verdant Hotel Death Trap Fall Fix

### DIFF
--- a/html/changelogs/SleepyGemmy-pv_fix.yml
+++ b/html/changelogs/SleepyGemmy-pv_fix.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed the Point Verdant death trap fall near the hotel."

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-2.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-2.dmm
@@ -1547,10 +1547,10 @@
 /area/point_verdant/outdoors)
 "em" = (
 /obj/effect/decal/road_marking/incline{
-	pixel_y = -5
+	pixel_y = -2
 	},
-/obj/structure/stairs/urban/left{
-	icon_state = "stairs-left-bot"
+/obj/structure/stairs/urban/road_ramp/left{
+	icon_state = "road-ramp-left-top"
 	},
 /turf/simulated/floor/sidewalk,
 /area/point_verdant/outdoors)
@@ -2364,15 +2364,14 @@
 /turf/simulated/floor/exoplanet/water/shallow/konyang,
 /area/point_verdant/water)
 "gB" = (
-/obj/effect/decal/road_marking/incline{
-	pixel_y = 26;
-	dir = 1
-	},
 /obj/structure/stairs/urban/road_ramp/right{
-	icon_state = "road-ramp-right-top";
-	pixel_y = 30
+	icon_state = "road-ramp-right-top"
 	},
-/turf/simulated/floor/asphalt,
+/obj/effect/decal/road_marking/incline{
+	dir = 1;
+	pixel_y = -2
+	},
+/turf/simulated/floor/sidewalk,
 /area/point_verdant/outdoors)
 "gC" = (
 /obj/structure/konyang_cliff{
@@ -3831,12 +3830,13 @@
 /turf/simulated/floor/asphalt,
 /area/point_verdant/outdoors)
 "kx" = (
-/obj/structure/stairs/urban/road_ramp/left{
-	icon_state = "road-ramp-left-top";
-	pixel_y = 29
+/obj/structure/flora/bush/konyang_reeds/water,
+/obj/structure/rod_railing{
+	name = "imposing rod railing";
+	layer = 9.1
 	},
-/turf/simulated/floor/asphalt,
-/area/point_verdant/outdoors)
+/turf/simulated/floor/exoplanet/water/shallow/konyang/no_smooth,
+/area/point_verdant/water)
 "ky" = (
 /obj/effect/decal/curb/corner{
 	dir = 8
@@ -4377,6 +4377,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/offices)
+"lJ" = (
+/obj/structure/utility_pole/street/on{
+	pixel_y = 24
+	},
+/turf/simulated/floor/sidewalk/detail,
+/area/point_verdant/outdoors)
 "lL" = (
 /obj/structure/flora/bush/konyang_reeds/water,
 /turf/simulated/floor/exoplanet/water/konyang,
@@ -9138,12 +9144,10 @@
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/offices)
 "xM" = (
-/obj/structure/flora/bush/konyang_reeds/water,
-/obj/structure/rod_railing{
-	name = "imposing rod railing";
-	layer = 9.1
+/obj/structure/stairs/urban/left{
+	icon_state = "stairs-left-bot"
 	},
-/turf/simulated/floor/exoplanet/water/shallow/konyang/no_smooth,
+/turf/simulated/floor/sidewalk,
 /area/point_verdant/outdoors)
 "xN" = (
 /obj/effect/floor_decal/corner/green/diagonal{
@@ -29564,9 +29568,9 @@ AQ
 gy
 ci
 ci
-bh
+lJ
 BT
-BT
+Of
 Jx
 yA
 iy
@@ -29821,10 +29825,10 @@ AQ
 gy
 ci
 oP
-BT
 ws
 Za
 gB
+iN
 ML
 iN
 iN
@@ -35730,12 +35734,12 @@ Zx
 Zx
 Zx
 LQ
-LQ
 GJ
 ll
 Tb
+xM
 em
-kx
+qn
 Zg
 qn
 qn
@@ -35988,10 +35992,10 @@ Sf
 Sf
 xy
 xy
-xy
 mw
 BT
 BT
+iz
 LN
 iL
 zv
@@ -36245,10 +36249,10 @@ MA
 MA
 MA
 MA
-wK
-xM
+kx
+BT
 bh
-Of
+iz
 LN
 iL
 zv
@@ -36502,8 +36506,8 @@ az
 az
 MA
 az
-lL
-xM
+kx
+BT
 BT
 PN
 LN
@@ -36759,8 +36763,8 @@ MA
 MA
 MA
 MA
-wK
-xM
+kx
+BT
 BT
 iz
 LN
@@ -37016,10 +37020,10 @@ lG
 lG
 lG
 lG
-lG
 Ob
 BT
-iz
+BT
+SM
 lF
 bb
 Hz
@@ -37273,10 +37277,10 @@ vA
 lp
 vA
 vA
-vA
 lp
 BT
-SM
+BT
+BT
 LN
 iL
 Hz

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-3.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-3.dmm
@@ -1836,6 +1836,15 @@
 	},
 /turf/simulated/open,
 /area/point_verdant/outdoors)
+"oi" = (
+/obj/effect/decal/curb/corner{
+	dir = 1
+	},
+/obj/structure/road_barrier{
+	layer = 9.1
+	},
+/turf/simulated/floor/sidewalk,
+/area/point_verdant/outdoors)
 "or" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1997,6 +2006,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/police)
+"pI" = (
+/obj/effect/decal/curb,
+/obj/machinery/light/small/floor,
+/obj/structure/road_barrier/bot_end{
+	dir = 1
+	},
+/turf/simulated/floor/sidewalk,
+/area/point_verdant/outdoors)
 "pL" = (
 /obj/random/dirt_75,
 /obj/structure/table/standard,
@@ -2589,6 +2606,12 @@
 	dir = 8;
 	pixel_x = 12;
 	pixel_y = 0
+	},
+/turf/simulated/floor/sidewalk,
+/area/point_verdant/outdoors)
+"ur" = (
+/obj/structure/road_barrier/bot_end{
+	layer = 9.1
 	},
 /turf/simulated/floor/sidewalk,
 /area/point_verdant/outdoors)
@@ -5545,6 +5568,9 @@
 /area/point_verdant/outdoors)
 "Ql" = (
 /obj/structure/urban_grate,
+/obj/structure/road_barrier{
+	layer = 9.1
+	},
 /turf/simulated/floor/sidewalk,
 /area/point_verdant/outdoors)
 "Qn" = (
@@ -19194,7 +19220,7 @@ GV
 bH
 cH
 wU
-ru
+pI
 rx
 DD
 Ni
@@ -19451,7 +19477,7 @@ VF
 Ht
 dq
 vL
-tC
+oi
 rx
 DD
 Ni
@@ -19708,7 +19734,7 @@ VF
 MG
 jo
 XZ
-hw
+Fz
 rx
 DD
 Ni
@@ -19965,7 +19991,7 @@ VF
 MG
 jo
 XZ
-hw
+Fz
 rx
 DD
 Ni
@@ -20222,7 +20248,7 @@ VF
 Wn
 SF
 XZ
-hw
+Fz
 rx
 DD
 Ni
@@ -20736,7 +20762,7 @@ HB
 HB
 HB
 XZ
-hw
+Fz
 rx
 DD
 Ni
@@ -20993,7 +21019,7 @@ SK
 SK
 SK
 tC
-hw
+ur
 rx
 DD
 Ni
@@ -21764,7 +21790,7 @@ oe
 aS
 Jx
 hw
-hw
+Jx
 rx
 DD
 Ni
@@ -22021,7 +22047,7 @@ Sy
 uT
 xh
 hw
-hw
+Fz
 rx
 DD
 Ni


### PR DESCRIPTION
no longer shall people randomly fall off the edge and hit the ground and die instantly where the stairs should be.

![image](https://github.com/Aurorastation/Aurora.3/assets/99297919/4ad47d94-badb-496e-a0ec-c7dba35dc188)