### PR TITLE
Adds the Scarab Salvager to the Badlands and Valley Hale

### DIFF
--- a/html/changelogs/hazelmouse - scarab_sectors.yml
+++ b/html/changelogs/hazelmouse - scarab_sectors.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazlemouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds the Scarab Salvager offship to the Badlands and Valley Hale sectors."
+  - bugfix: "Resolves a few minor mapping issues in the Scarab Salvager and Hivebot Hub maps."

--- a/maps/away/away_site/hivebot_hub/hivebot_hub.dmm
+++ b/maps/away/away_site/hivebot_hub/hivebot_hub.dmm
@@ -625,6 +625,12 @@
 	},
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/bridge)
+"dz" = (
+/obj/effect/landmark/entry_point/west{
+	name = "west, east compartment"
+	},
+/turf/simulated/wall/r_wall,
+/area/hivebothub/starboarddocks)
 "dE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -657,6 +663,12 @@
 	},
 /turf/simulated/floor/airless,
 /area/hivebothub/atmos)
+"dY" = (
+/obj/effect/landmark/entry_point/east{
+	name = "east, secure storage"
+	},
+/turf/simulated/wall/r_wall,
+/area/hivebothub/secure)
 "dZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1504,6 +1516,14 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/airless,
 /area/hivebothub/centralhall)
+"jO" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/portgen/basic{
+	anchored = 1
+	},
+/turf/simulated/floor/tiled/dark/full/airless,
+/area/hivebothub/portdocks)
 "jQ" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate{
@@ -1708,6 +1728,12 @@
 /obj/effect/decal/cleanable/floor_damage/rust,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/tiled/dark/airless,
+/area/hivebothub/portdocks)
+"ln" = (
+/obj/effect/landmark/entry_point/south{
+	name = "south, west compartment"
+	},
+/turf/simulated/wall/r_wall,
 /area/hivebothub/portdocks)
 "lz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1974,6 +2000,9 @@
 	pixel_x = 2
 	},
 /obj/item/stack/rods,
+/obj/effect/landmark/entry_point/south{
+	name = "south, control room"
+	},
 /turf/simulated/floor/airless,
 /area/hivebothub/bridge)
 "nh" = (
@@ -2349,6 +2378,7 @@
 	dir = 8
 	},
 /obj/item/material/twohanded/fireaxe,
+/obj/item/wrench,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/portdocks)
 "qA" = (
@@ -2381,9 +2411,11 @@
 /turf/simulated/floor/tiled/airless,
 /area/hivebothub/kitchen)
 "qG" = (
-/obj/structure/girder,
-/turf/simulated/floor/airless,
-/area/hivebothub/kitchen)
+/obj/effect/landmark/entry_point/north{
+	name = "north, west compartment"
+	},
+/turf/simulated/wall/r_wall,
+/area/hivebothub/portdocks)
 "qI" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -2790,6 +2822,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full/airless,
 /area/hivebothub/starboarddocks)
+"tn" = (
+/obj/effect/landmark/entry_point/west{
+	name = "west, power generation"
+	},
+/turf/simulated/wall/r_wall,
+/area/hivebothub/engi)
 "tp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3409,6 +3447,12 @@
 	},
 /turf/simulated/floor/airless,
 /area/hivebothub/portdocks)
+"xk" = (
+/obj/effect/landmark/entry_point/west{
+	name = "west, secure storage"
+	},
+/turf/simulated/wall/r_wall,
+/area/hivebothub/secure)
 "xo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -3789,6 +3833,12 @@
 	},
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/centralhall)
+"Ag" = (
+/obj/effect/landmark/entry_point/north{
+	name = "north, east compartment"
+	},
+/turf/simulated/wall/r_wall,
+/area/hivebothub/starboarddocks)
 "Ak" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -4689,6 +4739,12 @@
 	},
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/portdocks)
+"Ft" = (
+/obj/effect/landmark/entry_point/south{
+	name = "south, east compartment"
+	},
+/turf/simulated/wall/r_wall,
+/area/hivebothub/starboarddocks)
 "FI" = (
 /obj/structure/table/reinforced/steel,
 /obj/effect/decal/fake_object{
@@ -4825,6 +4881,12 @@
 	},
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/secure)
+"GV" = (
+/obj/effect/landmark/entry_point/west{
+	name = "west, crew facilities"
+	},
+/turf/simulated/wall/r_wall,
+/area/hivebothub/washroom)
 "GW" = (
 /obj/structure/filingcabinet/chestdrawer{
 	pixel_y = 17;
@@ -4879,6 +4941,9 @@
 	pixel_x = -3
 	},
 /obj/effect/decal/cleanable/floor_damage/broken1,
+/obj/random/tech_supply{
+	pixel_x = -4
+	},
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/centralhall)
 "Ht" = (
@@ -4930,6 +4995,12 @@
 /obj/effect/decal/cleanable/floor_damage/broken1,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/engi)
+"HO" = (
+/obj/effect/landmark/entry_point/east{
+	name = "east, crew quarters"
+	},
+/turf/simulated/wall/r_wall,
+/area/hivebothub/dorm1)
 "HT" = (
 /obj/structure/bed/stool/chair{
 	dir = 8
@@ -5411,6 +5482,12 @@
 	},
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/portdocks)
+"Ls" = (
+/obj/effect/landmark/entry_point/north{
+	name = "north, secure storage"
+	},
+/turf/simulated/wall/r_wall,
+/area/hivebothub/secure)
 "Lu" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -6086,9 +6163,6 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
-/obj/random/tech_supply{
-	pixel_x = -4
-	},
 /obj/structure/closet/walllocker/emerglocker/west{
 	pixel_x = 0;
 	pixel_y = 25
@@ -6706,6 +6780,12 @@
 /obj/item/trash/can,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/portdocks)
+"Uq" = (
+/obj/effect/landmark/entry_point/east{
+	name = "east, atmospherics"
+	},
+/turf/simulated/wall/r_wall,
+/area/hivebothub/atmos)
 "Ur" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/decal/cleanable/dirt,
@@ -6804,9 +6884,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow,
-/obj/machinery/power/portgen/basic{
-	anchored = 1
-	},
 /turf/simulated/floor/airless,
 /area/hivebothub/portdocks)
 "UY" = (
@@ -7120,6 +7197,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/starboarddocks)
+"Xk" = (
+/obj/effect/landmark/entry_point/east{
+	name = "east, west compartment"
+	},
+/turf/simulated/wall/r_wall,
+/area/hivebothub/portdocks)
 "Xo" = (
 /turf/simulated/floor/airless,
 /area/hivebothub/portdocks)
@@ -7378,6 +7461,9 @@
 	pixel_x = -4
 	},
 /obj/item/stack/rods,
+/obj/effect/landmark/entry_point/east{
+	name = "east, control room"
+	},
 /turf/simulated/floor/airless,
 /area/hivebothub/bridge)
 "Ze" = (
@@ -7408,10 +7494,12 @@
 /turf/space/dynamic,
 /area/hivebothub/exterior)
 "Zj" = (
-/obj/structure/lattice/catwalk,
-/obj/item/wrench,
-/turf/space/dynamic,
-/area/hivebothub/exterior)
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/effect/landmark/entry_point/west{
+	name = "west, control room"
+	},
+/turf/simulated/floor/airless,
+/area/hivebothub/bridge)
 "Zk" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -32312,7 +32400,7 @@ fH
 Qy
 mk
 fH
-fH
+Xk
 fH
 fH
 jR
@@ -33086,7 +33174,7 @@ ck
 ck
 eT
 mS
-ke
+jO
 fH
 xs
 Lj
@@ -35132,7 +35220,7 @@ yU
 yU
 jR
 jR
-fH
+ln
 hD
 iy
 bP
@@ -35142,7 +35230,7 @@ TY
 jT
 oY
 CE
-fH
+qG
 jR
 jR
 yU
@@ -37957,7 +38045,7 @@ Lj
 Lj
 qS
 jR
-Sh
+HO
 Sh
 mr
 IJ
@@ -37971,7 +38059,7 @@ ax
 DX
 yf
 aK
-aK
+Uq
 jR
 Oi
 Lj
@@ -38242,7 +38330,7 @@ ya
 rq
 jR
 UL
-UL
+dY
 UL
 UL
 jR
@@ -40050,7 +40138,7 @@ vz
 vz
 vz
 Hw
-UL
+Ls
 xs
 Lj
 Lj
@@ -40530,8 +40618,8 @@ Uw
 Uw
 cE
 Uw
-qG
-qG
+Uw
+Uw
 Uw
 vG
 FU
@@ -41034,7 +41122,7 @@ nw
 yU
 jR
 YA
-cF
+Zj
 cF
 YA
 KX
@@ -41046,7 +41134,7 @@ XJ
 FR
 wg
 Ej
-qG
+Uw
 eg
 jK
 Gx
@@ -41564,7 +41652,7 @@ bI
 ml
 cI
 zs
-tW
+ec
 nA
 nA
 dZ
@@ -41826,8 +41914,8 @@ VP
 jW
 ap
 qi
-tW
-tW
+ec
+ec
 jR
 yU
 yU
@@ -41840,7 +41928,7 @@ yU
 yU
 nG
 UL
-UL
+xk
 UL
 UL
 jR
@@ -42069,7 +42157,7 @@ Lj
 Lj
 nw
 jR
-bN
+GV
 bN
 Oy
 EN
@@ -42083,8 +42171,8 @@ yG
 za
 PZ
 ec
-ec
-Zj
+tn
+jR
 eG
 Lj
 Lj
@@ -44898,7 +44986,7 @@ ya
 ya
 jR
 jR
-CR
+Ft
 kZ
 nJ
 Wz
@@ -44908,7 +44996,7 @@ fd
 lK
 Gc
 NT
-CR
+Ag
 jR
 jR
 ya
@@ -47732,7 +47820,7 @@ CR
 UP
 Ly
 CR
-CR
+dz
 CR
 CR
 jR

--- a/maps/away/away_site/hivebot_hub/hivebot_hub.dmm
+++ b/maps/away/away_site/hivebot_hub/hivebot_hub.dmm
@@ -1136,7 +1136,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/light,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/centralhall)
@@ -1317,6 +1316,7 @@
 	pixel_x = -3
 	},
 /obj/effect/decal/cleanable/blood/oil/streak,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/centralhall)
 "ij" = (
@@ -2485,8 +2485,16 @@
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/portdocks)
 "rn" = (
-/turf/template_noop,
-/area/hivebothub/kitchen)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner/grey{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/blood/gibs/robot,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark/airless,
+/area/hivebothub/centralhall)
 "ro" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4801,7 +4809,6 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 10
 	},
-/obj/machinery/light,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/centralhall)
@@ -41291,7 +41298,7 @@ yU
 jR
 Uw
 Uw
-rn
+Uw
 Uw
 Uw
 Uw
@@ -41299,7 +41306,7 @@ Uw
 Uw
 Hr
 tb
-xr
+rn
 ec
 qO
 aa

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dm
@@ -10,7 +10,6 @@
 	ship_cost = 1
 	id = "coc_scarab"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/scarab_shuttle, /datum/shuttle/autodock/multi/lift/scarab)
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 	unit_test_groups = list(1)
 
 /singleton/submap_archetype/coc_scarab

--- a/maps/away/ships/coc/coc_scarab/coc_scarab.dm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab.dm
@@ -5,12 +5,12 @@
 	prefix = "ships/coc/coc_scarab/"
 	suffixes = list("coc_scarab_deck_1.dmm", "coc_scarab_deck_2.dmm")
 
-	sectors = list(SECTOR_COALITION, SECTOR_WEEPING_STARS, SECTOR_ARUSHA, SECTOR_LIBERTYS_CRADLE)
+	sectors = list(SECTOR_COALITION, SECTOR_WEEPING_STARS, SECTOR_ARUSHA, SECTOR_LIBERTYS_CRADLE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS)
 	spawn_weight = 1
 	ship_cost = 1
 	id = "coc_scarab"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/scarab_shuttle, /datum/shuttle/autodock/multi/lift/scarab)
-
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 	unit_test_groups = list(1)
 
 /singleton/submap_archetype/coc_scarab

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
@@ -2832,6 +2832,7 @@
 	name = "Engine"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/engine)
 "pj" = (
@@ -5230,6 +5231,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/supply,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/forehallway)
 "Bp" = (
@@ -5380,6 +5384,11 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/washroom)
 "BO" = (
@@ -6666,14 +6675,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/starboardhallway)
-"IG" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/mapped,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/turf/space/dynamic,
-/area/ship/coc_scarab/exterior)
 "II" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 8;
@@ -46878,7 +46879,7 @@ BZ
 Al
 Al
 Al
-IG
+nr
 Al
 cW
 cW


### PR DESCRIPTION
This adds the Scarab Salvager offship to the Badlands and Valley Hale sectors. Has assent from human lore, see [here.](https://discord.com/channels/724651070017765459/724653076866400336/1229465269903036457) They're space nomads so I feel it's reasonable for their range to be a little expanded to non-developed sectors.

Additionally, fixed a few mapping mistakes in the Hivebot Hub and Scarab Salvager maps.