### PR TITLE
Diona Lunchbox Loadout Fix

### DIFF
--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -208,7 +208,7 @@
 	filled = TRUE
 
 /obj/item/storage/toolbox/lunchbox/nymph
-	name = "\improper diona nymph lunchbox"
+	name = "Diona Nymph Lunchbox"
 	icon_state = "lunchbox_dionanymph"
 	item_state = "lunchbox_dionanymph"
 	desc = "A little lunchbox. This one has a diona nymph on the side."

--- a/html/changelogs/Crosarius-dionalunchbox.yml
+++ b/html/changelogs/Crosarius-dionalunchbox.yml
@@ -1,0 +1,6 @@
+author: Crosarius
+
+delete-after: True
+
+changes:
+  - bugfix: "Selecting diona nymph lunchbox in the loadout now correctly gives you the diona nymph lunchbox on spawn."


### PR DESCRIPTION
Changed the name of the diona lunchbox so it is actually granted on spawn, instead of becoming the rainbox lunchbox.