### PR TITLE
Kataphract sensors

### DIFF
--- a/html/changelogs/cactusmouth-sensors.yml
+++ b/html/changelogs/cactusmouth-sensors.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: CactusMouth
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds the sensors and IFF to the Kataphract ship which was missing."

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -3931,6 +3931,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
+"ny" = (
+/obj/structure/lattice/catwalk,
+/obj/item/hullbeacon/red,
+/turf/space,
+/area/kataphract_chapter/hull)
 "nz" = (
 /obj/effect/floor_decal/corner/yellow/full{
 	dir = 4
@@ -5057,6 +5062,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/brig)
+"Am" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/iff_beacon/name_change,
+/turf/space,
+/area/kataphract_chapter/hull)
 "Ap" = (
 /obj/machinery/photocopier,
 /obj/effect/floor_decal/corner_wide/dark_blue/full{
@@ -5195,6 +5205,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/main_ring)
+"Bp" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/shipsensors/weak,
+/turf/space,
+/area/kataphract_chapter/hull)
 "Bv" = (
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 8
@@ -35527,7 +35542,7 @@ GW
 GW
 GW
 GW
-iB
+ny
 iB
 iB
 iB
@@ -35779,7 +35794,7 @@ gj
 NV
 Ws
 gg
-iB
+Bp
 iB
 iB
 iB
@@ -36031,7 +36046,7 @@ aC
 lA
 zL
 nr
-iB
+tS
 iB
 iB
 iB
@@ -36283,7 +36298,7 @@ bQ
 aC
 gY
 nr
-iB
+tS
 iB
 iB
 iB
@@ -36535,7 +36550,7 @@ cy
 VU
 XQ
 Ac
-iB
+tS
 iB
 iB
 iB
@@ -36787,7 +36802,7 @@ JQ
 aC
 cI
 nr
-iB
+tS
 iB
 iB
 iB
@@ -37039,7 +37054,7 @@ kv
 la
 bg
 nr
-iB
+tS
 iB
 iB
 iB
@@ -37291,7 +37306,7 @@ JX
 jB
 lM
 nr
-iB
+Am
 iB
 iB
 iB
@@ -37543,7 +37558,7 @@ GW
 GW
 GW
 GW
-iB
+ny
 iB
 iB
 iB


### PR DESCRIPTION
Adds a small catwalk at the front of the Kataphract vessel, which contains the missing IFF transponder and Sensor. 

If they do not work, please contact me.

Thanks
