### PR TITLE
Einstein ERT Rig Armor Changes & ID Fixes

### DIFF
--- a/code/datums/outfits/ert/einstein.dm
+++ b/code/datums/outfits/ert/einstein.dm
@@ -27,6 +27,9 @@
 	)
 	id_iff = IFF_EE
 
+/obj/outfit/admin/ert/einstein/get_id_access()
+	return get_distress_access_lesser()
+
 /obj/outfit/admin/ert/einstein/medic
 	name = "Einstein Medic"
 	belt = /obj/item/storage/belt/medical/first_responder/combat

--- a/code/datums/outfits/ert/zenghu.dm
+++ b/code/datums/outfits/ert/zenghu.dm
@@ -26,6 +26,9 @@
 	)
 	id_iff = IFF_ZENGHU
 
+/obj/outfit/admin/ert/zeng/get_id_access()
+	return get_distress_access()
+
 /obj/outfit/admin/ert/zeng/medic
 	name = "Zeng-Hu Medic"
 	uniform = /obj/item/clothing/under/rank/medical/first_responder/zeng

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -202,7 +202,7 @@
 		/obj/item/rig_module/actuators/combat,
 		/obj/item/rig_module/storage,
 		/obj/item/rig_module/recharger
-		)
+	)
 
 /obj/item/rig/ert/assetprotection
 	name = "\improper heavy asset protection suit control module"

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -195,6 +195,14 @@
 	req_access = list()
 	req_one_access = list()
 	allowed_module_types = MODULE_GENERAL | MODULE_LIGHT_COMBAT | MODULE_HEAVY_COMBAT | MODULE_SPECIAL | MODULE_UTILITY
+	initial_modules = list(
+		/obj/item/rig_module/ai_container,
+		/obj/item/rig_module/vision/nvg,
+		/obj/item/rig_module/maneuvering_jets,
+		/obj/item/rig_module/actuators/combat,
+		/obj/item/rig_module/storage,
+		/obj/item/rig_module/recharger
+		)
 
 /obj/item/rig/ert/assetprotection
 	name = "\improper heavy asset protection suit control module"

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -183,7 +183,15 @@
 	suit_type = "apotheosis"
 	icon = 'icons/clothing/rig/apotheosis.dmi'
 	icon_state = "apotheosis"
-
+	armor = list(
+		melee = ARMOR_MELEE_MAJOR,
+		bullet = ARMOR_BALLISTIC_RIFLE,
+		laser = ARMOR_LASER_RIFLE,
+		energy = ARMOR_ENERGY_SMALL,
+		bomb = ARMOR_BOMB_RESISTANT,
+		bio = ARMOR_BIO_SHIELDED,
+		rad = ARMOR_RAD_SHIELDED
+	)
 	req_access = list()
 	req_one_access = list()
 	allowed_module_types = MODULE_GENERAL | MODULE_LIGHT_COMBAT | MODULE_HEAVY_COMBAT | MODULE_SPECIAL | MODULE_UTILITY

--- a/html/changelogs/RustingWithYou - eerigbuff.yml
+++ b/html/changelogs/RustingWithYou - eerigbuff.yml
@@ -39,3 +39,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
   - tweak: "Einstein ERT rigs now use the correct ERT rig statss."
+  - bugfix: "Fixes missing ID accesses on ERT outfits."

--- a/html/changelogs/RustingWithYou - eerigbuff.yml
+++ b/html/changelogs/RustingWithYou - eerigbuff.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Einstein ERT rigs now use the correct ERT rig statss."


### PR DESCRIPTION
The Einstein ERT rigs now use the armor values of the SCC rigs instead of the (terrible) values of the old NT ones, as well as having the same initial modules.

Also fixes missing ID access on EE and Zeng ERTs