### PR TITLE
Fixed device assemblies

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -132,3 +132,5 @@
 	// Sets the UI host to the transfer valve if its mounted on a transfer_valve
 	if(istype(loc,/obj/item/device/transfer_valve))
 		return loc
+
+	return holder || .

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -164,13 +164,18 @@
 		var/turf/T = get_turf(src)
 		if(!T)
 			return FALSE
+
 		if(a_left)
 			a_left.holder = null
 			a_left.forceMove(T)
+			a_left = null
+
 		if(a_right)
 			a_right.holder = null
 			a_right.forceMove(T)
-		QDEL_IN(src, 1)
+			a_right = null
+
+		qdel(src)
 
 
 /obj/item/device/assembly_holder/proc/process_activation(var/obj/D, var/normal = 1, var/special = 1)

--- a/html/changelogs/fluffyghost-fixdeviceassemblies.yml
+++ b/html/changelogs/fluffyghost-fixdeviceassemblies.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed device assemblies disappearing on deconstruction."
+  - bugfix: "Fixed UI not opening on device assemblies."


### PR DESCRIPTION
Fixed device assemblies disappearing on deconstruction.
Fixed UI not opening on device assemblies.

Fixes #18785 
Fixes #17753 