### PR TITLE
Gakal'zaal Lore Tweaks

### DIFF
--- a/code/__DEFINES/space_sectors.dm
+++ b/code/__DEFINES/space_sectors.dm
@@ -39,7 +39,7 @@
 #define ALL_GENERIC_SECTORS		list(SECTOR_STAR_NURSERY, SECTOR_GENERIC)
 
 //For sectors where corporate entities can or should appear. Corporate ships having this tag can be seen more reliably
-#define ALL_CORPORATE_SECTORS	list(ALL_TAU_CETI_SECTORS, SECTOR_SRANDMARR, SECTOR_UUEOAESA, ALL_COALITION_SECTORS, ALL_GENERIC_SECTORS, SECTOR_GAKAL, SECTOR_NRRAHRAHUL, SECTOR_BADLANDS)//Currently excludes Elyran sectors and Light's Edge
+#define ALL_CORPORATE_SECTORS	list(ALL_TAU_CETI_SECTORS, SECTOR_SRANDMARR, SECTOR_UUEOAESA, ALL_COALITION_SECTORS, ALL_GENERIC_SECTORS, SECTOR_NRRAHRAHUL, SECTOR_BADLANDS)//Currently excludes Elyran sectors and Light's Edge
 
 //For highly dangerous sectors with high piracy. Civilian and leisure ships should be less common or not found here.
 #define ALL_DANGEROUS_SECTORS	list(SECTOR_BADLANDS, ALL_VOID_SECTORS)

--- a/code/modules/clothing/spacesuits/void/alien/tajara.dm
+++ b/code/modules/clothing/spacesuits/void/alien/tajara.dm
@@ -173,7 +173,7 @@
 
 /obj/item/clothing/suit/space/void/dpra
 	name = "people's volunteer spacer militia voidsuit"
-	desc = "A refitted, sturdy voidsuit created from corporate models acquired during the liberation of Gaka'zaal. These armored models are issued to the People's volunteer spacer militia."
+	desc = "A refitted, sturdy voidsuit created from Hegemony models acquired during the liberation of Gakal'zaal. These armored models are issued to the People's Volunteer Spacer Militia."
 	icon = 'icons/obj/tajara_items.dmi'
 	icon_state = "DPRA_voidsuit"
 	item_state = "DPRA_voidsuit"
@@ -203,7 +203,7 @@
 
 /obj/item/clothing/head/helmet/space/void/dpra
 	name = "people's volunteer spacer militia voidsuit helmet"
-	desc = "A refitted, sturdy voidsuit created from corporate models acquired during the liberation of Gaka'zaal. These armored models are issued to the People's volunteer spacer militia."
+	desc = "A refitted, sturdy voidsuit created from Hegemony models acquired during the liberation of Gakal'zaal. These armored models are issued to the People's Volunteer Spacer Militia."
 	icon = 'icons/obj/tajara_items.dmi'
 	icon_state = "DPRA_voidsuit_helmet"
 	item_state = "DPRA_voidsuit_helmet"

--- a/code/modules/clothing/under/xenos/tajara.dm
+++ b/code/modules/clothing/under/xenos/tajara.dm
@@ -322,9 +322,9 @@
 	desc = "A military uniform used by the forces of the People's Volunteer Spacer Militia."
 	icon_state = "pvsm_crewman"
 	item_state = "pvsm_crewman"
-	desc_extended = "Having only recently claimed a space-positioned base alongside Gaka'zaal, the DPRA lacks any sort of trained force when it comes to orbital defense. Not wanting to \
+	desc_extended = "Having only recently claimed a space-positioned base alongside Gakal'zaal, the DPRA lacks any sort of trained force when it comes to orbital defense. Not wanting to \
 	rely purely on mercenaries due to the expenses and their scant loyalty, a militia was organized. Members of the Spacer Militia come from a variety of backgrounds: some coming back \
-	after being employed by mega-corporations; others from asteroid belts; some soldiers from Adhomai; and more from the Free Gakal'Zaal Station itself, having worked on it as maintenance."
+	after being employed by mega-corporations; others from asteroid belts; some soldiers from Adhomai; and more from the Free Gakal'zaal Station itself, having worked on it as maintenance."
 	starting_accessories = (/obj/item/clothing/accessory/storage/bayonet)
 	siemens_coefficient = 0.5
 	armor = list(

--- a/html/changelogs/RustingWithYou - goingloremode.yml
+++ b/html/changelogs/RustingWithYou - goingloremode.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Removes Gakal'zaal from the corporate sectors list and refluffs the PVSM voidsuits to not be based on corporate models."


### PR DESCRIPTION
Gakal is no longer in ALL_CORPORATE_SECTORS due to the general DPRA animosity towards corporations.
The DPRA voidsuits have had their fluff changed to state they were based on Hegemony rather than corporate designs acquired during the Gakal'zaal uprising, as there was little to no corporate presence there during the occupation.
Fixes several typos of the word "Gakal'zaal" which I stumbled across.