### PR TITLE
Shotgun Capacity Buff

### DIFF
--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -125,6 +125,7 @@
 	matter = list(DEFAULT_WALL_MATERIAL = 360)
 	reload_sound = /singleton/sound_category/shotgun_reload
 	drop_sound = /singleton/sound_category/casing_drop_sound_shotgun
+	max_stack = 8
 
 /obj/item/ammo_casing/shotgun/used/Initialize()
 	. = ..()

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -49,7 +49,7 @@
 	icon = 'icons/obj/guns/shotgun.dmi'
 	icon_state = "shotgun"
 	item_state = "shotgun"
-	max_shells = 4
+	max_shells = 7 // max of 8
 	w_class = ITEMSIZE_LARGE
 	force = 10
 	obj_flags = OBJ_FLAG_CONDUCTABLE
@@ -114,7 +114,7 @@
 	item_state = "cshotgun"
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2)
 	accuracy = 2
-	max_shells = 7 //match the ammo box capacity, also it can hold a round in the chamber anyways, for a total of 8.
+	max_shells = 13 // holds a max of 14 shells at once
 	ammo_type = /obj/item/ammo_casing/shotgun
 	fire_sound = 'sound/weapons/gunshot/gunshot_shotgun.ogg'
 	cycle_anim = FALSE

--- a/html/changelogs/geeves-more_shells_waiter_please.yml
+++ b/html/changelogs/geeves-more_shells_waiter_please.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Buffed the pump shotgun to hold 8 shells instead of 5."
+  - tweak: "Buffed the combat shotgun to hold 12 shells instead of 8."
+  - tweak: "Buffed shotgun shells to stack up to 8 instead of 5."


### PR DESCRIPTION
* Buffed the pump shotgun to hold 8 shells instead of 5.
* Buffed the combat shotgun to hold 12 shells instead of 8.
* Buffed shotgun shells to stack up to 8 instead of 5.