### PR TITLE
Scarab Salvager, Izharshan Shuttle, Hivebot Hub tweaks & fixes

### DIFF
--- a/html/changelogs/hazelmouse - offsite & offship tweaks.yml
+++ b/html/changelogs/hazelmouse - offsite & offship tweaks.yml
@@ -1,0 +1,61 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added more hivebots to the Hivebot Hub offsite."
+  - bugfix: "Fixed airlock on the Izharshan Shuttle offship."
+  - bugfix: "Fixed port CO2 console on Scarab Salvager offship."
+  - qol: "Various quality-of-life tweaks to the Scarab Salvager and Izharshan Shuttle offships."

--- a/maps/away/away_site/hivebot_hub/hivebot_hub.dmm
+++ b/maps/away/away_site/hivebot_hub/hivebot_hub.dmm
@@ -72,6 +72,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 9
 	},
+/mob/living/simple_animal/hostile/hivebot/guardian,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/centralhall)
 "aw" = (
@@ -145,6 +146,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/blood/oil/streak,
+/mob/living/simple_animal/hostile/hivebot/range,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/centralhall)
 "aP" = (
@@ -196,6 +198,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/floor_damage/rust,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/centralhall)
 "bn" = (
@@ -339,6 +342,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /obj/effect/decal/cleanable/floor_damage/broken5,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/centralhall)
 "bX" = (
@@ -510,6 +514,7 @@
 	},
 /obj/effect/decal/cleanable/floor_damage/rust,
 /obj/effect/decal/cleanable/blood/oil/streak,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/centralhall)
 "cO" = (
@@ -681,13 +686,11 @@
 /turf/simulated/floor/airless,
 /area/hivebothub/engi)
 "ea" = (
-/obj/item/ore/glass{
-	pixel_y = 8;
-	pixel_x = -5
-	},
-/obj/item/stack/rods,
-/obj/structure/girder,
-/turf/simulated/floor/airless,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor/tiled/dark/full/airless,
 /area/hivebothub/secure)
 "ec" = (
 /turf/simulated/wall/r_wall,
@@ -1021,8 +1024,6 @@
 /turf/simulated/floor/tiled/dark/full/airless,
 /area/hivebothub/secure)
 "gd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -1037,6 +1038,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/effect/decal/cleanable/floor_damage/broken1,
+/mob/living/simple_animal/hostile/hivebot/bomber,
+/mob/living/simple_animal/hostile/hivebotbeacon/weakened,
+/obj/effect/decal/cleanable/floor_damage/broken5,
+/obj/effect/decal/cleanable/floor_damage/broken0,
 /turf/simulated/floor/tiled/dark/full/airless,
 /area/hivebothub/centralhall)
 "gg" = (
@@ -2202,6 +2207,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /obj/effect/decal/cleanable/blood/oil,
+/mob/living/simple_animal/hostile/hivebot/range,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/centralhall)
 "oY" = (
@@ -3248,6 +3254,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/blood/oil,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/centralhall)
 "vI" = (
@@ -3471,6 +3478,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /obj/effect/decal/cleanable/blood/splatter,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/centralhall)
 "xs" = (
@@ -3678,6 +3686,22 @@
 	},
 /turf/simulated/floor/airless,
 /area/hivebothub/engi)
+"yH" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/mob/living/simple_animal/hostile/hivebot/bomber,
+/turf/simulated/floor/airless,
+/area/hivebothub/centralhall)
 "yO" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -3769,6 +3793,21 @@
 	},
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/starboarddocks)
+"zq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/mob/living/simple_animal/hostile/hivebot/guardian,
+/turf/simulated/floor/tiled/dark/full/airless,
+/area/hivebothub/centralhall)
 "zs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3848,6 +3887,22 @@
 /obj/structure/girder,
 /turf/simulated/floor/airless,
 /area/hivebothub/atmos)
+"Aq" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/mob/living/simple_animal/hostile/hivebot/guardian,
+/turf/simulated/floor/airless,
+/area/hivebothub/centralhall)
 "Ar" = (
 /obj/machinery/door/window/brigdoor/northright{
 	req_access = list();
@@ -4807,6 +4862,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/oil,
+/mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/airless,
 /area/hivebothub/centralhall)
 "Gc" = (
@@ -4849,6 +4905,9 @@
 /obj/item/gun/projectile/gyropistol,
 /obj/item/ammo_magazine/a75,
 /obj/item/anomaly_core,
+/obj/item/gun/projectile/automatic/rifle/shorty,
+/obj/item/ammo_magazine/c762,
+/obj/item/ammo_magazine/c762,
 /turf/simulated/floor/tiled/dark/full/airless,
 /area/hivebothub/secure)
 "Gw" = (
@@ -5181,16 +5240,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/steel,
-/obj/item/gun/projectile/automatic/rifle/shorty{
-	pixel_y = 18
-	},
-/obj/item/ammo_magazine/c762{
-	pixel_y = 4;
-	pixel_x = -7
-	},
-/obj/item/ammo_magazine/c762{
-	pixel_x = 6
-	},
 /turf/simulated/floor/tiled/dark/full/airless,
 /area/hivebothub/portdocks)
 "Jj" = (
@@ -5287,6 +5336,15 @@
 	},
 /turf/simulated/floor/wood/airless,
 /area/hivebothub/dorm2)
+"JK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner/grey{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/mob/living/simple_animal/hostile/hivebot/range/rapid,
+/turf/simulated/floor/tiled/dark/airless,
+/area/hivebothub/centralhall)
 "JO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/dinnerware{
@@ -5327,6 +5385,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/mob/living/simple_animal/hostile/hivebot,
 /turf/simulated/floor/airless,
 /area/hivebothub/centralhall)
 "Kb" = (
@@ -5566,9 +5625,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/floor_damage/broken0,
-/mob/living/simple_animal/hostile/hivebotbeacon/weakened,
-/obj/effect/decal/cleanable/floor_damage/broken5,
+/obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/airless,
 /area/hivebothub/centralhall)
 "MF" = (
@@ -5854,9 +5911,9 @@
 /area/hivebothub/starboarddocks)
 "Oa" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/phoron,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
 /turf/simulated/floor/tiled/dark/full/airless,
 /area/hivebothub/secure)
 "Ob" = (
@@ -5926,14 +5983,6 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/floor_damage/rust,
-/obj/item/ore/uranium{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/ore/glass{
-	pixel_y = 15;
-	pixel_x = -11
-	},
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/secure)
 "Oy" = (
@@ -6026,6 +6075,22 @@
 	},
 /turf/simulated/floor/tiled/dark/airless,
 /area/hivebothub/portdocks)
+"Pb" = (
+/obj/structure/lattice/catwalk/indoor/grate/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/blood/oil,
+/mob/living/simple_animal/hostile/hivebot/guardian,
+/turf/simulated/floor/airless,
+/area/hivebothub/centralhall)
 "Pf" = (
 /obj/structure/lattice,
 /obj/item/ore/uranium{
@@ -6340,8 +6405,8 @@
 /area/hivebothub/starboarddocks)
 "Rh" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/phoron,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/tiled/dark/full/airless,
 /area/hivebothub/secure)
 "Rk" = (
@@ -7081,16 +7146,10 @@
 /turf/simulated/floor/tiled/dark/full/airless,
 /area/hivebothub/secure)
 "WG" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/ore/uranium{
-	pixel_x = -8;
-	pixel_y = -2
-	},
-/obj/item/ore/uranium{
-	pixel_x = 4;
-	pixel_y = -16
-	},
-/turf/simulated/floor/tiled/dark/airless,
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
+/turf/simulated/floor/tiled/dark/full/airless,
 /area/hivebothub/secure)
 "WJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38587,7 +38646,7 @@ UL
 UL
 YY
 UL
-Oa
+ea
 Rh
 UL
 uP
@@ -39879,9 +39938,9 @@ hj
 bq
 pC
 Cz
-WG
+As
 Or
-ea
+UL
 xs
 Lj
 Lj
@@ -40106,12 +40165,12 @@ Pt
 Xi
 tS
 zc
-Xi
+yH
 fz
 gd
-fz
-zc
-Xi
+zq
+Pb
+Aq
 XO
 Mv
 vA
@@ -40367,7 +40426,7 @@ qd
 QB
 gy
 kV
-Kj
+JK
 oS
 rj
 aw
@@ -41414,8 +41473,8 @@ SI
 UL
 UL
 UL
-Rh
-Rh
+WG
+WG
 UL
 UL
 UL
@@ -41671,7 +41730,7 @@ UL
 UL
 Fd
 UL
-Rh
+WG
 Rh
 UL
 QZ

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_deck_1.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_deck_1.dmm
@@ -64,6 +64,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
+"aX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/space/dynamic,
+/area/ship/coc_scarab/exterior)
 "bb" = (
 /obj/machinery/atmospherics/binary/pump/fuel{
 	dir = 4;
@@ -228,7 +244,6 @@
 /turf/simulated/floor/airless,
 /area/shuttle/coc_scarab/central)
 "dz" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
@@ -247,13 +262,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/hangar)
 "dT" = (
-/obj/structure/lattice/catwalk,
 /obj/item/hullbeacon/red,
 /obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "eb" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
@@ -264,7 +277,6 @@
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "eq" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
@@ -958,7 +970,6 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/hangar)
 "qn" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/ladder/up{
 	pixel_y = 10
 	},
@@ -1099,7 +1110,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/turbolift/coc_scarab/scarab_lift)
 "sS" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/ladder/up{
 	pixel_y = 10
 	},
@@ -2306,7 +2316,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab/port)
 "NO" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
@@ -2333,7 +2342,6 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/hangar)
 "Ol" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
@@ -2657,7 +2665,6 @@
 /turf/simulated/floor/airless,
 /area/shuttle/coc_scarab/central)
 "UN" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
@@ -2916,22 +2923,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/airless,
 /area/shuttle/coc_scarab/central)
-"YF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor,
-/turf/space/dynamic,
-/area/ship/coc_scarab/exterior)
 "YG" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -33176,7 +33167,7 @@ Eo
 Eo
 Eo
 Eo
-YF
+aX
 Eo
 Eo
 Eo
@@ -33433,7 +33424,7 @@ Eo
 Eo
 Eo
 Eo
-YF
+aX
 Eo
 Eo
 Eo

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_deck_1.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_deck_1.dmm
@@ -351,12 +351,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/hangar)
 "fv" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /obj/machinery/door/blast/regular/open{
-	id = "scarab_hangar_port";
+	id = "scarab_hangar";
 	name = "Safety Blast Doors"
 	},
 /turf/simulated/floor/plating,
@@ -519,18 +519,18 @@
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
 "hY" = (
-/obj/machinery/button/remote/blast_door{
-	name = "Port Blast Shutters";
-	id = "scarab_hangar_port";
-	dir = 1;
-	pixel_y = 28
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/towel_flat{
 	name = "magnetic rug";
 	accent_color = "#724e6f";
 	color = "#724e6f";
 	desc = "An ornate rug. Magnetic strips have been fitted onto the bottom."
+	},
+/obj/machinery/button/remote/blast_door{
+	name = "Hangar Bay Blast Shutters";
+	id = "scarab_hangar_starboard";
+	dir = 1;
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/hangar)
@@ -569,7 +569,7 @@
 "iM" = (
 /obj/structure/table/reinforced/steel,
 /obj/machinery/button/remote/blast_door{
-	name = "Starboard Blast Shutters";
+	name = "Hangar Bay Blast Shutters";
 	id = "scarab_hangar_starboard";
 	dir = 1;
 	pixel_y = 28
@@ -587,15 +587,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab/port)
 "jz" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/effect/landmark/entry_point/port{
 	name = "port, hangar port"
 	},
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /obj/machinery/door/blast/regular/open{
-	id = "scarab_hangar_port";
+	id = "scarab_hangar";
 	name = "Safety Blast Doors"
 	},
 /turf/simulated/floor/plating,
@@ -847,15 +847,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab/central)
 "nY" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, hangar starboard"
 	},
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /obj/machinery/door/blast/regular/open{
-	id = "scarab_hangar_starboard";
+	id = "scarab_hangar";
 	name = "Safety Blast Doors"
 	},
 /turf/simulated/floor/plating,
@@ -896,12 +896,11 @@
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
 "pa" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "scarab_hangar_starboard";
+	id = "scarab_hangar";
 	name = "Safety Blast Doors"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -916,6 +915,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/hangar)
 "pr" = (

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_deck_1.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_deck_1.dmm
@@ -1,14 +1,23 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "au" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate/freezer/rations,
-/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
-/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
-/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
-/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/closet/crate,
+/obj/item/stack/material/steel/full,
+/obj/item/gun/custom_ka/frame01/prebuilt,
+/obj/item/gun/custom_ka/frame01/prebuilt,
+/obj/item/gun/custom_ka/frame01/prebuilt,
+/obj/item/gun/custom_ka/frame01/prebuilt,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/ore_detector,
+/obj/item/mining_scanner,
+/obj/item/pickaxe/drill,
+/obj/item/pickaxe/drill,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/coc_scarab/central)
 "ay" = (
@@ -25,13 +34,13 @@
 /turf/simulated/floor/carpet/rubber,
 /area/ship/coc_scarab/hangar)
 "aC" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid,
 /obj/machinery/door/blast/regular/open{
 	id = "scarab_shuttle_cockpit";
 	name = "Cockpit Blast Doors";
 	dir = 4
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/raider,
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
 "aE" = (
@@ -75,9 +84,6 @@
 /turf/simulated/floor/airless,
 /area/shuttle/coc_scarab/central)
 "bB" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -227,6 +233,7 @@
 	dir = 8
 	},
 /obj/item/hullbeacon/red,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "dL" = (
@@ -242,6 +249,7 @@
 "dT" = (
 /obj/structure/lattice/catwalk,
 /obj/item/hullbeacon/red,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "eb" = (
@@ -252,6 +260,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "eq" = (
@@ -263,6 +272,7 @@
 	dir = 1
 	},
 /obj/item/hullbeacon/red,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "es" = (
@@ -391,7 +401,6 @@
 /turf/simulated/floor/airless,
 /area/shuttle/coc_scarab/starboard)
 "gz" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, cockpit"
 	},
@@ -401,6 +410,7 @@
 	name = "Cockpit Blast Doors";
 	dir = 4
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/raider,
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
 "gA" = (
@@ -494,10 +504,14 @@
 /area/space)
 "hM" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
+/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
+/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
+/obj/item/reagent_containers/food/drinks/cans/beetle_milk,
+/obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/coc_scarab/central)
 "hN" = (
@@ -615,7 +629,6 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, fore"
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
@@ -623,6 +636,7 @@
 	id = "scarab_shuttle_starboard";
 	name = "Safety Blast Doors"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/raider,
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
 "kg" = (
@@ -745,6 +759,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "lW" = (
@@ -950,6 +965,8 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor,
+/obj/item/hullbeacon/red,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "qr" = (
@@ -1089,6 +1106,8 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor,
+/obj/item/hullbeacon/red,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "sZ" = (
@@ -1140,7 +1159,6 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/coc_scarab/central)
 "un" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
@@ -1151,6 +1169,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 6
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/raider,
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
 "ur" = (
@@ -1362,7 +1381,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/purple{
 	dir = 8
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
@@ -1370,6 +1388,7 @@
 	id = "scarab_shuttle_port";
 	name = "Safety Blast Doors"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/raider,
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
 "ya" = (
@@ -1560,7 +1579,6 @@
 /obj/effect/landmark/entry_point/port{
 	name = "port, fore"
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
@@ -1568,6 +1586,7 @@
 	id = "scarab_shuttle_port";
 	name = "Safety Blast Doors"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/raider,
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
 "BN" = (
@@ -1597,7 +1616,6 @@
 /turf/simulated/floor/carpet/rubber,
 /area/ship/coc_scarab/hangar)
 "BZ" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
@@ -1605,6 +1623,7 @@
 	id = "scarab_shuttle_cockpit";
 	name = "Cockpit Blast Doors"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/raider,
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
 "Cd" = (
@@ -1920,20 +1939,6 @@
 /area/ship/coc_scarab/hangar)
 "IO" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe/drill,
-/obj/item/pickaxe/drill,
-/obj/item/mining_scanner,
-/obj/item/ore_detector,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/item/gun/custom_ka/frame01/prebuilt,
-/obj/item/gun/custom_ka/frame01/prebuilt,
-/obj/item/gun/custom_ka/frame01/prebuilt,
-/obj/item/gun/custom_ka/frame01/prebuilt,
-/obj/item/stack/material/steel/full,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
@@ -2283,6 +2288,7 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab/port)
 "NJ" = (
@@ -2305,6 +2311,7 @@
 	dir = 4
 	},
 /obj/item/hullbeacon/red,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "NV" = (
@@ -2334,6 +2341,7 @@
 	dir = 1
 	},
 /obj/item/hullbeacon/red,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "Oq" = (
@@ -2424,7 +2432,6 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/hangar)
 "Pt" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
 	dir = 4
 	},
@@ -2440,7 +2447,11 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
-/turf/space/dynamic,
+/obj/structure/lattice/catwalk/indoor,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "Pv" = (
 /obj/structure/disposalpipe/segment,
@@ -2471,7 +2482,6 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/hangar)
 "Qj" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 9
 	},
@@ -2482,6 +2492,7 @@
 	id = "scarab_shuttle_cockpit";
 	name = "Cockpit Blast Doors"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/raider,
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
 "QG" = (
@@ -2523,6 +2534,7 @@
 	dir = 8
 	},
 /obj/structure/railing/mapped,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "RF" = (
@@ -2652,6 +2664,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "Vq" = (
@@ -2718,6 +2731,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab/central)
+"VT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/space/dynamic,
+/area/ship/coc_scarab/exterior)
 "Wa" = (
 /obj/effect/floor_decal/corner_wide/red{
 	dir = 6
@@ -2795,10 +2824,10 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/machinery/pipedispenser,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
+/obj/structure/table/reinforced/steel,
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
 "Wt" = (
@@ -2835,6 +2864,7 @@
 /obj/structure/table/reinforced/steel,
 /obj/item/stack/material/steel/full,
 /obj/item/storage/bag/inflatable,
+/obj/machinery/cell_charger,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab/port)
 "WW" = (
@@ -2932,7 +2962,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/purple{
 	dir = 4
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
@@ -2940,6 +2969,7 @@
 	id = "scarab_shuttle_starboard";
 	name = "Safety Blast Doors"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/raider,
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
 "Zz" = (
@@ -32127,7 +32157,7 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 qn
 Rw
 Eo
@@ -32384,10 +32414,10 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 uC
 DK
-WW
+Eo
 Eo
 Eo
 Eo
@@ -32641,10 +32671,10 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 uC
 DK
-WW
+Eo
 Eo
 Eo
 Eo
@@ -32898,10 +32928,10 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 uC
 DK
-WW
+Eo
 Eo
 Eo
 Eo
@@ -33145,9 +33175,8 @@ Eo
 Eo
 Eo
 Eo
-WW
-kg
-WW
+Eo
+VT
 Eo
 Eo
 Eo
@@ -33155,10 +33184,11 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
+Eo
 uC
 DK
-WW
+Eo
 Eo
 Eo
 Eo
@@ -33401,24 +33431,24 @@ Eo
 Eo
 Eo
 Eo
-WW
-WW
-kg
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
+Eo
+Eo
+VT
+Eo
+Eo
+Eo
+Eo
+Eo
+Eo
+Eo
+Eo
+Eo
 uC
 DK
-WW
-WW
-WW
-WW
+Eo
+Eo
+Eo
+Eo
 Eo
 Eo
 Eo
@@ -33655,10 +33685,10 @@ Eo
 Eo
 Eo
 Eo
-WW
-WW
-WW
-WW
+Eo
+Eo
+Eo
+Eo
 eq
 bB
 Gx
@@ -33911,8 +33941,8 @@ Eo
 Eo
 Eo
 Eo
-WW
-WW
+Eo
+Eo
 Ar
 Gw
 Gw
@@ -34168,7 +34198,7 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 Ar
 dT
 WW
@@ -34423,9 +34453,9 @@ Eo
 Eo
 Eo
 Eo
-WW
-WW
-WW
+Eo
+Eo
+Eo
 uC
 WW
 WW
@@ -34680,7 +34710,7 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 Ar
 Gw
 lW
@@ -34936,8 +34966,8 @@ Eo
 Eo
 Eo
 Eo
-WW
-WW
+Eo
+Eo
 uC
 WW
 WW
@@ -35193,7 +35223,7 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 eb
 lW
 WW
@@ -35450,7 +35480,7 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 uC
 lW
 lW
@@ -35707,7 +35737,7 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 uC
 lW
 lW
@@ -35964,7 +35994,7 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 UN
 lW
 WW
@@ -36221,8 +36251,8 @@ Eo
 Eo
 Eo
 Eo
-WW
-WW
+Eo
+Eo
 uC
 WW
 WW
@@ -36479,7 +36509,7 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 YG
 Cm
 lW
@@ -36736,9 +36766,9 @@ Eo
 Eo
 Eo
 Eo
-WW
-WW
-WW
+Eo
+Eo
+Eo
 uC
 WW
 WW
@@ -36995,7 +37025,7 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 YG
 dT
 WW
@@ -37252,8 +37282,8 @@ Eo
 Eo
 Eo
 Eo
-WW
-WW
+Eo
+Eo
 YG
 Cm
 Cm
@@ -37510,12 +37540,12 @@ Eo
 Eo
 Eo
 Eo
-WW
-WW
-WW
-WW
+Eo
+Eo
+Eo
+Eo
 Ol
-Cm
+lW
 Cm
 Cm
 Cm
@@ -37770,24 +37800,24 @@ Eo
 Eo
 Eo
 Eo
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
-WW
+Eo
+Eo
+lW
+Eo
+Eo
+Eo
+Eo
+Eo
+Eo
+Eo
+Eo
+Eo
 uC
 DK
-WW
-WW
-WW
-WW
+Eo
+Eo
+Eo
+Eo
 Eo
 Eo
 Eo
@@ -38028,9 +38058,8 @@ Eo
 Eo
 Eo
 Eo
-WW
-WW
-WW
+Eo
+lW
 Eo
 Eo
 Eo
@@ -38038,10 +38067,11 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
+Eo
 uC
 DK
-WW
+Eo
 Eo
 Eo
 Eo
@@ -38286,7 +38316,7 @@ Eo
 Eo
 Eo
 Eo
-WW
+Cm
 Eo
 Eo
 Eo
@@ -38295,10 +38325,10 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 uC
 DK
-WW
+Eo
 Eo
 Eo
 Eo
@@ -38552,10 +38582,10 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 uC
 DK
-WW
+Eo
 Eo
 Eo
 Eo
@@ -38809,10 +38839,10 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 uC
 DK
-WW
+Eo
 Eo
 Eo
 Eo
@@ -39066,7 +39096,7 @@ Eo
 Eo
 Eo
 Eo
-WW
+Eo
 sS
 lF
 Eo

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_deck_1.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_deck_1.dmm
@@ -90,7 +90,6 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -98,6 +97,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "bO" = (
@@ -340,11 +340,11 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/coc_scarab/central)
 "eY" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
 /obj/structure/railing/mapped,
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "fi" = (
@@ -763,7 +763,7 @@
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "lW" = (
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "mq" = (
@@ -965,8 +965,8 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor,
 /obj/item/hullbeacon/red,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "qr" = (
@@ -1106,8 +1106,8 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor,
 /obj/item/hullbeacon/red,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "sZ" = (
@@ -1207,10 +1207,10 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/hangar)
 "uC" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "uN" = (
@@ -1473,21 +1473,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab/central)
 "zc" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
 /obj/structure/railing/mapped,
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "Ar" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "AD" = (
@@ -1646,10 +1646,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/hangar)
 "Cm" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "Cy" = (
@@ -1686,8 +1686,8 @@
 /turf/simulated/floor/airless,
 /area/shuttle/coc_scarab/central)
 "DK" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "DP" = (
@@ -1819,10 +1819,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab/starboard)
 "Gw" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "Gx" = (
@@ -1833,9 +1833,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "GJ" = (
@@ -2179,7 +2179,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/lattice/catwalk/indoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -2187,6 +2186,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "Mj" = (
@@ -2447,10 +2447,10 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
-/obj/structure/lattice/catwalk/indoor,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "Pv" = (
@@ -2731,22 +2731,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab/central)
-"VT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor,
-/turf/space/dynamic,
-/area/ship/coc_scarab/exterior)
 "Wa" = (
 /obj/effect/floor_decal/corner_wide/red{
 	dir = 6
@@ -2932,14 +2916,30 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/airless,
 /area/shuttle/coc_scarab/central)
+"YF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/space/dynamic,
+/area/ship/coc_scarab/exterior)
 "YG" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "Za" = (
@@ -2976,7 +2976,7 @@
 /obj/structure/ladder/up{
 	pixel_y = 10
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "ZU" = (
@@ -33176,7 +33176,7 @@ Eo
 Eo
 Eo
 Eo
-VT
+YF
 Eo
 Eo
 Eo
@@ -33433,7 +33433,7 @@ Eo
 Eo
 Eo
 Eo
-VT
+YF
 Eo
 Eo
 Eo

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_deck_1.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_deck_1.dmm
@@ -53,18 +53,7 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab/port)
-"aR" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/empty/nitrogen,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/shuttle/coc_scarab/central)
-"aX" = (
+"aG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -80,6 +69,17 @@
 /obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
+"aR" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/empty/nitrogen,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/coc_scarab/central)
 "bb" = (
 /obj/machinery/atmospherics/binary/pump/fuel{
 	dir = 4;
@@ -766,7 +766,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/coc_scarab/central)
 "lF" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 4
@@ -2537,7 +2536,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab/central)
 "Rw" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
@@ -33167,7 +33165,7 @@ Eo
 Eo
 Eo
 Eo
-aX
+aG
 Eo
 Eo
 Eo
@@ -33424,7 +33422,7 @@ Eo
 Eo
 Eo
 Eo
-aX
+aG
 Eo
 Eo
 Eo

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
@@ -348,11 +348,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/forehallway)
-"ce" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/turf/simulated/open/airless,
-/area/ship/coc_scarab/exterior)
 "ci" = (
 /obj/structure/ladder{
 	pixel_y = 16
@@ -402,12 +397,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/hydroponics)
 "cu" = (
-/obj/structure/bed/handrail{
-	dir = 1;
-	pixel_y = -2;
-	name = "table handrail";
-	buckle_dir = 2
-	},
 /obj/effect/floor_decal/corner_wide/dark_green/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -605,13 +594,6 @@
 "dG" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/coc_scarab/armory)
-"dH" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
-/turf/simulated/open/airless,
-/area/ship/coc_scarab/exterior)
 "dI" = (
 /obj/machinery/door/airlock/external{
 	dir = 8
@@ -1227,6 +1209,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/thrust2)
+"ga" = (
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 10
+	},
+/turf/simulated/floor/airless,
+/area/ship/coc_scarab/exterior)
 "gc" = (
 /obj/effect/floor_decal/corner_wide/red{
 	dir = 1
@@ -1332,6 +1322,9 @@
 /obj/item/reagent_containers/food/condiment/shaker/spacespice{
 	pixel_y = 14;
 	pixel_x = 3
+	},
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 8
 	},
 /turf/simulated/floor/lino,
 /area/ship/coc_scarab/mess)
@@ -1471,11 +1464,6 @@
 /obj/effect/floor_decal/corner_wide/dark_green/diagonal,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/bed/handrail{
-	pixel_y = 7;
-	name = "table handrail";
-	buckle_dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/bunks)
@@ -2026,6 +2014,9 @@
 	name = "Mess Hall";
 	door_color = "#1F4B65"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/mess)
 "ki" = (
@@ -2380,37 +2371,25 @@
 	},
 /obj/effect/floor_decal/industrial/outline/service,
 /obj/structure/table/standard,
-/obj/item/storage/box/lights/mixed{
-	pixel_x = -7
-	},
 /obj/item/paper_bin{
 	pixel_x = 6;
 	pixel_y = 5
-	},
-/obj/item/storage/box/lights/mixed{
-	pixel_x = -7
 	},
 /obj/item/pen/black{
 	pixel_x = 6;
 	pixel_y = 5
 	},
+/obj/item/storage/box/lights/colored/yellow{
+	pixel_x = -5
+	},
+/obj/item/storage/box/lights/colored/yellow{
+	pixel_x = -5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/recycling)
 "mu" = (
 /obj/structure/lattice,
-/obj/item/wrench{
-	name = "lost lucky wrench";
-	desc = "This wrench was very lucky. Whoever was holding on to it, maybe not so much.";
-	pixel_y = -11;
-	pixel_x = -14
-	},
-/obj/item/ore/iron{
-	pixel_x = -6
-	},
-/obj/item/ore/iron{
-	pixel_y = -18;
-	pixel_x = 5
-	},
+/obj/structure/ship_weapon_dummy,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "my" = (
@@ -2515,6 +2494,23 @@
 /area/ship/coc_scarab/hydroponics)
 "ne" = (
 /obj/structure/grille,
+/turf/space/dynamic,
+/area/ship/coc_scarab/exterior)
+"nk" = (
+/obj/structure/lattice,
+/obj/item/wrench{
+	name = "lost lucky wrench";
+	desc = "This wrench was very lucky. Whoever was holding on to it, maybe not so much.";
+	pixel_y = -11;
+	pixel_x = -14
+	},
+/obj/item/ore/iron{
+	pixel_y = -18;
+	pixel_x = 5
+	},
+/obj/item/ore/iron{
+	pixel_x = -6
+	},
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "nl" = (
@@ -2860,16 +2856,13 @@
 /turf/simulated/floor/carpet/rubber,
 /area/ship/coc_scarab/engine)
 "pk" = (
-/obj/structure/table/steel,
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
-	pixel_x = -8;
-	pixel_y = -3
-	},
 /obj/effect/floor_decal/corner_wide/dark_green/diagonal,
+/obj/structure/bed/handrail{
+	dir = 1;
+	pixel_y = -2;
+	name = "table handrail";
+	buckle_dir = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/mess)
 "pl" = (
@@ -2926,6 +2919,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/grauwolf)
+"pF" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
+/turf/simulated/open/airless,
+/area/ship/coc_scarab/exterior)
 "pJ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3442,6 +3440,11 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/remote/blast_door{
+	name = "Atmospherics Blast Shutters";
+	id = "scarab_atmospherics";
+	pixel_y = -22
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/atmospherics)
 "sb" = (
@@ -3601,9 +3604,6 @@
 	},
 /obj/item/storage/box/fancy/egg_box,
 /obj/item/storage/box/fancy/egg_box,
-/obj/machinery/light/colored/decayed/dimmed{
-	dir = 1
-	},
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/reagent_containers/food/condiment/sugar,
@@ -3616,6 +3616,17 @@
 /obj/item/reagent_containers/food/drinks/carton/milk,
 /turf/simulated/floor/lino,
 /area/ship/coc_scarab/mess)
+"sy" = (
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "scarab_atmospherics";
+	name = "Safety Blast Doors"
+	},
+/turf/simulated/floor/plating,
+/area/ship/coc_scarab/atmospherics)
 "sA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing/mapped{
@@ -3890,6 +3901,9 @@
 "un" = (
 /obj/structure/table/steel,
 /obj/effect/floor_decal/corner_wide/dark_green/diagonal,
+/obj/item/storage/bag/circuits/basic{
+	pixel_x = -10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/bunks)
 "up" = (
@@ -4337,14 +4351,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/engine)
-"wH" = (
-/obj/effect/floor_decal/industrial/hatch/grey,
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 10
-	},
-/turf/simulated/floor/airless,
-/area/ship/coc_scarab/exterior)
 "wI" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4431,11 +4437,14 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/forehallway)
 "xe" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 5
 	},
-/obj/structure/lattice,
-/turf/simulated/open/airless,
+/turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "xm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -4550,6 +4559,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/mess)
 "xJ" = (
@@ -4653,12 +4665,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/thrust2)
-"yf" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/obj/structure/lattice,
-/obj/effect/floor_decal/industrial/hatch/grey,
-/turf/space/dynamic,
-/area/ship/coc_scarab/exterior)
 "yu" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
@@ -4788,6 +4794,11 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/remote/blast_door{
+	name = "Recycling Blast Shutters";
+	id = "scarab_recycling";
+	pixel_y = -22
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/recycling)
 "zc" = (
@@ -5405,7 +5416,8 @@
 "BG" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Washroom";
-	dir = 4
+	dir = 4;
+	id = "scarab_washroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -5418,6 +5430,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/washroom)
@@ -5622,6 +5637,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/ship/coc_scarab/grauwolf)
+"CB" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 8
+	},
+/turf/simulated/open/airless,
+/area/ship/coc_scarab/exterior)
 "CE" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/mirror{
@@ -5664,7 +5686,15 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, atmospherics"
 	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "scarab_atmospherics";
+	name = "Safety Blast Doors"
+	},
+/turf/simulated/floor/plating,
 /area/ship/coc_scarab/atmospherics)
 "CT" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -5842,7 +5872,15 @@
 /obj/effect/landmark/entry_point/port{
 	name = "port, recycling"
 	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "scarab_recycling";
+	name = "Safety Blast Doors"
+	},
+/turf/simulated/floor/plating,
 /area/ship/coc_scarab/recycling)
 "DR" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -6193,15 +6231,15 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/engine)
 "FI" = (
-/obj/machinery/computer/ship/engines/terminal{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/high/north{
 	req_access = null;
 	cell_type = /obj/item/cell/super
+	},
+/obj/machinery/computer/ship/navigation/terminal{
+	dir = 8
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/coc_scarab/bridge)
@@ -6269,6 +6307,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/bridge)
+"FW" = (
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/plating,
+/area/ship/coc_scarab/mess)
 "FX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/brown,
@@ -7029,9 +7072,6 @@
 /obj/item/clothing/accessory/holster/hip{
 	pixel_x = 7
 	},
-/obj/item/clothing/accessory/holster/armpit{
-	pixel_x = 7
-	},
 /obj/item/clothing/suit/armor/carrier/generic{
 	pixel_y = 4;
 	pixel_x = -6
@@ -7126,9 +7166,10 @@
 /area/ship/coc_scarab/forehallway)
 "KJ" = (
 /obj/effect/floor_decal/corner_wide/dark_green/diagonal,
-/obj/structure/table/steel,
-/obj/item/storage/bag/circuits/basic{
-	pixel_x = -10
+/obj/structure/bed/handrail{
+	pixel_y = 7;
+	name = "table handrail";
+	buckle_dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/bunks)
@@ -7207,7 +7248,9 @@
 /obj/structure/sign/flag/scarab/large/west{
 	pixel_x = -32
 	},
-/obj/item/gun/energy/retro,
+/obj/item/gun/projectile/automatic/mini_uzi,
+/obj/item/ammo_magazine/c45uzi,
+/obj/item/ammo_magazine/c45uzi,
 /turf/simulated/floor/carpet/rubber,
 /area/ship/coc_scarab/armory)
 "Li" = (
@@ -7305,12 +7348,6 @@
 /obj/effect/floor_decal/corner_wide/dark_green/diagonal,
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 8
-	},
-/obj/structure/bed/handrail{
-	dir = 8;
-	name = "table handrail";
-	pixel_x = 2;
-	buckle_dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
@@ -7474,20 +7511,7 @@
 /obj/structure/closet/crate/secure,
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/porthallway)
-"MT" = (
-/obj/effect/floor_decal/industrial/hatch/grey,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 5
-	},
-/turf/simulated/floor/airless,
-/area/ship/coc_scarab/exterior)
 "MU" = (
-/obj/structure/sign/flag/scarab/large/north{
-	pixel_y = 32
-	},
 /obj/machinery/appliance/cooker/stove,
 /turf/simulated/floor/lino,
 /area/ship/coc_scarab/mess)
@@ -7884,13 +7908,6 @@
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/airless,
-/area/ship/coc_scarab/exterior)
-"OK" = (
-/obj/effect/floor_decal/industrial/hatch/grey,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
-	},
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "ON" = (
@@ -8465,13 +8482,13 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/porthallway)
 "RA" = (
-/obj/machinery/computer/ship/navigation/terminal{
-	dir = 4
-	},
 /obj/machinery/alarm/north{
 	req_one_access = list()
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/ship/engines/terminal{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/ship/coc_scarab/bridge)
 "RE" = (
@@ -8540,11 +8557,6 @@
 /obj/effect/floor_decal/corner_wide/dark_green/diagonal,
 /obj/machinery/light/floor/decayed{
 	dir = 8
-	},
-/obj/structure/bed/handrail{
-	pixel_y = 7;
-	name = "table handrail";
-	buckle_dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/bunks)
@@ -8796,6 +8808,19 @@
 /obj/effect/floor_decal/corner_wide/dark_green/diagonal,
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/mess)
+"SN" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner_wide/dark_green/diagonal,
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/coc_scarab/mess)
 "SO" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 10
@@ -8816,12 +8841,6 @@
 /area/ship/coc_scarab/exterior)
 "SW" = (
 /obj/effect/floor_decal/corner_wide/dark_green/diagonal,
-/obj/structure/bed/handrail{
-	dir = 4;
-	name = "table handrail";
-	pixel_x = -2;
-	buckle_dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -9021,11 +9040,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/equipment)
 "Ue" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/mapped{
-	dir = 1
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
 	},
-/turf/simulated/open/airless,
+/turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "Ug" = (
 /obj/structure/lattice/catwalk,
@@ -9241,13 +9260,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/porthallway)
-"US" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 8
-	},
-/turf/simulated/open/airless,
-/area/ship/coc_scarab/exterior)
 "UT" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -9661,6 +9673,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/forehallway)
+"Xi" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
+/turf/simulated/open/airless,
+/area/ship/coc_scarab/exterior)
 "Xj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -9726,13 +9745,33 @@
 	pixel_x = -6
 	},
 /obj/structure/table/reinforced/steel,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/button/remote/blast_door{
+	name = "Hangar Bay Blast Shutters";
+	id = "scarab_hangar_starboard";
+	dir = 1;
+	pixel_y = 10;
+	pixel_x = -6
 	},
 /obj/item/device/binoculars{
 	pixel_y = 10;
 	pixel_x = -8
 	},
+/obj/machinery/button/remote/blast_door{
+	name = "Atmospherics Blast Shutters";
+	id = "scarab_atmospherics";
+	pixel_y = -22;
+	pixel_x = -6
+	},
+/obj/machinery/button/remote/blast_door{
+	name = "Recycling Blast Shutters";
+	id = "scarab_recycling";
+	pixel_y = -22;
+	pixel_x = 7
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/device/radio/intercom/expedition/hailing/east,
 /turf/simulated/floor/carpet/rubber,
 /area/ship/coc_scarab/bridge)
 "Xp" = (
@@ -9801,7 +9840,14 @@
 /obj/effect/floor_decal/corner_wide/dark_green/diagonal,
 /obj/structure/cable/green,
 /obj/machinery/power/apc/west,
-/obj/structure/table/steel,
+/obj/structure/bed/handrail{
+	pixel_y = 7;
+	name = "table handrail";
+	buckle_dir = 1
+	},
+/obj/machinery/computer/ship/navigation/terminal{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/bunks)
 "XI" = (
@@ -9884,6 +9930,17 @@
 /obj/machinery/alarm/south,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/cargobay)
+"Yh" = (
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "scarab_recycling";
+	name = "Safety Blast Doors"
+	},
+/turf/simulated/floor/plating,
+/area/ship/coc_scarab/recycling)
 "Ym" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
@@ -34584,9 +34641,9 @@ cW
 cW
 cW
 cW
-Al
-Al
-Al
+cW
+cW
+cW
 ne
 ne
 ne
@@ -34595,9 +34652,9 @@ nr
 ne
 ne
 ne
-Al
-Al
-Al
+cW
+cW
+cW
 cW
 cW
 cW
@@ -34841,7 +34898,7 @@ cW
 cW
 cW
 Af
-Al
+cW
 FC
 NU
 NU
@@ -34854,7 +34911,7 @@ NU
 NU
 NU
 Sw
-Al
+cW
 Af
 cW
 cW
@@ -35098,7 +35155,7 @@ cW
 cW
 cW
 cW
-Al
+cW
 Cz
 Al
 Al
@@ -35111,7 +35168,7 @@ Al
 Al
 Al
 nr
-Al
+cW
 cW
 cW
 cW
@@ -35355,7 +35412,7 @@ cW
 cW
 cW
 cW
-Al
+cW
 Cz
 Al
 pr
@@ -35368,7 +35425,7 @@ UG
 HP
 Al
 nr
-Al
+cW
 cW
 cW
 cW
@@ -35612,7 +35669,7 @@ cW
 cW
 cW
 Af
-Al
+cW
 Cz
 Al
 pr
@@ -35625,7 +35682,7 @@ UG
 HP
 Al
 nr
-Al
+cW
 Af
 cW
 cW
@@ -35869,7 +35926,7 @@ cW
 cW
 cW
 cW
-Al
+cW
 Cz
 Al
 pr
@@ -35882,7 +35939,7 @@ UG
 HP
 Al
 nr
-Al
+cW
 cW
 cW
 cW
@@ -38182,7 +38239,7 @@ cW
 cW
 cW
 cW
-Al
+cW
 Cz
 Al
 pr
@@ -38195,7 +38252,7 @@ UG
 HP
 Al
 nr
-Al
+cW
 cW
 cW
 cW
@@ -38439,7 +38496,7 @@ cW
 cW
 cW
 Af
-Al
+cW
 Cz
 Al
 pr
@@ -38452,7 +38509,7 @@ UG
 HP
 Al
 nr
-Al
+cW
 Af
 cW
 cW
@@ -38696,7 +38753,7 @@ cW
 cW
 cW
 cW
-Al
+cW
 Cz
 Al
 pr
@@ -38709,7 +38766,7 @@ UG
 HP
 Al
 nr
-Al
+cW
 cW
 cW
 cW
@@ -38953,7 +39010,7 @@ cW
 cW
 cW
 cW
-Al
+cW
 Cz
 Al
 Al
@@ -38966,7 +39023,7 @@ Al
 Al
 Al
 nr
-Al
+cW
 cW
 cW
 cW
@@ -39210,7 +39267,7 @@ cW
 cW
 cW
 Af
-Al
+cW
 nG
 jw
 xT
@@ -39223,7 +39280,7 @@ jx
 mh
 Uw
 Cf
-Al
+cW
 Af
 cW
 cW
@@ -39467,7 +39524,7 @@ cW
 cW
 cW
 cW
-Al
+cW
 ne
 ne
 Cz
@@ -39480,7 +39537,7 @@ Al
 Al
 Al
 Cf
-Al
+cW
 cW
 cW
 cW
@@ -39737,21 +39794,21 @@ dy
 dy
 op
 Cf
-Al
-Al
-Al
+cW
+cW
+cW
 ne
 ne
 ne
-Al
-Al
 ne
 ne
-Al
-Ue
+ne
+ne
+ne
+Cz
 Ug
 Ug
-SR
+Az
 gB
 gB
 gB
@@ -39986,10 +40043,10 @@ NU
 xT
 qB
 qB
-qB
-qB
+sy
+sy
 CQ
-qB
+sy
 qB
 qB
 jL
@@ -40005,10 +40062,10 @@ NU
 NU
 NU
 xT
-Ug
+xT
 SR
 qI
-au
+iq
 VF
 VF
 Ra
@@ -40021,8 +40078,8 @@ mD
 wP
 CA
 sH
-Al
-Al
+mu
+mu
 DR
 xT
 cW
@@ -40262,7 +40319,7 @@ Ea
 Ea
 Ea
 Ea
-qI
+Ea
 au
 aP
 Hs
@@ -40278,8 +40335,8 @@ Dy
 Qa
 JJ
 sH
-Al
-Al
+mu
+mu
 DR
 xT
 cW
@@ -40535,8 +40592,8 @@ Dy
 JJ
 JJ
 sH
-Al
-Al
+mu
+mu
 DR
 xT
 cW
@@ -41307,7 +41364,7 @@ dG
 dG
 dG
 hf
-US
+CB
 jm
 ze
 yu
@@ -41565,7 +41622,7 @@ Rw
 Lg
 hf
 xE
-MT
+xe
 Ug
 Ug
 NU
@@ -41822,8 +41879,8 @@ Em
 Xj
 hf
 Sv
-wH
-ce
+ga
+pF
 qI
 Be
 xT
@@ -43864,13 +43921,13 @@ vC
 aP
 yI
 Lz
-iQ
+FW
 sq
 GB
 Jg
 cu
 pk
-FZ
+SN
 FZ
 yy
 jY
@@ -44121,12 +44178,12 @@ Bm
 aP
 gc
 IP
-iQ
+FW
 MU
 sQ
 dV
 cu
-FZ
+pk
 FZ
 zK
 NB
@@ -44378,7 +44435,7 @@ nM
 BW
 EO
 xJ
-iQ
+FW
 rL
 sQ
 WL
@@ -44392,8 +44449,8 @@ QE
 QV
 hf
 nA
-OK
-dH
+Ue
+Xi
 sM
 ta
 xT
@@ -45659,7 +45716,7 @@ Ea
 Ea
 Ea
 Ea
-qI
+Ea
 vs
 aP
 vA
@@ -45897,10 +45954,10 @@ jw
 xT
 qA
 qA
-qA
-qA
+Yh
+Yh
 DN
-qA
+Yh
 qA
 qA
 EN
@@ -45916,10 +45973,10 @@ jw
 jw
 jw
 jw
-Ug
+xT
 XN
 qI
-xe
+Be
 Rk
 Rk
 Rk
@@ -46162,21 +46219,21 @@ jx
 jx
 Gb
 Cf
-Al
-Al
-Al
+cW
+cW
+cW
 ne
 ne
 ne
-Al
-Al
 ne
 ne
 ne
-Ue
+ne
+ne
+Cz
 Ug
 Ug
-XN
+rn
 Ea
 Ea
 Ea
@@ -46406,7 +46463,7 @@ cW
 cW
 cW
 cW
-Al
+cW
 ne
 ne
 Cz
@@ -46419,7 +46476,7 @@ Al
 Al
 Al
 Cf
-Al
+cW
 cW
 cW
 cW
@@ -46445,7 +46502,7 @@ Ea
 Ea
 Ea
 Ea
-yf
+Ea
 iq
 nr
 cW
@@ -46663,7 +46720,7 @@ cW
 cW
 cW
 Af
-Al
+cW
 FC
 NU
 xT
@@ -46676,7 +46733,7 @@ jx
 mh
 Uw
 Cf
-Al
+cW
 Af
 cW
 cW
@@ -46920,7 +46977,7 @@ cW
 cW
 cW
 cW
-Al
+cW
 Cz
 Al
 Al
@@ -46933,7 +46990,7 @@ Al
 Al
 Al
 nr
-Al
+cW
 cW
 cW
 cW
@@ -47177,7 +47234,7 @@ cW
 cW
 cW
 cW
-Al
+cW
 Cz
 Al
 Zz
@@ -47190,7 +47247,7 @@ OD
 vn
 Al
 nr
-Al
+cW
 cW
 cW
 cW
@@ -47434,7 +47491,7 @@ cW
 cW
 cW
 Af
-Al
+cW
 Cz
 Al
 Zz
@@ -47447,7 +47504,7 @@ OD
 vn
 Al
 nr
-Al
+cW
 Af
 cW
 cW
@@ -47691,7 +47748,7 @@ cW
 cW
 cW
 cW
-Al
+cW
 Cz
 Al
 Zz
@@ -47704,7 +47761,7 @@ OD
 vn
 Al
 nr
-Al
+cW
 cW
 cW
 cW
@@ -50004,7 +50061,7 @@ cW
 cW
 cW
 cW
-Al
+cW
 Cz
 Al
 Zz
@@ -50017,7 +50074,7 @@ OD
 vn
 Al
 nr
-Al
+cW
 cW
 cW
 cW
@@ -50261,7 +50318,7 @@ cW
 cW
 cW
 Af
-Al
+cW
 Cz
 Al
 Zz
@@ -50274,7 +50331,7 @@ OD
 vn
 Al
 nr
-Al
+cW
 Af
 cW
 cW
@@ -50518,7 +50575,7 @@ cW
 cW
 cW
 cW
-Al
+cW
 Cz
 Al
 Zz
@@ -50531,7 +50588,7 @@ OD
 vn
 Al
 nr
-Al
+cW
 cW
 cW
 cW
@@ -50775,9 +50832,9 @@ cW
 cW
 cW
 cW
-Al
+cW
 Cz
-Al
+nk
 Al
 Al
 Al
@@ -50788,7 +50845,7 @@ Al
 Al
 Al
 nr
-Al
+cW
 cW
 cW
 cW
@@ -51032,7 +51089,7 @@ cW
 cW
 cW
 Af
-Al
+cW
 ur
 jw
 jw
@@ -51045,7 +51102,7 @@ jw
 jw
 jw
 Uj
-Al
+cW
 Af
 cW
 cW
@@ -51289,9 +51346,9 @@ cW
 cW
 cW
 cW
-mu
-Al
-Al
+cW
+cW
+cW
 ne
 ne
 ne
@@ -51300,9 +51357,9 @@ nr
 ne
 ne
 ne
-Al
-Al
-Al
+cW
+cW
+cW
 cW
 cW
 cW

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
@@ -3151,12 +3151,18 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/coc_scarab/atmospherics)
 "qC" = (
-/obj/structure/railing/mapped{
-	dir = 8
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner_wide/dark_green/diagonal,
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
+	pixel_x = -7;
+	pixel_y = 7
 	},
-/obj/structure/lattice/catwalk/indoor,
-/turf/space/dynamic,
-/area/ship/coc_scarab/exterior)
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/coc_scarab/mess)
 "qI" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/lattice,
@@ -3305,7 +3311,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/porthallway)
 "rA" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
@@ -4599,19 +4604,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/forehallway)
-"xT" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner_wide/dark_green/diagonal,
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
-	pixel_x = -8;
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/coc_scarab/mess)
 "xU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7768,6 +7760,13 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/engistorage)
+"NU" = (
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk/indoor,
+/turf/space/dynamic,
+/area/ship/coc_scarab/exterior)
 "NV" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9553,7 +9552,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/bridge)
 "WA" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
@@ -34890,16 +34888,16 @@ cW
 Af
 cW
 FC
-qC
-qC
-qC
-qC
+NU
+NU
+NU
+NU
 NN
 NN
-qC
-qC
-qC
-qC
+NU
+NU
+NU
+NU
 Sw
 cW
 Af
@@ -36944,7 +36942,7 @@ cW
 cW
 cW
 oQ
-qC
+NU
 NN
 Al
 pr
@@ -36957,8 +36955,8 @@ UG
 HP
 Al
 NN
-qC
-qC
+NU
+NU
 cW
 cW
 cW
@@ -39288,16 +39286,16 @@ cW
 cW
 cW
 wp
-qC
-qC
-qC
-qC
-qC
-qC
-qC
-qC
-qC
-qC
+NU
+NU
+NU
+NU
+NU
+NU
+NU
+NU
+NU
+NU
 UK
 cW
 cW
@@ -39541,9 +39539,9 @@ cW
 wp
 ci
 En
-qC
-qC
-qC
+NU
+NU
+NU
 NN
 Az
 Ea
@@ -39556,7 +39554,7 @@ Ea
 Ea
 EX
 NN
-qC
+NU
 UK
 cW
 cW
@@ -40025,11 +40023,11 @@ cW
 cW
 wp
 WA
-qC
-qC
-qC
-qC
-qC
+NU
+NU
+NU
+NU
+NU
 NN
 qB
 qB
@@ -40042,15 +40040,15 @@ qB
 jL
 rc
 FN
-qC
-qC
-qC
-qC
-qC
-qC
-qC
-qC
-qC
+NU
+NU
+NU
+NU
+NU
+NU
+NU
+NU
+NU
 NN
 NN
 SR
@@ -41615,7 +41613,7 @@ xE
 xe
 Ug
 Ug
-qC
+NU
 Sw
 cW
 cW
@@ -43917,7 +43915,7 @@ GB
 Jg
 cu
 pk
-xT
+qC
 FZ
 yy
 jY
@@ -46712,7 +46710,7 @@ cW
 Af
 cW
 FC
-qC
+NU
 NN
 NN
 BZ
@@ -48766,7 +48764,7 @@ cW
 cW
 cW
 tK
-qC
+NU
 NN
 Al
 Zz
@@ -48779,8 +48777,8 @@ OD
 vn
 Al
 NN
-qC
-qC
+NU
+NU
 cW
 cW
 cW

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
@@ -3150,13 +3150,6 @@
 "qB" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/coc_scarab/atmospherics)
-"qC" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk/indoor,
-/turf/space/dynamic,
-/area/ship/coc_scarab/exterior)
 "qI" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/lattice,
@@ -4598,6 +4591,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/forehallway)
+"xT" = (
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner_wide/dark_green/diagonal,
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/coc_scarab/mess)
 "xU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -7755,18 +7761,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/engistorage)
 "NU" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner_wide/dark_green/diagonal,
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
-	pixel_x = -7;
-	pixel_y = 7
+/obj/structure/railing/mapped{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
-	pixel_x = -8;
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/coc_scarab/mess)
+/obj/structure/lattice/catwalk/indoor,
+/turf/space/dynamic,
+/area/ship/coc_scarab/exterior)
 "NV" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -34891,16 +34891,16 @@ cW
 Af
 cW
 FC
-qC
-qC
-qC
-qC
+NU
+NU
+NU
+NU
 NN
 NN
-qC
-qC
-qC
-qC
+NU
+NU
+NU
+NU
 Sw
 cW
 Af
@@ -36945,7 +36945,7 @@ cW
 cW
 cW
 oQ
-qC
+NU
 NN
 Al
 pr
@@ -36958,8 +36958,8 @@ UG
 HP
 Al
 NN
-qC
-qC
+NU
+NU
 cW
 cW
 cW
@@ -39289,16 +39289,16 @@ cW
 cW
 cW
 wp
-qC
-qC
-qC
-qC
-qC
-qC
-qC
-qC
-qC
-qC
+NU
+NU
+NU
+NU
+NU
+NU
+NU
+NU
+NU
+NU
 UK
 cW
 cW
@@ -39542,9 +39542,9 @@ cW
 wp
 ci
 En
-qC
-qC
-qC
+NU
+NU
+NU
 NN
 Az
 Ea
@@ -39557,7 +39557,7 @@ Ea
 Ea
 EX
 NN
-qC
+NU
 UK
 cW
 cW
@@ -39795,7 +39795,7 @@ ne
 ne
 ne
 ne
-ne
+cW
 Cz
 Ug
 Ug
@@ -40026,11 +40026,11 @@ cW
 cW
 wp
 WA
-qC
-qC
-qC
-qC
-qC
+NU
+NU
+NU
+NU
+NU
 NN
 qB
 qB
@@ -40043,15 +40043,15 @@ qB
 jL
 rc
 FN
-qC
-qC
-qC
-qC
-qC
-qC
-qC
-qC
-qC
+NU
+NU
+NU
+NU
+NU
+NU
+NU
+NU
+NU
 NN
 NN
 SR
@@ -41616,7 +41616,7 @@ xE
 xe
 Ug
 Ug
-qC
+NU
 Sw
 cW
 cW
@@ -43918,7 +43918,7 @@ GB
 Jg
 cu
 pk
-NU
+xT
 FZ
 yy
 jY
@@ -46220,7 +46220,7 @@ ne
 ne
 ne
 ne
-ne
+cW
 Cz
 Ug
 Ug
@@ -46713,7 +46713,7 @@ cW
 Af
 cW
 FC
-qC
+NU
 NN
 NN
 BZ
@@ -48767,7 +48767,7 @@ cW
 cW
 cW
 tK
-qC
+NU
 NN
 Al
 Zz
@@ -48780,8 +48780,8 @@ OD
 vn
 Al
 NN
-qC
-qC
+NU
+NU
 cW
 cW
 cW

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
@@ -2817,6 +2817,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/thrust1)
 "pa" = (

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
@@ -348,6 +348,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/forehallway)
+"ce" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
+/turf/simulated/open/airless,
+/area/ship/coc_scarab/exterior)
 "ci" = (
 /obj/structure/ladder{
 	pixel_y = 16
@@ -600,6 +605,13 @@
 "dG" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/coc_scarab/armory)
+"dH" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
+	},
+/turf/simulated/open/airless,
+/area/ship/coc_scarab/exterior)
 "dI" = (
 /obj/machinery/door/airlock/external{
 	dir = 8
@@ -765,7 +777,7 @@
 	},
 /obj/machinery/air_sensor{
 	id_tag = "scarab_thrust2_sensor";
-	frequency = 1339;
+	frequency = 1336;
 	output = 31
 	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
@@ -823,12 +835,12 @@
 /area/ship/coc_scarab/cargobay)
 "ev" = (
 /obj/machinery/door/firedoor/noid,
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/blast/regular/open{
 	id = "scarab_quarters_shutters";
 	dir = 4;
 	name = "Safety Blast Doors"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/bunks)
 "ez" = (
@@ -2117,7 +2129,6 @@
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "kN" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
@@ -2126,6 +2137,7 @@
 	id = "scarab_port_shutters";
 	name = "Safety Blast Doors"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/porthallway)
 "kR" = (
@@ -2732,7 +2744,6 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/thrust1)
 "oz" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
@@ -2744,6 +2755,7 @@
 	id = "scarab_starboard_shutters";
 	name = "Safety Blast Doors"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/starboardhallway)
 "oD" = (
@@ -4198,7 +4210,6 @@
 /area/ship/coc_scarab/medical)
 "vF" = (
 /obj/machinery/door/firedoor/noid,
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, bridge"
 	},
@@ -4207,6 +4218,7 @@
 	name = "Bridge Blast Doors";
 	dir = 4
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/bridge)
 "vG" = (
@@ -4325,6 +4337,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/engine)
+"wH" = (
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 10
+	},
+/turf/simulated/floor/airless,
+/area/ship/coc_scarab/exterior)
 "wI" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4499,11 +4519,15 @@
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "xE" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 10
 	},
-/turf/simulated/open/airless,
+/turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "xG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4629,6 +4653,12 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/thrust2)
+"yf" = (
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/lattice,
+/obj/effect/floor_decal/industrial/hatch/grey,
+/turf/space/dynamic,
+/area/ship/coc_scarab/exterior)
 "yu" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
@@ -6308,12 +6338,12 @@
 /area/ship/coc_scarab/starboardhallway)
 "Gl" = (
 /obj/machinery/door/firedoor/noid,
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/blast/regular/open{
 	id = "scarab_bridge";
 	name = "Bridge Blast Doors";
 	dir = 4
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/bridge)
 "Gm" = (
@@ -6633,7 +6663,6 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/porthallway)
 "IB" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
@@ -6656,6 +6685,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/starboardhallway)
 "IE" = (
@@ -6913,7 +6943,6 @@
 /area/ship/coc_scarab/porthallway)
 "JQ" = (
 /obj/structure/undies_wardrobe{
-	density = 0;
 	pixel_y = 11
 	},
 /obj/effect/floor_decal/corner_wide/dark_green/diagonal,
@@ -7175,12 +7204,10 @@
 /obj/item/gun/projectile/pistol,
 /obj/item/ammo_magazine/mc9mm,
 /obj/item/ammo_magazine/mc9mm,
-/obj/item/gun/projectile/automatic/mini_uzi,
-/obj/item/ammo_magazine/c45uzi,
-/obj/item/ammo_magazine/c45uzi,
 /obj/structure/sign/flag/scarab/large/west{
 	pixel_x = -32
 	},
+/obj/item/gun/energy/retro,
 /turf/simulated/floor/carpet/rubber,
 /area/ship/coc_scarab/armory)
 "Li" = (
@@ -7224,7 +7251,6 @@
 /area/ship/coc_scarab/forehallway)
 "LK" = (
 /obj/machinery/door/firedoor/noid,
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, crew quarters"
 	},
@@ -7233,6 +7259,7 @@
 	dir = 4;
 	name = "Safety Blast Doors"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/bunks)
 "LN" = (
@@ -7447,6 +7474,16 @@
 /obj/structure/closet/crate/secure,
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/porthallway)
+"MT" = (
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 5
+	},
+/turf/simulated/floor/airless,
+/area/ship/coc_scarab/exterior)
 "MU" = (
 /obj/structure/sign/flag/scarab/large/north{
 	pixel_y = 32
@@ -7748,7 +7785,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/porthallway)
 "Oe" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
@@ -7760,6 +7796,7 @@
 	id = "scarab_port_shutters";
 	name = "Safety Blast Doors"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/porthallway)
 "Of" = (
@@ -7847,6 +7884,13 @@
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/airless,
+/area/ship/coc_scarab/exterior)
+"OK" = (
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "ON" = (
@@ -8059,11 +8103,11 @@
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/blast/regular/open{
 	id = "scarab_bridge";
 	name = "Bridge Blast Doors"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/bridge)
 "PN" = (
@@ -8384,16 +8428,18 @@
 	name = "Weaponry (Longarms)"
 	},
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/item/gun/projectile/gauss,
-/obj/item/ammo_magazine/gauss,
-/obj/item/ammo_magazine/gauss,
-/obj/item/gun/projectile/automatic/xanusmg,
-/obj/item/ammo_magazine/c46m/extended,
-/obj/item/ammo_magazine/c46m/extended,
 /obj/machinery/light/small{
 	dir = 8;
 	must_start_working = 1
 	},
+/obj/item/gun/projectile/shotgun/pump,
+/obj/item/storage/box/shotgunshells,
+/obj/item/storage/box/shotgunshells,
+/obj/item/storage/box/stunshells,
+/obj/item/gun/projectile/gauss,
+/obj/item/ammo_magazine/gauss,
+/obj/item/ammo_magazine/gauss,
+/obj/item/ammo_magazine/gauss,
 /obj/item/gun/energy/gun,
 /obj/item/gun/energy/blaster/carbine,
 /turf/simulated/floor/carpet/rubber,
@@ -8914,7 +8960,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/equipment)
 "TO" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
@@ -8923,6 +8968,7 @@
 	id = "scarab_flak_battery";
 	name = "Safety Blast Doors"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/grauwolf)
 "TT" = (
@@ -9195,6 +9241,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/porthallway)
+"US" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 8
+	},
+/turf/simulated/open/airless,
+/area/ship/coc_scarab/exterior)
 "UT" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -41254,7 +41307,7 @@ dG
 dG
 dG
 hf
-dK
+US
 jm
 ze
 yu
@@ -41512,7 +41565,7 @@ Rw
 Lg
 hf
 xE
-xe
+MT
 Ug
 Ug
 NU
@@ -41769,8 +41822,8 @@ Em
 Xj
 hf
 Sv
-XN
-qI
+wH
+ce
 qI
 Be
 xT
@@ -44339,8 +44392,8 @@ QE
 QV
 hf
 nA
-SR
-qI
+OK
+dH
 sM
 ta
 xT
@@ -44596,8 +44649,8 @@ ay
 FO
 hf
 SR
+sM
 au
-Ug
 Ug
 jw
 Uj
@@ -46392,7 +46445,7 @@ Ea
 Ea
 Ea
 Ea
-Ea
+yf
 iq
 nr
 cW

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
@@ -2943,8 +2943,8 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/obj/machinery/alarm/east{
-	req_one_access = null
+/obj/machinery/light/colored/decayed/dimmed{
+	dir = 4
 	},
 /turf/simulated/floor/lino,
 /area/ship/coc_scarab/mess)
@@ -3151,18 +3151,12 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/coc_scarab/atmospherics)
 "qC" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner_wide/dark_green/diagonal,
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
-	pixel_x = -7;
-	pixel_y = 7
+/obj/structure/railing/mapped{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
-	pixel_x = -8;
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/dark,
-/area/ship/coc_scarab/mess)
+/obj/structure/lattice/catwalk/indoor,
+/turf/space/dynamic,
+/area/ship/coc_scarab/exterior)
 "qI" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/lattice,
@@ -5418,7 +5412,7 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Washroom";
 	dir = 4;
-	id = "scarab_washroom"
+	id_tag = "scarab_combustion"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -7761,12 +7755,18 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/engistorage)
 "NU" = (
-/obj/structure/railing/mapped{
-	dir = 8
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner_wide/dark_green/diagonal,
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
+	pixel_x = -7;
+	pixel_y = 7
 	},
-/obj/structure/lattice/catwalk/indoor,
-/turf/space/dynamic,
-/area/ship/coc_scarab/exterior)
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/coc_scarab/mess)
 "NV" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9097,6 +9097,9 @@
 /obj/effect/floor_decal/spline/plain/black,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/small/west,
+/obj/machinery/alarm/east{
+	req_one_access = null
+	},
 /turf/simulated/floor/lino,
 /area/ship/coc_scarab/mess)
 "Ut" = (
@@ -34888,16 +34891,16 @@ cW
 Af
 cW
 FC
-NU
-NU
-NU
-NU
+qC
+qC
+qC
+qC
 NN
 NN
-NU
-NU
-NU
-NU
+qC
+qC
+qC
+qC
 Sw
 cW
 Af
@@ -36942,7 +36945,7 @@ cW
 cW
 cW
 oQ
-NU
+qC
 NN
 Al
 pr
@@ -36955,8 +36958,8 @@ UG
 HP
 Al
 NN
-NU
-NU
+qC
+qC
 cW
 cW
 cW
@@ -39286,16 +39289,16 @@ cW
 cW
 cW
 wp
-NU
-NU
-NU
-NU
-NU
-NU
-NU
-NU
-NU
-NU
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
 UK
 cW
 cW
@@ -39539,9 +39542,9 @@ cW
 wp
 ci
 En
-NU
-NU
-NU
+qC
+qC
+qC
 NN
 Az
 Ea
@@ -39554,7 +39557,7 @@ Ea
 Ea
 EX
 NN
-NU
+qC
 UK
 cW
 cW
@@ -40023,11 +40026,11 @@ cW
 cW
 wp
 WA
-NU
-NU
-NU
-NU
-NU
+qC
+qC
+qC
+qC
+qC
 NN
 qB
 qB
@@ -40040,15 +40043,15 @@ qB
 jL
 rc
 FN
-NU
-NU
-NU
-NU
-NU
-NU
-NU
-NU
-NU
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
 NN
 NN
 SR
@@ -41613,7 +41616,7 @@ xE
 xe
 Ug
 Ug
-NU
+qC
 Sw
 cW
 cW
@@ -43915,7 +43918,7 @@ GB
 Jg
 cu
 pk
-qC
+NU
 FZ
 yy
 jY
@@ -46710,7 +46713,7 @@ cW
 Af
 cW
 FC
-NU
+qC
 NN
 NN
 BZ
@@ -48764,7 +48767,7 @@ cW
 cW
 cW
 tK
-NU
+qC
 NN
 Al
 Zz
@@ -48777,8 +48780,8 @@ OD
 vn
 Al
 NN
-NU
-NU
+qC
+qC
 cW
 cW
 cW

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_deck_2.dmm
@@ -124,13 +124,13 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/engine)
 "aM" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
 /obj/effect/shuttle_landmark/coc_scarab/dock6{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "aP" = (
@@ -1881,10 +1881,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/bunks)
 "jw" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "jx" = (
@@ -2559,8 +2559,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/mess)
 "nr" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "nA" = (
@@ -2589,13 +2589,13 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/porthallway)
 "nG" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 1
 	},
 /obj/structure/railing/mapped{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "nM" = (
@@ -2798,11 +2798,11 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/starboardhallway)
 "oQ" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
 /obj/effect/shuttle_landmark/coc_scarab/dock4,
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "oW" = (
@@ -3154,7 +3154,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "qI" = (
@@ -3310,6 +3310,7 @@
 	dir = 4
 	},
 /obj/item/hullbeacon/red,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "rC" = (
@@ -3848,11 +3849,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/mess)
 "tK" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
 /obj/effect/shuttle_landmark/coc_scarab/dock1,
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "tU" = (
@@ -3917,13 +3918,13 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/engine)
 "ur" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "ut" = (
@@ -4334,13 +4335,13 @@
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/thrust1)
 "wp" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "wE" = (
@@ -4410,7 +4411,6 @@
 /area/ship/coc_scarab/thrust1)
 "wZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
-/obj/structure/lattice/catwalk/indoor,
 /obj/structure/cable/green{
 	icon_state = "11-4"
 	},
@@ -4600,9 +4600,18 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/forehallway)
 "xT" = (
-/obj/structure/lattice/catwalk,
-/turf/space/dynamic,
-/area/ship/coc_scarab/exterior)
+/obj/structure/table/steel,
+/obj/effect/floor_decal/corner_wide/dark_green/diagonal,
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/coc_scarab/mess)
 "xU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4666,8 +4675,8 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/thrust2)
 "yu" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/open/airless,
 /area/ship/coc_scarab/exterior)
 "yv" = (
@@ -4876,13 +4885,13 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/engistorage)
 "zt" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 1
 	},
 /obj/effect/shuttle_landmark/coc_scarab/dock2{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "zu" = (
@@ -4989,11 +4998,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/forehallway)
 "zU" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
 /obj/effect/shuttle_landmark/coc_scarab/dock5{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "zV" = (
@@ -5623,10 +5632,10 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/atmospherics)
 "Cz" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "CA" = (
@@ -5972,10 +5981,10 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/armory)
 "En" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/open/airless,
 /area/ship/coc_scarab/exterior)
 "Er" = (
@@ -6200,13 +6209,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/recycling)
 "FC" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 1
 	},
 /obj/structure/railing/mapped{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "FF" = (
@@ -7025,11 +7034,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/starboardhallway)
 "Ke" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/open/airless,
 /area/ship/coc_scarab/exterior)
 "Ki" = (
@@ -7098,11 +7107,11 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/coc_scarab/grauwolf)
 "Kq" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
 /obj/structure/railing/mapped,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/open/airless,
 /area/ship/coc_scarab/exterior)
 "Kr" = (
@@ -7443,13 +7452,13 @@
 /turf/simulated/floor/plating,
 /area/ship/coc_scarab/engine)
 "Mv" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
 /obj/effect/shuttle_landmark/coc_scarab/dock3{
 	dir = 1
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "My" = (
@@ -7759,13 +7768,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/coc_scarab/engistorage)
-"NU" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/turf/space/dynamic,
-/area/ship/coc_scarab/exterior)
 "NV" = (
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8771,11 +8773,11 @@
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/bridge)
 "Sw" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "SE" = (
@@ -8806,19 +8808,6 @@
 	buckle_dir = 8
 	},
 /obj/effect/floor_decal/corner_wide/dark_green/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/ship/coc_scarab/mess)
-"SN" = (
-/obj/structure/table/steel,
-/obj/effect/floor_decal/corner_wide/dark_green/diagonal,
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/metal{
-	pixel_x = -8;
-	pixel_y = -3
-	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/mess)
 "SO" = (
@@ -8902,10 +8891,10 @@
 /turf/simulated/floor/reinforced,
 /area/ship/coc_scarab/grauwolf)
 "Tp" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/open/airless,
 /area/ship/coc_scarab/exterior)
 "Tr" = (
@@ -9047,7 +9036,7 @@
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "Ug" = (
-/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/open/airless,
 /area/ship/coc_scarab/exterior)
 "Uh" = (
@@ -9083,11 +9072,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/coc_scarab/armory)
 "Uj" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "Ul" = (
@@ -9209,11 +9198,11 @@
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "UK" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
 /obj/structure/railing/mapped,
+/obj/structure/lattice/catwalk/indoor,
 /turf/space/dynamic,
 /area/ship/coc_scarab/exterior)
 "UM" = (
@@ -9569,6 +9558,7 @@
 	dir = 8
 	},
 /obj/item/hullbeacon/red,
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/airless,
 /area/ship/coc_scarab/exterior)
 "WB" = (
@@ -34900,16 +34890,16 @@ cW
 Af
 cW
 FC
-NU
-NU
-NU
-NU
-xT
-xT
-NU
-NU
-NU
-NU
+qC
+qC
+qC
+qC
+NN
+NN
+qC
+qC
+qC
+qC
 Sw
 cW
 Af
@@ -36954,8 +36944,8 @@ cW
 cW
 cW
 oQ
-NU
-xT
+qC
+NN
 Al
 pr
 yH
@@ -36966,9 +36956,9 @@ Ef
 UG
 HP
 Al
-xT
-NU
-NU
+NN
+qC
+qC
 cW
 cW
 cW
@@ -37212,7 +37202,7 @@ cW
 cW
 jw
 jw
-xT
+NN
 Al
 pr
 yH
@@ -37223,7 +37213,7 @@ Ef
 UG
 HP
 Al
-xT
+NN
 jw
 aM
 cW
@@ -39270,11 +39260,11 @@ Af
 cW
 nG
 jw
-xT
+NN
 NN
 BZ
-Al
-Al
+NN
+NN
 bf
 jx
 mh
@@ -39298,16 +39288,16 @@ cW
 cW
 cW
 wp
-NU
-NU
-NU
-NU
-NU
-NU
-NU
-NU
-NU
-NU
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
 UK
 cW
 cW
@@ -39551,10 +39541,10 @@ cW
 wp
 ci
 En
-NU
-NU
-NU
-xT
+qC
+qC
+qC
+NN
 Az
 Ea
 Ea
@@ -39565,8 +39555,8 @@ Ea
 Ea
 Ea
 EX
-xT
-NU
+NN
+qC
 UK
 cW
 cW
@@ -39784,8 +39774,8 @@ ne
 ne
 ne
 FC
-xT
-xT
+NN
+NN
 Wi
 dy
 dy
@@ -40035,12 +40025,12 @@ cW
 cW
 wp
 WA
-NU
-NU
-NU
-NU
-NU
-xT
+qC
+qC
+qC
+qC
+qC
+NN
 qB
 qB
 sy
@@ -40053,16 +40043,16 @@ jL
 rc
 FN
 qC
-NU
-NU
-NU
-NU
-NU
-NU
-NU
-NU
-xT
-xT
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+qC
+NN
+NN
 SR
 qI
 iq
@@ -40081,7 +40071,7 @@ sH
 mu
 mu
 DR
-xT
+NN
 cW
 cW
 cW
@@ -40338,7 +40328,7 @@ sH
 mu
 mu
 DR
-xT
+NN
 cW
 cW
 cW
@@ -40595,7 +40585,7 @@ sH
 mu
 mu
 DR
-xT
+NN
 cW
 cW
 cW
@@ -41625,7 +41615,7 @@ xE
 xe
 Ug
 Ug
-NU
+qC
 Sw
 cW
 cW
@@ -41883,7 +41873,7 @@ ga
 pF
 qI
 Be
-xT
+NN
 Sw
 cW
 cW
@@ -43927,7 +43917,7 @@ GB
 Jg
 cu
 pk
-SN
+xT
 FZ
 yy
 jY
@@ -44453,7 +44443,7 @@ Ue
 Xi
 sM
 ta
-xT
+NN
 Uj
 cW
 cW
@@ -45476,7 +45466,7 @@ KJ
 hj
 ev
 DR
-xT
+NN
 Uj
 cW
 cW
@@ -45951,7 +45941,7 @@ jw
 jw
 jw
 jw
-xT
+NN
 qA
 qA
 Yh
@@ -45973,7 +45963,7 @@ jw
 jw
 jw
 jw
-xT
+NN
 XN
 qI
 Be
@@ -46209,8 +46199,8 @@ ne
 ne
 ne
 nG
-xT
-xT
+NN
+NN
 ht
 jx
 jx
@@ -46493,7 +46483,7 @@ Tp
 jw
 jw
 jw
-xT
+NN
 rn
 Ea
 Ea
@@ -46722,12 +46712,12 @@ cW
 Af
 cW
 FC
-NU
-xT
+qC
+NN
 NN
 BZ
-xT
-xT
+NN
+NN
 is
 jx
 mh
@@ -48776,8 +48766,8 @@ cW
 cW
 cW
 tK
-NU
-xT
+qC
+NN
 Al
 Zz
 oc
@@ -48788,9 +48778,9 @@ Ip
 OD
 vn
 Al
-xT
-NU
-NU
+NN
+qC
+qC
 cW
 cW
 cW
@@ -49034,7 +49024,7 @@ cW
 cW
 jw
 jw
-xT
+NN
 Al
 Zz
 oc
@@ -49045,7 +49035,7 @@ Ip
 OD
 vn
 Al
-xT
+NN
 jw
 Mv
 cW
@@ -51095,8 +51085,8 @@ jw
 jw
 jw
 jw
-xT
-xT
+NN
+NN
 jw
 jw
 jw

--- a/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dmm
+++ b/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dmm
@@ -67,6 +67,19 @@
 /obj/item/storage/bag/inflatable/emergency,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"bt" = (
+/obj/machinery/atmospherics/unary/engine,
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/dorms)
+"bJ" = (
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "bQ" = (
 /obj/structure/table/wood/gamblingtable,
 /obj/item/storage/pill_bottle/dice{
@@ -88,6 +101,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"ce" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "cg" = (
 /obj/effect/step_trigger/teleporter,
 /turf/space/transit/north,
@@ -119,12 +152,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"dC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "dD" = (
 /obj/structure/table/stone/marble,
 /obj/item/reagent_containers/food/condiment/shaker/salt{
@@ -196,6 +223,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"eX" = (
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
+	dir = 8;
+	start_pressure = 4000
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
+"fl" = (
+/obj/structure/ship_weapon_dummy,
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "fx" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -226,6 +269,37 @@
 /obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"fB" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "unathi_pirate_izharshan_shuttle";
+	name = "exterior access button";
+	pixel_x = 26;
+	pixel_y = 10
+	},
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_outer";
+	name = "Ship External Access";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"fJ" = (
+/obj/structure/ship_weapon_dummy,
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "fR" = (
 /obj/structure/ship_weapon_dummy,
 /obj/effect/floor_decal/industrial/warning{
@@ -240,20 +314,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"gq" = (
+"go" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"gr" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/dorms)
+"gq" = (
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "gE" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -325,15 +393,6 @@
 /obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"hv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "is" = (
 /obj/effect/floor_decal/corner_wide/dark_green{
 	dir = 5
@@ -346,6 +405,13 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"iw" = (
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, starboard engines"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "iE" = (
 /obj/machinery/vending/cigarette/hacked,
 /obj/effect/floor_decal/corner_wide/dark_green/full{
@@ -372,11 +438,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"jN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/dorms)
 "jX" = (
 /obj/structure/sink{
 	pixel_y = 18
@@ -387,31 +448,22 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "ll" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
 	dir = 1
 	},
-/turf/simulated/wall/shuttle/raider,
+/obj/effect/floor_decal/carpet{
+	dir = 5
+	},
+/turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "ln" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_wide/dark_green{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "lr" = (
 /obj/effect/floor_decal/corner_wide/dark_green{
 	dir = 10
@@ -472,15 +524,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"mj" = (
-/obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/operations)
-"mE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/dorms)
 "mF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -500,15 +543,6 @@
 /obj/effect/floor_decal/carpet,
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"mL" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/bed/handrail{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/shuttle/unathi_pirate_izharshan/dorms)
 "mT" = (
 /obj/machinery/shower{
 	dir = 1
@@ -570,16 +604,7 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "pg" = (
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 9
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "pz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -592,27 +617,15 @@
 /obj/machinery/appliance/cooker/stove,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"pW" = (
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/unathi_pirate_izharshan/dorms)
-"pX" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_outer";
-	name = "Ship External Access";
-	dir = 1
+"pP" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, airlock"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "re" = (
 /obj/machinery/power/apc/high/south{
@@ -642,15 +655,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"rV" = (
-/obj/effect/floor_decal/corner_wide/dark_green{
-	dir = 10
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "rY" = (
 /obj/structure/bed/handrail{
 	dir = 8
@@ -756,6 +760,28 @@
 	},
 /turf/space/transit/north,
 /area/space)
+"th" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"tx" = (
+/obj/structure/bed/stool/bar/padded/orange,
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "tB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -770,16 +796,6 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"tJ" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "tR" = (
 /obj/machinery/media/jukebox{
 	anchored = 1
@@ -813,11 +829,21 @@
 "uE" = (
 /obj/structure/bed/roller,
 /obj/machinery/vending/wallmed1{
-	pixel_x = -26
+	pixel_x = -26;
+	req_access = list()
 	},
 /obj/effect/floor_decal/industrial/outline/medical,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"uH" = (
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 5
+	},
+/obj/structure/sign/flag/izharshan{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "uK" = (
 /obj/machinery/alarm/west{
 	req_one_access = list(210)
@@ -844,13 +870,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"vC" = (
-/obj/structure/bed/stool/bar/padded/orange,
-/obj/effect/floor_decal/carpet{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "wk" = (
 /obj/effect/landmark/entry_point/port{
 	name = "port, dorms"
@@ -922,32 +941,6 @@
 /obj/item/pen,
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"yh" = (
-/obj/machinery/door/airlock/hatch{
-	req_access = list(210);
-	dir = 4;
-	name = "Crew Dormitories"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/grey,
-/obj/machinery/door/firedoor/noid{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "yo" = (
 /obj/structure/grille,
 /turf/simulated/floor/airless,
@@ -961,38 +954,17 @@
 "yN" = (
 /turf/template_noop,
 /area/space)
-"yO" = (
-/obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/dorms)
-"yZ" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
+"zn" = (
+/obj/effect/floor_decal/corner_wide/dark_green/full,
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = 6;
+	pixel_y = 1
 	},
-/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
-	dir = 8;
-	start_pressure = 4000
+/obj/structure/filingcabinet/filingcabinet{
+	pixel_x = -9;
+	pixel_y = 1
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/operations)
-"zj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "zr" = (
 /obj/structure/grille,
@@ -1085,23 +1057,6 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
-"Bi" = (
-/obj/effect/floor_decal/corner_wide/dark_green{
-	dir = 5
-	},
-/obj/structure/sign/flag/izharshan{
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"Br" = (
-/obj/structure/ship_weapon_dummy,
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 10
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
@@ -1230,32 +1185,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"Du" = (
+"Df" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
+/obj/structure/bed/handrail{
+	dir = 1
 	},
 /turf/simulated/floor/airless,
-/area/shuttle/unathi_pirate_izharshan/helm)
+/area/shuttle/unathi_pirate_izharshan/operations)
 "DI" = (
-/obj/effect/floor_decal/corner_wide/dark_green/full,
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/obj/structure/filingcabinet/filingcabinet{
-	pixel_x = -9;
-	pixel_y = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "DY" = (
 /obj/structure/lattice,
@@ -1278,6 +1219,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"Ew" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "EC" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -1287,24 +1235,21 @@
 /area/shuttle/unathi_pirate_izharshan/operations)
 "ED" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_wide/dark_green{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"ER" = (
+/obj/structure/ship_weapon_dummy,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "EY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
@@ -1356,41 +1301,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"FL" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1380;
-	master_tag = "unathi_pirate_izharshan_shuttle";
-	name = "exterior access button";
-	pixel_x = 26;
-	pixel_y = 10
+"Ga" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_outer";
-	name = "Ship External Access";
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
-	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"FM" = (
-/obj/effect/floor_decal/carpet{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 5
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Gb" = (
 /obj/structure/cable{
@@ -1400,13 +1315,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
-	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/operations)
-"Gh" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, starboard engines"
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
@@ -1454,6 +1362,13 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"Hr" = (
+/obj/structure/bed/stool/bar/padded/orange,
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "HZ" = (
 /obj/machinery/iff_beacon,
 /obj/effect/floor_decal/industrial/warning/full,
@@ -1476,6 +1391,15 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "IM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"Jt" = (
 /obj/machinery/hologram/holopad/long_range,
 /obj/effect/floor_decal/industrial/outline/custodial,
 /obj/effect/overmap/visitable/ship/landable/unathi_pirate_izharshan,
@@ -1508,9 +1432,6 @@
 	id = "izharshan_cockpit"
 	},
 /turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"Kf" = (
-/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Kt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -1595,6 +1516,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"Ml" = (
+/obj/structure/ship_weapon_dummy,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 10
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "My" = (
 /obj/machinery/power/apc/high/east{
 	req_access = list(210)
@@ -1630,13 +1559,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"MW" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, port engines"
-	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/dorms)
 "Nc" = (
 /obj/machinery/light{
 	dir = 8
@@ -1661,13 +1583,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"NA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "NR" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector{
@@ -1679,6 +1594,22 @@
 /obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"NY" = (
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 9
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"Oj" = (
+/obj/machinery/atmospherics/unary/engine,
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "Ol" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
@@ -1689,6 +1620,34 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"OK" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/dorms)
+"Pp" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_sensor";
+	pixel_x = -25;
+	pixel_y = 9;
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "Pq" = (
 /obj/effect/decal/cleanable/dirt{
 	pixel_x = -1
@@ -1789,6 +1748,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"QR" = (
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, port engines"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "Rf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1857,6 +1823,32 @@
 /obj/structure/reagent_dispensers/coolanttank,
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"Td" = (
+/obj/machinery/door/airlock/hatch{
+	req_access = list(210);
+	dir = 4;
+	name = "Crew Dormitories"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "Ti" = (
 /obj/effect/shuttle_landmark/ship/unathi_pirate_izharshan{
 	dir = 1
@@ -1967,29 +1959,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"Vx" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_sensor";
-	pixel_x = -25;
-	pixel_y = 9;
+"Vs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"VN" = (
-/obj/structure/ship_weapon_dummy,
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "VS" = (
 /obj/structure/bed/stool/bar/padded/orange,
 /obj/effect/floor_decal/carpet{
@@ -2037,29 +2026,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"Wj" = (
-/obj/structure/bed/stool/bar/padded/orange,
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "Wk" = (
 /obj/effect/landmark/entry_point/east{
 	name = "east, engineering"
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"WM" = (
-/obj/structure/ship_weapon_dummy,
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "WN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "WY" = (
@@ -2119,15 +2094,6 @@
 /obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"XQ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/bed/handrail{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "XV" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -2147,17 +2113,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"Yo" = (
-/obj/structure/ship_weapon_dummy,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "YA" = (
 /obj/structure/closet,
 /obj/item/clothing/head/unathi,
@@ -2208,6 +2163,42 @@
 /obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"YL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"YX" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_outer";
+	name = "Ship External Access";
+	dir = 1
+	},
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, airlock"
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "Zi" = (
 /obj/structure/table/reinforced/steel,
 /obj/effect/floor_decal/corner_wide/dark_green{
@@ -2297,6 +2288,16 @@
 "ZU" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"ZW" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 
 (1,1,1) = {"
 yN
@@ -31729,7 +31730,7 @@ ZU
 pz
 AK
 AS
-Br
+Ml
 ZU
 ZU
 ZU
@@ -31971,7 +31972,7 @@ yN
 yN
 yN
 yN
-mj
+Oj
 Kt
 Qs
 rL
@@ -31985,10 +31986,10 @@ fx
 Rm
 sq
 sS
-VN
+fl
 MH
-WM
-Yo
+fJ
+ER
 Ai
 yN
 yN
@@ -32228,7 +32229,7 @@ yN
 yN
 yN
 yN
-Gh
+iw
 Kt
 Cj
 Hd
@@ -32742,18 +32743,18 @@ yN
 yN
 yN
 yN
-XQ
+Df
 ZU
 wz
 Ib
-yZ
+eX
 ou
 xF
 iE
 tR
 jv
-ED
-DI
+Vs
+zn
 xF
 xM
 uK
@@ -32999,17 +33000,17 @@ yN
 yN
 yN
 yN
-Du
+th
 ZU
 SS
 xp
 xF
 xF
 xF
-Bi
-Kf
-Kf
-zj
+uH
+pg
+pg
+YL
 se
 xF
 us
@@ -33256,21 +33257,21 @@ yN
 yN
 yN
 yN
-dC
-ll
-NA
+Ga
+ED
+Ew
 xF
 xF
 NR
 Et
-pg
-Wj
-Wj
+NY
+tx
+tx
 VT
-rV
+bJ
 xF
 ak
-IM
+Jt
 eD
 JT
 dr
@@ -33513,13 +33514,13 @@ yN
 yN
 yN
 yN
-pX
+YX
 LL
 Tt
 ZO
 oZ
 lQ
-gq
+DI
 VS
 AC
 UF
@@ -33770,13 +33771,13 @@ yN
 yN
 yN
 Ti
-FL
+fB
 rY
 gE
 Zs
 eu
 nB
-Kf
+pg
 VS
 bQ
 xX
@@ -33784,7 +33785,7 @@ By
 Db
 Sl
 is
-tJ
+pP
 QF
 xF
 Yf
@@ -34034,14 +34035,14 @@ xF
 xF
 hq
 eV
-FM
-vC
-vC
+ll
+Hr
+Hr
 WY
 re
 xF
 lX
-hv
+IM
 zR
 JT
 dr
@@ -34284,7 +34285,7 @@ yN
 yN
 yN
 yN
-Vx
+Pp
 zZ
 QD
 zZ
@@ -34292,13 +34293,13 @@ xF
 xF
 xF
 uP
-Kf
-Kf
-zj
+pg
+pg
+YL
 se
 xF
 KE
-gr
+ZW
 Qj
 JT
 dr
@@ -34541,7 +34542,7 @@ yN
 yN
 yN
 yN
-mL
+OK
 zZ
 Pq
 zZ
@@ -34551,7 +34552,7 @@ xF
 Px
 lu
 GG
-ln
+ce
 ai
 xF
 bs
@@ -34803,12 +34804,12 @@ zZ
 sI
 zZ
 Fv
-pW
+gq
 xF
 xF
 xF
 xF
-yh
+Td
 xF
 xF
 xF
@@ -35055,7 +35056,7 @@ yN
 yN
 yN
 yN
-MW
+QR
 Mi
 Ol
 Fj
@@ -35312,18 +35313,18 @@ yN
 yN
 yN
 yN
-yO
+bt
 Mi
 CJ
 Xz
-mE
-jN
+go
 WN
-WN
-WN
+ln
+ln
+ln
 bl
 Lz
-pW
+gq
 Ay
 El
 jX

--- a/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dmm
+++ b/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dmm
@@ -67,19 +67,6 @@
 /obj/item/storage/bag/inflatable/emergency,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"bt" = (
-/obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/dorms)
-"bJ" = (
-/obj/effect/floor_decal/corner_wide/dark_green{
-	dir = 10
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "bQ" = (
 /obj/structure/table/wood/gamblingtable,
 /obj/item/storage/pill_bottle/dice{
@@ -101,26 +88,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"ce" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_wide/dark_green{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "cg" = (
 /obj/effect/step_trigger/teleporter,
 /turf/space/transit/north,
@@ -223,22 +190,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"eX" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
+"fi" = (
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
-	dir = 8;
-	start_pressure = 4000
+/obj/structure/sign/flag/izharshan{
+	pixel_y = 28
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/operations)
-"fl" = (
-/obj/structure/ship_weapon_dummy,
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "fx" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -269,42 +229,14 @@
 /obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"fB" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1380;
-	master_tag = "unathi_pirate_izharshan_shuttle";
-	name = "exterior access button";
-	pixel_x = 26;
-	pixel_y = 10
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_outer";
-	name = "Ship External Access";
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
-	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"fJ" = (
-/obj/structure/ship_weapon_dummy,
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "fR" = (
 /obj/structure/ship_weapon_dummy,
 /obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
 	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
@@ -314,13 +246,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"go" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/dorms)
 "gq" = (
-/turf/simulated/floor/carpet/rubber,
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, port engines"
+	},
+/turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "gE" = (
 /obj/machinery/light/small{
@@ -405,13 +336,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"iw" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, starboard engines"
-	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "iE" = (
 /obj/machinery/vending/cigarette/hacked,
 /obj/effect/floor_decal/corner_wide/dark_green/full{
@@ -431,6 +355,16 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"jq" = (
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/unathi_pirate_izharshan/dorms)
+"jr" = (
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, starboard engines"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "jv" = (
 /obj/machinery/vending/boozeomat/unathi_pirate,
 /obj/effect/floor_decal/corner_wide/dark_green{
@@ -442,28 +376,34 @@
 /obj/structure/sink{
 	pixel_y = 18
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8;
+	level = 2
+	},
+/obj/structure/mirror{
+	pixel_y = 33
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"ll" = (
-/obj/effect/floor_decal/carpet{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet{
+"kG" = (
+/obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/dorms)
+"ll" = (
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"ln" = (
+/obj/structure/bed/stool/bar/padded/orange,
 /obj/effect/floor_decal/carpet{
-	dir = 5
+	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"ln" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/dorms)
 "lr" = (
 /obj/effect/floor_decal/corner_wide/dark_green{
 	dir = 10
@@ -498,6 +438,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"lL" = (
+/obj/structure/ship_weapon_dummy,
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "lQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark,
@@ -524,6 +471,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"mn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/dorms)
+"mu" = (
+/obj/machinery/atmospherics/unary/engine,
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "mF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -544,13 +500,20 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "mT" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain/open/shower,
+/obj/structure/table/rack,
 /obj/item/soap/orange_soap,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"nh" = (
+/obj/structure/bed/stool/bar/padded/orange,
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "ns" = (
 /obj/machinery/computer/ship/helm{
 	dir = 1
@@ -604,7 +567,16 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "pg" = (
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 5
+	},
+/turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "pz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -617,15 +589,26 @@
 /obj/machinery/appliance/cooker/stove,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"pP" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+"qp" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"qV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 1
+	},
+/turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "re" = (
 /obj/machinery/power/apc/high/south{
@@ -640,6 +623,12 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"rp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "rL" = (
 /obj/machinery/light{
@@ -760,28 +749,6 @@
 	},
 /turf/space/transit/north,
 /area/space)
-"th" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
-	},
-/turf/simulated/floor/airless,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"tx" = (
-/obj/structure/bed/stool/bar/padded/orange,
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/turf/simulated/floor/carpet,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "tB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -826,6 +793,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"uB" = (
+/obj/structure/bed/stool/chair/shuttle,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "uE" = (
 /obj/structure/bed/roller,
 /obj/machinery/vending/wallmed1{
@@ -835,15 +806,6 @@
 /obj/effect/floor_decal/industrial/outline/medical,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"uH" = (
-/obj/effect/floor_decal/corner_wide/dark_green{
-	dir = 5
-	},
-/obj/structure/sign/flag/izharshan{
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "uK" = (
 /obj/machinery/alarm/west{
 	req_one_access = list(210)
@@ -954,18 +916,6 @@
 "yN" = (
 /turf/template_noop,
 /area/space)
-"zn" = (
-/obj/effect/floor_decal/corner_wide/dark_green/full,
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/obj/structure/filingcabinet/filingcabinet{
-	pixel_x = -9;
-	pixel_y = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "zr" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -1038,6 +988,11 @@
 	},
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"AD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "AK" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/clothing/ears/earmuffs,
@@ -1185,18 +1140,34 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"Df" = (
+"Di" = (
+/obj/structure/ship_weapon_dummy,
 /obj/effect/floor_decal/industrial/warning{
-	dir = 1
+	layer = 2.71;
+	dir = 4
 	},
-/obj/structure/bed/handrail{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"Dp" = (
+/obj/effect/floor_decal/corner_wide/dark_green/full,
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/structure/filingcabinet/filingcabinet{
+	pixel_x = -9;
+	pixel_y = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "DI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "DY" = (
 /obj/structure/lattice,
@@ -1204,11 +1175,13 @@
 /turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "El" = (
-/obj/structure/mirror{
-	pixel_y = 1
+/obj/structure/ship_weapon_dummy,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 10
 	},
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/unathi_pirate_izharshan/dorms)
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "Et" = (
 /obj/machinery/light{
 	dir = 8
@@ -1219,13 +1192,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"Ew" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "EC" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -1235,28 +1201,25 @@
 /area/shuttle/unathi_pirate_izharshan/operations)
 "ED" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 1
+	dir = 4
 	},
-/turf/simulated/wall/shuttle/raider,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"ER" = (
-/obj/structure/ship_weapon_dummy,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "EY" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8;
-	level = 2
-	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	pixel_y = 12
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
@@ -1264,7 +1227,7 @@
 /obj/machinery/door/airlock/hatch{
 	req_access = list(210);
 	dir = 4;
-	name = "Engineering"
+	name = "Crew Dormitories"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -1301,12 +1264,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"Ga" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/unathi_pirate_izharshan/helm)
+"FV" = (
+/obj/structure/ship_weapon_dummy,
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "Gb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1362,13 +1323,6 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"Hr" = (
-/obj/structure/bed/stool/bar/padded/orange,
-/obj/effect/floor_decal/carpet{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "HZ" = (
 /obj/machinery/iff_beacon,
 /obj/effect/floor_decal/industrial/warning/full,
@@ -1388,6 +1342,12 @@
 /area/shuttle/unathi_pirate_izharshan/operations)
 "Ih" = (
 /obj/structure/bed/stool/chair/shuttle,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "IM" = (
@@ -1397,12 +1357,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"Jt" = (
-/obj/machinery/hologram/holopad/long_range,
-/obj/effect/floor_decal/industrial/outline/custodial,
-/obj/effect/overmap/visitable/ship/landable/unathi_pirate_izharshan,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "JF" = (
@@ -1446,12 +1400,40 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"KH" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "KL" = (
 /obj/effect/landmark/entry_point/east{
 	name = "east, gunnery"
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"KO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_sensor";
+	pixel_x = -25;
+	pixel_y = 9;
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "KZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/vending/engivend{
@@ -1516,14 +1498,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"Ml" = (
-/obj/structure/ship_weapon_dummy,
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 10
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "My" = (
 /obj/machinery/power/apc/high/east{
 	req_access = list(210)
@@ -1583,6 +1557,10 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"Nt" = (
+/obj/machinery/atmospherics/unary/engine,
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "NR" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector{
@@ -1594,22 +1572,6 @@
 /obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"NY" = (
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 9
-	},
-/turf/simulated/floor/carpet,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"Oj" = (
-/obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "Ol" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5;
@@ -1620,33 +1582,35 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"OK" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+"On" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"Pa" = (
+/obj/machinery/door/airlock/hatch{
+	req_access = list(210);
+	dir = 4;
+	name = "Engineering"
 	},
-/obj/structure/bed/handrail{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/shuttle/unathi_pirate_izharshan/dorms)
-"Pp" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_sensor";
-	pixel_x = -25;
-	pixel_y = 9;
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Pq" = (
 /obj/effect/decal/cleanable/dirt{
@@ -1707,11 +1671,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /obj/machinery/alarm/north{
 	req_one_access = list(210)
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
@@ -1748,13 +1712,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"QR" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, port engines"
-	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/dorms)
 "Rf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1799,6 +1756,13 @@
 /obj/effect/floor_decal/industrial/outline/medical,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"Sc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "Sl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1814,21 +1778,7 @@
 /obj/machinery/meter,
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"SS" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/outline/engineering,
-/obj/item/reagent_containers/glass/bucket,
-/obj/structure/reagent_dispensers/coolanttank,
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/operations)
-"Td" = (
-/obj/machinery/door/airlock/hatch{
-	req_access = list(210);
-	dir = 4;
-	name = "Crew Dormitories"
-	},
+"Sy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -1843,12 +1793,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/hatch/grey,
-/obj/machinery/door/firedoor/noid{
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"SS" = (
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
+/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
+	dir = 8;
+	start_pressure = 4000
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "Ti" = (
 /obj/effect/shuttle_landmark/ship/unathi_pirate_izharshan{
 	dir = 1
@@ -1881,6 +1842,7 @@
 	req_access = list(210);
 	dir = 4;
 	name = "Washroom";
+	id_tag = "izharshan_washroom";
 	id = "izharshan_washroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1914,9 +1876,34 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"UB" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_outer";
+	name = "Ship External Access";
+	dir = 1
+	},
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, airlock"
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "UF" = (
 /obj/structure/table/wood/gamblingtable,
 /turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"UK" = (
+/obj/machinery/hologram/holopad/long_range,
+/obj/effect/floor_decal/industrial/outline/custodial,
+/obj/effect/overmap/visitable/ship/landable/unathi_pirate_izharshan,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Vb" = (
 /obj/machinery/light{
@@ -1959,26 +1946,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"Vs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_wide/dark_green{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "VS" = (
 /obj/structure/bed/stool/bar/padded/orange,
 /obj/effect/floor_decal/carpet{
@@ -2034,7 +2001,7 @@
 /area/shuttle/unathi_pirate_izharshan/operations)
 "WN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "WY" = (
@@ -2066,6 +2033,30 @@
 	},
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"Xw" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "unathi_pirate_izharshan_shuttle";
+	name = "exterior access button";
+	pixel_x = 26;
+	pixel_y = 10
+	},
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_outer";
+	name = "Ship External Access";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "Xz" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(210)
@@ -2094,8 +2085,19 @@
 /obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"XD" = (
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 9
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "XV" = (
-/obj/structure/mopbucket,
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/button/remote/airlock{
@@ -2104,14 +2106,26 @@
 	name = "Washroom Bolt Control";
 	pixel_x = -24;
 	pixel_y = 4;
-	specialfunctions = 4
+	specialfunctions = 4;
+	req_access = list(210)
 	},
+/obj/structure/table/rack,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "Yf" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"Yr" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "YA" = (
 /obj/structure/closet,
@@ -2163,7 +2177,16 @@
 /obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"YL" = (
+"YV" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/item/reagent_containers/glass/bucket,
+/obj/structure/reagent_dispensers/coolanttank,
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
+"Zf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -2178,26 +2201,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"YX" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_outer";
-	name = "Ship External Access";
-	dir = 1
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 9
 	},
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, airlock"
-	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Zi" = (
 /obj/structure/table/reinforced/steel,
@@ -2208,7 +2215,8 @@
 	name = "Cockpit Blast Shutters";
 	id = "izharshan_cockpit";
 	pixel_y = 8;
-	pixel_x = -5
+	pixel_x = -5;
+	req_access = list(210)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
@@ -2288,16 +2296,6 @@
 "ZU" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"ZW" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
 
 (1,1,1) = {"
 yN
@@ -31730,7 +31728,7 @@ ZU
 pz
 AK
 AS
-Ml
+El
 ZU
 ZU
 ZU
@@ -31972,7 +31970,7 @@ yN
 yN
 yN
 yN
-Oj
+mu
 Kt
 Qs
 rL
@@ -31986,10 +31984,10 @@ fx
 Rm
 sq
 sS
-fl
+FV
 MH
-fJ
-ER
+lL
+fR
 Ai
 yN
 yN
@@ -32229,7 +32227,7 @@ yN
 yN
 yN
 yN
-iw
+jr
 Kt
 Cj
 Hd
@@ -32243,7 +32241,7 @@ Wc
 ZU
 xg
 Ni
-fR
+Di
 pb
 yo
 yo
@@ -32496,7 +32494,7 @@ xF
 xF
 xF
 xF
-Fg
+Pa
 xF
 xF
 iW
@@ -32743,18 +32741,18 @@ yN
 yN
 yN
 yN
-Df
+KH
 ZU
 wz
 Ib
-eX
+SS
 ou
 xF
 iE
 tR
 jv
-Vs
-zn
+Zf
+Dp
 xF
 xM
 uK
@@ -33000,21 +32998,21 @@ yN
 yN
 yN
 yN
-th
+qp
 ZU
-SS
+YV
 xp
 xF
 xF
 xF
-uH
-pg
-pg
-YL
+fi
+ll
+ll
+ED
 se
 xF
 us
-Ih
+uB
 ns
 JT
 dr
@@ -33257,21 +33255,21 @@ yN
 yN
 yN
 yN
-Ga
-ED
-Ew
+rp
+qV
+Sc
 xF
 xF
 NR
 Et
-NY
-tx
-tx
+XD
+ln
+ln
 VT
-bJ
+DI
 xF
 ak
-Jt
+UK
 eD
 JT
 dr
@@ -33514,13 +33512,13 @@ yN
 yN
 yN
 yN
-YX
+UB
 LL
 Tt
 ZO
 oZ
 lQ
-DI
+On
 VS
 AC
 UF
@@ -33528,7 +33526,7 @@ mF
 lr
 wK
 BH
-Ih
+uB
 Zi
 xF
 Yf
@@ -33771,13 +33769,13 @@ yN
 yN
 yN
 Ti
-fB
+Xw
 rY
 gE
 Zs
 eu
 nB
-pg
+ll
 VS
 bQ
 xX
@@ -33785,7 +33783,7 @@ By
 Db
 Sl
 is
-pP
+Yr
 QF
 xF
 Yf
@@ -34035,9 +34033,9 @@ xF
 xF
 hq
 eV
-ll
-Hr
-Hr
+pg
+nh
+nh
 WY
 re
 xF
@@ -34285,7 +34283,7 @@ yN
 yN
 yN
 yN
-Pp
+KO
 zZ
 QD
 zZ
@@ -34293,13 +34291,13 @@ xF
 xF
 xF
 uP
-pg
-pg
-YL
+ll
+ll
+ED
 se
 xF
 KE
-ZW
+Ih
 Qj
 JT
 dr
@@ -34542,7 +34540,7 @@ yN
 yN
 yN
 yN
-OK
+kG
 zZ
 Pq
 zZ
@@ -34552,7 +34550,7 @@ xF
 Px
 lu
 GG
-ce
+Sy
 ai
 xF
 bs
@@ -34804,12 +34802,12 @@ zZ
 sI
 zZ
 Fv
-gq
+jq
 xF
 xF
 xF
 xF
-Td
+Fg
 xF
 xF
 xF
@@ -35056,7 +35054,7 @@ yN
 yN
 yN
 yN
-QR
+gq
 Mi
 Ol
 Fj
@@ -35313,20 +35311,20 @@ yN
 yN
 yN
 yN
-bt
+Nt
 Mi
 CJ
 Xz
-go
+mn
+AD
 WN
-ln
-ln
-ln
+WN
+WN
 bl
 Lz
-gq
+jq
 Ay
-El
+zZ
 jX
 zu
 zZ

--- a/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dmm
+++ b/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dmm
@@ -44,6 +44,18 @@
 /obj/effect/floor_decal/corner_wide/dark_green/full,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"aM" = (
+/obj/effect/floor_decal/corner_wide/dark_green/full,
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/structure/filingcabinet/filingcabinet{
+	pixel_x = -9;
+	pixel_y = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "bl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/green{
@@ -159,6 +171,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"ex" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "eD" = (
 /obj/machinery/computer/shuttle_control/explore/unathi_pirate_izharshan{
 	dir = 1
@@ -181,6 +213,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"eT" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "eV" = (
 /obj/machinery/light{
 	dir = 4
@@ -190,14 +232,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"fi" = (
-/obj/effect/floor_decal/corner_wide/dark_green{
-	dir = 5
+"fg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 1
 	},
-/obj/structure/sign/flag/izharshan{
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "fx" = (
 /obj/structure/cable/green{
@@ -232,11 +271,8 @@
 "fR" = (
 /obj/structure/ship_weapon_dummy,
 /obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
-	dir = 8
+	dir = 10
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
@@ -248,11 +284,8 @@
 /area/shuttle/unathi_pirate_izharshan/operations)
 "gq" = (
 /obj/machinery/atmospherics/unary/engine,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, port engines"
-	},
 /turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/dorms)
+/area/shuttle/unathi_pirate_izharshan/operations)
 "gE" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -355,16 +388,6 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"jq" = (
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/unathi_pirate_izharshan/dorms)
-"jr" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, starboard engines"
-	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "jv" = (
 /obj/machinery/vending/boozeomat/unathi_pirate,
 /obj/effect/floor_decal/corner_wide/dark_green{
@@ -385,24 +408,51 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"kG" = (
+"lk" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/bed/handrail{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
 	},
 /turf/simulated/floor/airless,
-/area/shuttle/unathi_pirate_izharshan/dorms)
-"ll" = (
-/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"ln" = (
+"ll" = (
 /obj/structure/bed/stool/bar/padded/orange,
 /obj/effect/floor_decal/carpet{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"ln" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "unathi_pirate_izharshan_shuttle";
+	name = "exterior access button";
+	pixel_x = 26;
+	pixel_y = 10
+	},
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_outer";
+	name = "Ship External Access";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "lr" = (
 /obj/effect/floor_decal/corner_wide/dark_green{
@@ -438,13 +488,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"lL" = (
-/obj/structure/ship_weapon_dummy,
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "lQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark,
@@ -471,14 +514,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"mn" = (
+"md" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"mu" = (
-/obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor,
+"mm" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "mF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -507,12 +555,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"nh" = (
-/obj/structure/bed/stool/bar/padded/orange,
-/obj/effect/floor_decal/carpet{
-	dir = 4
+"nm" = (
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 5
 	},
-/turf/simulated/floor/carpet,
+/obj/structure/sign/flag/izharshan{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "ns" = (
 /obj/machinery/computer/ship/helm{
@@ -532,10 +582,29 @@
 "nL" = (
 /turf/space,
 /area/space)
+"ob" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_sensor";
+	pixel_x = -25;
+	pixel_y = 9;
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "ou" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
 	dir = 8;
-	start_pressure = 4000
+	start_pressure = 10000
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -567,16 +636,7 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "pg" = (
-/obj/effect/floor_decal/carpet{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 5
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "pz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -589,27 +649,10 @@
 /obj/machinery/appliance/cooker/stove,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"qp" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
-	},
-/turf/simulated/floor/airless,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"qV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 1
-	},
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/unathi_pirate_izharshan/helm)
+"qI" = (
+/obj/structure/ship_weapon_dummy,
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "re" = (
 /obj/machinery/power/apc/high/south{
 	req_access = list(210)
@@ -623,12 +666,6 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"rp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "rL" = (
 /obj/machinery/light{
@@ -644,6 +681,32 @@
 /obj/machinery/meter,
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"rS" = (
+/obj/machinery/door/airlock/hatch{
+	req_access = list(210);
+	dir = 4;
+	name = "Engineering"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "rY" = (
 /obj/structure/bed/handrail{
 	dir = 8
@@ -690,6 +753,13 @@
 /obj/effect/floor_decal/industrial/loading/yellow,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"sB" = (
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, port engines"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "sI" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
@@ -792,10 +862,6 @@
 	pixel_x = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"uB" = (
-/obj/structure/bed/stool/chair/shuttle,
-/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "uE" = (
 /obj/structure/bed/roller,
@@ -903,6 +969,13 @@
 /obj/item/pen,
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"yl" = (
+/obj/structure/ship_weapon_dummy,
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "yo" = (
 /obj/structure/grille,
 /turf/simulated/floor/airless,
@@ -916,6 +989,25 @@
 "yN" = (
 /turf/template_noop,
 /area/space)
+"zo" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_outer";
+	name = "Ship External Access";
+	dir = 1
+	},
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, airlock"
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "zr" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -949,6 +1041,30 @@
 "zZ" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"Aa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet,
+/obj/effect/floor_decal/carpet{
+	dir = 10
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "Ac" = (
 /obj/machinery/vending/dinnerware,
 /obj/effect/decal/cleanable/dirt,
@@ -988,11 +1104,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"AD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/dorms)
 "AK" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/clothing/ears/earmuffs,
@@ -1140,26 +1251,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"Di" = (
-/obj/structure/ship_weapon_dummy,
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
-"Dp" = (
-/obj/effect/floor_decal/corner_wide/dark_green/full,
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/obj/structure/filingcabinet/filingcabinet{
-	pixel_x = -9;
-	pixel_y = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "DI" = (
 /obj/effect/floor_decal/corner_wide/dark_green{
 	dir = 10
@@ -1174,14 +1265,18 @@
 /obj/structure/grille,
 /turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"El" = (
+"Ec" = (
 /obj/structure/ship_weapon_dummy,
 /obj/effect/floor_decal/industrial/warning{
 	layer = 2.71;
-	dir = 10
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"El" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "Et" = (
 /obj/machinery/light{
 	dir = 8
@@ -1200,21 +1295,19 @@
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "ED" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/unathi_pirate_izharshan/dorms)
+"EI" = (
+/obj/effect/floor_decal/carpet{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/carpet{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/carpet{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "EY" = (
 /obj/structure/curtain/open/shower,
@@ -1264,10 +1357,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"FV" = (
-/obj/structure/ship_weapon_dummy,
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "Gb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1323,6 +1412,12 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"Hw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "HZ" = (
 /obj/machinery/iff_beacon,
 /obj/effect/floor_decal/industrial/warning/full,
@@ -1342,12 +1437,6 @@
 /area/shuttle/unathi_pirate_izharshan/operations)
 "Ih" = (
 /obj/structure/bed/stool/chair/shuttle,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "IM" = (
@@ -1358,6 +1447,26 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"Jy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "JF" = (
 /obj/machinery/power/apc/high/west{
@@ -1400,40 +1509,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"KH" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/bed/handrail{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "KL" = (
 /obj/effect/landmark/entry_point/east{
 	name = "east, gunnery"
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"KO" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_sensor";
-	pixel_x = -25;
-	pixel_y = 9;
-	dir = 4
-	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
-	},
-/turf/simulated/floor/airless,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "KZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/vending/engivend{
@@ -1445,6 +1526,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"Lm" = (
+/obj/structure/bed/stool/bar/padded/orange,
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "Lz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
@@ -1494,6 +1582,18 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"LO" = (
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
+	dir = 8;
+	start_pressure = 10000
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "Mi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/shuttle/raider,
@@ -1557,10 +1657,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"Nt" = (
-/obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/dorms)
 "NR" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector{
@@ -1582,33 +1678,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"On" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"Pa" = (
-/obj/machinery/door/airlock/hatch{
-	req_access = list(210);
-	dir = 4;
-	name = "Engineering"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"Pe" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/grey,
-/obj/machinery/door/firedoor/noid{
-	dir = 4
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
@@ -1646,6 +1722,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/rubber,
+/area/shuttle/unathi_pirate_izharshan/dorms)
+"Qd" = (
+/obj/machinery/atmospherics/unary/engine,
+/turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "Qj" = (
 /obj/effect/floor_decal/corner_wide/dark_green{
@@ -1756,13 +1836,6 @@
 /obj/effect/floor_decal/industrial/outline/medical,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"Sc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "Sl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1778,36 +1851,13 @@
 /obj/machinery/meter,
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"Sy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_wide/dark_green{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "SS" = (
 /obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
-	dir = 8;
-	start_pressure = 4000
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/item/reagent_containers/glass/bucket,
+/obj/structure/reagent_dispensers/coolanttank,
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "Ti" = (
@@ -1857,6 +1907,12 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"TT" = (
+/obj/machinery/hologram/holopad/long_range,
+/obj/effect/floor_decal/industrial/outline/custodial,
+/obj/effect/overmap/visitable/ship/landable/unathi_pirate_izharshan,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "Ut" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1876,35 +1932,28 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"UB" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_outer";
-	name = "Ship External Access";
-	dir = 1
+"Uu" = (
+/obj/structure/ship_weapon_dummy,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, airlock"
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
-	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/helm)
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "UF" = (
 /obj/structure/table/wood/gamblingtable,
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"UK" = (
-/obj/machinery/hologram/holopad/long_range,
-/obj/effect/floor_decal/industrial/outline/custodial,
-/obj/effect/overmap/visitable/ship/landable/unathi_pirate_izharshan,
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
+"UM" = (
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, starboard engines"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "Vb" = (
 /obj/machinery/light{
 	dir = 4
@@ -1946,10 +1995,29 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"Vq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"VE" = (
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 5
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "VS" = (
 /obj/structure/bed/stool/bar/padded/orange,
 /obj/effect/floor_decal/carpet{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
@@ -1968,14 +2036,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet,
-/obj/effect/floor_decal/carpet{
-	dir = 10
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Wc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -2033,30 +2094,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"Xw" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1380;
-	master_tag = "unathi_pirate_izharshan_shuttle";
-	name = "exterior access button";
-	pixel_x = 26;
-	pixel_y = 10
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_outer";
-	name = "Ship External Access";
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
-	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "Xz" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(210)
@@ -2085,18 +2122,6 @@
 /obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"XD" = (
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 9
-	},
-/turf/simulated/floor/carpet,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "XV" = (
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
@@ -2116,16 +2141,6 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/simulated/floor/airless,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"Yr" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "YA" = (
 /obj/structure/closet,
@@ -2177,35 +2192,11 @@
 /obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"YV" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/outline/engineering,
-/obj/item/reagent_containers/glass/bucket,
-/obj/structure/reagent_dispensers/coolanttank,
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "Zf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_wide/dark_green{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "Zi" = (
 /obj/structure/table/reinforced/steel,
 /obj/effect/floor_decal/corner_wide/dark_green{
@@ -2296,6 +2287,15 @@
 "ZU" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"ZX" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 
 (1,1,1) = {"
 yN
@@ -31728,7 +31728,7 @@ ZU
 pz
 AK
 AS
-El
+fR
 ZU
 ZU
 ZU
@@ -31970,7 +31970,7 @@ yN
 yN
 yN
 yN
-mu
+gq
 Kt
 Qs
 rL
@@ -31984,10 +31984,10 @@ fx
 Rm
 sq
 sS
-FV
+qI
 MH
-lL
-fR
+yl
+Uu
 Ai
 yN
 yN
@@ -32227,7 +32227,7 @@ yN
 yN
 yN
 yN
-jr
+UM
 Kt
 Cj
 Hd
@@ -32241,7 +32241,7 @@ Wc
 ZU
 xg
 Ni
-Di
+Ec
 pb
 yo
 yo
@@ -32494,7 +32494,7 @@ xF
 xF
 xF
 xF
-Pa
+rS
 xF
 xF
 iW
@@ -32741,18 +32741,18 @@ yN
 yN
 yN
 yN
-KH
+mm
 ZU
 wz
 Ib
-SS
+LO
 ou
 xF
 iE
 tR
 jv
-Zf
-Dp
+Jy
+aM
 xF
 xM
 uK
@@ -32998,21 +32998,21 @@ yN
 yN
 yN
 yN
-qp
+lk
 ZU
-YV
+SS
 xp
 xF
 xF
 xF
-fi
-ll
-ll
-ED
+nm
+pg
+pg
+VT
 se
 xF
 us
-uB
+Ih
 ns
 JT
 dr
@@ -33255,21 +33255,21 @@ yN
 yN
 yN
 yN
-rp
-qV
-Sc
+Hw
+fg
+Vq
 xF
 xF
 NR
 Et
-XD
-ln
-ln
-VT
+EI
+VS
+VS
+Aa
 DI
 xF
 ak
-UK
+TT
 eD
 JT
 dr
@@ -33512,21 +33512,21 @@ yN
 yN
 yN
 yN
-UB
+zo
 LL
 Tt
 ZO
 oZ
 lQ
-On
-VS
+El
+ll
 AC
 UF
 mF
 lr
 wK
 BH
-uB
+Ih
 Zi
 xF
 Yf
@@ -33769,21 +33769,21 @@ yN
 yN
 yN
 Ti
-Xw
+ln
 rY
 gE
 Zs
 eu
 nB
+pg
 ll
-VS
 bQ
 xX
 By
 Db
 Sl
 is
-Yr
+Pe
 QF
 xF
 Yf
@@ -34033,9 +34033,9 @@ xF
 xF
 hq
 eV
-pg
-nh
-nh
+VE
+Lm
+Lm
 WY
 re
 xF
@@ -34283,7 +34283,7 @@ yN
 yN
 yN
 yN
-KO
+ob
 zZ
 QD
 zZ
@@ -34291,13 +34291,13 @@ xF
 xF
 xF
 uP
-ll
-ll
-ED
+pg
+pg
+VT
 se
 xF
 KE
-Ih
+eT
 Qj
 JT
 dr
@@ -34540,7 +34540,7 @@ yN
 yN
 yN
 yN
-kG
+ZX
 zZ
 Pq
 zZ
@@ -34550,7 +34550,7 @@ xF
 Px
 lu
 GG
-Sy
+ex
 ai
 xF
 bs
@@ -34802,7 +34802,7 @@ zZ
 sI
 zZ
 Fv
-jq
+ED
 xF
 xF
 xF
@@ -35054,7 +35054,7 @@ yN
 yN
 yN
 yN
-gq
+sB
 Mi
 Ol
 Fj
@@ -35311,18 +35311,18 @@ yN
 yN
 yN
 yN
-Nt
+Qd
 Mi
 CJ
 Xz
-mn
-AD
+md
+Zf
 WN
 WN
 WN
 bl
 Lz
-jq
+ED
 Ay
 zZ
 jX

--- a/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dmm
+++ b/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dmm
@@ -1,17 +1,28 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ai" = (
 /obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner_wide/dark_green/full{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "ak" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "al" = (
 /obj/structure/closet/walllocker/medical{
-	pixel_x = 32
+	pixel_x = 32;
+	name = "Stabilization Kit"
 	},
 /obj/item/bodybag/cryobag,
 /obj/item/reagent_containers/glass/bottle/toxin,
@@ -25,11 +36,13 @@
 /obj/item/storage/pill_bottle/kelotane,
 /obj/item/storage/pill_bottle/bicaridine,
 /obj/item/storage/pill_bottle/mortaphenyl,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "av" = (
 /obj/machinery/computer/ship/targeting,
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/corner_wide/dark_green/full,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "bl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -38,22 +51,21 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "bs" = (
 /obj/structure/closet/walllocker/emerglocker{
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/effect/floor_decal/corner_wide/dark_green/full{
+	dir = 1
 	},
 /obj/structure/sign/flag/izharshan{
-	pixel_y = 32
+	pixel_y = 28
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/item/storage/bag/inflatable/emergency,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "bQ" = (
 /obj/structure/table/wood/gamblingtable,
@@ -81,48 +93,49 @@
 /turf/space/transit/north,
 /area/space)
 "cU" = (
-/obj/machinery/computer/ship/sensors{
-	dir = 1
-	},
-/turf/simulated/floor/shuttle/black,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"cV" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms";
+/obj/effect/floor_decal/corner_wide/dark_green/full{
 	dir = 4
 	},
-/obj/structure/plasticflaps/airtight,
-/turf/simulated/floor/tiled{
-	name = "cooled floor";
-	temperature = 278
+/obj/machinery/computer/ship/engines{
+	dir = 1
 	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"cV" = (
+/obj/machinery/shipsensors/weak,
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "dr" = (
 /obj/structure/lattice,
-/turf/template_noop,
+/turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "dv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/autolathe{
 	hacked = 1;
 	name = "Modified Autolathe"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"dC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "dD" = (
 /obj/structure/table/stone/marble,
 /obj/item/reagent_containers/food/condiment/shaker/salt{
-	pixel_x = 7;
+	pixel_x = 11;
 	pixel_y = -1
 	},
 /obj/item/reagent_containers/food/condiment/shaker/peppermill{
-	pixel_x = 2;
-	pixel_y = -1
+	pixel_x = 5
 	},
 /obj/item/reagent_containers/food/condiment/shaker/spacespice{
-	pixel_x = -4;
+	pixel_x = -2;
 	pixel_y = 0
 	},
 /obj/item/reagent_containers/food/condiment/enzyme{
@@ -132,32 +145,34 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "et" = (
-/obj/machinery/shipsensors/weak,
+/obj/structure/lattice,
 /turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "eu" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1380;
-	master_tag = "unathi_pirate_izharshan_shuttle";
-	name = "interior access button";
-	pixel_x = 26;
-	pixel_y = -9
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
 	},
-/obj/machinery/door/airlock/external{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airlock_sensor{
 	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_inner";
-	name = "Ship External Access";
-	dir = 1
+	id_tag = "unathi_pirate_izharshan_sensor";
+	pixel_x = 25;
+	pixel_y = -6;
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "eD" = (
 /obj/machinery/computer/shuttle_control/explore/unathi_pirate_izharshan{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "eG" = (
 /obj/structure/closet/walllocker{
@@ -169,11 +184,15 @@
 /obj/random/contraband,
 /obj/random/contraband,
 /obj/random/loot,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "eV" = (
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
@@ -187,7 +206,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "fA" = (
 /obj/item/reagent_containers/food/condiment/flour,
@@ -203,11 +222,17 @@
 /obj/item/reagent_containers/food/drinks/cans/threetowns,
 /obj/item/reagent_containers/food/drinks/cans/threetowns,
 /obj/item/reagent_containers/food/drinks/cans/threetowns,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "fR" = (
 /obj/structure/ship_weapon_dummy,
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "gh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -216,34 +241,58 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "gq" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/structure/window/reinforced,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, starboard engines"
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"gr" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/operations)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "gE" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1380;
 	id_tag = "unathi_pirate_izharshan_pump"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/structure/lattice/catwalk/indoor,
 /obj/structure/bed/handrail{
 	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "gL" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 1
 	},
-/obj/machinery/power/rtg,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/item/device/geiger,
+/obj/item/stack/material/tritium/full,
+/obj/item/stack/material/tritium/full,
+/obj/structure/closet/walllocker{
+	pixel_y = 30
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
@@ -262,6 +311,7 @@
 /obj/item/ship_ammunition/bruiser/flechette,
 /obj/item/ship_ammunition/bruiser/flechette,
 /obj/item/ship_ammunition/bruiser/flechette,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "hq" = (
@@ -269,34 +319,67 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"hv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "is" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "iE" = (
 /obj/machinery/vending/cigarette/hacked,
-/turf/simulated/floor/carpet,
+/obj/effect/floor_decal/corner_wide/dark_green/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "iW" = (
 /obj/machinery/door/airlock/hatch{
 	req_access = list(210);
+	dir = 4;
+	name = "Gunnery"
+	},
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "jv" = (
 /obj/machinery/vending/boozeomat/unathi_pirate,
-/turf/simulated/floor/carpet,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"jN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "jX" = (
 /obj/structure/sink{
-	pixel_y = 14
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	pixel_y = 18
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -304,22 +387,36 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "ll" = (
-/obj/structure/sign/flag/izharshan{
-	pixel_x = -32;
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 1
+	},
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"ln" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/dorms)
-"ln" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/structure/window/reinforced,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, port engines"
-	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/dorms)
+/area/shuttle/unathi_pirate_izharshan/helm)
 "lr" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -328,7 +425,13 @@
 /obj/structure/bed/stool/chair/sofa/orange{
 	dir = 8
 	},
-/turf/simulated/floor/carpet,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 6
+	},
+/obj/machinery/alarm/east{
+	req_one_access = list(210)
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "lE" = (
 /obj/structure/curtain/black{
@@ -344,30 +447,40 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "lQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "lS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5
+	},
+/obj/machinery/meter,
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "lX" = (
-/obj/machinery/firealarm/north,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"mj" = (
+/obj/machinery/atmospherics/unary/engine,
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
+"mE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "mF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -384,16 +497,23 @@
 	dir = 4
 	},
 /obj/structure/bed/stool/bar/padded/orange,
+/obj/effect/floor_decal/carpet,
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"mL" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "mT" = (
 /obj/machinery/shower{
 	dir = 1
 	},
 /obj/structure/curtain/open/shower,
-/obj/structure/bed/handrail{
-	dir = 1
-	},
 /obj/item/soap/orange_soap,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
@@ -401,10 +521,15 @@
 /obj/machinery/computer/ship/helm{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "nB" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "nL" = (
@@ -415,46 +540,80 @@
 	dir = 8;
 	start_pressure = 4000
 	},
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "oK" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8;
-	level = 2
-	},
-/obj/machinery/alarm/east{
-	req_one_access = list(210)
-	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "oZ" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_inner";
-	name = "Ship External Access";
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/closet/walllocker/emerglocker/north{
+	pixel_y = 0;
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor,
+/obj/item/storage/bag/inflatable/emergency,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "pb" = (
 /obj/structure/viewport/unathi,
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 6
+	},
+/turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "pg" = (
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 9
+	},
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "pz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/structure/bed/handrail,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "pK" = (
 /obj/machinery/appliance/cooker/stove,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"pW" = (
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/unathi_pirate_izharshan/dorms)
+"pX" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_outer";
+	name = "Ship External Access";
+	dir = 1
+	},
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, airlock"
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "re" = (
 /obj/machinery/power/apc/high/south{
 	req_access = list(210)
@@ -464,40 +623,55 @@
 	dir = 8;
 	level = 2
 	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "rL" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/powered/pump,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/obj/machinery/meter,
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"rY" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1380;
-	master_tag = "unathi_pirate_izharshan_shuttle";
-	name = "exterior access button";
-	pixel_x = 26;
-	pixel_y = 10
+"rV" = (
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 10
 	},
-/obj/machinery/door/airlock/external{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"rY" = (
+/obj/structure/bed/handrail{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_outer";
-	name = "Ship External Access";
-	dir = 1
+	id_tag = "unathi_pirate_izharshan_pump"
+	},
+/obj/structure/lattice/catwalk/indoor,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "se" = (
 /obj/machinery/light,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "sh" = (
@@ -510,6 +684,7 @@
 	dir = 4;
 	start_pressure = 4000
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "sq" = (
@@ -519,7 +694,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/loading/yellow,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "sI" = (
 /obj/machinery/door/window/brigdoor{
@@ -528,14 +704,18 @@
 	req_access = list(210);
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "sS" = (
 /obj/machinery/ammunition_loader/bruiser{
 	dir = 1;
 	weapon_id = "Izharshan Freighter Bruiser Cannon"
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "sT" = (
 /obj/structure/cable/green{
@@ -550,6 +730,8 @@
 /obj/machinery/alarm/west{
 	req_one_access = list(210)
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "sW" = (
@@ -563,6 +745,9 @@
 	},
 /obj/item/bedsheet/brown,
 /obj/structure/bed,
+/obj/machinery/alarm/east{
+	req_one_access = list(210)
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "sZ" = (
@@ -572,51 +757,82 @@
 /turf/space/transit/north,
 /area/space)
 "tB" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8;
+	target_pressure = 15000;
+	name = "Tanks to Thrusters"
+	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"tJ" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "tR" = (
-/obj/machinery/media/jukebox,
-/turf/simulated/floor/carpet,
+/obj/machinery/media/jukebox{
+	anchored = 1
+	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "uf" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, restroom"
 	},
-/turf/simulated/wall/shuttle/raider,
+/obj/structure/grille,
+/turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "us" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/recharger/wallcharger{
-	pixel_y = 24;
+	pixel_y = 22;
 	pixel_x = 5
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 5
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 32;
+	pixel_x = 5
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "uE" = (
 /obj/structure/bed/roller,
 /obj/machinery/vending/wallmed1{
 	pixel_x = -26
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/medical,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "uK" = (
 /obj/machinery/alarm/west{
 	req_one_access = list(210)
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "uP" = (
 /obj/structure/bed/stool/chair/sofa/right/orange,
-/turf/simulated/floor/carpet,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "va" = (
 /obj/structure/fuel_port/hydrogen{
@@ -628,6 +844,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"vC" = (
+/obj/structure/bed/stool/bar/padded/orange,
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "wk" = (
 /obj/effect/landmark/entry_point/port{
 	name = "port, dorms"
@@ -635,56 +858,95 @@
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "wz" = (
-/obj/machinery/power/rtg,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 1
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/power/portgen/basic/fusion,
+/obj/structure/sign/radiation{
+	pixel_y = 32
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "wK" = (
-/obj/machinery/door/airlock{
-	req_access = list(210);
-	dir = 1
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/structure/curtain/open/bed{
+	name = "curtain"
 	},
-/turf/simulated/floor,
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "xg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /obj/structure/bed/handrail,
-/turf/simulated/floor/shuttle/black,
+/obj/machinery/alarm/north{
+	req_one_access = list(210)
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "xp" = (
-/obj/structure/closet/walllocker/firecloset{
-	pixel_x = 32
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "xF" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "xM" = (
-/obj/structure/sign/flag/izharshan{
-	pixel_y = 32
+/obj/effect/floor_decal/corner_wide/dark_green/full{
+	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/structure/sign/flag/izharshan{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "xX" = (
 /obj/structure/table/wood/gamblingtable,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"yh" = (
+/obj/machinery/door/airlock/hatch{
+	req_access = list(210);
+	dir = 4;
+	name = "Crew Dormitories"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "yo" = (
 /obj/structure/grille,
@@ -699,21 +961,48 @@
 "yN" = (
 /turf/template_noop,
 /area/space)
+"yO" = (
+/obj/machinery/atmospherics/unary/engine,
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/dorms)
+"yZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
+	dir = 8;
+	start_pressure = 4000
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
+"zj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "zr" = (
 /obj/structure/grille,
 /obj/structure/lattice,
-/turf/template_noop,
+/turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "zu" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/toilet{
 	dir = 1;
 	pixel_y = -1
-	},
-/obj/structure/bed/handrail{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
@@ -723,19 +1012,25 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "zR" = (
-/obj/machinery/computer/ship/navigation{
-	dir = 1
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 10
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/machinery/computer/ship/targeting,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "zZ" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "Ac" = (
 /obj/machinery/vending/dinnerware,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "Ai" = (
@@ -745,7 +1040,8 @@
 /obj/structure/ship_weapon_dummy{
 	is_barrel = 1
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning/cee,
+/turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "Ay" = (
 /obj/structure/table/standard,
@@ -759,7 +1055,8 @@
 	pixel_x = -4
 	},
 /obj/item/storage/firstaid/regular,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/light,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "AC" = (
 /obj/structure/table/wood/gamblingtable,
@@ -776,14 +1073,37 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/device/binoculars/spyglass,
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "AS" = (
 /obj/structure/ship_weapon_dummy,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
+"Bi" = (
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 5
+	},
+/obj/structure/sign/flag/izharshan{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"Br" = (
+/obj/structure/ship_weapon_dummy,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 10
+	},
+/turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "By" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -801,36 +1121,41 @@
 	dir = 1
 	},
 /obj/structure/bed/stool/bar/padded/orange,
+/obj/effect/floor_decal/carpet,
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Bz" = (
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "BH" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Cj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/closet/secure_closet/engineering_welding{
 	req_access = list(210)
 	},
-/obj/item/stack/material/steel/full,
-/obj/item/stack/material/glass/full,
-/obj/item/stack/material/lead/full,
-/obj/item/stack/material/aluminium/full,
-/obj/item/stack/material/plastic/full,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "CJ" = (
@@ -872,6 +1197,8 @@
 /obj/item/melee/energy/sword/pirate{
 	pixel_y = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "CO" = (
@@ -886,30 +1213,58 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "Db" = (
-/obj/effect/overmap/visitable/ship/landable/unathi_pirate_izharshan,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"Du" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "DI" = (
+/obj/effect/floor_decal/corner_wide/dark_green/full,
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/structure/filingcabinet/filingcabinet{
+	pixel_x = -9;
+	pixel_y = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "DY" = (
-/obj/structure/grille,
 /obj/structure/lattice,
-/turf/template_noop,
+/obj/structure/grille,
+/turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "El" = (
 /obj/structure/mirror{
-	pixel_y = -2
+	pixel_y = 1
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/dorms)
@@ -917,24 +1272,40 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "EC" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "ED" = (
-/obj/machinery/telecomms/allinone/ship,
-/turf/simulated/floor/tiled{
-	name = "cooled floor";
-	temperature = 278
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/area/shuttle/unathi_pirate_izharshan/dorms)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "EY" = (
-/obj/structure/closet/crate/bin,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
 	level = 2
@@ -947,7 +1318,8 @@
 "Fg" = (
 /obj/machinery/door/airlock/hatch{
 	req_access = list(210);
-	dir = 4
+	dir = 4;
+	name = "Engineering"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -963,7 +1335,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Fj" = (
 /turf/simulated/floor/tiled/dark,
@@ -977,21 +1353,60 @@
 	identifier = "izharshan_crew";
 	name = "igs - izharshan_crew"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"Gb" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
+"FL" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "unathi_pirate_izharshan_shuttle";
+	name = "exterior access button";
+	pixel_x = 26;
+	pixel_y = 10
+	},
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_outer";
+	name = "Ship External Access";
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"FM" = (
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 5
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"Gb" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
+"Gh" = (
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, starboard engines"
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
@@ -999,7 +1414,10 @@
 /obj/structure/bed/stool/chair/sofa/left/orange{
 	dir = 8
 	},
-/turf/simulated/floor/carpet,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "GR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1016,7 +1434,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "Ha" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -1031,26 +1449,37 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
+	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "HZ" = (
 /obj/machinery/iff_beacon,
+/obj/effect/floor_decal/industrial/warning/full,
 /turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "Ib" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning/corner{
+	layer = 2.71
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 8;
+	target_pressure = 15000;
+	name = "Canister to Tanks"
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "Ih" = (
 /obj/structure/bed/stool/chair/shuttle,
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "IM" = (
 /obj/machinery/hologram/holopad/long_range,
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/outline/custodial,
+/obj/effect/overmap/visitable/ship/landable/unathi_pirate_izharshan,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "JF" = (
 /obj/machinery/power/apc/high/west{
@@ -1069,31 +1498,32 @@
 /obj/item/ship_ammunition/bruiser,
 /obj/item/ship_ammunition/bruiser,
 /obj/item/ship_ammunition/bruiser,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "JT" = (
-/obj/effect/map_effect/window_spawner/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/shuttle/raider,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "izharshan_cockpit"
+	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"Kf" = (
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "Kt" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/structure/window/reinforced,
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "KE" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/item/storage/secure/safe/unathi_pirate_izharshan{
 	pixel_y = 32
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "KL" = (
 /obj/effect/landmark/entry_point/east{
@@ -1109,6 +1539,7 @@
 /obj/structure/fuel_port/hydrogen{
 	pixel_x = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "Lz" = (
@@ -1121,30 +1552,48 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "LL" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_outer";
-	name = "Ship External Access";
-	dir = 1
+	id_tag = "unathi_pirate_izharshan";
+	pixel_x = -24;
+	req_access = list(210);
+	pixel_y = -5;
+	dir = 4
 	},
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, airlock"
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_sensor";
+	pixel_x = -25;
+	pixel_y = 7;
+	dir = 4
+	},
+/obj/structure/bed/handrail{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1337;
+	id_tag = "merchant_shuttle_dock_pump"
+	},
+/obj/structure/lattice/catwalk/indoor,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Mi" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/structure/window/reinforced,
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "My" = (
 /obj/machinery/power/apc/high/east{
@@ -1163,6 +1612,12 @@
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/plastique/seismic,
+/obj/item/plastique/seismic,
+/obj/item/plastique/seismic,
+/obj/item/plastique/seismic,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "MH" = (
@@ -1172,10 +1627,17 @@
 	pixel_x = -32;
 	pixel_y = -128
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"MW" = (
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, port engines"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "Nc" = (
-/obj/machinery/firealarm/west,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -1190,13 +1652,31 @@
 /obj/machinery/portable_atmospherics/canister/empty{
 	name = "waste canister"
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "Ni" = (
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"NA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "NR" = (
-/obj/structure/bed/handrail,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Ol" = (
@@ -1204,47 +1684,75 @@
 	dir = 5;
 	icon_state = "intact"
 	},
+/obj/structure/sign/flag/izharshan{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "Pq" = (
-/mob/living/simple_animal/chicken,
-/turf/simulated/floor/shuttle/black,
+/obj/effect/decal/cleanable/dirt{
+	pixel_x = -1
+	},
+/obj/machinery/alarm/north{
+	req_one_access = list(210)
+	},
+/mob/living/simple_animal/threshbeast{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	pixel_x = -1
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "Px" = (
 /obj/structure/bed/stool/chair/sofa/corner/concave/orange,
-/turf/simulated/floor/carpet,
+/obj/effect/floor_decal/corner_wide/dark_green/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "PN" = (
 /obj/machinery/sleeper{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/medical,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "PU" = (
 /obj/machinery/cryopod{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "Qj" = (
-/obj/machinery/computer/ship/engines{
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 10
+	},
+/obj/machinery/computer/ship/sensors{
 	dir = 1
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Qs" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/closet/secure_closet/engineering_electrical{
 	req_access = list(210)
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "Qv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/alarm/north{
+	req_one_access = list(210)
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
@@ -1252,12 +1760,34 @@
 /obj/structure/bed/handrail{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_y = -3;
+	pixel_x = -1
+	},
+/obj/effect/decal/cleanable/dirt{
+	pixel_x = -1
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "QF" = (
 /obj/structure/table/reinforced/steel,
-/obj/item/device/binoculars/spyglass,
-/turf/simulated/floor/shuttle/black,
+/obj/item/device/binoculars/spyglass{
+	pixel_x = 7
+	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 10
+	},
+/obj/item/device/radio{
+	name = "old radio";
+	icon_state = "radio";
+	desc = "An old, cheap radio that looks heavy enough to kill ssomeone.";
+	w_class = 3;
+	canhear_range = 6;
+	throwforce = 12;
+	pixel_y = 10;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Rf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1265,9 +1795,15 @@
 	},
 /obj/structure/table/rack,
 /obj/item/stack/material/glass/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/stack/material/plastic/full,
+/obj/item/stack/material/aluminium/full,
+/obj/item/stack/material/lead/full,
+/obj/item/stack/material/glass/full,
 /obj/item/stack/material/steel/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
+/obj/item/stack/material/steel/full,
+/obj/item/stack/rods/full,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "Rm" = (
@@ -1275,50 +1811,50 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/hatch{
 	req_access = list(210);
-	dir = 1
+	dir = 1;
+	name = "Gunnery"
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "RS" = (
 /turf/space/transit/north,
 /area/space)
 "RZ" = (
 /obj/structure/closet/walllocker/medical{
-	pixel_x = -32
+	pixel_x = -32;
+	name = "Blood Bags"
 	},
 /obj/machinery/iv_drip,
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/empty,
 /obj/item/reagent_containers/blood/empty,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/medical,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "Sl" = (
-/obj/machinery/door/airlock{
-	req_access = list(210);
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/structure/curtain/open/bed{
+	name = "curtain"
+	},
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Sr" = (
-/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
-	dir = 1;
-	start_pressure = 4000
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark/full,
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/obj/machinery/meter,
+/turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "SS" = (
-/obj/machinery/power/rtg,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/item/reagent_containers/glass/bucket,
+/obj/structure/reagent_dispensers/coolanttank,
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "Ti" = (
@@ -1328,32 +1864,32 @@
 /turf/template_noop,
 /area/space)
 "Tt" = (
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan";
-	pixel_x = -26;
-	req_access = list(210);
-	pixel_y = -8
-	},
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_sensor";
-	pixel_x = -25;
-	pixel_y = 9
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_pump"
+	id_tag = "unathi_pirate_izharshan_pump";
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
+/obj/structure/lattice/catwalk/indoor,
 /obj/structure/bed/handrail{
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "TF" = (
 /obj/machinery/door/airlock{
 	req_access = list(210);
-	dir = 4
+	dir = 4;
+	name = "Washroom";
+	id = "izharshan_washroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1361,7 +1897,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/shuttle/black,
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Ut" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -1379,6 +1919,7 @@
 /obj/structure/fuel_port/hydrogen{
 	pixel_x = 32
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "UF" = (
@@ -1386,23 +1927,12 @@
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Vb" = (
-/obj/machinery/firealarm/east,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /obj/structure/table/rack{
 	pixel_x = 3
 	},
-/obj/machinery/door/window/brigdoor{
-	base_state = "rightsecure";
-	icon_state = "rightsecure";
-	req_access = list(210);
-	dir = 8
-	},
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/shoes/magboots,
@@ -1433,10 +1963,38 @@
 /obj/item/device/gps,
 /obj/item/device/gps,
 /obj/item/device/gps,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"Vx" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_sensor";
+	pixel_x = -25;
+	pixel_y = 9;
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"VN" = (
+/obj/structure/ship_weapon_dummy,
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "VS" = (
 /obj/structure/bed/stool/bar/padded/orange,
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "VT" = (
@@ -1454,6 +2012,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet,
+/obj/effect/floor_decal/carpet{
+	dir = 10
+	},
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Wc" = (
@@ -1469,17 +2034,33 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"Wj" = (
+/obj/structure/bed/stool/bar/padded/orange,
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "Wk" = (
 /obj/effect/landmark/entry_point/east{
 	name = "east, engineering"
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"WM" = (
+/obj/structure/ship_weapon_dummy,
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "WN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "WY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1500,6 +2081,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet,
+/obj/effect/floor_decal/carpet{
+	dir = 6
 	},
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
@@ -1528,19 +2116,48 @@
 /obj/item/ammo_magazine/spitterpistol,
 /obj/item/ammo_magazine/crackrifle,
 /obj/item/gun/projectile/shotgun/pump/rifle/magazine_fed/crackrifle,
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"XQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "XV" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
+/obj/machinery/button/remote/airlock{
+	dir = 8;
+	id = "izharshan_washroom";
+	name = "Washroom Bolt Control";
+	pixel_x = -24;
+	pixel_y = 4;
+	specialfunctions = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "Yf" = (
 /obj/structure/lattice,
 /obj/structure/grille,
-/turf/template_noop,
+/turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"Yo" = (
+/obj/structure/ship_weapon_dummy,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "YA" = (
 /obj/structure/closet,
 /obj/item/clothing/head/unathi,
@@ -1588,26 +2205,21 @@
 	color = "#ba650b"
 	},
 /obj/item/clothing/head/pirate,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/service,
+/turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "Zi" = (
 /obj/structure/table/reinforced/steel,
-/obj/item/device/radio{
-	name = "old radio";
-	icon_state = "radio";
-	desc = "An old, cheap radio that looks heavy enough to kill ssomeone.";
-	w_class = 3;
-	canhear_range = 6;
-	throwforce = 12;
-	pixel_y = 2;
-	pixel_x = 1
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 10
 	},
-/obj/machinery/button/distress{
-	pixel_y = -2;
-	pixel_x = -9;
-	dir = 8
+/obj/machinery/button/remote/blast_door{
+	name = "Cockpit Blast Shutters";
+	id = "izharshan_cockpit";
+	pixel_y = 8;
+	pixel_x = -5
 	},
-/turf/simulated/floor/shuttle/black,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Zj" = (
 /obj/structure/grille,
@@ -1615,12 +2227,34 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, helm"
 	},
-/turf/template_noop,
+/turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Zs" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "unathi_pirate_izharshan_shuttle";
+	name = "interior access button";
+	pixel_x = 26;
+	pixel_y = -26;
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
+	},
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_outer";
+	name = "Ship External Access";
+	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/helm)
@@ -1637,14 +2271,27 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
-	dir = 4;
-	start_pressure = 4000
-	},
+/obj/machinery/telecomms/allinone/ship,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "ZO" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_outer";
+	name = "Ship External Access";
+	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "ZU" = (
@@ -31067,8 +31714,8 @@ yN
 yN
 yN
 yN
-yN
-yN
+ZU
+ZU
 ZU
 ZU
 zy
@@ -31082,7 +31729,7 @@ ZU
 pz
 AK
 AS
-fR
+Br
 ZU
 ZU
 ZU
@@ -31324,7 +31971,7 @@ yN
 yN
 yN
 yN
-yN
+mj
 Kt
 Qs
 rL
@@ -31338,10 +31985,10 @@ fx
 Rm
 sq
 sS
-fR
+VN
 MH
-fR
-fR
+WM
+Yo
 Ai
 yN
 yN
@@ -31581,8 +32228,8 @@ yN
 yN
 yN
 yN
-yN
-gq
+Gh
+Kt
 Cj
 Hd
 tB
@@ -31838,7 +32485,7 @@ yN
 yN
 yN
 yN
-yN
+ZU
 ZU
 gL
 Gb
@@ -32095,17 +32742,17 @@ yN
 yN
 yN
 yN
-yN
+XQ
 ZU
 wz
 Ib
-SS
+yZ
 ou
 xF
 iE
 tR
 jv
-VT
+ED
 DI
 xF
 xM
@@ -32352,17 +32999,17 @@ yN
 yN
 yN
 yN
-yN
+Du
 ZU
 SS
 xp
 xF
 xF
 xF
-pg
-pg
-pg
-VT
+Bi
+Kf
+Kf
+zj
 se
 xF
 us
@@ -32609,18 +33256,18 @@ yN
 yN
 yN
 yN
-yN
-xF
-xF
+dC
+ll
+NA
 xF
 xF
 NR
 Et
 pg
-VS
-VS
+Wj
+Wj
 VT
-DI
+rV
 xF
 ak
 IM
@@ -32866,13 +33513,13 @@ yN
 yN
 yN
 yN
-yN
+pX
 LL
 Tt
 ZO
 oZ
 lQ
-DI
+gq
 VS
 AC
 UF
@@ -33122,14 +33769,14 @@ yN
 yN
 yN
 yN
-yN
 Ti
+FL
 rY
 gE
 Zs
 eu
 nB
-DI
+Kf
 VS
 bQ
 xX
@@ -33137,7 +33784,7 @@ By
 Db
 Sl
 is
-Ih
+tJ
 QF
 xF
 Yf
@@ -33380,21 +34027,21 @@ yN
 yN
 yN
 yN
-yN
+xF
 xF
 xF
 xF
 xF
 hq
 eV
-pg
-VS
-VS
+FM
+vC
+vC
 WY
 re
 xF
 lX
-IM
+hv
 zR
 JT
 dr
@@ -33637,7 +34284,7 @@ yN
 yN
 yN
 yN
-yN
+Vx
 zZ
 QD
 zZ
@@ -33645,13 +34292,13 @@ xF
 xF
 xF
 uP
-pg
-pg
-VT
+Kf
+Kf
+zj
 se
 xF
 KE
-Ih
+gr
 Qj
 JT
 dr
@@ -33894,7 +34541,7 @@ yN
 yN
 yN
 yN
-yN
+mL
 zZ
 Pq
 zZ
@@ -33904,7 +34551,7 @@ xF
 Px
 lu
 GG
-VT
+ln
 ai
 xF
 bs
@@ -34151,17 +34798,17 @@ yN
 yN
 yN
 yN
-yN
+zZ
 zZ
 sI
 zZ
 Fv
-Fj
+pW
 xF
 xF
 xF
 xF
-Fg
+yh
 xF
 xF
 xF
@@ -34408,12 +35055,12 @@ yN
 yN
 yN
 yN
-yN
-ln
+MW
+Mi
 Ol
 Fj
 Fj
-ll
+Fj
 Ac
 fA
 pK
@@ -34665,24 +35312,24 @@ yN
 yN
 yN
 yN
-yN
+yO
 Mi
 CJ
 Xz
-WN
-WN
+mE
+jN
 WN
 WN
 WN
 bl
 Lz
-Fj
+pW
 Ay
 El
 jX
 zu
 zZ
-zZ
+et
 uf
 yN
 yN
@@ -34922,8 +35569,8 @@ yN
 yN
 yN
 yN
-yN
-yN
+zZ
+zZ
 zZ
 zZ
 eG
@@ -34939,7 +35586,7 @@ zZ
 EY
 mT
 zZ
-ED
+zZ
 zZ
 zZ
 yN

--- a/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dmm
+++ b/maps/away/ships/unathi_pirate/izharshan/unathi_pirate_izharshan.dmm
@@ -44,18 +44,6 @@
 /obj/effect/floor_decal/corner_wide/dark_green/full,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"aM" = (
-/obj/effect/floor_decal/corner_wide/dark_green/full,
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/obj/structure/filingcabinet/filingcabinet{
-	pixel_x = -9;
-	pixel_y = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "bl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable/green{
@@ -66,6 +54,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"bq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "bs" = (
 /obj/structure/closet/walllocker/emerglocker{
 	pixel_x = 32
@@ -104,6 +96,10 @@
 /obj/effect/step_trigger/teleporter,
 /turf/space/transit/north,
 /area/space)
+"cT" = (
+/obj/machinery/atmospherics/unary/engine,
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "cU" = (
 /obj/effect/floor_decal/corner_wide/dark_green/full{
 	dir = 4
@@ -131,6 +127,37 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"dy" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "unathi_pirate_izharshan_shuttle";
+	name = "exterior access button";
+	pixel_x = 26;
+	pixel_y = 10
+	},
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_outer";
+	name = "Ship External Access";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"dz" = (
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, starboard engines"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "dD" = (
 /obj/structure/table/stone/marble,
 /obj/item/reagent_containers/food/condiment/shaker/salt{
@@ -150,6 +177,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"el" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"eo" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "et" = (
 /obj/structure/lattice,
 /turf/simulated/floor/airless,
@@ -168,26 +211,6 @@
 	pixel_x = 25;
 	pixel_y = -6;
 	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"ex" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_wide/dark_green{
-	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
@@ -213,16 +236,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"eT" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "eV" = (
 /obj/machinery/light{
 	dir = 4
@@ -231,12 +244,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"fg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 1
-	},
-/turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "fx" = (
 /obj/structure/cable/green{
@@ -283,8 +290,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "gq" = (
-/obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "gE" = (
 /obj/machinery/light/small{
@@ -357,6 +364,13 @@
 /obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"ie" = (
+/obj/structure/bed/stool/bar/padded/orange,
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "is" = (
 /obj/effect/floor_decal/corner_wide/dark_green{
 	dir = 5
@@ -388,12 +402,30 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"jr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 1
+	},
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "jv" = (
 /obj/machinery/vending/boozeomat/unathi_pirate,
 /obj/effect/floor_decal/corner_wide/dark_green{
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
+"jM" = (
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 9
+	},
+/turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "jX" = (
 /obj/structure/sink{
@@ -408,52 +440,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"lk" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
-	},
-/turf/simulated/floor/airless,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "ll" = (
-/obj/structure/bed/stool/bar/padded/orange,
-/obj/effect/floor_decal/carpet{
+/obj/structure/ship_weapon_dummy,
+/obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
-/area/shuttle/unathi_pirate_izharshan/helm)
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "ln" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1380;
-	master_tag = "unathi_pirate_izharshan_shuttle";
-	name = "exterior access button";
-	pixel_x = 26;
-	pixel_y = 10
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_outer";
-	name = "Ship External Access";
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
-	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/helm)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "lr" = (
 /obj/effect/floor_decal/corner_wide/dark_green{
 	dir = 10
@@ -514,20 +511,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"md" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/dorms)
-"mm" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/bed/handrail{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "mF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -555,15 +538,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"nm" = (
-/obj/effect/floor_decal/corner_wide/dark_green{
-	dir = 5
-	},
-/obj/structure/sign/flag/izharshan{
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/dark,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "ns" = (
 /obj/machinery/computer/ship/helm{
 	dir = 1
@@ -582,25 +556,6 @@
 "nL" = (
 /turf/space,
 /area/space)
-"ob" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/airlock_sensor{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_sensor";
-	pixel_x = -25;
-	pixel_y = 9;
-	dir = 4
-	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
-	},
-/turf/simulated/floor/airless,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "ou" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
 	dir = 8;
@@ -611,6 +566,14 @@
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
+"oA" = (
+/obj/structure/ship_weapon_dummy,
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "oK" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -636,7 +599,13 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "pg" = (
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 5
+	},
+/obj/structure/sign/flag/izharshan{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "pz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -649,10 +618,13 @@
 /obj/machinery/appliance/cooker/stove,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"qI" = (
-/obj/structure/ship_weapon_dummy,
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
+"pN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	icon_state = "intact"
+	},
+/turf/simulated/wall/shuttle/raider,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "re" = (
 /obj/machinery/power/apc/high/south{
 	req_access = list(210)
@@ -681,32 +653,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"rS" = (
-/obj/machinery/door/airlock/hatch{
-	req_access = list(210);
-	dir = 4;
-	name = "Engineering"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/grey,
-/obj/machinery/door/firedoor/noid{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "rY" = (
 /obj/structure/bed/handrail{
 	dir = 8
@@ -753,13 +699,6 @@
 /obj/effect/floor_decal/industrial/loading/yellow,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"sB" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, port engines"
-	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/dorms)
 "sI" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
@@ -797,6 +736,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"sV" = (
+/obj/structure/bed/stool/bar/padded/orange,
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "sW" = (
 /obj/effect/ghostspawpoint{
 	identifier = "izharshan_captain";
@@ -842,6 +788,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"tS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "uf" = (
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, restroom"
@@ -849,6 +800,25 @@
 /obj/structure/grille,
 /turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"ui" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_outer";
+	name = "Ship External Access";
+	dir = 1
+	},
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, airlock"
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "us" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 22;
@@ -897,6 +867,18 @@
 	req_access = list(210)
 	},
 /turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/operations)
+"vv" = (
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
+	dir = 8;
+	start_pressure = 10000
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "wk" = (
 /obj/effect/landmark/entry_point/port{
@@ -963,19 +945,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"xN" = (
+/obj/effect/floor_decal/carpet{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 5
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "xX" = (
 /obj/structure/table/wood/gamblingtable,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"yl" = (
-/obj/structure/ship_weapon_dummy,
-/obj/effect/floor_decal/industrial/warning/cee{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "yo" = (
 /obj/structure/grille,
 /turf/simulated/floor/airless,
@@ -989,25 +976,6 @@
 "yN" = (
 /turf/template_noop,
 /area/space)
-"zo" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1380;
-	id_tag = "unathi_pirate_izharshan_outer";
-	name = "Ship External Access";
-	dir = 1
-	},
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, airlock"
-	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "unathi_pirate_izharshan";
-	master_tag = "unathi_pirate_izharshan";
-	shuttle_tag = "Scarab Shuttle"
-	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "zr" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -1041,30 +1009,6 @@
 "zZ" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"Aa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet,
-/obj/effect/floor_decal/carpet{
-	dir = 10
-	},
-/turf/simulated/floor/carpet,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "Ac" = (
 /obj/machinery/vending/dinnerware,
 /obj/effect/decal/cleanable/dirt,
@@ -1104,6 +1048,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"AD" = (
+/obj/structure/ship_weapon_dummy,
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "AK" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/clothing/ears/earmuffs,
@@ -1116,6 +1064,16 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"AP" = (
+/obj/structure/bed/stool/chair/shuttle,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "AS" = (
 /obj/structure/ship_weapon_dummy,
 /obj/machinery/light{
@@ -1251,6 +1209,30 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"De" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet,
+/obj/effect/floor_decal/carpet{
+	dir = 10
+	},
+/turf/simulated/floor/carpet,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "DI" = (
 /obj/effect/floor_decal/corner_wide/dark_green{
 	dir = 10
@@ -1265,18 +1247,13 @@
 /obj/structure/grille,
 /turf/simulated/floor/airless,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"Ec" = (
-/obj/structure/ship_weapon_dummy,
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "El" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, port engines"
+	},
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "Et" = (
 /obj/machinery/light{
 	dir = 8
@@ -1295,19 +1272,7 @@
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
 "ED" = (
-/turf/simulated/floor/carpet/rubber,
-/area/shuttle/unathi_pirate_izharshan/dorms)
-"EI" = (
-/obj/effect/floor_decal/carpet{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 9
-	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "EY" = (
 /obj/structure/curtain/open/shower,
@@ -1320,7 +1285,7 @@
 /obj/machinery/door/airlock/hatch{
 	req_access = list(210);
 	dir = 4;
-	name = "Crew Dormitories"
+	name = "Engineering"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -1345,6 +1310,17 @@
 "Fj" = (
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"Fo" = (
+/obj/structure/ship_weapon_dummy,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 2.71;
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "Fv" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 32;
@@ -1377,6 +1353,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"GM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "GR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -1412,11 +1393,22 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"Hw" = (
+"HE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+	dir = 4
 	},
-/turf/simulated/wall/shuttle/raider,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "HZ" = (
 /obj/machinery/iff_beacon,
@@ -1440,33 +1432,10 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "IM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/hologram/holopad/long_range,
+/obj/effect/floor_decal/industrial/outline/custodial,
+/obj/effect/overmap/visitable/ship/landable/unathi_pirate_izharshan,
 /turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"Jy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_wide/dark_green{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "JF" = (
 /obj/machinery/power/apc/high/west{
@@ -1497,9 +1466,14 @@
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Kt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/unathi_pirate_izharshan/operations)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "KE" = (
 /obj/item/storage/secure/safe/unathi_pirate_izharshan{
 	pixel_y = 32
@@ -1526,13 +1500,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"Lm" = (
-/obj/structure/bed/stool/bar/padded/orange,
-/obj/effect/floor_decal/carpet{
-	dir = 4
-	},
-/turf/simulated/floor/carpet,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "Lz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9;
@@ -1582,22 +1549,15 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"LO" = (
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
-	dir = 8;
-	start_pressure = 10000
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "Mi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/unathi_pirate_izharshan/dorms)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/bed/handrail{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "My" = (
 /obj/machinery/power/apc/high/east{
 	req_access = list(210)
@@ -1633,6 +1593,26 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"MR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "Nc" = (
 /obj/machinery/light{
 	dir = 8
@@ -1657,6 +1637,15 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"NQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "NR" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/atmospherics/portables_connector{
@@ -1678,16 +1667,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"Pe" = (
-/obj/structure/bed/stool/chair/shuttle,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "Pq" = (
 /obj/effect/decal/cleanable/dirt{
 	pixel_x = -1
@@ -1710,6 +1689,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
+"PM" = (
+/obj/effect/floor_decal/corner_wide/dark_green/full,
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/structure/filingcabinet/filingcabinet{
+	pixel_x = -9;
+	pixel_y = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "PN" = (
 /obj/machinery/sleeper{
 	dir = 1
@@ -1722,10 +1713,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/rubber,
-/area/shuttle/unathi_pirate_izharshan/dorms)
-"Qd" = (
-/obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor,
 /area/shuttle/unathi_pirate_izharshan/dorms)
 "Qj" = (
 /obj/effect/floor_decal/corner_wide/dark_green{
@@ -1759,6 +1746,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/unathi_pirate_izharshan/dorms)
+"Qw" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "unathi_pirate_izharshan_sensor";
+	pixel_x = -25;
+	pixel_y = 9;
+	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
+	},
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "QD" = (
 /obj/structure/bed/handrail{
 	dir = 4
@@ -1892,8 +1898,7 @@
 	req_access = list(210);
 	dir = 4;
 	name = "Washroom";
-	id_tag = "izharshan_washroom";
-	id = "izharshan_washroom"
+	id_tag = "izharshan_washroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1907,12 +1912,9 @@
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"TT" = (
-/obj/machinery/hologram/holopad/long_range,
-/obj/effect/floor_decal/industrial/outline/custodial,
-/obj/effect/overmap/visitable/ship/landable/unathi_pirate_izharshan,
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/helm)
+"Up" = (
+/turf/simulated/floor/carpet/rubber,
+/area/shuttle/unathi_pirate_izharshan/dorms)
 "Ut" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1932,28 +1934,25 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"Uu" = (
-/obj/structure/ship_weapon_dummy,
+"UD" = (
 /obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
-	layer = 2.71;
-	dir = 8
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "unathi_pirate_izharshan";
+	master_tag = "unathi_pirate_izharshan";
+	shuttle_tag = "Scarab Shuttle"
 	},
-/turf/simulated/floor/reinforced,
-/area/shuttle/unathi_pirate_izharshan/operations)
+/turf/simulated/floor/airless,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "UF" = (
 /obj/structure/table/wood/gamblingtable,
 /turf/simulated/floor/carpet,
 /area/shuttle/unathi_pirate_izharshan/helm)
-"UM" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, starboard engines"
-	},
-/turf/simulated/floor,
-/area/shuttle/unathi_pirate_izharshan/operations)
 "Vb" = (
 /obj/machinery/light{
 	dir = 4
@@ -1995,25 +1994,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"Vq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5;
-	icon_state = "intact"
-	},
-/turf/simulated/wall/shuttle/raider,
-/area/shuttle/unathi_pirate_izharshan/helm)
-"VE" = (
-/obj/effect/floor_decal/carpet{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet{
-	dir = 5
-	},
-/turf/simulated/floor/carpet,
-/area/shuttle/unathi_pirate_izharshan/helm)
 "VS" = (
 /obj/structure/bed/stool/bar/padded/orange,
 /obj/effect/floor_decal/carpet{
@@ -2036,7 +2016,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/corner_wide/dark_green{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/unathi_pirate_izharshan/helm)
 "Wc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -2060,6 +2043,32 @@
 	},
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/operations)
+"Wv" = (
+/obj/machinery/door/airlock/hatch{
+	req_access = list(210);
+	dir = 4;
+	name = "Crew Dormitories"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/full,
+/area/shuttle/unathi_pirate_izharshan/helm)
 "WN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2192,11 +2201,10 @@
 /obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/unathi_pirate_izharshan/dorms)
-"Zf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/dark/full,
-/area/shuttle/unathi_pirate_izharshan/dorms)
+"YJ" = (
+/obj/machinery/atmospherics/unary/engine,
+/turf/simulated/floor,
+/area/shuttle/unathi_pirate_izharshan/operations)
 "Zi" = (
 /obj/structure/table/reinforced/steel,
 /obj/effect/floor_decal/corner_wide/dark_green{
@@ -2287,15 +2295,6 @@
 "ZU" = (
 /turf/simulated/wall/shuttle/raider,
 /area/shuttle/unathi_pirate_izharshan/operations)
-"ZX" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/structure/bed/handrail{
-	dir = 1
-	},
-/turf/simulated/floor/airless,
-/area/shuttle/unathi_pirate_izharshan/dorms)
 
 (1,1,1) = {"
 yN
@@ -31970,8 +31969,8 @@ yN
 yN
 yN
 yN
+YJ
 gq
-Kt
 Qs
 rL
 CO
@@ -31984,10 +31983,10 @@ fx
 Rm
 sq
 sS
-qI
+AD
 MH
-yl
-Uu
+ll
+Fo
 Ai
 yN
 yN
@@ -32227,8 +32226,8 @@ yN
 yN
 yN
 yN
-UM
-Kt
+dz
+gq
 Cj
 Hd
 tB
@@ -32241,7 +32240,7 @@ Wc
 ZU
 xg
 Ni
-Ec
+oA
 pb
 yo
 yo
@@ -32494,7 +32493,7 @@ xF
 xF
 xF
 xF
-rS
+Fg
 xF
 xF
 iW
@@ -32741,18 +32740,18 @@ yN
 yN
 yN
 yN
-mm
+Mi
 ZU
 wz
 Ib
-LO
+vv
 ou
 xF
 iE
 tR
 jv
-Jy
-aM
+MR
+PM
 xF
 xM
 uK
@@ -32998,17 +32997,17 @@ yN
 yN
 yN
 yN
-lk
+UD
 ZU
 SS
 xp
 xF
 xF
 xF
-nm
 pg
-pg
-VT
+ED
+ED
+HE
 se
 xF
 us
@@ -33255,21 +33254,21 @@ yN
 yN
 yN
 yN
-Hw
-fg
-Vq
+el
+jr
+pN
 xF
 xF
 NR
 Et
-EI
+jM
 VS
 VS
-Aa
+De
 DI
 xF
 ak
-TT
+IM
 eD
 JT
 dr
@@ -33512,14 +33511,14 @@ yN
 yN
 yN
 yN
-zo
+ui
 LL
 Tt
 ZO
 oZ
 lQ
-El
-ll
+bq
+ie
 AC
 UF
 mF
@@ -33769,21 +33768,21 @@ yN
 yN
 yN
 Ti
-ln
+dy
 rY
 gE
 Zs
 eu
 nB
-pg
-ll
+ED
+ie
 bQ
 xX
 By
 Db
 Sl
 is
-Pe
+eo
 QF
 xF
 Yf
@@ -34033,14 +34032,14 @@ xF
 xF
 hq
 eV
-VE
-Lm
-Lm
+xN
+sV
+sV
 WY
 re
 xF
 lX
-IM
+NQ
 zR
 JT
 dr
@@ -34283,7 +34282,7 @@ yN
 yN
 yN
 yN
-ob
+Qw
 zZ
 QD
 zZ
@@ -34291,13 +34290,13 @@ xF
 xF
 xF
 uP
-pg
-pg
-VT
+ED
+ED
+HE
 se
 xF
 KE
-eT
+AP
 Qj
 JT
 dr
@@ -34540,7 +34539,7 @@ yN
 yN
 yN
 yN
-ZX
+Kt
 zZ
 Pq
 zZ
@@ -34550,7 +34549,7 @@ xF
 Px
 lu
 GG
-ex
+VT
 ai
 xF
 bs
@@ -34802,12 +34801,12 @@ zZ
 sI
 zZ
 Fv
-ED
+Up
 xF
 xF
 xF
 xF
-Fg
+Wv
 xF
 xF
 xF
@@ -35054,8 +35053,8 @@ yN
 yN
 yN
 yN
-sB
-Mi
+El
+ln
 Ol
 Fj
 Fj
@@ -35311,18 +35310,18 @@ yN
 yN
 yN
 yN
-Qd
-Mi
+cT
+ln
 CJ
 Xz
-md
-Zf
+GM
+tS
 WN
 WN
 WN
 bl
 Lz
-ED
+Up
 Ay
 zZ
 jX


### PR DESCRIPTION
This is a variety of fixes and changes for the Scarab Salvager and Izharshan Shuttle offships, plus a number of tweaks to the Hivebot Hub offsite. 

**Scarab Salvager**

- Portside CO2 console works, now.
- Windows are replaced with proper variants to fit the surrounding walls.
- Balance change, replaced the Xanu SMG in the armour with a pump shotgun, so there's at least one longarm you can't put into a bag to justify slinging over the armoured suit. Comes only with regular shells, beanbags, and stun shells - but you can print slugs if you're so inclined.

**Izharshan Shuttle**

- Fixed airlock. You can now cycle it, and it docks properly!
- Various small QoL changes. Removed shuttle floors, carpet should look nicer.
- Power is shifted from RTGs to a mini-fusion that can actually keep up with power consumption.
- Propulsion makes a little more sense now. It's still very slow as ships go, but I suppose that's the trade-off for being able to dock.
- Only balance change is the addition of four seismic charges to the ship. My thought is that, since a lot of ships lack docking ports and this is an offship that specialises in boarding actions, it'd be much more fashionable to blow a hole in the side of your quarry with improvised explosives than it would be to go through the 15 step process of disassembling a wall, or looking around for ages for an airlock. Conveniently, when the charges reduce reinforced walls to a girder, an energy cutlass can slice the girder apart.
**Note:** there's an odd bug in which telecommunications for this ship doesn't work until you clear all of the filtering frequencies with a multitool, but it _does_ work if you do that. If I find a fix I'll commit it, but otherwise I'd like to get this through quickly so the offship is at least mostly functional.

**Hivebot Hub**

- Adds drastically more hivebots. People keep expecting a horde of them with this offsite, which leads to them overpreparing and finding disappointingly little resistance after they do. This should give them a more satisfying challenge. The beacon is still the weakened version. 
- Moves the short-barrelled assault rifle to the 'end' of the map, since it used to trivialise the hivebot threat.
- More than halves the amount of phoron in the offsite. 8 full canisters was a little much.