### PR TITLE
Sets usesound and surgerysound vars on combitools when a tool bit is selected

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -828,6 +828,22 @@
 	if(tool)
 		playsound(user, 'sound/items/penclick.ogg', 25)
 		current_tool = tool
+		switch(tool)
+			if("wrench")
+				usesound = 'sound/items/wrench.ogg'
+				surgerysound = 'sound/items/surgery/bonesetter.ogg'
+			if("screwdriver")
+				usesound = 'sound/items/screwdriver.ogg'
+				surgerysound = 'sound/items/screwdriver.ogg'
+			if("wirecutters")
+				usesound = 'sound/items/wirecutter.ogg'
+				surgerysound = 'sound/items/surgery/hemostat.ogg'
+			if("crowbar")
+				usesound = /singleton/sound_category/crowbar_sound
+				surgerysound = 'sound/items/surgery/retractor.ogg'
+			if("multitool")
+				usesound = null
+				surgerysound = null
 		update_tool()
 	return 1
 

--- a/html/changelogs/hockaa-combitooltest.yml
+++ b/html/changelogs/hockaa-combitooltest.yml
@@ -1,0 +1,6 @@
+author: Hocka
+
+delete-after: True
+
+changes:
+  - tweak: "Combitools now have appropriate sounds corresponding to their selected bit."


### PR DESCRIPTION
Fixes combitools not having their usesound & surgerysound vars set, which usually resulted in either no noise or goofy regular hitting/punching noises.