### PR TITLE
Vaurca Filter Ports for Antag Bases

### DIFF
--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Peppermint96
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Added vaurca filter ports to all off-station antag maps."

--- a/maps/sccv_horizon/sccv_horizon-4_centcomm.dmm
+++ b/maps/sccv_horizon/sccv_horizon-4_centcomm.dmm
@@ -21745,6 +21745,7 @@
 	name = "station blueprints";
 	pixel_y = -8
 	},
+/obj/item/clothing/mask/gas/vaurca/filter,
 /turf/unsimulated/floor{
 	icon_state = "wood_preview"
 	},
@@ -22428,6 +22429,7 @@
 	pixel_y = 9
 	},
 /obj/item/spacecash/c1,
+/obj/item/clothing/mask/gas/vaurca/filter,
 /turf/unsimulated/floor{
 	icon_state = "wood_preview"
 	},
@@ -25606,7 +25608,6 @@
 	},
 /area/antag/mercenary)
 "blf" = (
-/obj/machinery/acting/changer,
 /obj/machinery/light,
 /turf/unsimulated/floor{
 	icon_state = "freezer"
@@ -31877,6 +31878,8 @@
 /area/antag/ninja)
 "bBT" = (
 /obj/structure/table/standard,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
 /turf/unsimulated/floor,
 /area/antag/ninja)
 "bBU" = (
@@ -35458,6 +35461,23 @@
 /obj/structure/flora/grass/green,
 /turf/simulated/floor/holofloor/snow,
 /area/horizon/holodeck/source_snowfield)
+"dBp" = (
+/obj/machinery/shower{
+	pixel_y = 20
+	},
+/obj/structure/closet/crate,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/turf/unsimulated/floor{
+	icon_state = "freezer"
+	},
+/area/antag/mercenary)
 "dBL" = (
 /turf/simulated/wall/shuttle/unique/ccia{
 	icon_state = "8,0"
@@ -39312,6 +39332,15 @@
 /obj/structure/bookcase/libraryspawn/nonfiction,
 /turf/simulated/floor/wood/yew,
 /area/centcom/shared_dream)
+"rhV" = (
+/obj/machinery/shower{
+	pixel_y = 20
+	},
+/obj/machinery/acting/changer,
+/turf/unsimulated/floor{
+	icon_state = "freezer"
+	},
+/area/antag/mercenary)
 "rkm" = (
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/holofloor/grass{
@@ -39953,6 +39982,19 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/centcom/shared_dream)
+"tZQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/turf/unsimulated/floor,
+/area/antag/raider)
 "ubF" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 1
@@ -40427,6 +40469,14 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/shuttle/transport1)
+"vFR" = (
+/obj/structure/table/steel,
+/obj/item/clothing/mask/gas/vaurca/filter,
+/turf/unsimulated/floor{
+	icon = 'icons/turf/flooring/circuit.dmi';
+	icon_state = "bcircuit"
+	},
+/area/antag/wizard)
 "vFS" = (
 /obj/effect/floor_decal/spline/plain/corner,
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -88363,7 +88413,7 @@ aVE
 aWV
 aXf
 aXf
-aXf
+vFR
 aVE
 aVE
 aVE
@@ -90694,7 +90744,7 @@ bgg
 bgg
 bfp
 baX
-bjT
+rhV
 bjS
 blg
 baX
@@ -90951,7 +91001,7 @@ bgf
 bgf
 biD
 baX
-bjT
+dBp
 bjS
 blg
 baX
@@ -102520,7 +102570,7 @@ bkk
 btd
 blz
 bjB
-btj
+tZQ
 bny
 boD
 bny


### PR DESCRIPTION
Adds a box of vaurca filters to each of the off-station antag bases.

I assume these are the right ones? Requested fromhttps://forums.aurorastation.org/topic/19992-give-offship-antags-easy-access-to-filter-bits/.
