### PR TITLE
Point Verdant Pharmacy and Le Soleil Royal Acces Fixes + Tweaks

### DIFF
--- a/html/changelogs/furrycactus - pv shutters.yml
+++ b/html/changelogs/furrycactus - pv shutters.yml
@@ -40,4 +40,5 @@ delete-after: True
 changes:
   - maptweak: "Fixed the access on the Point Verdant Pharmacy and Solei shutters and windoors."
   - maptweak: "Put some non-jumpsuit clothing in the PV Pharmacist closet."
+  - maptweak: "Added a box of empty autoinjectors to the PV Pharmacist basement."
   - maptweak: "Swapped the basic windoors at the front of some PV establishments for the cool new sliding doors."

--- a/html/changelogs/furrycactus - pv shutters.yml
+++ b/html/changelogs/furrycactus - pv shutters.yml
@@ -1,0 +1,43 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Furrycactus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Fixed the access on the Point Verdant Pharmacy and Solei shutters and windoors."
+  - maptweak: "Put some non-jumpsuit clothing in the PV Pharmacist closet."
+  - maptweak: "Swapped the basic windoors at the front of some PV establishments for the cool new sliding doors."

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-1.dmm
@@ -13583,6 +13583,11 @@
 	},
 /obj/structure/closet,
 /obj/item/clothing/suit/storage/toggle/labcoat,
+/obj/item/clothing/under/sl_suit,
+/obj/item/clothing/accessory/tie/darkgreen,
+/obj/item/clothing/shoes/laceup/brown,
+/obj/item/clothing/under/sundress,
+/obj/item/clothing/shoes/flats,
 /turf/simulated/floor/tiled/white,
 /area/point_verdant/interior/pharmacy)
 "Od" = (
@@ -15780,6 +15785,7 @@
 	pixel_x = 5;
 	pixel_y = -14
 	},
+/obj/item/storage/box/autoinjectors,
 /turf/simulated/floor/tiled,
 /area/point_verdant/interior/pharmacy)
 "Ur" = (

--- a/maps/away/away_site/konyang/point_verdant/point_verdant-2.dmm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant-2.dmm
@@ -3312,7 +3312,7 @@
 /obj/machinery/button/remote/blast_door{
 	id = "konyang_pharmacy";
 	name = "Pharmacy Shutters";
-	req_access = list(218);
+	req_access = list(219);
 	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
@@ -3783,10 +3783,10 @@
 /area/point_verdant/interior/parking)
 "kq" = (
 /obj/effect/decal/exterior_stairs/half,
-/obj/machinery/door/window/southleft,
 /obj/machinery/door/blast/shutters{
 	id = "konyang_minimart"
 	},
+/obj/machinery/door/urban/glass_sliding/double,
 /turf/simulated/floor/lino/diamond,
 /area/point_verdant/interior/minimart)
 "kr" = (
@@ -3874,10 +3874,10 @@
 /turf/simulated/floor/wood,
 /area/point_verdant/interior/cafe)
 "kD" = (
-/obj/machinery/door/window/southleft,
 /obj/machinery/door/blast/shutters/open{
 	id = "konyang_police"
 	},
+/obj/machinery/door/urban/glass_sliding,
 /turf/simulated/floor/lino,
 /area/point_verdant/interior/police)
 "kE" = (
@@ -5391,7 +5391,7 @@
 /obj/machinery/button/remote/blast_door{
 	id = "konyang_pharmacy";
 	name = "Pharmacy Shutters";
-	req_access = list(218);
+	req_access = list(219);
 	pixel_y = 25;
 	dir = 1;
 	pixel_x = 18
@@ -9706,11 +9706,11 @@
 /turf/simulated/floor/asphalt,
 /area/point_verdant/outdoors)
 "zi" = (
-/obj/machinery/door/window/southleft,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
 	id = "konyang_pharmacy"
 	},
+/obj/machinery/door/urban/glass_sliding/double,
 /turf/simulated/floor/lino/diamond,
 /area/point_verdant/interior/pharmacy)
 "zj" = (
@@ -10167,10 +10167,10 @@
 /area/point_verdant/outdoors)
 "Aj" = (
 /obj/effect/decal/exterior_stairs/half,
-/obj/machinery/door/window/southleft,
 /obj/machinery/door/blast/shutters{
 	id = "konyang_clinic"
 	},
+/obj/machinery/door/urban/glass_sliding/double,
 /turf/simulated/floor/lino/diamond,
 /area/point_verdant/interior/robotics)
 "Al" = (
@@ -11994,10 +11994,12 @@
 /turf/simulated/floor/exoplanet/water/shallow/konyang,
 /area/point_verdant/water)
 "ER" = (
-/obj/machinery/door/window/southright,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
 	id = "konyang_pharmacy"
+	},
+/obj/machinery/door/urban/glass_sliding/double{
+	dir = 1
 	},
 /turf/simulated/floor/lino/diamond,
 /area/point_verdant/interior/pharmacy)
@@ -12615,7 +12617,7 @@
 /area/point_verdant/outdoors)
 "Gw" = (
 /obj/machinery/door/window/southright{
-	req_access = list(218)
+	req_access = list(219)
 	},
 /turf/simulated/floor/lino/diamond,
 /area/point_verdant/interior/tailor)
@@ -13582,9 +13584,11 @@
 /area/point_verdant/water/deep)
 "Jf" = (
 /obj/effect/decal/exterior_stairs/half,
-/obj/machinery/door/window/southright,
 /obj/machinery/door/blast/shutters{
 	id = "konyang_clinic"
+	},
+/obj/machinery/door/urban/glass_sliding/double{
+	dir = 1
 	},
 /turf/simulated/floor/lino/diamond,
 /area/point_verdant/interior/robotics)
@@ -17978,13 +17982,6 @@
 	},
 /turf/simulated/floor/asphalt,
 /area/point_verdant/outdoors)
-"Uf" = (
-/obj/machinery/door/window/southright,
-/obj/machinery/door/blast/shutters/open{
-	id = "konyang_police"
-	},
-/turf/simulated/floor/lino,
-/area/point_verdant/interior/police)
 "Uh" = (
 /obj/effect/floor_decal/corner_wide/black{
 	dir = 5
@@ -18939,9 +18936,11 @@
 /area/point_verdant/interior/restaurant)
 "WI" = (
 /obj/effect/decal/exterior_stairs/half,
-/obj/machinery/door/window/southright,
 /obj/machinery/door/blast/shutters{
 	id = "konyang_minimart"
+	},
+/obj/machinery/door/urban/glass_sliding/double{
+	dir = 1
 	},
 /turf/simulated/floor/lino/diamond,
 /area/point_verdant/interior/minimart)
@@ -35514,7 +35513,7 @@ vH
 Yf
 Yf
 pg
-Uf
+kD
 BT
 iz
 LN


### PR DESCRIPTION
- Fixes #18555.
- Fixes #18529.
- Adds two outfits to the PV Pharmacist locker as alternatives to the default jumpsuit.
- Adds a box of empty autoinjectors to the PV Pharmacist basement so they can sell epi-pens or something.
- Swaps out some of the basic glass windoors at the front of some buildings for the new sliding glass doors. (If there was a reason they should be windoors and I should not do this though please let me know).