### PR TITLE
Recharger backpacks improvements

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -140,22 +140,31 @@
 	return null
 
 /**
-* Connects the energy gun to an external power supply
-*
-* * powersource - the power supply in question. Can either be /obj/item/rig_module/recharger or /obj/item/recharger_backpack.
-*/
+ * Connects the energy gun to an external power supply
+ *
+ * * powersource - the power supply in question. Can either be `/obj/item/rig_module/recharger` or `/obj/item/recharger_backpack`.
+ *
+ * Returns `TRUE` if the connection was successful, `FALSE` otherwise
+ */
 /obj/item/gun/energy/proc/connect(obj/item/powersource)
 	SHOULD_NOT_SLEEP(TRUE)
+
+	//Validate that the type is allowed first of all
+	if(!is_type_in_list(powersource, list(/obj/item/rig_module/recharger, /obj/item/recharger_backpack)))
+		stack_trace("Wrong type to connect the energy gun to!")
+		return FALSE
+
+	//If we're already connected with something, we can't connect with something else
 	if(recharger)
 		to_chat(usr, SPAN_WARNING("\The [src] is already connected to \the [recharger]!"))
-		return
+		return FALSE
 
 	if(istype(powersource, /obj/item/rig_module/recharger))
 		var/obj/item/rig_module/recharger/rigcharge = powersource
 
 		if(!rigcharge.holder || !rigcharge.holder.wearer)
 			to_chat(usr, SPAN_WARNING("\The [rigcharge] must be installed in a rig and active!"))
-			return
+			return FALSE
 
 		to_chat(usr, SPAN_NOTICE("You neatly plug \the [src] into \the [powersource]."))
 		playsound(get_turf(src), 'sound/machines/click.ogg', 30, 0)
@@ -164,12 +173,12 @@
 		self_recharge = TRUE
 		use_external_power = TRUE
 
-	if(istype(powersource, /obj/item/recharger_backpack))
+	else if(istype(powersource, /obj/item/recharger_backpack))
 		var/obj/item/recharger_backpack/back_charge = powersource
 
 		if(!ismob(loc))
 			to_chat(usr, SPAN_WARNING("\The [back_charge] must be worn on the back before a weapon can be connected!"))
-			return
+			return FALSE
 
 		to_chat(usr, SPAN_NOTICE("You neatly plug \the [src] into \the [powersource]."))
 		playsound(get_turf(src), 'sound/machines/click.ogg', 30, 0)
@@ -177,6 +186,8 @@
 		recharger = back_charge
 		self_recharge = TRUE
 		use_external_power = TRUE
+
+	return TRUE
 
 
 ///Disconnects the energy gun from its external power source if one exists.
@@ -200,7 +211,7 @@
 		var/obj/item/recharger_backpack/backcharger = recharger
 		to_chat(usr, SPAN_NOTICE("With a snap, \the [src] is disconnected from \the [recharger]."))
 		playsound(get_turf(src), 'sound/machines/click.ogg', 30, 0)
-		backcharger.connected = null
+		backcharger.disconnect(src)
 
 	recharger = null
 	self_recharge = initial(self_recharge)

--- a/html/changelogs/fluffyghost-rechargebackpackimprovements.yml
+++ b/html/changelogs/fluffyghost-rechargebackpackimprovements.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Recharger backpacks now intuitively handle the connection with a simple item-on-backpack click."
+  - backend: "Improved backend handling, cleanly handle ref dropping to gun, localized management of the backpack, DMdoc, you know the deal."


### PR DESCRIPTION
Recharger backpacks now intuitively handle the connection with a simple item-on-backpack click.
Improved backend handling, cleanly handle ref dropping to gun, localized management of the backpack, DMdoc, you know the deal.

Fixes #18538 