### PR TITLE
Adds blastdoors to the Grauwolf 

### DIFF
--- a/html/changelogs/changelog.yml
+++ b/html/changelogs/changelog.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: ReadThisNamePlz
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - maptweak: "Added blastdoors to the Grauwolf compartment and moved the longbow blastdoors button to be more visible."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -4812,6 +4812,17 @@
 	},
 /turf/simulated/floor/bluegrid/server,
 /area/server)
+"cav" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/shuttle/scc_space_ship/cardinal,
+/obj/machinery/door/blast/regular/open{
+	dir = 8;
+	id = "shutters_deck2_grauwolf";
+	name = "Safety Blast Door"
+	},
+/turf/simulated/floor/plating,
+/area/horizon/grauwolf)
 "caB" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
@@ -43944,7 +43955,7 @@
 /area/horizon/security/brig)
 "uBx" = (
 /obj/machinery/button/remote/blast_door{
-	id = "shutters_deck3_longbow";
+	id = "shutters_deck2_grauwolf";
 	name = "Safety Blast Doors Control";
 	pixel_y = -28;
 	dir = 6
@@ -48131,7 +48142,6 @@
 /obj/machinery/door/firedoor,
 /obj/structure/window/shuttle/scc_space_ship/cardinal,
 /obj/machinery/door/blast/regular/open{
-	dir = 8;
 	id = "shutters_deck2_grauwolf";
 	name = "Safety Blast Door"
 	},
@@ -50070,16 +50080,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/operations/lower/machinist)
-"xln" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/shuttle/scc_space_ship/cardinal,
-/obj/machinery/door/blast/regular/open{
-	id = "shutters_deck2_grauwolf";
-	name = "Safety Blast Door"
-	},
-/turf/simulated/floor/plating,
-/area/horizon/grauwolf)
 "xlz" = (
 /obj/machinery/computer/security/engineering{
 	name = "Drone Monitoring Cameras"
@@ -61075,7 +61075,7 @@ jJU
 jJU
 gyH
 vjt
-wtq
+cav
 qgN
 qgN
 qgN
@@ -61479,7 +61479,7 @@ cpl
 gqr
 tLi
 qbP
-wtq
+cav
 qgN
 qgN
 qgN
@@ -61679,9 +61679,9 @@ ozs
 ukM
 cpl
 cRE
-xln
-xln
-xln
+wtq
+wtq
+wtq
 qgN
 qgN
 qgN

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -35363,6 +35363,11 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, grauwolf compartment"
 	},
+/obj/machinery/door/blast/regular/open{
+	dir = 8;
+	id = "shutters_deck2_grauwolf";
+	name = "Safety Blast Door"
+	},
 /turf/simulated/floor/plating,
 /area/horizon/grauwolf)
 "qBg" = (
@@ -43938,6 +43943,12 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "uBx" = (
+/obj/machinery/button/remote/blast_door{
+	id = "shutters_deck3_longbow";
+	name = "Safety Blast Doors Control";
+	pixel_y = -28;
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/grauwolf)
 "uBK" = (
@@ -48119,6 +48130,11 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/structure/window/shuttle/scc_space_ship/cardinal,
+/obj/machinery/door/blast/regular/open{
+	dir = 8;
+	id = "shutters_deck2_grauwolf";
+	name = "Safety Blast Door"
+	},
 /turf/simulated/floor/plating,
 /area/horizon/grauwolf)
 "wtC" = (
@@ -50054,6 +50070,16 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/operations/lower/machinist)
+"xln" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/shuttle/scc_space_ship/cardinal,
+/obj/machinery/door/blast/regular/open{
+	id = "shutters_deck2_grauwolf";
+	name = "Safety Blast Door"
+	},
+/turf/simulated/floor/plating,
+/area/horizon/grauwolf)
 "xlz" = (
 /obj/machinery/computer/security/engineering{
 	name = "Drone Monitoring Cameras"
@@ -61653,9 +61679,9 @@ ozs
 ukM
 cpl
 cRE
-wtq
-wtq
-wtq
+xln
+xln
+xln
 qgN
 qgN
 qgN

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -8253,6 +8253,18 @@
 "fXr" = (
 /turf/simulated/wall,
 /area/maintenance/security_starboard)
+"fYi" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 6;
+	id = "shutters_deck3_longbow";
+	name = "Safety Blast Doors Control";
+	pixel_y = -27
+	},
+/turf/simulated/floor/tiled/dark,
+/area/horizon/longbow)
 "fZe" = (
 /obj/structure/platform/ledge{
 	dir = 8
@@ -27452,13 +27464,6 @@
 /obj/machinery/computer/ship/navigation,
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	dir = 4;
-	id = "shutters_deck3_longbow";
-	name = "Safety Blast Doors Control";
-	pixel_x = 22;
-	pixel_y = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/longbow)
@@ -61815,7 +61820,7 @@ nsP
 ogE
 ecI
 eUF
-ecI
+fYi
 mXh
 kHa
 oty


### PR DESCRIPTION
Adds blast doors to the Grauwolf, and shifts the longbow blastdoor button to be more visible. 

Mapdiff can show the changes. 