### PR TITLE
Fixed newline issue in custom item descriptions

### DIFF
--- a/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -308,7 +308,7 @@ var/datum/gear_tweak/custom_desc/gear_tweak_free_desc = new()
 	if(valid_custom_desc)
 		input_description = tgui_input_list(user, "Choose an item description.", "Character Preference", valid_custom_desc, metadata)
 	else
-		input_description = strip_html(tgui_input_text(user, "Choose an item description.", "Character Preference", metadata))
+		input_description = html_encode(STRIP_HTML_FULL(tgui_input_text(user, "Choose an item description.", "Character Preference", metadata, encode = FALSE, multiline = TRUE), MAX_MESSAGE_LEN))
 
 	return input_description
 

--- a/html/changelogs/fluffyghost-itemdescnewlinefix.yml
+++ b/html/changelogs/fluffyghost-itemdescnewlinefix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed newline issue in custom item descriptions."


### PR DESCRIPTION
Fixed newline issue in custom item descriptions

![image](https://github.com/Aurorastation/Aurora.3/assets/65877598/35b208c6-18a7-46f5-97b4-feeef01e5993)

Fixes #19132 