### PR TITLE
Fixes unselectable Sk'akh robes, again.

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/xeno/unathi.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/unathi.dm
@@ -459,7 +459,7 @@
 	gear_tweaks += new /datum/gear_tweak/path(cards)
 
 /datum/gear/uniform/unathi/skakh
-	display_name = "ska'kh robes selection"
+	display_name = "Skakh robes selection"
 	path = /obj/item/clothing/under/unathi/skakh
 	cost = 1
 	whitelisted = list(SPECIES_UNATHI)

--- a/html/changelogs/RustingWithYou - skakhfix2.yml
+++ b/html/changelogs/RustingWithYou - skakhfix2.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes unselectable Sk'akh robes in loadout."


### PR DESCRIPTION
The issue causing this is the presence of an apostrophe in the display name breaking encoding. Changes made on #18653 readded the apostrophe, meaning that this PR did not resolve the issue.

Fixes #18652, properly this time.