### PR TITLE
Flamethrower in vents injection

### DIFF
--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -94,6 +94,8 @@
 	else
 		. = ..()
 
+
+#define MAX_PIPES_BLAST_DISTANCE world.view * 2
 /**
  * Called when the flamethrower is attacking an atmos machine (eg. scrubbers or vents)
  *
@@ -138,6 +140,10 @@
 		if(!T)
 			continue
 
+		//If it's too far away, skip it
+		if((atmos_machine_being_attacked.z != T.z) || (get_dist(atmos_machine_being_attacked, T) > MAX_PIPES_BLAST_DISTANCE))
+			continue
+
 		var/datum/gas_mixture/air_transfer = gas_tank.air_contents.remove_ratio(0.02 * (throw_amount / 100))
 		if(!air_transfer)
 			to_chat(user, SPAN_WARNING("The flamethrower is out of fuel!"))
@@ -157,12 +163,24 @@
 
 	for(var/datum/pipeline/network_line_members as anything in atmos_machine_being_attacked.network.line_members)
 		for(var/obj/machinery/atmospherics/pipe/pipe_in_the_network as anything in (network_line_members.members + network_line_members.edges))
+
+			//Get the turf this pipe is on
+			var/turf/T = get_turf(pipe_in_the_network)
+			if(!T)
+				continue
+
+			//If it's too far away, skip it
+			if((atmos_machine_being_attacked.z != T.z) || (get_dist(atmos_machine_being_attacked, T) > MAX_PIPES_BLAST_DISTANCE))
+				continue
+
 			var/mob/living/M = locate() in pipe_in_the_network
 			if(M)
 				M.apply_damage(20, DAMAGE_BURN)
 				M.IgniteMob(1)
 
 			CHECK_TICK
+
+#undef MAX_PIPES_BLAST_DISTANCE
 
 /obj/item/flamethrower/afterattack(atom/target, mob/user, proximity)
 	if(proximity)

--- a/html/changelogs/fluffyghost-flamethrowerpipeblast.yml
+++ b/html/changelogs/fluffyghost-flamethrowerpipeblast.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Flamethrowers can now inject flame into a pipe, damaging mobs that are ventcrawling in it, and ejecting some of the fuel from atmos machines connected to it."


### PR DESCRIPTION
Flamethrowers can now inject flame into a pipe, damaging mobs that are ventcrawling in it, and ejecting some of the fuel from atmos machines connected to it