### PR TITLE
Reduced simple animal emote sounds to short range

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -762,9 +762,9 @@
 		to_chat(usr, SPAN_WARNING("Ability on cooldown 2 seconds."))
 		return
 
-	var/sound_to_play = pick(emote_sounds)
+	var/sound_to_play = LAZYPICK(emote_sounds, FALSE)
 	if(sound_to_play)
-		playsound(src, pick(emote_sounds), 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+		playsound(src, sound_to_play, 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 
 	if(client)
 		sound_time = FALSE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -41,7 +41,9 @@
 	var/speak_chance = 0
 	var/list/emote_hear = list()	//Hearable emotes
 	var/list/emote_see = list()		//Unlike speak_emote, the list of things in this variable only show by themselves with no spoken text. IE: Ian barks, Ian yaps
-	var/list/emote_sounds = list()
+
+	///A list of sounds that this animal will randomly play, lazy list
+	var/list/emote_sounds
 	var/sound_time = TRUE
 
 	var/turns_per_move = 1
@@ -475,7 +477,7 @@
 
 //This is called when an animal 'speaks'. It does nothing here, but descendants should override it to add audio
 /mob/living/simple_animal/proc/speak_audio()
-	if(emote_sounds.len)
+	if(LAZYLEN(emote_sounds))
 		make_noise(TRUE)
 	return
 
@@ -760,7 +762,10 @@
 		to_chat(usr, SPAN_WARNING("Ability on cooldown 2 seconds."))
 		return
 
-	playsound(src, pick(emote_sounds), 75, 1)
+	var/sound_to_play = pick(emote_sounds)
+	if(sound_to_play)
+		playsound(src, pick(emote_sounds), 75, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+
 	if(client)
 		sound_time = FALSE
 		addtimer(CALLBACK(src, PROC_REF(reset_sound_time)), 2 SECONDS)
@@ -800,7 +805,7 @@
 	if(speak_emote.len)
 		verb = pick(speak_emote)
 
-	if(emote_sounds.len)
+	if(LAZYLEN(emote_sounds))
 		var/sound_chance = TRUE
 		if(client) // we do not want people who assume direct control to spam
 			sound_chance = prob(50)

--- a/html/changelogs/fluffyghost-simpleanimaltweaksound.yml
+++ b/html/changelogs/fluffyghost-simpleanimaltweaksound.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Reduced simple animal emote sounds to medium range."
+  - backend: "Turned the var that hold those sounds into a lazylist, saving memory (as most simple animals don't have emote sounds)."

--- a/html/changelogs/fluffyghost-simpleanimaltweaksound.yml
+++ b/html/changelogs/fluffyghost-simpleanimaltweaksound.yml
@@ -38,5 +38,5 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Reduced simple animal emote sounds to medium range."
+  - tweak: "Reduced simple animal emote sounds to short range."
   - backend: "Turned the var that hold those sounds into a lazylist, saving memory (as most simple animals don't have emote sounds)."


### PR DESCRIPTION
Reduced simple animal emote sounds to short range.
Turned the var that hold those sounds into a lazylist, saving memory (as most simple animals don't have emote sounds).