### PR TITLE
Gas nades bounty fix

### DIFF
--- a/code/modules/cargo/bounties/item.dm
+++ b/code/modules/cargo/bounties/item.dm
@@ -1,10 +1,37 @@
 /datum/bounty/item
+	/**
+	 * The amount of items that are required to complete the bounty
+	 */
 	var/required_count = 1
+
+	/**
+	 * The amount of items that were shipped, that satisfies the bounty
+	 */
 	var/shipped_count = 0
-	var/list/wanted_types = list() // Types accepted for the bounty.
-	var/include_subtypes = TRUE     // Set to FALSE to make the datum apply only to a strict type.
-	var/list/exclude_types = list() // Types excluded.
-	var/random_count = 0 //number. This will randomize required_count when initialized by picking a random amount of required_count + and - this number. at least 1 will always be required count. Leave at 0 to not randomize.
+
+	/**
+	 * A `/list` of types accepted for the bounty
+	 *
+	 * If `include_subtypes` is `TRUE`, subtypes will also be accepted
+	 */
+	var/list/wanted_types = list()
+
+	/**
+	 * Boolean, if `TRUE`, subtypes of the types listed in `wanted_types` will be accepted
+	 */
+	var/include_subtypes = TRUE
+
+	/**
+	 * A `/list` of types excluded from the bounty
+	 */
+	var/list/exclude_types = list()
+
+	/**
+	 * This will randomize required_count when initialized by picking a random amount of required_count + and - this number
+	 *
+	 * At least 1 will always be required count. Leave at 0 to not randomize.
+	 */
+	var/random_count = 0
 
 
 /datum/bounty/item/New()

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -71,7 +71,7 @@
 	reward_high = 3200
 	required_count = 3
 	random_count = 1
-	wanted_types = list(/obj/item/grenade/chem_grenade/gas)
+	wanted_types = list(/obj/item/grenade/chem_grenade/gas, /obj/item/grenade/smokebomb)
 
 /datum/bounty/item/security/pepper
 	name = "Pepper Spray"

--- a/html/changelogs/fluffyghost-gasgrenadebountyfix.yml
+++ b/html/changelogs/fluffyghost-gasgrenadebountyfix.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - code_imp: "DMDoc'd the vars of /datum/bounty/item."
+  - bugfix: "All the two types of gas grenades are now allowed for the gas grenade bounty."


### PR DESCRIPTION
DMDoc'd the vars of /datum/bounty/item.
All the two types of gas grenades are now allowed for the gas grenade bounty.

Fixes #19064