### PR TITLE
COC Surveyor Fixes

### DIFF
--- a/maps/away/ships/coc/coc_surveyor/coc_surveyor.dm
+++ b/maps/away/ships/coc/coc_surveyor/coc_surveyor.dm
@@ -4,7 +4,7 @@
 	suffixes = list("ships/coc/coc_surveyor/coc_surveyor.dmm")
 	sectors = list(SECTOR_BADLANDS, ALL_COALITION_SECTORS, ALL_VOID_SECTORS)
 	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA)
-	spawn_weight = 1
+	spawn_weight = 9
 	ship_cost = 1
 	id = "coc_surveyor"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/coc_survey_shuttle)

--- a/maps/away/ships/coc/coc_surveyor/coc_surveyor.dm
+++ b/maps/away/ships/coc/coc_surveyor/coc_surveyor.dm
@@ -68,6 +68,20 @@
 	name = "Coalition Survey Ship - Fore"
 	landmark_tag = "nav_surveyor_4"
 
+/obj/effect/shuttle_landmark/coc_survey_ship/dock/port
+	name = "Port Dock"
+	landmark_tag = "nav_coc_surveyor_dock_port"
+	docking_controller = "airlock_coc_surveyor_dock_port"
+	base_turf = /turf/space
+	base_area = /area/space
+
+/obj/effect/shuttle_landmark/coc_survey_ship/dock/starboard
+	name = "Starboard Dock"
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	docking_controller = "airlock_coc_surveyor_dock_starboard"
+	base_turf = /turf/space
+	base_area = /area/space
+
 /obj/effect/overmap/visitable/ship/landable/coc_survey_shuttle
 	name = "COC Survey Shuttle"
 	desc = "The Minnow-class is a civilian transport shuttle, often used in the Coalition of Colonies."

--- a/maps/away/ships/coc/coc_surveyor/coc_surveyor.dmm
+++ b/maps/away/ships/coc/coc_surveyor/coc_surveyor.dmm
@@ -34,13 +34,16 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/starboard_propulsion)
 "aH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/starboard_propulsion)
 "aP" = (
@@ -435,6 +438,9 @@
 	landmark_tag = "nav_coc_surveyor_dock_starboard"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/coc_survey_ship/cargo)
 "et" = (
@@ -659,17 +665,9 @@
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/cryo)
 "gQ" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_wide/yellow/full{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/coc_survey_ship/atmos)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/coc_survey_ship/cargo)
 "gX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -911,28 +909,18 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "jt" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1389;
-	icon_state = "door_locked";
-	id_tag = "surveyor_shuttle_in";
-	dir = 4
+/obj/machinery/atmospherics/binary/pump/high_power{
+	layer = 2.8
 	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_coc_surveyor_dock_starboard";
-	master_tag = "airlock_coc_surveyor_dock_starboard";
-	landmark_tag = "nav_coc_surveyor_dock_starboard"
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
 	},
-/obj/machinery/access_button{
-	pixel_x = 12;
-	pixel_y = 28;
-	dir = 4
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/coc_survey_ship/cargo)
+/obj/effect/floor_decal/corner_wide/yellow,
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "jz" = (
 /turf/simulated/wall/shuttle/dark/cardinal/blue,
 /area/coc_survey_ship/medical)
@@ -1047,11 +1035,6 @@
 /area/coc_survey_ship/miningeva)
 "kH" = (
 /obj/machinery/light,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 8
 	},
@@ -1160,6 +1143,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "lr" = (
@@ -1333,6 +1317,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/east,
+/obj/effect/decal/cleanable/generic{
+	layer = 2.81
+	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/quarters)
 "mv" = (
@@ -1545,6 +1532,17 @@
 	},
 /turf/simulated/floor/carpet/lightblue,
 /area/coc_survey_ship/captain)
+"ou" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/coc_survey_ship/cargo)
 "oF" = (
 /obj/machinery/light/small/emergency{
 	dir = 4
@@ -1657,15 +1655,15 @@
 	dir = 4
 	},
 /obj/machinery/alarm/east,
+/obj/effect/decal/cleanable/generic{
+	layer = 2.81
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/cargo)
 "pw" = (
-/obj/structure/sign/radiation{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/coc_survey_ship/engineering)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/coc_survey_ship/hangar)
 "pA" = (
 /obj/structure/sign/flag/assunzione,
 /turf/simulated/wall,
@@ -1759,7 +1757,7 @@
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/reinforced,
 /area/coc_survey_ship/blaster)
 "qE" = (
 /obj/effect/floor_decal/industrial/loading/yellow{
@@ -1877,6 +1875,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "rp" = (
@@ -1907,8 +1906,16 @@
 /obj/machinery/alarm/west{
 	req_one_access = null
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
+"rR" = (
+/obj/structure/sign/radiation{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/coc_survey_ship/engineering)
 "rS" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Cryo and Medical"
@@ -1976,9 +1983,6 @@
 	master_tag = "airlock_coc_surveyor_dock_starboard";
 	landmark_tag = "nav_coc_surveyor_dock_starboard"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/cargo)
@@ -2012,7 +2016,7 @@
 "sH" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/east,
-/turf/simulated/floor,
+/turf/simulated/floor/reinforced,
 /area/coc_survey_ship/grauwolf)
 "sK" = (
 /obj/effect/floor_decal/corner/purple/diagonal,
@@ -2263,6 +2267,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "uK" = (
@@ -2369,20 +2374,19 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "vU" = (
-/obj/item/stack/material/tritium/full,
-/obj/item/stack/material/tritium/full,
-/obj/structure/closet/crate{
-	name = "DANGER - RADIOACTIVE MATERIAL"
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/effect/floor_decal/corner_wide/white/diagonal{
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/rubber,
-/area/coc_survey_ship/engineering)
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "vZ" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -2568,6 +2572,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/starboard_propulsion)
 "xe" = (
@@ -2666,6 +2671,28 @@
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/bridge)
+"ya" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/obj/machinery/airlock_sensor{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = -6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/coc_survey_ship/cargo)
 "yj" = (
 /obj/machinery/computer/ship/helm{
 	dir = 4
@@ -2735,17 +2762,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/kitchen)
+"yD" = (
+/obj/machinery/power/apc/south,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/coc_survey_ship/starboard_propulsion)
 "yK" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
-	layer = 2.8
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/yellow/full{
+	dir = 1
 	},
 /obj/effect/floor_decal/corner_wide/yellow{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner_wide/white{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner_wide/yellow,
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "yQ" = (
@@ -2796,6 +2831,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/cargo)
 "yZ" = (
@@ -2885,6 +2921,7 @@
 /area/coc_survey_ship/engineering)
 "zA" = (
 /obj/machinery/telecomms/allinone/ship,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating/cooled,
 /area/coc_survey_ship/engineering)
 "zJ" = (
@@ -2942,10 +2979,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/south,
 /turf/simulated/floor,
 /area/coc_survey_ship/starboard_propulsion)
 "Ai" = (
@@ -3222,6 +3255,18 @@
 /obj/item/device/suit_cooling_unit,
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
+"Ce" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	master_tag = "airlock_coc_surveyor_dock_port";
+	landmark_tag = "nav_coc_surveyor_dock_starboard";
+	name = "airlock_coc_surveyor_dock_port"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/coc_survey_ship/atmos)
 "Cm" = (
 /obj/effect/floor_decal/corner_wide/red/diagonal,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -3241,6 +3286,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "Cx" = (
@@ -3874,8 +3920,8 @@
 /obj/effect/floor_decal/corner_wide/white{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 1
 	},
 /obj/effect/floor_decal/corner_wide/white{
 	dir = 4
@@ -3955,8 +4001,6 @@
 /area/coc_survey_ship/blaster)
 "HH" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
-	id_tag = "surveyor_shuttle";
-	master_tag = "surveyor_shuttle";
 	pixel_y = 25;
 	tag_interior_door = "surveyor_shuttle_in";
 	tag_exterior_door = "surveyor_shuttle_out";
@@ -4102,7 +4146,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/reinforced,
 /area/coc_survey_ship/grauwolf)
 "IP" = (
 /obj/effect/floor_decal/corner/purple/diagonal,
@@ -4130,6 +4174,7 @@
 	tag_door = "hegemony_dock_doors";
 	pixel_y = -25
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "Jl" = (
@@ -4194,6 +4239,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "JM" = (
@@ -4206,27 +4252,21 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/port_propulsion)
 "JN" = (
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_coc_surveyor_dock_starboard";
-	master_tag = "airlock_coc_surveyor_dock_starboard";
-	landmark_tag = "nav_coc_surveyor_dock_starboard"
+/obj/machinery/computer/general_air_control/large_tank_control{
+	frequency = 451;
+	name = "Carbon Dioxide Supply Monitor";
+	output_tag = "survey_co2_out_port";
+	sensors = list("survey_sensor_port"="Tank");
+	input_tag = "survey_co2_in_port"
 	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
 	},
-/obj/machinery/airlock_sensor{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = -6
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/coc_survey_ship/cargo)
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "JP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -4285,25 +4325,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "Kr" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1389;
-	icon_state = "door_locked";
-	id_tag = "surveyor_shuttle_in";
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_coc_surveyor_dock_starboard";
-	master_tag = "airlock_coc_surveyor_dock_starboard";
-	landmark_tag = "nav_coc_surveyor_dock_starboard"
-	},
-/obj/machinery/access_button{
-	pixel_x = -12;
-	pixel_y = 28;
-	dir = 8
-	},
+/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor,
-/area/coc_survey_ship/cargo)
+/area/coc_survey_ship/hangar)
 "Ku" = (
 /obj/effect/floor_decal/corner_wide/yellow/diagonal,
 /obj/effect/floor_decal/corner_wide/white/diagonal{
@@ -4363,6 +4387,29 @@
 	},
 /turf/simulated/floor,
 /area/coc_survey_ship/miningeva)
+"KK" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1389;
+	icon_state = "door_locked";
+	id_tag = "surveyor_shuttle_in";
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/access_button{
+	pixel_x = 12;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/coc_survey_ship/cargo)
 "KL" = (
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 8
@@ -4400,21 +4447,25 @@
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/anomaly)
 "KQ" = (
-/obj/machinery/computer/general_air_control/large_tank_control{
-	frequency = 451;
-	name = "Carbon Dioxide Supply Monitor";
-	output_tag = "survey_co2_out_port";
-	sensors = list("survey_sensor_port"="Tank");
-	input_tag = "survey_co2_in_port"
+/obj/machinery/door/airlock/external{
+	frequency = 1389;
+	icon_state = "door_locked";
+	id_tag = "surveyor_shuttle_in";
+	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 5
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
 	},
-/obj/effect/floor_decal/corner_wide/white{
+/obj/machinery/access_button{
+	pixel_x = -12;
+	pixel_y = 28;
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/coc_survey_ship/atmos)
+/turf/simulated/floor,
+/area/coc_survey_ship/cargo)
 "KX" = (
 /obj/machinery/conveyor{
 	id = "Coallit_Mining_1";
@@ -4432,7 +4483,6 @@
 "Lk" = (
 /obj/machinery/airlock_sensor{
 	frequency = 1385;
-	id_tag = "surveyor_shuttle_chamber_sensor";
 	pixel_y = -23;
 	dir = 1
 	},
@@ -4472,7 +4522,7 @@
 /area/coc_survey_ship/quarters)
 "Lq" = (
 /obj/machinery/light,
-/turf/simulated/floor,
+/turf/simulated/floor/reinforced,
 /area/coc_survey_ship/blaster)
 "Lr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4490,17 +4540,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/starboard_propulsion)
 "Lx" = (
@@ -4576,6 +4623,8 @@
 /obj/machinery/alarm/east{
 	req_one_access = null
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "Ms" = (
@@ -4682,6 +4731,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
+"Ni" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor,
+/area/coc_survey_ship/cargo)
 "Nk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -4738,6 +4800,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "Nz" = (
@@ -4908,6 +4971,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/starboard_propulsion)
 "Po" = (
@@ -4932,8 +4996,26 @@
 /turf/template_noop,
 /area/space)
 "PU" = (
-/turf/simulated/floor,
-/area/coc_survey_ship/blaster)
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/door/window,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "PV" = (
 /obj/effect/floor_decal/corner_wide/yellow/diagonal,
 /obj/effect/floor_decal/corner_wide/white/diagonal{
@@ -5021,7 +5103,6 @@
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1389;
-	master_tag = "surveyor_shuttle";
 	name = "exterior access button";
 	pixel_x = 8;
 	pixel_y = 27;
@@ -5042,6 +5123,19 @@
 	},
 /turf/simulated/floor,
 /area/coc_survey_ship/miningeva)
+"QI" = (
+/obj/item/stack/material/tritium/full,
+/obj/item/stack/material/tritium/full,
+/obj/structure/closet/crate{
+	name = "DANGER - RADIOACTIVE MATERIAL"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/carpet/rubber,
+/area/coc_survey_ship/engineering)
 "QJ" = (
 /turf/simulated/floor,
 /area/coc_survey_ship/grauwolf)
@@ -5073,6 +5167,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "QT" = (
@@ -5106,6 +5201,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency,
 /turf/simulated/floor,
 /area/coc_survey_ship/atmos)
 "Rh" = (
@@ -5123,6 +5219,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/east,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "RH" = (
@@ -5418,6 +5515,9 @@
 /obj/item/storage/box/fancy/mre/random,
 /obj/item/storage/box/fancy/mre/random,
 /obj/machinery/light,
+/obj/effect/decal/cleanable/generic{
+	layer = 2.81
+	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/quarters)
 "Ud" = (
@@ -5647,13 +5747,6 @@
 /obj/structure/bed/handrail{
 	dir = 1
 	},
-/obj/machinery/airlock_sensor/airlock_exterior{
-	frequency = 1389;
-	id_tag = "surveyor_shuttle_exterior_sensor";
-	pixel_y = -25;
-	pixel_x = 41;
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 2;
 	id_tag = "surveyor_out_external";
@@ -5665,6 +5758,13 @@
 	name = "surveyor_shuttle"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/airlock_sensor/airlock_exterior{
+	frequency = 1389;
+	id_tag = "surveyor_shuttle_exterior_sensor";
+	pixel_y = -25;
+	pixel_x = 41;
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/coc_survey_shuttle)
 "Wd" = (
@@ -5699,26 +5799,9 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "Wq" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner_wide/white{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/door/window,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/coc_survey_ship/atmos)
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/coc_survey_ship/hangar)
 "Wv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5761,13 +5844,14 @@
 /area/coc_survey_ship/miningeva)
 "WO" = (
 /obj/machinery/light,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "WQ" = (
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/reinforced,
 /area/coc_survey_ship/grauwolf)
 "WR" = (
 /obj/machinery/door/airlock/external{
@@ -5796,6 +5880,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "Xc" = (
@@ -5806,6 +5891,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/starboard_propulsion)
 "Xh" = (
@@ -5854,6 +5940,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "Xx" = (
@@ -8962,7 +9049,7 @@ PG
 PG
 PG
 jn
-Kr
+KQ
 BR
 jn
 PG
@@ -9065,7 +9152,7 @@ jn
 jn
 jn
 eq
-eq
+sn
 jn
 jn
 PG
@@ -9166,8 +9253,8 @@ jn
 jn
 tR
 jn
-JN
-sn
+ya
+Ni
 jn
 jn
 jn
@@ -9258,8 +9345,8 @@ Ln
 NL
 aA
 aA
-aA
 RM
+yD
 Pt
 dJ
 dJ
@@ -9268,7 +9355,7 @@ Oa
 HF
 le
 jn
-jt
+KK
 dC
 jn
 XK
@@ -9365,7 +9452,7 @@ Lu
 Ig
 hL
 hL
-hL
+ou
 hL
 Eo
 Uq
@@ -9681,7 +9768,7 @@ nI
 Pt
 Tq
 dH
-dH
+gQ
 dH
 VM
 bU
@@ -9783,7 +9870,7 @@ gO
 Pt
 Tq
 HF
-dH
+gQ
 dH
 dH
 UF
@@ -10288,16 +10375,16 @@ PG
 ZM
 dS
 ZM
-dT
-dT
+Wq
+Wq
 JK
-dT
-dT
+Wq
+Wq
 JK
-dT
-dT
+Wq
+Wq
 JK
-dT
+Wq
 rG
 cM
 CC
@@ -10390,10 +10477,10 @@ PG
 ZM
 dT
 ZM
+Wq
 dT
 dT
-dT
-dT
+pw
 dT
 dT
 dT
@@ -10492,6 +10579,7 @@ PG
 ZM
 dT
 ZM
+Wq
 dT
 dT
 dT
@@ -10499,8 +10587,7 @@ dT
 dT
 dT
 dT
-dT
-dT
+pw
 dT
 Xu
 vZ
@@ -10612,7 +10699,7 @@ ne
 Ai
 gm
 kj
-QJ
+sz
 Hx
 QJ
 YA
@@ -10696,7 +10783,7 @@ PG
 ZM
 dT
 ZM
-dT
+Wq
 dT
 dT
 Zd
@@ -10706,7 +10793,7 @@ Ul
 Zd
 dT
 dT
-dT
+Wq
 cM
 Dy
 DN
@@ -10714,7 +10801,7 @@ DN
 GH
 NO
 SZ
-QJ
+sz
 WQ
 QJ
 xC
@@ -10798,7 +10885,7 @@ PG
 ZM
 dT
 ZM
-dT
+Wq
 dT
 ul
 ul
@@ -10900,7 +10987,7 @@ PG
 ZM
 dT
 ZM
-dT
+Wq
 dT
 ul
 im
@@ -10910,7 +10997,7 @@ Wv
 RV
 ul
 dT
-dT
+Wq
 Vh
 Vh
 Vh
@@ -11104,7 +11191,7 @@ PG
 ZM
 dT
 ZM
-dT
+Wq
 dT
 Zd
 Zw
@@ -11206,7 +11293,7 @@ PG
 ZM
 dT
 ZM
-dT
+Wq
 dT
 ul
 Zw
@@ -11308,7 +11395,7 @@ PG
 ZM
 dT
 ZM
-dT
+Wq
 dT
 bd
 Zw
@@ -11512,7 +11599,7 @@ PG
 ZM
 dT
 ZM
-dT
+Wq
 dT
 ul
 Sn
@@ -11614,7 +11701,7 @@ PG
 ZM
 dT
 ZM
-dT
+Wq
 dT
 ul
 MR
@@ -11716,7 +11803,7 @@ PG
 ZM
 dT
 ZM
-dT
+Wq
 dT
 ul
 xB
@@ -11920,7 +12007,7 @@ PG
 ZM
 dT
 ZM
-dT
+Wq
 CW
 gr
 HH
@@ -12022,7 +12109,7 @@ PG
 ZM
 dT
 ZM
-dT
+Wq
 Wb
 GS
 wM
@@ -12124,7 +12211,7 @@ PG
 ZM
 dT
 ZM
-dT
+Wq
 ul
 Ff
 Qv
@@ -12328,13 +12415,13 @@ PG
 ZM
 dT
 ZM
+Wq
 dT
 dT
 dT
 dT
 dT
-dT
-dT
+Kr
 dT
 dT
 eN
@@ -12346,7 +12433,7 @@ Mt
 oS
 Vh
 Bm
-PU
+Pq
 fC
 wU
 Os
@@ -12430,14 +12517,14 @@ PG
 ZM
 dT
 ZM
+Wq
 dT
 dT
 dT
 dT
 dT
 dT
-dT
-dT
+pw
 dT
 zJ
 Xu
@@ -12448,7 +12535,7 @@ JP
 RJ
 KH
 HG
-PU
+Pq
 qA
 wU
 wU
@@ -12532,14 +12619,14 @@ PG
 ZM
 dT
 ZM
-dT
-dT
+Wq
+Wq
 ro
-dT
-dT
+Wq
+Wq
 ro
-dT
-dT
+Wq
+Wq
 ro
 Rv
 Mj
@@ -12550,7 +12637,7 @@ ep
 ps
 Vh
 DE
-PU
+Pq
 Lq
 lh
 lh
@@ -13237,7 +13324,7 @@ MY
 qc
 XD
 Bv
-pw
+rR
 MJ
 wB
 Uy
@@ -13345,9 +13432,9 @@ pp
 Uy
 XR
 XR
-KQ
+JN
 GY
-hH
+vU
 hH
 HL
 XR
@@ -13447,9 +13534,9 @@ OY
 Uy
 aP
 rp
-yK
+jt
 VP
-Wq
+PU
 NR
 uV
 XR
@@ -13543,13 +13630,13 @@ Uy
 kt
 Uy
 sx
-vU
+QI
 sc
 Qe
 Uy
 Id
 bG
-gQ
+yK
 Hy
 DH
 wh
@@ -13756,7 +13843,7 @@ PG
 PG
 PG
 DH
-lr
+Ce
 lr
 DH
 Ol

--- a/maps/away/ships/coc/coc_surveyor/coc_surveyor.dmm
+++ b/maps/away/ships/coc/coc_surveyor/coc_surveyor.dmm
@@ -38,11 +38,17 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/coc_survey_ship/starboard_propulsion)
 "aP" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plating/cooled,
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	frequency = 451;
+	id_tag = "survey_co2_out_port"
+	},
+/turf/simulated/floor/reinforced/carbon_dioxide,
 /area/coc_survey_ship/atmos)
 "aS" = (
 /obj/effect/floor_decal/corner_wide/grey/diagonal,
@@ -77,6 +83,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 9
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "COC Survey Shuttle";
+	master_tag = "surveyor_shuttle";
+	name = "surveyor_shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "bd" = (
@@ -100,7 +112,7 @@
 /area/coc_survey_ship/cryo)
 "bx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
@@ -111,6 +123,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/engineering)
 "bB" = (
@@ -142,19 +155,16 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/engineering)
 "bF" = (
 /turf/space,
 /area/space)
 "bG" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/alarm/south{
-	req_one_access = null
-	},
-/turf/simulated/floor/plating/cooled,
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "bM" = (
 /obj/structure/table/steel,
@@ -282,6 +292,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/medical)
+"dC" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1389;
+	icon_state = "door_locked";
+	id_tag = "surveyor_shuttle_in";
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/access_button{
+	pixel_x = 12;
+	pixel_y = -28;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/tiled/dark/full,
+/area/coc_survey_ship/cargo)
 "dH" = (
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/cargo)
@@ -398,20 +429,14 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
 "eq" = (
-/obj/machinery/door/airlock/hatch{
-	dir = 4;
-	name = "Telecomms"
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/plasticflaps/airtight,
-/turf/simulated/floor/tiled/white,
-/area/coc_survey_ship/atmos)
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/coc_survey_ship/cargo)
 "et" = (
 /obj/effect/floor_decal/corner_wide/black/diagonal,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -461,7 +486,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/coc_survey_ship/port_propulsion)
@@ -504,9 +528,6 @@
 /obj/effect/floor_decal/corner_wide/white{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/air{
-	start_pressure = 8000
-	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "fC" = (
@@ -527,7 +548,7 @@
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor,
 /area/coc_survey_ship/port_propulsion)
 "fK" = (
@@ -615,9 +636,10 @@
 /obj/effect/floor_decal/corner_wide/white/diagonal{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "gK" = (
@@ -637,14 +659,17 @@
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/cryo)
 "gQ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/loading/yellow{
-	dir = 4
+/obj/effect/floor_decal/corner_wide/yellow/full{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/rubber,
-/area/coc_survey_ship/engineering)
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "gX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -790,7 +815,6 @@
 /obj/machinery/embedded_controller/radio/simple_docking_controller{
 	frequency = 1385;
 	id_tag = "surveyor_shuttle_dock";
-	tag_door = "hegemony_dock_doors";
 	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/dark,
@@ -887,14 +911,28 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "jt" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/door/firedoor/noid,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Reactor Room";
+/obj/machinery/door/airlock/external{
+	frequency = 1389;
+	icon_state = "door_locked";
+	id_tag = "surveyor_shuttle_in";
 	dir = 4
 	},
-/turf/simulated/floor/reinforced,
-/area/coc_survey_ship/engineering)
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/access_button{
+	pixel_x = 12;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/coc_survey_ship/cargo)
 "jz" = (
 /turf/simulated/wall/shuttle/dark/cardinal/blue,
 /area/coc_survey_ship/medical)
@@ -952,17 +990,19 @@
 /turf/simulated/floor/reinforced,
 /area/coc_survey_ship/grauwolf)
 "kt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/plasticflaps/airtight{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/rubber,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating/cooled,
 /area/coc_survey_ship/engineering)
 "ku" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor,
 /area/coc_survey_ship/port_propulsion)
 "kw" = (
@@ -980,12 +1020,6 @@
 /obj/effect/floor_decal/corner_wide/white{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/emergency{
 	pixel_y = 6
@@ -994,6 +1028,7 @@
 	pixel_y = -6
 	},
 /obj/item/device/multitool,
+/obj/item/clothing/gloves/yellow,
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "kA" = (
@@ -1012,13 +1047,13 @@
 /area/coc_survey_ship/miningeva)
 "kH" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/coc_survey_ship/starboard_propulsion)
@@ -1128,6 +1163,12 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "lr" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	master_tag = "airlock_coc_surveyor_dock_port";
+	landmark_tag = "nav_coc_surveyor_dock_starboard";
+	name = "airlock_coc_surveyor_dock_port"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/atmos)
 "lx" = (
@@ -1235,6 +1276,9 @@
 /obj/machinery/alarm/north{
 	req_one_access = null
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/engineering)
 "md" = (
@@ -1257,10 +1301,7 @@
 /obj/effect/floor_decal/corner_wide/white/diagonal{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -1312,14 +1353,13 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "mG" = (
@@ -1530,7 +1570,7 @@
 "oQ" = (
 /obj/machinery/air_sensor{
 	frequency = 451;
-	id_tag = "survey_sensor"
+	id_tag = "survey_sensor_starboard"
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/coc_survey_ship/starboard_propulsion)
@@ -1620,11 +1660,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/cargo)
 "pw" = (
-/obj/structure/railing/mapped,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/sign/radiation{
+	pixel_x = 32;
+	pixel_y = -32
 	},
-/turf/simulated/floor/greengrid,
+/turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/engineering)
 "pA" = (
 /obj/structure/sign/flag/assunzione,
@@ -1634,6 +1674,7 @@
 /obj/machinery/alarm/west{
 	req_one_access = null
 	},
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor,
 /area/coc_survey_ship/port_propulsion)
 "pK" = (
@@ -1777,15 +1818,33 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor,
 /area/coc_survey_ship/engineering)
 "rb" = (
 /turf/simulated/wall/shuttle/dark/cardinal/blue,
 /area/coc_survey_ship/port_propulsion)
 "ri" = (
-/obj/effect/map_effect/airlock/e_to_w/long/square,
-/turf/simulated/wall/shuttle/dark/cardinal/blue,
-/area/coc_survey_ship/cargo)
+/obj/machinery/door/airlock/external{
+	frequency = 1389;
+	icon_state = "door_locked";
+	id_tag = "surveyor_shuttle_in";
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	master_tag = "airlock_coc_surveyor_dock_port";
+	landmark_tag = "nav_coc_surveyor_dock_starboard";
+	name = "airlock_coc_surveyor_dock_port"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = -19;
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/coc_survey_ship/atmos)
 "rk" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Dorms"
@@ -1821,13 +1880,9 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "rp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plating/cooled,
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "rq" = (
 /obj/effect/floor_decal/corner_wide/white/diagonal,
@@ -1854,12 +1909,6 @@
 	},
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
-"rR" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/coc_survey_ship/starboard_propulsion)
 "rS" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Cryo and Medical"
@@ -1882,9 +1931,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner_wide/yellow,
-/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
-	dir = 4
-	},
+/obj/machinery/vending/tool,
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "sc" = (
@@ -1924,6 +1971,15 @@
 /turf/simulated/wall/shuttle/dark/cardinal/blue,
 /area/coc_survey_ship/cargo)
 "sn" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/coc_survey_ship/cargo)
 "so" = (
@@ -2118,6 +2174,9 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/door/window{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/cargo)
 "tY" = (
@@ -2184,6 +2243,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 9
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/engineering)
@@ -2292,9 +2354,6 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
 "vI" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide{
 	start_pressure = 8000.63
 	},
@@ -2313,15 +2372,17 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "vU" = (
-/obj/effect/floor_decal/corner_wide/yellow/diagonal,
-/obj/effect/floor_decal/corner_wide/white/diagonal{
-	dir = 8
+/obj/item/stack/material/tritium/full,
+/obj/item/stack/material/tritium/full,
+/obj/structure/closet/crate{
+	name = "DANGER - RADIOACTIVE MATERIAL"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/coc_survey_ship/atmos)
+/turf/simulated/floor/carpet/rubber,
+/area/coc_survey_ship/engineering)
 "vZ" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -2335,6 +2396,29 @@
 	},
 /turf/simulated/floor,
 /area/coc_survey_ship/miningeva)
+"wh" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1389;
+	icon_state = "door_locked";
+	id_tag = "surveyor_shuttle_in";
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	master_tag = "airlock_coc_surveyor_dock_port";
+	landmark_tag = "nav_coc_surveyor_dock_starboard";
+	name = "airlock_coc_surveyor_dock_port"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/machinery/access_button{
+	pixel_x = -12;
+	pixel_y = 28;
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/coc_survey_ship/atmos)
 "wn" = (
 /obj/structure/sign/flag/vysoka,
 /turf/simulated/wall,
@@ -2398,19 +2482,21 @@
 /turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/engineering)
 "wK" = (
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 5
-	},
 /obj/effect/floor_decal/corner_wide/yellow,
 /obj/effect/floor_decal/corner_wide/white{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
@@ -2421,6 +2507,12 @@
 	id_tag = "surveyor_out_internal"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "COC Survey Shuttle";
+	master_tag = "surveyor_shuttle";
+	name = "surveyor_shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor,
 /area/shuttle/coc_survey_shuttle)
 "wQ" = (
@@ -2644,10 +2736,18 @@
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/kitchen)
 "yK" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light,
-/turf/simulated/floor/carpet/rubber,
-/area/coc_survey_ship/engineering)
+/obj/machinery/atmospherics/binary/pump/high_power{
+	layer = 2.8
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_wide/yellow,
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "yQ" = (
 /obj/effect/floor_decal/corner_wide/orange{
 	dir = 10
@@ -2664,21 +2764,12 @@
 /area/coc_survey_ship/starboard_propulsion)
 "yW" = (
 /obj/effect/floor_decal/corner_wide/yellow{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner_wide/white{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/effect/floor_decal/corner_wide/yellow,
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "yX" = (
@@ -2793,18 +2884,8 @@
 /turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/engineering)
 "zA" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/stack/material/tritium/full,
-/obj/item/stack/material/tritium/full,
-/obj/structure/closet/crate{
-	name = "DANGER - RADIOACTIVE MATERIAL"
-	},
-/turf/simulated/floor/carpet/rubber,
+/obj/machinery/telecomms/allinone/ship,
+/turf/simulated/floor/plating/cooled,
 /area/coc_survey_ship/engineering)
 "zJ" = (
 /obj/structure/cable{
@@ -2987,10 +3068,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/sign/radiation{
-	pixel_x = 32;
-	pixel_y = -32
-	},
 /turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/engineering)
 "BC" = (
@@ -3034,9 +3111,28 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
 "BR" = (
-/obj/effect/map_effect/airlock/w_to_e/long/square,
-/turf/simulated/wall/shuttle/dark/cardinal/blue,
-/area/coc_survey_ship/atmos)
+/obj/machinery/door/airlock/external{
+	frequency = 1389;
+	icon_state = "door_locked";
+	id_tag = "surveyor_shuttle_in";
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/shuttle_landmark/coc_survey_ship/dock/starboard{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/access_button{
+	pixel_x = -12;
+	pixel_y = -28;
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/coc_survey_ship/cargo)
 "BS" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1389;
@@ -3045,6 +3141,22 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "COC Survey Shuttle";
+	master_tag = "surveyor_shuttle";
+	name = "surveyor_shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/airlock_sensor{
+	pixel_x = -11;
+	dir = 8;
+	pixel_y = -26
+	},
+/obj/machinery/access_button{
+	pixel_x = -4;
+	pixel_y = -26;
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "BU" = (
@@ -3056,9 +3168,10 @@
 /obj/machinery/computer/general_air_control/large_tank_control{
 	frequency = 451;
 	name = "Carbon Dioxide Supply Monitor";
-	output_tag = "survey_out";
-	sensors = list("survey_sensor"="Tank");
-	dir = 8
+	output_tag = "survey_sensor_out_starboard";
+	sensors = list("survey_sensor_starboard"="Tank");
+	dir = 8;
+	input_tag = "survey_in_starboard"
 	},
 /turf/simulated/floor,
 /area/coc_survey_ship/starboard_propulsion)
@@ -3216,6 +3329,12 @@
 /obj/structure/bed/handrail{
 	dir = 1
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "COC Survey Shuttle";
+	master_tag = "surveyor_shuttle";
+	name = "surveyor_shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/coc_survey_shuttle)
 "CZ" = (
@@ -3292,6 +3411,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/engineering)
 "DD" = (
@@ -3391,6 +3511,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
+"Ew" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1389;
+	icon_state = "door_locked";
+	id_tag = "surveyor_shuttle_in";
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	master_tag = "airlock_coc_surveyor_dock_port";
+	landmark_tag = "nav_coc_surveyor_dock_starboard";
+	name = "airlock_coc_surveyor_dock_port"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button{
+	pixel_x = 12;
+	pixel_y = -28;
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/coc_survey_ship/atmos)
 "EC" = (
 /obj/machinery/light{
 	dir = 1
@@ -3419,6 +3559,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "EJ" = (
@@ -3430,6 +3571,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
@@ -3454,6 +3598,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/engineering)
 "EX" = (
@@ -3466,6 +3611,28 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/bridge)
+"Fa" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	master_tag = "airlock_coc_surveyor_dock_port";
+	landmark_tag = "nav_coc_surveyor_dock_starboard";
+	name = "airlock_coc_surveyor_dock_port"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = -6
+	},
+/obj/machinery/airlock_sensor{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/turf/simulated/floor,
+/area/coc_survey_ship/atmos)
 "Fb" = (
 /obj/structure/ore_box,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3511,6 +3678,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6;
 	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 6
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/engineering)
@@ -3559,8 +3729,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/table/steel,
-/obj/item/clothing/gloves/yellow,
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "FU" = (
@@ -3702,18 +3870,17 @@
 /turf/simulated/wall/shuttle/dark/cardinal/khaki,
 /area/shuttle/coc_survey_shuttle)
 "GY" = (
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 5
-	},
 /obj/effect/floor_decal/corner_wide/yellow,
 /obj/effect/floor_decal/corner_wide/white{
 	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
 	},
-/obj/machinery/vending/tool,
-/obj/machinery/light{
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -3757,9 +3924,16 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/grauwolf)
 "Hy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
 	},
+/obj/effect/floor_decal/corner_wide/yellow/full{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "HF" = (
@@ -3798,6 +3972,11 @@
 	id_tag = "surveyor_shuttle_pump_in"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "COC Survey Shuttle";
+	master_tag = "surveyor_shuttle";
+	name = "surveyor_shuttle"
+	},
 /turf/simulated/floor,
 /area/shuttle/coc_survey_shuttle)
 "HI" = (
@@ -3836,8 +4015,16 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "Id" = (
-/obj/machinery/telecomms/allinone/ship,
-/turf/simulated/floor/plating/cooled,
+/obj/machinery/air_sensor{
+	frequency = 451;
+	id_tag = "survey_sensor_port";
+	pixel_x = -16
+	},
+/obj/machinery/atmospherics/unary/outlet_injector{
+	frequency = 451;
+	id = "survey_sensor_in_port"
+	},
+/turf/simulated/floor/reinforced/carbon_dioxide,
 /area/coc_survey_ship/atmos)
 "Ig" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3858,7 +4045,7 @@
 "Ih" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
 	frequency = 451;
-	id_tag = "survey_out";
+	id_tag = "survey_sensor_out_starboard";
 	dir = 8
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
@@ -3998,6 +4185,9 @@
 /obj/structure/table/rack,
 /obj/item/inflatable_dispenser,
 /obj/item/pipewrench,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "JK" = (
@@ -4016,14 +4206,27 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/port_propulsion)
 "JN" = (
-/obj/effect/floor_decal/corner_wide/yellow/diagonal,
-/obj/effect/floor_decal/corner_wide/white/diagonal{
-	dir = 8
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
 	},
-/obj/structure/table/steel,
-/obj/item/gun/energy/plasmacutter,
-/turf/simulated/floor/tiled,
-/area/coc_survey_ship/atmos)
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/obj/machinery/airlock_sensor{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = -6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/coc_survey_ship/cargo)
 "JP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -4082,8 +4285,25 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "Kr" = (
-/turf/simulated/floor/greengrid,
-/area/coc_survey_ship/engineering)
+/obj/machinery/door/airlock/external{
+	frequency = 1389;
+	icon_state = "door_locked";
+	id_tag = "surveyor_shuttle_in";
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/access_button{
+	pixel_x = -12;
+	pixel_y = 28;
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/coc_survey_ship/cargo)
 "Ku" = (
 /obj/effect/floor_decal/corner_wide/yellow/diagonal,
 /obj/effect/floor_decal/corner_wide/white/diagonal{
@@ -4107,24 +4327,28 @@
 /turf/simulated/floor/carpet/lightblue,
 /area/coc_survey_ship/captain)
 "KD" = (
-/obj/machinery/airlock_sensor/airlock_interior{
-	dir = 8;
-	pixel_x = 23;
-	pixel_y = 5;
-	id_tag = "surveyor_shuttle_interior_sensor";
-	frequency = 1389
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
+/obj/machinery/door/airlock/external{
 	frequency = 1389;
-	master_tag = "surveyor_shuttle";
-	name = "interior access button";
-	pixel_x = 23;
-	pixel_y = -6;
+	icon_state = "door_locked";
+	id_tag = "surveyor_shuttle_in";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/coc_survey_shuttle)
+/obj/effect/map_effect/marker/airlock/docking{
+	master_tag = "airlock_coc_surveyor_dock_port";
+	landmark_tag = "nav_coc_surveyor_dock_starboard";
+	name = "airlock_coc_surveyor_dock_port"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button{
+	pixel_x = 12;
+	pixel_y = 28;
+	dir = 4
+	},
+/obj/effect/shuttle_landmark/coc_survey_ship/dock/port{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/coc_survey_ship/atmos)
 "KH" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Mining Laser"
@@ -4176,9 +4400,21 @@
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/anomaly)
 "KQ" = (
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/carpet/rubber,
-/area/coc_survey_ship/engineering)
+/obj/machinery/computer/general_air_control/large_tank_control{
+	frequency = 451;
+	name = "Carbon Dioxide Supply Monitor";
+	output_tag = "survey_co2_out_port";
+	sensors = list("survey_sensor_port"="Tank");
+	input_tag = "survey_co2_in_port"
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "KX" = (
 /obj/machinery/conveyor{
 	id = "Coallit_Mining_1";
@@ -4206,6 +4442,11 @@
 	id_tag = "surveyor_shuttle_pump_in"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "COC Survey Shuttle";
+	master_tag = "surveyor_shuttle";
+	name = "surveyor_shuttle"
+	},
 /turf/simulated/floor,
 /area/shuttle/coc_survey_shuttle)
 "Ln" = (
@@ -4256,6 +4497,9 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 5
 	},
 /turf/simulated/floor,
 /area/coc_survey_ship/starboard_propulsion)
@@ -4364,6 +4608,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/engineering)
 "MC" = (
@@ -4394,6 +4639,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor,
 /area/coc_survey_ship/engineering)
 "MH" = (
@@ -4542,12 +4788,7 @@
 /area/coc_survey_ship/atmos)
 "NT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide{
-	start_pressure = 8000.63
-	},
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor,
 /area/coc_survey_ship/port_propulsion)
 "Oa" = (
@@ -4590,11 +4831,8 @@
 /obj/effect/floor_decal/corner_wide/white{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/portable_atmospherics/canister/air{
+	start_pressure = 8000
 	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
@@ -4697,15 +4935,21 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/blaster)
 "PV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 9
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/effect/floor_decal/corner_wide/white/diagonal{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
-/area/coc_survey_ship/starboard_propulsion)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "Qb" = (
 /obj/effect/floor_decal/corner_wide/yellow/diagonal,
 /obj/effect/floor_decal/corner_wide/white/diagonal{
@@ -4783,6 +5027,12 @@
 	pixel_y = 27;
 	dir = 4
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "COC Survey Shuttle";
+	master_tag = "surveyor_shuttle";
+	name = "surveyor_shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "Qx" = (
@@ -4792,14 +5042,6 @@
 	},
 /turf/simulated/floor,
 /area/coc_survey_ship/miningeva)
-"QI" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8;
-	layer = 2.8
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/tiled,
-/area/coc_survey_ship/atmos)
 "QJ" = (
 /turf/simulated/floor,
 /area/coc_survey_ship/grauwolf)
@@ -4854,6 +5096,18 @@
 	name = "shuttle bay blast door"
 	},
 /area/coc_survey_ship/hangar)
+"QZ" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	master_tag = "airlock_coc_surveyor_dock_port";
+	landmark_tag = "nav_coc_surveyor_dock_starboard";
+	name = "airlock_coc_surveyor_dock_port"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/coc_survey_ship/atmos)
 "Rh" = (
 /obj/machinery/suspension_gen{
 	dir = 1
@@ -4960,9 +5214,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "Sq" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 1;
-	layer = 2.8
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
@@ -5147,7 +5400,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 9
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/coc_survey_ship/port_propulsion)
@@ -5276,15 +5529,18 @@
 /obj/effect/floor_decal/corner_wide/white{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /obj/structure/table/steel,
 /obj/item/stack/material/glass/full,
 /obj/item/stack/material/steel/full,
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 9
+	},
+/obj/item/gun/energy/plasmacutter,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
@@ -5367,18 +5623,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/cargo)
 "VP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner_wide/yellow/full{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner_wide/white{
 	dir = 8
 	},
-/obj/machinery/vending/engivend{
-	req_access = null
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 9
 	},
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/yellow,
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "VX" = (
@@ -5402,6 +5659,12 @@
 	id_tag = "surveyor_out_external";
 	frequency = 1389
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "COC Survey Shuttle";
+	master_tag = "surveyor_shuttle";
+	name = "surveyor_shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/coc_survey_shuttle)
 "Wd" = (
@@ -5436,9 +5699,26 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "Wq" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
-/turf/simulated/floor,
-/area/coc_survey_ship/engineering)
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/door/window,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "Wv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5450,7 +5730,8 @@
 "WC" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
-	frequency = 451
+	frequency = 451;
+	id = "survey_sensor_in_starboard"
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/coc_survey_ship/starboard_propulsion)
@@ -5498,6 +5779,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "COC Survey Shuttle";
+	master_tag = "surveyor_shuttle";
+	name = "surveyor_shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "WY" = (
@@ -5516,6 +5803,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/coc_survey_ship/starboard_propulsion)
 "Xh" = (
@@ -5598,6 +5888,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/engineering)
 "XK" = (
@@ -5613,10 +5906,8 @@
 /obj/effect/floor_decal/corner_wide/white{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8;
-	layer = 2.8
+/obj/machinery/vending/engivend{
+	req_access = null
 	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
@@ -5764,9 +6055,11 @@
 /obj/effect/floor_decal/corner_wide/white/diagonal{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "Yw" = (
@@ -6953,7 +7246,7 @@ PG
 PG
 PG
 PG
-PG
+Kf
 PG
 PG
 PG
@@ -7039,7 +7332,7 @@ PG
 PG
 PG
 PG
-Kf
+PG
 PG
 PG
 PG
@@ -8669,9 +8962,9 @@ PG
 PG
 PG
 jn
-sn
-sn
-ri
+Kr
+BR
+jn
 PG
 PG
 PG
@@ -8771,8 +9064,8 @@ PG
 jn
 jn
 jn
-sn
-sn
+eq
+eq
 jn
 jn
 PG
@@ -8873,7 +9166,7 @@ jn
 jn
 tR
 jn
-sn
+JN
 sn
 jn
 jn
@@ -8963,7 +9256,7 @@ CQ
 OH
 Ln
 NL
-rR
+aA
 aA
 aA
 RM
@@ -8975,8 +9268,8 @@ Oa
 HF
 le
 jn
-sn
-sn
+jt
+dC
 jn
 XK
 ui
@@ -9065,7 +9358,7 @@ jI
 wX
 Pk
 id
-PV
+Xc
 Xc
 aH
 Lu
@@ -11428,7 +11721,7 @@ dT
 ul
 xB
 Xj
-KD
+xB
 Kq
 hF
 ul
@@ -12645,7 +12938,7 @@ Uy
 JI
 hH
 jo
-JN
+hH
 Ku
 Wn
 qY
@@ -12849,9 +13142,9 @@ MF
 EI
 my
 Yv
+PV
 gD
-gD
-gD
+RH
 UL
 XR
 em
@@ -12944,8 +13237,8 @@ MY
 qc
 XD
 Bv
+pw
 MJ
-gQ
 wB
 Uy
 fr
@@ -12953,7 +13246,7 @@ OE
 yW
 wK
 mg
-RH
+hH
 ky
 XR
 nB
@@ -13045,16 +13338,16 @@ NT
 Uy
 lZ
 EJ
-yK
+sx
+zr
 Uy
-jt
 pp
 Uy
 XR
-eq
 XR
+KQ
 GY
-vU
+hH
 hH
 HL
 XR
@@ -13147,16 +13440,16 @@ TI
 ra
 bx
 uC
+sx
 uq
 uW
-Kr
 OY
-Wq
+Uy
 aP
 rp
-XR
+yK
 VP
-NR
+Wq
 NR
 uV
 XR
@@ -13248,20 +13541,20 @@ dL
 DR
 Uy
 kt
+Uy
 sx
-KQ
+vU
 sc
-pw
 Qe
 Uy
 Id
 bG
-XR
+gQ
 Hy
 DH
-lr
-lr
-BR
+wh
+ri
+DH
 wF
 mt
 cF
@@ -13350,8 +13643,8 @@ rb
 rb
 MY
 zA
-zr
-zr
+Uy
+sx
 MY
 MY
 Wg
@@ -13359,10 +13652,10 @@ Eb
 DH
 DH
 DH
-QI
 DH
-lr
-lr
+DH
+Fa
+QZ
 DH
 Ol
 Ol
@@ -13460,8 +13753,8 @@ PG
 PG
 PG
 PG
-DH
-DH
+PG
+PG
 DH
 lr
 lr
@@ -13565,8 +13858,8 @@ PG
 PG
 PG
 DH
-lr
-lr
+KD
+Ew
 DH
 PG
 PG
@@ -14504,7 +14797,7 @@ PG
 PG
 PG
 PG
-PG
+Pr
 PG
 PG
 PG
@@ -14895,7 +15188,7 @@ PG
 PG
 PG
 PG
-Pr
+PG
 PG
 PG
 PG

--- a/maps/away/ships/coc/coc_surveyor/coc_surveyor.dmm
+++ b/maps/away/ships/coc/coc_surveyor/coc_surveyor.dmm
@@ -79,12 +79,8 @@
 "bb" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1389;
-	icon_state = "door_locked";
 	id_tag = "surveyor_shuttle_out";
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 9
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	shuttle_tag = "COC Survey Shuttle";
@@ -92,6 +88,9 @@
 	name = "surveyor_shuttle"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "bd" = (
@@ -216,9 +215,8 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/research)
 "cx" = (
-/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
-	dir = 1;
-	start_pressure = 5000
+/obj/structure/fuel_port/hydrogen{
+	pixel_y = -31
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
@@ -310,10 +308,12 @@
 	},
 /obj/machinery/access_button{
 	pixel_x = 12;
-	pixel_y = -28;
+	pixel_y = 28;
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/coc_survey_ship/cargo)
 "dH" = (
@@ -387,6 +387,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "ee" = (
@@ -432,17 +433,14 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
 "eq" = (
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_coc_surveyor_dock_starboard";
-	master_tag = "airlock_coc_surveyor_dock_starboard";
-	landmark_tag = "nav_coc_surveyor_dock_starboard"
+/obj/machinery/power/apc/south,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
 /turf/simulated/floor,
-/area/coc_survey_ship/cargo)
+/area/coc_survey_ship/starboard_propulsion)
 "et" = (
 /obj/effect/floor_decal/corner_wide/black/diagonal,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -607,11 +605,16 @@
 /turf/simulated/wall,
 /area/coc_survey_ship/grauwolf)
 "gr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 5
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/effect/floor_decal/corner_wide/white/diagonal{
+	dir = 8
 	},
-/turf/simulated/wall/shuttle/dark/cardinal/khaki,
-/area/shuttle/coc_survey_shuttle)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "gu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -642,10 +645,15 @@
 /obj/effect/floor_decal/corner_wide/white/diagonal{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "gK" = (
@@ -665,9 +673,9 @@
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/cryo)
 "gQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/coc_survey_ship/cargo)
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor,
+/area/coc_survey_ship/hangar)
 "gX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -706,6 +714,7 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide{
 	start_pressure = 8000.63
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "hH" = (
@@ -810,11 +819,6 @@
 /obj/item/storage/firstaid/large/o2,
 /obj/item/storage/firstaid/large/stab,
 /obj/item/storage/firstaid/large/trauma,
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1385;
-	id_tag = "surveyor_shuttle_dock";
-	pixel_y = 25
-	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "iu" = (
@@ -909,18 +913,9 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "jt" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	layer = 2.8
-	},
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner_wide/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_wide/yellow,
-/turf/simulated/floor/tiled,
-/area/coc_survey_ship/atmos)
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/coc_survey_ship/hangar)
 "jz" = (
 /turf/simulated/wall/shuttle/dark/cardinal/blue,
 /area/coc_survey_ship/medical)
@@ -1153,6 +1148,9 @@
 	name = "airlock_coc_surveyor_dock_port"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/coc_survey_ship/atmos)
 "lx" = (
@@ -1354,7 +1352,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/full,
 /area/shuttle/coc_survey_shuttle)
 "mK" = (
 /obj/structure/sign/flag/coalition,
@@ -1416,7 +1414,7 @@
 /obj/machinery/computer/shuttle_control/explore/coc_survey_shuttle{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/full,
 /area/shuttle/coc_survey_shuttle)
 "nr" = (
 /turf/simulated/wall/shuttle/dark/cardinal/blue,
@@ -1520,6 +1518,10 @@
 	},
 /turf/simulated/wall/shuttle/dark/cardinal/blue,
 /area/coc_survey_ship/cargo)
+"on" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/coc_survey_ship/cargo)
 "oo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -1532,17 +1534,6 @@
 	},
 /turf/simulated/floor/carpet/lightblue,
 /area/coc_survey_ship/captain)
-"ou" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/coc_survey_ship/cargo)
 "oF" = (
 /obj/machinery/light/small/emergency{
 	dir = 4
@@ -1661,9 +1652,28 @@
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/cargo)
 "pw" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external{
+	frequency = 1389;
+	icon_state = "door_locked";
+	id_tag = "surveyor_shuttle_in";
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/shuttle_landmark/coc_survey_ship/dock/starboard{
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/access_button{
+	pixel_x = -12;
+	pixel_y = -28;
+	dir = 8
+	},
 /turf/simulated/floor,
-/area/coc_survey_ship/hangar)
+/area/coc_survey_ship/cargo)
 "pA" = (
 /obj/structure/sign/flag/assunzione,
 /turf/simulated/wall,
@@ -1780,6 +1790,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/cargo)
+"qT" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1385;
+	id_tag = "surveyor_shuttle_dock";
+	pixel_x = 25;
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/coc_survey_ship/hangar)
 "qY" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 10
@@ -1892,6 +1912,19 @@
 /obj/machinery/power/apc/west,
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/mess_hall)
+"rr" = (
+/obj/item/stack/material/tritium/full,
+/obj/item/stack/material/tritium/full,
+/obj/structure/closet/crate{
+	name = "DANGER - RADIOACTIVE MATERIAL"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/carpet/rubber,
+/area/coc_survey_ship/engineering)
 "rt" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/floor_decal/corner_wide/orange{
@@ -1910,12 +1943,21 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "rR" = (
-/obj/structure/sign/radiation{
-	pixel_x = 32;
-	pixel_y = -32
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1389;
+	id_tag = "surveyor_out_internal"
 	},
-/turf/simulated/floor/carpet/rubber,
-/area/coc_survey_ship/engineering)
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "COC Survey Shuttle";
+	master_tag = "surveyor_shuttle";
+	name = "surveyor_shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor,
+/area/shuttle/coc_survey_shuttle)
 "rS" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Cryo and Medical"
@@ -1984,6 +2026,9 @@
 	landmark_tag = "nav_coc_surveyor_dock_starboard"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/coc_survey_ship/cargo)
 "so" = (
@@ -2153,6 +2198,28 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/coc_survey_ship/grauwolf)
+"tz" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/obj/machinery/airlock_sensor{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = -6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/coc_survey_ship/cargo)
 "tI" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -2238,6 +2305,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
+"uA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/coc_survey_ship/cargo)
 "uC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -2303,7 +2381,7 @@
 /area/coc_survey_ship/miningeva)
 "uU" = (
 /obj/machinery/computer/ship/sensors,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/full,
 /area/shuttle/coc_survey_shuttle)
 "uV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -2353,6 +2431,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/quarters)
+"vq" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor,
+/area/coc_survey_ship/cargo)
 "vs" = (
 /obj/structure/table/steel,
 /obj/machinery/recharger,
@@ -2671,33 +2762,11 @@
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/bridge)
-"ya" = (
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_coc_surveyor_dock_starboard";
-	master_tag = "airlock_coc_surveyor_dock_starboard";
-	landmark_tag = "nav_coc_surveyor_dock_starboard"
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
-	},
-/obj/machinery/airlock_sensor{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = -6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/coc_survey_ship/cargo)
 "yj" = (
 /obj/machinery/computer/ship/helm{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/full,
 /area/shuttle/coc_survey_shuttle)
 "yn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2762,23 +2831,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/kitchen)
-"yD" = (
-/obj/machinery/power/apc/south,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/coc_survey_ship/starboard_propulsion)
 "yK" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_wide/yellow/full{
-	dir = 1
+/obj/machinery/computer/general_air_control/large_tank_control{
+	frequency = 451;
+	name = "Carbon Dioxide Supply Monitor";
+	output_tag = "survey_co2_out_port";
+	sensors = list("survey_sensor_port"="Tank");
+	input_tag = "survey_co2_in_port"
 	},
 /obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner_wide/white{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -2835,13 +2899,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/cargo)
 "yZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/binary/pump/on{
+	name = "Scrubbers to Waste"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
 /area/shuttle/coc_survey_shuttle)
 "za" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "zc" = (
@@ -3038,7 +3108,8 @@
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
 /area/shuttle/coc_survey_shuttle)
 "AM" = (
 /obj/effect/floor_decal/corner_wide/paleblue/diagonal,
@@ -3151,9 +3222,6 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/shuttle_landmark/coc_survey_ship/dock/starboard{
-	dir = 4
-	},
 /obj/effect/map_effect/marker/airlock/docking{
 	name = "airlock_coc_surveyor_dock_starboard";
 	master_tag = "airlock_coc_surveyor_dock_starboard";
@@ -3161,7 +3229,7 @@
 	},
 /obj/machinery/access_button{
 	pixel_x = -12;
-	pixel_y = -28;
+	pixel_y = 28;
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -3169,7 +3237,6 @@
 "BS" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1389;
-	icon_state = "door_locked";
 	id_tag = "surveyor_shuttle_in";
 	dir = 4
 	},
@@ -3255,18 +3322,6 @@
 /obj/item/device/suit_cooling_unit,
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
-"Ce" = (
-/obj/effect/map_effect/marker/airlock/docking{
-	master_tag = "airlock_coc_surveyor_dock_port";
-	landmark_tag = "nav_coc_surveyor_dock_starboard";
-	name = "airlock_coc_surveyor_dock_port"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light/small/emergency{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/coc_survey_ship/atmos)
 "Cm" = (
 /obj/effect/floor_decal/corner_wide/red/diagonal,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -3367,9 +3422,7 @@
 /area/coc_survey_ship/cargo)
 "CW" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2;
-	id_tag = "surveyor_out_external";
-	frequency = 1389
+	dir = 2
 	},
 /obj/structure/lattice/catwalk,
 /obj/structure/bed/handrail{
@@ -3688,7 +3741,7 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
 "Ff" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
 /turf/simulated/wall/shuttle/dark/cardinal/khaki,
@@ -3912,7 +3965,7 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
 "GS" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/red,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/wall/shuttle/dark/cardinal/khaki,
 /area/shuttle/coc_survey_shuttle)
 "GY" = (
@@ -4007,8 +4060,7 @@
 	tag_interior_sensor = "surveyor_shuttle_interior_sensor";
 	tag_exterior_sensor = "surveyor_shuttle_exterior_sensor";
 	tag_chamber_sensor = "surveyor_shuttle_chamber_sensor";
-	tag_airpump = "surveyor_shuttle_pump_in";
-	frequency = 1389
+	tag_airpump = "surveyor_shuttle_pump_in"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -4020,6 +4072,9 @@
 	shuttle_tag = "COC Survey Shuttle";
 	master_tag = "surveyor_shuttle";
 	name = "surveyor_shuttle"
+	},
+/obj/machinery/light/small/emergency{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/coc_survey_shuttle)
@@ -4069,6 +4124,15 @@
 	id = "survey_sensor_in_port"
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
+/area/coc_survey_ship/atmos)
+"If" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	master_tag = "airlock_coc_surveyor_dock_port";
+	landmark_tag = "nav_coc_surveyor_dock_starboard";
+	name = "airlock_coc_surveyor_dock_port"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
 /area/coc_survey_ship/atmos)
 "Ig" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4183,13 +4247,25 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/binary/passive_gate/supply{
+	target_pressure = 250;
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor,
 /area/shuttle/coc_survey_shuttle)
 "Jm" = (
 /turf/simulated/floor/reinforced,
+/area/shuttle/coc_survey_shuttle)
+"Jn" = (
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "Jt" = (
 /obj/structure/ship_weapon_dummy,
@@ -4252,21 +4328,14 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/port_propulsion)
 "JN" = (
-/obj/machinery/computer/general_air_control/large_tank_control{
-	frequency = 451;
-	name = "Carbon Dioxide Supply Monitor";
-	output_tag = "survey_co2_out_port";
-	sensors = list("survey_sensor_port"="Tank");
-	input_tag = "survey_co2_in_port"
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/white{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/coc_survey_ship/atmos)
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_survey_shuttle)
 "JP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -4298,9 +4367,6 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
 "Kc" = (
-/obj/structure/fuel_port/hydrogen{
-	pixel_y = -31
-	},
 /obj/machinery/computer/ship/engines{
 	dir = 1
 	},
@@ -4325,9 +4391,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "Kr" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor,
-/area/coc_survey_ship/hangar)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_survey_shuttle)
 "Ku" = (
 /obj/effect/floor_decal/corner_wide/yellow/diagonal,
 /obj/effect/floor_decal/corner_wide/white/diagonal{
@@ -4387,29 +4453,6 @@
 	},
 /turf/simulated/floor,
 /area/coc_survey_ship/miningeva)
-"KK" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1389;
-	icon_state = "door_locked";
-	id_tag = "surveyor_shuttle_in";
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_coc_surveyor_dock_starboard";
-	master_tag = "airlock_coc_surveyor_dock_starboard";
-	landmark_tag = "nav_coc_surveyor_dock_starboard"
-	},
-/obj/machinery/access_button{
-	pixel_x = 12;
-	pixel_y = 28;
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/coc_survey_ship/cargo)
 "KL" = (
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 8
@@ -4447,25 +4490,17 @@
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/anomaly)
 "KQ" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1389;
-	icon_state = "door_locked";
-	id_tag = "surveyor_shuttle_in";
-	dir = 4
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_coc_surveyor_dock_starboard";
-	master_tag = "airlock_coc_surveyor_dock_starboard";
-	landmark_tag = "nav_coc_surveyor_dock_starboard"
+/obj/effect/floor_decal/corner_wide/yellow/full{
+	dir = 1
 	},
-/obj/machinery/access_button{
-	pixel_x = -12;
-	pixel_y = 28;
+/obj/effect/floor_decal/corner_wide/yellow{
 	dir = 8
 	},
-/turf/simulated/floor,
-/area/coc_survey_ship/cargo)
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "KX" = (
 /obj/machinery/conveyor{
 	id = "Coallit_Mining_1";
@@ -4482,7 +4517,6 @@
 /area/coc_survey_ship/blaster)
 "Lk" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1385;
 	pixel_y = -23;
 	dir = 1
 	},
@@ -4731,22 +4765,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
-"Ni" = (
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_coc_surveyor_dock_starboard";
-	master_tag = "airlock_coc_surveyor_dock_starboard";
-	landmark_tag = "nav_coc_surveyor_dock_starboard"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light/small/emergency,
-/turf/simulated/floor,
-/area/coc_survey_ship/cargo)
 "Nk" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor,
 /area/shuttle/coc_survey_shuttle)
 "Nm" = (
 /obj/item/clothing/accessory/badge/passcard/konyang,
@@ -4864,10 +4886,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
 /area/shuttle/coc_survey_shuttle)
 "Ol" = (
 /turf/simulated/wall/shuttle/dark/cardinal/blue,
@@ -4924,6 +4945,27 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/research)
+"OV" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1389;
+	icon_state = "door_locked";
+	id_tag = "surveyor_shuttle_in";
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/access_button{
+	pixel_x = 12;
+	pixel_y = -28;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/tiled/dark/full,
+/area/coc_survey_ship/cargo)
 "OX" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot{
 	dir = 4
@@ -5017,21 +5059,16 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "PV" = (
-/obj/effect/floor_decal/corner_wide/yellow/diagonal,
-/obj/effect/floor_decal/corner_wide/white/diagonal{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 5
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/coc_survey_ship/atmos)
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/coc_survey_ship/starboard_propulsion)
 "Qb" = (
 /obj/effect/floor_decal/corner_wide/yellow/diagonal,
 /obj/effect/floor_decal/corner_wide/white/diagonal{
@@ -5086,23 +5123,17 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "Qv" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1389;
-	icon_state = "door_locked";
 	id_tag = "surveyor_shuttle_out";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/red{
 	dir = 4
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
-	frequency = 1389;
 	name = "exterior access button";
 	pixel_x = 8;
 	pixel_y = 27;
@@ -5114,6 +5145,10 @@
 	name = "surveyor_shuttle"
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "Qx" = (
@@ -5124,18 +5159,18 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/miningeva)
 "QI" = (
-/obj/item/stack/material/tritium/full,
-/obj/item/stack/material/tritium/full,
-/obj/structure/closet/crate{
-	name = "DANGER - RADIOACTIVE MATERIAL"
+/obj/machinery/atmospherics/binary/pump/high_power{
+	layer = 2.8
 	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
 	},
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/carpet/rubber,
-/area/coc_survey_ship/engineering)
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_wide/yellow,
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "QJ" = (
 /turf/simulated/floor,
 /area/coc_survey_ship/grauwolf)
@@ -5307,7 +5342,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/mech_recharger,
+/obj/machinery/alarm/north{
+	req_one_access = null
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "Sq" = (
@@ -5318,14 +5358,14 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/port_propulsion)
 "Ss" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/coc_survey_shuttle)
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/coc_survey_ship/cargo)
 "Sy" = (
 /obj/structure/table/steel,
 /obj/item/clothing/under/rank/medical/surgeon,
@@ -5573,10 +5613,8 @@
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/kitchen)
 "Uw" = (
-/obj/machinery/alarm/north{
-	req_one_access = null
-	},
-/obj/machinery/atmospherics/pipe/tank/air,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/mech_recharger,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "Uy" = (
@@ -5586,8 +5624,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
@@ -5722,6 +5760,13 @@
 /obj/structure/janitorialcart/full,
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/cargo)
+"VO" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_survey_shuttle)
 "VP" = (
 /obj/effect/floor_decal/corner_wide/white{
 	dir = 8
@@ -5748,9 +5793,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 2;
-	id_tag = "surveyor_out_external";
-	frequency = 1389
+	dir = 2
 	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	shuttle_tag = "COC Survey Shuttle";
@@ -5759,7 +5802,6 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/airlock_sensor/airlock_exterior{
-	frequency = 1389;
 	id_tag = "surveyor_shuttle_exterior_sensor";
 	pixel_y = -25;
 	pixel_x = 41;
@@ -5799,7 +5841,7 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "Wq" = (
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "Wv" = (
@@ -5856,7 +5898,6 @@
 "WR" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1389;
-	icon_state = "door_locked";
 	id_tag = "surveyor_shuttle_in";
 	dir = 4
 	},
@@ -5884,16 +5925,12 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "Xc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/obj/structure/sign/radiation{
+	pixel_x = 32;
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/coc_survey_ship/starboard_propulsion)
+/turf/simulated/floor/carpet/rubber,
+/area/coc_survey_ship/engineering)
 "Xh" = (
 /obj/machinery/mineral/unloading_machine{
 	dir = 8
@@ -5901,8 +5938,8 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/miningeva)
 "Xj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
@@ -6297,7 +6334,7 @@
 /area/coc_survey_ship/bridge)
 "Zw" = (
 /obj/structure/bed/stool/chair/shuttle,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/full,
 /area/shuttle/coc_survey_shuttle)
 "Zy" = (
 /obj/structure/cable/green{
@@ -9049,8 +9086,8 @@ PG
 PG
 PG
 jn
-KQ
 BR
+pw
 jn
 PG
 PG
@@ -9151,8 +9188,8 @@ PG
 jn
 jn
 jn
-eq
 sn
+Ss
 jn
 jn
 PG
@@ -9253,8 +9290,8 @@ jn
 jn
 tR
 jn
-ya
-Ni
+tz
+vq
 jn
 jn
 jn
@@ -9346,7 +9383,7 @@ NL
 aA
 aA
 RM
-yD
+eq
 Pt
 dJ
 dJ
@@ -9355,8 +9392,8 @@ Oa
 HF
 le
 jn
-KK
 dC
+OV
 jn
 XK
 ui
@@ -9445,14 +9482,14 @@ jI
 wX
 Pk
 id
-Xc
-Xc
+PV
+PV
 aH
 Lu
 Ig
 hL
 hL
-ou
+uA
 hL
 Eo
 Uq
@@ -9768,7 +9805,7 @@ nI
 Pt
 Tq
 dH
-gQ
+on
 dH
 VM
 bU
@@ -9870,7 +9907,7 @@ gO
 Pt
 Tq
 HF
-gQ
+on
 dH
 dH
 UF
@@ -10375,16 +10412,16 @@ PG
 ZM
 dS
 ZM
-Wq
-Wq
+jt
+jt
 JK
-Wq
-Wq
+jt
+jt
 JK
-Wq
-Wq
+jt
+jt
 JK
-Wq
+jt
 rG
 cM
 CC
@@ -10477,10 +10514,10 @@ PG
 ZM
 dT
 ZM
+jt
+dT
+dT
 Wq
-dT
-dT
-pw
 dT
 dT
 dT
@@ -10579,15 +10616,15 @@ PG
 ZM
 dT
 ZM
+jt
+dT
+dT
+dT
+dT
+dT
+dT
+dT
 Wq
-dT
-dT
-dT
-dT
-dT
-dT
-dT
-pw
 dT
 Xu
 vZ
@@ -10783,7 +10820,7 @@ PG
 ZM
 dT
 ZM
-Wq
+jt
 dT
 dT
 Zd
@@ -10793,7 +10830,7 @@ Ul
 Zd
 dT
 dT
-Wq
+jt
 cM
 Dy
 DN
@@ -10885,7 +10922,7 @@ PG
 ZM
 dT
 ZM
-Wq
+jt
 dT
 ul
 ul
@@ -10987,7 +11024,7 @@ PG
 ZM
 dT
 ZM
-Wq
+jt
 dT
 ul
 im
@@ -10997,7 +11034,7 @@ Wv
 RV
 ul
 dT
-Wq
+jt
 Vh
 Vh
 Vh
@@ -11191,7 +11228,7 @@ PG
 ZM
 dT
 ZM
-Wq
+jt
 dT
 Zd
 Zw
@@ -11293,12 +11330,12 @@ PG
 ZM
 dT
 ZM
-Wq
+jt
 dT
 ul
 Zw
-Nk
-Ss
+xB
+Zy
 Jm
 bV
 ul
@@ -11395,12 +11432,12 @@ PG
 ZM
 dT
 ZM
-Wq
+jt
 dT
 bd
 Zw
 ha
-Qt
+JN
 Jm
 gx
 zc
@@ -11599,7 +11636,7 @@ PG
 ZM
 dT
 ZM
-Wq
+jt
 dT
 ul
 Sn
@@ -11701,14 +11738,14 @@ PG
 ZM
 dT
 ZM
-Wq
+jt
 dT
 ul
 MR
 Xj
-xB
-xB
-xB
+Nk
+Kr
+VO
 ul
 dT
 Cn
@@ -11803,12 +11840,12 @@ PG
 ZM
 dT
 ZM
-Wq
+jt
 dT
 ul
 xB
-Xj
-xB
+Kq
+Jn
 Kq
 hF
 ul
@@ -12007,9 +12044,9 @@ PG
 ZM
 dT
 ZM
-Wq
+jt
 CW
-gr
+MD
 HH
 Lk
 ul
@@ -12109,11 +12146,11 @@ PG
 ZM
 dT
 ZM
-Wq
+jt
 Wb
 GS
 wM
-wM
+rR
 ul
 QV
 MD
@@ -12211,7 +12248,7 @@ PG
 ZM
 dT
 ZM
-Wq
+jt
 ul
 Ff
 Qv
@@ -12415,13 +12452,13 @@ PG
 ZM
 dT
 ZM
-Wq
+jt
 dT
 dT
 dT
 dT
 dT
-Kr
+gQ
 dT
 dT
 eN
@@ -12517,14 +12554,14 @@ PG
 ZM
 dT
 ZM
+jt
+dT
+dT
+dT
+dT
+dT
+dT
 Wq
-dT
-dT
-dT
-dT
-dT
-dT
-pw
 dT
 zJ
 Xu
@@ -12619,14 +12656,14 @@ PG
 ZM
 dT
 ZM
-Wq
-Wq
+jt
+jt
 ro
-Wq
-Wq
+qT
+jt
 ro
-Wq
-Wq
+jt
+jt
 ro
 Rv
 Mj
@@ -13229,8 +13266,8 @@ MF
 EI
 my
 Yv
-PV
 gD
+gr
 RH
 UL
 XR
@@ -13324,7 +13361,7 @@ MY
 qc
 XD
 Bv
-rR
+Xc
 MJ
 wB
 Uy
@@ -13432,7 +13469,7 @@ pp
 Uy
 XR
 XR
-JN
+yK
 GY
 vU
 hH
@@ -13534,7 +13571,7 @@ OY
 Uy
 aP
 rp
-jt
+QI
 VP
 PU
 NR
@@ -13630,13 +13667,13 @@ Uy
 kt
 Uy
 sx
-QI
+rr
 sc
 Qe
 Uy
 Id
 bG
-yK
+KQ
 Hy
 DH
 wh
@@ -13843,8 +13880,8 @@ PG
 PG
 PG
 DH
-Ce
 lr
+If
 DH
 Ol
 PG

--- a/maps/away/ships/coc/coc_surveyor/coc_surveyor.dmm
+++ b/maps/away/ships/coc/coc_surveyor/coc_surveyor.dmm
@@ -308,12 +308,10 @@
 	},
 /obj/machinery/access_button{
 	pixel_x = 12;
-	pixel_y = 28;
+	pixel_y = -28;
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark/full,
 /area/coc_survey_ship/cargo)
 "dH" = (
@@ -433,14 +431,9 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
 "eq" = (
-/obj/machinery/power/apc/south,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor,
-/area/coc_survey_ship/starboard_propulsion)
+/area/coc_survey_ship/hangar)
 "et" = (
 /obj/effect/floor_decal/corner_wide/black/diagonal,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -605,14 +598,24 @@
 /turf/simulated/wall,
 /area/coc_survey_ship/grauwolf)
 "gr" = (
-/obj/effect/floor_decal/corner_wide/yellow/diagonal,
-/obj/effect/floor_decal/corner_wide/white/diagonal{
+/obj/machinery/atmospherics/portables_connector,
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner_wide/white{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/door/window,
+/obj/structure/window{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/window{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "gu" = (
@@ -673,9 +676,10 @@
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/cryo)
 "gQ" = (
-/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor,
-/area/coc_survey_ship/hangar)
+/area/shuttle/coc_survey_shuttle)
 "gX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -707,6 +711,10 @@
 /obj/effect/floor_decal/corner/lime/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/cryo)
+"hx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_survey_shuttle)
 "hF" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -972,6 +980,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/coc_survey_ship/grauwolf)
+"kr" = (
+/obj/structure/sign/radiation{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/turf/simulated/floor/carpet/rubber,
+/area/coc_survey_ship/engineering)
 "kt" = (
 /obj/structure/plasticflaps/airtight{
 	dir = 4
@@ -1297,6 +1312,28 @@
 /obj/item/clothing/suit/storage/toggle/labcoat,
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/research)
+"mj" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/obj/machinery/airlock_sensor{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = -6
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/coc_survey_ship/cargo)
 "mo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -1352,7 +1389,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "mK" = (
 /obj/structure/sign/flag/coalition,
@@ -1414,7 +1451,7 @@
 /obj/machinery/computer/shuttle_control/explore/coc_survey_shuttle{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "nr" = (
 /turf/simulated/wall/shuttle/dark/cardinal/blue,
@@ -1517,10 +1554,6 @@
 	name = "starboard aft wing"
 	},
 /turf/simulated/wall/shuttle/dark/cardinal/blue,
-/area/coc_survey_ship/cargo)
-"on" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/cargo)
 "oo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1658,21 +1691,21 @@
 	id_tag = "surveyor_shuttle_in";
 	dir = 4
 	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/shuttle_landmark/coc_survey_ship/dock/starboard{
-	dir = 4
-	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/map_effect/marker/airlock/docking{
 	name = "airlock_coc_surveyor_dock_starboard";
 	master_tag = "airlock_coc_surveyor_dock_starboard";
 	landmark_tag = "nav_coc_surveyor_dock_starboard"
 	},
 /obj/machinery/access_button{
-	pixel_x = -12;
-	pixel_y = -28;
-	dir = 8
+	pixel_x = 12;
+	pixel_y = 28;
+	dir = 4
 	},
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/coc_survey_ship/cargo)
 "pA" = (
 /obj/structure/sign/flag/assunzione,
@@ -1790,16 +1823,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/cargo)
-"qT" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1385;
-	id_tag = "surveyor_shuttle_dock";
-	pixel_x = 25;
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/coc_survey_ship/hangar)
 "qY" = (
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 10
@@ -1912,19 +1935,6 @@
 /obj/machinery/power/apc/west,
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/mess_hall)
-"rr" = (
-/obj/item/stack/material/tritium/full,
-/obj/item/stack/material/tritium/full,
-/obj/structure/closet/crate{
-	name = "DANGER - RADIOACTIVE MATERIAL"
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/carpet/rubber,
-/area/coc_survey_ship/engineering)
 "rt" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/floor_decal/corner_wide/orange{
@@ -1932,6 +1942,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
+"rA" = (
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/yellow/full{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "rG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1943,21 +1965,16 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "rR" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1389;
-	id_tag = "surveyor_out_internal"
+/obj/effect/floor_decal/corner_wide/yellow/diagonal,
+/obj/effect/floor_decal/corner_wide/white/diagonal{
+	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	shuttle_tag = "COC Survey Shuttle";
-	master_tag = "surveyor_shuttle";
-	name = "surveyor_shuttle"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/effect/map_effect/marker_helper/airlock/out,
-/obj/machinery/light/small/emergency,
-/turf/simulated/floor,
-/area/shuttle/coc_survey_shuttle)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "rS" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Cryo and Medical"
@@ -2041,6 +2058,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/anomaly)
+"ss" = (
+/obj/machinery/atmospherics/binary/pump/high_power{
+	layer = 2.8
+	},
+/obj/effect/floor_decal/corner_wide/yellow{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner_wide/white{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner_wide/yellow,
+/turf/simulated/floor/tiled,
+/area/coc_survey_ship/atmos)
 "su" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/loot,
@@ -2198,28 +2228,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/coc_survey_ship/grauwolf)
-"tz" = (
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_coc_surveyor_dock_starboard";
-	master_tag = "airlock_coc_surveyor_dock_starboard";
-	landmark_tag = "nav_coc_surveyor_dock_starboard"
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = 6
-	},
-/obj/machinery/airlock_sensor{
-	dir = 2;
-	pixel_y = 28;
-	pixel_x = -6
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/coc_survey_ship/cargo)
 "tI" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -2305,17 +2313,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
-"uA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/coc_survey_ship/cargo)
 "uC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -2381,7 +2378,7 @@
 /area/coc_survey_ship/miningeva)
 "uU" = (
 /obj/machinery/computer/ship/sensors,
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "uV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -2431,19 +2428,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/quarters)
-"vq" = (
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_coc_surveyor_dock_starboard";
-	master_tag = "airlock_coc_surveyor_dock_starboard";
-	landmark_tag = "nav_coc_surveyor_dock_starboard"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light/small/emergency,
-/turf/simulated/floor,
-/area/coc_survey_ship/cargo)
 "vs" = (
 /obj/structure/table/steel,
 /obj/machinery/recharger,
@@ -2528,6 +2512,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/cryo)
+"wv" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor,
+/area/coc_survey_ship/cargo)
 "wB" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -2595,6 +2592,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
+"wL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/coc_survey_ship/cargo)
 "wM" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -2766,7 +2774,7 @@
 /obj/machinery/computer/ship/helm{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "yn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2832,21 +2840,12 @@
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/kitchen)
 "yK" = (
-/obj/machinery/computer/general_air_control/large_tank_control{
-	frequency = 451;
-	name = "Carbon Dioxide Supply Monitor";
-	output_tag = "survey_co2_out_port";
-	sensors = list("survey_sensor_port"="Tank");
-	input_tag = "survey_co2_in_port"
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner_wide/white{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/coc_survey_ship/atmos)
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_survey_shuttle)
 "yQ" = (
 /obj/effect/floor_decal/corner_wide/orange{
 	dir = 10
@@ -3485,6 +3484,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/coc_survey_ship/starboard_propulsion)
+"Dx" = (
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_survey_shuttle)
 "Dy" = (
 /obj/effect/floor_decal/corner/purple/diagonal,
 /obj/structure/cable{
@@ -3746,6 +3752,15 @@
 	},
 /turf/simulated/wall/shuttle/dark/cardinal/khaki,
 /area/shuttle/coc_survey_shuttle)
+"Fh" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/coc_survey_shuttle)
 "Fr" = (
 /obj/machinery/mineral/processing_unit_console{
 	id = "coalition_miner";
@@ -3767,6 +3782,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/mess_hall)
+"Fu" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1389;
+	id_tag = "surveyor_out_internal"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "COC Survey Shuttle";
+	master_tag = "surveyor_shuttle";
+	name = "surveyor_shuttle"
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor,
+/area/shuttle/coc_survey_shuttle)
 "Fw" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -4125,15 +4156,6 @@
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/coc_survey_ship/atmos)
-"If" = (
-/obj/effect/map_effect/marker/airlock/docking{
-	master_tag = "airlock_coc_surveyor_dock_port";
-	landmark_tag = "nav_coc_surveyor_dock_starboard";
-	name = "airlock_coc_surveyor_dock_port"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/coc_survey_ship/atmos)
 "Ig" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4260,13 +4282,6 @@
 "Jm" = (
 /turf/simulated/floor/reinforced,
 /area/shuttle/coc_survey_shuttle)
-"Jn" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/coc_survey_shuttle)
 "Jt" = (
 /obj/structure/ship_weapon_dummy,
 /turf/simulated/floor/reinforced,
@@ -4328,14 +4343,18 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/port_propulsion)
 "JN" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/item/stack/material/tritium/full,
+/obj/item/stack/material/tritium/full,
+/obj/structure/closet/crate{
+	name = "DANGER - RADIOACTIVE MATERIAL"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/coc_survey_shuttle)
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/carpet/rubber,
+/area/coc_survey_ship/engineering)
 "JP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -4391,9 +4410,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "Kr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/coc_survey_shuttle)
+/obj/effect/map_effect/marker/airlock/docking{
+	master_tag = "airlock_coc_surveyor_dock_port";
+	landmark_tag = "nav_coc_surveyor_dock_starboard";
+	name = "airlock_coc_surveyor_dock_port"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
+/area/coc_survey_ship/atmos)
 "Ku" = (
 /obj/effect/floor_decal/corner_wide/yellow/diagonal,
 /obj/effect/floor_decal/corner_wide/white/diagonal{
@@ -4490,17 +4514,28 @@
 /turf/simulated/floor/tiled/white,
 /area/coc_survey_ship/anomaly)
 "KQ" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 1
+/obj/machinery/door/airlock/external{
+	frequency = 1389;
+	icon_state = "door_locked";
+	id_tag = "surveyor_shuttle_in";
+	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/yellow/full{
-	dir = 1
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/shuttle_landmark/coc_survey_ship/dock/starboard{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner_wide/yellow{
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
+/obj/machinery/access_button{
+	pixel_x = -12;
+	pixel_y = -28;
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/coc_survey_ship/atmos)
+/turf/simulated/floor,
+/area/coc_survey_ship/cargo)
 "KX" = (
 /obj/machinery/conveyor{
 	id = "Coallit_Mining_1";
@@ -4766,10 +4801,14 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/miningeva)
 "Nk" = (
+/obj/effect/map_effect/marker/airlock/docking{
+	name = "airlock_coc_surveyor_dock_starboard";
+	master_tag = "airlock_coc_surveyor_dock_starboard";
+	landmark_tag = "nav_coc_surveyor_dock_starboard"
+	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor,
-/area/shuttle/coc_survey_shuttle)
+/area/coc_survey_ship/cargo)
 "Nm" = (
 /obj/item/clothing/accessory/badge/passcard/konyang,
 /obj/item/clothing/accessory/badge/passcard/konyang,
@@ -4945,27 +4984,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/coc_survey_ship/research)
-"OV" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1389;
-	icon_state = "door_locked";
-	id_tag = "surveyor_shuttle_in";
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_coc_surveyor_dock_starboard";
-	master_tag = "airlock_coc_surveyor_dock_starboard";
-	landmark_tag = "nav_coc_surveyor_dock_starboard"
-	},
-/obj/machinery/access_button{
-	pixel_x = 12;
-	pixel_y = -28;
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/turf/simulated/floor/tiled/dark/full,
-/area/coc_survey_ship/cargo)
 "OX" = (
 /obj/structure/bed/stool/chair/office/bridge/pilot{
 	dir = 4
@@ -5038,23 +5056,18 @@
 /turf/template_noop,
 /area/space)
 "PU" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 6
+/obj/machinery/computer/general_air_control/large_tank_control{
+	frequency = 451;
+	name = "Carbon Dioxide Supply Monitor";
+	output_tag = "survey_co2_out_port";
+	sensors = list("survey_sensor_port"="Tank");
+	input_tag = "survey_co2_in_port"
 	},
 /obj/effect/floor_decal/corner_wide/yellow{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner_wide/white{
 	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/door/window,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
@@ -5122,8 +5135,8 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
@@ -5159,18 +5172,9 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/miningeva)
 "QI" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	layer = 2.8
-	},
-/obj/effect/floor_decal/corner_wide/yellow{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner_wide/white{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner_wide/yellow,
-/turf/simulated/floor/tiled,
-/area/coc_survey_ship/atmos)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/coc_survey_ship/cargo)
 "QJ" = (
 /turf/simulated/floor,
 /area/coc_survey_ship/grauwolf)
@@ -5358,14 +5362,15 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/port_propulsion)
 "Ss" = (
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_coc_surveyor_dock_starboard";
-	master_tag = "airlock_coc_surveyor_dock_starboard";
-	landmark_tag = "nav_coc_surveyor_dock_starboard"
-	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1385;
+	id_tag = "surveyor_shuttle_dock";
+	pixel_x = 25;
+	dir = 8
+	},
 /turf/simulated/floor,
-/area/coc_survey_ship/cargo)
+/area/coc_survey_ship/hangar)
 "Sy" = (
 /obj/structure/table/steel,
 /obj/item/clothing/under/rank/medical/surgeon,
@@ -5760,13 +5765,6 @@
 /obj/structure/janitorialcart/full,
 /turf/simulated/floor/tiled/dark,
 /area/coc_survey_ship/cargo)
-"VO" = (
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/coc_survey_shuttle)
 "VP" = (
 /obj/effect/floor_decal/corner_wide/white{
 	dir = 8
@@ -5841,9 +5839,14 @@
 /turf/simulated/floor/tiled,
 /area/coc_survey_ship/atmos)
 "Wq" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/south,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
-/area/coc_survey_ship/hangar)
+/area/coc_survey_ship/starboard_propulsion)
 "Wv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5925,12 +5928,9 @@
 /turf/simulated/floor,
 /area/coc_survey_ship/hangar)
 "Xc" = (
-/obj/structure/sign/radiation{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/simulated/floor/carpet/rubber,
-/area/coc_survey_ship/engineering)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
+/area/coc_survey_ship/hangar)
 "Xh" = (
 /obj/machinery/mineral/unloading_machine{
 	dir = 8
@@ -6334,7 +6334,7 @@
 /area/coc_survey_ship/bridge)
 "Zw" = (
 /obj/structure/bed/stool/chair/shuttle,
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_survey_shuttle)
 "Zy" = (
 /obj/structure/cable/green{
@@ -9087,7 +9087,7 @@ PG
 PG
 jn
 BR
-pw
+KQ
 jn
 PG
 PG
@@ -9189,7 +9189,7 @@ jn
 jn
 jn
 sn
-Ss
+Nk
 jn
 jn
 PG
@@ -9290,8 +9290,8 @@ jn
 jn
 tR
 jn
-tz
-vq
+mj
+wv
 jn
 jn
 jn
@@ -9383,7 +9383,7 @@ NL
 aA
 aA
 RM
-eq
+Wq
 Pt
 dJ
 dJ
@@ -9392,8 +9392,8 @@ Oa
 HF
 le
 jn
+pw
 dC
-OV
 jn
 XK
 ui
@@ -9489,7 +9489,7 @@ Lu
 Ig
 hL
 hL
-uA
+wL
 hL
 Eo
 Uq
@@ -9805,7 +9805,7 @@ nI
 Pt
 Tq
 dH
-on
+QI
 dH
 VM
 bU
@@ -9907,7 +9907,7 @@ gO
 Pt
 Tq
 HF
-on
+QI
 dH
 dH
 UF
@@ -10517,7 +10517,7 @@ ZM
 jt
 dT
 dT
-Wq
+Xc
 dT
 dT
 dT
@@ -10624,7 +10624,7 @@ dT
 dT
 dT
 dT
-Wq
+Xc
 dT
 Xu
 vZ
@@ -11437,7 +11437,7 @@ dT
 bd
 Zw
 ha
-JN
+Qt
 Jm
 gx
 zc
@@ -11539,7 +11539,7 @@ dT
 ul
 Uw
 za
-Qt
+Fh
 BW
 Rh
 ul
@@ -11743,9 +11743,9 @@ dT
 ul
 MR
 Xj
-Nk
-Kr
-VO
+gQ
+hx
+yK
 ul
 dT
 Cn
@@ -11845,7 +11845,7 @@ dT
 ul
 xB
 Kq
-Jn
+Dx
 Kq
 hF
 ul
@@ -12150,7 +12150,7 @@ jt
 Wb
 GS
 wM
-rR
+Fu
 ul
 QV
 MD
@@ -12458,7 +12458,7 @@ dT
 dT
 dT
 dT
-gQ
+eq
 dT
 dT
 eN
@@ -12561,7 +12561,7 @@ dT
 dT
 dT
 dT
-Wq
+Xc
 dT
 zJ
 Xu
@@ -12659,7 +12659,7 @@ ZM
 jt
 jt
 ro
-qT
+Ss
 jt
 ro
 jt
@@ -13267,7 +13267,7 @@ EI
 my
 Yv
 gD
-gr
+rR
 RH
 UL
 XR
@@ -13361,7 +13361,7 @@ MY
 qc
 XD
 Bv
-Xc
+kr
 MJ
 wB
 Uy
@@ -13469,7 +13469,7 @@ pp
 Uy
 XR
 XR
-yK
+PU
 GY
 vU
 hH
@@ -13571,9 +13571,9 @@ OY
 Uy
 aP
 rp
-QI
+ss
 VP
-PU
+gr
 NR
 uV
 XR
@@ -13667,13 +13667,13 @@ Uy
 kt
 Uy
 sx
-rr
+JN
 sc
 Qe
 Uy
 Id
 bG
-KQ
+rA
 Hy
 DH
 wh
@@ -13881,7 +13881,7 @@ PG
 PG
 DH
 lr
-If
+Kr
 DH
 Ol
 PG


### PR DESCRIPTION
* Fixes #17604.
* Makes the docking airlocks all proper. Gives them docking points.
* Adds an extra CO2 tank in atmospherics (to fix my own crappy mapping).
* Cleans up the atmospherics on the shuttle a bit (another fix of my own crappy mapping).
* Adds some dirt and decals across the ship. 
* This isn't actually Courier's fault I was just teasing she made it before airlock markers were a thing. I'm sorry.
* Spawn weight is high while I figure out wtf the shuttle airlock is doing.