### PR TITLE
Gravity proc tweaks

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -150,6 +150,7 @@
 #include "code\__DEFINES\dcs\signals\signals_record.dm"
 #include "code\__DEFINES\dcs\signals\signals_spatial_grid.dm"
 #include "code\__DEFINES\dcs\signals\signals_subsystem.dm"
+#include "code\__DEFINES\dcs\signals\signals_turf.dm"
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_main.dm"
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_movable.dm"
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_movement.dm"

--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
@@ -16,3 +16,5 @@
 	#define COMPONENT_ATOM_BLOCK_EXIT (1<<0)
 ///from base of atom/Exited(): (atom/movable/gone, direction)
 #define COMSIG_ATOM_EXITED "atom_exited"
+///from base of atom/has_gravity(): (turf/location, list/forced_gravities)
+#define COMSIG_ATOM_HAS_GRAVITY "atom_has_gravity"

--- a/code/__DEFINES/dcs/signals/signals_turf.dm
+++ b/code/__DEFINES/dcs/signals/signals_turf.dm
@@ -1,0 +1,6 @@
+// Turf signals. Format:
+// When the signal is called: (signal arguments)
+// All signals send the source datum of the signal as the first argument
+
+///from base of atom/has_gravity(): (atom/asker, list/forced_gravities)
+#define COMSIG_TURF_HAS_GRAVITY "turf_has_gravity"

--- a/code/__HELPERS/paths/path.dm
+++ b/code/__HELPERS/paths/path.dm
@@ -336,7 +336,7 @@
 		src.thrown = !!construct_from.throwing
 
 		src.anchored = construct_from.anchored
-	src.has_gravity = has_gravity(construct_from)
+	src.has_gravity = construct_from.has_gravity()
 	if(ismob(construct_from))
 		var/mob/living/mob_construct = construct_from
 		src.incapacitated = mob_construct.incapacitated()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -48,9 +48,14 @@ var/global/list/area_blurb_stated_to = list()
 	var/oneoff_light 	= 0
 	var/oneoff_environ 	= 0
 
+	///Boolean, if this area has gravity
 	var/has_gravity = TRUE
-	var/alwaysgravity = 0
-	var/nevergravity = 0
+
+	///Boolean, if this area always has gravity
+	var/alwaysgravity = FALSE
+
+	///Boolean, if this area never has gravity
+	var/nevergravity = FALSE
 
 	var/list/all_doors = list() //Added by Strumpetplaya - Alarm Change - Contains a list of doors adjacent to this area
 	var/air_doors_activated = FALSE
@@ -390,23 +395,12 @@ var/list/mob/living/forced_ambiance_list = new
 	for(var/obj/machinery/door/window/temp_windoor in src)
 		temp_windoor.open()
 
-/area/proc/has_gravity()
+/area/has_gravity(turf/gravity_turf)
 	if(alwaysgravity)
 		return TRUE
 	if(nevergravity)
 		return FALSE
 	return has_gravity
-
-/area/space/has_gravity()
-	return 0
-
-/proc/has_gravity(atom/AT, turf/T)
-	if(!T)
-		T = get_turf(AT)
-	var/area/A = get_area(T)
-	if(A && A.has_gravity())
-		return 1
-	return 0
 
 //A useful proc for events.
 //This returns a random area of the station which is meaningful. Ie, a room somewhere

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -136,6 +136,40 @@
 	SEND_SIGNAL(src, COMSIG_ATOM_EXITED, gone, direction)
 
 /**
+ * Returns true if this atom has gravity for the passed in turf
+ *
+ * Sends signals [COMSIG_ATOM_HAS_GRAVITY] and [COMSIG_TURF_HAS_GRAVITY], both can force gravity with
+ * the forced gravity var.
+ *
+ * micro-optimized to hell because this proc is very hot, being called several times per movement every movement.
+ *
+ * This is slightly different from TG's version due to Aurora reasons.
+ */
+/atom/proc/has_gravity(turf/gravity_turf)
+	if(!isturf(gravity_turf))
+		gravity_turf = get_turf(src)
+
+		if(!gravity_turf)//no gravity in nullspace
+			return FALSE
+
+	var/list/forced_gravity = list()
+	SEND_SIGNAL(src, COMSIG_ATOM_HAS_GRAVITY, gravity_turf, forced_gravity)
+	SEND_SIGNAL(gravity_turf, COMSIG_TURF_HAS_GRAVITY, src, forced_gravity)
+	if(length(forced_gravity))
+		var/positive_grav = max(forced_gravity)
+		var/negative_grav = min(min(forced_gravity), 0) //negative grav needs to be below or equal to 0
+
+		//our gravity is sum of the most massive positive and negative numbers returned by the signal
+		//so that adding two forced_gravity elements with an effect size of 1 each doesnt add to 2 gravity
+		//but negative force gravity effects can cancel out positive ones
+
+		return (positive_grav + negative_grav)
+
+	var/area/turf_area = gravity_turf.loc
+
+	return turf_area.has_gravity()
+
+/**
  * This proc is used for telling whether something can pass by this atom in a given direction, for use by the pathfinding system.
  *
  * Trying to generate one long path across the station will call this proc on every single object on every single tile that we're seeing if we can move through, likely

--- a/code/modules/mob/living/maneuvers/_maneuver.dm
+++ b/code/modules/mob/living/maneuvers/_maneuver.dm
@@ -13,7 +13,7 @@
 		if(!silent)
 			to_chat(user, SPAN_WARNING("You are buckled down and cannot maneuver!"))
 		return FALSE
-	if(!has_gravity(user))
+	if(!user.has_gravity())
 		if(!silent)
 			to_chat(user, SPAN_WARNING("You cannot maneuver in zero gravity!"))
 		return FALSE

--- a/html/changelogs/fluffyghost-gravityproctweak.yml
+++ b/html/changelogs/fluffyghost-gravityproctweak.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - code_imp: "Tweaked gravity check proc to be more inline with TG's version."
+  - code_imp: "Added signals for gravity check, that allows atoms to perform anti-gravity."
+  - bugfix: "Fixed roller beds thinking they have no gravity and thus not emitting the rolling sound."

--- a/maps/_common/areas/areas.dm
+++ b/maps/_common/areas/areas.dm
@@ -39,6 +39,7 @@ Generally you don't want to put your areas in here; if the area is only used in 
 	base_turf = /turf/space
 	is_outside = OUTSIDE_YES
 	area_flags = AREA_FLAG_IS_BACKGROUND
+	nevergravity = TRUE //There's no gravity in space
 
 /area/space/atmosalert()
 	return


### PR DESCRIPTION
Tweaked gravity check proc to be more inline with TG's version.
Added signals for gravity check, that allows atoms to perform anti-gravity.
Fixed roller beds thinking they have no gravity and thus not emitting the rolling sound.

Fixes #19045 