### PR TITLE
Intrepid Fuel Compartment Access Fix

### DIFF
--- a/html/changelogs/furrycactus - intrepid access fix.yml
+++ b/html/changelogs/furrycactus - intrepid access fix.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Furrycactus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Fixes an access problem with the Intrepid fueling compartment that unintentionally made most jobs unable to access it."
+  - maptweak: "Moved Intrepid cryo to the port thruster compartment instead of starboard and removed access requirements on that airlock, so people can cryo if they're on the Intrepid without needing someone to let them in to do it."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -4884,8 +4884,7 @@
 	},
 /obj/machinery/door/airlock/hatch{
 	dir = 1;
-	name = "Thruster Compartment";
-	req_access = list(73)
+	name = "Thruster Compartment"
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -8918,8 +8917,11 @@
 /obj/structure/bed/handrail{
 	dir = 4
 	},
-/obj/machinery/alarm/west,
-/obj/machinery/power/apc/intrepid/east,
+/obj/machinery/computer/cryopod{
+	pixel_x = 28;
+	pixel_y = 7
+	},
+/obj/machinery/power/apc/intrepid/west,
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/engine_compartment)
 "fYt" = (
@@ -9334,7 +9336,7 @@
 /obj/machinery/door/airlock/hatch{
 	dir = 1;
 	name = "Thruster Compartment";
-	req_access = list(73)
+	req_one_access = list(73,11,24)
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/engine_compartment)
@@ -10867,10 +10869,10 @@
 /area/shuttle/intrepid/cargo_bay)
 "hqn" = (
 /obj/structure/lattice/catwalk/indoor,
-/obj/structure/closet/firecloset/full,
 /obj/machinery/light/small/red{
 	dir = 4
 	},
+/obj/machinery/cryopod,
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/engine_compartment)
 "hqo" = (
@@ -13356,7 +13358,7 @@
 /area/hallway/primary/aft)
 "jkq" = (
 /obj/structure/lattice/catwalk/indoor,
-/obj/machinery/cryopod,
+/obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/engine_compartment)
 "jks" = (
@@ -27047,10 +27049,6 @@
 "sDd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/lattice/catwalk/indoor,
-/obj/machinery/computer/cryopod{
-	pixel_x = 28;
-	pixel_y = 7
-	},
 /obj/structure/bed/handrail{
 	dir = 8
 	},
@@ -28262,6 +28260,7 @@
 	dir = 1
 	},
 /obj/machinery/recharge_station,
+/obj/machinery/alarm/west,
 /turf/simulated/floor/plating,
 /area/shuttle/intrepid/engine_compartment)
 "twq" = (
@@ -30160,7 +30159,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
 /obj/machinery/door/window/southright{
-	req_access = list(73,11)
+	req_one_access = list(73,11,24)
 	},
 /obj/machinery/light_switch{
 	pixel_x = 21;
@@ -32936,7 +32935,7 @@
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
 	name = "Utility and Atmosphere Control";
-	req_access = list(73,11)
+	req_one_access = list(73,11,24)
 	},
 /obj/structure/cable{
 	icon_state = "4-8"


### PR DESCRIPTION
- Fixes some small access issues as a result of #18584. The access tags on the Intrepid fuel bay were unintentionally put in the req_access field instead of req_access_one, so a few jobs lost access. This fixes it, adds Engineering and Atmos access to the fuel compartment, and also moves Intrepid cryo to the port thruster compartment instead of starboard and removes access on that door. 