### PR TITLE
Removal of Soul from PV Police Roles (Point Verdant Police Headset)

### DIFF
--- a/html/changelogs/Ben10083 - Police_Headset.yml
+++ b/html/changelogs/Ben10083 - Police_Headset.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Point Verdant Police now spawn with headsets instead of bounced radios, as the role had too much soul."

--- a/maps/away/away_site/konyang/point_verdant/point_verdant_ghostroles.dm
+++ b/maps/away/away_site/konyang/point_verdant/point_verdant_ghostroles.dm
@@ -73,8 +73,8 @@
 	shoes = /obj/item/clothing/shoes/jackboots
 	head = /obj/item/clothing/head/konyang/police
 	id = /obj/item/card/id
+	l_ear = /obj/item/device/radio/headset/ship
 	belt = /obj/item/storage/belt/security
-	l_pocket = /obj/item/device/radio/map_preset
 	r_pocket = /obj/item/storage/wallet/random
 	back = /obj/item/storage/backpack/satchel
 


### PR DESCRIPTION
I tried. I even fixed bounced radios, sadly the anti-soul league has convinced me to replace the bounced radio with headset, so they can hear hailing and personal frequency at the same time.