### PR TITLE
Boots Armor Value Parity

### DIFF
--- a/code/modules/clothing/shoes/boots.dm
+++ b/code/modules/clothing/shoes/boots.dm
@@ -9,8 +9,7 @@
 	armor = list(
 		melee = ARMOR_MELEE_KNIVES,
 		energy = ARMOR_ENERGY_MINOR,
-		bomb = ARMOR_BOMB_MINOR,
-		rad = ARMOR_RAD_MINOR
+		bomb = ARMOR_BOMB_MINOR
 	)
 	siemens_coefficient = 0.75
 	can_hold_knife = TRUE

--- a/code/modules/clothing/shoes/boots.dm
+++ b/code/modules/clothing/shoes/boots.dm
@@ -7,7 +7,10 @@
 	item_state = "jackboots"
 	force = 3
 	armor = list(
-		melee = ARMOR_MELEE_KNIVES
+		melee = ARMOR_MELEE_KNIVES,
+		energy = ARMOR_ENERGY_MINOR,
+		bomb = ARMOR_BOMB_MINOR,
+		rad = ARMOR_RAD_MINOR
 	)
 	siemens_coefficient = 0.75
 	can_hold_knife = TRUE

--- a/html/changelogs/Chevy-AuroraChev.yml
+++ b/html/changelogs/Chevy-AuroraChev.yml
@@ -1,0 +1,4 @@
+author: Chevy
+delete-after: True
+changes:
+  - balance: "Raised jackboot armor values to meet those of workboots."

--- a/html/changelogs/Chevy-AuroraChev.yml
+++ b/html/changelogs/Chevy-AuroraChev.yml
@@ -1,4 +1,4 @@
 author: Chevy
 delete-after: True
 changes:
-  - balance: "Raised jackboot armor values to meet those of workboots."
+  - balance: "Raised jackboot armor values to meet those of workboots, except for the radiation armor, which remains unique to workboots."


### PR DESCRIPTION
Workboots are objectively superior to jackboots at present; they have melee, energy, bomb, and radiation armor. Jackboots only have melee armor, at an equivalent value to workboots. I don't see any reason why the shoes that engineers wear would be necessarily better armored than those worn by dedicated security/military forces on the ship and throughout the spur, so I have raised jackboot armor values to meet those of workboots. Now they have identical armor values.