### PR TITLE
Fix null client field value in examine

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -391,7 +391,7 @@
 	if(print_flavor_text()) msg += "[print_flavor_text()]\n"
 
 	if(GLOB.config.allow_Metadata && client?.prefs.metadata)
-			msg += "<span class='deadsay'>OOC Notes:</span> <a href='?src=\ref[src];metadata=1'>\[View\]</a>\n"
+		msg += "<span class='deadsay'>OOC Notes:</span> <a href='?src=\ref[src];metadata=1'>\[View\]</a>\n"
 
 	msg += "</span>"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -390,8 +390,9 @@
 
 	if(print_flavor_text()) msg += "[print_flavor_text()]\n"
 
-	if (GLOB.config.allow_Metadata && client.prefs.metadata)
-		msg += "<span class='deadsay'>OOC Notes:</span> <a href='?src=\ref[src];metadata=1'>\[View\]</a>\n"
+	if(!isnull(client))
+		if(GLOB.config.allow_Metadata && client.prefs.metadata)
+			msg += "<span class='deadsay'>OOC Notes:</span> <a href='?src=\ref[src];metadata=1'>\[View\]</a>\n"
 
 	msg += "</span>"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -390,8 +390,7 @@
 
 	if(print_flavor_text()) msg += "[print_flavor_text()]\n"
 
-	if(!isnull(client))
-		if(GLOB.config.allow_Metadata && client.prefs.metadata)
+	if(GLOB.config.allow_Metadata && client?.prefs.metadata)
 			msg += "<span class='deadsay'>OOC Notes:</span> <a href='?src=\ref[src];metadata=1'>\[View\]</a>\n"
 
 	msg += "</span>"

--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -1,0 +1,6 @@
+author: SidVeld
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed an issue that caused the character examine message to disappear when the player controlling it is not in the body."


### PR DESCRIPTION
# Fix null client field value in examine

When inspecting a character that doesn't have a client (the player has become a ghost or something else), an error occurs and the final message is displayed incorrectly.

This is my bug and I'm going to fix it by adding a check on the value of the `client` field

![изображение](https://github.com/Aurorastation/Aurora.3/assets/22749671/c29cc60c-5776-4c49-9d79-b4e6fdb847cd)
