### PR TITLE
Fixes PDA Chat Client not working properly after PDA loses charge

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -64,7 +64,7 @@
 		else
 			if((!computer.registered_id && !computer.register_account(src)))
 				return
-	if(service_state == PROGRAM_STATE_DISABLED)
+	if(service_state <= PROGRAM_STATE_KILLED) // Killed or disabled.
 		computer.enable_service(null, user, src)
 	if(computer.hidden_uplink && syndi_auth)
 		if(alert(user, "Resume or close and secure?", filedesc, "Resume", "Close") == "Resume")

--- a/html/changelogs/llywelwyn-pdafix.yml
+++ b/html/changelogs/llywelwyn-pdafix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Llywelwyn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed PDA Chat Client not working properly after a PDA loses charge."


### PR DESCRIPTION
fixes https://github.com/Aurorastation/Aurora.3/issues/19156

tl;dr: chat client is supposed to try turning the service back on automatically when you open it, but it was only doing that if manually disabled, which is a different state. this makes it do it if it's killed (like via running out of charge) or disabled manually

- bugfix: "Fixed PDA Chat Client not working properly after a PDA loses charge."