### PR TITLE
Tajaran Smugglers Modernization and bugfixes

### DIFF
--- a/html/changelogs/LynxSolstice-Tajara-Smuggler-Modernization.yml
+++ b/html/changelogs/LynxSolstice-Tajara-Smuggler-Modernization.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: LynxSolstice
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Brings the fuel tank of the Tajaran Smuggler vessel into the modern age."
+  - bugfix: "Fixes all the un-pixelshifted lights, and adds an airlock where someone forgot to add one again when pulling out the old deprecated airlocks."

--- a/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dmm
+++ b/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dmm
@@ -615,9 +615,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -758,14 +755,6 @@
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/atmos)
-"dQy" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/tajaran_smuggler/engine)
 "dQZ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -1227,16 +1216,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/tajaran_smuggler)
-"fUw" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/tajaran_smuggler/engine)
 "fVv" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/machinery/airlock_sensor{
@@ -1476,9 +1455,6 @@
 "hgE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/firealarm/east,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -3745,9 +3721,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -4210,21 +4183,6 @@
 	temperature = 278.15
 	},
 /area/shuttle/tajaran_smuggler_cargo)
-"wmb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/north{
-	req_access = null
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/tajaran_smuggler/engine)
 "wmx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
@@ -35402,8 +35360,8 @@ xRX
 xRX
 xRX
 cQX
-wmb
-fUw
+rgA
+dCR
 kJl
 mLa
 kgm
@@ -35660,7 +35618,7 @@ xRX
 xRX
 cQX
 rgA
-ePD
+mIz
 kJl
 qcp
 nsN
@@ -35917,7 +35875,7 @@ xRX
 xRX
 cQX
 nZg
-dQy
+dCR
 ttC
 hgE
 cCV

--- a/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dmm
+++ b/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dmm
@@ -40,7 +40,9 @@
 	},
 /area/tajaran_smuggler)
 "aci" = (
-/obj/machinery/computer/ship/engines,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -79,17 +81,19 @@
 /turf/simulated/floor/plating,
 /area/shuttle/tajaran_smuggler)
 "agg" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/tajaran_smuggler)
 "ahU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/extinguisher_cabinet/east,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -126,9 +130,7 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/tajaran_smuggler)
 "atB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -339,11 +341,12 @@
 /area/tajaran_smuggler/captain_quarters)
 "bcf" = (
 /obj/structure/bed/stool/bar/padded/red,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor/wood{
 	temperature = 278.15
@@ -396,7 +399,8 @@
 /area/shuttle/tajaran_smuggler_cargo)
 "buK" = (
 /obj/machinery/light/small{
-	dir = 4
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -418,7 +422,9 @@
 	dir = 8;
 	id = "tajara_smuggler"
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	pixel_y = -23
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -475,6 +481,14 @@
 	temperature = 278.15
 	},
 /area/shuttle/tajaran_smuggler_cargo)
+"bIa" = (
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/tajaran_smuggler/engine)
 "bOZ" = (
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
@@ -494,7 +508,8 @@
 /area/tajaran_smuggler/bridge)
 "bVS" = (
 /obj/machinery/light/small{
-	dir = 8
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -540,10 +555,11 @@
 /turf/template_noop,
 /area/shuttle/tajaran_smuggler_cargo)
 "cds" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 5
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -599,6 +615,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -633,15 +652,8 @@
 	},
 /area/tajaran_smuggler)
 "cQX" = (
-/obj/machinery/telecomms/allinone/ship,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled{
-	name = "cooled floor";
-	temperature = 278
-	},
-/area/tajaran_smuggler/engine)
+/turf/simulated/wall/shuttle/raider,
+/area/space)
 "cRY" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -682,7 +694,9 @@
 /area/tajaran_smuggler/bridge)
 "dyx" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	pixel_y = -23
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -745,11 +759,8 @@
 	},
 /area/tajaran_smuggler/atmos)
 "dQy" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -765,12 +776,39 @@
 	},
 /area/tajaran_smuggler/hangar)
 "dTw" = (
-/obj/effect/map_effect/airlock/w_to_e/long/square,
-/turf/simulated/wall/shuttle/raider,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	pixel_x = 12;
+	pixel_y = -28;
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/cee,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking/tajaran_smuggler/dock/port,
+/obj/effect/shuttle_landmark/tajaran_smuggler/dock/port{
+	dir = 4;
+	landmark_tag = "nav_tajaran_smuggler_dock_port_south";
+	docking_controller = "airlock_tajaran_smuggler_dock_port_south";
+	name = "Dock, Port, South"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/tajaran_smuggler)
+"dWJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/tajaran_smuggler/engine)
 "dZr" = (
 /obj/machinery/light/small{
-	dir = 1
+	dir = 1;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -868,7 +906,7 @@
 	},
 /area/tajaran_smuggler/atmos)
 "eEC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 5
 	},
 /turf/simulated/floor{
@@ -917,9 +955,6 @@
 	},
 /area/tajaran_smuggler)
 "ePD" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 4;
@@ -993,17 +1028,29 @@
 /area/shuttle/tajaran_smuggler_cargo)
 "eVI" = (
 /obj/machinery/light/small{
-	dir = 1
+	dir = 1;
+	pixel_y = 5
 	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/atmos)
 "eYk" = (
-/obj/machinery/light/small,
-/turf/simulated/floor{
-	temperature = 278.15
+/obj/machinery/door/airlock/external{
+	dir = 4
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking/tajaran_smuggler/dock/port,
+/obj/machinery/access_button{
+	pixel_x = 12;
+	pixel_y = 28;
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/tajaran_smuggler)
 "eYX" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
@@ -1015,29 +1062,34 @@
 	},
 /area/tajaran_smuggler/atmos)
 "fjf" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = -6
+	},
+/obj/effect/floor_decal/industrial/outline_door/red{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	temperature = 278.15
+/obj/effect/floor_decal/industrial/outline_straight/red{
+	dir = 1
 	},
-/area/tajaran_smuggler/engine)
+/obj/effect/map_effect/marker/airlock/docking/tajaran_smuggler/dock/port,
+/turf/simulated/floor/plating,
+/area/tajaran_smuggler)
 "fji" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/turf/simulated/floor/plating{
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/engine)
 "fjy" = (
 /obj/structure/largecrate/animal/adhomai/fatshouter,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1118,14 +1170,15 @@
 	dir = 4;
 	pixel_x = -32
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4;
 	icon_state = "map_scrubber_on"
 	},
 /obj/machinery/firealarm/north,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 5
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -1146,26 +1199,28 @@
 	},
 /area/tajaran_smuggler)
 "fOQ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/cult/tome{
 	desc = "A black stone altar dedicated to Minharrzka, the goddess of the waters and patroness of sailors.";
 	icon_state = "churchaltar";
 	name = "altar"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/engine)
 "fQq" = (
-/obj/effect/landmark/entry_point/port{
-	name = "port, airlock"
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/turf/simulated/floor{
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating{
 	temperature = 278.15
 	},
-/area/tajaran_smuggler)
+/area/tajaran_smuggler/engine)
 "fRI" = (
 /obj/machinery/atmospherics/portables_connector/aux,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
@@ -1173,25 +1228,31 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/tajaran_smuggler)
 "fUw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/meter,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/engine)
 "fVv" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms";
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
+/obj/machinery/airlock_sensor{
+	dir = 2;
+	pixel_y = 28;
+	pixel_x = 6
+	},
+/obj/effect/floor_decal/industrial/outline_door/red{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline_straight/red{
 	dir = 1
 	},
-/obj/structure/plasticflaps/airtight,
-/turf/simulated/floor/tiled{
-	name = "cooled floor";
-	temperature = 278
-	},
-/area/tajaran_smuggler/engine)
+/obj/effect/map_effect/marker/airlock/docking/tajaran_smuggler/dock/port,
+/turf/simulated/floor/plating,
+/area/tajaran_smuggler)
 "fXG" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
@@ -1202,7 +1263,8 @@
 /area/tajaran_smuggler/atmos)
 "fYt" = (
 /obj/machinery/light/small{
-	dir = 8
+	dir = 8;
+	pixel_x = -12
 	},
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/toilet{
@@ -1253,13 +1315,14 @@
 /area/tajaran_smuggler/bridge)
 "gfd" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -1370,6 +1433,18 @@
 	temperature = 278.15
 	},
 /area/shuttle/tajaran_smuggler_cargo)
+"gVo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/telecomms/allinone/ship,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled{
+	name = "cooled floor";
+	temperature = 278
+	},
+/area/tajaran_smuggler/engine)
 "gXv" = (
 /obj/machinery/shipsensors/weak,
 /obj/structure/railing/mapped,
@@ -1390,26 +1465,40 @@
 	},
 /area/shuttle/tajaran_smuggler_cargo)
 "gXD" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/obj/effect/floor_decal/industrial/outline_door/red{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/tajaran_smuggler/engine)
+/obj/effect/floor_decal/industrial/outline_straight/red,
+/obj/effect/map_effect/marker/airlock/docking/tajaran_smuggler/dock/port,
+/turf/simulated/floor/plating,
+/area/tajaran_smuggler)
 "hgE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/firealarm/east,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/engine)
+"hhr" = (
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/cee,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking/tajaran_smuggler/dock/port,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tajaran_smuggler)
 "hiw" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -1429,7 +1518,9 @@
 	},
 /area/tajaran_smuggler/captain_quarters)
 "hpQ" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	pixel_y = -23
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1522,10 +1613,11 @@
 	},
 /area/tajaran_smuggler)
 "hGt" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1560,6 +1652,18 @@
 	},
 /turf/simulated/floor/airless,
 /area/tajaran_smuggler/engine)
+"hOZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
+	dir = 8
+	},
+/obj/machinery/light/small/emergency,
+/obj/effect/floor_decal/industrial/outline_door/red{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline_straight/red,
+/obj/effect/map_effect/marker/airlock/docking/tajaran_smuggler/dock/port,
+/turf/simulated/floor/plating,
+/area/tajaran_smuggler)
 "hPd" = (
 /obj/structure/table/wood,
 /obj/item/device/flashlight/lamp,
@@ -1598,9 +1702,6 @@
 /turf/simulated/floor/airless,
 /area/shuttle/tajaran_smuggler)
 "hVK" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -1610,6 +1711,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -1649,20 +1754,21 @@
 	},
 /area/tajaran_smuggler/atmos)
 "iav" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/black,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/engine)
 "ifp" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -1701,17 +1807,16 @@
 "ive" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/light/small{
-	dir = 8
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/shuttle/tajaran_smuggler_cargo)
 "iwP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
-/turf/simulated/floor{
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
+/turf/simulated/floor/plating{
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/engine)
@@ -1732,6 +1837,7 @@
 /area/shuttle/tajaran_smuggler)
 "iOh" = (
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/closet/emcloset,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1764,8 +1870,16 @@
 	},
 /area/tajaran_smuggler/atmos)
 "iRD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/wall/shuttle/raider,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 5
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
 /area/tajaran_smuggler/engine)
 "iSa" = (
 /obj/structure/cable/green{
@@ -1888,14 +2002,15 @@
 /turf/simulated/wall/shuttle/raider,
 /area/tajaran_smuggler/bridge)
 "jEu" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -1963,7 +2078,8 @@
 /area/tajaran_smuggler/power)
 "jVO" = (
 /obj/machinery/light/small{
-	dir = 8
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -1995,11 +2111,21 @@
 	},
 /area/tajaran_smuggler/hangar)
 "kaR" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/turf/simulated/floor{
-	temperature = 278.15
+/obj/machinery/door/airlock/external{
+	dir = 4
 	},
-/area/tajaran_smuggler/engine)
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking/tajaran_smuggler/dock/port,
+/obj/machinery/access_button{
+	pixel_x = -25;
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/tajaran_smuggler)
 "kbf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -2121,11 +2247,12 @@
 	},
 /area/tajaran_smuggler/power)
 "kFw" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor/wood{
 	temperature = 278.15
@@ -2133,7 +2260,8 @@
 /area/tajaran_smuggler)
 "kIx" = (
 /obj/machinery/light/small{
-	dir = 4
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -2235,6 +2363,16 @@
 	temperature = 278.15
 	},
 /area/shuttle/tajaran_smuggler_cargo)
+"llj" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8
+	},
+/obj/effect/map_effect/marker/large_tank{
+	master_tag = "tajaran_smugglers_co2";
+	name = "tajaran_smugglers_co2"
+	},
+/turf/simulated/floor/reinforced/carbon_dioxide,
+/area/tajaran_smuggler/engine)
 "lmO" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white{
@@ -2466,10 +2604,13 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning/cee,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/shuttle_landmark/tajaran_smuggler/dock/port{
-	dir = 4
-	},
 /obj/effect/map_effect/marker/airlock/docking/tajaran_smuggler/dock/port,
+/obj/effect/shuttle_landmark/tajaran_smuggler/dock/port{
+	dir = 4;
+	landmark_tag = "nav_tajaran_smuggler_dock_port_north";
+	docking_controller = "airlock_tajaran_smuggler_dock_port_north";
+	name = "Dock, Port, North"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/adhomian_circus/hangar)
 "mgd" = (
@@ -2608,10 +2749,11 @@
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/void/engineering,
 /obj/item/clothing/head/helmet/space/void/engineering,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/item/device/gps/engineering,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 5
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -2786,7 +2928,12 @@
 /area/shuttle/tajaran_smuggler)
 "nZg" = (
 /obj/effect/landmark/entry_point/aft,
-/turf/simulated/wall/shuttle/raider,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
 /area/tajaran_smuggler/engine)
 "nZw" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -2808,7 +2955,7 @@
 /area/tajaran_smuggler)
 "obG" = (
 /obj/machinery/door/airlock/hatch{
-	name = "Dock";
+	name = "Telecomms";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2890,15 +3037,16 @@
 /area/tajaran_smuggler/dorms)
 "oKX" = (
 /obj/structure/closet/cabinet,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/item/clothing/under/tajaran,
 /obj/item/clothing/under/tajaran/dpra,
 /obj/item/clothing/under/tajaran/dpra/alt,
 /obj/item/clothing/accessory/holster/hip,
 /obj/item/clothing/accessory/storage/pouches/black,
 /obj/random/spacecash,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -2931,6 +3079,12 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/tajaran_smuggler)
+"oXk" = (
+/obj/structure/extinguisher_cabinet/north,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -2999,13 +3153,15 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9;
 	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/machinery/light/small{
+	pixel_y = -23
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -3040,6 +3196,16 @@
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/captain_quarters)
+"pVd" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms";
+	dir = 4
+	},
+/obj/structure/plasticflaps/airtight,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/tajaran_smuggler/engine)
 "pVt" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3099,10 +3265,10 @@
 	},
 /area/tajaran_smuggler)
 "qil" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 9
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -3227,11 +3393,29 @@
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/captain_quarters)
-"rfR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
+"reo" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
 	},
-/obj/machinery/meter,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/tajaran_smuggler)
+"rfC" = (
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/tajaran_smuggler/engine)
+"rfR" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -3245,7 +3429,9 @@
 	},
 /area/tajaran_smuggler/engine)
 "rgA" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -3275,9 +3461,6 @@
 /turf/simulated/wall/shuttle/raider,
 /area/tajaran_smuggler)
 "rtf" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -3285,6 +3468,10 @@
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "tajara_smuggler"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 5
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -3321,6 +3508,19 @@
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/hangar)
+"rFf" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = 5
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/tajaran_smuggler/engine)
 "rLM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -3408,7 +3608,8 @@
 	dir = 1
 	},
 /obj/machinery/light/small{
-	dir = 1
+	dir = 1;
+	pixel_y = 5
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -3432,12 +3633,10 @@
 /turf/space/transit/north,
 /area/space)
 "sSs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 8
-	},
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
 	dir = 1
 	},
+/obj/machinery/meter,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -3455,6 +3654,16 @@
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/hangar)
+"sZS" = (
+/obj/machinery/atmospherics/unary/vent_pump/siphon/atmos{
+	dir = 1
+	},
+/obj/effect/map_effect/marker/large_tank{
+	master_tag = "tajaran_smugglers_co2";
+	name = "tajaran_smugglers_co2"
+	},
+/turf/simulated/floor/reinforced/carbon_dioxide,
+/area/tajaran_smuggler/engine)
 "taq" = (
 /obj/structure/bed/stool/bar/padded/red,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -3522,7 +3731,8 @@
 /obj/item/reagent_containers/food/drinks/carton/fatshouters,
 /obj/item/reagent_containers/food/drinks/carton/fatshouters,
 /obj/machinery/light/small{
-	dir = 1
+	dir = 1;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/white{
 	temperature = 278.15
@@ -3535,6 +3745,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -3547,10 +3760,11 @@
 	},
 /area/tajaran_smuggler)
 "ttH" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/simulated/floor/tiled/white{
 	temperature = 278.15
 	},
@@ -3680,10 +3894,7 @@
 	},
 /area/tajaran_smuggler/engine)
 "uqg" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/engine)
@@ -3697,6 +3908,18 @@
 	temperature = 278.15
 	},
 /area/tajaran_smuggler)
+"uzC" = (
+/obj/machinery/computer/general_air_control/large_tank_control/terminal{
+	dir = 1
+	},
+/obj/effect/map_effect/marker/large_tank{
+	master_tag = "tajaran_smugglers_co2";
+	name = "tajaran_smugglers_co2"
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/tajaran_smuggler/engine)
 "uzP" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -3715,11 +3938,12 @@
 	},
 /area/shuttle/tajaran_smuggler_cargo)
 "uHV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/vehicle/bike/monowheel,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = 12
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -3811,7 +4035,6 @@
 	},
 /area/tajaran_smuggler/bridge)
 "vwF" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -3883,11 +4106,11 @@
 /turf/simulated/floor/plating,
 /area/adhomian_circus/hangar)
 "vMT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -3987,6 +4210,21 @@
 	temperature = 278.15
 	},
 /area/shuttle/tajaran_smuggler_cargo)
+"wmb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/north{
+	req_access = null
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/tajaran_smuggler/engine)
 "wmx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
@@ -3994,23 +4232,21 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/tajaran_smuggler)
 "wnl" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = -12
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/tajaran_smuggler/hangar)
 "wqH" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 8
 	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/tajaran_smuggler)
+/turf/simulated/wall/shuttle/raider,
+/area/tajaran_smuggler/engine)
 "wrb" = (
 /turf/simulated/wall/shuttle/raider,
 /area/tajaran_smuggler)
@@ -4062,12 +4298,12 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/tajaran_smuggler_cargo)
 "xeO" = (
-/obj/machinery/atmospherics/portables_connector{
+/obj/machinery/air_sensor,
+/obj/effect/map_effect/marker/large_tank{
+	master_tag = "tajaran_smugglers_co2";
+	name = "tajaran_smugglers_co2"
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
+/turf/simulated/floor/reinforced/carbon_dioxide,
 /area/tajaran_smuggler/engine)
 "xmZ" = (
 /obj/structure/lattice,
@@ -4075,7 +4311,8 @@
 /area/space)
 "xoc" = (
 /obj/machinery/light/small{
-	dir = 8
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor/carpet/art{
 	temperature = 278.15
@@ -4100,15 +4337,13 @@
 	},
 /area/tajaran_smuggler)
 "xto" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/computer/ship/engines,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -4240,7 +4475,8 @@
 "yjk" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/light/small{
-	dir = 4
+	dir = 4;
+	pixel_x = 12
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -32852,11 +33088,11 @@ xRX
 xRX
 xRX
 bxR
-iRD
+kJl
 eEC
 uqg
+fQq
 kJl
-uhO
 uhO
 kJl
 xRX
@@ -33109,11 +33345,11 @@ xRX
 xRX
 xRX
 hOL
-iRD
-iav
-eEC
 kJl
-uhO
+iav
+uqg
+bIa
+kJl
 uhO
 kJl
 kJl
@@ -33366,10 +33602,10 @@ xRX
 xRX
 xRX
 bxR
-iRD
-atB
-fji
 kJl
+atB
+kJl
+wqH
 kJl
 kJl
 kJl
@@ -33624,12 +33860,12 @@ xRX
 xRX
 kJl
 kJl
+dWJ
+fji
+llj
 kJl
-iwP
 kJl
-cQX
-fVv
-mIz
+gVo
 kJl
 buM
 shH
@@ -33880,13 +34116,13 @@ xRX
 xRX
 xRX
 xRX
-xRX
-kJl
+cQX
+aci
 iwP
+xeO
 kJl
 kJl
-kJl
-dCR
+pVd
 kJl
 mET
 wCo
@@ -34137,11 +34373,11 @@ xRX
 xRX
 xRX
 xRX
-xRX
-kJl
+cQX
+sSs
 fji
+sZS
 kJl
-xeO
 xto
 oUn
 kJl
@@ -34394,13 +34630,13 @@ xRX
 xRX
 xRX
 xRX
-xRX
+cQX
+iRD
 kJl
-sSs
 kJl
-xeO
+kJl
 vwF
-rgA
+dCR
 kJl
 eVI
 pPS
@@ -34651,13 +34887,13 @@ xRX
 xRX
 xRX
 xRX
-xRX
-kJl
-iwP
-kJl
-aci
-gXD
+cQX
 rgA
+uqg
+uzC
+kJl
+ePD
+dCR
 kJl
 ucT
 exM
@@ -34908,9 +35144,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
-kJl
-iwP
+cQX
+rgA
+dCR
 kJl
 xdk
 rfR
@@ -35165,8 +35401,8 @@ xRX
 xRX
 xRX
 xRX
-xRX
-kJl
+cQX
+wmb
 fUw
 kJl
 mLa
@@ -35422,8 +35658,8 @@ xRX
 xRX
 xRX
 xRX
-xRX
-kJl
+cQX
+rgA
 ePD
 kJl
 qcp
@@ -35679,7 +35915,7 @@ xRX
 xRX
 xRX
 xRX
-xRX
+cQX
 nZg
 dQy
 ttC
@@ -35695,7 +35931,7 @@ nrG
 ifp
 tEE
 nrG
-ifp
+reo
 nZw
 jEu
 mwu
@@ -35936,9 +36172,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
-kJl
-fjf
+cQX
+iRD
+mIz
 kJl
 kJl
 kJl
@@ -36193,9 +36429,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
-kJl
-fUw
+cQX
+rgA
+dCR
 kJl
 qyO
 dAf
@@ -36224,7 +36460,7 @@ jOg
 bfg
 agg
 vMT
-wqH
+wrb
 wrb
 pfE
 pfE
@@ -36450,9 +36686,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
-kJl
-iwP
+cQX
+rgA
+dCR
 kJl
 xKJ
 erW
@@ -36479,10 +36715,10 @@ lOJ
 kmF
 jOg
 iOh
-xTp
+lGQ
 ahU
-jIP
 wrb
+pfE
 pfE
 pfE
 aMU
@@ -36707,9 +36943,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
-kJl
-iwP
+cQX
+rgA
+dCR
 kJl
 luH
 jRk
@@ -36736,10 +36972,10 @@ ilo
 rDk
 jOg
 lGQ
-xpN
+lGQ
+lGQ
 wrb
-wrb
-wrb
+pfE
 pfE
 pfE
 aMU
@@ -36964,9 +37200,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
-kJl
-fji
+cQX
+iRD
+mIz
 kJl
 neJ
 erW
@@ -36994,8 +37230,8 @@ mwV
 jOg
 lGQ
 lGQ
-dTw
-pfE
+lGQ
+wrb
 pfE
 pfE
 pfE
@@ -37221,9 +37457,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
-kJl
-sSs
+cQX
+rgA
+dCR
 kJl
 jcn
 vGR
@@ -37251,8 +37487,8 @@ mwV
 jOg
 lGQ
 lGQ
+lGQ
 wrb
-pfE
 pfE
 pfE
 pfE
@@ -37478,9 +37714,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
-kJl
-fji
+cQX
+rgA
+mIz
 kJl
 cds
 izs
@@ -37506,10 +37742,10 @@ oie
 ilo
 dyx
 jOg
-lGQ
-eYk
+oXk
+xTp
+jIP
 wrb
-pfE
 pfE
 pfE
 wrb
@@ -37735,9 +37971,9 @@ xRX
 xRX
 xRX
 xRX
-xRX
-kJl
-iwP
+cQX
+rfC
+dCR
 kJl
 izs
 izs
@@ -37763,8 +37999,8 @@ bci
 ilo
 mwV
 jOg
-fQq
 lGQ
+xpN
 wrb
 wrb
 wrb
@@ -37993,8 +38229,8 @@ xRX
 xRX
 kJl
 kJl
-kJl
-iwP
+rFf
+dCR
 kJl
 izs
 kBu
@@ -38020,9 +38256,9 @@ ilo
 ilo
 mwV
 jOg
-xRX
-xRX
-xRX
+lGQ
+xpN
+wrb
 xRX
 xRX
 xRX
@@ -38249,9 +38485,9 @@ xRX
 xRX
 xRX
 bxR
-iRD
-eEC
-iwP
+kJl
+atB
+dCR
 kJl
 izs
 xHI
@@ -38277,9 +38513,9 @@ ilo
 ilo
 mwV
 jOg
-xRX
-xRX
-xRX
+kaR
+hhr
+wrb
 xRX
 xRX
 xRX
@@ -38506,9 +38742,9 @@ xRX
 xRX
 xRX
 qrf
-iRD
-kaR
-qil
+kJl
+atB
+mIz
 wrb
 lyG
 wbG
@@ -38534,9 +38770,9 @@ lXE
 lXE
 akP
 jOg
-xRX
-xRX
-xRX
+fVv
+gXD
+wrb
 xRX
 xRX
 xRX
@@ -38763,7 +38999,7 @@ xRX
 xRX
 xRX
 bxR
-iRD
+kJl
 qil
 fOQ
 wrb
@@ -38791,9 +39027,9 @@ rAo
 rAo
 jOg
 jOg
-xRX
-xRX
-xRX
+fjf
+hOZ
+wrb
 xRX
 xRX
 xRX
@@ -39046,11 +39282,11 @@ xRX
 xRX
 xRX
 xRX
-xRX
-xRX
-xRX
-xRX
-xRX
+jOg
+jOg
+eYk
+dTw
+wrb
 xRX
 xRX
 xRX


### PR DESCRIPTION
Brings the fuel tank of the Tajaran Smuggler vessel into the modern age, and fixes all the un-pixelshifted lights, and adds an airlock where someone forgot to add one again when pulling out the old deprecated airlocks.