### PR TITLE
Makes Wounds Appear on the Health Doll

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -934,6 +934,27 @@
 						no_damage = 0
 					health_images += E.get_damage_hud_image()
 
+				// Add wound overlays
+				for(var/obj/item/organ/external/O in organs)
+					if(O.damage_state == "00") continue
+					var/cache_index = "[O.damage_state]/[O.icon_name]/[species.blood_color]/[species.get_bodytype()]"
+					var/list/damage_icon_parts = SSicon_cache.damage_icon_parts
+					var/icon/DI = damage_icon_parts[cache_index]
+					if(!DI)
+						DI = new /icon(species.damage_overlays, O.damage_state)			// the damage icon for whole human
+						DI.Blend(new /icon(species.damage_mask, O.icon_name), ICON_MULTIPLY)	// mask with this organ's pixels
+						DI.Blend(species.blood_color, ICON_MULTIPLY)
+						damage_icon_parts[cache_index] = DI
+					health_images += DI
+					if(O.is_stump())
+						continue
+					var/bandage_icon = species.bandages_icon
+					if(!bandage_icon)
+						continue
+					var/bandage_level = O.bandage_level()
+					if(bandage_level)
+						health_images += image(bandage_icon, "[O.icon_name][bandage_level]")
+
 				// Apply a fire overlay if we're burning.
 				if(on_fire)
 					var/image/burning_image = image('icons/mob/screen1_health.dmi', "burning", pixel_x = species.healths_overlay_x)

--- a/html/changelogs/karljohansson-healthdoll.yml
+++ b/html/changelogs/karljohansson-healthdoll.yml
@@ -1,0 +1,6 @@
+author: Karl Johansson
+
+delete-after: True
+
+changes:
+  - rscadd: "Added wounds and bandages to the health doll."


### PR DESCRIPTION
Adds wound overlays to the health doll. Basically ports [what I did on Baystation12](https://github.com/Baystation12/Baystation12/pull/33765) in a roundabout way.

**Why?**
Personally, it felt pretty jarring _not_ having them. More broadly, it's a nice indicator of how hurt your character is and makes the health doll a little less misleading about how beat up you are (as it only displays the level of pain a certain body part is in).

**Did you test this?**
I did. It works fine with Humans, Skrell, Machines, Unathi, Diona, and Tajara. If there's species I missed, it shouldn't be too tricky to go back and check those, too.

**Some examples**
Let's say you've been stabbed with a kitchen knife a few times. That might look a bit like this.
![image](https://github.com/Aurorastation/Aurora.3/assets/77447558/aa0cef03-aba9-407b-8002-cba8856b5290)
And once it's bandaged, it'd look like this.
![image](https://github.com/Aurorastation/Aurora.3/assets/77447558/60da7c3b-100e-48f1-ac6e-7d8cb168390b)
