### PR TITLE
Add a two-item limit to Sanasomnum in the uplink

### DIFF
--- a/code/datums/uplink/medical.dm
+++ b/code/datums/uplink/medical.dm
@@ -17,6 +17,7 @@
 /datum/uplink_item/item/medical/sanasomnum
 	name = "Sanasomnum Injector"
 	bluecrystal_cost = 3
+	item_limit = 2
 	path = /obj/item/reagent_containers/hypospray/autoinjector/sanasomnum
 
 /datum/uplink_item/item/medical/combathypo


### PR DESCRIPTION
Per discord, this was missed in the original PR. This is being added now, to combat the easy supply of it.

Two injections should be enough for its OOC purpose of being a tool to facilitate roleplay, without being oppressive in allowing ease of use to get back into combat constantly.