### PR TITLE
non-natural exoplanet turfs no longer generate resource deposits

### DIFF
--- a/code/modules/overmap/exoplanets/decor/_turfs.dm
+++ b/code/modules/overmap/exoplanets/decor/_turfs.dm
@@ -6,7 +6,7 @@
 	name = "space land"
 	icon = 'icons/turf/desert.dmi'
 	icon_state = "desert"
-	has_resources = 1
+	has_resources = TRUE
 	footstep_sound = /singleton/sound_category/asteroid_footstep
 	turf_flags = TURF_FLAG_BACKGROUND
 

--- a/code/modules/overmap/exoplanets/decor/turfs/abyss.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/abyss.dm
@@ -11,6 +11,7 @@
 		/obj/item/projectile,
 		/obj/effect
 		))
+	has_resources = FALSE
 
 /turf/simulated/floor/exoplanet/abyss/Initialize()
 	. = ..()

--- a/code/modules/overmap/exoplanets/decor/turfs/asphalt.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/asphalt.dm
@@ -3,6 +3,7 @@
 	desc = "Once-hot asphalt."
 	icon = 'icons/turf/flooring/urban_turfs.dmi'
 	icon_state = "asphalt0"
+	has_resources = FALSE
 
 /turf/simulated/floor/exoplanet/asphalt/Initialize(mapload)
 	. = ..()

--- a/code/modules/overmap/exoplanets/decor/turfs/carpet.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/carpet.dm
@@ -6,6 +6,7 @@
 	broken_overlay = "carpet"
 	initial_flooring = /singleton/flooring/carpet
 	footstep_sound = /singleton/sound_category/carpet_footstep
+	has_resources = FALSE
 
 /turf/simulated/floor/exoplanet/carpet/art
 	icon_state = "artcarpet"

--- a/code/modules/overmap/exoplanets/decor/turfs/concrete.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/concrete.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/turf/flooring/concrete.dmi'
 	icon_state = "concrete0"
 	does_footprint = FALSE
+	has_resources = FALSE
 
 /turf/simulated/floor/exoplanet/concrete/square
 	icon_state = "concrete3"

--- a/code/modules/overmap/exoplanets/decor/turfs/foundation.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/foundation.dm
@@ -3,6 +3,7 @@
 	desc = "The unclean but highly compacted solid foundation for a building or structure."
 	icon = 'icons/turf/flooring/urban_turfs.dmi'
 	icon_state = "rust"
+	has_resources = FALSE
 
 /turf/simulated/floor/exoplanet/foundation/Initialize(mapload)
 	. = ..()

--- a/code/modules/overmap/exoplanets/decor/turfs/linoleum.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/linoleum.dm
@@ -4,6 +4,7 @@
 	icon_state = "lino_preview"
 	initial_flooring = /singleton/flooring/linoleum
 	tile_outline = "linoleum"
+	has_resources = FALSE
 
 /turf/simulated/floor/exoplanet/lino/diamond
 	icon_state = "lino_diamond_preview"

--- a/code/modules/overmap/exoplanets/decor/turfs/plating.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/plating.dm
@@ -1,4 +1,6 @@
 /turf/simulated/floor/exoplanet/plating
+	name = "plating"
 	icon = 'icons/turf/flooring/plating.dmi'
 	icon_state = "plating"
 	footstep_sound = /singleton/sound_category/plating_footstep
+	has_resources = FALSE

--- a/code/modules/overmap/exoplanets/decor/turfs/sidewalk.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/sidewalk.dm
@@ -3,6 +3,7 @@
 	desc = "Great for speeding on."
 	icon = 'icons/turf/flooring/urban_turfs.dmi'
 	icon_state = "sidewalk-tile"
+	has_resources = FALSE
 
 /turf/simulated/floor/exoplanet/sidewalk/blocks
 	name = "blocked sidewalk tiles"

--- a/code/modules/overmap/exoplanets/decor/turfs/tiled.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/tiled.dm
@@ -8,6 +8,7 @@
 	tile_outline_alpha = 125
 	broken_overlay = "tiled"
 	burned_overlay = "tiled"
+	has_resources = FALSE
 
 /turf/simulated/floor/exoplanet/tiled/dark
 	name = "plasteel tiles"

--- a/code/modules/overmap/exoplanets/decor/turfs/water.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/water.dm
@@ -2,6 +2,7 @@
 	does_footprint = FALSE
 	footstep_sound = /singleton/sound_category/water_footstep
 	movement_cost = 4
+	has_resources = FALSE
 	///How many objects are currently on this turf? Used to stop empty water turfs from processing.
 	var/numobjects = 0
 	///Is this water deep enough to drown in?

--- a/code/modules/overmap/exoplanets/decor/turfs/wood.dm
+++ b/code/modules/overmap/exoplanets/decor/turfs/wood.dm
@@ -9,6 +9,7 @@
 	broken_overlay = "wood"
 	tile_outline_alpha = 75
 	color = WOOD_COLOR_GENERIC
+	has_resources = FALSE
 
 /turf/simulated/floor/exoplanet/wood/bamboo
 	initial_flooring = /singleton/flooring/wood/bamboo

--- a/html/changelogs/RustingWithYou - exoplanetturf.yml
+++ b/html/changelogs/RustingWithYou - exoplanetturf.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Non-natural exoplanet turfs will no longer generate mineral resources overlays."


### PR DESCRIPTION
The exoplanet turf variants of non-exoplanet turfs (tiles, wooden floors, etc) will no longer generate underground resource deposits. This prevents underground resource images from showing up on these turfs, because it generally looks weird to see a gold deposit pop up on someone's floorboards.