### PR TITLE
Kin of S'rendarr Rosette

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/xeno/tajara.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/tajara.dm
@@ -456,7 +456,7 @@
 	charm["bone charm"] = /obj/item/clothing/accessory/tajaran/charm/bone
 	charm["silver seashell charm"] = /obj/item/clothing/accessory/tajaran/charm/steel/silver/seashell
 	charm["tajani charm"] = /obj/item/clothing/accessory/tajaran/charm/tajani
-	charm["holy sun rosette"] = /obj/item/clothing/accessory/tajaran/srendarr
+	charm["Kin of S'rendarr rosette"] = /obj/item/clothing/accessory/tajaran/kin_srendarr
 	gear_tweaks += new /datum/gear_tweak/path(charm)
 
 /datum/gear/tail_cloth

--- a/code/modules/clothing/under/accessories/xeno/tajara.dm
+++ b/code/modules/clothing/under/accessories/xeno/tajara.dm
@@ -310,15 +310,16 @@
 	drop_sound = 'sound/items/drop/paper.ogg'
 	pickup_sound = 'sound/items/pickup/paper.ogg'
 
-/obj/item/clothing/accessory/tajaran/srendarr
-	name = "holy sun rosette"
+/obj/item/clothing/accessory/tajaran/kin_srendarr
+	name = "\improper S'rendarr rosette"
 	desc = "A simple rosette accessory depicting the Tajaran god S'rendarr."
+	desc_extended = "A rosette accessory depicting the Tajaran God S'rendarr in his sun form. Rosettes were worn by the pious worshippers of S'rendarr and Messa as displays of faith. This fell out of fashion before the First Revolution but has returned in the modern era. Outwardly a sign of devoted faith, but to those who know this rosette marks a member of the Kin of S'rendarr."
 	icon_state = "rosette"
 	item_state = "rosette"
 	slot_flags = SLOT_MASK | SLOT_TIE
 	w_class = ITEMSIZE_TINY
 
-/obj/item/clothing/accessory/tajaran/srendarr/get_mask_examine_text(mob/user)
+/obj/item/clothing/accessory/tajaran/kin_srendarr/get_mask_examine_text(mob/user)
 	return "around [user.get_pronoun("his")] neck"
 
 /obj/item/clothing/accessory/tajaran/council_badge

--- a/html/changelogs/Ben10083 - Rosette.yml
+++ b/html/changelogs/Ben10083 - Rosette.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - spellcheck: "Holy sun rosette now specified as being used for the Kin of S'rendarr. New extended desc added to replace the old one that didn't fit the rosette."


### PR DESCRIPTION
Holy Sun Rosette renamed and description updated to specify as being used by the Kin of S'rendarr. This was confirmed with Tajaran loredevs to be the case.