### PR TITLE
Napalm Grenade Telecrystal Cost Increase

### DIFF
--- a/code/datums/uplink/grenades.dm
+++ b/code/datums/uplink/grenades.dm
@@ -39,3 +39,9 @@
 	telecrystal_cost = 2
 	path = /obj/item/storage/box/cardox
 	desc = "A box of five grenades that deploy cardox smoke in the thrown area. This smoke is incredibly toxic, especially to vaurca. It can also clear K'ois outbreaks with ease."
+
+/datum/uplink_item/item/grenades/napalm
+	name = "3x Napalm Grenades"
+	telecrystal_cost = 8
+	path = /obj/item/storage/box/grenades/napalm
+	desc = "A box of three grenades that deploy napalm in the thrown area, and ignite it."

--- a/code/datums/uplink/grenades.dm
+++ b/code/datums/uplink/grenades.dm
@@ -39,9 +39,3 @@
 	telecrystal_cost = 2
 	path = /obj/item/storage/box/cardox
 	desc = "A box of five grenades that deploy cardox smoke in the thrown area. This smoke is incredibly toxic, especially to vaurca. It can also clear K'ois outbreaks with ease."
-
-/datum/uplink_item/item/grenades/napalm
-	name = "3x Napalm Grenades"
-	telecrystal_cost = 5
-	path = /obj/item/storage/box/grenades/napalm
-	desc = "A box of three grenades that deploy napalm in the thrown area, and ignite it."

--- a/html/changelogs/Ben10083 - Napalm Uplink.yml
+++ b/html/changelogs/Ben10083 - Napalm Uplink.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Napalm grenades removed from uplink."

--- a/html/changelogs/Ben10083 - Napalm Uplink.yml
+++ b/html/changelogs/Ben10083 - Napalm Uplink.yml
@@ -55,4 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - rscdel: "Napalm grenades removed from uplink."
+  - balance: "Napalm grenades now cost 8 telecrystals in uplink."


### PR DESCRIPTION
Napalm Grenade now costs 8 telecrystals (from 5) in uplink.

As it stands it is too powerful for its cost, this should better reflect it's effectiveness. 