### PR TITLE
TCAF Shuttle Bugfixes

### DIFF
--- a/html/changelogs/LynxSolstice-TCAF-Shuttle-fixes.yml
+++ b/html/changelogs/LynxSolstice-TCAF-Shuttle-fixes.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: LynxSolstice
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Adds an engine control, and weapons control console to the TCAF gunship, since it was missing both."

--- a/maps/away/ships/biesel/tcaf_corvette/tcaf_corvette.dmm
+++ b/maps/away/ships/biesel/tcaf_corvette/tcaf_corvette.dmm
@@ -1236,6 +1236,9 @@
 "jj" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/table/rack,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 35
+	},
 /turf/simulated/floor/shuttle/black,
 /area/shuttle/tcaf)
 "jk" = (
@@ -1308,7 +1311,7 @@
 "jE" = (
 /obj/structure/ship_weapon_dummy/barrel,
 /turf/simulated/floor/plating,
-/area/tcaf_corvette/hangar)
+/area/shuttle/tcaf)
 "jI" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack,
@@ -3460,13 +3463,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/tcaf_corvette/security)
 "CJ" = (
-/obj/structure/bed/stool/chair/shuttle{
-	dir = 8
-	},
 /obj/machinery/alarm/east{
 	req_one_access = list(204)
 	},
 /obj/machinery/light,
+/obj/machinery/computer/ship/targeting{
+	dir = 8
+	},
 /turf/simulated/floor/shuttle/tan,
 /area/shuttle/tcaf)
 "CL" = (
@@ -3609,10 +3612,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/tcaf_corvette/storage)
 "El" = (
-/obj/structure/table/rack,
 /obj/machinery/light,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -24
+/obj/machinery/computer/ship/engines{
+	dir = 4
 	},
 /turf/simulated/floor/shuttle/tan,
 /area/shuttle/tcaf)
@@ -4798,6 +4800,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/bed/stool/chair/office/bridge/pilot,
 /turf/simulated/floor/shuttle/tan,
 /area/shuttle/tcaf)
 "NH" = (
@@ -5083,9 +5086,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/bed/stool/chair/shuttle{
-	dir = 8
-	},
 /obj/machinery/power/apc/super/east{
 	req_access = list(204)
 	},
@@ -5369,6 +5369,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/structure/bed/stool/chair/office/bridge/pilot,
 /turf/simulated/floor/shuttle/tan,
 /area/shuttle/tcaf)
 "SC" = (


### PR DESCRIPTION
Adds a weapons console and engines console to the TCAF shuttle, which it was missing for some reason.
