### PR TITLE
Konyang QoL Buffs

### DIFF
--- a/html/changelogs/peppermint-burger-fix.yml
+++ b/html/changelogs/peppermint-burger-fix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Peppermint96
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes burger employees spawning without shoes."

--- a/html/changelogs/peppermint-konyangQoL.yml
+++ b/html/changelogs/peppermint-konyangQoL.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Peppermint
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Added a bunch of QoL additions to the Konyang away map."

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
@@ -2809,13 +2809,6 @@
 /obj/item/clothing/shoes/magboots,
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/offices/kaf)
-"it" = (
-/obj/structure/ledge/quarter{
-	dir = 1
-	},
-/obj/effect/map_effect/particle_emitter/bar_smoke,
-/turf/simulated/floor/lino,
-/area/point_verdant/interior/bar)
 "iu" = (
 /obj/structure/table/wood,
 /obj/item/device/taperecorder{
@@ -3196,6 +3189,10 @@
 	},
 /turf/simulated/floor/sidewalk/blocks,
 /area/point_verdant/outdoors)
+"jC" = (
+/obj/item/storage/box/fancy/yoke/ebisu,
+/turf/simulated/floor/lino,
+/area/point_verdant/interior/bar)
 "jD" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/machinery/light{
@@ -3388,6 +3385,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/rubber,
 /area/point_verdant/interior/offices)
+"jZ" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/black,
+/obj/item/clothing/accessory/holster/hip/brown,
+/turf/simulated/floor/wood,
+/area/point_verdant/interior/police)
 "ka" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -3582,10 +3586,6 @@
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/offices/kaf)
 "kC" = (
-/obj/machinery/light/colored/decayed{
-	dir = 8;
-	pixel_x = -10
-	},
 /obj/structure/toilet{
 	dir = 4
 	},
@@ -3941,6 +3941,7 @@
 /obj/item/device/flashlight/lamp/green{
 	pixel_y = 14
 	},
+/obj/item/clothing/accessory/holster/thigh/brown,
 /turf/simulated/floor/carpet/lightblue,
 /area/point_verdant/interior/police)
 "lx" = (
@@ -5402,6 +5403,8 @@
 /obj/item/clothing/suit/storage/vest/konyang,
 /obj/item/clothing/suit/storage/vest/konyang,
 /obj/item/clothing/suit/storage/vest/konyang,
+/obj/item/clothing/accessory/holster/armpit,
+/obj/item/clothing/accessory/holster/armpit,
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/police)
 "qb" = (
@@ -5944,6 +5947,14 @@
 /obj/item/storage/box/folders{
 	pixel_y = 5
 	},
+/obj/item/device/flashlight/maglight{
+	pixel_y = -7;
+	pixel_x = -2
+	},
+/obj/item/device/flashlight/maglight{
+	pixel_y = -7;
+	pixel_x = -2
+	},
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/police)
 "rM" = (
@@ -6479,6 +6490,17 @@
 /obj/structure/extinguisher_cabinet/south,
 /turf/simulated/floor/tiled/full,
 /area/point_verdant/interior/offices)
+"te" = (
+/obj/structure/closet,
+/obj/item/device/quikpay,
+/obj/item/clothing/under/konyang,
+/obj/item/clothing/under/konyang/blue,
+/obj/item/clothing/suit/storage/toggle/konyang/dbjacket,
+/obj/item/clothing/under/pants/black,
+/obj/item/clothing/under/pants/camo,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/flight,
+/turf/simulated/floor/lino,
+/area/point_verdant/interior/bar)
 "tg" = (
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/bar)
@@ -8452,6 +8474,10 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/asphalt,
 /area/point_verdant/outdoors)
+"zr" = (
+/obj/machinery/media/jukebox,
+/turf/simulated/floor/wood,
+/area/point_verdant/interior/bar)
 "zs" = (
 /obj/item/stack/tile/wood,
 /obj/structure/ledge/quarter{
@@ -9733,6 +9759,7 @@
 	pixel_x = 2;
 	pixel_y = 2
 	},
+/obj/item/holomenu,
 /turf/simulated/floor/lino/diamond,
 /area/point_verdant/interior/bar)
 "Dq" = (
@@ -10516,6 +10543,8 @@
 /obj/item/clothing/suit/storage/vest/konyang,
 /obj/item/clothing/suit/storage/vest/konyang,
 /obj/item/clothing/suit/storage/vest/konyang,
+/obj/item/clothing/accessory/holster/armpit,
+/obj/item/clothing/accessory/holster/armpit,
 /turf/simulated/floor/tiled/dark,
 /area/point_verdant/interior/police)
 "FE" = (
@@ -12249,6 +12278,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior)
+"Ky" = (
+/obj/effect/map_effect/particle_emitter/bar_smoke,
+/turf/simulated/floor/tiled/full,
+/area/point_verdant/interior/bar)
 "Kz" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 1
@@ -13901,14 +13934,6 @@
 	icon_state = "black"
 	},
 /area/point_verdant/interior)
-"Pg" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 12;
-	pixel_y = 8
-	},
-/turf/simulated/floor/lino,
-/area/point_verdant/interior/bar)
 "Ph" = (
 /obj/structure/lattice/catwalk/indoor/urban,
 /turf/simulated/floor/exoplanet/water/shallow/konyang,
@@ -14231,10 +14256,6 @@
 	pixel_x = 12;
 	pixel_y = 8
 	},
-/obj/machinery/vending/boozeomat{
-	req_access = null;
-	layer = 2.89
-	},
 /obj/machinery/button/remote/blast_door{
 	id = "konyang_bar";
 	name = "Store Shutters";
@@ -14243,7 +14264,11 @@
 	req_access = list(219);
 	pixel_x = 20
 	},
-/turf/simulated/floor/lino,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/lino/diamond,
 /area/point_verdant/interior/bar)
 "Qa" = (
 /obj/random/dirt_75,
@@ -15041,6 +15066,7 @@
 	pixel_x = -3;
 	pixel_y = -2
 	},
+/obj/item/clothing/accessory/holster/hip,
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/police)
 "Si" = (
@@ -15152,6 +15178,7 @@
 	pixel_x = 7;
 	pixel_y = 5
 	},
+/obj/item/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/lino,
 /area/point_verdant/interior/bar)
 "St" = (
@@ -17385,6 +17412,13 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/hotel)
+"YI" = (
+/obj/machinery/vending/boozeomat{
+	req_access = null;
+	layer = 2.89
+	},
+/turf/simulated/floor/lino,
+/area/point_verdant/interior/bar)
 "YJ" = (
 /obj/structure/flora/bush/konyang_reeds,
 /obj/structure/trash_pile,
@@ -26668,7 +26702,7 @@ wr
 fR
 SF
 hb
-AR
+jZ
 kT
 lC
 Ue
@@ -43594,7 +43628,7 @@ AV
 AV
 bk
 sZ
-tg
+zr
 tg
 cE
 iw
@@ -44110,7 +44144,7 @@ bk
 bk
 Od
 HL
-Tq
+Ky
 jm
 iw
 sZ
@@ -44368,7 +44402,7 @@ bk
 Od
 GT
 Tq
-it
+jm
 iw
 sZ
 mj
@@ -45140,7 +45174,7 @@ bk
 bk
 sZ
 di
-iw
+YI
 sZ
 hP
 sZ
@@ -45397,7 +45431,7 @@ bk
 bk
 sZ
 IE
-Pg
+iw
 iw
 iw
 sZ
@@ -45653,10 +45687,10 @@ AV
 AV
 bk
 sZ
-sZ
-sZ
-sZ
-sZ
+te
+iw
+jC
+jC
 sZ
 Sx
 Sx
@@ -45909,16 +45943,16 @@ AV
 AV
 AV
 bk
-bk
-Fn
-Fn
-bk
-LE
-OC
+sZ
+sZ
+sZ
+sZ
+sZ
+sZ
 Sx
 Sx
 Sx
-OC
+ud
 nk
 Fn
 rf
@@ -46166,7 +46200,7 @@ AV
 AV
 AV
 AV
-AV
+bk
 Fn
 Fn
 bk
@@ -46423,7 +46457,7 @@ AV
 AV
 AV
 AV
-AV
+bk
 bk
 Fn
 Fn
@@ -46680,8 +46714,8 @@ ZZ
 AV
 AV
 AV
-AV
-AV
+bk
+bk
 bk
 Fn
 LE

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-2.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-2.dmm
@@ -106,6 +106,26 @@
 	},
 /turf/simulated/floor/sidewalk,
 /area/point_verdant/outdoors)
+"ap" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/closet/secure_closet/freezer,
+/obj/random/dirt_75,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/seaweed,
+/obj/item/reagent_containers/food/snacks/seaweed,
+/obj/item/reagent_containers/food/snacks/seaweed,
+/obj/item/reagent_containers/food/snacks/seaweed,
+/turf/simulated/floor/tiled/white,
+/area/point_verdant/interior/restaurant)
 "aq" = (
 /turf/simulated/floor/wood,
 /area/point_verdant/outdoors)
@@ -2555,6 +2575,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/clothing/under/pants/black,
+/obj/item/clothing/under/pants/jeans,
+/obj/item/clothing/under/pants/dress,
 /turf/simulated/floor/carpet/magenta,
 /area/point_verdant/interior/tailor)
 "gY" = (
@@ -2682,8 +2705,21 @@
 /turf/simulated/floor/sidewalk/flat,
 /area/point_verdant/outdoors)
 "hp" = (
-/obj/structure/extinguisher_cabinet/north,
+/obj/structure/stairs_lower{
+	dir = 4;
+	pixel_y = 6
+	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/closet/secure_closet/freezer,
+/obj/item/storage/box/fancy/egg_box,
+/obj/item/storage/box/fancy/egg_box,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/storage/box/fancy/egg_box,
+/obj/item/reagent_containers/food/condiment/flour,
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/restaurant)
 "hs" = (
@@ -3343,6 +3379,10 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = -6;
+	pixel_y = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/restaurant)
 "ji" = (
@@ -3546,6 +3586,12 @@
 /obj/machinery/appliance/cooker/fryer,
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/streetvendor)
+"jM" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/random/dirt_75,
+/obj/structure/extinguisher_cabinet/north,
+/turf/simulated/floor/tiled/white,
+/area/point_verdant/interior/restaurant)
 "jN" = (
 /turf/simulated/wall/wood,
 /area/point_verdant/interior/spaceport)
@@ -8027,6 +8073,7 @@
 	pixel_y = 6
 	},
 /obj/item/clothing/under/dress/sailordress,
+/obj/item/clothing/under/suit_jacket/nt_skirtsuit,
 /turf/simulated/floor/lino/diamond,
 /area/point_verdant/interior/tailor)
 "uT" = (
@@ -8565,16 +8612,11 @@
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/offices)
 "wl" = (
-/obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/closet/secure_closet/freezer,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/ringer_button{
+	id = "medbay_ringer";
+	pixel_y = 17
+	},
+/turf/simulated/wall/wood,
 /area/point_verdant/interior/restaurant)
 "wm" = (
 /obj/effect/decal/road_marking{
@@ -8786,13 +8828,26 @@
 /turf/simulated/floor/exoplanet/konyang,
 /area/point_verdant/outdoors)
 "wS" = (
+/obj/structure/table/stone/marble,
+/obj/item/material/kitchen/rollingpin{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = 6;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/effect/floor_decal/corner/grey/diagonal,
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/storage/box/fancy/egg_box,
-/obj/item/storage/box/fancy/egg_box,
-/obj/item/storage/box/fancy/egg_box,
-/obj/item/storage/box/fancy/egg_box,
-/obj/random/dirt_75,
+/obj/item/reagent_containers/cooking_container/board{
+	pixel_x = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/restaurant)
 "wT" = (
@@ -12472,8 +12527,10 @@
 /turf/simulated/floor/concrete,
 /area/point_verdant/outdoors)
 "Gf" = (
-/obj/structure/closet/secure_closet/freezer/chicken_and_fish,
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/closet/crate/bin/urban/compact{
+	pixel_y = 9
+	},
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/restaurant)
 "Gg" = (
@@ -12574,6 +12631,9 @@
 /obj/structure/rod_railing{
 	dir = 8
 	},
+/obj/item/clothing/suit/storage/toggle/leather_jacket/designer,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/designer/black,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/flight,
 /turf/simulated/floor/carpet/magenta,
 /area/point_verdant/interior/tailor)
 "Gs" = (
@@ -12611,7 +12671,7 @@
 /area/point_verdant/outdoors)
 "Gw" = (
 /obj/machinery/door/window/southright{
-	req_access = list(218)
+	req_access = list(219)
 	},
 /turf/simulated/floor/lino/diamond,
 /area/point_verdant/interior/tailor)
@@ -12676,27 +12736,21 @@
 /turf/simulated/floor/exoplanet/konyang,
 /area/point_verdant/outdoors)
 "GH" = (
-/obj/structure/table/stone/marble,
-/obj/item/material/kitchen/rollingpin{
-	pixel_x = -7;
-	pixel_y = 3
-	},
-/obj/item/material/kitchen/rollingpin{
-	pixel_x = -25;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = 6;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/closet/secure_closet/freezer,
+/obj/random/dirt_75,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
+/obj/item/reagent_containers/food/snacks/meat,
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/restaurant)
 "GI" = (
@@ -15381,6 +15435,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/offices)
+"NI" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/random/dirt_75,
+/obj/machinery/chem_master/condimaster,
+/turf/simulated/floor/tiled/white,
+/area/point_verdant/interior/restaurant)
 "NJ" = (
 /obj/structure/road_barrier/bot_in{
 	dir = 8
@@ -16699,18 +16759,12 @@
 /turf/simulated/floor/exoplanet/water/shallow/konyang/no_smooth,
 /area/point_verdant/outdoors)
 "QM" = (
-/obj/item/reagent_containers/cooking_container/board{
-	pixel_x = 8
-	},
 /obj/structure/table/stone/marble,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = -6;
-	pixel_y = 8
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/chemical_dispenser/bar_soft/full,
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/restaurant)
 "QN" = (
@@ -19756,13 +19810,12 @@
 /obj/machinery/space_heater/stationary{
 	pixel_y = 29
 	},
-/obj/structure/closet/crate/bin/urban/compact{
-	pixel_y = 9
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/sink/kitchen{
+	name = "sink";
+	dir = 8;
+	pixel_x = 19
+	},
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/restaurant)
 "YN" = (
@@ -48572,7 +48625,7 @@ xH
 Ja
 bP
 dX
-wl
+yH
 wS
 sd
 jh
@@ -48830,8 +48883,8 @@ Zm
 bP
 cA
 zk
-zk
-zk
+BE
+BE
 BE
 BE
 Wb
@@ -49087,7 +49140,7 @@ bp
 OB
 kF
 qg
-yH
+hp
 BE
 eN
 FN
@@ -49601,8 +49654,8 @@ OB
 no
 OB
 OB
-OB
-hp
+ap
+BE
 OB
 WH
 BE
@@ -50111,8 +50164,8 @@ Wq
 zS
 YV
 CT
-OB
-xm
+wl
+jM
 xn
 No
 eH
@@ -50372,7 +50425,7 @@ vl
 xm
 xn
 dm
-zk
+NI
 zk
 fp
 zk

--- a/maps/away/away_site/konyang/point_verdant/point_verdant_ghostroles.dm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant_ghostroles.dm
@@ -289,6 +289,7 @@
 /datum/outfit/admin/konyang_gwok
 	name = "UP! Burger Employee"
 	uniform = /obj/item/clothing/under/rank/konyang/burger
+	shoes = /obj/item/clothing/shoes/workboots/dark
 	suit = /obj/item/clothing/accessory/apron/chef
 	head = /obj/item/clothing/head/konyang/burger
 	id = /obj/item/card/id


### PR DESCRIPTION
QoL changes taken from https://forums.aurorastation.org/topic/19899-minor-mapping-peeves-in-point-verdant/#comment-172793. Originally was going to fix the lighting and bar access but looks like another pr grabbed it.

- Added holsters and extra maglights for the police.
- Fixed access on the tailor shop and added some male clothing options.
- Added a condimaster and drive through ringer to the burger joint.
- Added meat, potatos, and some seaweed to the fridges. Couldn't figure out how to add onions : (
- Added the local beer/enzyme/a sink to the bar and a wardrobe of Konyang outfits for variety.
- Added holo menues to both the bar and the burger place, as well as a jukebox to the former.
