### PR TITLE
Fixes pre-3 hour transfer vote factor, so it correctly checks for a 2/3rds majority to transfer

### DIFF
--- a/code/datums/votes/crew_transfer.dm
+++ b/code/datums/votes/crew_transfer.dm
@@ -45,11 +45,12 @@ GLOBAL_VAR(last_transfer_vote)
 /datum/vote/crewtransfer/get_vote_result(list/non_voters)
 	SHOULD_CALL_PARENT(FALSE)
 
-	//Calculate the factor based on the duration in minutes
-	var/factor = 0.5
+	// Calculate the factor based on the duration in minutes
+	// Formula for an x/y majority: (y-x)/x
+	var/factor = 1.0
 	switch(get_round_duration() / (10 * 60)) // minutes
 		if(0 to 180) //Up to 3 hours
-			factor = 0.67 //2/3rd, rounded up from 0.6 periodic
+			factor = 0.5 //2/3rds majority: transfer requires 2x the votes. (3-2)/2 = 0.5
 		else
 			factor = 1.0 //Equal weight
 

--- a/html/changelogs/llywelwyn-transferfix.yml
+++ b/html/changelogs/llywelwyn-transferfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Llywelwyn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Corrected the vote factor applied to pre-3 hour transfers, so it correctly checks for a 2/3rds supermajority to transfer."


### PR DESCRIPTION
changes:
  - bugfix: "Corrected the vote factor applied to pre-3 hour transfers, so it correctly checks for a 2/3rds supermajority to transfer."

![image](https://github.com/Aurorastation/Aurora.3/assets/82828093/18c1bbcb-3a4f-4498-8f35-f67603aa9679)
