### PR TITLE
OOC notes rewrite and examine boxes in HUD's output

### DIFF
--- a/code/__DEFINES/_macros.dm
+++ b/code/__DEFINES/_macros.dm
@@ -32,6 +32,9 @@
 
 /// Adds a generic box around whatever message you're sending in chat. Really makes things stand out.
 #define EXAMINE_BLOCK(str) ("<div class='examine_block'>" + str + "</div>")
+#define EXAMINE_BLOCK_BLUE(str) ("<div class='examine_block--blue'>" + str + "</div>")
+#define EXAMINE_BLOCK_RED(str) ("<div class='examine_block--red'>" + str + "</div>")
+#define EXAMINE_BLOCK_DEEP_CYAN(str) ("<div class='examine_block--deep-cyan'>" + str + "</div>")
 
 #define FONT_SIZE_SMALL "10px"
 #define FONT_SIZE_NORMAL "13px"

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -306,7 +306,7 @@
 		var/new_metadata = sanitize(
 			input(
 				user,
-				"Enter any information you'd like others to see, such as Roleplay-preferences:",
+				"Enter any information you'd like others to see, such as roleplay preferences.",
 				"Game Preference",
 				html_decode(pref.metadata)
 			) as message|null,
@@ -361,8 +361,8 @@
 		if (CanUseTopic(user))
 			var/user_choice = alert(
 				user,
-				"Are you sure you wish to clear ooc notes of this character?",
-				"Clear OOC notes Confirmation",
+				"Are you sure you wish to clear this character's OOC notes?",
+				"Clear OOC Notes Confirmation",
 				"Yes",
 				"No"
 			)

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -198,7 +198,8 @@
 				dat += "<b>Serial Number:</b> [pref.machine_serial_number] (<a href='?src=\ref[src];namehelp=1'>?</a>)<br>"
 				dat += "<b>Ownership Status:</b> [pref.machine_ownership_status] (<a href='?src=\ref[src];namehelp=1'>?</a>)<br>"
 	if(GLOB.config.allow_Metadata)
-		dat += "<b>OOC Notes:</b> <a href='?src=\ref[src];metadata=1'> Edit </a><br>"
+		dat += "<b>OOC Notes:</b> <a href='?src=\ref[src];metadata=1'> Edit </a>" \
+			+ "<a href='?src=\ref[src];clear_metadata=1'>Clear</a>" + "<br>"
 
 	. = dat.Join()
 
@@ -302,10 +303,18 @@
 		return TOPIC_REFRESH
 
 	else if(href_list["metadata"])
-		var/new_metadata = sanitize(input(user, "Enter any information you'd like others to see, such as Roleplay-preferences:", "Game Preference" , pref.metadata) as message|null)
+		var/new_metadata = sanitize(
+			input(
+				user,
+				"Enter any information you'd like others to see, such as Roleplay-preferences:",
+				"Game Preference",
+				html_decode(pref.metadata)
+			) as message|null,
+			MAX_MESSAGE_LEN
+		)
 		if(new_metadata && CanUseTopic(user))
-			pref.metadata = sanitize(new_metadata)
-			return TOPIC_REFRESH
+			pref.metadata = new_metadata
+		return TOPIC_REFRESH
 
 	else if(href_list["ipc_tag"])
 		if(!pref.can_edit_ipc_tag)
@@ -346,6 +355,22 @@
 		var/new_ownership_status = input(user, "Choose your IPC's ownership status.", "IPC Ownership Status") as null|anything in ownership_options
 		if(new_ownership_status && CanUseTopic(user))
 			pref.machine_ownership_status = new_ownership_status
+			return TOPIC_REFRESH
+
+	else if (href_list["clear_metadata"])
+		if (CanUseTopic(user))
+			var/user_choice = alert(
+				user,
+				"Are you sure you wish to clear ooc notes of this character?",
+				"Clear OOC notes Confirmation",
+				"Yes",
+				"No"
+			)
+
+			if (user_choice == "No")
+				return TOPIC_NOACTION
+
+			pref.metadata = ""
 			return TOPIC_REFRESH
 
 	return ..()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -390,6 +390,9 @@
 
 	if(print_flavor_text()) msg += "[print_flavor_text()]\n"
 
+	if (GLOB.config.allow_Metadata && client.prefs.metadata)
+		msg += "<span class='deadsay'>OOC notes:</span> <a href='?src=\ref[src];metadata=1'>\[View\]</a>\n"
+
 	msg += "</span>"
 
 	if(src in GLOB.intent_listener)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -391,7 +391,7 @@
 	if(print_flavor_text()) msg += "[print_flavor_text()]\n"
 
 	if (GLOB.config.allow_Metadata && client.prefs.metadata)
-		msg += "<span class='deadsay'>OOC notes:</span> <a href='?src=\ref[src];metadata=1'>\[View\]</a>\n"
+		msg += "<span class='deadsay'>OOC Notes:</span> <a href='?src=\ref[src];metadata=1'>\[View\]</a>\n"
 
 	msg += "</span>"
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -576,7 +576,9 @@
 									U.handle_regular_hud_updates()
 
 			if(!modified)
-				to_chat(usr, SPAN_WARNING("Unable to locate a data core entry for this person."))
+				to_chat(
+					usr, EXAMINE_BLOCK_RED(SPAN_WARNING("Unable to locate a data core entry for this person."))
+				)
 
 	if (href_list["secrecord"])
 		if(hasHUD(usr,"security"))
@@ -591,15 +593,18 @@
 			var/datum/record/general/R = SSrecords.find_record("name", perpname)
 			if(istype(R) && istype(R.security))
 				if(hasHUD(usr,"security"))
-					to_chat(usr, "<b>Name:</b> [R.name]")
-					to_chat(usr, "<b>Criminal Status:</b> [R.security.criminal]")
-					to_chat(usr, "<b>Crimes:</b> [R.security.crimes]")
-					to_chat(usr, "<b>Notes:</b> [R.security.notes]")
-					to_chat(usr, "<a href='?src=\ref[src];secrecordComment=`'>\[View Comment Log\]</a>")
+					var/message = "<b>Information</b>\n\n" \
+						+ "<b>Criminal Status:</b> [R.security.criminal]\n" \
+						+ "<b>Crimes:</b> [R.security.crimes]\n" \
+						+ "<b>Notes:</b> [R.security.notes]\n" \
+						+ "<a href='?src=\ref[src];secrecordComment=`'>\[View Comment Log\]</a>"
+					to_chat(usr, EXAMINE_BLOCK_RED(message))
 					read = 1
 
 			if(!read)
-				to_chat(usr, SPAN_WARNING("Unable to locate a data core entry for this person."))
+				to_chat(
+					usr, EXAMINE_BLOCK_RED(SPAN_WARNING("Unable to locate a data core entry for this person."))
+				)
 
 	if (href_list["secrecordComment"])
 		if(hasHUD(usr,"security"))
@@ -614,16 +619,20 @@
 			var/datum/record/general/R = SSrecords.find_record("name", perpname)
 			if(istype(R) && istype(R.security))
 				if(hasHUD(usr, "security"))
+					var/message = "<b>Comments: [name]</b>\n\n"
 					read = 1
 					if(R.security.comments.len > 0)
 						for(var/comment in R.security.comments)
-							to_chat(usr, comment)
+							message += comment + "\n\n"
 					else
-						to_chat(usr, "No comments found")
-					to_chat(usr, "<a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a>")
+						message += "No comments found.\n"
+					message += "<a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a>"
+					to_chat(usr, EXAMINE_BLOCK_RED(message))
 
 			if(!read)
-				to_chat(usr, SPAN_WARNING("Unable to locate a data core entry for this person."))
+				to_chat(
+					usr, EXAMINE_BLOCK_RED(SPAN_WARNING("Unable to locate a data core entry for this person."))
+				)
 
 	if (href_list["secrecordadd"])
 		if(hasHUD(usr,"security"))
@@ -675,7 +684,9 @@
 								U.handle_regular_hud_updates()
 
 			if(!modified)
-				to_chat(usr, SPAN_WARNING("Unable to locate a data core entry for this person."))
+				to_chat(
+					usr, EXAMINE_BLOCK_DEEP_CYAN(SPAN_WARNING("Unable to locate a data core entry for this person."))
+				)
 
 	if (href_list["medrecord"])
 		if(hasHUD(usr,"medical"))
@@ -690,15 +701,19 @@
 			var/datum/record/general/R = SSrecords.find_record("name", perpname)
 			if(istype(R) && istype(R.medical))
 				if(hasHUD(usr, "medical"))
-					to_chat(usr, "<b>Name:</b> [R.name]	<b>Blood Type:</b> [R.medical.blood_type]")
-					to_chat(usr, "<b>DNA:</b> [R.medical.blood_dna]")
-					to_chat(usr, "<b>Disabilities:</b> [R.medical.disabilities]")
-					to_chat(usr, "<b>Notes:</b> [R.medical.notes]")
-					to_chat(usr, "<a href='?src=\ref[src];medrecordComment=`'>\[View Comment Log\]</a>")
+					var/message = "<b>Medical information</b>\n\n" \
+						+ "<b>Name:</b> [R.name] <b>Blood Type:</b> [R.medical.blood_type]\n" \
+						+ "<b>DNA:</b> [R.medical.blood_dna]\n" \
+						+ "<b>Disabilities:</b> [R.medical.disabilities]\n" \
+						+ "<b>Notes:</b> [R.medical.notes]\n" \
+						+ "<a href='?src=\ref[src];medrecordComment=`'>\[View Comment Log\]</a>"
+					to_chat(usr, EXAMINE_BLOCK_DEEP_CYAN(message))
 					read = 1
 
 			if(!read)
-				to_chat(usr, SPAN_WARNING("Unable to locate a data core entry for this person."))
+				to_chat(
+					usr, EXAMINE_BLOCK_DEEP_CYAN(SPAN_WARNING("Unable to locate a data core entry for this person."))
+				)
 
 	if (href_list["medrecordComment"])
 		if(hasHUD(usr,"medical"))
@@ -713,16 +728,20 @@
 			var/datum/record/general/R = SSrecords.find_record("name", perpname)
 			if(istype(R) && istype(R.medical))
 				if(hasHUD(usr, "medical"))
+					var/message = "<b>Medical comments: [name]</b>\n\n"
 					read = 1
 					if(R.medical.comments.len > 0)
 						for(var/comment in R.medical.comments)
-							to_chat(usr, comment)
+							message += comment + "\n\n"
 					else
-						to_chat(usr, "No comments found")
-					to_chat(usr, "<a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>")
+						message += "No comments found.\n"
+					message += "<a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>"
+					to_chat(usr, EXAMINE_BLOCK_DEEP_CYAN(message))
 
 			if(!read)
-				to_chat(usr, SPAN_WARNING("Unable to locate a data core entry for this person."))
+				to_chat(
+					usr, EXAMINE_BLOCK_DEEP_CYAN(SPAN_WARNING("Unable to locate a data core entry for this person."))
+				)
 
 	if (href_list["medrecordadd"])
 		if(hasHUD(usr,"medical"))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -791,6 +791,15 @@
 				flavor_texts[href_list["flavor_change"]] = msg
 				set_flavor()
 				return
+
+	if (href_list["metadata"])
+		var/message = "<b>OOC notes: [name]</b>" \
+			+ "\n\n" \
+			+ client.prefs.metadata \
+			+ "\n\n" \
+			+ SPAN_WARNING("Remember, this is ooc information.")
+		to_chat(usr, EXAMINE_BLOCK(message))
+
 	..()
 	return
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -576,9 +576,7 @@
 									U.handle_regular_hud_updates()
 
 			if(!modified)
-				to_chat(
-					usr, EXAMINE_BLOCK_RED(SPAN_WARNING("Unable to locate a data core entry for this person."))
-				)
+				to_chat(usr, EXAMINE_BLOCK_RED(SPAN_WARNING("Unable to locate a data core entry for this person.")))
 
 	if (href_list["secrecord"])
 		if(hasHUD(usr,"security"))
@@ -593,7 +591,7 @@
 			var/datum/record/general/R = SSrecords.find_record("name", perpname)
 			if(istype(R) && istype(R.security))
 				if(hasHUD(usr,"security"))
-					var/message = "<b>Information</b>\n\n" \
+					var/message = "<b>Security Records: [R.name]</b>\n\n" \
 						+ "<b>Criminal Status:</b> [R.security.criminal]\n" \
 						+ "<b>Crimes:</b> [R.security.crimes]\n" \
 						+ "<b>Notes:</b> [R.security.notes]\n" \
@@ -602,9 +600,7 @@
 					read = 1
 
 			if(!read)
-				to_chat(
-					usr, EXAMINE_BLOCK_RED(SPAN_WARNING("Unable to locate a data core entry for this person."))
-				)
+				to_chat(usr, EXAMINE_BLOCK_RED(SPAN_WARNING("Unable to locate a data core entry for this person.")))
 
 	if (href_list["secrecordComment"])
 		if(hasHUD(usr,"security"))
@@ -619,20 +615,18 @@
 			var/datum/record/general/R = SSrecords.find_record("name", perpname)
 			if(istype(R) && istype(R.security))
 				if(hasHUD(usr, "security"))
-					var/message = "<b>Comments: [name]</b>\n\n"
+					var/message = "<b>Security Record Comments: [name]</b>\n\n"
 					read = 1
 					if(R.security.comments.len > 0)
 						for(var/comment in R.security.comments)
 							message += comment + "\n\n"
 					else
 						message += "No comments found.\n"
-					message += "<a href='?src=\ref[src];secrecordadd=`'>\[Add comment\]</a>"
+					message += "<a href='?src=\ref[src];secrecordadd=`'>\[Add Comment\]</a>"
 					to_chat(usr, EXAMINE_BLOCK_RED(message))
 
 			if(!read)
-				to_chat(
-					usr, EXAMINE_BLOCK_RED(SPAN_WARNING("Unable to locate a data core entry for this person."))
-				)
+				to_chat(usr, EXAMINE_BLOCK_RED(SPAN_WARNING("Unable to locate a data core entry for this person.")))
 
 	if (href_list["secrecordadd"])
 		if(hasHUD(usr,"security"))
@@ -684,9 +678,7 @@
 								U.handle_regular_hud_updates()
 
 			if(!modified)
-				to_chat(
-					usr, EXAMINE_BLOCK_DEEP_CYAN(SPAN_WARNING("Unable to locate a data core entry for this person."))
-				)
+				to_chat(usr, EXAMINE_BLOCK_DEEP_CYAN(SPAN_WARNING("Unable to locate a data core entry for this person.")))
 
 	if (href_list["medrecord"])
 		if(hasHUD(usr,"medical"))
@@ -701,7 +693,7 @@
 			var/datum/record/general/R = SSrecords.find_record("name", perpname)
 			if(istype(R) && istype(R.medical))
 				if(hasHUD(usr, "medical"))
-					var/message = "<b>Medical information</b>\n\n" \
+					var/message = "<b>Medical Records: [R.name]</b>\n\n" \
 						+ "<b>Name:</b> [R.name] <b>Blood Type:</b> [R.medical.blood_type]\n" \
 						+ "<b>DNA:</b> [R.medical.blood_dna]\n" \
 						+ "<b>Disabilities:</b> [R.medical.disabilities]\n" \
@@ -711,9 +703,7 @@
 					read = 1
 
 			if(!read)
-				to_chat(
-					usr, EXAMINE_BLOCK_DEEP_CYAN(SPAN_WARNING("Unable to locate a data core entry for this person."))
-				)
+				to_chat(usr, EXAMINE_BLOCK_DEEP_CYAN(SPAN_WARNING("Unable to locate a data core entry for this person.")))
 
 	if (href_list["medrecordComment"])
 		if(hasHUD(usr,"medical"))
@@ -728,20 +718,18 @@
 			var/datum/record/general/R = SSrecords.find_record("name", perpname)
 			if(istype(R) && istype(R.medical))
 				if(hasHUD(usr, "medical"))
-					var/message = "<b>Medical comments: [name]</b>\n\n"
+					var/message = "<b>Medical Record Comments: [name]</b>\n\n"
 					read = 1
 					if(R.medical.comments.len > 0)
 						for(var/comment in R.medical.comments)
 							message += comment + "\n\n"
 					else
 						message += "No comments found.\n"
-					message += "<a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>"
+					message += "<a href='?src=\ref[src];medrecordadd=`'>\[Add Comment\]</a>"
 					to_chat(usr, EXAMINE_BLOCK_DEEP_CYAN(message))
 
 			if(!read)
-				to_chat(
-					usr, EXAMINE_BLOCK_DEEP_CYAN(SPAN_WARNING("Unable to locate a data core entry for this person."))
-				)
+				to_chat(usr, EXAMINE_BLOCK_DEEP_CYAN(SPAN_WARNING("Unable to locate a data core entry for this person.")))
 
 	if (href_list["medrecordadd"])
 		if(hasHUD(usr,"medical"))
@@ -812,11 +800,11 @@
 				return
 
 	if (href_list["metadata"])
-		var/message = "<b>OOC notes: [name]</b>" \
+		var/message = "<b>OOC Notes: [name]</b>" \
 			+ "\n\n" \
 			+ client.prefs.metadata \
 			+ "\n\n" \
-			+ SPAN_WARNING("Remember, this is ooc information.")
+			+ SPAN_WARNING("Remember, this is OOC information.")
 		to_chat(usr, EXAMINE_BLOCK(message))
 
 	..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -569,22 +569,6 @@ default behaviour is:
 /mob/living/proc/UpdateDamageIcon()
 	return
 
-
-/mob/living/proc/Examine_OOC()
-	set name = "Examine Meta-Info (OOC)"
-	set category = "OOC"
-	set src in view()
-
-	if(GLOB.config.allow_Metadata)
-		if(client)
-			to_chat(usr, "[src]'s Metainfo:<br>[client.prefs.metadata]")
-		else
-			to_chat(usr, "[src] does not have any stored infomation!")
-	else
-		to_chat(usr, "OOC Metadata is not supported by this server!")
-
-	return
-
 /mob/living/Move(a, b, flag)
 	if (buckled_to)
 		return

--- a/html/changelogs/sidveld-ooc-notes-changelog.yml
+++ b/html/changelogs/sidveld-ooc-notes-changelog.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: SidVeld
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added ability to view ooc notes in examine."
+  - tweak: "Medical and Security huds messages wrapped into boxes."

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -614,6 +614,21 @@ em {
   border: 1px solid #a4bad6;
   margin: 0.5em;
   padding: 0.5em 0.75em;
+
+  &--blue {
+    @extend .examine_block;
+    border-color: #3c5dc0;
+  }
+
+  &--red {
+    @extend .examine_block;
+    border-color: #e21111;
+  }
+
+  &--deep-cyan {
+    @extend .examine_block;
+    border-color: #0f7e62;
+  }
 }
 
 .examine_block .icon {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -628,6 +628,21 @@ h2.alert {
   border: 1px solid #111a27;
   margin: 0.5em;
   padding: 0.5em 0.75em;
+
+  &--blue {
+    @extend .examine_block;
+    border-color: #3c5dc0;
+  }
+
+  &--red {
+    @extend .examine_block;
+    border-color: #a30000;
+  }
+
+  &--deep-cyan {
+    @extend .examine_block;
+    border-color: #0a5c47;
+  }
 }
 
 .examine_block .icon {


### PR DESCRIPTION
# OOC notes rewrite and examine boxes in HUD's output

This pull request contains two changes.

## OCC Notes: return

Gives you the ability to view OOC notes when examining a character. Requires `ALLOW_METADATA` to be enabled in the config.

![изображение](https://github.com/Aurorastation/Aurora.3/assets/22749671/c8221dde-669a-429a-ae38-bbe40db48ba2)

## Examine boxes in Huds

I liked the examine boxes so much I wanted to use them somewhere else. I created three new subclasses of examine boxes and use them in med/sec hud's messages. I hope you enjoy it.

### Security

![изображение](https://github.com/Aurorastation/Aurora.3/assets/22749671/47aa6ea0-c71f-4d11-acba-ff6817fb6dc7)

### Medical

![изображение](https://github.com/Aurorastation/Aurora.3/assets/22749671/b7b59cd8-f619-465c-959b-57019164bee9)
