### PR TITLE
No Hulk Screaming for Vaurca & IPCs

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -38,9 +38,9 @@
 
 	return ..()
 
-/obj/structure/attack_hand(mob/user)
+/obj/structure/attack_hand(mob/living/user)
 	if(breakable)
-		if((user.mutations & HULK) && !(user.isSynthetic) && !(isvaurca(user)))
+		if((user.mutations & HULK) && !(user.isSynthetic()) && !(isvaurca(user)))
 			user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
 			attack_generic(user,1,"smashes")
 		else if(istype(user,/mob/living/carbon/human))

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -40,7 +40,7 @@
 
 /obj/structure/attack_hand(mob/user)
 	if(breakable)
-		if((user.mutations & HULK))
+		if((user.mutations & HULK) && !(user.isSynthetic) && !(isvaurca(user)))
 			user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ))
 			attack_generic(user,1,"smashes")
 		else if(istype(user,/mob/living/carbon/human))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -206,9 +206,9 @@
 		step(src, get_dir(AM, src))
 	take_damage(tforce)
 
-/obj/structure/window/attack_hand(var/mob/user)
+/obj/structure/window/attack_hand(var/mob/living/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	if((user.mutations & HULK))
+	if((user.mutations & HULK) && !(user.isSynthetic()) && !(isvaurca(user)))
 		user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!"))
 		user.visible_message(SPAN_DANGER("[user] smashes through [src]!"))
 		user.do_attack_animation(src)

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -200,7 +200,7 @@
 			SPAN_WARNING("You successfully break your [handcuffed.name].")
 			)
 
-		if((isunathi(src)) || (mutations & HULK))
+		if((isunathi(src)) || (mutations & HULK) && !(src.isSynthetic()) && !(isvaurca(src)))
 			say(pick("RAAAAAAAARGH!", "HNNNNNNNNNGGGGGGH!", "GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", "AAAAAAARRRGH!" ))
 			stamina -= 100 //takes a bunch of stamina
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -100,7 +100,7 @@ var/list/channel_to_radio_key = new
 	if(!message_range)
 		message_range = world.view
 
-	if((mutations & HULK))
+	if((mutations & HULK) && !src.isSynthetic() && !isvaurca(src))
 		var/ending = copytext(message, length(message), length(message) + 1)
 		if(ending && GLOB.correct_punctuation[ending])
 			message = copytext(message, 1, length(message))

--- a/html/changelogs/RustingWithYou - warformscream.yml
+++ b/html/changelogs/RustingWithYou - warformscream.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "IPCs and Vaurca will no longer scream everything when hulked."


### PR DESCRIPTION
If Vaurca/IPCs are hulked, they will no longer scream everything they say. For IPCs this is largely just added for the sake of completeness as hulked IPCs are impossible in normal gameplay, for Vaurca it actually has a limited in-game impact as warforms are hulked and thus won't be yelling "GGHRAHHRAH" through their synthetic voice box. 
