### PR TITLE
Mob death signal mannequin ref clearing

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -146,6 +146,7 @@
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_main.dm"
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_movable.dm"
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_x_act.dm"
+#include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_living.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob_main.dm"
 #include "code\__DEFINES\dcs\signals\signals_object\signals_object.dm"
 #include "code\__HELPERS\_global_objects.dm"

--- a/code/__DEFINES/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/dcs/signals/signals_global.dm
@@ -8,3 +8,5 @@
 
 /// called post /obj/item initialize (obj/item/created_item)
 #define COMSIG_GLOB_ATOM_AFTER_POST_INIT "!atom_after_post_init"
+/// mob died somewhere : (mob/living, gibbed)
+#define COMSIG_GLOB_MOB_DEATH "!mob_death"

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -1,0 +1,2 @@
+///from base of mob/living/death(): (gibbed)
+#define COMSIG_LIVING_DEATH "living_death"

--- a/code/controllers/hooks-defs.dm
+++ b/code/controllers/hooks-defs.dm
@@ -17,13 +17,6 @@
 /hook/roundend
 
 /**
- * Death hook.
- * Called in death.dm when someone dies.
- * Parameters: var/mob/living/carbon/human, var/gibbed
- */
-/hook/death
-
-/**
  * Cloning hook.
  * Called in cloning.dm when someone is brought back by the wonders of modern science.
  * Parameters: var/mob/living/carbon/human

--- a/code/controllers/subsystems/mob.dm
+++ b/code/controllers/subsystems/mob.dm
@@ -10,7 +10,10 @@ SUBSYSTEM_DEF(mobs)
 	var/list/processing = list()
 
 	var/list/all_rats = list()	// Contains all *living* rats.
-	var/list/mannequins = list()	//Contains all mannequins used by character preview
+
+	///Contains all mannequins used by character preview
+	var/list/mob/living/carbon/human/dummy/mannequin/mannequins = list()
+
 	var/list/greatworms = list()
 	var/list/greatasses = list()
 

--- a/code/controllers/subsystems/statistics.dm
+++ b/code/controllers/subsystems/statistics.dm
@@ -37,6 +37,9 @@ SUBSYSTEM_DEF(statistics)
 GENERAL_PROTECT_DATUM(/datum/controller/subsystem/statistics)
 
 /datum/controller/subsystem/statistics/Initialize(timeofday)
+
+	RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, PROC_REF(something_died))
+
 	for (var/type in subtypesof(/datum/statistic) - list(/datum/statistic/numeric, /datum/statistic/grouped))
 		var/datum/statistic/S = new type
 		if (!S.name)
@@ -176,6 +179,12 @@ GENERAL_PROTECT_DATUM(/datum/controller/subsystem/statistics)
 		var/sql = "INSERT INTO ss13_feedback VALUES (null, Now(), \"[GLOB.round_id]\", \"[FV.get_variable()]\", [FV.get_value()], \"[FV.get_details()]\")"
 		var/DBQuery/query_insert = GLOB.dbcon.NewQuery(sql)
 		query_insert.Execute()
+
+/datum/controller/subsystem/statistics/proc/something_died(datum/source, mob/dead_mob, gibbed)
+	if(dead_mob.ckey)
+		IncrementGroupedStat("ckey_deaths", dead_mob.ckey)
+		if(gibbed)
+			IncrementSimpleStat("gibs")
 
 // Sanitize inputs to avoid SQL injection attacks
 /proc/sql_sanitize_text(var/text)

--- a/code/controllers/subsystems/virtual_reality.dm
+++ b/code/controllers/subsystems/virtual_reality.dm
@@ -37,10 +37,15 @@ SUBSYSTEM_DEF(virtualreality)
 /datum/controller/subsystem/virtualreality/proc/add_robot(var/mob/living/robot, var/network)
 	if(robot && network)
 		robots[network] += robot
+		RegisterSignal(robot, COMSIG_QDELETING, PROC_REF(remove_robot), TRUE)
 
 /datum/controller/subsystem/virtualreality/proc/remove_robot(var/mob/living/robot, var/network)
-	if(robot && network)
-		robots[network].Remove(robot)
+	if(robot)
+		if(network in robots) //This is because signals cannot pass parameters, and QDEL passes the force parameter here
+			robots[network].Remove(robot)
+		else
+			for(var/k in robots)
+				robots[k].Remove(robot)
 
 /datum/controller/subsystem/virtualreality/proc/add_bound(var/mob/living/silicon/bound, var/network)
 	if(bound && network)

--- a/code/datums/statistic.dm
+++ b/code/datums/statistic.dm
@@ -127,15 +127,6 @@
 	var/ckey = values[1]
 	. = "[ckey], with [values[ckey]] deaths."
 
-/hook/death/proc/increment_statistics(mob/living/carbon/human/H, gibbed)
-	. = TRUE
-	if (!H.ckey)
-		return
-
-	SSstatistics.IncrementGroupedStat("ckey_deaths", H.ckey)
-	if (gibbed)
-		SSstatistics.IncrementSimpleStat("gibs")
-
 /hook/clone/proc/increment_statistics(mob/living/carbon/human/H)
 	. = TRUE
 	if (!H.ckey)

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -104,6 +104,8 @@
 		if(hostile_in_sight.target_mob == src)
 			hostile_in_sight.target_mob = null
 
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_MOB_DEATH, src, gibbed)
+
 	return 1
 
 /mob/proc/set_respawn_time()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -58,8 +58,6 @@
 
 			remove_verb(src, /mob/living/carbon/proc/release_control)
 
-	callHook("death", list(src, gibbed))
-
 	if(!gibbed)
 		if(species.death_sound)
 			playsound(loc, species.death_sound, 80, 1, 1)

--- a/code/modules/projectiles/targeting/targeting_mob.dm
+++ b/code/modules/projectiles/targeting/targeting_mob.dm
@@ -28,6 +28,9 @@
 
 /mob/living/death(gibbed,deathmessage="seizes up and falls limp...")
 	. = ..()
+
+	SEND_SIGNAL(src, COMSIG_LIVING_DEATH, gibbed)
+
 	if(.)
 		stop_aiming(no_message=1)
 

--- a/code/unit_tests/create_and_destroy.dm
+++ b/code/unit_tests/create_and_destroy.dm
@@ -22,7 +22,6 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 	// Specific paths excluded
 	var/list/ignore = list(
 		//Never meant to be created, errors out the ass for mobcode reasons
-		/mob/living/carbon,
 		/atom/movable/typing_indicator,
 		//Internal organs
 		/obj/item/organ/external,

--- a/code/unit_tests/create_and_destroy.dm
+++ b/code/unit_tests/create_and_destroy.dm
@@ -21,7 +21,6 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 
 	// Specific paths excluded
 	var/list/ignore = list(
-		//Never meant to be created, errors out the ass for mobcode reasons
 		/atom/movable/typing_indicator,
 		//Internal organs
 		/obj/item/organ/external,

--- a/html/changelogs/FluffyGhost-mob_death_signal_mannequin_ref_clearing.yml
+++ b/html/changelogs/FluffyGhost-mob_death_signal_mannequin_ref_clearing.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed a reference that was kept on deleted mobs/mannequins."
+  - refactor: "Turned the hook for mob deaths into a signal."


### PR DESCRIPTION
Fixed a reference that was kept on deleted mobs/mannequins.
Turned the hook for mob deaths into a signal.