### PR TITLE
Blueprints Display Wire Schemas Again

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -7,6 +7,12 @@
 	w_class = ITEMSIZE_SMALL
 	var/list/valid_z_levels = list()
 	var/area_prefix
+	///Will these blueprints display the wire schema?
+	var/show_wires = TRUE
+	///Airlock wires
+	var/datum/wires/airlock/blueprint/airlock_wires
+	///Vending machine wires
+	var/datum/wires/vending/blueprint/vending_wires
 
 /obj/item/blueprints/Initialize(mapload, ...)
 	. = ..()
@@ -14,6 +20,9 @@
 
 /obj/item/blueprints/LateInitialize()
 	. = ..()
+	if(show_wires)
+		airlock_wires = new(src)
+		vending_wires = new(src)
 	desc = "Blueprints of the [station_name()]. There is a \"Classified\" stamp and several coffee stains on it."
 	if(set_valid_z_levels())
 		create_blueprint_component()
@@ -22,6 +31,15 @@
 	if(use_check_and_message(usr, USE_DISALLOW_SILICONS) || usr.get_active_hand() != src)
 		return
 	add_fingerprint(user)
+	if(show_wires)
+		var/choice = tgui_alert(user, "Select blueprint action", "Blueprints", list("Airlock Wire Schema", "Vending Wire Schema", "Use Blueprints"))
+		if(choice == "Airlock Wire Schema")
+			airlock_wires.get_wire_diagram(user)
+		else if(choice == "Vending Wire Schema")
+			vending_wires.get_wire_diagram(user)
+		if(choice != "Use Blueprints") //Don't do the normal blueprints stuff if the user just wants wires
+			return
+
 	var/datum/component/eye/blueprints = GetComponent(/datum/component/eye)
 	if(!(user.z in valid_z_levels))
 		to_chat(user, SPAN_WARNING("The markings on this are entirely irrelevant to your whereabouts!"))
@@ -60,6 +78,7 @@
 /obj/item/blueprints/outpost
 	name = "outpost blueprints"
 	icon_state = "blueprints2"
+	show_wires = FALSE
 
 /obj/item/blueprints/outpost/attack_self(mob/user)
 	if(!length(valid_z_levels) || !valid_z_levels) //Outpost blueprints can initialize before exoplanets, so put this in here to doublecheck it.

--- a/html/changelogs/RustingWithYou - returnofwires.yml
+++ b/html/changelogs/RustingWithYou - returnofwires.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Blueprints display wire schemas again."


### PR DESCRIPTION
as title, blueprints have regained their lost functionality of displaying airlock & vending wire layouts. outpost blueprints don't have this functionality