### PR TITLE
Reallocates the Phoron from the Intrepid

### DIFF
--- a/html/changelogs/furrycactus - intrepid phoron.yml
+++ b/html/changelogs/furrycactus - intrepid phoron.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Furrycactus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Takes the 30 phoron sheets off of the Intrepid and splits it into 15 for Research and 15 for Machinist."

--- a/html/changelogs/furrycactus - intrepid phoron.yml
+++ b/html/changelogs/furrycactus - intrepid phoron.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscadd: "Takes the 30 phoron sheets off of the Intrepid and splits it into 15 for Research and 15 for Machinist."
+  - rscadd: "Takes the 30 phoron sheets off of the Intrepid and splits it into 15 for Scientists and 15 for the Machinists."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -24456,9 +24456,6 @@
 /turf/simulated/floor/grass,
 /area/horizon/hydroponics/lower)
 "qIS" = (
-/obj/item/stack/material/phoron{
-	amount = 30
-	},
 /obj/item/stack/material/uranium{
 	amount = 10
 	},

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -15010,6 +15010,9 @@
 	departmentType = 2;
 	name = "Research and Development Requests Console"
 	},
+/obj/item/stack/material/phoron{
+	amount = 15
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "gQD" = (
@@ -49503,6 +49506,9 @@
 /obj/machinery/camera/network/supply{
 	c_tag = "Operations -  Machinist Workshop Starboard";
 	dir = 1
+	},
+/obj/item/stack/material/phoron{
+	amount = 15
 	},
 /turf/simulated/floor/tiled,
 /area/operations/lower/machinist)


### PR DESCRIPTION
- Takes the 30 phoron sheets off of the Intrepid and splits it into 15 for Scientists and 15 for the Machinists.

The Phoron crystals can't actually be used as fuel as they are on the Intrepid, nor are they able to be used when constructing an RTG as the circuitboard is not for an advanced RTG. (Only 5 sheets are used in that recipe anyway, not the 30 in the crate.)

As it stands, I've noticed most Scientists and Machinists split the Phoron between each other anyhow, since they have no access to it otherwise, so this just removes that extra step.