### PR TITLE
Upgraded cyborg rechargers specify that they only repair stationbounds

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -178,9 +178,9 @@
 	desc = initial(desc)
 	desc += " Uses a dedicated internal power cell to deliver [charging_power]W when in use."
 	if(weld_rate)
-		desc += "<br>It is capable of repairing structural damage."
+		desc += "<br>It is capable of repairing a stationbound's structural damage."
 	if(wire_rate)
-		desc += "<br>It is capable of repairing burn damage."
+		desc += "<br>It is capable of repairing a stationbound's burn damage."
 
 /obj/machinery/recharge_station/proc/build_overlays()
 	cut_overlays()

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -178,7 +178,7 @@
 	desc = initial(desc)
 	desc += " Uses a dedicated internal power cell to deliver [charging_power]W when in use."
 	if(weld_rate)
-		desc += "<br>It is capable of repairing a stationbound's structural damage."
+		desc += "<br>It is capable of repairing stationbounds' structural damage."
 	if(wire_rate)
 		desc += "<br>It is capable of repairing stationbounds' burn damage."
 

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -180,7 +180,7 @@
 	if(weld_rate)
 		desc += "<br>It is capable of repairing a stationbound's structural damage."
 	if(wire_rate)
-		desc += "<br>It is capable of repairing a stationbound's burn damage."
+		desc += "<br>It is capable of repairing stationbounds' burn damage."
 
 /obj/machinery/recharge_station/proc/build_overlays()
 	cut_overlays()

--- a/html/changelogs/sniblet-it-is-capable.yml
+++ b/html/changelogs/sniblet-it-is-capable.yml
@@ -1,0 +1,13 @@
+# Your name.
+author: Sniblet
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Upgraded cyborg rechargers now specify that they only repair stationbounds."


### PR DESCRIPTION
They only repair stationbounds. I always thought they were supposed to repair IPCs, and since they didn't, I thought something was broken.
Nothing is broken. They just don't repair IPCs, only living/silicon/robot s. Now it'll say that on examine.
"It is capable of repairing (structural/burn) damage." > "It is capable of repairing a stationbound's (structural/burn) damage."