### PR TITLE
NKA Merchant Navy Soul Changes

### DIFF
--- a/html/changelogs/Lavillastrangiato - nkasoul.yml
+++ b/html/changelogs/Lavillastrangiato - nkasoul.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Lavillastrangiato
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes any access problems on the NKA merchant navy vessel."
+  - qol: "Adds various dirt, decorations, and a CO2 tank to the NKA merchant navy vessel."

--- a/maps/away/ships/nka/nka_merchant/nka_merchant.dm
+++ b/maps/away/ships/nka/nka_merchant/nka_merchant.dm
@@ -4,7 +4,7 @@
 	description = "A merchant ship of the New Kingdom's Mercantile Flotilla."
 	suffixes = list("ships/nka/nka_merchant/nka_merchant.dmm")
 	ship_cost = 1
-	spawn_weight = 9
+	spawn_weight = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/nka_merchant_shuttle)
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_VALLEY_HALE, SECTOR_CORP_ZONE, SECTOR_TAU_CETI)
 

--- a/maps/away/ships/nka/nka_merchant/nka_merchant.dm
+++ b/maps/away/ships/nka/nka_merchant/nka_merchant.dm
@@ -90,7 +90,7 @@
 	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY
 
-/obj/machinery/computer/shuttle_control/explore/nka_merchant_shuttle
+/obj/machinery/computer/shuttle_control/explore/terminal/nka_merchant_shuttle
 	name = "shuttle control console"
 	shuttle_tag = "Her Majesty's Mercantile Flotilla Shuttle"
 

--- a/maps/away/ships/nka/nka_merchant/nka_merchant.dm
+++ b/maps/away/ships/nka/nka_merchant/nka_merchant.dm
@@ -4,7 +4,7 @@
 	description = "A merchant ship of the New Kingdom's Mercantile Flotilla."
 	suffixes = list("ships/nka/nka_merchant/nka_merchant.dmm")
 	ship_cost = 1
-	spawn_weight = 1
+	spawn_weight = 9
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/nka_merchant_shuttle)
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_VALLEY_HALE, SECTOR_CORP_ZONE, SECTOR_TAU_CETI)
 

--- a/maps/away/ships/nka/nka_merchant/nka_merchant.dmm
+++ b/maps/away/ships/nka/nka_merchant/nka_merchant.dmm
@@ -85,13 +85,11 @@
 	},
 /area/nka_merchant/hangar)
 "am" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/turf/simulated/floor/tiled{
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating{
 	temperature = 278.15
 	},
-/area/nka_merchant/engineering)
+/area/nka_merchant/engine)
 "ao" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -280,9 +278,11 @@
 	},
 /area/nka_merchant/engineering)
 "aO" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
+/obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#BDB6AE";
-	frame_color = "#BDB6AE"
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -345,7 +345,7 @@
 /obj/item/reagent_containers/food/snacks/cone_cake,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm/cold/east{
-	req_one_access = list(212)
+	req_one_access = list(213)
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -517,12 +517,6 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/merchant)
-"bD" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/hangar)
 "bE" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating{
@@ -569,6 +563,9 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/effect/floor_decal/corner/white{
 	dir = 10
+	},
+/obj/machinery/alarm/cold/south{
+	req_one_access = list(213)
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -626,7 +623,7 @@
 /area/nka_merchant/mess)
 "bY" = (
 /obj/machinery/alarm/cold/south{
-	req_one_access = list(212)
+	req_one_access = list(213)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
@@ -792,7 +789,7 @@
 /area/nka_merchant/mess)
 "cq" = (
 /obj/machinery/alarm/cold/north{
-	req_one_access = list(212)
+	req_one_access = list(213)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -812,6 +809,12 @@
 /obj/item/flame/candle{
 	pixel_y = 5
 	},
+/obj/item/coin/silver,
+/obj/item/coin/silver{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/snacks/grown/mtear,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -866,13 +869,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/full,
 /area/nka_merchant/engine)
 "cH" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/alarm/cold/east{
-	req_one_access = list(212)
-	},
 /obj/effect/floor_decal/corner/white/full{
 	dir = 4
 	},
@@ -973,16 +975,11 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/eva)
-"cU" = (
-/obj/effect/floor_decal/corner/green/full{
-	dir = 8
-	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/mess)
 "cZ" = (
-/obj/effect/floor_decal/corner/dark_blue,
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1042,13 +1039,13 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 6
 	},
-/obj/machinery/alarm/cold/east{
-	req_one_access = list(212)
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/alarm/cold/east{
+	req_one_access = list(213)
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -1304,27 +1301,6 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/nka_merchant/eva)
-"dR" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
-	},
-/obj/structure/closet/secure_closet/guncabinet{
-	req_access = list(213);
-	name = "gun cabinet (rifles)"
-	},
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/item/clothing/accessory/storage/bayonet,
-/obj/item/clothing/accessory/storage/bayonet,
-/obj/item/gun/projectile/shotgun/pump/rifle,
-/obj/item/gun/projectile/shotgun/pump/rifle,
-/obj/item/ammo_magazine/boltaction,
-/obj/item/ammo_magazine/boltaction,
-/obj/item/ammo_magazine/boltaction,
-/obj/item/ammo_magazine/boltaction,
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant)
 "dV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /turf/simulated/wall/shuttle/space_ship,
@@ -1368,6 +1344,27 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/warehouse)
+"eg" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	req_access = list(213);
+	name = "gun cabinet (rifles)"
+	},
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/item/clothing/accessory/storage/bayonet,
+/obj/item/clothing/accessory/storage/bayonet,
+/obj/item/gun/projectile/shotgun/pump/rifle,
+/obj/item/gun/projectile/shotgun/pump/rifle,
+/obj/item/ammo_magazine/boltaction,
+/obj/item/ammo_magazine/boltaction,
+/obj/item/ammo_magazine/boltaction,
+/obj/item/ammo_magazine/boltaction,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "ei" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -1438,21 +1435,14 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/barracks)
-"es" = (
-/obj/machinery/air_sensor,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/map_effect/marker/large_tank{
-	master_tag = "merchant_navy_ship_co2";
-	name = "merchant_navy_ship_co2"
-	},
-/turf/simulated/floor/reinforced/carbon_dioxide,
-/area/nka_merchant/engine)
 "et" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/lino/diamond{
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating{
 	temperature = 278.15
 	},
-/area/nka_merchant/mess)
+/area/nka_merchant/engine)
 "ex" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/lightblue{
@@ -1796,6 +1786,27 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engine)
+"gb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	icon_state = "map-scrubbers"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "gc" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/spacecash/c1000{
@@ -1924,12 +1935,37 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
+"gz" = (
+/obj/machinery/alarm/cold/south{
+	req_one_access = list(213)
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
 "gB" = (
 /obj/effect/landmark/entry_point/port{
 	name = "port, bridge"
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/nka_merchant)
+"gD" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
+/obj/structure/flora/pottedplant/woodyshrub,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
+"gF" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "gK" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -1975,8 +2011,8 @@
 /area/nka_merchant/eva)
 "hc" = (
 /obj/machinery/suit_cycler/offship/nka,
-/obj/effect/floor_decal/corner/white/full{
-	dir = 8
+/obj/effect/floor_decal/corner/white{
+	dir = 5
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -2178,7 +2214,7 @@
 	dir = 5
 	},
 /obj/machinery/alarm/cold/north{
-	req_one_access = list(212)
+	req_one_access = list(213)
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -2186,8 +2222,9 @@
 /area/nka_merchant)
 "it" = (
 /obj/machinery/light,
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 10
+/obj/effect/decal/cleanable/floor_damage/tiled_broken0,
+/obj/effect/floor_decal/corner/dark_blue/full{
+	dir = 4
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -2233,6 +2270,13 @@
 "iB" = (
 /turf/template_noop,
 /area/space)
+"iJ" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/junk,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/nka_merchant/warehouse)
 "iK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -2333,6 +2377,15 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/warehouse)
+"jc" = (
+/obj/machinery/suit_cycler/offship/nka,
+/obj/effect/floor_decal/corner/white/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/eva)
 "je" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
@@ -2458,6 +2511,14 @@
 /obj/effect/map_effect/map_helper/ruler_tiles_3,
 /turf/template_noop,
 /area/space)
+"jD" = (
+/obj/effect/floor_decal/corner/green/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/mess)
 "jE" = (
 /obj/structure/table/standard,
 /obj/item/toy/comic/azmarian/issue_4,
@@ -2555,9 +2616,11 @@
 	},
 /area/nka_merchant/mess)
 "kf" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
+/obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#BDB6AE";
-	frame_color = "#BDB6AE"
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 8;
@@ -2573,6 +2636,14 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/mess)
+"kh" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/engineering)
 "kj" = (
 /obj/machinery/door/airlock/glass_mining{
 	req_access = list(213);
@@ -2592,21 +2663,6 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/nka_merchant/merchant)
-"ko" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/hangar)
 "kr" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -2694,7 +2750,7 @@
 	req_one_access = list(113)
 	},
 /obj/machinery/alarm/cold/north{
-	req_one_access = list(212)
+	req_one_access = list(213)
 	},
 /turf/simulated/floor/plating{
 	temperature = 278.15
@@ -2728,7 +2784,7 @@
 	dir = 8
 	},
 /obj/machinery/alarm/cold/north{
-	req_one_access = list(212)
+	req_one_access = list(213)
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4;
@@ -2738,6 +2794,7 @@
 	dir = 4;
 	pixel_x = -32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2761,9 +2818,6 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/nka_merchant/bridge)
 "kL" = (
-/obj/machinery/alarm/cold/east{
-	req_one_access = list(212)
-	},
 /obj/effect/floor_decal/corner/green{
 	dir = 6
 	},
@@ -2868,7 +2922,7 @@
 	dir = 8
 	},
 /obj/machinery/alarm/cold/west{
-	req_one_access = list(212)
+	req_one_access = list(213)
 	},
 /obj/structure/sign/flag/nka/large/north{
 	pixel_y = 32
@@ -2891,16 +2945,6 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/merchant)
-"lq" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
-	dir = 8
-	},
-/obj/effect/map_effect/marker/large_tank{
-	master_tag = "merchant_navy_ship_co2";
-	name = "merchant_navy_ship_co2"
-	},
-/turf/simulated/floor/reinforced/carbon_dioxide,
-/area/nka_merchant/engine)
 "ls" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2931,6 +2975,7 @@
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3072,11 +3117,11 @@
 	},
 /area/nka_merchant/engine)
 "mj" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/effect/floor_decal/corner/dark_blue/full{
-	dir = 4
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3085,15 +3130,6 @@
 /obj/effect/shuttle_landmark/nka_merchant/nav4,
 /turf/template_noop,
 /area/space)
-"ml" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 10
-	},
-/obj/machinery/vending/snack,
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant)
 "ms" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -3127,6 +3163,14 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
+"mD" = (
+/obj/effect/floor_decal/corner/green/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/mess)
 "mE" = (
 /obj/machinery/floodlight,
 /obj/effect/floor_decal/corner/dark_blue{
@@ -3186,6 +3230,12 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/bridge)
+"ng" = (
+/obj/effect/floor_decal/corner/dark_blue,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "ni" = (
 /obj/structure/table/standard,
 /obj/item/storage/toolbox/mechanical,
@@ -3233,8 +3283,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4;
+	icon_state = "map-scrubbers"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3283,13 +3334,27 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/nka_merchant/mess)
-"od" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+"nP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
-/area/nka_merchant/warehouse)
+/area/nka_merchant/hangar)
+"nU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/eva)
 "og" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/blue,
@@ -3359,6 +3424,14 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
+"oU" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "pf" = (
 /obj/structure/extinguisher_cabinet/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3443,6 +3516,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3481,12 +3555,6 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/engineering)
-"qX" = (
-/obj/effect/decal/cleanable/blood/drip/oil,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3548,35 +3616,21 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/mess)
-"rB" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 8
-	},
-/turf/simulated/floor/plating{
+"se" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/lino/diamond{
 	temperature = 278.15
 	},
-/area/nka_merchant/engine)
-"rM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/area/nka_merchant/mess)
+"sj" = (
 /obj/effect/floor_decal/corner/dark_blue{
-	dir = 9
+	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
-/area/nka_merchant/hangar)
-"sb" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
-/area/nka_merchant/eva)
+/area/nka_merchant)
 "sk" = (
 /obj/machinery/atmospherics/binary/pump/fuel/on,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3634,6 +3688,7 @@
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3667,7 +3722,7 @@
 	dir = 6
 	},
 /obj/machinery/alarm/cold/east{
-	req_one_access = list(212)
+	req_one_access = list(213)
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
@@ -3677,22 +3732,12 @@
 	temperature = 278.15
 	},
 /area/nka_merchant)
-"tH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+"tW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/hangar)
-"tO" = (
-/obj/effect/floor_decal/corner/green/full{
-	dir = 4
-	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/mess)
+/turf/simulated/wall/shuttle/space_ship,
+/area/nka_merchant/engine)
 "tY" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 1
@@ -3711,6 +3756,15 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/hangar)
+"uk" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8;
+	level = 2
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
 "uy" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/purple,
@@ -3740,6 +3794,24 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/hangar)
+"uU" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
+/obj/random/junk,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
+"vb" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "vi" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
@@ -3871,6 +3943,22 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/nka_merchant_shuttle)
+"wN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "wP" = (
 /obj/effect/floor_decal/corner/dark_blue/full,
 /turf/simulated/floor/tiled{
@@ -4057,6 +4145,25 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
+"yE" = (
+/obj/effect/floor_decal/corner/dark_blue/full{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	req_access = list(213);
+	name = "gun cabinet (revolver)"
+	},
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/item/gun/projectile/revolver/adhomian,
+/obj/item/gun/projectile/revolver/adhomian,
+/obj/item/gun/projectile/revolver/adhomian,
+/obj/item/ammo_magazine/c38,
+/obj/item/ammo_magazine/c38,
+/obj/item/ammo_magazine/c38,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "yK" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor/plating{
@@ -4088,6 +4195,20 @@
 /obj/effect/landmark/entry_point/starboard,
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/nka_merchant_shuttle)
+"zA" = (
+/obj/machinery/atmospherics/binary/pump/high_power,
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
+"zG" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 6
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "zY" = (
 /obj/machinery/door/airlock/command{
 	req_access = list(213);
@@ -4103,12 +4224,6 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/nka_merchant)
-"Ac" = (
-/obj/random/junk,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/nka_merchant/warehouse)
 "AB" = (
 /obj/machinery/computer/ship/navigation/terminal{
 	dir = 1
@@ -4118,38 +4233,18 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/bridge)
-"AL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	icon_state = "map-scrubbers"
+"AC" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled{
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating{
 	temperature = 278.15
 	},
-/area/nka_merchant/hangar)
+/area/nka_merchant/engine)
 "AT" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/nka_merchant/engine)
-"AW" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/hangar)
 "AY" = (
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 8
@@ -4160,6 +4255,18 @@
 	temperature = 278.15
 	},
 /area/nka_merchant)
+"Bq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
 "Bv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6;
@@ -4173,39 +4280,13 @@
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
 /area/nka_merchant/hangar)
-"BG" = (
-/obj/structure/sign/flag/nka/large/south{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant)
-"BW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant)
 "BY" = (
 /obj/structure/railing/mapped,
 /obj/machinery/conveyor{
@@ -4246,6 +4327,15 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/nka_merchant)
+"Cm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "Co" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
@@ -4261,26 +4351,9 @@
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/nka_merchant_shuttle)
-"Cs" = (
-/obj/effect/floor_decal/corner/green/full{
-	dir = 1
-	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/mess)
 "Df" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/nka_merchant_shuttle)
-"Dl" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant)
 "Do" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6;
@@ -4298,6 +4371,14 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/eva)
+"Dq" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 9
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/eva)
 "Dx" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 9
@@ -4306,6 +4387,29 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/captain_quarters)
+"DC" = (
+/obj/random/junk,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/nka_merchant/warehouse)
+"DI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "DK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4322,10 +4426,18 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/merchant)
+"DM" = (
+/obj/effect/decal/cleanable/blood/drip/oil,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/engineering)
 "DU" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
+/obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#BDB6AE";
-	frame_color = "#BDB6AE"
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -4339,6 +4451,14 @@
 	temperature = 278.15
 	},
 /area/nka_merchant)
+"Eb" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/mess)
 "Ed" = (
 /obj/machinery/door/airlock{
 	req_access = list(213);
@@ -4349,6 +4469,18 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/mess)
+"Ee" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
 "Eh" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -4360,6 +4492,12 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/warehouse)
+"Ei" = (
+/obj/effect/floor_decal/corner/dark_blue/full,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "En" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4545,14 +4683,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/nka_merchant_shuttle)
-"FY" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 9
-	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/hangar)
 "Gj" = (
 /obj/machinery/iff_beacon,
 /obj/structure/railing/mapped{
@@ -4565,15 +4695,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/nka_merchant/bridge)
-"Go" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
-/area/nka_merchant/engine)
 "GE" = (
 /obj/item/modular_computer/console/preset/merchant/nka{
 	dir = 8
@@ -4609,6 +4730,13 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
+"GZ" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/nka_merchant/warehouse)
 "Hg" = (
 /obj/machinery/hologram/holopad/long_range,
 /obj/effect/overmap/visitable/ship/landable/nka_merchant_shuttle,
@@ -4679,32 +4807,22 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/nka_merchant_shuttle)
-"Ih" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/floor_damage/tiled_broken0,
-/obj/effect/floor_decal/corner/dark_blue/full{
-	dir = 4
-	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/hangar)
-"It" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/hangar)
 "IA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
 /area/nka_merchant/eva)
+"IC" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "IJ" = (
 /obj/machinery/pipedispenser/disposal,
 /obj/effect/floor_decal/corner/yellow/full{
@@ -4748,14 +4866,6 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/warehouse)
-"Jl" = (
-/obj/effect/floor_decal/corner/green{
-	dir = 5
-	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/mess)
 "Jo" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light{
@@ -4774,6 +4884,12 @@
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/nka_merchant_shuttle)
+"Js" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/nka_merchant/warehouse)
 "Jv" = (
 /obj/item/device/radio,
 /obj/item/device/radio,
@@ -4804,18 +4920,6 @@
 "JO" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/nka_merchant/captain_quarters)
-"JU" = (
-/obj/random/dirt_75,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/nka_merchant/warehouse)
-"JW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/nka_merchant/warehouse)
 "JX" = (
 /obj/machinery/door/airlock{
 	req_access = list(213);
@@ -4868,6 +4972,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/nka_merchant_shuttle)
+"Ko" = (
+/obj/effect/floor_decal/corner/green/full{
+	dir = 1
+	},
+/obj/machinery/alarm/cold/east{
+	req_one_access = list(213)
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/mess)
+"Ky" = (
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
 "KB" = (
 /obj/machinery/shipsensors/weak,
 /obj/structure/railing/mapped{
@@ -4903,18 +5027,6 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/mess)
-"KW" = (
-/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
-/area/nka_merchant/engine)
-"Lg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 8
-	},
-/turf/simulated/wall/shuttle/space_ship,
-/area/nka_merchant/engine)
 "Ll" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4926,16 +5038,6 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engine)
-"Lq" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/outline/firefighting_closet,
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant)
 "Ls" = (
 /obj/effect/landmark{
 	name = "carpspawn"
@@ -4963,6 +5065,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/nka_merchant/eva)
+"MY" = (
+/obj/structure/sign/flag/nka/large/south{
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "Ni" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/binary/pump/on{
@@ -4992,9 +5105,7 @@
 /turf/simulated/floor/tiled/full,
 /area/nka_merchant/engineering)
 "Nq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -5002,6 +5113,9 @@
 	},
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -5019,15 +5133,6 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/nka_merchant_shuttle)
-"Nt" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 10
-	},
-/obj/structure/flora/pottedplant/woodyshrub,
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant)
 "NJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -5037,15 +5142,6 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
-"NU" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 10
-	},
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant)
 "NZ" = (
 /obj/structure/bed/stool/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5096,15 +5192,16 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/bridge/secondary)
-"OI" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 10
+"OG" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8
 	},
-/obj/random/junk,
-/turf/simulated/floor/tiled{
-	temperature = 278.15
+/obj/effect/map_effect/marker/large_tank{
+	master_tag = "merchant_navy_ship_co2";
+	name = "merchant_navy_ship_co2"
 	},
-/area/nka_merchant)
+/turf/simulated/floor/reinforced/carbon_dioxide,
+/area/nka_merchant/engine)
 "OJ" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 6
@@ -5130,6 +5227,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -5155,16 +5254,6 @@
 	temperature = 278.15
 	},
 /area/nka_merchant)
-"OU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/structure/extinguisher_cabinet/east{
-	layer = 3.3;
-	pixel_y = 1
-	},
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
-/area/nka_merchant/eva)
 "OX" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/black,
 /turf/simulated/wall/shuttle/space_ship,
@@ -5188,25 +5277,21 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
-"Pl" = (
-/obj/effect/floor_decal/corner/dark_blue/full{
-	dir = 1
+"Pm" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
 	},
-/obj/structure/closet/secure_closet/guncabinet{
-	req_access = list(213);
-	name = "gun cabinet (revolver)"
-	},
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/item/gun/projectile/revolver/adhomian,
-/obj/item/gun/projectile/revolver/adhomian,
-/obj/item/gun/projectile/revolver/adhomian,
-/obj/item/ammo_magazine/c38,
-/obj/item/ammo_magazine/c38,
-/obj/item/ammo_magazine/c38,
+/obj/machinery/vending/snack,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
 /area/nka_merchant)
+"Py" = (
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
 "PJ" = (
 /obj/structure/toilet{
 	dir = 4
@@ -5238,6 +5323,17 @@
 /obj/effect/shuttle_landmark/nka_merchant_shuttle/transit,
 /turf/space/transit/north,
 /area/space)
+"Qa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
 "Qh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6;
@@ -5263,15 +5359,21 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/bridge/secondary)
+"QE" = (
+/obj/random/dirt_75,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/nka_merchant/warehouse)
 "QK" = (
-/obj/machinery/suit_cycler/offship/nka,
-/obj/effect/floor_decal/corner/white{
+/obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
 	},
+/obj/random/junk,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
-/area/nka_merchant/eva)
+/area/nka_merchant)
 "RC" = (
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
@@ -5280,6 +5382,12 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/merchant)
+"RI" = (
+/obj/effect/decal/cleanable/floor_damage/rust,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/engineering)
 "RM" = (
 /obj/structure/table/standard,
 /obj/structure/window/reinforced{
@@ -5298,6 +5406,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -5333,17 +5442,15 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
-"SQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 8
+"SS" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating{
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
-/area/nka_merchant/engine)
+/area/nka_merchant)
 "Tk" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -5356,13 +5463,14 @@
 	},
 /area/nka_merchant/bridge)
 "Tu" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 6
+/obj/machinery/air_sensor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/map_effect/marker/large_tank{
+	master_tag = "merchant_navy_ship_co2";
+	name = "merchant_navy_ship_co2"
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/hangar)
+/turf/simulated/floor/reinforced/carbon_dioxide,
+/area/nka_merchant/engine)
 "TF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black{
 	dir = 8
@@ -5397,21 +5505,23 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engine)
-"TZ" = (
+"Uc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
+"Ul" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
 /area/nka_merchant/hangar)
-"Ub" = (
-/obj/machinery/atmospherics/binary/pump/high_power,
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
-/area/nka_merchant/engine)
 "Up" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5422,14 +5532,6 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/hangar)
-"Uv" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
-/area/nka_merchant/engine)
 "UB" = (
 /obj/structure/table/rack,
 /obj/item/inflatable_dispenser,
@@ -5455,12 +5557,6 @@
 	temperature = 278.15
 	},
 /area/nka_merchant)
-"UJ" = (
-/obj/effect/decal/cleanable/floor_damage/rust,
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/engineering)
 "UK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 5
@@ -5493,9 +5589,11 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/nka_merchant)
 "Vv" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
+/obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#BDB6AE";
-	frame_color = "#BDB6AE"
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 8;
@@ -5505,6 +5603,21 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/bridge)
+"VR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "VT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
@@ -5525,7 +5638,11 @@
 	},
 /area/nka_merchant/warehouse)
 "Wr" = (
-/obj/effect/floor_decal/corner/dark_blue/full,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/corner/dark_blue/full{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -5551,6 +5668,16 @@
 	temperature = 278.15
 	},
 /area/nka_merchant)
+"WS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/structure/extinguisher_cabinet/east{
+	layer = 3.3;
+	pixel_y = 1
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/eva)
 "WZ" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/nka_merchant/warehouse)
@@ -5577,6 +5704,12 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/barracks)
+"Xh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "Xy" = (
 /obj/structure/closet/walllocker/medical{
 	pixel_x = 32
@@ -5584,7 +5717,7 @@
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/regular,
 /obj/machinery/alarm/cold/north{
-	req_one_access = list(212)
+	req_one_access = list(213)
 	},
 /obj/effect/floor_decal/corner/white/full{
 	dir = 1
@@ -5605,13 +5738,6 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engine)
-"XV" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/random/junk,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/nka_merchant/warehouse)
 "Yo" = (
 /obj/item/flame/lighter/adhomai,
 /obj/structure/table/standard,
@@ -5648,14 +5774,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/nka_merchant_shuttle)
 "YB" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4;
+	icon_state = "map_scrubber_on"
 	},
-/obj/random/junk,
-/turf/simulated/floor/tiled{
+/turf/simulated/floor/plating{
 	temperature = 278.15
 	},
-/area/nka_merchant)
+/area/nka_merchant/engine)
 "YM" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
@@ -5699,28 +5825,11 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engine)
-"Zi" = (
-/obj/effect/floor_decal/corner/dark_blue{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant)
 "Zr" = (
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
 /area/nka_merchant/engine)
-"Zz" = (
-/obj/effect/floor_decal/corner/white{
-	dir = 9
-	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
-/area/nka_merchant/eva)
 "ZX" = (
 /obj/effect/decal/cleanable/blood/drip/oil,
 /obj/machinery/portable_atmospherics/powered/scrubber,
@@ -17116,7 +17225,7 @@ iB
 iB
 YX
 dV
-Uv
+et
 cr
 AT
 AT
@@ -17128,7 +17237,7 @@ pA
 cS
 gN
 lO
-am
+kh
 mK
 fJ
 yr
@@ -17280,7 +17389,7 @@ vo
 Fy
 RS
 Zr
-Go
+AC
 AT
 jA
 vA
@@ -17306,7 +17415,7 @@ Vj
 dd
 fY
 KT
-cU
+mD
 bS
 Fm
 Fm
@@ -17440,13 +17549,13 @@ iB
 iB
 AT
 AT
-rB
+Ky
 Zr
 eD
 AT
 vA
 vA
-sb
+nU
 OZ
 pA
 dI
@@ -17466,9 +17575,9 @@ ij
 dE
 Vj
 ai
-et
+se
 fx
-Jl
+Eb
 dZ
 nA
 kZ
@@ -17604,7 +17713,7 @@ iB
 AT
 aI
 AT
-Lg
+tW
 AT
 hx
 Wx
@@ -17766,10 +17875,10 @@ iB
 AT
 aI
 ga
-lq
+OG
 AT
 xX
-OU
+WS
 IA
 jw
 pA
@@ -17792,7 +17901,7 @@ Vj
 fE
 FH
 nq
-Jl
+Eb
 gi
 cN
 cN
@@ -17926,9 +18035,9 @@ iB
 iB
 iB
 AT
-SQ
-KW
-es
+Qa
+Py
+Tu
 AT
 vA
 vA
@@ -17938,7 +18047,7 @@ pA
 cM
 Sg
 aP
-UJ
+RI
 kV
 fJ
 fJ
@@ -17960,7 +18069,7 @@ eV
 eV
 EU
 Vp
-Lq
+IC
 xc
 ih
 kI
@@ -18092,15 +18201,15 @@ TU
 ga
 fk
 AT
-hc
-Zz
-Zz
+jc
+Dq
+Dq
 cT
 pA
 yK
 GV
 Ni
-qX
+DM
 br
 fJ
 og
@@ -18116,7 +18225,7 @@ PJ
 eB
 eB
 Ed
-Jl
+Eb
 io
 ie
 kg
@@ -18254,7 +18363,7 @@ aI
 AT
 AT
 AT
-QK
+hc
 bq
 gU
 sn
@@ -18272,7 +18381,7 @@ lW
 JX
 eE
 bH
-ml
+Pm
 Vp
 Si
 eB
@@ -18286,7 +18395,7 @@ qY
 Vp
 fv
 Fd
-lu
+MY
 Vp
 pL
 pL
@@ -18412,8 +18521,8 @@ iB
 iB
 iB
 AT
-aI
-Zr
+Uc
+am
 iT
 AT
 dF
@@ -18434,19 +18543,19 @@ Yo
 fJ
 aJ
 xc
-NU
+SS
 Vp
 eF
 eB
 iw
 Vj
-Cs
+Ko
 rp
 pf
 kL
-tO
+jD
 Vp
-YB
+QK
 xc
 ih
 Vp
@@ -18575,10 +18684,10 @@ iB
 AT
 AT
 TU
-Ub
+zA
 wQ
 AT
-QK
+hc
 bq
 fK
 Jv
@@ -18596,7 +18705,7 @@ fJ
 fJ
 fI
 xc
-Nt
+gD
 Vp
 Vj
 Vj
@@ -18610,7 +18719,7 @@ Vj
 Vp
 fI
 xc
-Zi
+vb
 Vp
 Vp
 Vp
@@ -18740,7 +18849,7 @@ gh
 Zr
 iY
 AT
-QK
+hc
 bq
 Do
 gv
@@ -18752,8 +18861,8 @@ aS
 bv
 pA
 ni
-FY
-Wr
+gF
+Ei
 TH
 lt
 tY
@@ -18899,7 +19008,7 @@ iB
 hE
 OX
 kx
-Zr
+am
 iY
 AT
 rq
@@ -19061,7 +19170,7 @@ iB
 vo
 fH
 aI
-Zr
+am
 Zr
 AT
 vA
@@ -19089,13 +19198,13 @@ cm
 cm
 cm
 PV
-Dl
+sj
 Ka
 cm
 EC
 Vp
 nw
-BW
+DI
 ih
 hS
 yv
@@ -19222,22 +19331,22 @@ iB
 iB
 AT
 AT
-SQ
-Zr
+Bq
+YB
 Zr
 AT
 Bv
 tw
 nz
-rM
-rM
-AL
-rM
-rM
+nP
+nP
+gb
+wN
+nP
 cJ
 aC
-rM
-ko
+nP
+VR
 wt
 bY
 TH
@@ -19257,7 +19366,7 @@ wr
 wr
 Vp
 fI
-BW
+DI
 OT
 Vp
 Vp
@@ -19385,19 +19494,19 @@ iB
 iB
 AT
 aI
-Zr
+Ee
 OL
 cG
 Nq
-TZ
+Cm
 fd
 yc
 yc
-tH
+Ul
 yc
 yc
 yc
-yc
+Xh
 yc
 yc
 yc
@@ -19410,7 +19519,7 @@ cQ
 WZ
 ec
 WZ
-JW
+Js
 bM
 wr
 lk
@@ -19420,7 +19529,7 @@ RC
 Vp
 iq
 xc
-BG
+lu
 Vp
 pL
 pL
@@ -19547,7 +19656,7 @@ iB
 iB
 AT
 aI
-Zr
+uk
 jn
 AT
 iU
@@ -19582,7 +19691,7 @@ aw
 Vp
 hV
 jm
-OI
+uU
 Vp
 pL
 pL
@@ -19726,8 +19835,8 @@ EQ
 Df
 uK
 iZ
-bD
-AW
+Xh
+oU
 ac
 bM
 bM
@@ -19870,7 +19979,7 @@ iB
 iB
 iB
 AT
-aI
+Uc
 Zr
 jn
 AT
@@ -19888,8 +19997,8 @@ OP
 Df
 Df
 iZ
-bD
-it
+Xh
+cZ
 WZ
 jJ
 bM
@@ -19904,7 +20013,7 @@ bB
 lS
 ji
 Vp
-dR
+eg
 xc
 ih
 UL
@@ -20033,7 +20142,7 @@ iB
 iB
 AT
 aI
-Zr
+am
 jn
 AT
 En
@@ -20058,7 +20167,7 @@ Er
 Er
 Er
 ey
-JU
+QE
 fA
 wr
 az
@@ -20066,7 +20175,7 @@ FC
 lp
 eA
 Vp
-Pl
+yE
 bV
 iz
 OD
@@ -20195,7 +20304,7 @@ iB
 iB
 AT
 aI
-Zr
+am
 zi
 AT
 iU
@@ -20216,7 +20325,7 @@ yc
 bj
 WZ
 kQ
-od
+GZ
 lR
 bM
 BY
@@ -20358,7 +20467,7 @@ AT
 AT
 gh
 Zr
-Zr
+gz
 AT
 iU
 ht
@@ -20375,14 +20484,14 @@ Df
 uK
 iZ
 yc
-It
+mj
 WZ
 cc
-XV
+iJ
 aU
 bM
 BY
-Ac
+DC
 bM
 wr
 vQ
@@ -20536,8 +20645,8 @@ Co
 sX
 sX
 jy
-cZ
-mj
+ng
+Wr
 WZ
 WZ
 gm
@@ -20680,25 +20789,25 @@ iB
 iB
 ol
 dV
-Zr
+am
 aH
 mg
 AT
 aX
-Tu
-Tu
-Tu
+zG
+zG
+zG
 dA
-Tu
-Tu
-Tu
-Tu
-Tu
-Tu
+zG
+zG
+zG
+zG
+zG
+zG
 dA
-Tu
-Tu
-Ih
+zG
+zG
+it
 TH
 WZ
 WZ

--- a/maps/away/ships/nka/nka_merchant/nka_merchant.dmm
+++ b/maps/away/ships/nka/nka_merchant/nka_merchant.dmm
@@ -36,9 +36,7 @@
 	name = "Warehouse";
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
+/turf/simulated/floor/tiled/full,
 /area/nka_merchant/warehouse)
 "ae" = (
 /obj/structure/bed/stool/chair/office/dark{
@@ -871,6 +869,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/full,
 /area/nka_merchant/engine)
 "cH" = (
@@ -1283,6 +1282,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/full,
 /area/nka_merchant/captain_quarters)
 "dO" = (
@@ -1529,6 +1531,8 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 5
 	},
+/obj/machinery/door/firedoor/noid,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1760,6 +1764,9 @@
 	name = "Airlock Access";
 	dir = 4
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/full,
 /area/nka_merchant/eva)
 "fY" = (
@@ -1832,6 +1839,9 @@
 	},
 /obj/structure/railing/mapped{
 	dir = 8
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
 /turf/simulated/floor/reinforced{
 	temperature = 278.15
@@ -2096,9 +2106,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/tiled/full,
 /area/nka_merchant/bridge)
 "hS" = (
 /obj/machinery/door/window/eastright{
@@ -2108,6 +2117,8 @@
 /obj/effect/floor_decal/corner/white/full{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/noid,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2661,6 +2672,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/full,
 /area/nka_merchant/merchant)
 "kr" = (
@@ -3167,6 +3181,9 @@
 /obj/effect/floor_decal/corner/green/full{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3331,6 +3348,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/full,
 /area/nka_merchant/mess)
@@ -3881,6 +3901,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/full,
 /area/nka_merchant/eva)
 "wi" = (
@@ -4062,7 +4085,7 @@
 	},
 /area/nka_merchant/barracks)
 "xX" = (
-/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/atmospherics/portables_connector/aux,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/door/window{
 	req_one_access = list(212)
@@ -4222,6 +4245,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/full,
 /area/nka_merchant)
 "AB" = (
@@ -4465,6 +4489,7 @@
 	name = "Crew Quarters";
 	dir = 1
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/freezer{
 	temperature = 278.15
 	},
@@ -4933,6 +4958,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/full,
 /area/nka_merchant/barracks)
 "Ka" = (
@@ -5102,6 +5128,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/full,
 /area/nka_merchant/engineering)
 "Nq" = (
@@ -5188,9 +5217,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/tiled/full,
 /area/nka_merchant/bridge/secondary)
 "OG" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -5398,6 +5426,8 @@
 /obj/effect/floor_decal/corner/white/full{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/noid,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -5481,6 +5511,9 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/nka_merchant/hangar)
 "TN" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
 /turf/simulated/floor/reinforced{
 	temperature = 278.15
 	},

--- a/maps/away/ships/nka/nka_merchant/nka_merchant.dmm
+++ b/maps/away/ships/nka/nka_merchant/nka_merchant.dmm
@@ -23,6 +23,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -71,23 +74,24 @@
 /area/nka_merchant/captain_quarters)
 "al" = (
 /obj/structure/cable/green,
-/obj/machinery/power/apc/south{
-	is_critical = 1;
+/obj/machinery/power/apc/high/south{
 	req_access = list(213)
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
 /area/nka_merchant/hangar)
 "am" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
+/obj/effect/floor_decal/corner/yellow{
 	dir = 9
 	},
-/turf/simulated/floor/plating{
+/turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
-/area/nka_merchant/engine)
+/area/nka_merchant/engineering)
 "ao" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -95,6 +99,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 6
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -141,9 +148,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
+/turf/simulated/floor/tiled/full,
 /area/nka_merchant/merchant)
 "aw" = (
 /obj/structure/table/standard,
@@ -200,6 +205,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 9
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -226,7 +234,7 @@
 	},
 /area/nka_merchant/mess)
 "aF" = (
-/obj/machinery/computer/ship/engines{
+/obj/machinery/computer/ship/engines/terminal{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/white{
@@ -242,10 +250,7 @@
 	dir = 1
 	},
 /obj/structure/plasticflaps/airtight,
-/turf/simulated/floor/tiled{
-	name = "cooled floor";
-	temperature = 278
-	},
+/turf/simulated/floor/tiled/full,
 /area/nka_merchant/engine)
 "aI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -267,12 +272,18 @@
 /obj/machinery/vending/engineering{
 	req_access = list(213)
 	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
 "aO" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE"
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -345,6 +356,9 @@
 	dir = 8;
 	level = 2
 	},
+/obj/effect/floor_decal/corner/dark_blue/full{
+	dir = 1
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -358,6 +372,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -415,6 +430,9 @@
 /obj/machinery/conveyor_switch{
 	id = "merchant_navy"
 	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -425,21 +443,30 @@
 	},
 /area/nka_merchant/eva)
 "br" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light,
 /obj/structure/dispenser/oxygen,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
 "bs" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
 "bu" = (
 /obj/machinery/pipedispenser,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
+	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -448,7 +475,6 @@
 "bv" = (
 /obj/structure/table/rack,
 /obj/item/stack/rods,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/item/stack/material/glass/full,
 /obj/item/stack/material/glass/full,
 /obj/item/stack/material/steel/full,
@@ -456,6 +482,10 @@
 /obj/item/stack/material/steel/full,
 /obj/item/stack/material/wood/full,
 /obj/item/storage/box/lights/bulbs,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -487,6 +517,12 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/merchant)
+"bD" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "bE" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating{
@@ -515,6 +551,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/item/trash/hakhmaps,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -530,6 +567,9 @@
 "bL" = (
 /obj/structure/table/standard,
 /obj/item/storage/toolbox/mechanical,
+/obj/effect/floor_decal/corner/white{
+	dir = 10
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -579,6 +619,7 @@
 /obj/structure/table/stone/marble,
 /obj/machinery/chemical_dispenser/bar_soft/full,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/lino/diamond{
 	temperature = 278.15
 	},
@@ -601,6 +642,9 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -656,12 +700,11 @@
 	},
 /area/nka_merchant/warehouse)
 "ce" = (
-/obj/structure/table/standard,
-/obj/item/device/flashlight/lamp,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4;
 	icon_state = "map_scrubber_on"
 	},
+/obj/structure/flora/pottedplant/smalltree,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -704,9 +747,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
+/turf/simulated/floor/tiled/full,
 /area/nka_merchant/hangar)
 "cl" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -825,15 +866,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
+/turf/simulated/floor/tiled/full,
 /area/nka_merchant/engine)
 "cH" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/alarm/cold/east{
 	req_one_access = list(212)
 	},
+/obj/effect/floor_decal/corner/white/full{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -855,6 +898,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 9
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -914,17 +960,33 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/portgen/basic/fusion,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
 "cT" = (
 /obj/structure/dispenser/oxygen,
+/obj/effect/floor_decal/corner/white/full,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
 /area/nka_merchant/eva)
+"cU" = (
+/obj/effect/floor_decal/corner/green/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/mess)
+"cZ" = (
+/obj/effect/floor_decal/corner/dark_blue,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "db" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	icon_state = "map-supply";
@@ -1028,6 +1090,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1039,6 +1102,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 9
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1048,6 +1114,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/dark_blue/full,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1076,6 +1144,9 @@
 "dA" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 6
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -1112,7 +1183,9 @@
 	dir = 1
 	},
 /obj/machinery/suit_cycler/offship/nka,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/white{
+	dir = 5
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1213,9 +1286,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
+/turf/simulated/floor/tiled/full,
 /area/nka_merchant/captain_quarters)
 "dO" = (
 /obj/machinery/airlock_sensor{
@@ -1230,8 +1301,30 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker/airlock/docking/nka_merchant/dock/starboard,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/nka_merchant/eva)
+"dR" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	req_access = list(213);
+	name = "gun cabinet (rifles)"
+	},
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/item/clothing/accessory/storage/bayonet,
+/obj/item/clothing/accessory/storage/bayonet,
+/obj/item/gun/projectile/shotgun/pump/rifle,
+/obj/item/gun/projectile/shotgun/pump/rifle,
+/obj/item/ammo_magazine/boltaction,
+/obj/item/ammo_magazine/boltaction,
+/obj/item/ammo_magazine/boltaction,
+/obj/item/ammo_magazine/boltaction,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "dV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /turf/simulated/wall/shuttle/space_ship,
@@ -1241,6 +1334,7 @@
 	dir = 1
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1327,6 +1421,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1334,19 +1431,28 @@
 "em" = (
 /obj/structure/table/standard,
 /obj/item/book/manual/nka_manifesto,
-/obj/structure/sign/flag/nka/large/south,
+/obj/structure/sign/flag/nka/large/south{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
 /area/nka_merchant/barracks)
-"et" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/black{
-	dir = 1
+"es" = (
+/obj/machinery/air_sensor,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/map_effect/marker/large_tank{
+	master_tag = "merchant_navy_ship_co2";
+	name = "merchant_navy_ship_co2"
 	},
-/turf/simulated/floor/plating{
+/turf/simulated/floor/reinforced/carbon_dioxide,
+/area/nka_merchant/engine)
+"et" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/lino/diamond{
 	temperature = 278.15
 	},
-/area/nka_merchant/engine)
+/area/nka_merchant/mess)
 "ex" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/lightblue{
@@ -1385,7 +1491,10 @@
 	},
 /area/nka_merchant/mess)
 "eD" = (
-/obj/machinery/light,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4
+	},
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -1414,6 +1523,7 @@
 	pixel_x = 28;
 	pixel_y = -3
 	},
+/obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/tiled/freezer{
 	temperature = 278.15
 	},
@@ -1471,15 +1581,15 @@
 	},
 /area/nka_merchant/merchant)
 "fk" = (
-/obj/machinery/atmospherics/portables_connector{
+/obj/machinery/atmospherics/unary/vent_pump/siphon/atmos{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide{
-	start_pressure = 8000.63
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/map_effect/marker/large_tank{
+	master_tag = "merchant_navy_ship_co2";
+	name = "merchant_navy_ship_co2"
 	},
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
+/turf/simulated/floor/reinforced/carbon_dioxide,
 /area/nka_merchant/engine)
 "fm" = (
 /turf/simulated/floor/tiled{
@@ -1509,6 +1619,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1525,6 +1638,7 @@
 "fx" = (
 /obj/structure/table/stone/marble,
 /obj/machinery/chemical_dispenser/bar_alc/full,
+/obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/lino/diamond{
 	temperature = 278.15
 	},
@@ -1656,9 +1770,7 @@
 	name = "Airlock Access";
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
+/turf/simulated/floor/tiled/full,
 /area/nka_merchant/eva)
 "fY" = (
 /turf/simulated/floor/lino/diamond{
@@ -1678,9 +1790,8 @@
 	},
 /area/nka_merchant/mess)
 "ga" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 6
-	},
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -1797,6 +1908,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/white{
+	dir = 10
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1861,7 +1975,9 @@
 /area/nka_merchant/eva)
 "hc" = (
 /obj/machinery/suit_cycler/offship/nka,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/white/full{
+	dir = 8
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1872,6 +1988,9 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -1899,6 +2018,7 @@
 	brightness_color = "#FA8282";
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -1922,6 +2042,7 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
 	},
+/obj/random/junk,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1996,6 +2117,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/corner/white{
+	dir = 6
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2062,6 +2186,9 @@
 /area/nka_merchant)
 "it" = (
 /obj/machinery/light,
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2076,9 +2203,6 @@
 /turf/space/transit/north,
 /area/space)
 "iw" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/machinery/door/window{
 	dir = 1
 	},
@@ -2118,6 +2242,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 8
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2136,8 +2263,12 @@
 	},
 /area/nka_merchant/engineering)
 "iT" = (
-/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
+/obj/machinery/computer/general_air_control/large_tank_control/terminal{
 	dir = 1
+	},
+/obj/effect/map_effect/marker/large_tank{
+	master_tag = "merchant_navy_ship_co2";
+	name = "merchant_navy_ship_co2"
 	},
 /turf/simulated/floor/plating{
 	temperature = 278.15
@@ -2146,6 +2277,9 @@
 "iU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -2226,6 +2360,10 @@
 	layer = 3.3;
 	pixel_y = 1
 	},
+/obj/effect/decal/cleanable/floor_damage/rust,
+/obj/effect/floor_decal/corner/white{
+	dir = 6
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2255,7 +2393,7 @@
 	},
 /area/nka_merchant/engine)
 "jt" = (
-/obj/machinery/computer/ship/sensors{
+/obj/machinery/computer/ship/sensors/terminal{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/white/full{
@@ -2266,9 +2404,8 @@
 	},
 /area/nka_merchant/bridge/secondary)
 "ju" = (
-/obj/machinery/computer/ship/helm{
-	dir = 1;
-	req_access = null
+/obj/machinery/computer/ship/helm/terminal{
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -2298,6 +2435,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -2323,6 +2461,10 @@
 "jE" = (
 /obj/structure/table/standard,
 /obj/item/toy/comic/azmarian/issue_4,
+/obj/item/device/flashlight/lamp{
+	pixel_y = 12;
+	pixel_x = -7
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2362,6 +2504,7 @@
 /obj/effect/floor_decal/industrial/outline_straight/red,
 /obj/effect/map_effect/marker/airlock/docking/nka_merchant/dock/starboard,
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/nka_merchant/eva)
 "jU" = (
@@ -2379,6 +2522,9 @@
 	},
 /obj/machinery/power/apc/north{
 	req_access = list(213)
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 5
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -2401,12 +2547,18 @@
 /area/nka_merchant/merchant)
 "kb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
 /area/nka_merchant/mess)
 "kf" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE"
+	},
 /obj/machinery/door/blast/regular/open{
 	dir = 8;
 	id = "merchant_navy_bridge"
@@ -2438,10 +2590,23 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/tiled/full,
+/area/nka_merchant/merchant)
+"ko" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 1
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
-/area/nka_merchant/merchant)
+/area/nka_merchant/hangar)
 "kr" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -2489,7 +2654,7 @@
 	},
 /area/nka_merchant/barracks)
 "kx" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/black,
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -2599,6 +2764,9 @@
 /obj/machinery/alarm/cold/east{
 	req_one_access = list(212)
 	},
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2641,8 +2809,11 @@
 	},
 /area/nka_merchant/barracks)
 "kV" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2699,7 +2870,9 @@
 /obj/machinery/alarm/cold/west{
 	req_one_access = list(212)
 	},
-/obj/structure/sign/flag/nka/large/north,
+/obj/structure/sign/flag/nka/large/north{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2718,6 +2891,16 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/merchant)
+"lq" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/large_tank{
+	master_tag = "merchant_navy_ship_co2";
+	name = "merchant_navy_ship_co2"
+	},
+/turf/simulated/floor/reinforced/carbon_dioxide,
+/area/nka_merchant/engine)
 "ls" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2735,13 +2918,16 @@
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 8
 	},
-/obj/machinery/vending/snack,
+/obj/structure/closet/firecloset,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
 /area/nka_merchant)
 "lu" = (
-/obj/structure/sign/flag/nka/large/south,
+/obj/structure/sign/flag/nka/large/south{
+	pixel_y = -32
+	},
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
 	},
@@ -2776,6 +2962,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
+/obj/random/junk,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -2878,14 +3065,18 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/tiled{
 	name = "cooled floor";
 	temperature = 278
 	},
 /area/nka_merchant/engine)
 "mj" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/corner/dark_blue/full{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2894,6 +3085,15 @@
 /obj/effect/shuttle_landmark/nka_merchant/nav4,
 /turf/template_noop,
 /area/space)
+"ml" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "ms" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -2929,6 +3129,9 @@
 /area/nka_merchant/engineering)
 "mE" = (
 /obj/machinery/floodlight,
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2944,6 +3147,8 @@
 /obj/item/stack/material/tritium/full,
 /obj/item/stack/material/tritium/full,
 /obj/item/stack/material/tritium/full,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/floor_decal/corner/yellow/full,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2953,6 +3158,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/blood/drip/oil,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -2983,6 +3189,9 @@
 "ni" = (
 /obj/structure/table/standard,
 /obj/item/storage/toolbox/mechanical,
+/obj/effect/floor_decal/corner/dark_blue/full{
+	dir = 8
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2992,6 +3201,7 @@
 	dir = 2;
 	req_access = list(213)
 	},
+/obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/lino/diamond{
 	temperature = 278.15
 	},
@@ -3014,6 +3224,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/item/trash/cigbutt,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3039,6 +3250,9 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 9
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -3067,10 +3281,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
+/turf/simulated/floor/tiled/full,
+/area/nka_merchant/mess)
+"od" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
 	temperature = 278.15
 	},
-/area/nka_merchant/mess)
+/area/nka_merchant/warehouse)
 "og" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/blue,
@@ -3146,6 +3365,9 @@
 	dir = 9;
 	pixel_y = 0
 	},
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3168,6 +3390,7 @@
 /obj/effect/floor_decal/industrial/loading/yellow{
 	dir = 1
 	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3214,8 +3437,8 @@
 	id = "merchant_navy_bridge";
 	name = "Bridge Blastdoor";
 	req_access = list(213);
-	dir = 8;
-	pixel_x = 32
+	dir = 4;
+	pixel_x = 21
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -3228,6 +3451,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/floor_damage/rust,
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3235,6 +3462,9 @@
 "qt" = (
 /obj/machinery/vending/tool{
 	req_access = list(213)
+	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -3248,12 +3478,24 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/engineering)
+"qX" = (
+/obj/effect/decal/cleanable/blood/drip/oil,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
 "qY" = (
 /obj/structure/bed/stool/bar/padded/red,
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3271,6 +3513,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3282,6 +3527,9 @@
 /obj/item/device/gps,
 /obj/item/device/gps,
 /obj/item/device/gps,
+/obj/effect/floor_decal/corner/white/full{
+	dir = 1
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3300,6 +3548,35 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/mess)
+"rB" = (
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
+"rM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
+"sb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/eva)
 "sk" = (
 /obj/machinery/atmospherics/binary/pump/fuel/on,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3307,12 +3584,15 @@
 /area/shuttle/nka_merchant_shuttle)
 "sn" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green,
 /obj/machinery/power/apc/south{
 	is_critical = 1;
 	req_access = list(213)
 	},
+/obj/effect/floor_decal/corner/white{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3350,6 +3630,9 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 9
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -3394,6 +3677,22 @@
 	temperature = 278.15
 	},
 /area/nka_merchant)
+"tH" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
+"tO" = (
+/obj/effect/floor_decal/corner/green/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/mess)
 "tY" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 1
@@ -3405,6 +3704,9 @@
 "uh" = (
 /obj/structure/table/standard,
 /obj/item/storage/toolbox/electrical,
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3430,6 +3732,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline_straight/red,
 /obj/effect/map_effect/marker/airlock/docking/nka_merchant/dock/starboard,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/nka_merchant/eva)
 "uK" = (
@@ -3451,6 +3754,7 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker/airlock/docking/nka_merchant/dock/starboard,
+/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/nka_merchant/eva)
 "vo" = (
@@ -3505,9 +3809,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
+/turf/simulated/floor/tiled/full,
 /area/nka_merchant/eva)
 "wi" = (
 /obj/machinery/computer/ship/navigation/terminal{
@@ -3519,6 +3821,9 @@
 /obj/effect/floor_decal/spline/plain/grey{
 	dir = 8
 	},
+/obj/structure/sign/painting_frame/shumaila{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/nka_merchant_shuttle)
 "wj" = (
@@ -3527,6 +3832,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/nka_merchant_shuttle)
 "wm" = (
@@ -3572,10 +3878,14 @@
 	},
 /area/nka_merchant)
 "wQ" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide{
+	start_pressure = 8000.63
+	},
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/small,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -3640,8 +3950,8 @@
 	id = "merchant_navy_bridge";
 	name = "Bridge Blastdoor";
 	req_access = list(213);
-	dir = 4;
-	pixel_x = -32
+	dir = 8;
+	pixel_x = -21
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -3791,12 +4101,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
+/turf/simulated/floor/tiled/full,
+/area/nka_merchant)
+"Ac" = (
+/obj/random/junk,
+/turf/simulated/floor{
 	temperature = 278.15
 	},
-/area/nka_merchant)
+/area/nka_merchant/warehouse)
 "AB" = (
-/obj/machinery/computer/ship/navigation{
+/obj/machinery/computer/ship/navigation/terminal{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/dark_blue/full,
@@ -3804,14 +4118,44 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/bridge)
+"AL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	icon_state = "map-scrubbers"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "AT" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/nka_merchant/engine)
+"AW" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "AY" = (
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -3826,10 +4170,42 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/floor_decal/corner/dark_blue/full{
+	dir = 8
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
 /area/nka_merchant/hangar)
+"BG" = (
+/obj/structure/sign/flag/nka/large/south{
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
+"BW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "BY" = (
 /obj/structure/railing/mapped,
 /obj/machinery/conveyor{
@@ -3885,9 +4261,26 @@
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/nka_merchant_shuttle)
+"Cs" = (
+/obj/effect/floor_decal/corner/green/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/mess)
 "Df" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/nka_merchant_shuttle)
+"Dl" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "Do" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6;
@@ -3930,7 +4323,10 @@
 	},
 /area/nka_merchant/merchant)
 "DU" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE"
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -3973,6 +4369,9 @@
 	id_tag = "nka_merchant_shuttle_dock";
 	pixel_y = 25
 	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -4010,7 +4409,6 @@
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 4
 	},
-/obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -4041,6 +4439,9 @@
 /area/shuttle/nka_merchant_shuttle)
 "EU" = (
 /obj/machinery/light,
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -4114,6 +4515,9 @@
 	is_critical = 1;
 	req_access = list(213)
 	},
+/obj/structure/sign/painting_frame/shumaila{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -4130,6 +4534,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/airless,
 /area/shuttle/nka_merchant_shuttle)
 "FW" = (
@@ -4140,6 +4545,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/nka_merchant_shuttle)
+"FY" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "Gj" = (
 /obj/machinery/iff_beacon,
 /obj/structure/railing/mapped{
@@ -4152,6 +4565,15 @@
 	},
 /turf/simulated/floor/airless,
 /area/nka_merchant/bridge)
+"Go" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
 "GE" = (
 /obj/item/modular_computer/console/preset/merchant/nka{
 	dir = 8
@@ -4214,6 +4636,9 @@
 /obj/machinery/vending/engivend{
 	req_access = list(213)
 	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -4254,6 +4679,26 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/nka_merchant_shuttle)
+"Ih" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/floor_damage/tiled_broken0,
+/obj/effect/floor_decal/corner/dark_blue/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
+"It" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
 "IA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /turf/simulated/floor/plating{
@@ -4262,6 +4707,9 @@
 /area/nka_merchant/eva)
 "IJ" = (
 /obj/machinery/pipedispenser/disposal,
+/obj/effect/floor_decal/corner/yellow/full{
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -4300,6 +4748,14 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/warehouse)
+"Jl" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/mess)
 "Jo" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light{
@@ -4330,6 +4786,9 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/effect/floor_decal/corner/white{
+	dir = 10
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -4340,13 +4799,23 @@
 	name = "Warehouse";
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
+/turf/simulated/floor/tiled/full,
 /area/nka_merchant/warehouse)
 "JO" = (
 /turf/simulated/wall/shuttle/space_ship,
 /area/nka_merchant/captain_quarters)
+"JU" = (
+/obj/random/dirt_75,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/nka_merchant/warehouse)
+"JW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/nka_merchant/warehouse)
 "JX" = (
 /obj/machinery/door/airlock{
 	req_access = list(213);
@@ -4360,9 +4829,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
+/turf/simulated/floor/tiled/full,
 /area/nka_merchant/barracks)
 "Ka" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -4385,7 +4852,12 @@
 /area/nka_merchant)
 "Kg" = (
 /obj/structure/bed/stool/bar/padded/red,
-/obj/structure/sign/flag/nka/large/south,
+/obj/structure/sign/flag/nka/large/south{
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -4426,21 +4898,44 @@
 /area/shuttle/nka_merchant_shuttle)
 "KT" = (
 /obj/machinery/vending/dinnerware,
+/obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/lino/diamond{
 	temperature = 278.15
 	},
 /area/nka_merchant/mess)
+"KW" = (
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
+"Lg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
+/turf/simulated/wall/shuttle/space_ship,
+/area/nka_merchant/engine)
 "Ll" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
 /area/nka_merchant/engine)
+"Lq" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "Ls" = (
 /obj/effect/landmark{
 	name = "carpspawn"
@@ -4494,18 +4989,19 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	temperature = 278.15
-	},
+/turf/simulated/floor/tiled/full,
 /area/nka_merchant/engineering)
 "Nq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -4519,8 +5015,19 @@
 	req_one_access = null
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/nka_merchant_shuttle)
+"Nt" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
+/obj/structure/flora/pottedplant/woodyshrub,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "NJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -4530,6 +5037,15 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
+"NU" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "NZ" = (
 /obj/structure/bed/stool/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4580,6 +5096,15 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/bridge/secondary)
+"OI" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
+/obj/random/junk,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "OJ" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 6
@@ -4630,6 +5155,16 @@
 	temperature = 278.15
 	},
 /area/nka_merchant)
+"OU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/aux,
+/obj/structure/extinguisher_cabinet/east{
+	layer = 3.3;
+	pixel_y = 1
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/eva)
 "OX" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/black,
 /turf/simulated/wall/shuttle/space_ship,
@@ -4653,6 +5188,25 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
+"Pl" = (
+/obj/effect/floor_decal/corner/dark_blue/full{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	req_access = list(213);
+	name = "gun cabinet (revolver)"
+	},
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/item/gun/projectile/revolver/adhomian,
+/obj/item/gun/projectile/revolver/adhomian,
+/obj/item/gun/projectile/revolver/adhomian,
+/obj/item/ammo_magazine/c38,
+/obj/item/ammo_magazine/c38,
+/obj/item/ammo_magazine/c38,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "PJ" = (
 /obj/structure/toilet{
 	dir = 4
@@ -4709,6 +5263,15 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/bridge/secondary)
+"QK" = (
+/obj/machinery/suit_cycler/offship/nka,
+/obj/effect/floor_decal/corner/white{
+	dir = 5
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/eva)
 "RC" = (
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
@@ -4770,6 +5333,17 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engineering)
+"SQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
 "Tk" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 9
@@ -4782,23 +5356,13 @@
 	},
 /area/nka_merchant/bridge)
 "Tu" = (
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/structure/closet/secure_closet/guncabinet{
-	req_access = list(213);
-	name = "gun cabinet (rifles)"
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 6
 	},
-/obj/item/ammo_magazine/boltaction,
-/obj/item/ammo_magazine/boltaction,
-/obj/item/ammo_magazine/boltaction,
-/obj/item/ammo_magazine/boltaction,
-/obj/item/gun/projectile/shotgun/pump/rifle,
-/obj/item/gun/projectile/shotgun/pump/rifle,
-/obj/item/clothing/accessory/storage/bayonet,
-/obj/item/clothing/accessory/storage/bayonet,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
-/area/nka_merchant)
+/area/nka_merchant/hangar)
 "TF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black{
 	dir = 8
@@ -4833,6 +5397,21 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engine)
+"TZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/hangar)
+"Ub" = (
+/obj/machinery/atmospherics/binary/pump/high_power,
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
 "Up" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4843,13 +5422,24 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/hangar)
+"Uv" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/nka_merchant/engine)
 "UB" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/table/rack,
 /obj/item/inflatable_dispenser,
 /obj/item/clothing/gloves/yellow/specialt,
 /obj/item/clothing/gloves/yellow/specialt,
 /obj/item/clothing/gloves/yellow/specialt,
+/obj/effect/floor_decal/corner/yellow{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -4865,6 +5455,12 @@
 	temperature = 278.15
 	},
 /area/nka_merchant)
+"UJ" = (
+/obj/effect/decal/cleanable/floor_damage/rust,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/engineering)
 "UK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 5
@@ -4887,6 +5483,7 @@
 /obj/effect/floor_decal/spline/plain/grey{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/nka_merchant_shuttle)
 "Vj" = (
@@ -4896,7 +5493,10 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/nka_merchant)
 "Vv" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE"
+	},
 /obj/machinery/door/blast/regular/open{
 	dir = 8;
 	id = "merchant_navy_bridge"
@@ -4925,21 +5525,11 @@
 	},
 /area/nka_merchant/warehouse)
 "Wr" = (
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/structure/closet/secure_closet/guncabinet{
-	req_access = list(213);
-	name = "gun cabinet (revolver)"
-	},
-/obj/item/ammo_magazine/c38,
-/obj/item/ammo_magazine/c38,
-/obj/item/ammo_magazine/c38,
-/obj/item/gun/projectile/revolver/adhomian,
-/obj/item/gun/projectile/revolver/adhomian,
-/obj/item/gun/projectile/revolver/adhomian,
+/obj/effect/floor_decal/corner/dark_blue/full,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
-/area/nka_merchant)
+/area/nka_merchant/hangar)
 "Wx" = (
 /turf/simulated/floor/plating{
 	temperature = 278.15
@@ -4956,6 +5546,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -5009,17 +5600,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 9
 	},
-/obj/machinery/light,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
 /area/nka_merchant/engine)
+"XV" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/junk,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/nka_merchant/warehouse)
 "Yo" = (
 /obj/item/flame/lighter/adhomai,
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
 	level = 2
+	},
+/obj/structure/sign/painting_frame/shumaila{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -5046,6 +5647,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/nka_merchant_shuttle)
+"YB" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 5
+	},
+/obj/random/junk,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "YM" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
@@ -5069,7 +5679,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -5090,12 +5699,31 @@
 	temperature = 278.15
 	},
 /area/nka_merchant/engine)
+"Zi" = (
+/obj/effect/floor_decal/corner/dark_blue{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant)
 "Zr" = (
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
 /area/nka_merchant/engine)
+"Zz" = (
+/obj/effect/floor_decal/corner/white{
+	dir = 9
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/nka_merchant/eva)
 "ZX" = (
+/obj/effect/decal/cleanable/blood/drip/oil,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating{
 	temperature = 278.15
 	},
@@ -16488,7 +17116,7 @@ iB
 iB
 YX
 dV
-Zr
+Uv
 cr
 AT
 AT
@@ -16500,7 +17128,7 @@ pA
 cS
 gN
 lO
-bA
+am
 mK
 fJ
 yr
@@ -16652,7 +17280,7 @@ vo
 Fy
 RS
 Zr
-Zr
+Go
 AT
 jA
 vA
@@ -16678,7 +17306,7 @@ Vj
 dd
 fY
 KT
-eV
+cU
 bS
 Fm
 Fm
@@ -16812,13 +17440,13 @@ iB
 iB
 AT
 AT
-aI
+rB
 Zr
 eD
 AT
 vA
 vA
-Wx
+sb
 OZ
 pA
 dI
@@ -16838,9 +17466,9 @@ ij
 dE
 Vj
 ai
-fY
+et
 fx
-eV
+Jl
 dZ
 nA
 kZ
@@ -16975,8 +17603,8 @@ iB
 iB
 AT
 aI
-Zr
-Zr
+AT
+Lg
 AT
 hx
 Wx
@@ -17009,7 +17637,7 @@ nA
 cp
 Vp
 Vp
-Tu
+Vp
 Vp
 kI
 kF
@@ -17137,11 +17765,11 @@ iB
 iB
 AT
 aI
-Zr
-Zr
+ga
+lq
 AT
 xX
-IA
+OU
 IA
 jw
 pA
@@ -17164,7 +17792,7 @@ Vj
 fE
 FH
 nq
-eV
+Jl
 gi
 cN
 cN
@@ -17298,9 +17926,9 @@ iB
 iB
 iB
 AT
-aI
-Zr
-Zr
+SQ
+KW
+es
 AT
 vA
 vA
@@ -17310,7 +17938,7 @@ pA
 cM
 Sg
 aP
-bA
+UJ
 kV
 fJ
 fJ
@@ -17332,7 +17960,7 @@ eV
 eV
 EU
 Vp
-aJ
+Lq
 xc
 ih
 kI
@@ -17460,19 +18088,19 @@ iB
 iB
 iB
 AT
-aI
+TU
 ga
 fk
 AT
 hc
-bq
-bq
+Zz
+Zz
 cT
 pA
 yK
 GV
 Ni
-bA
+qX
 br
 fJ
 og
@@ -17488,7 +18116,7 @@ PJ
 eB
 eB
 Ed
-eV
+Jl
 io
 ie
 kg
@@ -17623,10 +18251,10 @@ iB
 iB
 AT
 aI
-et
-iT
 AT
-hc
+AT
+AT
+QK
 bq
 gU
 sn
@@ -17644,11 +18272,11 @@ lW
 JX
 eE
 bH
-ih
+ml
 Vp
 Si
 eB
-eB
+Vj
 Vj
 jV
 rs
@@ -17785,7 +18413,7 @@ iB
 iB
 AT
 aI
-et
+Zr
 iT
 AT
 dF
@@ -17806,19 +18434,19 @@ Yo
 fJ
 aJ
 xc
-ih
+NU
 Vp
 eF
 eB
 iw
 Vj
-eV
+Cs
 rp
 pf
 kL
-eV
+tO
 Vp
-aJ
+YB
 xc
 ih
 Vp
@@ -17946,11 +18574,11 @@ iB
 iB
 AT
 AT
-aI
 TU
+Ub
 wQ
 AT
-hc
+QK
 bq
 fK
 Jv
@@ -17968,7 +18596,7 @@ fJ
 fJ
 fI
 xc
-ih
+Nt
 Vp
 Vj
 Vj
@@ -17982,7 +18610,7 @@ Vj
 Vp
 fI
 xc
-ih
+Zi
 Vp
 Vp
 Vp
@@ -18108,11 +18736,11 @@ iB
 iB
 vo
 UK
-aI
 gh
+Zr
 iY
 AT
-hc
+QK
 bq
 Do
 gv
@@ -18124,8 +18752,8 @@ aS
 bv
 pA
 ni
-yc
-yc
+FY
+Wr
 TH
 lt
 tY
@@ -18271,7 +18899,7 @@ iB
 hE
 OX
 kx
-am
+Zr
 iY
 AT
 rq
@@ -18434,7 +19062,7 @@ vo
 fH
 aI
 Zr
-iY
+Zr
 AT
 vA
 vA
@@ -18461,13 +19089,13 @@ cm
 cm
 cm
 PV
-cm
+Dl
 Ka
 cm
 EC
 Vp
 nw
-xc
+BW
 ih
 hS
 yv
@@ -18594,22 +19222,22 @@ iB
 iB
 AT
 AT
-aI
+SQ
 Zr
 Zr
 AT
 Bv
 tw
 nz
-wt
-wt
-aC
-wt
-wt
+rM
+rM
+AL
+rM
+rM
 cJ
 aC
-wt
-wt
+rM
+ko
 wt
 bY
 TH
@@ -18629,7 +19257,7 @@ wr
 wr
 Vp
 fI
-xc
+BW
 OT
 Vp
 Vp
@@ -18761,11 +19389,11 @@ Zr
 OL
 cG
 Nq
-yc
+TZ
 fd
 yc
 yc
-yc
+tH
 yc
 yc
 yc
@@ -18782,7 +19410,7 @@ cQ
 WZ
 ec
 WZ
-ci
+JW
 bM
 wr
 lk
@@ -18792,7 +19420,7 @@ RC
 Vp
 iq
 xc
-lu
+BG
 Vp
 pL
 pL
@@ -18954,7 +19582,7 @@ aw
 Vp
 hV
 jm
-ih
+OI
 Vp
 pL
 pL
@@ -19098,8 +19726,8 @@ EQ
 Df
 uK
 iZ
-yc
-yc
+bD
+AW
 ac
 bM
 bM
@@ -19260,7 +19888,7 @@ OP
 Df
 Df
 iZ
-yc
+bD
 it
 WZ
 jJ
@@ -19276,7 +19904,7 @@ bB
 lS
 ji
 Vp
-aJ
+dR
 xc
 ih
 UL
@@ -19430,7 +20058,7 @@ Er
 Er
 Er
 ey
-ci
+JU
 fA
 wr
 az
@@ -19438,7 +20066,7 @@ FC
 lp
 eA
 Vp
-dX
+Pl
 bV
 iz
 OD
@@ -19588,7 +20216,7 @@ yc
 bj
 WZ
 kQ
-bM
+od
 lR
 bM
 BY
@@ -19601,7 +20229,7 @@ gc
 fi
 Vp
 Vp
-Wr
+Vp
 Vp
 UL
 Xy
@@ -19728,7 +20356,7 @@ iB
 iB
 AT
 AT
-aI
+gh
 Zr
 Zr
 AT
@@ -19747,14 +20375,14 @@ Df
 uK
 iZ
 yc
-mj
+It
 WZ
 cc
-bM
+XV
 aU
 bM
 BY
-ci
+Ac
 bM
 wr
 vQ
@@ -19908,7 +20536,7 @@ Co
 sX
 sX
 jy
-yc
+cZ
 mj
 WZ
 WZ
@@ -20057,20 +20685,20 @@ aH
 mg
 AT
 aX
-yc
-yc
-yc
+Tu
+Tu
+Tu
 dA
-yc
-yc
-yc
-yc
-yc
-yc
+Tu
+Tu
+Tu
+Tu
+Tu
+Tu
 dA
-yc
-yc
-it
+Tu
+Tu
+Ih
 TH
 WZ
 WZ

--- a/maps/away/ships/nka/nka_merchant/nka_merchant.dmm
+++ b/maps/away/ships/nka/nka_merchant/nka_merchant.dmm
@@ -5240,7 +5240,7 @@
 /obj/structure/sign/flag/nka{
 	pixel_y = -32
 	},
-/obj/machinery/computer/shuttle_control/explore/nka_merchant_shuttle{
+/obj/machinery/computer/shuttle_control/explore/terminal/nka_merchant_shuttle{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,


### PR DESCRIPTION
* Fixes some access issues on the NKA Merchant ship.
* Adds some emergency shutters.
* Adds some dirt, trash, and assorted decorations.
* Adds a CO2 tank.
* Makes all the consoles terminals.

Also: Fixes #15699 (because it's fixed)