### PR TITLE
Additional spawnpoint work

### DIFF
--- a/code/controllers/subsystems/initialization/atlas.dm
+++ b/code/controllers/subsystems/initialization/atlas.dm
@@ -173,7 +173,6 @@ SUBSYSTEM_DEF(atlas)
 		world.map_panic("Selected map does not exist!")
 
 	load_map_meta()
-	setup_spawnpoints()
 
 	world.update_status()
 
@@ -211,6 +210,8 @@ SUBSYSTEM_DEF(atlas)
 		current_sector = selected_sector
 
 	current_sector.setup_current_sector()
+
+	setup_spawnpoints()
 
 	return SS_INIT_SUCCESS
 

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -127,6 +127,25 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/lobby_mobs_location)
 	return INITIALIZE_HINT_QDEL
 
 /**
+ * # Force spawnpoint
+ *
+ * A spawnpoint that is forced to be used at spawn (join AND latejoin), *overriding everything else*, depending on the `job_tag` var
+ *
+ * If the `job_tag` is set to "Anyone", the spawnpoint will be used for all jobs
+ */
+/obj/effect/landmark/force_spawnpoint
+	name = "force spawnpoint"
+	var/job_tag = "Anyone"
+
+/obj/effect/landmark/force_spawnpoint/Initialize()
+	. = ..()
+	LAZYADD(GLOB.force_spawnpoints[job_tag], get_turf(src))
+
+/obj/effect/landmark/force_spawnpoint/Destroy()
+	LAZYREMOVE(GLOB.force_spawnpoints[job_tag], get_turf(src))
+	. = ..()
+
+/**
  * # Skrell SROM (dreaming) marker
  *
  * Used to indicate where the SROM is located
@@ -189,18 +208,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/lobby_mobs_location)
 
 /obj/effect/landmark/distress_team_equipment
 	name = "distress equipment"
-
-/obj/effect/landmark/force_spawnpoint
-	name = "force spawnpoint"
-	var/job_tag = "Anyone"
-
-/obj/effect/landmark/force_spawnpoint/Initialize()
-	. = ..()
-	LAZYADD(GLOB.force_spawnpoints[job_tag], get_turf(src))
-
-/obj/effect/landmark/force_spawnpoint/Destroy()
-	LAZYREMOVE(GLOB.force_spawnpoints[job_tag], get_turf(src))
-	. = ..()
 
 /obj/effect/landmark/ruin
 	var/datum/map_template/ruin/ruin_template

--- a/html/changelogs/fluffyghost-additionalspawnpointwork.yml
+++ b/html/changelogs/fluffyghost-additionalspawnpointwork.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed some latejoin spawnpoints that were not working (eg. borgs)."
+  - rscadd: "Runtime map now uses proper spawnpoints instead of forced ones."
+  - code_imp: "Moved and DMDoc'd force spawnpoints."

--- a/maps/runtime/runtime-1.dmm
+++ b/maps/runtime/runtime-1.dmm
@@ -1397,10 +1397,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/construction)
-"dA" = (
-/obj/effect/landmark/force_spawnpoint,
-/turf/simulated/floor/plating,
-/area/construction)
 "dB" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
@@ -1431,6 +1427,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/runtime)
+"dV" = (
+/obj/effect/landmark/start{
+	name = "Xenobotanist"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"em" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Physician"
+	},
+/turf/simulated/floor/tiled,
+/area/construction)
+"eq" = (
+/obj/effect/landmark/start{
+	name = "Chef"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "eH" = (
 /obj/machinery/firealarm/south,
 /obj/machinery/firealarm/north,
@@ -1469,12 +1486,30 @@
 "fX" = (
 /turf/template_noop,
 /area/space)
+"gC" = (
+/obj/effect/landmark/start{
+	name = "Atmospheric Technician"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "gF" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
+"hz" = (
+/obj/effect/landmark/start{
+	name = "Bridge Crew"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"hI" = (
+/obj/effect/landmark/start{
+	name = "Surgeon"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "ie" = (
 /obj/effect/map_effect/window_spawner/full/reinforced,
 /obj/structure/cable{
@@ -1484,6 +1519,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/central_one)
+"if" = (
+/obj/effect/landmark/start{
+	name = "Lab Assistant"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"iq" = (
+/obj/effect/landmark/start{
+	name = "Security Officer"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"iA" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Bartender"
+	},
+/turf/simulated/floor/tiled,
+/area/construction)
 "jf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1528,6 +1584,12 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
+"kV" = (
+/obj/effect/landmark/start{
+	name = "Hangar Technician"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "mn" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 10
@@ -1541,6 +1603,21 @@
 /obj/machinery/computer/security,
 /turf/simulated/floor/tiled,
 /area/bridge)
+"mT" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Operations Manager"
+	},
+/turf/simulated/floor/tiled,
+/area/construction)
+"nv" = (
+/obj/effect/landmark/start{
+	name = "Research Director"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "nB" = (
 /obj/machinery/atmospherics/binary/pump/high_power/on{
 	dir = 4
@@ -1566,6 +1643,12 @@
 /obj/item/stack/material/glass/full,
 /turf/simulated/floor/plating,
 /area/construction)
+"pd" = (
+/obj/effect/landmark/start{
+	name = "Executive Officer"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "pv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1575,12 +1658,20 @@
 /obj/effect/overmap/visitable/ship/runtime,
 /turf/simulated/floor/tiled,
 /area/bridge)
-"pM" = (
-/obj/effect/landmark/force_spawnpoint{
-	job_tag = "Chief Engineer";
-	name = "force spawnpoint (CE)"
+"pD" = (
+/obj/effect/landmark/start{
+	name = "Assistant"
 	},
+/turf/simulated/floor/plating,
+/area/construction)
+"pM" = (
 /turf/simulated/floor/tiled,
+/area/construction)
+"pT" = (
+/obj/effect/landmark/start{
+	name = "Engineer"
+	},
+/turf/simulated/floor/plating,
 /area/construction)
 "pX" = (
 /obj/structure/cable{
@@ -1618,6 +1709,12 @@
 /obj/item/blueprints/shuttle,
 /turf/simulated/floor/shuttle,
 /area/shuttle/runtime)
+"rE" = (
+/obj/effect/landmark/start{
+	name = "Xenoarchaeologist"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "sf" = (
 /obj/machinery/computer/ship/sensors/terminal,
 /turf/simulated/floor/tiled,
@@ -1643,6 +1740,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
+"tl" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/landmark/start{
+	name = "Passenger"
+	},
+/turf/simulated/floor/tiled,
+/area/construction)
 "tr" = (
 /obj/machinery/alarm/south,
 /turf/simulated/floor/tiled,
@@ -1662,6 +1766,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/primary)
+"uC" = (
+/obj/effect/landmark/start{
+	name = "Machinist"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "uI" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 1
@@ -1728,6 +1838,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/plating,
 /area/storage/primary)
+"xP" = (
+/obj/effect/landmark/latejoin,
+/turf/simulated/floor/plating,
+/area/construction)
 "yC" = (
 /obj/structure/lattice,
 /obj/machinery/power/terminal{
@@ -1789,10 +1903,20 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/storage/primary)
+"Cu" = (
+/obj/effect/landmark/latejoinlift,
+/turf/simulated/floor/plating,
+/area/construction)
 "Eu" = (
 /obj/effect/landmark/entry_point/aft,
 /turf/simulated/wall/r_wall,
 /area/maintenance/maintcentral)
+"Ex" = (
+/obj/effect/landmark/start{
+	name = "Investigator"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "ES" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/shipsensors,
@@ -1806,6 +1930,12 @@
 /obj/machinery/alarm/west,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
+"FU" = (
+/obj/effect/landmark/start{
+	name = "Chief Engineer"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "FZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/recharge_station,
@@ -1819,12 +1949,42 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
+"Gp" = (
+/obj/effect/landmark/start{
+	name = "Psychiatrist"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"GF" = (
+/obj/effect/landmark/start{
+	name = "Pharmacist"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"GH" = (
+/obj/effect/landmark/start{
+	name = "Scientist"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"Hg" = (
+/obj/effect/landmark/start{
+	name = "Chaplain"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "HB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
+"HD" = (
+/obj/effect/landmark/start{
+	name = "Captain"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "HJ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -1899,6 +2059,27 @@
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
+"KM" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/landmark/start{
+	name = "Security Cadet"
+	},
+/turf/simulated/floor/tiled,
+/area/construction)
+"KR" = (
+/obj/effect/landmark/start{
+	name = "Head of Security"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"KU" = (
+/obj/effect/landmark/start{
+	name = "Consular Officer"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "Lp" = (
 /obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled,
@@ -1928,6 +2109,10 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
+"MW" = (
+/obj/effect/landmark/latejoincryo,
+/turf/simulated/floor/plating,
+/area/construction)
 "Nn" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
@@ -1938,6 +2123,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
+"Oe" = (
+/obj/effect/landmark/start{
+	name = "Corporate Liaison"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "Ot" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
@@ -1994,10 +2185,28 @@
 /obj/item/device/radio/intercom/south,
 /turf/simulated/floor/tiled,
 /area/bridge)
+"Sj" = (
+/obj/effect/landmark/start{
+	name = "Warden"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "Sz" = (
 /obj/machinery/alarm/north,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
+"SA" = (
+/obj/effect/landmark/start{
+	name = "First Responder"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
+"SP" = (
+/obj/effect/landmark/start{
+	name = "Engineering Apprentice"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "Tj" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
@@ -2035,6 +2244,12 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
+/area/construction)
+"TW" = (
+/obj/effect/landmark/start{
+	name = "Gardener"
+	},
+/turf/simulated/floor/plating,
 /area/construction)
 "Uf" = (
 /turf/simulated/floor/plating,
@@ -2082,6 +2297,12 @@
 /obj/turbolift_map_holder/runtime,
 /turf/simulated/floor/plating,
 /area/turbolift/main_station)
+"WV" = (
+/obj/effect/landmark/start{
+	name = "Xenobiologist"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "XQ" = (
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 1
@@ -2098,6 +2319,12 @@
 	},
 /turf/template_noop,
 /area/template_noop)
+"Yi" = (
+/obj/effect/landmark/start{
+	name = "Chief Medical Officer"
+	},
+/turf/simulated/floor/plating,
+/area/construction)
 "YI" = (
 /obj/machinery/door/airlock/external/khaki{
 	dir = 4
@@ -5973,11 +6200,11 @@ cU
 qH
 oo
 de
+SP
 de
 de
 de
-de
-de
+Oe
 de
 dv
 dx
@@ -6230,11 +6457,11 @@ cV
 de
 de
 de
+pT
 de
 de
 de
-de
-de
+KU
 de
 de
 dx
@@ -6485,9 +6712,9 @@ bB
 cN
 cV
 de
+hz
 de
-dA
-dA
+gC
 dq
 dq
 de
@@ -6742,14 +6969,14 @@ eI
 cK
 cV
 de
+pd
 de
-dA
-dA
+FU
 dq
 dq
+xP
 de
-de
-de
+nv
 de
 du
 cK
@@ -6999,14 +7226,14 @@ bB
 cO
 cV
 de
+HD
 de
-dA
-dA
+de
 dq
 dq
+MW
 de
-de
-de
+if
 de
 dC
 cK
@@ -7254,17 +7481,17 @@ cz
 bB
 bB
 cO
-cV
+tl
 pM
 db
-dA
-dA
-dq
-dq
 de
+de
+dq
+dq
+Cu
 Jd
-de
-de
+GH
+dV
 du
 cK
 ae
@@ -7513,15 +7740,15 @@ bB
 cO
 cV
 de
+KR
 de
-dA
-dA
+GF
 dq
 dq
 de
 de
-de
-de
+rE
+WV
 du
 cK
 ae
@@ -7770,9 +7997,9 @@ zQ
 cK
 WH
 de
+iq
 de
-dA
-dA
+Yi
 dq
 dq
 de
@@ -8027,15 +8254,15 @@ bB
 cN
 cV
 de
+Sj
 de
-dA
-dA
-de
-de
-de
+SA
+Gp
 de
 de
-de
+eq
+Hg
+kV
 ds
 cK
 ae
@@ -8284,15 +8511,15 @@ bB
 cN
 cV
 de
+Ex
+de
+hI
 de
 de
 de
-de
-de
-de
-de
-de
-de
+TW
+pD
+uC
 dk
 cK
 ae
@@ -8541,14 +8768,14 @@ bB
 cK
 cW
 df
+KM
+dj
+em
 dj
 dj
 dj
-dj
-dj
-dj
-dj
-dj
+iA
+mT
 df
 dy
 cK

--- a/maps/runtime/runtime-2.dmm
+++ b/maps/runtime/runtime-2.dmm
@@ -13,6 +13,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/construction/storage)
+"az" = (
+/obj/effect/landmark/latejoincyborg,
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/turret_protected/ai_upload_foyer)
 "aO" = (
 /turf/simulated/floor/tiled,
 /area/construction/storage)
@@ -6087,9 +6094,9 @@ GG
 oF
 Vp
 Ws
-wJ
+az
 Ml
-wJ
+az
 Xd
 ki
 wf


### PR DESCRIPTION
Fixed some latejoin spawnpoints that were not working (eg. borgs).
Runtime map now uses proper spawnpoints instead of forced ones.
Moved and DMDoc'd force spawnpoints.

After a quick testmerge (because I don't trust spawnpoints at all), this should be good to go in