### PR TITLE
Fix ipc antag hanging roundstart, async post_equip proc

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -597,6 +597,8 @@ var/datum/controller/subsystem/ticker/SSticker
 	return SETUP_OK
 
 /datum/controller/subsystem/ticker/proc/roundstart()
+	SHOULD_NOT_SLEEP(TRUE)
+
 	mode.post_setup()
 	//Cleanup some stuff
 	for(var/obj/effect/landmark/start/S in GLOB.landmarks_list)

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -356,10 +356,17 @@
 		var/obj/item/clothing/accessory/A = new suit_accessory
 		S.attach_accessory(H, A)
 
+/**
+ * This proc handles actions done after the outfit was equipped,
+ * eg. toggling internals, personalizations or similar
+ *
+ * This process can and does sleep, and should never be waited upon, but only invoked asyncronously (`INVOKE_ASYNC`)
+ */
 /obj/outfit/proc/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	//to be overriden for changing items post equip (such as toggeling internals, ...)
 
 /obj/outfit/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	SHOULD_NOT_SLEEP(TRUE)
 	//Start with uniform,suit,backpack for additional slots
 	if(back)
 		equip_item(H, back, slot_back)
@@ -512,7 +519,7 @@
 			else
 				H.equip_or_collect(ID, slot_wear_id)
 
-	post_equip(H, visualsOnly)
+	INVOKE_ASYNC(src, PROC_REF(post_equip), H, visualsOnly)
 
 	if(!visualsOnly)
 		apply_fingerprints(H)

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -186,6 +186,8 @@
 	return 1
 
 /datum/antagonist/proc/draft_antagonist(var/datum/mind/player)
+	SHOULD_NOT_SLEEP(TRUE)
+
 	//Check if the player can join in this antag role, or if the player has already been given an antag role.
 	if(!can_become_antag(player))
 		log_traitor("[player.key] was selected for [role_text] by lottery, but is not allowed to be that role.")

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -1,4 +1,5 @@
 /datum/antagonist/proc/add_antagonist(var/datum/mind/player, var/ignore_role, var/do_not_equip, var/move_to_spawn, var/do_not_announce, var/preserve_appearance)
+	SHOULD_NOT_SLEEP(TRUE)
 
 	if(!add_antagonist_mind(player, ignore_role))
 		return 0

--- a/code/game/antagonist/antagonist_equip.dm
+++ b/code/game/antagonist/antagonist_equip.dm
@@ -1,4 +1,6 @@
 /datum/antagonist/proc/equip(var/mob/living/carbon/human/player)
+	SHOULD_NOT_SLEEP(TRUE)
+
 	if(!istype(player))
 		return FALSE
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -492,6 +492,8 @@ var/list/slot_equipment_priority = list( \
 			. += I
 
 /mob/living/carbon/human/proc/equipOutfit(outfit, visualsOnly = FALSE)
+	SHOULD_NOT_SLEEP(TRUE)
+
 	var/obj/outfit/O = null
 
 	if(ispath(outfit))

--- a/code/modules/organs/organ_icon.dm
+++ b/code/modules/organs/organ_icon.dm
@@ -18,7 +18,7 @@
 	var/limb_exception = FALSE
 	if(robotize_type)
 		var/datum/robolimb/R = GLOB.all_robolimbs[robotize_type]
-		if(R.paintable)
+		if(R?.paintable)
 			limb_exception = TRUE
 	if((status & ORGAN_ROBOT) && !limb_exception)
 		return

--- a/html/changelogs/fluffyghost-fixipcantagtaghangingroundstart.yml
+++ b/html/changelogs/fluffyghost-fixipcantagtaghangingroundstart.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Should fix the antag IPC selection from hanging roundstart."
+  - backend: "The proc that called it had a lot of sleep, it is now invoked asyncronously, possibly speeds up roundstart spawn."


### PR DESCRIPTION
Should fix the antag IPC selection from hanging roundstart.
The proc that called it had a lot of sleep, it is now invoked asyncronously, possibly speeds up roundstart spawn.