### PR TITLE
Intrepid Cockpit Fix

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -170,7 +170,7 @@
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return 1
 	if(is_full_window())
-		return 0	//full tile window, you can't move into it!
+		return !density	//full tile window, you can't move into it if it's solid!
 	if(get_dir(loc, target) & dir)
 		return !density
 	else

--- a/html/changelogs/intrepid-cockpit-fixes.yml
+++ b/html/changelogs/intrepid-cockpit-fixes.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed an issue where you couldn't access either of the Intrepid copilot chairs without climbing over them."


### PR DESCRIPTION
Fixes being unable to access the Intrepid's copilot chairs, outside of climbing over the back of them.

This was due to the window present on their tile not checking for density, despite being specifically modified to allow passage.
