### PR TITLE
Hidden Item Table Layer Bugfix

### DIFF
--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -267,8 +267,10 @@
 		auto_align(attacking_item, params)
 		return
 
-#define CELLS 8								//Amount of cells per row/column in grid
-#define CELLSIZE (world.icon_size/CELLS)	//Size of a cell in pixels
+/// Amount of cells per row/column in grid
+#define CELLS 8
+/// Size of a cell in pixels
+#define CELLSIZE (world.icon_size/CELLS)
 /*
 Automatic alignment of items to an invisible grid, defined by CELLS and CELLSIZE.
 Since the grid will be shifted to own a cell that is perfectly centered on the turf, we end up with two 'cell halves'
@@ -281,14 +283,19 @@ closest to where the cursor has clicked on.
 Note: This proc can be overwritten to allow for different types of auto-alignment.
 */
 /obj/item/var/list/center_of_mass = list("x" = 16,"y" = 16)
+
 /obj/structure/table/proc/auto_align(obj/item/W, click_parameters, var/animate = FALSE)
+	if(initial(W.layer) <= BELOW_TABLE_LAYER) // stuff below tables should not accidentally be adjusted to be above them
+		W.layer = initial(W.layer)
+		return TRUE
+
 	if(!W.center_of_mass)
 		W.randpixel_xy()
 		W.layer = initial(W.layer) + ((32 - W.pixel_y) / 1000)
-		return
+		return TRUE
 
 	if(!click_parameters)
-		return
+		return FALSE
 
 	var/list/mouse_control = mouse_safe_xy(click_parameters)
 	var/mouse_x = mouse_control["icon-x"]
@@ -309,6 +316,7 @@ Note: This proc can be overwritten to allow for different types of auto-alignmen
 			W.pixel_x = target_x
 			W.pixel_y = target_y
 		W.layer = initial(W.layer) + ((32 - W.pixel_y) / 1000)
+		return TRUE
 
 #undef CELLS
 #undef CELLSIZE

--- a/html/changelogs/Ben10083 - Bugfix.yml
+++ b/html/changelogs/Ben10083 - Bugfix.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Items set to be layered below tables will not have initial layer changed, fixing certain interactions."


### PR DESCRIPTION
Fixes #18836

Items set with layer below tables will not have auto-align code adjust layer. This prevents scenarios such as with Spybugs where item is adjusted to a layer above the table, making them visible.