### PR TITLE
Readds the user-defined chat message limit, now for tgchat

### DIFF
--- a/html/changelogs/llywelwyn-messagelimit.yml
+++ b/html/changelogs/llywelwyn-messagelimit.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Llywelwyn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a tgchat setting to let players decide how many messages can be stored in chat before they start getting pruned."

--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -4,7 +4,6 @@
  * @license MIT
  */
 
-export const MAX_VISIBLE_MESSAGES = 2500;
 export const MAX_PERSISTED_MESSAGES = 1000;
 export const MESSAGE_SAVE_INTERVAL = 10000;
 export const MESSAGE_PRUNE_INTERVAL = 60000;

--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -9,7 +9,7 @@ import { storage } from 'common/storage';
 import { loadSettings, updateSettings, addHighlightSetting, removeHighlightSetting, updateHighlightSetting } from '../settings/actions';
 import { selectSettings } from '../settings/selectors';
 import { addChatPage, changeChatPage, changeScrollTracking, loadChat, rebuildChat, removeChatPage, saveChatToDisk, clearChatMessages, toggleAcceptedType, updateMessageCount } from './actions';
-import { MAX_PERSISTED_MESSAGES, MESSAGE_SAVE_INTERVAL } from './constants';
+import { MAX_PERSISTED_MESSAGES, MESSAGE_SAVE_INTERVAL, MESSAGE_PRUNE_INTERVAL } from './constants';
 import { createMessage, serializeMessage } from './model';
 import { chatRenderer } from './renderer';
 import { selectChat, selectCurrentChatPage } from './selectors';
@@ -78,6 +78,10 @@ export const chatMiddleware = (store) => {
   setInterval(() => {
     saveChatToStorage(store);
   }, MESSAGE_SAVE_INTERVAL);
+  setInterval(() => {
+    const settings = selectSettings(store.getState());
+    chatRenderer.pruneMessagesTo(settings.maxMessages, MAX_PERSISTED_MESSAGES);
+  }, MESSAGE_PRUNE_INTERVAL);
   return (next) => (action) => {
     const { type, payload } = action;
     if (!initialized) {

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -7,7 +7,7 @@
 import { EventEmitter } from 'common/events';
 import { classes } from 'common/react';
 import { createLogger } from 'tgui/logging';
-import { COMBINE_MAX_MESSAGES, COMBINE_MAX_TIME_WINDOW, IMAGE_RETRY_DELAY, IMAGE_RETRY_LIMIT, IMAGE_RETRY_MESSAGE_AGE, MAX_PERSISTED_MESSAGES, MAX_VISIBLE_MESSAGES, MESSAGE_PRUNE_INTERVAL, MESSAGE_TYPES, MESSAGE_TYPE_INTERNAL, MESSAGE_TYPE_UNKNOWN } from './constants';
+import { COMBINE_MAX_MESSAGES, COMBINE_MAX_TIME_WINDOW, IMAGE_RETRY_DELAY, IMAGE_RETRY_LIMIT, IMAGE_RETRY_MESSAGE_AGE, MAX_PERSISTED_MESSAGES, MESSAGE_TYPES, MESSAGE_TYPE_INTERNAL, MESSAGE_TYPE_UNKNOWN } from './constants';
 import { render } from 'inferno';
 import { canPageAcceptType, createMessage, isSameMessage } from './model';
 import { highlightNode, linkifyNode } from './replaceInTextNode';
@@ -135,8 +135,6 @@ class ChatRenderer {
         this.scrollToBottom();
       }
     };
-    // Periodic message pruning
-    setInterval(() => this.pruneMessages(), MESSAGE_PRUNE_INTERVAL);
   }
 
   isReady() {
@@ -511,10 +509,6 @@ class ChatRenderer {
         logger.log(`pruned ${fromIndex} stored messages`);
       }
     }
-  }
-
-  pruneMessages() {
-    this.pruneMessagesTo(MAX_VISIBLE_MESSAGES, MAX_PERSISTED_MESSAGES);
   }
 
   rebuildChat() {

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -50,7 +50,7 @@ export const SettingsPanel = (props, context) => {
 };
 
 export const SettingsGeneral = (props, context) => {
-  const { theme, fontFamily, fontSize, lineHeight } = useSelector(
+  const { theme, fontFamily, fontSize, lineHeight, maxMessages } = useSelector(
     context,
     selectSettings
   );
@@ -145,6 +145,24 @@ export const SettingsGeneral = (props, context) => {
               dispatch(
                 updateSettings({
                   lineHeight: value,
+                })
+              )
+            }
+          />
+        </LabeledList.Item>
+        <LabeledList.Item label="Max messages">
+          <NumberInput
+            width="4em"
+            step={50}
+            stepPixelSize={2}
+            minValue={2000}
+            maxValue={16000}
+            value={maxMessages}
+            format={(value) => toFixed(value)}
+            onChange={(e, value) =>
+              dispatch(
+                updateSettings({
+                  maxMessages: value,
                 })
               )
             }

--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -15,6 +15,7 @@ const initialState = {
   fontSize: 13,
   fontFamily: FONTS[0],
   lineHeight: 1.2,
+  maxMessages: 2500,
   theme: 'light',
   adminMusicVolume: 0.5,
   // Keep these two state vars for compatibility with other servers


### PR DESCRIPTION

![image](https://github.com/Aurorastation/Aurora.3/assets/82828093/57bc8f41-1825-44aa-8724-b9ee987f2d4e)

changes:
  - rscadd: "Added a tgchat setting to let players decide how many messages can be stored in chat before they start getting pruned."

we had this before it just got lost with the swap over to tgchat

removed the const for max messages, replaced it with a setting that defaults to what the previous value was (2500). moved the message pruning interval out of the renderer to the middleware so it can get access to the settings. set the limits to around the same as what we had before the swap to tgchat (2,000 to 16,000)