### PR TITLE
Sounds Audible Through Walls Fix

### DIFF
--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -40,8 +40,8 @@
 	var/pressure_affected = TRUE
 	/// Are the sounds subject to reverb? Defaults to TRUE.
 	var/use_reverb = TRUE
-	/// Are we ignoring walls? Defaults to TRUE.
-	var/ignore_walls = TRUE
+	/// Are we ignoring walls? Defaults to FALSE.
+	var/ignore_walls = FALSE
 
 	// State stuff
 	/// The source of the sound, or the recipient of the sound.

--- a/code/datums/looping_sounds/machinery_sounds.dm
+++ b/code/datums/looping_sounds/machinery_sounds.dm
@@ -13,7 +13,6 @@
 	mid_sounds = list('sound/machines/sm/loops/calm.ogg' = 1)
 	mid_length = 60
 	volume = 40
-	ignore_walls = FALSE
 	falloff_distance = 4
 	vary = TRUE
 
@@ -72,15 +71,7 @@
 	)
 	mid_length = 1.8 SECONDS
 	extra_range = SHORT_RANGE_SOUND_EXTRARANGE
-	ignore_walls = FALSE
 	volume = 10
-
-//	mid_length = 1.8 SECONDS
-//	extra_range = -11
-//	falloff_distance = 1
-//	falloff_exponent = 5 (falloff system from /tg/)(not smart enough to port it)
-//	volume = 50
-//	ignore_walls = FALSE
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /datum/looping_sound/computer
@@ -93,7 +84,6 @@
 	end_volume = 10
 	volume = 1
 	extra_range = SILENCED_SOUND_EXTRARANGE
-	ignore_walls = FALSE
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -102,7 +92,6 @@
 	mid_length = 1.8 SECONDS
 	extra_range = 10
 	volume = 70
-	ignore_walls = FALSE
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -110,6 +99,5 @@
 	mid_sounds = list('sound/machines/firealarm/FireAlarm1.ogg' = 1,'sound/machines/firealarm/FireAlarm2.ogg' = 1,'sound/machines/firealarm/FireAlarm3.ogg' = 1,'sound/machines/firealarm/FireAlarm4.ogg' = 1)
 	mid_length = 2.4 SECONDS
 	volume = 75
-	ignore_walls = FALSE
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/blob.dm
@@ -83,7 +83,7 @@
 		"<span class=\"danger\">You reach out and touch \the [src]. Everything immediately goes quiet. Your last thought is \"That was not a wise decision.\"</span>",\
 		"<span class=\"warning\">You hear an unearthly noise.</span>")
 
-	playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
+	playsound(src, 'sound/effects/supermatter.ogg', 50, 1, ignore_walls = TRUE)
 
 	Consume(user)
 
@@ -92,7 +92,7 @@
 		"<span class=\"danger\">You touch \the [attacking_item] to \the [src] when everything suddenly goes silent.\"</span>\n<span class=\"notice\">\The [attacking_item] flashes into dust as you flinch away from \the [src].</span>",\
 		"<span class=\"warning\">Everything suddenly goes silent.</span>")
 
-	playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
+	playsound(src, 'sound/effects/supermatter.ogg', 50, 1, ignore_walls = TRUE)
 
 	user.drop_from_inventory(attacking_item,src)
 	Consume(attacking_item)
@@ -111,7 +111,7 @@
 		AM.visible_message("<span class=\"warning\">\The [AM] smacks into \the [src] and rapidly flashes to ash.</span>",\
 		"<span class=\"warning\">You hear a loud crack as you are washed with a wave of heat.</span>")
 
-	playsound(src, 'sound/effects/supermatter.ogg', 50, 1)
+	playsound(src, 'sound/effects/supermatter.ogg', 50, 1, ignore_walls = TRUE)
 
 	Consume(AM)
 

--- a/code/game/gamemodes/technomancer/spells/projectile/projectile.dm
+++ b/code/game/gamemodes/technomancer/spells/projectile/projectile.dm
@@ -21,7 +21,7 @@
 		new_projectile.fire(direct_target = pb_target)
 		log_and_message_admins("has casted [src] at \the [hit_atom].")
 		if(fire_sound)
-			playsound(src, fire_sound, 75, 1)
+			playsound(src, fire_sound, 75, 1, ignore_walls = TRUE)
 		if(aspect != ASPECT_PSIONIC)
 			adjust_instability(instability_per_shot)
 		return TRUE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -535,9 +535,9 @@
 		playsound(src, pickup_sound, PICKUP_SOUND_VOLUME)
 	else if(slot_flags && slot)
 		if(equip_sound)
-			playsound(src, equip_sound, EQUIP_SOUND_VOLUME, TRUE, ignore_walls = FALSE)
+			playsound(src, equip_sound, EQUIP_SOUND_VOLUME, TRUE)
 		else
-			playsound(src, drop_sound, DROP_SOUND_VOLUME, ignore_walls = FALSE)
+			playsound(src, drop_sound, DROP_SOUND_VOLUME)
 	if(item_action_slot_check(user, slot))
 		add_verb(user, verbs)
 		for(var/v in verbs)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -42,7 +42,7 @@
  * * required_preferences - What preference is required to be on on the client, for the sound to play
  * * required_asfx_toggles - What toggles are required to be on on the client, for the sound to play
  */
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = TRUE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE, required_preferences, required_asfx_toggles)
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff_exponent = SOUND_FALLOFF_EXPONENT, frequency = null, channel = 0, pressure_affected = TRUE, ignore_walls = FALSE, falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, use_reverb = TRUE, required_preferences, required_asfx_toggles)
 	if(isarea(source))
 		CRASH("playsound(): source is an area")
 

--- a/code/modules/effects/map_effects/sound_emitter.dm
+++ b/code/modules/effects/map_effects/sound_emitter.dm
@@ -27,7 +27,7 @@
 
 	var/sound_pressure_affected = TRUE // If false, people in low pressure or vacuum will hear the sound.
 
-	var/sound_ignore_walls = FALSE // If false, walls will completely muffle the sound.
+	var/sound_ignore_walls = TRUE // If false, walls will completely muffle the sound.
 
 	var/sound_preference = null // Player preference to check before playing this sound to them, if any.
 

--- a/code/modules/effects/map_effects/sound_emitter.dm
+++ b/code/modules/effects/map_effects/sound_emitter.dm
@@ -27,7 +27,7 @@
 
 	var/sound_pressure_affected = TRUE // If false, people in low pressure or vacuum will hear the sound.
 
-	var/sound_ignore_walls = TRUE // If false, walls will completely muffle the sound.
+	var/sound_ignore_walls = FALSE // If false, walls will completely muffle the sound.
 
 	var/sound_preference = null // Player preference to check before playing this sound to them, if any.
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -1417,7 +1417,7 @@ var/list/total_extraction_beacons = list()
 	QDEL_NULL(effect_overlay)
 	if(location)
 		new /obj/effect/overlay/temp/explosion(location)
-		playsound(location, 'sound/effects/Explosion1.ogg', 100, 1)
+		playsound(location, 'sound/effects/Explosion1.ogg', 100, 1, ignore_walls = TRUE)
 		for(var/atom/A in range(4,location))
 			if(istype(A,/turf/simulated/mineral))
 				var/turf/simulated/mineral/M = A

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -253,7 +253,7 @@
 	if(has_jetpack)
 		jetpack = new /obj/item/tank/jetpack/carbondioxide/synthetic(src)
 
-	playsound(get_turf(src), spawn_sound, 75, pitch_toggle, ignore_walls = FALSE)
+	playsound(get_turf(src), spawn_sound, 75, pitch_toggle)
 
 /mob/living/silicon/robot/SetName(pickedName as text)
 	custom_name = pickedName

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -507,7 +507,7 @@
 	if(suppressed)
 		playsound(loc, suppressed_sound, suppressed_volume, vary_fire_sound)
 	else
-		playsound(loc, fire_sound, fire_sound_volume, vary_fire_sound, falloff_distance  = 0.5)
+		playsound(loc, fire_sound, fire_sound_volume, vary_fire_sound, falloff_distance  = 0.5, ignore_walls = TRUE)
 
 /obj/item/gun/proc/process_point_blank(obj/projectile, mob/user, atom/target)
 	var/obj/item/projectile/P = projectile

--- a/code/modules/reagents/reagent_containers/food/cans.dm
+++ b/code/modules/reagents/reagent_containers/food/cans.dm
@@ -192,7 +192,7 @@
 			visible_message(SPAN_WARNING("\The [name] bursts violently into pieces!"))
 		if(LETHAL_FUEL_CAPACITY to INFINITY) // boom
 			fragem(src, shrapnelcount, shrapnelcount, 3, 5, 15, 3, TRUE, 5)
-			playsound(get_turf(src), 'sound/effects/Explosion1.ogg', 50)
+			playsound(get_turf(src), 'sound/effects/Explosion1.ogg', 50, ignore_walls = TRUE)
 			visible_message(SPAN_DANGER("<b>\The [name] explodes!</b>"))
 	qdel(src)
 

--- a/html/changelogs/SleepyGemmy-sound_fix.yml
+++ b/html/changelogs/SleepyGemmy-sound_fix.yml
@@ -1,0 +1,6 @@
+author: SleepyGemmy
+
+delete-after: True
+
+changes:
+  - tweak: "Made sounds not play through walls by default again."


### PR DESCRIPTION
makes it so that sounds don't play through walls again, unless they're sufficiently loud, such as gunshots and explosions.
fixes #18756.