### PR TITLE
Miscellanious Engineering Tweaks

### DIFF
--- a/html/changelogs/furrycactus - misc-eng-tweaks.yml
+++ b/html/changelogs/furrycactus - misc-eng-tweaks.yml
@@ -1,0 +1,44 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Furrycactus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Fixed a subgrid and maingrid overlap in Engineering Deck 1 wiring."
+  - maptweak: "Configured Reactor Waste to Mix regulator in Atmospherics to start OFF at roundstart, and Mix tank Input and Output as well."
+  - maptweak: "Gave Atmos Tech access to the INDRA SMES room, but not to the reactor or control room itself. Removed the access they had to the reactor room itself through the bolted door (likely oversight)."
+  - maptweak: "Made a tiny handful of stylistic changes with some floor decals and computers."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -384,13 +384,12 @@
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/computer/general_air_control/large_tank_control/terminal{
 	sensors = list("co2_sensor"="Tank");
 	output_tag = "CO2_out_fuelbay";
 	name = "Carbon Dioxide - Fuel Bay"
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
 "apQ" = (
@@ -2162,17 +2161,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "bBR" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/custodial,
 /obj/machinery/computer/general_air_control/large_tank_control/terminal{
 	sensors = list("ph_sensor"="Tank");
 	output_tag = "ph_out";
 	name = "Phoron Supply Console";
 	input_tag = "ph_in"
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
 "bCi" = (
@@ -11837,16 +11835,6 @@
 /obj/machinery/alarm/south,
 /turf/simulated/floor/tiled,
 /area/rnd/eva)
-"ifg" = (
-/obj/effect/floor_decal/corner_wide/black{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/engineering/atmos/propulsion)
 "ifu" = (
 /obj/structure/table/stone/marble,
 /obj/item/reagent_containers/glass/bucket{
@@ -14629,18 +14617,16 @@
 	},
 /area/shuttle/intrepid/crew_compartment)
 "keQ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/computer/general_air_control/large_tank_control/terminal{
 	sensors = list("co2_sensor"="Tank");
 	output_tag = "co2_out";
 	name = "Carbon Dioxide Supply Console";
 	input_tag = "co2_in"
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
 "keZ" = (
@@ -16350,7 +16336,6 @@
 /area/engineering/atmos/air)
 "lqh" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -16360,7 +16345,6 @@
 	name = "Hydrogen Supply Console";
 	input_tag = "h_in"
 	},
-/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
 "lqr" = (
@@ -16612,6 +16596,16 @@
 /obj/structure/bed/stool/chair/office/light,
 /turf/simulated/floor/plating,
 /area/engineering/storage/lower)
+"lAc" = (
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos/propulsion)
 "lAU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -29796,6 +29790,12 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
+"uym" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/structure/lattice,
+/obj/machinery/meter,
+/turf/space/dynamic,
+/area/horizon/exterior)
 "uza" = (
 /obj/machinery/door/blast/regular{
 	_wifi_id = "waste";
@@ -30554,14 +30554,13 @@
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/outline/custodial,
 /obj/machinery/computer/general_air_control/large_tank_control/terminal{
 	sensors = list("ph_sensor"="Tank");
 	output_tag = "Ph_out_FuelBay";
 	name = "Phoron Supply - Fuel Bay";
 	max_pressure_setting = 2000
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
 "uYW" = (
@@ -56362,7 +56361,7 @@ dKY
 nRZ
 pOp
 fFm
-qEq
+uym
 lQF
 aZd
 gaC
@@ -59611,7 +59610,7 @@ uVL
 oWe
 xMk
 aQE
-ifg
+lAc
 uVL
 lUr
 rSW

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -384,14 +384,13 @@
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
-/obj/machinery/computer/general_air_control/large_tank_control{
-	max_pressure_setting = 5000;
-	name = "Carbon Dioxide - Fuel Bay";
-	output_tag = "CO2_out_fuelbay";
-	sensors = list("co2_sensor"="Tank")
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/machinery/computer/general_air_control/large_tank_control/terminal{
+	sensors = list("co2_sensor"="Tank");
+	output_tag = "CO2_out_fuelbay";
+	name = "Carbon Dioxide - Fuel Bay"
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
 "apQ" = (
@@ -1101,11 +1100,11 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -1269,9 +1268,6 @@
 	dir = 6
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "aWx" = (
@@ -2166,16 +2162,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "bBR" = (
-/obj/machinery/computer/general_air_control/large_tank_control{
-	input_tag = "ph_in";
-	name = "Phoron Supply Monitor";
-	output_tag = "ph_out";
-	sensors = list("ph_sensor"="Tank")
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/custodial,
+/obj/machinery/computer/general_air_control/large_tank_control/terminal{
+	sensors = list("ph_sensor"="Tank");
+	output_tag = "ph_out";
+	name = "Phoron Supply Console";
+	input_tag = "ph_in"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
@@ -4706,8 +4702,7 @@
 	dir = 4;
 	frequency = 1441;
 	id = "mixed_in";
-	name = "mixed gas injector";
-	use_power = 1
+	name = "mixed gas injector"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos)
@@ -6176,9 +6171,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/binary/passive_gate/on{
-	name = "Reactor Waste to Mix"
-	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 1
 	},
@@ -6193,6 +6185,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/machinery/atmospherics/binary/passive_gate{
+	name = "Reactor Waste to Mix"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
@@ -10552,6 +10547,7 @@
 	dir = 4;
 	req_one_access = list(12,26)
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "hgA" = (
@@ -11787,6 +11783,7 @@
 	output_tag = "ph_out_starboardthruster";
 	sensors = list("ph_sensor"="Tank")
 	},
+/obj/effect/floor_decal/industrial/outline/custodial,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "ieu" = (
@@ -11840,6 +11837,16 @@
 /obj/machinery/alarm/south,
 /turf/simulated/floor/tiled,
 /area/rnd/eva)
+"ifg" = (
+/obj/effect/floor_decal/corner_wide/black{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/engineering/atmos/propulsion)
 "ifu" = (
 /obj/structure/table/stone/marble,
 /obj/item/reagent_containers/glass/bucket{
@@ -12417,6 +12424,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "iES" = (
@@ -12715,9 +12723,6 @@
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "iNX" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 6
-	},
 /obj/machinery/computer/general_air_control/large_tank_control/terminal{
 	sensors = list("port_prop_sensor"="Port Propulsion Sensor");
 	output_tag = "port_prop_out";
@@ -12725,6 +12730,10 @@
 	name = "Port Propulsion Control Console";
 	input_tag = "port_prop_in"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "iOn" = (
@@ -13056,9 +13065,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/operations)
 "jaP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 10
-	},
 /obj/machinery/computer/general_air_control/large_tank_control/terminal{
 	sensors = list("starboard_prop_sensor"="Starboard  Propulsion  Sensor");
 	output_tag = "starboard_prop_out";
@@ -13066,6 +13072,10 @@
 	name = "Starboard Propulsion Control Console";
 	input_tag = "starboard_prop_in"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/purple{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "jbm" = (
@@ -14619,17 +14629,17 @@
 	},
 /area/shuttle/intrepid/crew_compartment)
 "keQ" = (
-/obj/machinery/computer/general_air_control/large_tank_control{
-	input_tag = "co2_in";
-	name = "Carbon Dioxide Supply Monitor";
-	output_tag = "co2_out";
-	sensors = list("co2_sensor"="Tank")
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/computer/general_air_control/large_tank_control/terminal{
+	sensors = list("co2_sensor"="Tank");
+	output_tag = "co2_out";
+	name = "Carbon Dioxide Supply Console";
+	input_tag = "co2_in"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
@@ -16339,18 +16349,18 @@
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "lqh" = (
-/obj/machinery/computer/general_air_control/large_tank_control{
-	input_tag = "h_in";
-	name = "Hydrogen Supply Monitor";
-	output_tag = "h_out";
-	sensors = list("h_sensor"="Tank")
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/computer/general_air_control/large_tank_control/terminal{
+	sensors = list("h_sensor"="Tank");
+	output_tag = "h_out";
+	name = "Hydrogen Supply Console";
+	input_tag = "h_in"
+	},
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
 "lqr" = (
@@ -16737,9 +16747,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "lFS" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -16747,6 +16754,10 @@
 /obj/machinery/computer/security/engineering/terminal{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/propulsion/starboard)
 "lGb" = (
@@ -17226,8 +17237,7 @@
 	name = "mixed gas vent";
 	pressure_checks = 2;
 	pressure_checks_default = 2;
-	pump_direction = 0;
-	use_power = 1
+	pump_direction = 0
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/atmos)
@@ -21677,6 +21687,7 @@
 	c_tag = "Engineering - Atmospherics Tanks 1";
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "oXD" = (
@@ -23112,6 +23123,7 @@
 	output_tag = "H2_out_portthruster";
 	sensors = list("h_sensor"="Tank")
 	},
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "pSx" = (
@@ -26838,7 +26850,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
@@ -26849,6 +26861,7 @@
 	output_tag = "ph_out_portthruster";
 	sensors = list("ph_sensor"="Tank")
 	},
+/obj/effect/floor_decal/industrial/outline/custodial,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
 "sxc" = (
@@ -28426,10 +28439,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "tEV" = (
@@ -29126,12 +29139,13 @@
 /turf/simulated/floor/tiled,
 /area/operations/storage)
 "ubq" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "ucs" = (
@@ -29601,6 +29615,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "urv" = (
@@ -30539,14 +30554,14 @@
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
-/obj/machinery/computer/general_air_control/large_tank_control{
-	max_pressure_setting = 1000;
-	name = "Phoron Supply - Fuel Bay";
-	output_tag = "Ph_out_FuelBay";
-	sensors = list("ph_sensor"="Tank")
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/obj/effect/floor_decal/industrial/outline/custodial,
+/obj/machinery/computer/general_air_control/large_tank_control/terminal{
+	sensors = list("ph_sensor"="Tank");
+	output_tag = "Ph_out_FuelBay";
+	name = "Phoron Supply - Fuel Bay";
+	max_pressure_setting = 2000
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
 "uYW" = (
@@ -31692,11 +31707,11 @@
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "vOf" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
@@ -32380,6 +32395,7 @@
 	output_tag = "H2_out_starboardthruster";
 	sensors = list("h_sensor"="Tank")
 	},
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion/starboard)
 "wmx" = (
@@ -33134,9 +33150,6 @@
 	tag_west_con = 0
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -34018,13 +34031,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/intrepid/cockpit)
 "xnS" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/computer/security/engineering/terminal{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/propulsion)
 "xof" = (
@@ -34086,6 +34100,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/plating,
 /area/engineering/atmos/air)
 "xpS" = (
@@ -34644,10 +34659,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "xHW" = (
@@ -59596,7 +59611,7 @@ uVL
 oWe
 xMk
 aQE
-uzC
+ifg
 uVL
 lUr
 rSW

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -1893,7 +1893,7 @@
 /obj/machinery/door/airlock/glass_engineering{
 	dir = 1;
 	name = "INDRA Reactor";
-	req_access = list(11)
+	req_one_access = list(11,24)
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9305,7 +9305,7 @@
 /obj/machinery/door/airlock/glass_engineering{
 	dir = 4;
 	name = "INDRA Reactor";
-	req_access = list(11)
+	req_one_access = list(11,24)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/full,
@@ -18062,11 +18062,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_monitoring)
 "ioS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
 /obj/machinery/firealarm/east,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/engine_waste)
 "ioW" = (
@@ -21701,7 +21702,7 @@
 /obj/machinery/door/airlock/maintenance{
 	dir = 1;
 	name = "INDRA Reactor Maintenance";
-	req_access = list(11)
+	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/smes/rust)
@@ -32267,7 +32268,7 @@
 	id_tag = "r-ust_electrical_maintenance";
 	locked = 1;
 	name = "INDRA Reactor SMES";
-	req_one_access = list(11,24)
+	req_access = list(11)
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/smes/rust)
@@ -36201,7 +36202,7 @@
 	RCon_tag = "Supermatter - Containment";
 	charge = 2000000;
 	input_attempt = 1;
-	input_level = 100000;
+	input_level = 200000;
 	is_critical = 1;
 	output_attempt = 1;
 	output_level = 200000


### PR DESCRIPTION
  - Fixed a subgrid and maingrid overlap in Engineering Deck 1 wiring.
  - Configured Reactor Waste to Mix regulator in Atmospherics to start OFF at roundstart, and Mix tank Input and Output as well.
  - Gave Atmos Tech access to the INDRA SMES room, but not to the reactor or control room itself. Removed the access they had to the reactor room itself through the bolted door (likely oversight).
  - Made a tiny handful of stylistic changes with some floor decals and computers.