### PR TITLE
Mutable appearances plane

### DIFF
--- a/code/defines/mutable_appearance.dm
+++ b/code/defines/mutable_appearance.dm
@@ -4,10 +4,10 @@
 
 // Mutable appearances are children of images, just so you know.
 
-/mutable_appearance/New()
+/mutable_appearance/New(mutable_appearance/to_copy)
 	..()
-	plane = FLOAT_PLANE // No clue why this is 0 by default yet images are on FLOAT_PLANE
-						// And yes this does have to be in the constructor, BYOND ignores it if you set it as a normal var
+	if(!to_copy)
+		plane = FLOAT_PLANE
 
 // Helper similar to image()
 /proc/mutable_appearance(icon, icon_state = "", layer = FLOAT_LAYER, plane = FLOAT_PLANE)

--- a/html/changelogs/FluffyGhost-mutable_appearances_plane.yml
+++ b/html/changelogs/FluffyGhost-mutable_appearances_plane.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - backend: "Updated mutable appearances to only set the floating plane if they're not copying from an image, as per TG version."


### PR DESCRIPTION
Updated mutable appearances to only set the floating plane if they're not copying from an image, as per TG version