### PR TITLE
Adds Species Martial Arts to Uplink

### DIFF
--- a/code/datums/uplink/martial_arts.dm
+++ b/code/datums/uplink/martial_arts.dm
@@ -23,8 +23,8 @@
 	path = /obj/item/martial_manual/gun_kata
 
 /datum/uplink_item/item/martial_arts/skrell
-	name = "Karak Vikul"
-	desc = "A manual containing instructions on the Skrellian martial art of Karak Vikul. Only usable by Skrell."
+	name = "Karak Virul"
+	desc = "A manual containing instructions on the Skrellian martial art of Karak Virul. Only usable by Skrell."
 	telecrystal_cost = 2
 	path = /obj/item/martial_manual/skrell
 

--- a/code/datums/uplink/martial_arts.dm
+++ b/code/datums/uplink/martial_arts.dm
@@ -21,3 +21,27 @@
 	desc = "A manual containing basic Gun-Kata instruction and techniques. This is for projectile weapons, allowing you to reload by using a gun on a magazine, and automatically ejecting the magazine when it's empty."
 	telecrystal_cost = 1
 	path = /obj/item/martial_manual/gun_kata
+
+/datum/uplink_item/item/martial_arts/skrell
+	name = "Karak Vikul"
+	desc = "A manual containing instructions on the Skrellian martial art of Karak Vikul. Only usable by Skrell."
+	telecrystal_cost = 2
+	path = /obj/item/martial_manual/skrell
+
+/datum/uplink_item/item/martial_arts/tajara
+	name = "Baghrar"
+	desc = "A manual containing instructions on the Tajaran martial art of Baghrar. Only usable by Tajara."
+	telecrystal_cost = 2
+	path = /obj/item/martial_manual/tajara
+
+/datum/uplink_item/item/martial_arts/unathi
+	name = "Kis-Khan"
+	desc = "A manual containing instructions on the Unathi martial art of Kis-Khan. Only usable by Unathi."
+	telecrystal_cost = 2
+	path = /obj/item/martial_manual/unathi
+
+/datum/uplink_item/item/martial_arts/vaurca
+	name = "Vk'utet"
+	desc = "A data disk containing instructions on the Vaurca martial art of Vk'utet. Only usable by Vaurca."
+	telecrystal_cost = 2
+	path = /obj/item/martial_manual/vaurca

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -206,6 +206,7 @@
 	icon_state ="cqcmanual"
 	item_state ="book1"
 	var/martial_art = /datum/martial_art/sol_combat
+	///List of species capable of learning this martial art.
 	var/list/species_restriction
 
 /obj/item/martial_manual/attack_self(mob/user as mob)

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -206,14 +206,18 @@
 	icon_state ="cqcmanual"
 	item_state ="book1"
 	var/martial_art = /datum/martial_art/sol_combat
+	var/list/species_restriction
 
 /obj/item/martial_manual/attack_self(mob/user as mob)
 	if(!ishuman(user))
 		return
 	var/mob/living/carbon/human/H = user
+	if(species_restriction && !(H.species in species_restriction))
+		to_chat(H, SPAN_WARNING("Your species is incapable of learning this martial art!"))
+		return
 	var/datum/martial_art/F = new martial_art(null)
 	F.teach(H)
-	to_chat(H, "<span class='notice'>You have learned the martial art of [F.name].</span>")
+	to_chat(H, SPAN_NOTICE("You have learned the martial art of [F.name]."))
 	if(F.possible_weapons)
 		var/weapon = pick(F.possible_weapons)
 		var/obj/item/W = new weapon(get_turf(user))

--- a/code/modules/martial_arts/skrell.dm
+++ b/code/modules/martial_arts/skrell.dm
@@ -91,6 +91,7 @@
 	name = "karak virul manual"
 	desc = "A manual designated to teach the user about the skrellian martial art of Karak Virul."
 	martial_art = /datum/martial_art/karak_virul
+	species_restriction = list(SPECIES_SKRELL, SPECIES_SKRELL_AXIORI)
 
 #undef PAINFUL_PALM
 #undef SKRELL_LEG_SWEEP

--- a/code/modules/martial_arts/tajara.dm
+++ b/code/modules/martial_arts/tajara.dm
@@ -104,6 +104,7 @@
 	matches or stabbing forward with the claws in typical matches. Modern Baghrariri, or people who fight in the Baghrar style for sport, usually fight with implements that cover and \
 	support their claws to avoid serious bodily damage. Modern Baghrar matches are decided upon with a point scoring system over three 10 minute rounds of fighting, but historical \
 	victories were secured by knocking opponents onto the ground."
+	species_restriction = list(SPECIES_TAJARA, SPECIES_TAJARA_MSAI, SPECIES_TAJARA_ZHAN)
 
 #undef EYE_RAKE
 #undef CLAW_PUNCH

--- a/code/modules/martial_arts/unathi.dm
+++ b/code/modules/martial_arts/unathi.dm
@@ -104,6 +104,7 @@
 	icon_state = "scroll"
 	item_state = "scroll"
 	martial_art = /datum/martial_art/kis_khan
+	species_restriction = list(SPECIES_UNATHI)
 
 #undef TAIL_SWEEP
 #undef SWIFT_DISARM

--- a/code/modules/martial_arts/vaurca.dm
+++ b/code/modules/martial_arts/vaurca.dm
@@ -95,6 +95,7 @@
 	icon = 'icons/obj/vaurca_items.dmi'
 	icon_state = "harddisk"
 	martial_art = /datum/martial_art/vkutet
+	species_restriction = list(SPECIES_VAURCA_WORKER, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_BREEDER, SPECIES_VAURCA_BULWARK)
 
 #undef PIERCING_STRIKE
 #undef SWIFT_BITE

--- a/html/changelogs/RustingWithYou - martialarts.yml
+++ b/html/changelogs/RustingWithYou - martialarts.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds species-specific martial arts to the uplink."
+  - tweak: "Martial arts manuals can now be species-restricted."


### PR DESCRIPTION
Species-specific martial arts manuals can now be purchased in the uplink. Manuals can now have species-restriction, to prevent stuff like a Vaurca learning the Unathi martial art and somehow doing a tail sweep.