### PR TITLE
Shotgun Ammo Display Tweak

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1027,6 +1027,7 @@
 /obj/item/gun/proc/can_autofire(object, location, params)
 	return (can_autofire && world.time >= next_fire_time)
 
+/// Called when the gun's ammo state changes, checks if it's being held by a mob or in a mob's bag, and then updates the maptext
 /obj/item/gun/proc/update_maptext()
 	if(displays_maptext)
 		if(!ismob(loc) && !ismob(loc.loc))
@@ -1035,7 +1036,9 @@
 		handle_maptext()
 
 
+/// Updates the maptext for the gun when a holographic ammo display is attached. Called in update_maptext() in gun.dm
 /obj/item/gun/proc/handle_maptext()
+	SHOULD_NOT_SLEEP(TRUE)
 	var/ammo = get_ammo()
 	if(ammo > 9)
 		if(ammo < 20)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -1032,15 +1032,19 @@
 		if(!ismob(loc) && !ismob(loc.loc))
 			maptext = ""
 			return
-		var/ammo = get_ammo()
-		if(ammo > 9)
-			if(ammo < 20)
-				maptext_x = 20
-			else
-				maptext_x = 18
+		handle_maptext()
+
+
+/obj/item/gun/proc/handle_maptext()
+	var/ammo = get_ammo()
+	if(ammo > 9)
+		if(ammo < 20)
+			maptext_x = 20
 		else
-			maptext_x = 22
-		maptext = "<span style=\"font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: 7px;\">[ammo]</span>"
+			maptext_x = 18
+	else
+		maptext_x = 22
+	maptext = "<span style=\"font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: 7px;\">[ammo]</span>"
 
 /obj/item/gun/get_print_info(var/no_clear = TRUE)
 	if(no_clear)

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -68,7 +68,7 @@
 	var/cycle_anim = TRUE
 
 /obj/item/gun/projectile/shotgun/pump/handle_maptext()
-	var/ammo = length(loaded) || 0
+	var/ammo = length(loaded)
 	if(ammo > 9)
 		maptext_x = 12
 	else

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -67,6 +67,15 @@
 	///Whether the item icon has a cycling animation
 	var/cycle_anim = TRUE
 
+/obj/item/gun/projectile/shotgun/pump/handle_maptext()
+	var/ammo = length(loaded) || 0
+	if(ammo > 9)
+		maptext_x = 12
+	else
+		maptext_x = 16
+	var/ammo_display = "[ammo]+[chambered?.BB ? "1" : "0"]"
+	maptext = "<span style=\"font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: 7px;\">[ammo_display]</span>"
+
 /obj/item/gun/projectile/shotgun/pump/consume_next_projectile()
 	if(chambered)
 		return chambered.BB

--- a/html/changelogs/geeves-shotgun_ammo_display_tweak.yml
+++ b/html/changelogs/geeves-shotgun_ammo_display_tweak.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - tweak: "Shotguns now more accurately reflect shells in the tube and whether there's a shell in the chamber."


### PR DESCRIPTION
* Shotguns now more accurately reflect shells in the tube and whether there's a shell in the chamber.

![image](https://github.com/Aurorastation/Aurora.3/assets/22774890/49be9fce-91c7-4b5b-b7a5-f29da8df9251)
![image](https://github.com/Aurorastation/Aurora.3/assets/22774890/a5e33a1a-3e29-4ff9-ac46-9b1cc844b354)
