### PR TITLE
Slimes can't eat bots such as cleanbots

### DIFF
--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -15,7 +15,7 @@
 	Feedon(M)
 
 /mob/living/carbon/slime/proc/invalidFeedTarget(var/mob/living/M)
-	if(!M || !istype(M))
+	if(!M || !istype(M) || istype(M, /mob/living/bot/cleanbot))
 		return "This subject is incompatible.."
 	if(istype(M, /mob/living/carbon/slime)) // No cannibalism... yet
 		return "I cannot feed on other slimes..."

--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -15,7 +15,7 @@
 	Feedon(M)
 
 /mob/living/carbon/slime/proc/invalidFeedTarget(var/mob/living/M)
-	if(!M || !istype(M) || istype(M, /mob/living/bot/cleanbot))
+	if(!M || !istype(M) || istype(M, /mob/living/bot))
 		return "This subject is incompatible.."
 	if(istype(M, /mob/living/carbon/slime)) // No cannibalism... yet
 		return "I cannot feed on other slimes..."

--- a/html/changelogs/AlaunusLux - slimes-cant-eat-cleanbots.yml
+++ b/html/changelogs/AlaunusLux - slimes-cant-eat-cleanbots.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: AlaunusLux
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Slimes will no longer target cleanbots."

--- a/html/changelogs/AlaunusLux - slimes-cant-eat-cleanbots.yml
+++ b/html/changelogs/AlaunusLux - slimes-cant-eat-cleanbots.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Slimes will no longer target cleanbots."
+  - tweak: "Slimes will no longer try to feed on bots such as cleanbots."


### PR DESCRIPTION
Slimes will no longer target cleanbots or similar bots. 

As it was, slimes spammed the chat with attack logs when they came near Dr. Clean B. Ot.