### PR TITLE
[Bugfix] Minor additions and turf fix for the AI core

### DIFF
--- a/html/changelogs/ReadThisNamePlz-AICoreAdditions.yml
+++ b/html/changelogs/ReadThisNamePlz-AICoreAdditions.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ReadThisNamePlz
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added two additional cameras to the AI area."
+  - rscadd: "Added a camera to the CIC Foyer."
+  - rscadd: "Added holopads to the AI core."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -6220,6 +6220,10 @@
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - CIC Foyer";
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/maintenance/security_starboard)
 "eEz" = (

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -10056,6 +10056,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
 "hcg" = (
@@ -14152,6 +14153,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/device/radio/intercom/south,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/aibunker)
 "jKD" = (
@@ -15311,7 +15313,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/reinforced,
 /area/bridge/selfdestruct)
 "kxi" = (
 /obj/effect/landmark/entry_point/starboard{
@@ -23282,6 +23284,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad/long_range,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
 "pNE" = (
@@ -26343,6 +26346,7 @@
 "rRK" = (
 /obj/machinery/porta_turret,
 /obj/effect/floor_decal/industrial/warning/full,
+/obj/item/device/radio/intercom/south,
 /turf/simulated/floor/tiled/dark,
 /area/turret_protected/ai_upload_foyer)
 "rRN" = (
@@ -28056,6 +28060,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "Bridge - Restricted Area";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/bridge/selfdestruct)
@@ -35182,6 +35190,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
+	},
+/obj/machinery/camera/network/command{
+	c_tag = "AI Core - Upload Airlock"
 	},
 /turf/simulated/floor,
 /area/turret_protected/ai_upload_foyer)


### PR DESCRIPTION
I did not realize that there was a missing floor tile from the scuttle chamber. It was covered by decals in SDMM and I did not notice it during the test-merge. 

I also overlooked adding a holopad to the AI upload. 

Additional changes: Three extra cameras that I had intended to add, but it slipped my mind. Sorry!