### PR TITLE
Added more fantasy drugs to the game

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -413,7 +413,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	name = "adhomian cigarette"
 	desc = "An adhomian cigarette made from processed S'rendarr's Hand."
 	reagents_to_add = list(
-		/singleton/reagent/toxin/tobacco = 5,
+		/singleton/reagent/toxin/tobacco/srendarrs_hand = 5,
 		/singleton/reagent/mental/nicotine = 5
 	)
 
@@ -421,7 +421,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	name = "adhomian menthol cigarette"
 	desc = "An adhomian cigarette made from processed S'rendarr's Hand, with menthol added."
 	reagents_to_add = list(
-		/singleton/reagent/toxin/tobacco = 5,
+		/singleton/reagent/toxin/tobacco/srendarrs_hand = 5,
 		/singleton/reagent/mental/nicotine = 5,
 		/singleton/reagent/menthol = 5
 	)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
@@ -287,6 +287,29 @@
 		else
 			M.seizure()
 
+/singleton/reagent/drugs/colorspace
+	name = "Colorspace"
+	description = "A psychedelic drug that alters thought and perception."
+	taste_description = "flavorless paste"
+	color = "#a7a6a4"
+	initial_effect_message_list = list("Your skin tickles.", "You seem to leave this world behind...")
+	sober_message_list = list("The world grows still again.", "Colors seem duller.")
+
+/singleton/reagent/drugs/colorspace/affect_blood(mob/living/carbon/M, alien, removed, datum/reagents/holder)
+	..()
+
+	var/drug_strength = 80 * power
+
+	if(alien == IS_SKRELL)
+		drug_strength *= 0.8
+
+	M.druggy = max(M.druggy, 15)
+	M.hallucination = max(M.hallucination, drug_strength)
+
+	if(prob(15))
+		to_chat(SPAN_GOOD(pick("The floor is melting...", "Everything is so much brighter! Wow!", "Everything is shifting around you.")))
+
+
 /singleton/reagent/drugs/night_juice
 	name = "Nightlife"
 	description = "A liquid narcotic commonly used by the more wealthy drug-abusing citizens of the Eridani Federation. Works as a potent stimulant that causes extreme awakefulness. Lethal in high doses."

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
@@ -118,6 +118,34 @@
 	M.add_chemical_effect(CE_HALLUCINATE, power)
 	M.confused = max(M.confused, power)
 
+/singleton/reagent/drugs/snowflake
+	name = "Snowflake"
+	description = "A recreational stimulant refined from frost oil, found in certain plants."
+	taste_description = "metallic and bitter"
+	reagent_state = LIQUID
+	color = "#bbd7eb"
+	overdose = 15
+	fallback_specific_heat = 15
+	default_temperature = T0C - 40
+	initial_effect_message_list = list("You feel euphoric!", "You feel unstoppable.")
+	sober_message_list = list("You feel a bit more sluggish", "You feel terrible...", "You feel pretty dehydrated.")
+
+/singleton/reagent/drugs/snowflake/affect_blood(mob/living/carbon/M, alien, removed, datum/reagents/holder)
+	..()
+	M.add_chemical_effect(CE_PAINKILLER, 3 * power)
+	M.bodytemperature = max(M.bodytemperature - 15 * TEMPERATURE_DAMAGE_COEFFICIENT * power, 0)
+	if(prob(12))
+		M.emote(pick("shiver", "sniff"))
+	if(prob(5))
+		to_chat(M, SPAN_WARNING(pick("You just can't seem to stop sniffling...", "You feel impatient...", "Your eyes feel a bit dry.")))
+
+/singleton/reagent/drugs/snowflake/overdose(mob/living/carbon/M, alien, removed, datum/reagents/holder)
+	if(prob(35))
+		M.vomit()
+		M.adjustToxLoss(5)
+		M.add_chemical_effect(CE_NEUROTOXIC, 1)
+	..()
+
 /singleton/reagent/drugs/impedrezene
 	name = "Impedrezene"
 	description = "Impedrezene is a narcotic that impedes one's ability by slowing down the higher brain cell functions."

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
@@ -141,7 +141,7 @@
 
 /singleton/reagent/drugs/snowflake/overdose(mob/living/carbon/M, alien, removed, datum/reagents/holder)
 	if(prob(35))
-		M.vomit()
+		M.add_chemical_effect(CE_EMETIC, M.chem_doses[type])
 		M.adjustToxLoss(5)
 		M.add_chemical_effect(CE_NEUROTOXIC, 1)
 	..()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drugs.dm
@@ -142,7 +142,6 @@
 /singleton/reagent/drugs/snowflake/overdose(mob/living/carbon/M, alien, removed, datum/reagents/holder)
 	if(prob(35))
 		M.add_chemical_effect(CE_EMETIC, M.chem_doses[type])
-		M.adjustToxLoss(5)
 		M.add_chemical_effect(CE_NEUROTOXIC, 1)
 	..()
 
@@ -298,7 +297,7 @@
 /singleton/reagent/drugs/colorspace/affect_blood(mob/living/carbon/M, alien, removed, datum/reagents/holder)
 	..()
 
-	var/drug_strength = 80 * power
+	var/drug_strength = 20 * power
 
 	if(alien == IS_SKRELL)
 		drug_strength *= 0.8

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -715,6 +715,12 @@
 	nicotine = REM * 0.1
 	taste_mult = 2
 
+/singleton/reagent/toxin/tobacco/srendarrs_hand
+	name = "S'rendarr's Hand"
+	description = "S'rendarr's Hand, known as Alyad'al S'rendarr to the tajara, originates from Adhomai. The nicotine-containing leaves are often dried out and stuffed into pipes or rolled in paper for smoking."
+	taste_description = "honeyed tobacco"
+	nicotine = 0.3
+
 /singleton/reagent/toxin/oracle
 	name = "Oracle"
 	description = "Oracle originates from Vysoka, where it is often chewed, or dried and smoked or snorted. This is a common variant."

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -236,6 +236,13 @@
 	required_reagents = list(/singleton/reagent/mercury = 1, /singleton/reagent/sugar = 1, /singleton/reagent/lithium = 1)
 	result_amount = 3
 
+/datum/chemical_reaction/snowflake
+	name = "Snowflake"
+	id = "snowflake"
+	result = /singleton/reagent/drugs/snowflake
+	required_reagents = list(/singleton/reagent/frostoil = 1, /singleton/reagent/fuel = 1, /singleton/reagent/sulfur = 1)
+	result_amount = 1
+
 /datum/chemical_reaction/cocaine
 	name = "Cocaine"
 	id = "cocaine"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -905,6 +905,13 @@
 	required_temperature_min = T0C + 621 //Mix reactants with 10u salt, then pour 30u of solution in one go into 30u of pyrosilicate. Pyrosilicate will be consumed; salt must be separated.
 	result_amount = 3
 
+/datum/chemical_reaction/colorspace
+	name = "Colorspace"
+	id = "colorspace"
+	result = /singleton/reagent/drugs/colorspace
+	required_reagents = list(/singleton/reagent/hydrazine = 1, /singleton/reagent/ethanol = 1, /singleton/reagent/silicon = 1)
+	result_amount = 1
+
 /* Solidification */
 
 /datum/chemical_reaction/phoronsolidification

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -909,7 +909,7 @@
 	name = "Colorspace"
 	id = "colorspace"
 	result = /singleton/reagent/drugs/colorspace
-	required_reagents = list(/singleton/reagent/hydrazine = 1, /singleton/reagent/ethanol = 1, /singleton/reagent/silicon = 1)
+	required_reagents = list(/singleton/reagent/hydrazine = 1, /singleton/reagent/alcohol = 1, /singleton/reagent/silicon = 1)
 	result_amount = 1
 
 /* Solidification */

--- a/html/changelogs/GeneralCamo - More Fantasy Drugs.yml
+++ b/html/changelogs/GeneralCamo - More Fantasy Drugs.yml
@@ -38,5 +38,6 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Added Snowflake, a recreational drug refined from frost oil, combined with sulfur and welding fuel."
+  - rscadd: "Added Snowflake, a recreational drug refined from frost oil, combined with sulfur and welding fuel. Ported from Polaris."
   - rscadd: "Added S'rendarr's Hand, a special variant of tobacco now found in Adhomian cigarettes."
+  - rscadd: "Added colorspace, a recreational drug that alters perception. Ported from Polaris."

--- a/html/changelogs/GeneralCamo - More Fantasy Drugs.yml
+++ b/html/changelogs/GeneralCamo - More Fantasy Drugs.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: GeneralCamo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added Snowflake, a recreational drug refined from frost oil, combined with sulfur and welding fuel."
+  - rscadd: "Added S'rendarr's Hand, a special variant of tobacco now found in Adhomian cigarettes."


### PR DESCRIPTION
This ports a few drugs from Polaris, as additional fantasy drugs. This was originally intended for #16773, but that PR quickly grew too massive for these to be reasonably reviewed.

In addition, Adhomian cigarettes now use a special subtype of tobacco, which is a sweeter and stronger variety. This was originally also intended for #16773, and has the blessing of the tajaran team (the taste description comes from them), but I honestly forgot to do it.