### PR TITLE
Fixes Missing Open Space Landmarks

### DIFF
--- a/html/changelogs/RustingWithYou - shuttlefix.yml
+++ b/html/changelogs/RustingWithYou - shuttlefix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes shuttle open space landmarks generating on the wrong z-levels."

--- a/maps/away/ships/konyang/air_konyang/air_konyang.dm
+++ b/maps/away/ships/konyang/air_konyang/air_konyang.dm
@@ -57,6 +57,7 @@
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/ship/air_konyang
+	shuttle_name = "Air Konyang Transport"
 	landmark_tag = "nav_air_konyang_start"
 
 /obj/effect/shuttle_landmark/air_konyang_transit

--- a/maps/away/ships/konyang/einstein_shuttle/einstein_shuttle.dm
+++ b/maps/away/ships/konyang/einstein_shuttle/einstein_shuttle.dm
@@ -99,6 +99,7 @@
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/ship/einstein_shuttle
+	shuttle_name = "Einstein Shuttle"
 	landmark_tag = "nav_start_einstein"
 
 /obj/effect/shuttle_landmark/einstein_shuttle_transit

--- a/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dm
+++ b/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dm
@@ -12,7 +12,6 @@
 	sectors = list(SECTOR_NRRAHRAHUL, SECTOR_BADLANDS, SECTOR_GAKAL, SECTOR_UUEOAESA)
 
 	unit_test_groups = list(1)
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 /singleton/submap_archetype/unathi_pirate_izharshan
 	map = "Izharshan Shuttle"
@@ -110,6 +109,7 @@
 	defer_initialisation = TRUE
 
 /obj/effect/shuttle_landmark/ship/unathi_pirate_izharshan
+	shuttle_name = "Izharshan Freighter"
 	landmark_tag = "nav_izharshan_space"
 
 /obj/effect/shuttle_landmark/izharshan_transit


### PR DESCRIPTION
Open space landmarks were placed on the wrong z-levels for shuttles not using mapped zs. Fixes the issue of #18978