### PR TITLE
Hard deletes fun from Konyang (Point Verdant Radio Changes)

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -31,11 +31,15 @@
 	var/turf/T = get_turf(src)
 	var/obj/effect/overmap/visitable/V = GLOB.map_sectors["[T.z]"]
 	if(istype(V) && V.comms_support)
-		if(V.comms_name)
+		var/freq_name = V.name
+		if(V.freq_name)
+			freq_name = V.freq_name
+			name = "[V.freq_name] encryption key"
+		else if(V.comms_name)
 			name = "[V.comms_name] encryption key"
 
 		channels += list(
-			"[V.name]" = TRUE,
+			"[freq_name]" = TRUE,
 			CHANNEL_HAILING = TRUE
 		)
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -773,8 +773,8 @@ var/global/list/default_interrogation_channels = list(
 
 /obj/item/device/radio/map_preset/set_internal_channels()
 	return list(
-		num2text(default_frequency),
-		num2text(HAIL_FREQ)
+		num2text(default_frequency) = list(),
+		num2text(HAIL_FREQ) = list()
 	)
 
 /obj/item/device/radio/hailing
@@ -782,7 +782,7 @@ var/global/list/default_interrogation_channels = list(
 
 /obj/item/device/radio/hailing/set_internal_channels()
 	return list(
-		num2text(HAIL_FREQ)
+		num2text(HAIL_FREQ) = list()
 	)
 
 /obj/item/device/radio/hailing/Initialize()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -53,48 +53,55 @@ var/global/list/default_interrogation_channels = list(
 	var/const/FREQ_LISTENING = TRUE
 	/// Automatically set on initialize, only update if bypass_default_internal is set to TRUE
 	var/list/internal_channels
-	/// If TRUE, skips automatically replacing internal_channels on init()
-	var/bypass_default_internal = FALSE
-	var/clicksound = /singleton/sound_category/button_sound //played sound on usage
-	var/clickvol = 10 //volume
+	/// played sound on usage
+	var/clicksound = /singleton/sound_category/button_sound
+	/// volume of clicksound
+	var/clickvol = 10
 
 	var/obj/item/cell/cell = /obj/item/cell/device
 	var/last_radio_sound = -INFINITY
 
-	// If FALSE, broadcasting and listening don't matter and this radio does nothing
+	/// If FALSE, broadcasting and listening don't matter and this radio does nothing
 	VAR_PRIVATE/on = TRUE
 
-	VAR_PRIVATE/frequency = PUB_FREQ // Current frequency the radio is set to
-	var/default_frequency = PUB_FREQ // frequency the radio defaults to on reset / startup
+	/// Current frequency the radio is set to
+	VAR_PRIVATE/frequency = PUB_FREQ
+	/// frequency the radio defaults to on reset / startup
+	var/default_frequency = PUB_FREQ
 
-	// Whether the radio transmits dialogue it hears nearby onto its radio channel
+	/// Whether the radio transmits dialogue it hears nearby onto its radio channel
 	VAR_PRIVATE/broadcasting = FALSE
-	// Whether the radio is currently receiving radio messages from its frequencies
+	/// Whether the radio is currently receiving radio messages from its frequencies
 	VAR_PRIVATE/listening = TRUE
 
 	//the below vars are used to track listening and broadcasting should they be forced off for whatever reason but "supposed" to be active
 	//eg player sets the radio to listening, but an emp or whatever turns it off, its still supposed to be activated but was forced off,
 	//when it wears off it sets listening to should_be_listening
 
-	///used for tracking what broadcasting should be in the absence of things forcing it off, eg its set to broadcast but gets emp'd temporarily
+	/// used for tracking what broadcasting should be in the absence of things forcing it off, eg its set to broadcast but gets emp'd temporarily
 	var/should_be_broadcasting = FALSE
-	///used for tracking what listening should be in the absence of things forcing it off, eg its set to listen but gets emp'd temporarily
+	/// used for tracking what listening should be in the absence of things forcing it off, eg its set to listen but gets emp'd temporarily
 	var/should_be_listening = TRUE
 
 	/// Both the range around the radio in which mobs can hear what it receives and the range the radio can hear
 	var/canhear_range = 3
 
 	var/last_transmission
-	var/traitor_frequency = 0 //tune to frequency to unlock traitor supplies
-	var/mob/living/announcer/announcer = null // used in autosay, held by the radio for re-use
+	/// tune to frequency to unlock traitor supplies
+	var/traitor_frequency = 0
+	/// used in autosay, held by the radio for re-use
+	var/mob/living/announcer/announcer = null
 	var/datum/wires/radio/wires = null
 	var/show_modify_on_examine = TRUE
 	var/b_stat = 0
 
-	var/list/channels = list() //see communications.dm for full list. First non-common, non-entertainment channel is a "default" for :h
+	/// see communications.dm for full list. First non-common, non-entertainment channel is a "default" for :h
+	var/list/channels = list()
 	var/subspace_transmission = FALSE
-	var/syndie = FALSE //Holder to see if it's a syndicate encrypted radio
-	var/independent = FALSE // if TRUE, can say/hear on the Special Channel!!! (TBD)
+	/// Holder to see if it's a syndicate encrypted radio
+	var/syndie = FALSE
+	/// if TRUE, can say/hear on the Special Channel!!! (TBD)
+	var/independent = FALSE
 
 	var/datum/radio_frequency/radio_connection
 	var/list/datum/radio_frequency/secure_radio_connections = list()
@@ -105,12 +112,15 @@ var/global/list/default_interrogation_channels = list(
 		frequency = new_frequency
 		radio_connection = SSradio.add_object(src, new_frequency, RADIO_CHAT)
 
+/// By default copies default_internal_channels. Override on child for radios that need snowflake.
+/obj/item/device/radio/proc/set_internal_channels()
+	return default_internal_channels.Copy()
+
 /obj/item/device/radio/Initialize()
 	. = ..()
 
 	wires = new(src)
-	if(!bypass_default_internal)
-		internal_channels = default_internal_channels.Copy()
+	internal_channels = set_internal_channels()
 
 	if(frequency < RADIO_LOW_FREQ || frequency > RADIO_HIGH_FREQ)
 		frequency = sanitize_frequency(frequency, RADIO_LOW_FREQ, RADIO_HIGH_FREQ)
@@ -739,7 +749,6 @@ var/global/list/default_interrogation_channels = list(
 
 /obj/item/device/radio/map_preset
 	channels = list()
-	bypass_default_internal = TRUE
 
 /obj/item/device/radio/map_preset/Initialize()
 	if(!SSatlas.current_map.use_overmap)
@@ -757,25 +766,28 @@ var/global/list/default_interrogation_channels = list(
 			freq_name = TRUE,
 			CHANNEL_HAILING = TRUE
 		)
-		internal_channels += list(
-			num2text(frequency),
-			num2text(HAIL_FREQ)
-		)
 		if(V.comms_name)
 			name = "[V.comms_name] shortwave radio"
 
 	return ..()
 
+/obj/item/device/radio/map_preset/set_internal_channels()
+	return list(
+		num2text(default_frequency),
+		num2text(HAIL_FREQ)
+	)
+
 /obj/item/device/radio/hailing
-	bypass_default_internal = TRUE
 	default_frequency = HAIL_FREQ
+
+/obj/item/device/radio/hailing/set_internal_channels()
+	return list(
+		num2text(HAIL_FREQ)
+	)
 
 /obj/item/device/radio/hailing/Initialize()
 	channels = list(
 		CHANNEL_HAILING = TRUE
-	)
-	internal_channels += list(
-		num2text(HAIL_FREQ),
 	)
 	return ..()
 

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -48,6 +48,8 @@ var/global/area/overmap/map_overmap // Global object used to locate the overmap 
 	var/comms_support = FALSE
 	/// Snowflake name to apply to comms equipment ("shipboard radio headset", "intercom (shipboard)", "shipboard telecommunications mainframe"), etc.
 	var/comms_name = "shipboard"
+	/// Snowflake name to label frequency, if not set, frequency defaults to overmap name
+	var/freq_name = ""
 	/// Whether away ship comms have access to the common channel / PUB_FREQ
 	var/use_common = FALSE
 	var/list/navigation_viewers // list of weakrefs to people viewing the overmap via this ship

--- a/html/changelogs/Ben10083 - Konyang Radio.yml
+++ b/html/changelogs/Ben10083 - Konyang Radio.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Point Verdant has a new bounced radio, with a private frequency for police and removal of common and entertainment channels."
+  - maptweak: "A bounced radio with only hailing frequency added to Point Verdant Shuttleport"
+  - refactor: "Radio code modified to allow for custom frequency names."
+  - bugfix: "Map preset bounced radios now work as intended (maybe)."

--- a/html/changelogs/Ben10083 - Konyang Radio.yml
+++ b/html/changelogs/Ben10083 - Konyang Radio.yml
@@ -41,4 +41,4 @@ changes:
   - rscadd: "Point Verdant has a new bounced radio, with a private frequency for police and removal of common and entertainment channels."
   - maptweak: "A bounced radio with only hailing frequency added to Point Verdant Shuttleport"
   - refactor: "Radio code modified to allow for custom frequency names."
-  - bugfix: "Map preset bounced radios now work as intended (maybe)."
+  - bugfix: "Map preset bounced radios, such as the ones from the IPC Refugee ship, now work as intended (maybe)."

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
@@ -3250,12 +3250,8 @@
 /turf/simulated/floor/asphalt,
 /area/point_verdant/outdoors)
 "jO" = (
-/obj/structure/closet/crate/bin/filled,
-/obj/item/trash/cigbutt,
-/obj/random/junk,
-/obj/random/junk,
-/obj/item/trash/cigbutt,
-/turf/simulated/floor/tiled/full,
+/obj/machinery/telecomms/allinone/ship,
+/turf/simulated/floor/tiled,
 /area/point_verdant/interior/police)
 "jP" = (
 /turf/simulated/wall,
@@ -27433,8 +27429,8 @@ cp
 ch
 HF
 lC
-rf
-rf
+lC
+lC
 rf
 rf
 rf
@@ -27688,10 +27684,10 @@ wF
 ch
 FP
 AN
+AN
+ai
 jO
 lC
-rf
-rf
 rf
 rf
 rf
@@ -27947,8 +27943,8 @@ AN
 AN
 VF
 lC
-rf
-rf
+lC
+lC
 rf
 rf
 rf

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-3.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-3.dmm
@@ -3975,11 +3975,11 @@
 /area/point_verdant/interior/hotel)
 "El" = (
 /obj/structure/table/steel,
-/obj/item/device/radio{
+/obj/item/device/measuring_tape,
+/obj/item/device/radio/hailing{
 	pixel_x = 8;
 	pixel_y = 3
 	},
-/obj/item/device/measuring_tape,
 /turf/simulated/floor/tiled/full,
 /area/point_verdant/interior/spaceport)
 "Em" = (

--- a/maps/away/away_site/konyang/point_verdant/point_verdant.dm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant.dm
@@ -25,6 +25,10 @@
 	requires_contact = FALSE
 	instant_contact = TRUE
 
+	comms_support = TRUE
+	comms_name = "National Police" //these comms should only be used by Konyang Police ghostroles
+	freq_name = "Corporate District Patrol"
+
 	initial_generic_waypoints = list(
 		"nav_point_verdant_waterdock_01",
 		"nav_point_verdant_waterdock_02",

--- a/maps/away/away_site/konyang/point_verdant/point_verdant_ghostroles.dm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant_ghostroles.dm
@@ -74,7 +74,7 @@
 	head = /obj/item/clothing/head/konyang/police
 	id = /obj/item/card/id
 	belt = /obj/item/storage/belt/security
-	l_pocket = /obj/item/device/radio
+	l_pocket = /obj/item/device/radio/map_preset
 	r_pocket = /obj/item/storage/wallet/random
 	back = /obj/item/storage/backpack/satchel
 


### PR DESCRIPTION
- Refactoring of radio code to fix bounced radio map presets, and adds them to police loadout with own channel
- Maps can now set a frequency name to name the radio channel for extra snowflaking
- Point Verdant should now only have access to hailing frequency (no more common and entertainment), other Konyang ghostroles should probably be looked into
- new bounced radio subtype that only has hailing frequency