### PR TITLE
Augment Spritesheet fix

### DIFF
--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -139,13 +139,18 @@
 /obj/item/organ/external/proc/get_internal_organs_overlay()
 	for(var/obj/item/organ/internal/O in internal_organs)
 		if(O.on_mob_icon)
-			var/cache_key = "[O.on_mob_icon]-[O.item_state || O.icon_state]"
+			var/internal_organ_icon = O.on_mob_icon
+			var/cache_key = "[internal_organ_icon]-[O.item_state || O.icon_state]"
+			if(owner && O.sprite_sheets && O.sprite_sheets[owner.species.get_bodytype()])
+				cache_key = "[O.sprite_sheets[owner.species.get_bodytype()]]-[O.item_state || O.icon_state]"
+				internal_organ_icon = O.sprite_sheets[owner.species.get_bodytype()]
 
 			var/icon/organ_icon = SSicon_cache.internal_organ_cache[cache_key]
 			if (!organ_icon)
-				organ_icon = new /icon(O.on_mob_icon, O.item_state || O.icon_state)
+				organ_icon = new /icon(internal_organ_icon, O.item_state || O.icon_state)
 				SSicon_cache.internal_organ_cache[cache_key] = organ_icon
 
+			to_chat(cache_key)
 			add_overlay(organ_icon)
 			mob_icon.Blend(organ_icon, ICON_OVERLAY)
 
@@ -265,7 +270,10 @@
 
 	for(var/obj/item/organ/internal/O in internal_organs)
 		if(O.on_mob_icon)
-			keyparts += "[O.on_mob_icon]-[O.item_state || O.icon_state]"
+			if(owner && O.sprite_sheets && O.sprite_sheets[owner.species.get_bodytype()])
+				keyparts += "[O.sprite_sheets[owner.species.get_bodytype()]]-[O.item_state || O.icon_state]"
+			else
+				keyparts += "[O.on_mob_icon]-[O.item_state || O.icon_state]"
 
 	. = keyparts.Join("_")
 

--- a/html/changelogs/wezzy_organ_spritesheet.yml
+++ b/html/changelogs/wezzy_organ_spritesheet.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Wowzewow (Wezzy)
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Makes augments compatible with spritesheets."


### PR DESCRIPTION
Makes augments/organs work with spritesheets. I'd much rather depreciate spritesheets altogether for contained sprites but this will work for now.
