### PR TITLE
Make it mechanically possible for tall people to "tower over" short people

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -487,11 +487,11 @@
 		return height_string
 
 	switch(height - examiner.height)
-		if(-999 to -100)
+		if(-999 to -51)
 			height_descriptor = "absolutely tiny compared to"
-		if(-99 to -51)
+		if(-50 to -31)
 			height_descriptor = "much smaller than"
-		if(-50 to -21)
+		if(-30 to -21)
 			height_descriptor = "significantly shorter than"
 		if(-20 to -11)
 			height_descriptor = "shorter than"
@@ -503,9 +503,9 @@
 			height_descriptor = "slightly taller than"
 		if(11 to 20)
 			height_descriptor = "taller than"
-		if(21 to 50)
+		if(21 to 30)
 			height_descriptor = "significantly taller than"
-		if(51 to 100)
+		if(31 to 50)
 			height_descriptor = "much larger than"
 		else
 			height_descriptor = "to tower over"

--- a/html/changelogs/crosarius-heightdiffs.yml
+++ b/html/changelogs/crosarius-heightdiffs.yml
@@ -1,0 +1,6 @@
+author: Crosarius
+
+delete-after: True
+
+changes:
+  - qol: "Makes the 'They are absolutely tiny compared to you' and 'they tower over you!' height descriptor messages appear at 50 cm height difference instead of 100 cm"


### PR DESCRIPTION
This is a simple value change that makes the "they are absolutely tiny compared to you!" and "they tower over you!" messages appear at 50 cm height difference, instead of 100 cm height difference. 

This will make it mechanically possible to actually get these messages outside of edge cases like Vaurca Bulwarks or Breeders or max-height G2s. Now tall Unathi will be able to tower over shorter Humans, Skrell, etc. Previously, this was impossible due to the difference between the minimum heights for Skrell, Humans, etc and the maximum heights for Unathi, etc being less than 100. 