### PR TITLE
Removed compile guards for OpenDream around list removeall

### DIFF
--- a/.github/workflows/byond.yml
+++ b/.github/workflows/byond.yml
@@ -191,14 +191,7 @@ jobs:
       - name: Set ENV variables
         run: bash dependencies.sh
 
-      #Restores SpacemanDMM from the cache repository
-      - name: Restore OpenDream cache
-        uses: actions/cache@v3
-        with:
-          path: ~/OpenDream/*
-          key: ${{ runner.os }}-opendream
-
-      - name: Install OpenDream
+      - name: Download OpenDream Compiler
         run: |
           bash tools/ci/install_od.sh
 

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -113,13 +113,7 @@
  * Returns TRUE if the list had nulls, FALSE otherwise
 **/
 /proc/list_clear_nulls(list/list_to_clear)
-//Sorry, OpenDream doesn't have this proc yet for lists
-#if !defined(OPENDREAM)
 	return (list_to_clear.RemoveAll(null) > 0)
-#else
-	return FALSE
-#endif
-
 
 /// Passed into BINARY_INSERT to compare keys
 #define COMPARE_KEY __BIN_LIST[__BIN_MID]

--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -69,10 +69,7 @@
 	// set up sectors
 	sectors = flatten_list(sectors)
 	sectors_blacklist = flatten_list(sectors_blacklist)
-//opendream doesn't have this proc for lists yet so we need this to prevent the linter from shitting itself
-#if !defined(OPENDREAM)
 	sectors.RemoveAll(sectors_blacklist)
-#endif
 
 	// adjust weight from sector dependent override
 	var/datum/space_sector/current_sector = SSatlas.current_sector

--- a/html/changelogs/fluffyghost-opendreamlistremoveall.yml
+++ b/html/changelogs/fluffyghost-opendreamlistremoveall.yml
@@ -38,4 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
+  - bugfix: "Fixed OpenDream CI to download the precompiled version of what we need from the OpenDream repo."
   - backend: "Removed compile guards for OpenDream around list removeall() as it was implemented in OpenDream."

--- a/html/changelogs/fluffyghost-opendreamlistremoveall.yml
+++ b/html/changelogs/fluffyghost-opendreamlistremoveall.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Removed compile guards for OpenDream around list removeall() as it was implemented in OpenDream."

--- a/tools/ci/install_od.sh
+++ b/tools/ci/install_od.sh
@@ -1,29 +1,10 @@
 #!/bin/bash
 set -eo pipefail
 
-if [ -d "$HOME/OpenDream/" ];
-then
-  echo "Using cached OpenDream directory."
+echo "Download OpenDream Compiler."
 
-  if [ -a "$HOME/OpenDream/OpenDream.sln" ];
-  then
-    echo "OpenDream is already compiled."
-    exit
-  else
-    echo "OpenDream is not compiled, compiling it now..."
-    git -C $HOME/OpenDream fetch origin
-    git -C $HOME/OpenDream reset --hard origin/master
+cd $HOME
 
-    git -C $HOME/OpenDream submodule update --init --recursive
-  fi
+wget -v https://github.com/OpenDreamProject/OpenDream/releases/download/latest/DMCompiler_linux-x64.tar.gz
 
-
-else
-  echo "Setting up OpenDream."
-
-  git clone https://github.com/OpenDreamProject/OpenDream.git $HOME/OpenDream
-  git -C $HOME/OpenDream submodule update --init --recursive
-fi
-
-dotnet restore $HOME/OpenDream
-dotnet build $HOME/OpenDream/OpenDream.sln -c Release --property WarningLevel=1
+tar -xf DMCompiler_linux-x64.tar.gz

--- a/tools/ci/run_od.sh
+++ b/tools/ci/run_od.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -eo pipefail
-dotnet $HOME/OpenDream/DMCompiler/bin/Release/net7.0/DMCompiler.dll --suppress-unimplemented aurorastation.dme
+dotnet $HOME/DMCompiler_linux-x64/DMCompiler.dll --suppress-unimplemented aurorastation.dme


### PR DESCRIPTION
Fixed OpenDream CI to download the precompiled version of what we need from the OpenDream repo.
Removed compile guards for OpenDream around list removeall() as it was implemented in OpenDream.