### PR TITLE
2/3rds -> 3/5ths majority to transfer.

### DIFF
--- a/code/datums/votes/crew_transfer.dm
+++ b/code/datums/votes/crew_transfer.dm
@@ -60,7 +60,7 @@ GLOBAL_VAR(last_transfer_vote)
 		result = list("Continue The Round")
 
 	if(round(get_round_duration() / 36000)+12 <= 14)
-		to_world(SPAN_VOTE("Majority voting rule in effect. 2/3rds majority needed to initiate transfer."))
+		to_world(SPAN_VOTE("Majority voting rule in effect. 3/5ths majority needed to initiate transfer."))
 
 	return result
 

--- a/code/datums/votes/crew_transfer.dm
+++ b/code/datums/votes/crew_transfer.dm
@@ -49,7 +49,7 @@ GLOBAL_VAR(last_transfer_vote)
 	var/factor = 0.5
 	switch(get_round_duration() / (10 * 60)) // minutes
 		if(0 to 180) //Up to 3 hours
-			factor = 0.67 //2/3rd, rounded up from 0.6 periodic
+			factor = 0.67 //3/5ths majority - (5-3)/3 =~ 0.67
 		else
 			factor = 1.0 //Equal weight
 

--- a/html/changelogs/supermajority.yml
+++ b/html/changelogs/supermajority.yml
@@ -1,0 +1,6 @@
+author: Pirouette
+
+delete-after: True
+
+changes:
+  - spellcheck: "Fixed the 2/3rds majority transfer description to say 3/5ths majority, in line with intended behavior."


### PR DESCRIPTION
**This is not changing the behavior. This is only accurately redescribing it.**

Under the current math, a 3-for 2-against vote would result in a transfer, as would an 18-for and 12-against, or a 261-for, 174-against. None of these are a 2/3rds majority; all of these are a 3/5ths majority. I was told this is the intended behavior desired by Head Developers by a developer on the Discord [here](https://discord.com/channels/157516682288562176/302201161044328450/1218431327829885059) so I thought it best to change the language rather than the math.