### PR TITLE
Items dropping fixes and improvements

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -143,6 +143,7 @@
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_movable.dm"
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_x_act.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_main.dm"
+#include "code\__DEFINES\dcs\signals\signals_object\signals_object.dm"
 #include "code\__HELPERS\_global_objects.dm"
 #include "code\__HELPERS\_lists.dm"
 #include "code\__HELPERS\_string_lists.dm"

--- a/code/__DEFINES/dcs/signals/signals_object/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object/signals_object.dm
@@ -1,0 +1,9 @@
+// Object signals. Format:
+// When the signal is called: (signal arguments)
+// All signals send the source datum of the signal as the first argument
+
+
+// /obj/item signals
+
+///from base of obj/item/dropped(): (mob/user)
+#define COMSIG_ITEM_DROPPED "item_drop"

--- a/code/game/gamemodes/changeling/implements/items.dm
+++ b/code/game/gamemodes/changeling/implements/items.dm
@@ -28,7 +28,7 @@
 	STOP_PROCESSING(SSprocessing, src)
 	return ..()
 
-/obj/item/melee/arm_blade/dropped(var/mob/living/user)
+/obj/item/melee/arm_blade/dropped(mob/user)
 	. = ..()
 	visible_message("<span class='danger'>With a sickening crunch, [user] reforms their arm blade into an arm!</span>",
 	"<span class='warning'>You hear organic matter ripping and tearing!</span>")
@@ -86,7 +86,7 @@
 	STOP_PROCESSING(SSprocessing, src)
 	return ..()
 
-/obj/item/shield/riot/changeling/dropped(var/mob/living/user)
+/obj/item/shield/riot/changeling/dropped(mob/user)
 	. = ..()
 	visible_message("<span class='danger'>With a sickening crunch, [user] reforms their shield into an arm!</span>",
 	"<span class='warning'>You hear organic matter ripping and tearing!</span>")

--- a/code/game/gamemodes/technomancer/devices/gloves_of_regen.dm
+++ b/code/game/gamemodes/technomancer/devices/gloves_of_regen.dm
@@ -28,7 +28,7 @@
 			wearer.custom_pain("You feel a sharp pain in your hands!",1)
 	..()
 
-/obj/item/clothing/gloves/regen/dropped(var/mob/living/carbon/human/H)
+/obj/item/clothing/gloves/regen/dropped(mob/user)
 	..()
 	if(wearer)
 		if(wearer.can_feel_pain())

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -454,14 +454,27 @@
 		playsound(src, drop_sound, THROW_SOUND_VOLUME)
 	return ..()
 
-//Apparently called whenever an item is dropped on the floor, thrown, or placed into a container.
-//It is called after loc is set, so if placed in a container its loc will be that container.
-/obj/item/proc/dropped(var/mob/user)
+/**
+ * Called when an item is removed from a `/mob` inventory (including hands and whatnot),
+ * for whatever reason (dropped on the floor, thrown, put in a container, etc.)
+ *
+ * This is called after the _new_ location (`loc`) is set on the object, so if it's eg. put in a container,
+ * the loc inside here would point to the container, not the mob that had it in hand
+ *
+ * * user - The `/mob` that dropped the object
+ */
+/obj/item/proc/dropped(mob/user)
 	SHOULD_CALL_PARENT(TRUE)
+
 	remove_item_verbs(user)
+
+	if(item_flags & ITEM_FLAG_HELD_MAP_TEXT)
+		check_maptext()
+
 	if(zoom)
 		zoom(user) //binoculars, scope, etc
-	SEND_SIGNAL(src, COMSIG_ITEM_REMOVE, src)
+
+	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
 
 /obj/item/proc/remove_item_verbs(mob/user)
 	if(ismech(user)) //very snowflake, but necessary due to how mechs work
@@ -1146,11 +1159,6 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 		maptext = ""
 
 /obj/item/throw_at()
-	..()
-	if(item_flags & ITEM_FLAG_HELD_MAP_TEXT)
-		check_maptext()
-
-/obj/item/dropped(var/mob/user)
 	..()
 	if(item_flags & ITEM_FLAG_HELD_MAP_TEXT)
 		check_maptext()

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -276,7 +276,7 @@
 	name = initial(name)
 	update_icon()
 
-/obj/item/shockpaddles/dropped(var/mob/living/user)
+/obj/item/shockpaddles/dropped(mob/user)
 	..()
 	if(user)
 		var/obj/item/offhand/O = user.get_inactive_hand()

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -94,7 +94,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		user.visible_message("In a feat of redundancy, <b>[user]</b> lights \the [src] using \the [attacking_item].", range = 3)
 		light()
 
-/obj/item/flame/match/dropped(mob/user as mob)
+/obj/item/flame/match/dropped(mob/user)
 	if(lit)
 		spawn(0)
 			var/turf/location = src.loc	// Light up the turf we land on.

--- a/code/game/objects/items/weapons/cloaking_device.dm
+++ b/code/game/objects/items/weapons/cloaking_device.dm
@@ -39,7 +39,7 @@
 	register_owner(user)
 
 //Handles dropped or thrown cloakers
-/obj/item/cloaking_device/dropped(var/mob/user)
+/obj/item/cloaking_device/dropped(mob/user)
 	..()
 	var/mob/M = get_holding_mob()
 	if(!M)

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -83,7 +83,7 @@
 			O.unwield()
 	return ..()
 
-/obj/item/material/twohanded/dropped(mob/user as mob)
+/obj/item/material/twohanded/dropped(mob/user)
 	. = ..()
 	//handles unwielding a twohanded weapon when dropped as well as clearing up the offhand
 	if(user)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -39,7 +39,7 @@
 	edge = initial(edge)
 	w_class = initial(w_class)
 
-/obj/item/melee/energy/dropped(var/mob/user)
+/obj/item/melee/energy/dropped(mob/user)
 	..()
 	if(!istype(loc,/mob))
 		deactivate(user)

--- a/code/game/objects/items/weapons/storage/laundry_basket.dm
+++ b/code/game/objects/items/weapons/storage/laundry_basket.dm
@@ -64,7 +64,7 @@
 	else
 		return ..()
 
-/obj/item/storage/laundry_basket/dropped(mob/user as mob)
+/obj/item/storage/laundry_basket/dropped(mob/user)
 	qdel(linked)
 	return ..()
 
@@ -84,7 +84,7 @@
 	pickup_sound = null
 	equip_sound = null
 
-/obj/item/storage/laundry_basket/offhand/dropped(mob/user as mob)
+/obj/item/storage/laundry_basket/offhand/dropped(mob/user)
 	. = ..()
 	user.drop_from_inventory(linked)
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -745,7 +745,7 @@
 	attacking_item.add_fingerprint(user)
 	return handle_item_insertion(attacking_item, null, user)
 
-/obj/item/storage/dropped(mob/user as mob)
+/obj/item/storage/dropped(mob/user)
 	return ..()
 
 /obj/item/storage/attack_hand(mob/user)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -138,7 +138,7 @@
 	radio_connection = SSradio.add_object(src, frequency, RADIO_CHAT)
 
 //Triggers the deadmanswitch if its dropped or moved into ones backpack
-/obj/item/device/assembly/signaler/dropped(var/mob/user)
+/obj/item/device/assembly/signaler/dropped(mob/user)
 	. = ..()
 	if(deadman)
 		if(!user.client)

--- a/code/modules/battlemonsters/items/core.dm
+++ b/code/modules/battlemonsters/items/core.dm
@@ -4,7 +4,7 @@
 	var/facedown = TRUE
 	var/rotated = FALSE
 
-/obj/item/battle_monsters/dropped(mob/user as mob)
+/obj/item/battle_monsters/dropped(mob/user)
 	set_dir(user.dir)
 	if(rotated)
 		set_dir(turn(dir,90))

--- a/code/modules/cargo/delivery/package.dm
+++ b/code/modules/cargo/delivery/package.dm
@@ -79,7 +79,7 @@
 	O.desc = "Your second grip on \the [initial(name)]."
 	user.put_in_inactive_hand(O)
 
-/obj/item/cargo_package/dropped(var/mob/living/user)
+/obj/item/cargo_package/dropped(mob/user)
 	..()
 	item_state = initial(item_state)
 	if(user)

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -800,7 +800,7 @@
 	..()
 	null_wearer(user)
 
-/obj/item/rig/dropped(var/mob/user)
+/obj/item/rig/dropped(mob/user)
 	..()
 
 	if(user.client)

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -75,7 +75,7 @@
 	check_limb_support()
 	..()
 
-/obj/item/clothing/suit/space/dropped(var/mob/user)
+/obj/item/clothing/suit/space/dropped(mob/user)
 	check_limb_support(user)
 	..()
 

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -336,7 +336,7 @@
 		add_overlay(I)
 		i++
 
-/obj/item/hand/dropped(mob/user as mob)
+/obj/item/hand/dropped(mob/user)
 	. = ..()
 	if(locate(/obj/structure/table, loc))
 		src.update_icon(user.dir)

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -255,7 +255,7 @@
 	if(istype(module_active, /obj/item/gripper))
 		var/obj/item/gripper/G = module_active
 		if(G.wrapped == O)
-			G.drop(get_turf(src), FALSE) //We don't need to see the "released X item" message if we're putting stuff in fridges and the like.
+			G.drop(get_turf(src), src, FALSE) //We don't need to see the "released X item" message if we're putting stuff in fridges and the like.
 
 /mob/living/silicon/robot/drop_item()
 	if(istype(module_active, /obj/item/gripper))
@@ -272,7 +272,7 @@
 			target = loc
 		if (istype(W.loc, /obj/item/gripper))
 			var/obj/item/gripper/G = W.loc
-			G.drop(target, do_feedback)
+			G.drop(target, src, do_feedback)
 			return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/silicon/robot/items/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/items/gripper.dm
@@ -107,7 +107,7 @@
 
 /obj/item/gripper/CtrlClick(mob/user)
 	if(wrapped)
-		drop(get_turf(src))
+		drop(get_turf(src), user)
 		return
 	to_chat(user, SPAN_WARNING("\The [src] isn't gripping anything!"))
 
@@ -118,7 +118,21 @@
 
 	drop(get_turf(src), usr)
 
-/obj/item/gripper/proc/drop(var/atom/target, mob/user, var/feedback = TRUE)
+/**
+ * Drop an item from the gripper onto the target
+ *
+ * * target - An `/atom` to drop (move) the item onto
+ * * user - The `/mob` that is dropping it
+ * * feedback - Boolean, if `TRUE` prints a message about the drop
+ */
+/obj/item/gripper/proc/drop(atom/target, mob/user, feedback = TRUE)
+	if(!istype(target))
+		crash_with("The target to drop the item onto is not specified or is incorrect!")
+
+	if(!istype(user))
+		crash_with("The user that is performing the drop is not specified or is incorrect!")
+
+
 	if(wrapped)
 		if(wrapped.loc == src)
 			if(force_holder)
@@ -128,6 +142,7 @@
 			force_holder = null
 		if(feedback)
 			to_chat(loc, SPAN_NOTICE("You release \the [wrapped].")) // loc will always be the cyborg
+
 	wrapped = null
 	update_icon()
 	return TRUE

--- a/code/modules/overmap/ship_weaponry/_ship_ammunition.dm
+++ b/code/modules/overmap/ship_weaponry/_ship_ammunition.dm
@@ -141,7 +141,7 @@
 /obj/item/ship_ammunition/proc/unwield()
 	wielded = FALSE
 
-/obj/item/ship_ammunition/dropped(var/mob/living/user)
+/obj/item/ship_ammunition/dropped(mob/user)
 	..()
 	if(user)
 		var/obj/item/offhand/O = user.get_inactive_hand()

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -199,7 +199,7 @@
 			var/obj/item/paper/P = src[1]
 			if(istype(loc, /obj/item/gripper)) //Hacky but without it there's a ghost icon with grippers and it all spills on the floor.
 				var/obj/item/gripper/G = loc
-				G.drop(get_turf(src), FALSE)
+				G.drop(get_turf(src), usr, FALSE)
 				G.grip_item(P, usr, FALSE)
 			else
 				usr.put_in_hands(P)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -834,7 +834,7 @@
 /obj/item/gun/on_give()
 	update_maptext()
 
-/obj/item/gun/dropped(mob/living/user)
+/obj/item/gun/dropped(mob/user)
 	..()
 	queue_icon_update()
 	//Unwields the item when dropped, deletes the offhand
@@ -878,7 +878,7 @@
 	else
 		qdel(src)
 
-/obj/item/offhand/dropped(mob/living/user)
+/obj/item/offhand/dropped(mob/user)
 	. = ..()
 	if(user)
 		var/obj/item/gun/O = user.get_inactive_hand()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -221,7 +221,7 @@
 		connect(backcharge)
 
 
-/obj/item/gun/energy/dropped(mob/living/user)
+/obj/item/gun/energy/dropped(mob/user)
 	. = ..()
 
 	if(recharger)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -373,7 +373,7 @@
 		to_chat(user, "<span class='warning'>\The [src] is far too large for you to pick up.</span>")
 		return
 
-/obj/item/gun/energy/vaurca/typec/dropped(var/mob/user)
+/obj/item/gun/energy/vaurca/typec/dropped(mob/user)
 	..()
 	if(!istype(loc,/mob))
 		playsound(user, 'sound/weapons/saberoff.ogg', 50, 1)

--- a/code/modules/psionics/equipment/psipower_blade.dm
+++ b/code/modules/psionics/equipment/psipower_blade.dm
@@ -25,7 +25,7 @@
 			armor_penetration = 40
 			icon_state = "psiblade_long"
 
-/obj/item/psychic_power/psiblade/dropped(var/mob/living/user)
+/obj/item/psychic_power/psiblade/dropped(mob/user)
 	. = ..()
 	playsound(loc, 'sound/effects/psi/power_fail.ogg', 30, 1)
 	QDEL_IN(src, 1)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -138,7 +138,7 @@
 		else if(isrobot(user))
 			var/obj/item/gripper/G = user.get_active_hand()
 			if(istype(G))
-				G.drop(src, FALSE)
+				G.drop(src, user, FALSE)
 				if(is_type_in_list(wrapped, G.can_hold))
 					G.grip_item(wrapped, user, FALSE)
 				else

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -89,7 +89,7 @@ GLOBAL_LIST_EMPTY(gps_list)
 	GLOB.moved_event.register(user, src, PROC_REF(update_position))
 	update_icon()
 
-/obj/item/device/gps/dropped(var/mob/user)
+/obj/item/device/gps/dropped(mob/user)
 	..()
 	if(isturf(loc))
 		held_by = null

--- a/html/changelogs/fluffyghost-fixdrop.yml
+++ b/html/changelogs/fluffyghost-fixdrop.yml
@@ -1,0 +1,47 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed a runtime with items dropping."
+  - backend: "Added the signal for items dropping specifically."
+  - backend: "DMDoc some functions."
+  - backend: "Added some guards to the borg gripper to ensure proper vars are passed in."
+  - bugfix: "Updated all the functions that call the borg gripper drop to pass in correct parameters."
+  - backend: "Consolidated /obj/item/proc/dropped into a single function (it had an overload at the same level)."
+  - refactor: "Refactored the /obj/item/proc/dropped implementations to respect the parent header."


### PR DESCRIPTION
Fixed a runtime with items dropping.
Added the signal for items dropping specifically.
DMDoc some functions.
Added some guards to the borg gripper to ensure proper vars are passed in.
Updated all the functions that call the borg gripper drop to pass in correct parameters.
Consolidated /obj/item/proc/dropped into a single function (it had an overload at the same level).
Refactored the /obj/item/proc/dropped implementations to respect the parent header.