### PR TITLE
Shotgun Pumping Tweaks

### DIFF
--- a/code/modules/projectiles/guns/projectile/rifle.dm
+++ b/code/modules/projectiles/guns/projectile/rifle.dm
@@ -236,9 +236,7 @@
 
 /obj/item/gun/projectile/shotgun/pump/rifle/vintage/unique_action(mob/living/user as mob)
 	if(wielded)
-		if(world.time >= recentpump + 10)
-			pump(user)
-			recentpump = world.time
+		pump(user)
 		return
 	else
 		if(open_bolt && has_clip)

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -77,6 +77,7 @@
 		return
 	pump(user)
 
+/obj/item/gun/projectile/shotgun/pump/proc/pump(mob/M)
 	playsound(M, rack_sound, 60, FALSE)
 	to_chat(M, SPAN_NOTICE("You [rack_verb] \the [src]!"))
 	if(cycle_anim)

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -61,7 +61,6 @@
 	handle_casings = HOLD_CASINGS
 	fire_sound = 'sound/weapons/gunshot/gunshot_shotgun2.ogg'
 	is_wieldable = TRUE
-	var/recentpump = 0 // to prevent spammage
 	var/rack_sound = /singleton/sound_category/shotgun_pump
 	var/rack_verb = "pump"
 	///Whether the item icon has a cycling animation
@@ -76,14 +75,7 @@
 	if(jam_num)
 		to_chat(user, SPAN_WARNING("\The [src] is jammed!"))
 		return
-	if(world.time >= recentpump + 10)
-		pump(user)
-		recentpump = world.time
-
-/obj/item/gun/projectile/shotgun/pump/proc/pump(mob/M)
-	if(!wielded)
-		if(!do_after(M, 2 SECONDS)) // have to stand still for 2 seconds instead of doing it instantly. bad idea during a shootout
-			return
+	pump(user)
 
 	playsound(M, rack_sound, 60, FALSE)
 	to_chat(M, SPAN_NOTICE("You [rack_verb] \the [src]!"))

--- a/html/changelogs/geeves-let_me_pump.yml
+++ b/html/changelogs/geeves-let_me_pump.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscdel: "Removed the one second cooldown between shotgun pumps. The standard firing delay still applies."
+  - rscdel: "Removed the forced wait when you pump a shotgun one-handed, similarly to how CM does it."


### PR DESCRIPTION
* Removed the one second cooldown between shotgun pumps. The standard firing delay still applies.
* Removed the forced wait when you pump a shotgun one-handed, similarly to how CM does it.