### PR TITLE
Personel > personnel, ops personnel glare dampener fix

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -822,8 +822,8 @@
 	icon_state = "geneticist"
 
 /obj/item/toy/figure/hop
-	name = "head of personel action figure"
-	desc = "A \"Space Life\" brand head of personel action figure."
+	name = "head of personnel action figure"
+	desc = "A \"Space Life\" brand head of personnel action figure."
 	icon_state = "hop"
 
 /obj/item/toy/figure/hos

--- a/code/modules/client/preference_setup/loadout/items/augments.dm
+++ b/code/modules/client/preference_setup/loadout/items/augments.dm
@@ -199,7 +199,7 @@
 	display_name = "retractable glare dampeners"
 	description = "A subdermal implant installed just above the brow line that deploys a thin sheath of hyperpolycarbonate that protects from eye damage associated with arc flash."
 	path = /obj/item/organ/internal/augment/tool/correctivelens/glare_dampener
-	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician", "Engineering Apprentice", "Machinist", "Engineering Personnel", "Operations Personel")
+	allowed_roles = list("Chief Engineer", "Engineer", "Atmospheric Technician", "Engineering Apprentice", "Machinist", "Engineering Personnel", "Operations Personnel")
 	cost = 2
 
 /datum/gear/augment/drill

--- a/html/changelogs/sniblet-nothin-personel.yml
+++ b/html/changelogs/sniblet-nothin-personel.yml
@@ -1,0 +1,14 @@
+# Your name.
+author: Sniblet
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - spellcheck: "Replaced all instances of 'personel' with personnel."
+  - buxfix: "The Operations Personnel job can now spawn with a glare dampener augment."

--- a/html/changelogs/sniblet-nothin-personel.yml
+++ b/html/changelogs/sniblet-nothin-personel.yml
@@ -11,4 +11,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - spellcheck: "Replaced all instances of 'personel' with personnel."
-  - buxfix: "The Operations Personnel job can now spawn with a glare dampener augment."
+  - bugfix: "The Operations Personnel job can now spawn with a glare dampener augment."


### PR DESCRIPTION
Operations Personnel could not spawn with glare dampeners in the event because glare dampeners were for Operations Personel (sic).
An action figure is also spelled wrong.