### PR TITLE
Offship RND Servers

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -100,7 +100,11 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	return
 
 /obj/machinery/computer/rdconsole/proc/SyncTechs()
+	var/turf/turf = get_turf(src)
 	for(var/obj/machinery/r_n_d/server/S in SSmachinery.machinery)
+		var/turf/ST = get_turf(S)
+		if(ST && !AreConnectedZLevels(ST.z, turf.z))
+			continue
 		var/server_processed = 0
 		if((id in S.id_with_upload) || istype(S, /obj/machinery/r_n_d/server/centcom))
 			for(var/tech_id in files.known_tech)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -230,13 +230,20 @@
 		temp_server = null
 		consoles = list()
 		servers = list()
+		var/turf/T = get_turf(src)
 		for(var/obj/machinery/r_n_d/server/S in SSmachinery.machinery)
+			var/turf/ST = get_turf(S)
+			if(ST && !AreConnectedZLevels(ST.z, T.z))
+				continue
 			if(S.server_id == text2num(href_list["access"]) || S.server_id == text2num(href_list["data"]) || S.server_id == text2num(href_list[TRANSFER_CREW]))
 				temp_server = S
 				break
 		if(href_list["access"])
 			screen = 1
 			for(var/obj/machinery/computer/rdconsole/C in SSmachinery.machinery)
+				var/turf/CT = get_turf(C)
+				if(CT && !AreConnectedZLevels(CT.z, T.z))
+					continue
 				if(C.sync)
 					consoles += C
 		else if(href_list["data"])
@@ -244,7 +251,8 @@
 		else if(href_list[TRANSFER_CREW])
 			screen = 3
 			for(var/obj/machinery/r_n_d/server/S in SSmachinery.machinery)
-				if(S == src)
+				var/turf/ST = get_turf(S)
+				if(S == src || (ST && !AreConnectedZLevels(ST.z, T.z)))
 					continue
 				servers += S
 
@@ -289,9 +297,10 @@
 	switch(screen)
 		if(0) //Main Menu
 			dat += "Connected Servers:<BR><BR>"
-
+			var/turf/T = get_turf(src)
 			for(var/obj/machinery/r_n_d/server/S in SSmachinery.machinery)
-				if(istype(S, /obj/machinery/r_n_d/server/centcom) && !badmin)
+				var/turf/ST = get_turf(S)
+				if((istype(S, /obj/machinery/r_n_d/server/centcom) && !badmin) || (ST && !AreConnectedZLevels(ST.z, T.z)))
 					continue
 				dat += "[S.name] || "
 				dat += "<A href='?src=\ref[src];access=[S.server_id]'> Access Rights</A> | "

--- a/html/changelogs/RustingWithYou - offshiprnd.yml
+++ b/html/changelogs/RustingWithYou - offshiprnd.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Offship RND servers and consoles will no longer sync with the Horizon's database."


### PR DESCRIPTION
RND servers and consoles will now only sync with each other if they are on connected Z-levels. This allows for offship servers and RND equipment to be mapped in without syncing with or erasing the Horizon's tech levels.