### PR TITLE
Unicode support in drunken speech and whispers

### DIFF
--- a/code/modules/mob/living/whisper.dm
+++ b/code/modules/mob/living/whisper.dm
@@ -28,7 +28,7 @@
 
 	if(!had_speaking)
 		if(speaking)
-			message = copytext_char(message,2+length(speaking.key))
+			message = copytext_char(message, 2 + length(speaking.key))
 		else
 			speaking = get_default_language()
 

--- a/code/modules/mob/living/whisper.dm
+++ b/code/modules/mob/living/whisper.dm
@@ -28,11 +28,11 @@
 
 	if(!had_speaking)
 		if(speaking)
-			message = copytext(message,2+length(speaking.key))
+			message = copytext_char(message,2+length(speaking.key))
 		else
 			speaking = get_default_language()
 
-	if(length(message) >= 1 && copytext(message, 1, 2) == "%")
+	if(length_char(message) >= 1 && copytext_char(message, 1, 2) == "%")
 		if(speaking?.sing_verb)
 			is_singing = TRUE
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -368,7 +368,7 @@ var/list/global/organ_rel_size = list(
 	p = 1
 	var/intag = 0
 	while(p <= n)
-		var/char = copytext(te, p, p + 1)
+		var/char = copytext_char(te, p, p + 1)
 		if (char == "<") //let's try to not break tags
 			intag = !intag
 		if (intag || char == " " || prob(pr))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -382,12 +382,12 @@ var/list/global/organ_rel_size = list(
 
 /proc/slur(phrase, strength = 100)
 	phrase = html_decode(phrase)
-	var/leng=length(phrase)
-	var/counter=length(phrase)
+	var/leng=length_char(phrase)
+	var/counter=length_char(phrase)
 	var/newphrase=""
 	var/newletter=""
 	while(counter>=1)
-		newletter=copytext(phrase,(leng-counter)+1,(leng-counter)+2)
+		newletter=copytext_char(phrase,(leng-counter)+1,(leng-counter)+2)
 		if(prob(strength))
 			if(rand(1,3)==3)
 				if(lowertext(newletter)=="o")	newletter="u"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -382,28 +382,35 @@ var/list/global/organ_rel_size = list(
 
 /proc/slur(phrase, strength = 100)
 	phrase = html_decode(phrase)
-	var/leng=length_char(phrase)
-	var/counter=length_char(phrase)
-	var/newphrase=""
-	var/newletter=""
-	while(counter>=1)
-		newletter=copytext_char(phrase,(leng-counter)+1,(leng-counter)+2)
-		if(prob(strength))
-			if(rand(1,3)==3)
-				if(lowertext(newletter)=="o")	newletter="u"
-				if(lowertext(newletter)=="s")	newletter="ch"
-				if(lowertext(newletter)=="a")	newletter="ah"
-				if(lowertext(newletter)=="c")	newletter="k"
-			switch(rand(1,15))
-				if(1,3,5,8)
-					newletter="[lowertext(newletter)]"
-				if(2,4,6,15)
-					newletter="[uppertext(newletter)]"
-				if(7)
-					newletter+="'"
+	var/leng = length_char(phrase)
+	var/counter = length_char(phrase)
+	var/newphrase = ""
+	var/newletter = ""
+	while (counter >= 1)
+		newletter = copytext_char(phrase, (leng - counter) + 1, (leng - counter) + 2)
+		if (prob(strength))
+			if (rand(1, 3) == 3)
+				switch (lowertext(newletter))
+					if ("o")
+						newletter = "u"
+					if ("s")
+						newletter = "ch"
+					if ("a")
+						newletter = "ah"
+					if ("c")
+						newletter = "k"
+
+			switch (rand(1, 15))
+				if (1, 3, 5, 8)
+					newletter = "[lowertext(newletter)]"
+				if (2, 4, 6, 15)
+					newletter = "[uppertext(newletter)]"
+				if (7)
+					newletter += "'"
 				else
 					. = null // For dreamchecker, does nothing
-		newphrase+="[newletter]";counter-=1
+		newphrase += "[newletter]"
+		counter -= 1
 	return newphrase
 
 /proc/Gibberish(t, p)//t is the inputted message, and any value higher than 70 for p will cause letters to be replaced instead of added

--- a/html/changelogs/SidVeld - unicode-in-whisper-and-slur.yml
+++ b/html/changelogs/SidVeld - unicode-in-whisper-and-slur.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: SidVeld
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Slur and whisper procs support unicode."


### PR DESCRIPTION
# Unicode support in drunken speech and whispers.

The main reason for opening this pull request is problems with the display of Cyrillic characters in players' messages.

For example, drunk characters have almost all letters changed to question marks.

![изображение](https://github.com/Aurorastation/Aurora.3/assets/22749671/e884edc4-0662-4dde-b225-675c57847144)

The same problem with characters trying to hear someone else's whispers. Unfortunately I don't have a screenshot handy, but the message looks like this:

`Someone whispers, "******<?>***<?>****<?>*****"`

## Changes

Some of the procs are slightly modified. Now they use analogs with `_char` suffix. 
Such methods support Unicode and hence Cyrillic.

Slur:

![изображение](https://github.com/Aurorastation/Aurora.3/assets/22749671/cdf6e2b6-9e3b-4778-9d43-5c38138a8236)

Whisper:

![изображение](https://github.com/Aurorastation/Aurora.3/assets/22749671/6d09fc33-0a80-4d30-9df5-318631a545b2)

![изображение](https://github.com/Aurorastation/Aurora.3/assets/22749671/cff742df-fafa-4978-91bb-af4b0f5409a2)