### PR TITLE
Fixed sound tokens still listening to destroy events

### DIFF
--- a/code/datums/sound_player.dm
+++ b/code/datums/sound_player.dm
@@ -1,4 +1,4 @@
-var/singleton/sound_player/sound_player = new()
+GLOBAL_DATUM_INIT(sound_player, /singleton/sound_player, new)
 
 /*
 	A sound player/manager for looping 3D sound effects.
@@ -104,7 +104,7 @@ var/singleton/sound_player/sound_player = new()
 	src.sound_type  = sound_type
 
 	if(sound.repeat) // Non-looping sounds may not reserve a sound channel due to the risk of not hearing when someone forgets to stop the token
-		var/channel = sound_player.PrivGetChannel(src) //Attempt to find a channel
+		var/channel = GLOB.sound_player.PrivGetChannel(src) //Attempt to find a channel
 		if(!isnum(channel))
 			CRASH("All available sound channels are in active use.")
 		sound.channel = channel
@@ -114,7 +114,7 @@ var/singleton/sound_player/sound_player = new()
 	listeners = list()
 	listener_status = list()
 
-	GLOB.destroyed_event.register(source, src, TYPE_PROC_REF(/datum, qdel_self))
+	GLOB.destroyed_event.register(source, src, /datum/proc/qdel_self)
 
 	PrivLocateListeners()
 	START_PROCESSING(SSprocessing, src)
@@ -154,10 +154,10 @@ var/singleton/sound_player/sound_player = new()
 	listeners = null
 	listener_status = null
 
-	GLOB.destroyed_event.unregister(source, src, TYPE_PROC_REF(/datum, qdel_self))
+	GLOB.destroyed_event.unregister(source, src, /datum/proc/qdel_self)
 	source = null
 
-	sound_player.PrivStopSound(src)
+	GLOB.sound_player.PrivStopSound(src)
 	STOP_PROCESSING(SSprocessing, src)
 
 /datum/sound_token/process()

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -197,7 +197,7 @@
 	if(!current_track)
 		return
 
-	token = sound_player.PlayLoopingSound(src, src, current_track.sound, 30, 7, 1, prefer_mute = TRUE, sound_type = ASFX_MUSIC)
+	token = GLOB.sound_player.PlayLoopingSound(src, src, current_track.sound, 30, 7, 1, prefer_mute = TRUE, sound_type = ASFX_MUSIC)
 
 	playing = 1
 	update_use_power(POWER_USE_ACTIVE)

--- a/code/game/objects/items/devices/geiger.dm
+++ b/code/game/objects/items/devices/geiger.dm
@@ -18,7 +18,7 @@
 
 /obj/item/device/geiger/proc/update_sound(playing)
 	if(playing && !sound_token)
-		sound_token = sound_player.PlayLoopingSound(src, sound_id, 'sound/items/geiger.ogg', volume = geiger_volume, range = 4, falloff = 3, prefer_mute = TRUE)
+		sound_token = GLOB.sound_player.PlayLoopingSound(src, sound_id, 'sound/items/geiger.ogg', volume = geiger_volume, range = 4, falloff = 3, prefer_mute = TRUE)
 	else if(!playing && sound_token)
 		QDEL_NULL(sound_token)
 

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -245,7 +245,7 @@
 	if (!active)
 		QDEL_NULL(sound_token)
 		return
-	sound_token = sound_player.PlayLoopingSound(src, sound_id,'sound/items/shield/energy/shield-loop.ogg', 10, 4)
+	sound_token = GLOB.sound_player.PlayLoopingSound(src, sound_id,'sound/items/shield/energy/shield-loop.ogg', 10, 4)
 
 /obj/item/shield/energy/hegemony
 	name = "hegemony barrier"

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -75,7 +75,7 @@
 	if(linked && sensors?.use_power && !(sensors.stat & NOPOWER))
 		var/volume = 15
 		if(!sound_token)
-			sound_token = sound_player.PlayLoopingSound(src, sound_id, working_sound, volume = volume, range = 10, sound_type = ASFX_CONSOLE_AMBIENCE)
+			sound_token = GLOB.sound_player.PlayLoopingSound(src, sound_id, working_sound, volume = volume, range = 10, sound_type = ASFX_CONSOLE_AMBIENCE)
 		sound_token.SetVolume(volume)
 	else if(sound_token)
 		QDEL_NULL(sound_token)

--- a/code/modules/synthesized_instruments/sound_token.dm
+++ b/code/modules/synthesized_instruments/sound_token.dm
@@ -25,7 +25,7 @@
 	src.player = player
 	src.sound_type = ASFX_INSTRUMENT
 
-	var/channel = sound_player.PrivGetChannel(src) //Attempt to find a channel
+	var/channel = GLOB.sound_player.PrivGetChannel(src) //Attempt to find a channel
 	if(!isnum(channel))
 		CRASH("All available sound channels are in active use.")
 	sound.channel = channel
@@ -52,5 +52,6 @@
 
 /datum/sound_token/instrument/Destroy()
 	. = ..()
+	GLOB.destroyed_event.unregister(source, src, /datum/proc/qdel_self)
 	player.unsubscribe(src)
 	player = null

--- a/html/changelogs/fluffyghost-fixsoundtokenslisteningevents.yml
+++ b/html/changelogs/fluffyghost-fixsoundtokenslisteningevents.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed sound tokens still listening to destroy events for the sound source, which was spamming the logs."
+  - backend: "Turned the sound player var into a GLOB var."


### PR DESCRIPTION
Fixed sound tokens still listening to destroy events for the sound source, which was spamming the logs.
Turned the sound player var into a GLOB var.