### PR TITLE
Remove light overlays from queue if force deleted

### DIFF
--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -40,6 +40,8 @@
 		T.lighting_overlay = null
 		T.luminosity = 1
 
+	SSlighting.overlay_queue -= src
+
 	return ..()
 
 // This is a macro PURELY so that the if below is actually readable.

--- a/html/changelogs/FluffyGhost-remove_light_overlays_from_queue_if_force_deleted.yml
+++ b/html/changelogs/FluffyGhost-remove_light_overlays_from_queue_if_force_deleted.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Lighting overlays are now removed from the queue immediately if they are force deleted, instead of leaving an hanging ref and wait for the subsystem to dereference us."


### PR DESCRIPTION
Lighting overlays are now removed from the queue immediately if they are force deleted, instead of leaving an hanging ref and wait for the subsystem to dereference us