### PR TITLE
Stops Uplink Implants From Appearing On Body Scans

### DIFF
--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -565,7 +565,8 @@
 				else if(istype(I, /obj/effect/spider))
 					organic += I
 				else
-					unk += 1
+					if(!istype(I, /obj/item/implant/uplink))
+						unk += 1
 			if (unk)
 				wounds += "unknown objects present"
 			var/friends = length(organic)

--- a/html/changelogs/Acetrea - uplinkhidden.yml
+++ b/html/changelogs/Acetrea - uplinkhidden.yml
@@ -27,7 +27,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: Acetrea
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/Acetrea - uplinkhidden.yml
+++ b/html/changelogs/Acetrea - uplinkhidden.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Tweaked Uplink Implants to not show up on Body Scanners."


### PR DESCRIPTION
https://forums.aurorastation.org/topic/19910-remove-implant-uplinks-from-showing-up-on-body-scanners

As I said in the Forum post, Antagonist's Uplink Implants are very easily mistakable as Shrapnel and are commonly removed on an Antagonist's first visit to Medbay. I think having these not seen by Medical and therefore stopping them from being removed would allow for more Antagonist Roleplay. This would be especially useful when an Antagonist ends up in Medical within the first hour of the round and has more plans post-medbay and post-brig.