### PR TITLE
Job Title Fix

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -54,6 +54,9 @@ SUBSYSTEM_DEF(jobs)
 			continue
 		occupations += job
 		name_occupations[job.title] = job
+		if(length(job.alt_titles))
+			for(var/alt_title in job.alt_titles)
+				name_occupations[alt_title] = job
 		type_occupations[J] = job
 		if(!length(bitflag_to_job["[job.department_flag]"]))
 			bitflag_to_job["[job.department_flag]"] = list()

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -54,7 +54,7 @@ SUBSYSTEM_DEF(jobs)
 			continue
 		occupations += job
 		name_occupations[job.title] = job
-		if(length(job.alt_titles))
+		if(LAZYLEN(job.alt_titles))
 			for(var/alt_title in job.alt_titles)
 				name_occupations[alt_title] = job
 		type_occupations[J] = job

--- a/html/changelogs/geeevs-job_title_fix.yml
+++ b/html/changelogs/geeevs-job_title_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Changing the ID of someone with an alt-title will no longer boot them to the Misc section of the manifest."


### PR DESCRIPTION
* Changing the ID of someone with an alt-title will no longer boot them to the Misc section of the manifest.

salt pr