### PR TITLE
New INDRA Reaction: Iron+Phoron Nucleosynthesis

### DIFF
--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -169,11 +169,11 @@ var/global/list/fusion_reactions
 
 // Any now we go even further beyond!!!!
 /singleton/fusion_reaction/iron_phoron
-    p_react = "iron"
-    s_react = GAS_PHORON
-    minimum_energy_level = 100000
-    energy_consumption = 10
-    energy_production = 4
-    radiation = 30
-    instability = 5
-    products = list("uranium" = 10, "lead" = 10, "borosilicate glass" = 10) // Psuedoscience but here we are
+	p_react = "iron"
+	s_react = GAS_PHORON
+	minimum_energy_level = 100000
+	energy_consumption = 10
+	energy_production = 4
+	radiation = 30
+	instability = 5
+	products = list("uranium" = 10, "lead" = 10, "borosilicate glass" = 10) // Psuedoscience but here we are

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -166,3 +166,14 @@ var/global/list/fusion_reactions
 	radiation = 3
 	instability = 2.5
 	products = list(GAS_HELIUM = 1)
+
+// Any now we go even further beyond!!!!
+/singleton/fusion_reaction/iron_phoron
+    p_react = "iron"
+    s_react = GAS_PHORON
+    minimum_energy_level = 100000
+    energy_consumption = 10
+    energy_production = 4
+    radiation = 30
+    instability = 5
+    products = list("uranium" = 10, "lead" = 10, "borosilicate glass" = 10) // Psuedoscience but here we are

--- a/html/changelogs/QuestioningMark-NewINDRAfusionReactions.yml
+++ b/html/changelogs/QuestioningMark-NewINDRAfusionReactions.yml
@@ -38,4 +38,4 @@ delete-after: True
 # Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
 # Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - tweak: "Adds new nucleosynthesis reaction in INDRA reactor for producing small amounts of uranium, borosilicate glass & lead."
+  - rscadd: "Adds new nucleosynthesis reaction in INDRA reactor for producing small amounts of uranium, borosilicate glass & lead."

--- a/html/changelogs/QuestioningMark-NewINDRAfusionReactions.yml
+++ b/html/changelogs/QuestioningMark-NewINDRAfusionReactions.yml
@@ -1,0 +1,41 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   maptweak
+#   spellcheck (typo fixes)
+#   experiment
+#   balance
+#   admin
+#   backend
+#   security
+#   refactor
+#################################
+
+# Your name.
+author: QuestioningMark
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, all entries are changed into a single [] after a master changelog generation. Just remove the brackets when you add new entries.
+# Please surround your changes in  double quotes ("), as certain characters otherwise screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - tweak: "Adds new nucleosynthesis reaction in INDRA reactor for producing small amounts of uranium, borosilicate glass & lead."


### PR DESCRIPTION
Adds a new INDRA fusion reaction, allowing the production of lead, uranium and borosilicate glass. 

This requires cooperation across departments to receive iron and phoron from either science or pharmacy.

This is to enable a slow, low yeild manner to obtain uranium, lead and borosilicate glass in absence of miners, or to recieve a trickle of uranium, lead, and borosilicate glass that doesn't outpace the payloads miners can produce.