### PR TITLE
Restricts Psionic Teleport to Loners

### DIFF
--- a/code/__DEFINES/psi.dm
+++ b/code/__DEFINES/psi.dm
@@ -10,6 +10,7 @@
 #define PSI_FLAG_APEX			16	/// An ability automatically given to Psionic Apex users.
 #define PSI_FLAG_LIMITLESS		32  /// An ability automatically given to Limitless users.
 #define PSI_FLAG_SPECIAL		64 	/// Unselectable in the point shop - must be handed out manually.
+#define PSI_FLAG_LONER			128 /// An ability only available to Loners.
 
 /// Psi shop points given by a certain rank.
 #define PSI_POINTS_HARMONIOUS  10

--- a/code/modules/psionics/abilities/jump.dm
+++ b/code/modules/psionics/abilities/jump.dm
@@ -3,7 +3,7 @@
 	desc = "Teleport to a destination you click on."
 	icon_state = "tech_dispel"
 	point_cost = 3
-	ability_flags = PSI_FLAG_ANTAG
+	ability_flags = PSI_FLAG_LONER
 	spell_path = /obj/item/spell/jump
 
 /obj/item/spell/jump

--- a/code/modules/psionics/abilities/warp.dm
+++ b/code/modules/psionics/abilities/warp.dm
@@ -3,7 +3,7 @@
 	desc = "Warp through objects."
 	icon_state = "tech_blink"
 	point_cost = 4
-	ability_flags = PSI_FLAG_ANTAG
+	ability_flags = PSI_FLAG_LONER
 	spell_path = /obj/item/spell/warp
 
 /obj/item/spell/warp

--- a/code/modules/psionics/interface/ui_hub.dm
+++ b/code/modules/psionics/interface/ui_hub.dm
@@ -70,6 +70,8 @@
 				continue
 		if(owner_rank < PSI_RANK_HARMONIOUS && (P.ability_flags & PSI_FLAG_ANTAG))
 			continue
+		if(!(owner.mind in loners.current_antagonists) && (P.ability_flags & PSI_FLAG_LONER))
+			continue
 		data["available_psionics"] += list(
 			list(
 				"name" = P.name,

--- a/html/changelogs/RustingWithYou - psiteleport.yml
+++ b/html/changelogs/RustingWithYou - psiteleport.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Psionic teleport abilities are now only available to loners."


### PR DESCRIPTION
The psionic Jump and Warp powers are now only available to loners, rather than any psionic antagonist.

As a solo non-crew antagonist, loner needs some way of avoiding the security deathpile, but these abilities being available to any antagonist with an uplink can become extremely frustrating to play against. Similar abilities to these two are generally restricted to similar roles - burglars, technomancers and some ninjas having similar 'evade security' abilities, which rapidly become annoying on traitors or mercs.