### PR TITLE
AI Law Boards Secure Storage

### DIFF
--- a/html/changelogs/Ben10083 - Lawboard.yml
+++ b/html/changelogs/Ben10083 - Lawboard.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Most of the AI Law boards beside law upload console in AI Upload have been moved to AI Secure Storage."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -1446,27 +1446,7 @@
 /area/horizon/security/interrogation)
 "aYW" = (
 /obj/structure/table/steel,
-/obj/item/aiModule/robocop{
-	pixel_x = -7
-	},
-/obj/item/aiModule/paladin{
-	pixel_x = -1
-	},
-/obj/item/aiModule/corp{
-	pixel_x = 5
-	},
-/obj/item/aiModule/purge{
-	pixel_y = 9;
-	pixel_x = -7
-	},
-/obj/item/aiModule/reset{
-	pixel_y = 9;
-	pixel_x = -1
-	},
-/obj/item/aiModule/quarantine{
-	pixel_x = 5;
-	pixel_y = 9
-	},
+/obj/item/aiModule/reset,
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 1
 	},
@@ -2729,6 +2709,27 @@
 	name = "High Risk Modules";
 	desc = "Warning: Experimental modules designed to be used in extreme situations. Exercise extreme caution when utilizing.";
 	req_access = list(20)
+	},
+/obj/item/aiModule/robocop{
+	pixel_x = -7
+	},
+/obj/item/aiModule/paladin{
+	pixel_x = -1
+	},
+/obj/item/aiModule/corp{
+	pixel_x = 5
+	},
+/obj/item/aiModule/purge{
+	pixel_y = 9;
+	pixel_x = -7
+	},
+/obj/item/aiModule/quarantine{
+	pixel_x = 5;
+	pixel_y = 9
+	},
+/obj/item/aiModule/nanotrasen{
+	pixel_x = -1;
+	pixel_y = 9
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/turret_protected/ai_upload)


### PR DESCRIPTION
Most of the AI Law Boards that were beside AI Upload moved to AI secure storage.

It would not be ideal for the hazardous laws such as the purging of all laws to be left beside the console made to upload said laws, most moved to Ai Secure storage.