### PR TITLE
Further SFA ship decay.

### DIFF
--- a/html/changelogs/dansemacabre-sfadecay.yml
+++ b/html/changelogs/dansemacabre-sfadecay.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: TheDanseMacabre
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - refactor: "Reworks the SFA ghostroles and the SFA corvette to reflect a state of further decay."
+

--- a/maps/away/ships/sol_pirate/sfa_patrol_ship.dmm
+++ b/maps/away/ships/sol_pirate/sfa_patrol_ship.dmm
@@ -1078,6 +1078,9 @@
 /obj/machinery/power/apc/west{
 	req_access = list(203)
 	},
+/obj/random/voidsuit/freebooter,
+/obj/random/voidsuit/freebooter,
+/obj/random/voidsuit/freebooter,
 /turf/simulated/floor/tiled/dark,
 /area/ship/sfa_patrol_ship/Suit_Storage)
 "dnC" = (
@@ -1550,8 +1553,7 @@
 	inserted_light = /obj/item/light/tube/colored/blue;
 	icon_state = "tube_empty"
 	},
-/obj/machinery/suit_cycler/offship/sol/sfa,
-/obj/machinery/suit_cycler/offship/sol/sfa,
+/obj/machinery/suit_cycler,
 /turf/simulated/floor/tiled/dark,
 /area/ship/sfa_patrol_ship/Suit_Storage)
 "eLQ" = (
@@ -1804,6 +1806,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/sfa_patrol_ship)
+"fua" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/holofloor/wood,
+/area/ship/sfa_patrol_ship/Quarters)
 "fus" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 1
@@ -2446,13 +2452,13 @@
 	},
 /obj/item/gun/projectile/pistol/sol,
 /obj/item/gun/projectile/pistol/sol,
-/obj/item/gun/projectile/pistol/sol,
-/obj/item/gun/projectile/pistol/sol,
-/obj/item/gun/projectile/automatic/c20r/sol,
 /obj/item/gun/projectile/automatic/c20r/sol,
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
+/obj/random/civgun,
+/obj/random/civgun,
+/obj/random/civgun,
 /turf/simulated/floor/tiled/dark,
 /area/ship/sfa_patrol_ship/SFA_Armory)
 "hnc" = (
@@ -2673,7 +2679,10 @@
 /area/shuttle/sfa_shuttle)
 "ilb" = (
 /obj/structure/table/wood,
-/obj/item/device/flashlight/lamp/lava/red,
+/obj/item/reagent_containers/pill/cyanide{
+	name = "cyanide pill";
+	desc = "a cyanide pill. Useful if you're about to be captured after years of committing piracy on the run."
+	},
 /turf/simulated/floor/carpet/art,
 /area/ship/sfa_patrol_ship/Officer)
 "imn" = (
@@ -3044,17 +3053,13 @@
 /area/ship/sfa_patrol_ship/kitchenmedbay)
 "jqd" = (
 /obj/structure/table/steel,
-/obj/item/laser_components/modifier/stock,
-/obj/item/screwdriver,
-/obj/item/laser_components/modifier/scope{
-	pixel_y = 8
-	},
 /obj/machinery/alarm/east{
 	req_one_access = list(24,11,203)
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
+/obj/item/clothing/suit/storage/vest/legion,
 /turf/simulated/floor/tiled/dark,
 /area/ship/sfa_patrol_ship/SFA_Armory)
 "jqA" = (
@@ -4176,6 +4181,28 @@
 /obj/item/clothing/accessory/storage/webbing,
 /obj/item/clothing/accessory/storage/webbing,
 /obj/item/clothing/accessory/storage/webbing,
+/obj/item/clothing/under/pants/camo,
+/obj/item/clothing/under/pants/camo,
+/obj/item/clothing/head/bandana/colorable/random,
+/obj/item/clothing/accessory/bandanna/black,
+/obj/item/clothing/accessory/bandanna/black,
+/obj/item/clothing/head/bandana,
+/obj/item/clothing/under/tactical,
+/obj/item/clothing/under/pants/mustang,
+/obj/item/clothing/under/pants/track,
+/obj/item/clothing/under/syndicate/tracksuit,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/shoes/sneakers/black,
+/obj/item/clothing/shoes/sneakers/hitops/black,
+/obj/item/clothing/under/legion,
+/obj/item/clothing/head/softcap/tcfl,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/military/old,
+/obj/item/clothing/suit/storage/toggle/leather_jacket/flight,
+/obj/item/clothing/head/beanie/random,
+/obj/item/clothing/head/bucket/boonie/blue,
+/obj/item/clothing/accessory/silversun/random,
+/obj/item/clothing/accessory/silversun/random,
 /turf/simulated/floor/holofloor/wood,
 /area/ship/sfa_patrol_ship/Quarters)
 "mUT" = (
@@ -5149,6 +5176,8 @@
 /obj/item/clothing/ears/skrell/band/silver,
 /obj/item/clothing/ears/skrell/band/ebony,
 /obj/item/clothing/ears/skrell/band/bluejewels,
+/obj/item/clothing/under/suit_jacket/charcoal,
+/obj/item/clothing/shoes/laceup,
 /turf/simulated/floor/carpet/art,
 /area/ship/sfa_patrol_ship/Officer)
 "qfX" = (
@@ -5967,10 +5996,10 @@
 	req_access = list(203)
 	},
 /obj/item/gun/projectile/automatic/rifle/sol,
-/obj/item/gun/projectile/automatic/rifle/sol,
 /obj/effect/floor_decal/corner/red/full{
 	dir = 4
 	},
+/obj/random/civgun/rifle,
 /turf/simulated/floor/tiled/dark,
 /area/ship/sfa_patrol_ship/SFA_Armory)
 "taa" = (
@@ -6070,7 +6099,7 @@
 /area/ship/sfa_patrol_ship/hangar)
 "tIq" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/suit_cycler/offship/sol/sfa,
+/obj/machinery/suit_cycler,
 /turf/simulated/floor/tiled/dark,
 /area/ship/sfa_patrol_ship/Suit_Storage)
 "tIr" = (
@@ -47138,7 +47167,7 @@ cIy
 rzY
 qPf
 cCo
-bLU
+fua
 mLa
 ozI
 rrj

--- a/maps/away/ships/sol_pirate/sfa_patrol_ship_ghostroles.dm
+++ b/maps/away/ships/sol_pirate/sfa_patrol_ship_ghostroles.dm
@@ -1,26 +1,25 @@
 /datum/ghostspawner/human/sfa_navy_crewman
 	short_name = "sfa_navy_crewman"
-	name = "SFA Navy Crewman"
-	desc = "Crew the Southern Fleet Administration corvette. Figure out what to do now that the warlord you serve is dead."
+	name = "SFA Remnant"
+	desc = "Crew the Southern Fleet Administration remnant corvette. Try to stay one step ahead of everyone out to get you."
 	tags = list("External")
-	mob_name_prefix = "PO3. "
 
 	spawnpoints = list("sfa_navy_crewman")
-	max_count = 2
+	max_count = 4
 
 	outfit = /obj/outfit/admin/sfa_navy_crewman
 	possible_species = list(SPECIES_HUMAN)
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 
-	assigned_role = "SFA Navy Crewman"
-	special_role = "SFA Navy Crewman"
+	assigned_role = "Independent Spacer"
+	special_role = "SFA Remnant"
 	respawn_flag = null
 
 	culture_restriction = list(/singleton/origin_item/culture/solarian)
 
 
 /obj/outfit/admin/sfa_navy_crewman
-	name = "SFA Navy Crewman"
+	name = "SFA Remnant"
 
 	uniform = /obj/item/clothing/under/rank/sol/
 	shoes = /obj/item/clothing/shoes/jackboots
@@ -40,10 +39,9 @@
 
 /datum/ghostspawner/human/sfa_navy_officer
 	short_name = "sfa_navy_officer"
-	name = "SFA Navy Officer"
-	desc = "Pilot and command a Southern Fleet Administration corvette. Figure out what to do now that the warlord you serve is dead."
+	name = "SFA Remnant Officer"
+	desc = "Pilot and command the Southern Fleet Administration remnant corvette. Be sure to take your cyanide capsule before anyone captures you."
 	tags = list("External")
-	mob_name_prefix = "LT. "
 
 	spawnpoints = list("sfa_navy_officer")
 	max_count = 1
@@ -52,15 +50,15 @@
 	possible_species = list(SPECIES_HUMAN)
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 
-	assigned_role = "SFA Navy Officer"
-	special_role = "SFA Navy Officer"
+	assigned_role = "Independent Spacer Captain"
+	special_role = "SFA Remnant Officer"
 	respawn_flag = null
 
 	culture_restriction = list(/singleton/origin_item/culture/solarian)
 
 
 /obj/outfit/admin/sfa_navy_officer
-	name = "SFA Navy Officer"
+	name = "SFA Remnant Officer"
 
 	uniform = /obj/item/clothing/under/rank/sol/dress/subofficer
 	shoes = /obj/item/clothing/shoes/laceup
@@ -75,46 +73,6 @@
 	backpack_contents = list(/obj/item/storage/box/survival = 1, /obj/item/melee/energy/sword/knife/sol = 1)
 
 /obj/outfit/admin/sfa_navy_officer/get_id_access()
-	return list(ACCESS_SOL_SHIPS, ACCESS_EXTERNAL_AIRLOCKS)
-
-/datum/ghostspawner/human/sfa_marine
-	short_name = "sfa_marine"
-	name = "SFA Marine"
-	desc = "Protect the Southern Fleet Administration corvette. Figure out what to do now that the warlord you serve is dead."
-	tags = list("External")
-	mob_name_prefix = "Pfc. "
-
-	spawnpoints = list("sfa_navy_crewman")
-	max_count = 2
-
-	outfit = /obj/outfit/admin/sfa_marine
-	possible_species = list(SPECIES_HUMAN)
-	allow_appearance_change = APPEARANCE_PLASTICSURGERY
-
-	assigned_role = "SFA Marine"
-	special_role = "SFA Marine"
-	respawn_flag = null
-
-	culture_restriction = list(/singleton/origin_item/culture/solarian)
-
-
-/obj/outfit/admin/sfa_marine
-	name = "SFA Marine"
-
-	uniform = /obj/item/clothing/under/rank/sol/marine
-	shoes = /obj/item/clothing/shoes/jackboots
-	back = /obj/item/storage/backpack/satchel
-	belt = /obj/item/storage/belt/military
-	head = /obj/item/clothing/head/sol/marine
-	accessory = /obj/item/clothing/accessory/storage/pouches/black
-
-	id = /obj/item/card/id/sfa_ship
-
-	l_ear = /obj/item/device/radio/headset/ship
-
-	backpack_contents = list(/obj/item/storage/box/survival = 1, /obj/item/melee/energy/sword/knife/sol = 1)
-
-/obj/outfit/admin/sfa_marine/get_id_access()
 	return list(ACCESS_SOL_SHIPS, ACCESS_EXTERNAL_AIRLOCKS)
 
 //items


### PR DESCRIPTION
This PR edits the SFA ship and the relevant ghostroles to further depict the gradual decay of the remaining SFA ships and forces. The SFA corvette's ghostroles have now lost all semblance of military organization or traditions, with everyone losing their ranks and being amalgamated into a generic SFA pirate remnant role (with their IDs now changed to match the freebooter), with a generic officer leading them. They've also lost some of their Solarian weapons and armor, replaced by random civilian alternatives. 