### PR TITLE
Adds tinted windows to the bar

### DIFF
--- a/html/changelogs/hazelmouse - bar tinted windows.yml
+++ b/html/changelogs/hazelmouse - bar tinted windows.yml
@@ -56,4 +56,3 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Adds tinted windows to the bar backroom, so you can have your shady dealings in private."
-  - rscdel: "Removes the banana peel in Pun-Pun's enclosure."

--- a/html/changelogs/hazelmouse - bar tinted windows.yml
+++ b/html/changelogs/hazelmouse - bar tinted windows.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds tinted windows to the bar backroom, so you can have your shady dealings in private."
+  - rscdel: "Removes the banana peel in Pun-Pun's enclosure."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -6994,7 +6994,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/bar)
 "din" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/polarized/firedoor{
+	id = "bar"
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/bar/backroom)
 "dit" = (
@@ -17447,7 +17449,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/firealarm/west,
+/obj/machinery/alarm/west,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/bar/backroom)
 "hSU" = (
@@ -31224,10 +31226,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "oqB" = (
-/obj/machinery/light_switch{
-	pixel_x = 9;
-	pixel_y = -19
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -40143,10 +40141,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/kitchen)
 "sGq" = (
-/obj/machinery/camera/network/service{
-	c_tag = "Service - Deck 2 - Bar Backroom";
-	dir = 1
-	},
+/obj/machinery/firealarm/south,
 /turf/simulated/floor/tiled/dark,
 /area/horizon/bar/backroom)
 "sGR" = (
@@ -43396,9 +43391,6 @@
 /area/medical/cryo)
 "uhw" = (
 /obj/structure/table/wood,
-/obj/machinery/alarm/north{
-	req_one_access = list(24,11,55)
-	},
 /obj/item/storage/box/lights/colored/blue{
 	pixel_x = 6;
 	pixel_y = 10
@@ -43422,6 +43414,17 @@
 /obj/item/storage/box/lights/colored/yellow{
 	pixel_x = -6;
 	pixel_y = 2
+	},
+/obj/machinery/button/switch/windowtint{
+	dir = 1;
+	id = "bar";
+	pixel_y = 30;
+	pixel_x = 5
+	},
+/obj/machinery/light_switch{
+	pixel_x = -5;
+	pixel_y = 30;
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/bar/backroom)
@@ -45297,6 +45300,10 @@
 /area/horizon/exterior)
 "uZh" = (
 /obj/structure/closet/secure_closet/cabinet/beer/horizon,
+/obj/machinery/camera/network/service{
+	c_tag = "Service - Deck 2 - Bar Backroom";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/bar/backroom)
 "uZi" = (
@@ -46918,12 +46925,8 @@
 	},
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp/green{
-	pixel_x = 8;
+	pixel_x = 1;
 	pixel_y = 3
-	},
-/obj/item/bananapeel{
-	pixel_x = -7;
-	pixel_y = 1
 	},
 /turf/simulated/floor/carpet,
 /area/horizon/bar/backroom)


### PR DESCRIPTION
Gives the bar backroom tinted windows that can be toggled from inside, for private conversations or shady dealings. It feels odd that an ostensibly private space is invariably in full view of a public hallway.