### PR TITLE
Horizon Mapping QoL and Fixes

### DIFF
--- a/html/changelogs/CourierBravo - Horizon QOL Changes.yml
+++ b/html/changelogs/CourierBravo - Horizon QOL Changes.yml
@@ -1,0 +1,64 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: CourierBravo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Added several pice scanners and an extra quikpay to operations."
+  - qol: "Added more trash bags to janitorial."
+  - qol: "Doubled the number of bluespace flares, to encourage their use."
+  - bugfix: "Replaced an empty first aid kit in teleporter room with an actual first aid kit."
+  - bugfix: "Removed a floor light under a door that shouldn't be there."
+  - bugfix: "Properly orented the airtight flaps in the fuel bay and the kitchen."
+  - bugfix: "Finally added the rubber ducky mentioned in July, 2022."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -18184,7 +18184,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/plasticflaps/airtight,
+/obj/structure/plasticflaps/airtight{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hangar/intrepid)
 "mxX" = (
@@ -21240,6 +21242,9 @@
 	pixel_y = 8
 	},
 /obj/structure/table/rack,
+/obj/item/device/spaceflare,
+/obj/item/device/spaceflare,
+/obj/item/device/spaceflare,
 /obj/item/device/spaceflare,
 /obj/item/device/spaceflare,
 /obj/item/device/spaceflare,
@@ -30462,7 +30467,7 @@
 	dir = 6
 	},
 /obj/structure/table/standard,
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/tiled/dark,
 /area/teleporter)
 "uWc" = (
@@ -33974,7 +33979,9 @@
 "xmc" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
-/obj/structure/plasticflaps/airtight,
+/obj/structure/plasticflaps/airtight{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass_mining{
 	dir = 4;
 	name = "Fuel Bay";
@@ -34147,6 +34154,15 @@
 	},
 /obj/effect/floor_decal/industrial/outline/custodial,
 /obj/machinery/power/apc/super/south,
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash{
+	pixel_x = -9;
+	pixel_y = 2
+	},
+/obj/item/storage/bag/trash{
+	pixel_x = -4;
+	pixel_y = -2
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/custodial)
 "xqn" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -9301,6 +9301,7 @@
 /obj/machinery/power/apc/low/north,
 /obj/machinery/alarm/west,
 /obj/structure/closet/secure_closet/operations_manager,
+/obj/item/device/price_scanner,
 /turf/simulated/floor/tiled,
 /area/operations/qm)
 "epN" = (
@@ -20985,7 +20986,17 @@
 	c_tag = "Second Deck - Commissary Backroom";
 	dir = 1
 	},
-/obj/item/folder/yellow,
+/obj/item/folder/yellow{
+	pixel_y = 3
+	},
+/obj/item/device/price_scanner{
+	pixel_y = 4;
+	pixel_x = -16
+	},
+/obj/item/device/quikpay{
+	destinationact = "Operations";
+	pixel_y = 3
+	},
 /turf/simulated/floor/tiled,
 /area/horizon/commissary)
 "jAo" = (
@@ -26967,6 +26978,7 @@
 /obj/structure/table/rack,
 /obj/item/towel,
 /obj/random/soap,
+/obj/item/bikehorn/rubberducky,
 /turf/simulated/floor/tiled/white,
 /area/operations/break_room)
 "muQ" = (
@@ -32021,6 +32033,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/item/storage/bag/trash,
+/obj/item/storage/bag/trash{
+	pixel_x = -9;
+	pixel_y = 2
+	},
+/obj/item/storage/bag/trash{
+	pixel_x = -4;
+	pixel_y = -2
 	},
 /turf/simulated/floor/tiled,
 /area/horizon/custodial/auxiliary)
@@ -37546,6 +37567,7 @@
 	pixel_y = 5
 	},
 /obj/item/pen/black,
+/obj/item/device/price_scanner,
 /turf/simulated/floor/tiled,
 /area/operations/office)
 "rqS" = (
@@ -40542,7 +40564,9 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
 "sSZ" = (
-/obj/structure/plasticflaps/airtight,
+/obj/structure/plasticflaps/airtight{
+	dir = 4
+	},
 /obj/machinery/door/airlock/freezer{
 	dir = 4;
 	name = "Freezer";

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -29891,9 +29891,6 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 5
 	},
-/obj/machinery/light/floor{
-	dir = 1
-	},
 /obj/machinery/door/airlock/glass{
 	dir = 4
 	},


### PR DESCRIPTION
Makes various QoL changes and fixes. Adding price scanners and an extra quikpay to operations, more trash bags to janitorial, doubled bluespace flares, replacing the teleporter first aid kit with an actually functional kit, removing a misplaced floor light, properly orienting some airtight flaps, and FINALLY putting in the rubber ducky mentioned in PR #14462 