### PR TITLE
Fix some gamemodes from not being votable

### DIFF
--- a/code/datums/votes/round_type.dm
+++ b/code/datums/votes/round_type.dm
@@ -63,9 +63,24 @@
 /datum/vote/gamemode/finalize_vote(winning_option)
 	to_world(SPAN_WARNING("<b>The round will start soon.</b>"))
 
-	if(GLOB.master_mode != lowertext(winning_option))
-		SSpersistent_configuration.last_gamemode = lowertext(winning_option)
-		GLOB.master_mode = lowertext(winning_option)
+	var/winning_option_lowertext = lowertext(winning_option)
+
+	if(GLOB.master_mode != winning_option_lowertext)
+		SSpersistent_configuration.last_gamemode = winning_option_lowertext
+
+		//This is because `/datum/configuration/proc/pick_mode()` uses the config tag, for god-knows what reason
+		//unless it's one of these snowflake gamemodes
+		if(winning_option_lowertext in list(ROUNDTYPE_STR_SECRET, ROUNDTYPE_STR_MIXED_SECRET, ROUNDTYPE_STR_RANDOM))
+			GLOB.master_mode = winning_option_lowertext
+
+		else
+
+			for(var/votable_mode_name in GLOB.config.votable_modes)
+				var/datum/game_mode/M = GLOB.gamemode_cache[votable_mode_name]
+
+				if(M.name == winning_option)
+					GLOB.master_mode = M.config_tag
+					break
 
 /datum/vote/gamemode/reset()
 	. = ..()

--- a/html/changelogs/fluffyghost-fixgamemodevote.yml
+++ b/html/changelogs/fluffyghost-fixgamemodevote.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "For some cursed reason the gamemode selection uses the config tag instead of the name, that sometimes is the same as the config tag, either way this should fix some gamemodes from not being votable and thus the system reverting to extended."


### PR DESCRIPTION
For some cursed reason the gamemode selection uses the config tag instead of the name, that sometimes is the same as the config tag, either way this should fix some gamemodes from not being votable and thus the system reverting to extended