### PR TITLE
Unicode support in browser

### DIFF
--- a/code/__DEFINES/_macros.dm
+++ b/code/__DEFINES/_macros.dm
@@ -127,7 +127,7 @@
 #define from_target(target, receiver)                       target >> (receiver)
 #define to_file(file_entry, file_content)                   file_entry << file_content
 
-#define place_meta_charset(content) istext(content) ? "<meta charset=\"utf-8\">" + content : content
+#define (place_meta_charset(content) istext(content) ? "<meta charset=\"utf-8\">" + (content) : (content))
 
 #define legacy_chat(target, message)                        to_target(target, message)
 #define to_world(message)                                   to_chat(world, message)

--- a/code/__DEFINES/_macros.dm
+++ b/code/__DEFINES/_macros.dm
@@ -127,7 +127,7 @@
 #define from_target(target, receiver)                       target >> (receiver)
 #define to_file(file_entry, file_content)                   file_entry << file_content
 
-#define (place_meta_charset(content) istext(content) ? "<meta charset=\"utf-8\">" + (content) : (content))
+#define place_meta_charset(content) (istext(content) ? "<meta charset=\"utf-8\">" + (content) : (content))
 
 #define legacy_chat(target, message)                        to_target(target, message)
 #define to_world(message)                                   to_chat(world, message)

--- a/code/__DEFINES/_macros.dm
+++ b/code/__DEFINES/_macros.dm
@@ -125,7 +125,7 @@
 /// General I/O helpers
 #define to_target(target, payload)                          target << (payload)
 #define from_target(target, receiver)                       target >> (receiver)
-#define to_file(file_entry, file_content)					file_entry << file_content
+#define to_file(file_entry, file_content)                   file_entry << file_content
 
 #define place_meta_charset(content) istext(content) ? "<meta charset=\"utf-8\">" + content : content
 

--- a/code/__DEFINES/_macros.dm
+++ b/code/__DEFINES/_macros.dm
@@ -127,10 +127,7 @@
 #define from_target(target, receiver)                       target >> (receiver)
 #define to_file(file_entry, file_content)					file_entry << file_content
 
-/proc/place_meta_charset(content)
-	if(istext(content))
-		content = "<meta charset=\"utf-8\">" + content
-	return content
+#define place_meta_charset(content) istext(content) ? "<meta charset=\"utf-8\">" + content : content
 
 #define legacy_chat(target, message)                        to_target(target, message)
 #define to_world(message)                                   to_chat(world, message)

--- a/code/__DEFINES/_macros.dm
+++ b/code/__DEFINES/_macros.dm
@@ -125,13 +125,18 @@
 /// General I/O helpers
 #define to_target(target, payload)                          target << (payload)
 #define from_target(target, receiver)                       target >> (receiver)
-#define to_file(file_entry, file_content)                   file_entry << file_content
+#define to_file(file_entry, file_content)
+
+/proc/place_meta_charset(content)
+	if(istext(content))
+		content = "<meta charset=\"utf-8\">" + content
+	return content
 
 #define legacy_chat(target, message)                        to_target(target, message)
 #define to_world(message)                                   to_chat(world, message)
 #define sound_to(target, sound)                             to_target(target, sound)
 #define to_save(handle, value)                              to_target(handle, value) //semantics postport: what did they mean by this
-#define show_browser(target, browser_content, browser_name) to_target(target, browse(browser_content, browser_name))
+#define show_browser(target, browser_content, browser_name) to_target(target, browse(place_meta_charset(browser_content), browser_name))
 #define send_rsc(target, content, title)                    to_target(target, browse_rsc(content, title))
 #define send_output(target, msg, control)                   to_target(target, output(msg, control))
 #define send_link(target, url)                              to_target(target, link(url))

--- a/code/__DEFINES/_macros.dm
+++ b/code/__DEFINES/_macros.dm
@@ -125,7 +125,7 @@
 /// General I/O helpers
 #define to_target(target, payload)                          target << (payload)
 #define from_target(target, receiver)                       target >> (receiver)
-#define to_file(file_entry, file_content)
+#define to_file(file_entry, file_content)					file_entry << file_content
 
 /proc/place_meta_charset(content)
 	if(istext(content))

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -78,7 +78,7 @@
 	return {"<!DOCTYPE html>
 <html>
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+	<meta http-equiv="Content-Type" content="text/html; utf-8">
 	<head>
 		[head_content]
 	</head>

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -988,7 +988,7 @@ var/list/obj/machinery/newscaster/allCasters = list()
 
 		dat+="<BR><HR><div align='center'>[src.curr_page+1]</div>"
 
-		human_user << browse(dat, "window=newspaper_main;size=300x400")
+		show_browser(human_user, dat, "window=newspaper_main;size=300x400")
 		onclose(human_user, "newspaper_main")
 	else
 		to_chat(user, "The paper is full of intelligible symbols!")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -339,7 +339,7 @@ var/global/enabled_spooking = 0
 		dat += "<A href='?src=\ref[src];add_player_info=[key]'>Add Comment</A><br>"
 
 		dat += "</body></html>"
-		usr << browse(dat, "window=adminplayerinfo;size=480x480")
+		show_browser(usr, dat, "window=adminplayerinfo;size=480x480")
 	else
 		show_notes_sql(key)
 

--- a/code/modules/admin/player_notes_sql.dm
+++ b/code/modules/admin/player_notes_sql.dm
@@ -176,7 +176,7 @@
 			dat += "<tr><td colspan='4' bgcolor='white'>&nbsp</td></tr>"
 
 	dat += "</table>"
-	usr << browse(dat,"window=lookupnotes;size=900x500")
+	show_browser(usr, dat, "window=lookupnotes;size=900x500")
 
 /proc/show_player_info_discord(var/ckey)
 	if (!ckey)

--- a/code/modules/admin/verbs/warning.dm
+++ b/code/modules/admin/verbs/warning.dm
@@ -201,7 +201,7 @@
 		dat += "</tr>"
 
 	dat += "</table>"
-	usr << browse(dat, "window=mywarnings;size=900x500")
+	show_browser(usr, dat, "window=mywarnings;size=900x500")
 
 /*
  * A proc for acknowledging a warning
@@ -410,7 +410,7 @@
 
 		dat +="</table>"
 
-	usr << browse(dat, "window=lookupwarns;size=900x500")
+	show_browser(usr, dat, "window=lookupwarns;size=900x500")
 	feedback_add_details("admin_verb","WARN-LKUP")
 
 //Admin Proc to add a new User Notification

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -367,7 +367,7 @@ nanoui is used to open and update nano browser uis
 	return {"
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
-	<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<head>
 		<script type='text/javascript'>
 			function receiveUpdateData(jsonString)

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -134,7 +134,14 @@
 	else if(istype(pages[page], /obj/item/photo))
 		var/obj/item/photo/P = W
 		send_rsc(user, P.img, "tmp_photo.png")
-		user << browse(dat + "<html><head><title>[P.name]</title></head>" + "<body style='overflow:hidden'>" + "<div> <img src='tmp_photo.png' width = '180'" + "[P.scribble ? "<div> Written on the back:<br><i>[P.scribble]</i>" : null]" + "</body></html>", "window=[name]")
+
+		dat += "<html><head><title>[P.name]</title></head>" \
+		+ "<body style='overflow:hidden'>" \
+		+ "<div> <img src='tmp_photo.png' width = '180'" \
+		+ "[P.scribble ? "<div> Written on the back:<br><i>[P.scribble]</i>" : null]" \
+		+ "</body></html>"
+
+		show_browser(user, dat, "window=[name]")
 
 /obj/item/paper_bundle/attack_self(mob/user as mob)
 	src.show_content(user)
@@ -178,7 +185,7 @@
 			var/obj/A = pages[page]
 			playsound(src.loc, /singleton/sound_category/page_sound, 50, 1)
 			if(A.type != P.type)
-				usr << browse(null, "window=[name]")
+				show_browser(usr, null, "window=[name]")
 	if(href_list["prev_page"])
 		if(page > 1)
 			var/obj/P = pages[page]
@@ -186,7 +193,7 @@
 			var/obj/A = pages[page]
 			playsound(src.loc, /singleton/sound_category/page_sound, 50, 1)
 			if(A.type != P.type)
-				usr << browse(null, "window=[name]")
+				show_browser(usr, null, "window=[name]")
 	if(href_list["remove"])
 		var/obj/item/W = pages[page]
 		usr.put_in_hands(W)
@@ -204,7 +211,7 @@
 			else
 				usr.put_in_hands(P)
 			usr.unset_machine(src)
-			usr << browse(null, "window=[name]")
+			show_browser(usr, null, "window=[name]")
 			qdel(src)
 			return
 

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -68,7 +68,12 @@ var/global/photo_count = 0
 
 /obj/item/photo/proc/show(mob/user as mob)
 	send_rsc(user, img, "tmp_photo_[id].png")
-	user << browse("<html><head><title>[name]</title></head>" + "<body style='overflow:hidden;margin:0;text-align:center'>" + "<img src='tmp_photo_[id].png' width='[64*photo_size]' style='-ms-interpolation-mode:nearest-neighbor' />" + "[scribble ? "<br>Written on the back:<br><i>[scribble]</i>" : ""]" + "</body></html>", "window=book;size=[64*photo_size]x[scribble ? 400 : 64*photo_size]")
+	var/dat = "<html><head><title>[name]</title></head>" \
+		+ "<body style='overflow:hidden;margin:0;text-align:center'>" \
+		+ "<img src='tmp_photo_[id].png' width='[64*photo_size]' style='-ms-interpolation-mode:nearest-neighbor' />" \
+		+ "[scribble ? "<br>Written on the back:<br><i>[scribble]</i>" : ""]" \
+		+ "</body></html>"
+	show_browser(user, dat, "window=book;size=[64*photo_size]x[scribble ? 400 : 64*photo_size]")
 	onclose(user, "[name]")
 	return
 

--- a/html/changelogs/unicode-in-browser-changelog.yml
+++ b/html/changelogs/unicode-in-browser-changelog.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: SidVeld
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added Unicode support in browser windows."


### PR DESCRIPTION
# Unicode support in browser

Adds Unicode support to browser windows. You should open the window via `show_browser` macro. Otherwise, Cyrillic or other Unicode characters may not work.

The solution is taken from Nebula.

## Screenshots

### Pre-changes

![изображение](https://github.com/Aurorastation/Aurora.3/assets/22749671/e72bf1ea-50dc-4e57-a763-c27904dacd3b)

![изображение](https://github.com/Aurorastation/Aurora.3/assets/22749671/27e7e26b-fe05-426a-94f3-ad47c15be0c3)


### Post-changes

![изображение](https://github.com/Aurorastation/Aurora.3/assets/22749671/4be837bb-81ea-408e-976f-f55f691f4fa4)

![изображение](https://github.com/Aurorastation/Aurora.3/assets/22749671/87c8d99f-6416-4118-97b6-dd9f414f3e37)

![изображение](https://github.com/Aurorastation/Aurora.3/assets/22749671/c6036d9f-cbd4-496e-8b80-a0da5e67a013)

![изображение](https://github.com/Aurorastation/Aurora.3/assets/22749671/17dd1117-5faa-47c8-951d-53eeb168e4dc)
