### PR TITLE
Idris Wreck - Mapping Tweaks

### DIFF
--- a/html/changelogs/CourierBravo - Idris Wreck pretty-ing.yml
+++ b/html/changelogs/CourierBravo - Idris Wreck pretty-ing.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: CourierBravo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Made various changes to the Iris Wreck away site to make it look more pretty and in line with our current ship designs."
+  - bugfix: "Idris Wreck seemed to use steel tiles and regular tiles interchangably. Standardized on regular tiles."
+  - bugfix: "Fixed some misplaced lighting and infrastructure in the Idris Wreck"

--- a/html/changelogs/CourierBravo - Idris Wreck pretty-ing.yml
+++ b/html/changelogs/CourierBravo - Idris Wreck pretty-ing.yml
@@ -56,5 +56,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - qol: "Made various changes to the Iris Wreck away site to make it look more pretty and in line with our current ship designs."
-  - bugfix: "Idris Wreck seemed to use steel tiles and regular tiles interchangably. Standardized on regular tiles."
+  - bugfix: "Idris Wreck seemed to use two different colors of steel tiles. One for airless and one for pressurized They're nearly identical, but there's a very slight color difference. Standardized on one style of tiles."
   - bugfix: "Fixed some misplaced lighting and infrastructure in the Idris Wreck"

--- a/maps/away/away_site/idris_wreck/idris_wreck.dmm
+++ b/maps/away/away_site/idris_wreck/idris_wreck.dmm
@@ -4,7 +4,7 @@
 	color = "#4B7A73";
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "ad" = (
 /obj/machinery/light{
@@ -40,7 +40,7 @@
 "ai" = (
 /obj/structure/table/wood/mahogany,
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/idris,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "ap" = (
 /turf/simulated/wall/shuttle/idris,
@@ -50,13 +50,19 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/starbthrust)
+"ax" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
+/area/idris_wreck/central)
 "aC" = (
 /obj/machinery/anti_bluespace,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "aJ" = (
 /obj/machinery/light{
@@ -100,7 +106,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/bridge)
 "aY" = (
 /turf/template_noop,
@@ -132,7 +138,10 @@
 /obj/structure/closet/crate/rad,
 /obj/item/stack/material/uranium/full,
 /obj/item/stack/material/uranium/full,
-/turf/simulated/floor/airless,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 2
+	},
+/turf/simulated/floor,
 /area/idris_wreck/vault)
 "bp" = (
 /obj/structure/cable/green{
@@ -140,16 +149,18 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/structure/safe/cash,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "br" = (
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/power/portgen/basic/advanced,
-/turf/simulated/floor/tiled/airless,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/floor,
 /area/idris_wreck/vault)
 "bu" = (
 /obj/structure/cable{
@@ -193,7 +204,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/central)
 "bB" = (
 /obj/structure/table/stone/marble,
@@ -217,15 +228,22 @@
 /obj/structure/sign/flag/idris/large/east{
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "bG" = (
 /obj/effect/floor_decal/corner{
 	color = "#4B7A73";
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
+"bH" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "bJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -260,7 +278,7 @@
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/mainthall)
 "bS" = (
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
@@ -272,7 +290,7 @@
 	color = "#4B7A73";
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "bU" = (
 /turf/simulated/floor/tiled/airless,
@@ -319,7 +337,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "cv" = (
 /obj/effect/floor_decal/corner{
@@ -334,7 +352,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/central)
 "cB" = (
 /obj/effect/floor_decal/corner{
@@ -368,6 +386,12 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/airless,
 /area/idris_wreck/starbthrust)
+"cV" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
+/area/idris_wreck/armory)
 "da" = (
 /obj/machinery/door/firedoor/noid/closed,
 /obj/effect/floor_decal/corner{
@@ -396,7 +420,7 @@
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/central)
 "dx" = (
 /obj/machinery/light{
@@ -406,7 +430,7 @@
 	color = "#4B7A73";
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/afthall)
 "dA" = (
 /obj/effect/landmark/scorcher,
@@ -417,7 +441,7 @@
 /obj/item/paper_bin,
 /obj/item/pen/fountain/captain,
 /obj/item/stamp/idris,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "dF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -425,7 +449,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/noid/closed,
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/central)
 "dM" = (
 /turf/simulated/floor/reinforced/airless,
@@ -445,7 +469,7 @@
 /area/idris_wreck/starbthrust)
 "ee" = (
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/armory)
 "ei" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -466,7 +490,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "el" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -483,7 +507,7 @@
 	name = "EVA Storage";
 	req_access = list(220)
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/eva)
 "eq" = (
 /turf/simulated/wall/shuttle/idris,
@@ -526,11 +550,11 @@
 	color = "#4B7A73";
 	dir = 10
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "fj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/eva)
 "fo" = (
 /obj/effect/floor_decal/corner{
@@ -544,7 +568,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "fv" = (
 /turf/simulated/floor/airless,
@@ -554,7 +578,7 @@
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(220)
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/armory)
 "fy" = (
 /obj/effect/floor_decal/corner/full{
@@ -574,7 +598,7 @@
 /obj/item/gun/projectile/shotgun/pump,
 /obj/item/storage/box/shotgunammo,
 /obj/item/storage/box/shotgunammo,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/armory)
 "fD" = (
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
@@ -621,7 +645,7 @@
 /obj/random/finances,
 /obj/random/highvalue/no_crystal,
 /obj/random/highvalue/no_crystal,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "fL" = (
 /obj/effect/floor_decal/corner{
@@ -631,7 +655,7 @@
 /obj/effect/landmark/corpse/idris/robot,
 /obj/effect/decal/cleanable/blood/oil,
 /obj/item/gun/energy/rifle/laser/noctiluca,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/central)
 "fM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -659,7 +683,7 @@
 	dir = 6
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/eva)
 "gu" = (
 /obj/machinery/vending/snack,
@@ -722,7 +746,7 @@
 	color = "#4B7A73";
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "gM" = (
 /obj/structure/cable{
@@ -744,7 +768,7 @@
 	id_tag = "idris_wreck_vault";
 	name = "Vault"
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/central)
 "gT" = (
 /obj/structure/cable/green{
@@ -755,12 +779,12 @@
 	id_tag = "idris_wreck_vault1";
 	name = "Vault"
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/vault)
 "gW" = (
 /obj/effect/landmark/corpse/idris,
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "gX" = (
 /obj/machinery/telecomms/allinone/ship,
@@ -779,7 +803,7 @@
 "he" = (
 /obj/machinery/hologram/holopad/long_range,
 /obj/effect/overmap/visitable/idris_wreck,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "hh" = (
 /obj/structure/sign/flag/idris/large/north{
@@ -845,7 +869,7 @@
 	color = "#4B7A73";
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "hL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -864,7 +888,7 @@
 	pixel_x = 32;
 	pixel_y = -5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/armory)
 "hU" = (
 /obj/structure/cable/green{
@@ -872,7 +896,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/structure/safe/highvalue,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "hV" = (
 /obj/structure/table/wood/mahogany,
@@ -914,12 +938,22 @@
 /obj/effect/landmark/corpse/idris,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/item/gun/bang/sec,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "iq" = (
 /obj/effect/landmark/scorcher,
 /turf/simulated/floor/reinforced/airless,
 /area/idris_wreck/atmos)
+"it" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "iu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
@@ -957,7 +991,7 @@
 	color = "#4B7A73";
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/central)
 "jd" = (
 /obj/structure/cable/green{
@@ -982,7 +1016,7 @@
 	},
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/floor_decal/industrial/outline/engineering,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/engi)
 "jl" = (
 /obj/effect/floor_decal/industrial/outline/security,
@@ -1009,7 +1043,7 @@
 /obj/item/clothing/accessory/holster/hip,
 /obj/item/clothing/accessory/holster/hip,
 /obj/item/clothing/accessory/holster/hip,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/armory)
 "jo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1027,14 +1061,14 @@
 	req_one_access = list(103)
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "jx" = (
 /obj/machinery/door/airlock/security{
 	req_access = list(220);
 	name = "Security Unit Storage"
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/armory)
 "jy" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1068,7 +1102,7 @@
 /obj/effect/floor_decal/corner/diagonal{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "jX" = (
 /obj/structure/cable/green{
@@ -1080,7 +1114,7 @@
 	color = "#4B7A73"
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "kg" = (
 /obj/machinery/light{
@@ -1106,7 +1140,7 @@
 	color = "#4B7A73";
 	dir = 10
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "kK" = (
 /obj/machinery/light{
@@ -1116,7 +1150,7 @@
 	color = "#4B7A73";
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/afthall)
 "kQ" = (
 /obj/effect/landmark/scorcher,
@@ -1157,7 +1191,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "lH" = (
 /obj/effect/floor_decal/corner/full{
@@ -1165,7 +1199,7 @@
 	dir = 4
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/cryoentrance)
 "lN" = (
 /obj/structure/filingcabinet/filingcabinet{
@@ -1178,7 +1212,7 @@
 	color = "#4B7A73";
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "lT" = (
 /obj/effect/floor_decal/industrial/outline/security,
@@ -1188,7 +1222,7 @@
 /obj/item/clothing/shoes/magboots,
 /obj/item/device/suit_cooling_unit,
 /obj/item/clothing/mask/breath,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/eva)
 "md" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -1213,7 +1247,7 @@
 "mf" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "mh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1245,11 +1279,11 @@
 /obj/structure/sign/flag/idris/large/west{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "mp" = (
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/central)
 "mq" = (
 /obj/effect/floor_decal/corner{
@@ -1257,7 +1291,7 @@
 	dir = 5
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/central)
 "mF" = (
 /obj/structure/table/steel,
@@ -1268,7 +1302,7 @@
 	color = "#4B7A73";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "mL" = (
 /obj/effect/shuttle_landmark/idris_wreck/nav1,
@@ -1335,7 +1369,7 @@
 	color = "#4B7A73";
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/eva)
 "nN" = (
 /obj/structure/cable/green{
@@ -1351,7 +1385,7 @@
 /obj/random/finances,
 /obj/random/highvalue/no_crystal,
 /obj/random/highvalue/no_crystal,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "nR" = (
 /obj/effect/floor_decal/corner{
@@ -1375,7 +1409,7 @@
 	req_access = list(220)
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "og" = (
 /obj/machinery/light,
@@ -1401,7 +1435,7 @@
 	color = "#4B7A73";
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/cryoentrance)
 "oy" = (
 /turf/simulated/wall/shuttle/idris{
@@ -1436,7 +1470,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "oM" = (
 /obj/machinery/light{
@@ -1447,7 +1481,7 @@
 	dir = 5
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
 "oO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1464,6 +1498,9 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
+"oW" = (
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "oZ" = (
 /obj/structure/sign/flag/idris/large/south{
 	pixel_y = -32
@@ -1472,7 +1509,7 @@
 	color = "#4B7A73";
 	dir = 10
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/central)
 "pa" = (
 /obj/effect/landmark/corpse/idris/captain,
@@ -1512,7 +1549,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "py" = (
 /obj/machinery/light{
@@ -1535,14 +1572,14 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/captain)
 "pJ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/reagent_dispensers/coolanttank,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "pL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1604,7 +1641,7 @@
 	color = "#4B7A73";
 	dir = 10
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "qt" = (
 /obj/structure/sign/flag/idris/large/north{
@@ -1617,7 +1654,7 @@
 /obj/item/clothing/shoes/magboots,
 /obj/item/device/suit_cooling_unit,
 /obj/item/clothing/mask/breath,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/eva)
 "qA" = (
 /obj/effect/landmark/corpse/izharshan,
@@ -1632,7 +1669,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "qS" = (
 /obj/structure/lattice,
@@ -1651,7 +1688,7 @@
 /obj/effect/floor_decal/corner/diagonal{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "rp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1674,6 +1711,13 @@
 /obj/effect/landmark/scorcher,
 /turf/simulated/floor/airless,
 /area/idris_wreck/starbthrust)
+"ru" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "ry" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1681,7 +1725,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "rB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1703,7 +1747,7 @@
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/starbthrust)
 "rE" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/eva)
 "rK" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
@@ -1719,7 +1763,7 @@
 	dir = 5
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
 "sg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1732,7 +1776,7 @@
 	color = "#4B7A73"
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "sj" = (
 /obj/structure/cable/green{
@@ -1741,7 +1785,7 @@
 /obj/effect/floor_decal/corner/diagonal{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "sk" = (
 /obj/effect/floor_decal/industrial/outline/security,
@@ -1760,7 +1804,7 @@
 /obj/item/ammo_magazine/c45m,
 /obj/item/ammo_magazine/c45m,
 /obj/item/ammo_magazine/c45m,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/armory)
 "ss" = (
 /obj/effect/floor_decal/corner/full{
@@ -1773,13 +1817,13 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "sx" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/bridge)
 "sC" = (
 /obj/machinery/light,
@@ -1804,7 +1848,7 @@
 /obj/effect/floor_decal/corner/diagonal{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "ta" = (
 /obj/machinery/porta_turret/stationary{
@@ -1814,7 +1858,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "tb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -1827,6 +1871,13 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/idris_wreck/cryoentrance)
+"tf" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "tk" = (
 /mob/living/simple_animal/hostile/icarus_drone/malf,
 /obj/effect/floor_decal/corner{
@@ -1884,6 +1935,12 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/airless,
 /area/idris_wreck/forehall)
+"tB" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/full,
+/area/idris_wreck/central)
 "tC" = (
 /obj/machinery/computer/ship/engines{
 	dir = 4
@@ -1892,7 +1949,7 @@
 	color = "#4B7A73";
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "tF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1952,7 +2009,7 @@
 /obj/random/finances,
 /obj/random/highvalue/no_crystal,
 /obj/random/highvalue/no_crystal,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "ug" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2006,7 +2063,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "uO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
@@ -2026,7 +2083,7 @@
 	color = "#4B7A73";
 	dir = 10
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/cryoentrance)
 "uW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2055,7 +2112,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "vn" = (
 /obj/effect/shuttle_landmark/idris_wreck/nav4,
@@ -2067,13 +2124,13 @@
 "vu" = (
 /obj/effect/floor_decal/industrial/outline/engineering,
 /obj/structure/closet/radiation,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/afthall)
 "vJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/mainthall)
 "vQ" = (
 /obj/effect/decal/cleanable/blood/oil,
@@ -2103,7 +2160,7 @@
 "vZ" = (
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/machinery/portable_atmospherics/canister/empty/phoron,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "wc" = (
 /obj/structure/cable{
@@ -2115,7 +2172,7 @@
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/central)
 "wi" = (
 /obj/effect/landmark/corpse/izharshan,
@@ -2148,7 +2205,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/central)
 "wq" = (
 /obj/structure/table/wood/mahogany,
@@ -2159,7 +2216,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "ws" = (
 /obj/machinery/light{
@@ -2177,7 +2234,7 @@
 	color = "#4B7A73";
 	dir = 10
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
 "wz" = (
 /obj/item/clothing/accessory/holster/hip,
@@ -2223,7 +2280,14 @@
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
+/area/idris_wreck/central)
+"xb" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
 /area/idris_wreck/central)
 "xf" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -2328,20 +2392,20 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/engi)
 "yc" = (
 /obj/effect/floor_decal/corner{
 	color = "#4B7A73";
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/afthall)
 "yg" = (
 /obj/item/photo{
 	desc = "A picture of a smiling human woman in a wedding dress, standing on what looks like a beautiful Silversun beach. The photograph is faded, and stained with dried blood"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "yj" = (
 /turf/simulated/wall/shuttle/idris,
@@ -2350,13 +2414,13 @@
 /obj/effect/floor_decal/corner/full{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
 "yu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/central)
 "yB" = (
 /obj/structure/cable/green{
@@ -2369,7 +2433,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "yC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2394,10 +2458,10 @@
 	name = "Bridge";
 	req_access = list(220)
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/forehall)
 "yO" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/armory)
 "yR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2450,7 +2514,7 @@
 	color = "#4B7A73";
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "zu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -2469,7 +2533,7 @@
 	color = "#4B7A73";
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/afthall)
 "zE" = (
 /obj/structure/cable{
@@ -2486,7 +2550,7 @@
 /obj/effect/floor_decal/corner/full{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "zI" = (
 /obj/machinery/photocopier,
@@ -2497,7 +2561,7 @@
 	color = "#4B7A73";
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "zL" = (
 /obj/effect/floor_decal/corner/full{
@@ -2512,7 +2576,7 @@
 	dir = 6
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "zR" = (
 /obj/structure/cable/green{
@@ -2522,7 +2586,7 @@
 /obj/effect/floor_decal/corner/diagonal{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "zT" = (
 /obj/effect/landmark/corpse/izharshan,
@@ -2535,7 +2599,7 @@
 	color = "#4B7A73";
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "Ah" = (
 /obj/effect/floor_decal/corner/full{
@@ -2567,7 +2631,7 @@
 	req_access = list(220);
 	dir = 4
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/captain)
 "Ap" = (
 /obj/effect/landmark/scorcher,
@@ -2585,7 +2649,7 @@
 	dir = 10
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
 "AJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2597,7 +2661,7 @@
 	req_access = list(220);
 	name = "Armory"
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/armory)
 "AL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2606,13 +2670,13 @@
 	req_access = list(220);
 	name = "Security Unit Storage"
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/armory)
 "AM" = (
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/mainthall)
 "AN" = (
 /obj/structure/cable{
@@ -2655,7 +2719,7 @@
 	color = "#4B7A73";
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/cryoentrance)
 "AZ" = (
 /obj/structure/cable{
@@ -2665,7 +2729,7 @@
 	color = "#4B7A73"
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "Bg" = (
 /obj/structure/cable{
@@ -2683,7 +2747,7 @@
 /obj/effect/floor_decal/corner{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "Bj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2698,7 +2762,7 @@
 /obj/effect/floor_decal/corner/diagonal{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "Bp" = (
 /obj/machinery/door/firedoor/noid/closed,
@@ -2754,7 +2818,7 @@
 /obj/effect/floor_decal/corner/full{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/afthall)
 "BU" = (
 /obj/structure/table/wood/mahogany,
@@ -2763,7 +2827,7 @@
 	color = "#4B7A73";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "BX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2780,12 +2844,12 @@
 /obj/effect/floor_decal/corner/full{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "Ca" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/eva)
 "Cc" = (
 /obj/effect/floor_decal/spline/plain{
@@ -2826,7 +2890,7 @@
 	color = "#4B7A73";
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "CJ" = (
 /turf/simulated/floor/lino{
@@ -2842,7 +2906,7 @@
 	id_tag = "idris_wreck_vault";
 	name = "Vault"
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/central)
 "CS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2873,7 +2937,7 @@
 	color = "#4B7A73";
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "Dd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -2918,7 +2982,7 @@
 	color = "#4B7A73";
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/afthall)
 "Dx" = (
 /obj/structure/table/steel,
@@ -2928,14 +2992,14 @@
 /obj/effect/floor_decal/corner/full{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "DI" = (
 /obj/effect/floor_decal/corner{
 	color = "#4B7A73";
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/cryoentrance)
 "DJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2982,7 +3046,7 @@
 /obj/machinery/door/firedoor/noid/closed{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/central)
 "Ec" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -2997,14 +3061,14 @@
 	color = "#4B7A73";
 	dir = 10
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "Eh" = (
 /obj/effect/floor_decal/corner{
 	color = "#4B7A73"
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/central)
 "El" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
@@ -3029,7 +3093,7 @@
 	color = "#4B7A73";
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/eva)
 "Ey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3047,7 +3111,7 @@
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/mainthall)
 "EC" = (
 /obj/effect/landmark/corpse/izharshan,
@@ -3085,7 +3149,7 @@
 	req_access = list(220)
 	},
 /obj/item/gun/energy/rifle,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/armory)
 "ES" = (
 /obj/structure/bed/stool/chair/sofa/left/teal{
@@ -3097,7 +3161,7 @@
 /obj/effect/floor_decal/corner/full{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "EZ" = (
 /obj/machinery/light{
@@ -3246,14 +3310,14 @@
 	color = "#4B7A73";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/afthall)
 "GN" = (
 /obj/effect/floor_decal/corner{
 	color = "#4B7A73";
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "GU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3266,7 +3330,7 @@
 	name = "Thrusters";
 	req_access = list(220)
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/afthall)
 "GV" = (
 /obj/machinery/vending/cigarette,
@@ -3274,7 +3338,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/cryoentrance)
 "GW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3314,7 +3378,7 @@
 	color = "#4B7A73";
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/cryoentrance)
 "Hx" = (
 /obj/effect/floor_decal/corner{
@@ -3334,7 +3398,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/central)
 "HF" = (
 /obj/machinery/button/remote/airlock{
@@ -3369,10 +3433,10 @@
 	pixel_x = 32;
 	pixel_y = 5
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/armory)
 "HL" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "HM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3433,7 +3497,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "Io" = (
 /obj/effect/landmark/corpse/idris,
@@ -3452,7 +3516,7 @@
 	color = "#4B7A73";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "Iy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3495,7 +3559,7 @@
 	color = "#4B7A73";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
 "Je" = (
 /obj/structure/cable/green{
@@ -3509,7 +3573,7 @@
 /obj/effect/floor_decal/corner/diagonal{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "Jm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3530,6 +3594,13 @@
 /obj/effect/landmark/scorcher,
 /turf/simulated/floor/airless,
 /area/idris_wreck/starbthrust)
+"Jz" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "JE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3605,7 +3676,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "Kb" = (
 /obj/effect/floor_decal/spline/plain{
@@ -3635,7 +3706,7 @@
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/floor_decal/industrial/outline/engineering,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/engi)
 "Km" = (
 /obj/item/storage/backpack/satchel/idris,
@@ -3660,7 +3731,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
 "KA" = (
 /obj/machinery/appliance/cooker/oven,
@@ -3676,7 +3747,7 @@
 	color = "#4B7A73";
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "KD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3736,13 +3807,13 @@
 /obj/item/clothing/accessory/holster/hip,
 /obj/item/clothing/accessory/holster/hip,
 /obj/item/clothing/accessory/holster/hip,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/armory)
 "KY" = (
 /obj/effect/floor_decal/corner{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/central)
 "Lc" = (
 /mob/living/simple_animal/hostile/icarus_drone/malf,
@@ -3786,7 +3857,7 @@
 	color = "#4B7A73"
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "Lr" = (
 /turf/simulated/floor/tiled/airless,
@@ -3829,7 +3900,7 @@
 	color = "#4B7A73";
 	dir = 10
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
 "LN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3844,12 +3915,12 @@
 /obj/machinery/door/firedoor/noid/closed{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/central)
 "LT" = (
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/structure/safe/highvalue,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "Mf" = (
 /obj/structure/cable,
@@ -3917,14 +3988,14 @@
 /obj/structure/bed/stool/chair/office/bridge/generic{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "MF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/closet/crate/rad,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "MH" = (
 /obj/structure/cable/green{
@@ -3938,7 +4009,7 @@
 /obj/random/vault_weapon,
 /obj/random/finances,
 /obj/random/finances,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "ML" = (
 /obj/effect/landmark/scorcher,
@@ -3957,7 +4028,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "Nr" = (
 /obj/machinery/light,
@@ -3966,14 +4037,14 @@
 	dir = 10
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
 "ND" = (
 /obj/effect/shuttle_landmark/idris_wreck/nav2,
 /turf/template_noop,
 /area/space)
 "NG" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/cryoentrance)
 "NH" = (
 /obj/structure/sign/flag/idris/large/south{
@@ -4000,7 +4071,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "Oh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -4056,7 +4127,7 @@
 	color = "#4B7A73";
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/central)
 "OT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4073,7 +4144,7 @@
 	name = "Cryogenics";
 	req_access = list(220)
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/cryoentrance)
 "Pb" = (
 /obj/structure/bed/stool/chair/padded/teal,
@@ -4118,13 +4189,13 @@
 	color = "#4B7A73";
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
 "Px" = (
 /obj/effect/floor_decal/corner/full{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/cryoentrance)
 "PB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4138,7 +4209,7 @@
 	id_tag = "idris_wreck_vault1";
 	name = "Vault"
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/vault)
 "PT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4174,7 +4245,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/captain)
 "Qe" = (
 /obj/structure/cable/green{
@@ -4188,14 +4259,14 @@
 /obj/effect/floor_decal/corner/diagonal{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "Qv" = (
 /obj/effect/floor_decal/corner{
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "Qw" = (
 /obj/random/civgun/rifle,
@@ -4214,7 +4285,7 @@
 	color = "#4B7A73";
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/afthall)
 "QD" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -4233,14 +4304,17 @@
 	color = "#4B7A73";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "QG" = (
 /obj/machinery/power/smes/buildable/main_engine,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/floor,
 /area/idris_wreck/vault)
 "QK" = (
 /obj/structure/closet/secure_closet/cabinet,
@@ -4263,11 +4337,11 @@
 	color = "#4B7A73";
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
 "QR" = (
 /obj/effect/floor_decal/industrial/outline/security,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "QU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4372,7 +4446,7 @@
 	color = "#4B7A73";
 	dir = 10
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "RQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4403,10 +4477,10 @@
 /obj/effect/floor_decal/corner/diagonal{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "RU" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "RZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -4440,25 +4514,33 @@
 /obj/random/rig_module,
 /obj/random/rig_module,
 /obj/random/rig_module,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "Si" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/airless,
 /area/idris_wreck/captain)
+"Sj" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "So" = (
 /obj/effect/floor_decal/corner{
 	color = "#4B7A73";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "Sq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/mainthall)
 "St" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -4469,7 +4551,7 @@
 /obj/structure/bed/stool/chair/office/bridge/generic{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "SC" = (
 /obj/effect/floor_decal/corner{
@@ -4507,14 +4589,17 @@
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor,
 /area/idris_wreck/engi)
 "SP" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
 	req_access = list(220)
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/captain)
 "SQ" = (
 /obj/structure/cable/green{
@@ -4541,7 +4626,7 @@
 "SY" = (
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/structure/safe/cash,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "Tb" = (
 /obj/structure/table/steel,
@@ -4554,7 +4639,7 @@
 /obj/effect/floor_decal/corner/diagonal{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "Tg" = (
 /mob/living/simple_animal/hostile/icarus_drone/malf,
@@ -4569,12 +4654,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/central)
 "Tr" = (
 /obj/structure/table/wood/mahogany,
 /obj/item/modular_computer/laptop/preset/command,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "Tt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4582,7 +4667,7 @@
 /obj/effect/floor_decal/corner/diagonal{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
 "Tv" = (
 /obj/effect/landmark/scorcher,
@@ -4628,7 +4713,7 @@
 /obj/structure/bed/stool/chair/office/bridge/generic,
 /obj/effect/landmark/corpse/idris,
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "TU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4666,7 +4751,7 @@
 	name = "Central Ring";
 	req_access = list(220)
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/central)
 "UH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4699,7 +4784,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
 "US" = (
 /turf/simulated/wall/shuttle/idris,
@@ -4707,7 +4792,7 @@
 "UU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/cryoentrance)
 "UX" = (
 /obj/effect/floor_decal/corner{
@@ -4723,11 +4808,11 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/eva)
 "Vq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/mainthall)
 "Vv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4740,7 +4825,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "Vy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -4759,7 +4844,7 @@
 	color = "#4B7A73";
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "VG" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
@@ -4802,7 +4887,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
 "VY" = (
 /obj/effect/floor_decal/corner{
@@ -4818,7 +4903,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/empty/north,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/armory)
 "Wd" = (
 /obj/effect/floor_decal/corner{
@@ -4826,7 +4911,7 @@
 	dir = 10
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/captain)
 "Wf" = (
 /obj/effect/floor_decal/corner{
@@ -4876,8 +4961,16 @@
 /obj/effect/floor_decal/corner/diagonal{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
+"Wo" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "Wr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -4926,12 +5019,12 @@
 /area/idris_wreck/cryo)
 "WC" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "WD" = (
 /obj/machinery/suit_cycler/security,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/eva)
 "WE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -4956,17 +5049,17 @@
 	dir = 9
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/cryoentrance)
 "WR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/cryoentrance)
 "WZ" = (
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "Xm" = (
 /obj/effect/floor_decal/corner{
@@ -5019,7 +5112,10 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/floor,
 /area/idris_wreck/engi)
 "XT" = (
 /obj/effect/landmark/corpse/izharshan,
@@ -5068,7 +5164,7 @@
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/starbthrust)
 "Yu" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/vault)
 "Yx" = (
 /obj/structure/table/stone/marble,
@@ -5095,6 +5191,10 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
+"YK" = (
+/obj/machinery/door/firedoor/noid/closed,
+/turf/simulated/floor/tiled/full,
+/area/idris_wreck/central)
 "YO" = (
 /obj/effect/shuttle_landmark/idris_wreck/nav3,
 /turf/template_noop,
@@ -5127,7 +5227,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/cryoentrance)
 "Zu" = (
 /obj/effect/floor_decal/corner{
@@ -5135,7 +5235,7 @@
 	dir = 10
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/central)
 "Zv" = (
 /obj/structure/sign/flag/idris/large/east{
@@ -5146,7 +5246,7 @@
 	dir = 6
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/central)
 "ZE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5166,7 +5266,7 @@
 	dir = 8
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/full/airless,
+/turf/simulated/floor/tiled/full,
 /area/idris_wreck/engi)
 "ZN" = (
 /obj/machinery/light,
@@ -5183,7 +5283,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
 "ZS" = (
 /obj/effect/floor_decal/corner{
@@ -5191,7 +5291,7 @@
 	dir = 10
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
 "ZU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15938,20 +16038,20 @@ Ap
 aY
 IR
 iS
-FB
-ad
-FB
+bH
+it
+bH
 mp
-FB
-FB
-ad
-FB
-jy
-UX
-FB
-ad
-FB
-UP
+bH
+bH
+it
+bH
+ax
+Sj
+bH
+it
+bH
+YK
 FB
 FB
 ad
@@ -16094,7 +16194,7 @@ fD
 Ok
 iq
 IR
-Df
+Jz
 Ry
 oO
 Bu
@@ -16251,21 +16351,21 @@ Qx
 dM
 dM
 IR
-Df
+Jz
 Jm
-bU
+oW
 KY
 mp
 Zv
-cv
-cv
-cv
-AE
-cv
-cv
-XD
+tf
+tf
+tf
+tB
+tf
+tf
+Wo
 OP
-UP
+YK
 fo
 bU
 Rt
@@ -16411,7 +16511,7 @@ IR
 wo
 Jm
 Eh
-Ai
+ru
 IR
 IR
 IR
@@ -16722,7 +16822,7 @@ oT
 oC
 mP
 IR
-Df
+Jz
 Jm
 oZ
 IR
@@ -16881,7 +16981,7 @@ fJ
 IR
 HC
 Ib
-SC
+xb
 IR
 Sb
 Sb
@@ -17352,7 +17452,7 @@ Cw
 UC
 ps
 Wm
-SC
+xb
 IR
 Sb
 Sb
@@ -17821,7 +17921,7 @@ eL
 AN
 Mf
 IR
-Df
+Jz
 Hi
 oZ
 IR
@@ -17978,9 +18078,9 @@ gd
 bu
 gd
 IR
-Df
+Jz
 rp
-SC
+xb
 IR
 Sb
 Sb
@@ -18490,7 +18590,7 @@ Vl
 kS
 Wa
 ee
-iN
+cV
 yO
 jx
 bW

--- a/maps/away/away_site/idris_wreck/idris_wreck.dmm
+++ b/maps/away/away_site/idris_wreck/idris_wreck.dmm
@@ -1,9 +1,20 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/captain)
 "ad" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "ae" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -34,14 +45,28 @@
 "ap" = (
 /turf/simulated/wall/shuttle/idris,
 /area/idris_wreck/bridge)
+"ar" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/starbthrust)
 "aC" = (
 /obj/machinery/anti_bluespace,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
+"aJ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/atmos)
 "aK" = (
 /obj/machinery/light,
 /obj/item/organ/external/arm,
@@ -65,18 +90,23 @@
 "aO" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/random/civgun/rifle,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "aQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "aY" = (
 /turf/template_noop,
 /area/space)
 "aZ" = (
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/cryo)
 "bh" = (
@@ -102,7 +132,7 @@
 /obj/structure/closet/crate/rad,
 /obj/item/stack/material/uranium/full,
 /obj/item/stack/material/uranium/full,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/airless,
 /area/idris_wreck/vault)
 "bp" = (
 /obj/structure/cable/green{
@@ -110,7 +140,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/structure/safe/cash,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "br" = (
 /obj/structure/cable/green{
@@ -119,13 +149,13 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/power/portgen/basic/advanced,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "bu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/dark/full/airless,
 /area/idris_wreck/engi)
 "bw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -155,8 +185,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/atmos)
+"bA" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
 "bB" = (
 /obj/structure/table/stone/marble,
 /obj/machinery/chemical_dispenser/bar_alc/full{
@@ -167,12 +205,26 @@
 	initial_gas = null
 	},
 /area/idris_wreck/kitchen)
+"bC" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/portthrust)
 "bF" = (
 /obj/effect/floor_decal/industrial/outline/security,
 /obj/structure/sign/flag/idris/large/east{
 	pixel_x = 32
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/bridge)
+"bG" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "bJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -192,12 +244,34 @@
 /obj/effect/landmark/corpse/idris,
 /turf/template_noop,
 /area/space)
+"bR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full/airless,
+/area/idris_wreck/mainthall)
 "bS" = (
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
 /turf/simulated/floor/plating,
 /area/idris_wreck/engi)
 "bT" = (
 /obj/structure/table/standard,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "bU" = (
@@ -207,15 +281,23 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/armory)
 "bX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/portthrust)
+"cd" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
 "cj" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -227,8 +309,10 @@
 /turf/simulated/floor/reinforced,
 /area/idris_wreck/vault)
 "cm" = (
-/obj/structure/plasticflaps/airtight,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/structure/plasticflaps/airtight{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/engi)
 "cp" = (
 /obj/structure/bed/stool/chair/office/bridge/generic{
@@ -237,15 +321,27 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
+"cv" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
 "cx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
+"cB" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/portthrust)
 "cF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -272,24 +368,45 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/airless,
 /area/idris_wreck/starbthrust)
+"da" = (
+/obj/machinery/door/firedoor/noid/closed,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/full/airless,
+/area/idris_wreck/forehall)
+"df" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless,
+/area/idris_wreck/central)
 "dp" = (
 /obj/item/clothing/mask/breath,
 /turf/template_noop,
 /area/space)
 "du" = (
 /obj/effect/landmark/corpse/izharshan,
-/obj/effect/decal/cleanable/blood/splatter,
 /obj/random/civgun/rifle,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "dx" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/afthall)
 "dA" = (
 /obj/effect/landmark/scorcher,
@@ -307,9 +424,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/firedoor/noid/closed,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "dM" = (
 /turf/simulated/floor/reinforced/airless,
@@ -322,15 +438,15 @@
 /obj/effect/landmark/scorcher,
 /turf/simulated/floor/airless,
 /area/idris_wreck/starbthrust)
+"dY" = (
+/obj/effect/landmark/scorcher,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/starbthrust)
 "ee" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/sign/flag/idris/large/south{
-	pixel_y = -32
-	},
-/turf/simulated/floor/exoplanet/tiled,
-/area/idris_wreck/central)
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/armory)
 "ei" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/empty{
@@ -339,7 +455,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/atmos)
 "ek" = (
 /obj/machinery/porta_turret/stationary{
@@ -349,7 +466,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "el" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -361,13 +478,12 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/glass_security{
 	dir = 4;
 	name = "EVA Storage";
 	req_access = list(220)
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/eva)
 "eq" = (
 /turf/simulated/wall/shuttle/idris,
@@ -384,36 +500,68 @@
 /obj/structure/sign/flag/idris/large/east{
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/cryo)
 "eL" = (
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/portgen/basic/fusion,
-/turf/simulated/floor/tiled/airless,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
 /area/idris_wreck/engi)
+"eO" = (
+/obj/effect/landmark/scorcher,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
 "fg" = (
 /mob/living/simple_animal/hostile/icarus_drone/malf,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "fj" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/eva)
+"fo" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 4
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
 "fs" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
+"fv" = (
+/turf/simulated/floor/airless,
+/area/idris_wreck/kitchen)
 "fw" = (
 /obj/effect/floor_decal/industrial/outline/security,
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(220)
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/armory)
+"fy" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/portthrust)
 "fA" = (
 /obj/effect/floor_decal/industrial/outline/security,
 /obj/structure/sign/flag/idris/large/west{
@@ -426,7 +574,7 @@
 /obj/item/gun/projectile/shotgun/pump,
 /obj/item/storage/box/shotgunammo,
 /obj/item/storage/box/shotgunammo,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/armory)
 "fD" = (
 /obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
@@ -456,12 +604,12 @@
 /obj/machinery/computer/cryopod{
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/cryo)
 "fJ" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/empty/phoron,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/atmos)
 "fK" = (
 /obj/effect/floor_decal/industrial/hatch/grey,
@@ -473,8 +621,18 @@
 /obj/random/finances,
 /obj/random/highvalue/no_crystal,
 /obj/random/highvalue/no_crystal,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
+"fL" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/obj/effect/landmark/corpse/idris/robot,
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/gun/energy/rifle/laser/noctiluca,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
 "fM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -486,17 +644,29 @@
 /turf/simulated/floor/plating,
 /area/idris_wreck/bridge)
 "gd" = (
-/obj/effect/landmark/scorcher,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/dark/full/airless,
 /area/idris_wreck/engi)
 "gk" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/effect/landmark/scorcher,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
 	},
-/turf/simulated/floor/exoplanet/tiled,
-/area/idris_wreck/armory)
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/atmos)
+"gp" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/eva)
 "gu" = (
 /obj/machinery/vending/snack,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/kitchen)
 "gz" = (
@@ -504,14 +674,29 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/empty/east,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
 "gF" = (
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/forehall)
+"gG" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 8
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/portthrust)
 "gJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -522,7 +707,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/airless,
 /area/idris_wreck/central)
 "gK" = (
@@ -534,21 +718,33 @@
 /obj/item/paper_bin,
 /obj/item/pen/black,
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/idris,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "gM" = (
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/obj/effect/floor_decal/industrial/warning/cee,
+/turf/simulated/floor/plating,
 /area/idris_wreck/engi)
+"gN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/landmark/scorcher,
+/turf/simulated/floor/airless,
+/area/idris_wreck/central)
 "gS" = (
 /obj/machinery/door/airlock/vault/bolted{
 	req_access = list(103);
 	id_tag = "idris_wreck_vault";
 	name = "Vault"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "gT" = (
 /obj/structure/cable/green{
@@ -559,12 +755,12 @@
 	id_tag = "idris_wreck_vault1";
 	name = "Vault"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/vault)
 "gW" = (
 /obj/effect/landmark/corpse/idris,
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "gX" = (
 /obj/machinery/telecomms/allinone/ship,
@@ -578,20 +774,27 @@
 /obj/random/contraband,
 /obj/random/dirt_75,
 /obj/random/dirt_75,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "he" = (
 /obj/machinery/hologram/holopad/long_range,
 /obj/effect/overmap/visitable/idris_wreck,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "hh" = (
 /obj/structure/sign/flag/idris/large/north{
 	pixel_y = 32
 	},
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/idris_wreck/central)
+"hi" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/portthrust)
 "ht" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -638,7 +841,11 @@
 /turf/simulated/floor/airless,
 /area/idris_wreck/captain)
 "hH" = (
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "hL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -646,7 +853,7 @@
 	},
 /obj/structure/bed/stool/chair/padded/teal,
 /obj/effect/landmark/corpse/idris,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/cryo)
 "hT" = (
 /obj/machinery/recharger/wallcharger{
@@ -657,7 +864,7 @@
 	pixel_x = 32;
 	pixel_y = -5
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/armory)
 "hU" = (
 /obj/structure/cable/green{
@@ -665,7 +872,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/structure/safe/highvalue,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "hV" = (
 /obj/structure/table/wood/mahogany,
@@ -677,14 +884,15 @@
 /obj/item/gun/energy/rifle,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/forehall)
 "ia" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/idris_wreck/central)
 "id" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -695,11 +903,18 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/airless,
 /area/idris_wreck/forehall)
+"ii" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
 "ip" = (
 /obj/effect/landmark/corpse/idris,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/item/gun/bang/sec,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "iq" = (
 /obj/effect/landmark/scorcher,
@@ -710,8 +925,23 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/atmos)
+"iA" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/idris_wreck/mainthall)
 "iE" = (
 /obj/machinery/atmospherics/unary/engine,
 /turf/simulated/floor/airless,
@@ -720,8 +950,15 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/armory)
+"iS" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
 "jd" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -736,6 +973,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
 /turf/simulated/floor/airless,
 /area/idris_wreck/forehall)
 "je" = (
@@ -744,7 +982,7 @@
 	},
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/floor_decal/industrial/outline/engineering,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "jl" = (
 /obj/effect/floor_decal/industrial/outline/security,
@@ -771,13 +1009,13 @@
 /obj/item/clothing/accessory/holster/hip,
 /obj/item/clothing/accessory/holster/hip,
 /obj/item/clothing/accessory/holster/hip,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/armory)
 "jo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/kitchen)
 "jt" = (
 /obj/machinery/turretid/lethal{
@@ -789,20 +1027,20 @@
 	req_one_access = list(103)
 	},
 /obj/machinery/light,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "jx" = (
 /obj/machinery/door/airlock/security{
 	req_access = list(220);
 	name = "Security Unit Storage"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/armory)
 "jy" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "jC" = (
 /obj/effect/floor_decal/spline/plain{
@@ -815,12 +1053,22 @@
 /area/idris_wreck/kitchen)
 "jF" = (
 /obj/machinery/atmospherics/pipe/tank/air,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/atmos)
 "jU" = (
-/obj/structure/closet/radiation,
-/obj/effect/floor_decal/industrial/outline/engineering,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/structure/table/standard,
+/obj/item/stack/material/glass/full{
+	pixel_y = 5;
+	pixel_x = -6
+	},
+/obj/item/stack/material/steel/full{
+	pixel_y = 5;
+	pixel_x = 7
+	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "jX" = (
 /obj/structure/cable/green{
@@ -828,17 +1076,47 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
+"kg" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
+"kl" = (
+/obj/effect/landmark/scorcher,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
 "kH" = (
 /obj/item/toy/desk/dippingbird,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "kK" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/afthall)
 "kQ" = (
 /obj/effect/landmark/scorcher,
@@ -852,7 +1130,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/atmos)
 "kZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -868,15 +1146,27 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/forehall)
 "ln" = (
 /obj/structure/table/wood/mahogany,
 /obj/machinery/photocopier/faxmachine{
 	department = "Idris Vault Ship - Captain's Office"
 	},
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
+"lH" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 4
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/cryoentrance)
 "lN" = (
 /obj/structure/filingcabinet/filingcabinet{
 	pixel_x = -6
@@ -884,7 +1174,11 @@
 /obj/structure/filingcabinet/filingcabinet{
 	pixel_x = 6
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "lT" = (
 /obj/effect/floor_decal/industrial/outline/security,
@@ -894,7 +1188,7 @@
 /obj/item/clothing/shoes/magboots,
 /obj/item/device/suit_cooling_unit,
 /obj/item/clothing/mask/breath,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/eva)
 "md" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -913,12 +1207,13 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/landmark/scorcher,
+/obj/random/dirt_75,
 /turf/simulated/floor/airless,
 /area/idris_wreck/armory)
 "mf" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "mh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -930,11 +1225,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
 "mn" = (
 /obj/effect/landmark/corpse/idris,
 /obj/machinery/light,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/portthrust)
 "mo" = (
@@ -943,18 +1245,30 @@
 /obj/structure/sign/flag/idris/large/west{
 	pixel_x = -32
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "mp" = (
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
+/area/idris_wreck/central)
+"mq" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "mF" = (
 /obj/structure/table/steel,
 /obj/item/paper_bin,
 /obj/item/pen/fountain/head,
 /obj/item/stamp/idris,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "mL" = (
 /obj/effect/shuttle_landmark/idris_wreck/nav1,
@@ -963,7 +1277,7 @@
 "mP" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/phoron_scarce,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/atmos)
 "mW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -984,6 +1298,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
 "nb" = (
@@ -992,13 +1309,17 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/empty/north,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/portthrust)
 "nm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/cryo)
 "nw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1007,8 +1328,15 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/afthall)
+"nG" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/eva)
 "nN" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -1023,14 +1351,19 @@
 /obj/random/finances,
 /obj/random/highvalue/no_crystal,
 /obj/random/highvalue/no_crystal,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "nR" = (
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/forehall)
 "oa" = (
-/turf/simulated/floor/tiled/airless,
-/area/idris_wreck/engi)
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/wall/shuttle/idris,
+/area/idris_wreck/portthrust)
 "od" = (
 /obj/machinery/button/remote/airlock{
 	dir = 1;
@@ -1042,12 +1375,13 @@
 	req_access = list(220)
 	},
 /obj/machinery/light,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "og" = (
 /obj/machinery/light,
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/tiled/airless,
+/obj/random/dirt_75,
+/turf/simulated/floor/airless,
 /area/idris_wreck/starbthrust)
 "om" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1062,6 +1396,13 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/idris_wreck/afthall)
+"ow" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/cryoentrance)
 "oy" = (
 /turf/simulated/wall/shuttle/idris{
 	can_open = 1
@@ -1071,15 +1412,43 @@
 /obj/structure/bed/stool/chair/padded/teal{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/idris_wreck/kitchen)
+"oC" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full/airless,
+/area/idris_wreck/atmos)
 "oG" = (
 /turf/simulated/wall/shuttle/idris,
 /area/idris_wreck/portthrust)
 "oJ" = (
 /obj/machinery/light,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/portthrust)
+"oK" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/bridge)
+"oM" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/mainthall)
 "oO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1090,13 +1459,20 @@
 /turf/simulated/floor/plating,
 /area/idris_wreck/central)
 "oT" = (
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
 "oZ" = (
 /obj/structure/sign/flag/idris/large/south{
 	pixel_y = -32
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "pa" = (
 /obj/effect/landmark/corpse/idris/captain,
@@ -1110,12 +1486,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/service{
 	name = "Cryogenics";
 	req_access = list(220)
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/cryo)
 "pj" = (
 /turf/simulated/floor/carpet/brown,
@@ -1137,26 +1512,37 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "py" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/forehall)
+"pF" = (
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/atmos)
 "pI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/captain)
 "pJ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/reagent_dispensers/coolanttank,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "pL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1171,14 +1557,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
 	req_access = list(220);
 	name = "Port Nacelle"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/portthrust)
+"pM" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/kitchen)
 "pX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -1207,6 +1599,13 @@
 	initial_gas = null
 	},
 /area/idris_wreck/kitchen)
+"qo" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/captain)
 "qt" = (
 /obj/structure/sign/flag/idris/large/north{
 	pixel_y = 32
@@ -1218,7 +1617,7 @@
 /obj/item/clothing/shoes/magboots,
 /obj/item/device/suit_cooling_unit,
 /obj/item/clothing/mask/breath,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/eva)
 "qA" = (
 /obj/effect/landmark/corpse/izharshan,
@@ -1233,7 +1632,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "qS" = (
 /obj/structure/lattice,
@@ -1249,7 +1648,10 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "rp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1269,11 +1671,9 @@
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/cryo)
 "rs" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/exoplanet/tiled,
-/area/idris_wreck/central)
+/obj/effect/landmark/scorcher,
+/turf/simulated/floor/airless,
+/area/idris_wreck/starbthrust)
 "ry" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1281,7 +1681,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "rB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1303,7 +1703,7 @@
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/starbthrust)
 "rE" = (
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/eva)
 "rK" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
@@ -1314,23 +1714,12 @@
 /turf/template_noop,
 /area/space)
 "sd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/door/firedoor/noid{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/mainthall)
 "sg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1339,7 +1728,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/engi)
+"sj" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "sk" = (
 /obj/effect/floor_decal/industrial/outline/security,
@@ -1358,23 +1760,34 @@
 /obj/item/ammo_magazine/c45m,
 /obj/item/ammo_magazine/c45m,
 /obj/item/ammo_magazine/c45m,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/armory)
+"ss" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/forehall)
 "su" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "sx" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "sC" = (
 /obj/machinery/light,
 /obj/effect/landmark/scorcher,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "sI" = (
@@ -1385,10 +1798,13 @@
 "sO" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/armory)
 "sV" = (
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "ta" = (
 /obj/machinery/porta_turret/stationary{
@@ -1398,7 +1814,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "tb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -1413,10 +1829,43 @@
 /area/idris_wreck/cryoentrance)
 "tk" = (
 /mob/living/simple_animal/hostile/icarus_drone/malf,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/forehall)
+"to" = (
+/obj/structure/closet/secure_closet{
+	name = "employee equipment"
+	},
+/obj/item/clothing/under/rank/security/idris,
+/obj/item/storage/backpack/satchel/idris,
+/obj/item/clothing/shoes/jackboots{
+	name = "Walk Like Idris jackboots"
+	},
+/obj/item/clothing/head/beret/corporate/idris,
+/obj/item/clothing/accessory/holster/hip,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/cryo)
+"ty" = (
+/obj/effect/landmark/scorcher,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/portthrust)
 "tz" = (
 /obj/effect/landmark/scorcher,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/portthrust)
 "tA" = (
@@ -1439,7 +1888,11 @@
 /obj/machinery/computer/ship/engines{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "tF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1451,17 +1904,16 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/service{
 	dir = 4;
 	name = "Cafeteria";
 	req_access = list(220)
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/kitchen)
 "tJ" = (
 /obj/structure/closet/crate/bin/filled,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/idris_wreck/kitchen)
 "tQ" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1469,14 +1921,26 @@
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/starbthrust)
 "tV" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/turf/simulated/floor/airless,
+/area/idris_wreck/starbthrust)
+"tW" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/portthrust)
+"tY" = (
+/turf/simulated/floor/airless,
+/area/idris_wreck/forehall)
+"tZ" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
 	},
 /turf/simulated/floor/tiled/airless,
-/area/idris_wreck/starbthrust)
-"tY" = (
-/turf/simulated/floor/tiled/airless,
-/area/idris_wreck/forehall)
+/area/idris_wreck/portthrust)
 "ue" = (
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/structure/closet/crate/secure{
@@ -1488,7 +1952,7 @@
 /obj/random/finances,
 /obj/random/highvalue/no_crystal,
 /obj/random/highvalue/no_crystal,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "ug" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1530,14 +1994,25 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/airless,
 /area/idris_wreck/portthrust)
+"uI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/turf/simulated/floor/airless,
+/area/idris_wreck/portthrust)
 "uM" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "uO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
 "uS" = (
@@ -1547,8 +2022,12 @@
 /turf/simulated/floor/plating,
 /area/idris_wreck/armory)
 "uU" = (
-/turf/template_noop,
-/area/idris_wreck/portthrust)
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/cryoentrance)
 "uW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -1572,7 +2051,11 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/empty/north,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "vn" = (
 /obj/effect/shuttle_landmark/idris_wreck/nav4,
@@ -1582,20 +2065,23 @@
 /turf/simulated/wall/shuttle/idris,
 /area/idris_wreck/starbthrust)
 "vu" = (
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/empty/east,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/structure/closet/radiation,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/afthall)
 "vJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/mainthall)
 "vQ" = (
 /obj/effect/decal/cleanable/blood/oil,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "vU" = (
@@ -1617,20 +2103,19 @@
 "vZ" = (
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/machinery/portable_atmospherics/canister/empty/phoron,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "wc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/scorcher,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/dark/full/airless,
 /area/idris_wreck/engi)
 "wd" = (
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "wi" = (
 /obj/effect/landmark/corpse/izharshan,
@@ -1640,7 +2125,11 @@
 	dir = 4
 	},
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/forehall)
 "wn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1648,15 +2137,18 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/firedoor/noid/closed,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "wo" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "wq" = (
 /obj/structure/table/wood/mahogany,
@@ -1667,22 +2159,45 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "ws" = (
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
+"wy" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/mainthall)
 "wz" = (
 /obj/item/clothing/accessory/holster/hip,
 /turf/template_noop,
 /area/space)
+"wC" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/starbthrust)
 "wD" = (
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
 "wI" = (
@@ -1705,11 +2220,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "xf" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1726,8 +2240,20 @@
 /area/idris_wreck/kitchen)
 "xr" = (
 /obj/machinery/light,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/starbthrust)
+"xB" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/portthrust)
 "xH" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 9
@@ -1751,6 +2277,14 @@
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/sign/radiation{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/structure/sign/radiation{
+	pixel_x = 32;
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/idris_wreck/afthall)
 "xO" = (
@@ -1778,6 +2312,9 @@
 /area/idris_wreck/afthall)
 "xQ" = (
 /obj/machinery/atmospherics/binary/passive_gate/on,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
 "xW" = (
@@ -1785,23 +2322,42 @@
 /obj/structure/sign/flag/idris/large/north{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "yb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/engi)
+"yc" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/afthall)
 "yg" = (
 /obj/item/photo{
 	desc = "A picture of a smiling human woman in a wedding dress, standing on what looks like a beautiful Silversun beach. The photograph is faded, and stained with dried blood"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "yj" = (
 /turf/simulated/wall/shuttle/idris,
 /area/idris_wreck/eva)
+"yn" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/mainthall)
+"yu" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/full/airless,
+/area/idris_wreck/central)
 "yB" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -1809,6 +2365,10 @@
 	},
 /obj/machinery/power/apc/empty/north,
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "yC" = (
@@ -1830,15 +2390,14 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/command{
 	name = "Bridge";
 	req_access = list(220)
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/forehall)
 "yO" = (
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/armory)
 "yR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1879,12 +2438,39 @@
 /turf/simulated/floor/airless,
 /area/idris_wreck/central)
 "zn" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/kitchen)
 "zp" = (
 /obj/structure/bed/stool/chair/sofa/right/teal,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
+"zu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/turf/simulated/floor/airless,
+/area/idris_wreck/starbthrust)
+"zv" = (
+/obj/machinery/power/apc/empty/east,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/afthall)
 "zE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1893,17 +2479,39 @@
 	name = "Reactor Array";
 	req_access = list(220)
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/engi)
 "zG" = (
 /obj/machinery/computer/ship/engines,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "zI" = (
 /obj/machinery/photocopier,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/captain)
+"zL" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
+"zP" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "zR" = (
@@ -1911,7 +2519,10 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/empty/west,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "zT" = (
 /obj/effect/landmark/corpse/izharshan,
@@ -1920,15 +2531,27 @@
 /area/space)
 "zX" = (
 /obj/structure/table/wood/mahogany,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "Ah" = (
-/obj/machinery/door/firedoor/noid{
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 8
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/portthrust)
+"Ai" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
 	dir = 4
 	},
-/obj/machinery/light,
-/turf/simulated/floor/exoplanet/tiled,
-/area/idris_wreck/mainthall)
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
 "An" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -1939,59 +2562,57 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/command{
 	name = "Captain's Office";
 	req_access = list(220);
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/captain)
 "Ap" = (
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/idris_wreck/atmos)
 "AE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "AF" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
 	},
-/obj/effect/landmark/scorcher,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/airless,
-/area/idris_wreck/central)
+/area/idris_wreck/mainthall)
 "AJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/security{
 	req_access = list(220);
 	name = "Armory"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/armory)
 "AL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/security{
 	req_access = list(220);
 	name = "Security Unit Storage"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/armory)
 "AM" = (
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/mainthall)
 "AN" = (
 /obj/structure/cable{
@@ -2000,34 +2621,52 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/dark/full/airless,
 /area/idris_wreck/engi)
 "AO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 9
 	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
 "AQ" = (
 /obj/effect/landmark/scorcher,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/idris_wreck/atmos)
 "AS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
 "AU" = (
 /obj/machinery/vending/cola,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/cryoentrance)
+"AZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/engi)
 "Bg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2038,8 +2677,14 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/dark/full/airless,
 /area/idris_wreck/engi)
+"Bh" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/bridge)
 "Bj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -2050,11 +2695,14 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "Bp" = (
 /obj/machinery/door/firedoor/noid/closed,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/forehall)
 "Bt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -2084,6 +2732,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
 "BB" = (
@@ -2096,14 +2747,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/landmark/scorcher,
+/obj/random/dirt_75,
 /turf/simulated/floor/airless,
 /area/idris_wreck/portthrust)
 "BK" = (
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/afthall)
 "BU" = (
 /obj/structure/table/wood/mahogany,
 /obj/machinery/light,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "BX" = (
@@ -2118,12 +2777,15 @@
 /obj/machinery/computer/ship/navigation{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "Ca" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/eva)
 "Cc" = (
 /obj/effect/floor_decal/spline/plain{
@@ -2137,8 +2799,15 @@
 /area/idris_wreck/kitchen)
 "Ch" = (
 /obj/machinery/vending/dinnerware,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/kitchen)
+"Cj" = (
+/turf/simulated/floor/airless,
+/area/idris_wreck/central)
 "Cw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2148,6 +2817,17 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/idris_wreck/afthall)
+"CH" = (
+/obj/structure/table/steel,
+/obj/item/paper_bin,
+/obj/item/pen/black,
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/idris,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/bridge)
 "CJ" = (
 /turf/simulated/floor/lino{
 	initial_gas = null
@@ -2162,7 +2842,7 @@
 	id_tag = "idris_wreck_vault";
 	name = "Vault"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "CS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2174,28 +2854,40 @@
 /turf/simulated/floor/airless,
 /area/idris_wreck/cryo)
 "CY" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/airless,
+/obj/random/dirt_75,
+/turf/simulated/floor/airless,
 /area/idris_wreck/starbthrust)
 "CZ" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/tank/phoron/shuttle,
 /obj/item/tank/phoron/shuttle,
 /obj/structure/closet/crate/secure/phoron,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/atmos)
 "Dc" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/coffeemaster/full{
 	pixel_y = 7
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
+"Dd" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full/airless,
+/area/idris_wreck/forehall)
 "Df" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "Dh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -2221,15 +2913,29 @@
 /obj/effect/landmark/scorcher,
 /turf/simulated/floor/airless,
 /area/idris_wreck/central)
+"Dn" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/afthall)
 "Dx" = (
 /obj/structure/table/steel,
 /obj/machinery/photocopier/faxmachine{
 	department = "Idris Vault Ship - Bridge"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "DI" = (
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/cryoentrance)
 "DJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2240,7 +2946,7 @@
 "DN" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/atmos)
 "DR" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
@@ -2248,10 +2954,17 @@
 /area/idris_wreck/cryo)
 "DW" = (
 /obj/structure/cable,
-/turf/simulated/floor/tiled/airless,
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
 /area/idris_wreck/engi)
 "DX" = (
 /obj/effect/landmark/scorcher,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/cryo)
 "Ea" = (
@@ -2269,7 +2982,7 @@
 /obj/machinery/door/firedoor/noid/closed{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "Ec" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -2280,8 +2993,19 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
+"Eh" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
 "El" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
@@ -2290,6 +3014,10 @@
 /obj/structure/sign/flag/idris/large/west{
 	pixel_x = -32
 	},
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "Eq" = (
@@ -2297,7 +3025,11 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/empty/east,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/eva)
 "Ey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2312,17 +3044,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/mainthall)
 "EC" = (
 /obj/effect/landmark/corpse/izharshan,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/random/civgun/rifle,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/forehall)
 "EG" = (
 /obj/random/spacecash,
@@ -2350,7 +3085,7 @@
 	req_access = list(220)
 	},
 /obj/item/gun/energy/rifle,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/armory)
 "ES" = (
 /obj/structure/bed/stool/chair/sofa/left/teal{
@@ -2359,13 +3094,16 @@
 /obj/structure/sign/flag/idris/large/west{
 	pixel_x = -32
 	},
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "EZ" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/idris_wreck/central)
 "Ff" = (
 /turf/simulated/wall/shuttle/idris,
@@ -2387,6 +3125,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
 /turf/simulated/floor/plating,
 /area/idris_wreck/mainthall)
 "Fp" = (
@@ -2399,8 +3138,23 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/idris_wreck/vault)
+"Fx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/turf/simulated/floor/airless,
+/area/idris_wreck/central)
 "FB" = (
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "FD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
@@ -2416,6 +3170,22 @@
 /obj/effect/landmark/corpse/idris/robot,
 /turf/template_noop,
 /area/space)
+"FL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/airless,
+/area/idris_wreck/starbthrust)
+"FR" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/starbthrust)
 "FU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -2431,14 +3201,24 @@
 	req_access = list(220);
 	name = "Engineering"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/engi)
 "Ga" = (
 /turf/simulated/wall/shuttle/idris,
 /area/idris_wreck/cryoentrance)
 "Gc" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless,
+/area/idris_wreck/forehall)
+"Gd" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "Gg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2455,8 +3235,26 @@
 /area/idris_wreck/central)
 "Gl" = (
 /obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/forehall)
+"Gx" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/afthall)
+"GN" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/bridge)
 "GU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2464,16 +3262,19 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/engineering{
 	name = "Thrusters";
 	req_access = list(220)
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/afthall)
 "GV" = (
 /obj/machinery/vending/cigarette,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/cryoentrance)
 "GW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2482,8 +3283,17 @@
 /obj/machinery/atmospherics/binary/pump/fuel{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
+"Hf" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/starbthrust)
 "Hi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2500,15 +3310,31 @@
 /area/idris_wreck/central)
 "Hp" = (
 /obj/structure/table/steel,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/cryoentrance)
+"Hx" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/forehall)
 "HC" = (
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/empty/north,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "HF" = (
 /obj/machinery/button/remote/airlock{
@@ -2519,6 +3345,10 @@
 	pixel_y = 25;
 	specialfunctions = 4;
 	req_access = list(220)
+	},
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
 	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
@@ -2539,11 +3369,17 @@
 	pixel_x = 32;
 	pixel_y = 5
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/armory)
 "HL" = (
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
+"HM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/idris_wreck/starbthrust)
 "HQ" = (
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/starbthrust)
@@ -2559,7 +3395,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/landmark/scorcher,
 /turf/simulated/floor/airless,
 /area/idris_wreck/portthrust)
@@ -2569,9 +3404,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/firedoor/noid/closed,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/forehall)
 "Ib" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2595,15 +3429,60 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
+"Io" = (
+/obj/effect/landmark/corpse/idris,
+/obj/item/gun/energy/rifle,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/landmark/scorcher,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/forehall)
 "Iv" = (
 /obj/machinery/computer/ship/sensors,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
+"Iy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/turf/simulated/floor/airless,
+/area/idris_wreck/central)
 "IB" = (
-/turf/simulated/wall/shuttle/idris,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/airless,
+/area/idris_wreck/portthrust)
+"IF" = (
+/obj/effect/landmark/scorcher,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/starbthrust)
 "IG" = (
 /obj/structure/window_frame/empty,
 /turf/simulated/floor/airless,
@@ -2611,13 +3490,26 @@
 "IR" = (
 /turf/simulated/wall/shuttle/idris,
 /area/idris_wreck/central)
+"IW" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/mainthall)
 "Je" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/obj/structure/closet/radiation,
-/obj/effect/floor_decal/industrial/outline/engineering,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/structure/table/standard,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 13
+	},
+/obj/item/storage/toolbox/electrical,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "Jm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2631,14 +3523,23 @@
 /area/idris_wreck/central)
 "Jo" = (
 /obj/machinery/atmospherics/pipe/tank,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/atmos)
 "Jr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/landmark/scorcher,
 /turf/simulated/floor/airless,
 /area/idris_wreck/starbthrust)
+"JE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
+/turf/simulated/floor/plating,
+/area/idris_wreck/forehall)
 "JF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -2661,6 +3562,12 @@
 "JM" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/airless,
+/area/idris_wreck/forehall)
+"JO" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/forehall)
 "JQ" = (
 /obj/effect/floor_decal/spline/plain{
@@ -2694,6 +3601,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "Kb" = (
@@ -2706,13 +3617,25 @@
 	initial_gas = null
 	},
 /area/idris_wreck/kitchen)
+"Kc" = (
+/obj/effect/landmark/scorcher,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/starbthrust)
+"Ke" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/starbthrust)
 "Kj" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/floor_decal/industrial/outline/engineering,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "Km" = (
 /obj/item/storage/backpack/satchel/idris,
@@ -2733,7 +3656,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/mainthall)
 "KA" = (
 /obj/machinery/appliance/cooker/oven,
@@ -2745,21 +3672,32 @@
 /obj/machinery/computer/ship/sensors{
 	dir = 8
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "KD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/bed/stool/chair/padded/teal{
 	dir = 1
 	},
 /turf/simulated/floor/airless,
 /area/idris_wreck/kitchen)
+"KJ" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/carpet/brown,
+/area/idris_wreck/captain)
+"KP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/obj/effect/landmark/scorcher,
+/turf/simulated/floor/airless,
+/area/idris_wreck/starbthrust)
 "KQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2798,8 +3736,14 @@
 /obj/item/clothing/accessory/holster/hip,
 /obj/item/clothing/accessory/holster/hip,
 /obj/item/clothing/accessory/holster/hip,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/armory)
+"KY" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
 "Lc" = (
 /mob/living/simple_animal/hostile/icarus_drone/malf,
 /turf/template_noop,
@@ -2820,6 +3764,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/idris_wreck/forehall)
+"Li" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/kitchen)
 "Ll" = (
 /obj/machinery/appliance/cooker/fryer,
 /turf/simulated/floor/lino{
@@ -2830,7 +3782,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "Lr" = (
 /turf/simulated/floor/tiled/airless,
@@ -2845,11 +3801,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
 	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
 "LH" = (
 /obj/machinery/vending/boozeomat/abandoned,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "LI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2866,7 +3825,11 @@
 /area/idris_wreck/eva)
 "LL" = (
 /obj/machinery/light,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/mainthall)
 "LN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2878,24 +3841,29 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/firedoor/noid/closed{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "LT" = (
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/structure/safe/highvalue,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "Mf" = (
 /obj/structure/cable,
 /obj/machinery/power/portgen/basic/fusion,
-/turf/simulated/floor/tiled/airless,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
 /area/idris_wreck/engi)
 "Mh" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/blue,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
 "Mm" = (
@@ -2909,6 +3877,10 @@
 	},
 /obj/item/clothing/head/beret/corporate/idris,
 /obj/item/clothing/accessory/holster/hip,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/cryo)
 "Mn" = (
@@ -2921,9 +3893,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/landmark/scorcher,
 /obj/effect/landmark/corpse/idris/robot,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/dark/full/airless,
 /area/idris_wreck/engi)
 "Mv" = (
 /obj/effect/landmark/scorcher,
@@ -2946,14 +3917,14 @@
 /obj/structure/bed/stool/chair/office/bridge/generic{
 	dir = 8
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "MF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/closet/crate/rad,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "MH" = (
 /obj/structure/cable/green{
@@ -2967,7 +3938,7 @@
 /obj/random/vault_weapon,
 /obj/random/finances,
 /obj/random/finances,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "ML" = (
 /obj/effect/landmark/scorcher,
@@ -2986,18 +3957,30 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
+"Nr" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/mainthall)
 "ND" = (
 /obj/effect/shuttle_landmark/idris_wreck/nav2,
 /turf/template_noop,
 /area/space)
+"NG" = (
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/cryoentrance)
 "NH" = (
 /obj/structure/sign/flag/idris/large/south{
 	pixel_y = -32
 	},
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/idris_wreck/armory)
 "NL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -3013,7 +3996,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "Oh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -3040,6 +4027,13 @@
 /obj/structure/closet/secure_closet{
 	name = "employee equipment"
 	},
+/turf/simulated/floor/airless,
+/area/idris_wreck/cryo)
+"OB" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/cryo)
 "OH" = (
@@ -3048,13 +4042,21 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/empty/west,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/forehall)
 "OP" = (
 /obj/structure/sign/flag/idris/large/east{
 	pixel_x = 32
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "OT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3066,21 +4068,31 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/service{
 	dir = 4;
 	name = "Cryogenics";
 	req_access = list(220)
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/cryoentrance)
 "Pb" = (
 /obj/structure/bed/stool/chair/padded/teal,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/kitchen)
+"Pc" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/forehall)
 "Pg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -3099,13 +4111,26 @@
 /area/idris_wreck/kitchen)
 "Pj" = (
 /obj/machinery/cryopod,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/cryo)
+"Pn" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/mainthall)
+"Px" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/cryoentrance)
 "PB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/atmos)
 "PF" = (
 /obj/machinery/door/airlock/vault/bolted{
@@ -3113,7 +4138,7 @@
 	id_tag = "idris_wreck_vault1";
 	name = "Vault"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/vault)
 "PT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3128,13 +4153,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
 	req_access = list(220);
 	name = "Starboard Nacelle"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/mainthall)
 "PU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -3143,14 +4167,14 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/afthall)
 "Qa" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/captain)
 "Qe" = (
 /obj/structure/cable/green{
@@ -3161,8 +4185,18 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
+"Qv" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/captain)
 "Qw" = (
 /obj/random/civgun/rifle,
 /turf/template_noop,
@@ -3172,17 +4206,21 @@
 /turf/simulated/floor/plating,
 /area/idris_wreck/atmos)
 "QA" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/idris_wreck/portthrust)
+"QB" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/afthall)
 "QD" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/recharge_station,
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/armory)
 "QE" = (
 /turf/simulated/wall/shuttle/idris,
@@ -3191,15 +4229,18 @@
 /obj/machinery/computer/ship/navigation{
 	dir = 8
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "QG" = (
 /obj/machinery/power/smes/buildable/main_engine,
-/obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/airless,
 /area/idris_wreck/vault)
 "QK" = (
 /obj/structure/closet/secure_closet/cabinet,
@@ -3217,9 +4258,16 @@
 	},
 /turf/simulated/floor/carpet/brown,
 /area/idris_wreck/captain)
+"QL" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/mainthall)
 "QR" = (
 /obj/effect/floor_decal/industrial/outline/security,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "QU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3235,6 +4283,7 @@
 	dir = 5
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/random/dirt_75,
 /turf/simulated/floor/airless,
 /area/idris_wreck/starbthrust)
 "QW" = (
@@ -3243,6 +4292,10 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/empty/north,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/starbthrust)
 "Rb" = (
@@ -3250,12 +4303,27 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/empty/north,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/cryo)
+"Rj" = (
+/obj/structure/cable,
+/obj/machinery/power/portgen/basic/fusion,
+/obj/effect/floor_decal/industrial/warning/cee{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/idris_wreck/engi)
 "Rn" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "scrubbers to waste";
 	dir = 1
+	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
 	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
@@ -3293,9 +4361,18 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/idris_wreck/central)
+"RI" = (
+/obj/effect/landmark/scorcher,
+/obj/random/dirt_75,
+/turf/simulated/floor/airless,
+/area/idris_wreck/starbthrust)
 "RM" = (
 /obj/machinery/computer/ship/helm,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "RQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3323,11 +4400,29 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
+"RU" = (
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/bridge)
+"RZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/wall/shuttle/idris,
+/area/idris_wreck/starbthrust)
 "Sb" = (
 /turf/simulated/wall/r_wall,
 /area/idris_wreck/vault)
+"Sc" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/starbthrust)
 "Sf" = (
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/structure/closet/crate/secure{
@@ -3345,35 +4440,43 @@
 /obj/random/rig_module,
 /obj/random/rig_module,
 /obj/random/rig_module,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "Si" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/airless,
 /area/idris_wreck/captain)
+"So" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/bridge)
 "Sq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/light,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/mainthall)
 "St" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/atmos)
 "SB" = (
 /obj/structure/bed/stool/chair/office/bridge/generic{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "SC" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "SD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3404,71 +4507,69 @@
 /obj/structure/cable/green{
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/airless,
 /area/idris_wreck/engi)
 "SP" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
 	req_access = list(220)
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/captain)
 "SQ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/idris_wreck/kitchen)
 "SR" = (
 /obj/effect/landmark/corpse/idris,
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/idris_wreck/cryo)
 "SW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/landmark/scorcher,
 /turf/simulated/floor/airless,
 /area/idris_wreck/portthrust)
 "SY" = (
 /obj/effect/floor_decal/industrial/hatch/grey,
 /obj/structure/safe/cash,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "Tb" = (
 /obj/structure/table/steel,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/idris_wreck/cryo)
 "Te" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "Tg" = (
 /mob/living/simple_animal/hostile/icarus_drone/malf,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/forehall)
 "Tn" = (
-/obj/effect/landmark/corpse/idris/robot,
-/obj/item/gun/energy/rifle/laser/noctiluca,
-/obj/effect/decal/cleanable/blood/oil,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "Tr" = (
 /obj/structure/table/wood/mahogany,
@@ -3478,11 +4579,14 @@
 "Tt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "Tv" = (
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/idris_wreck/armory)
 "Tw" = (
 /turf/simulated/wall/shuttle/idris,
@@ -3505,7 +4609,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/idris_wreck/central)
 "TN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3514,13 +4618,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/obj/random/dirt_75,
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
 "TO" = (
 /obj/structure/bed/stool/chair/office/bridge/generic,
 /obj/effect/landmark/corpse/idris,
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
 "TU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3534,15 +4642,19 @@
 /area/idris_wreck/afthall)
 "Ut" = (
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/forehall)
 "UB" = (
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/portgen/basic/fusion,
-/obj/effect/landmark/scorcher,
-/turf/simulated/floor/tiled/airless,
+/obj/effect/floor_decal/industrial/warning/cee,
+/turf/simulated/floor/plating,
 /area/idris_wreck/engi)
 "UC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3550,12 +4662,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/glass_command{
 	name = "Central Ring";
 	req_access = list(220)
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "UH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3577,34 +4688,46 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/landmark/scorcher,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/dark/full/airless,
 /area/idris_wreck/engi)
 "UP" = (
 /obj/machinery/door/firedoor/noid/closed,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
 "UR" = (
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/mainthall)
 "US" = (
 /turf/simulated/wall/shuttle/idris,
 /area/idris_wreck/engi)
 "UU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/cryoentrance)
+"UX" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
 "Vl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/industrial/outline/emergency_closet,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/eva)
 "Vq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/mainthall)
 "Vv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3626,8 +4749,18 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
+"VD" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/bridge)
 "VG" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/plating,
@@ -3665,16 +4798,43 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/empty/north,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/mainthall)
+"VY" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/forehall)
 "Wa" = (
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/empty/north,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/armory)
+"Wd" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/captain)
+"Wf" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/portthrust)
 "Wi" = (
 /obj/item/grenade/empgrenade,
 /obj/structure/lattice,
@@ -3713,7 +4873,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/engi)
 "Wr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3739,16 +4902,17 @@
 /turf/simulated/floor/airless,
 /area/idris_wreck/starbthrust)
 "Wv" = (
-/obj/machinery/light{
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/airless,
-/area/idris_wreck/central)
+/area/idris_wreck/portthrust)
 "Wy" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/forehall)
 "WA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3762,11 +4926,12 @@
 /area/idris_wreck/cryo)
 "WC" = (
 /obj/machinery/light,
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "WD" = (
 /obj/machinery/suit_cycler/security,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/eva)
 "WE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -3786,14 +4951,35 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/empty/west,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/cryoentrance)
 "WR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/cryoentrance)
+"WZ" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/bridge)
+"Xm" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 4
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/starbthrust)
+"Xr" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/airless,
+/area/idris_wreck/kitchen)
 "Xu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -3804,13 +4990,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
 	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
+"Xy" = (
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/portthrust)
 "XD" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "XK" = (
 /obj/item/material/shard,
@@ -3824,13 +5019,17 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/airless,
 /area/idris_wreck/engi)
 "XT" = (
 /obj/effect/landmark/corpse/izharshan,
 /obj/item/thermal_drill,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/landmark/scorcher,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/central)
 "XX" = (
@@ -3838,6 +5037,10 @@
 	dir = 1
 	},
 /obj/effect/landmark/scorcher,
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/starbthrust)
 "Yb" = (
@@ -3855,10 +5058,17 @@
 	pixel_x = -32
 	},
 /obj/machinery/door/firedoor/noid/closed,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/central)
+"Yt" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/starbthrust)
 "Yu" = (
-/turf/simulated/floor/exoplanet/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/vault)
 "Yx" = (
 /obj/structure/table/stone/marble,
@@ -3880,12 +5090,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/effect/floor_decal/corner/diagonal{
+	color = "#4B7A73"
+	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
 "YO" = (
 /obj/effect/shuttle_landmark/idris_wreck/nav3,
 /turf/template_noop,
 /area/space)
+"YQ" = (
+/obj/effect/landmark/scorcher,
+/turf/simulated/floor/airless,
+/area/idris_wreck/cryo)
 "Zg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -3906,8 +5123,31 @@
 /obj/structure/sign/flag/idris/large/north{
 	pixel_y = 32
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/cryoentrance)
+"Zu" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
+"Zv" = (
+/obj/structure/sign/flag/idris/large/east{
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/central)
 "ZE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3925,12 +5165,34 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/exoplanet/tiled,
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/engi)
+"ZN" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/portthrust)
 "ZO" = (
 /obj/item/gun/bang/sec,
-/turf/simulated/floor/exoplanet/tiled,
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/bridge)
+"ZS" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled/airless,
+/area/idris_wreck/mainthall)
 "ZU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10885,7 +12147,7 @@ aY
 aY
 aY
 aY
-aY
+vs
 vs
 vs
 vs
@@ -11042,8 +12304,8 @@ aY
 aY
 aY
 aY
-aY
 Kr
+RZ
 Oh
 HQ
 HQ
@@ -11199,10 +12461,10 @@ aY
 aY
 aY
 aY
-aY
 vs
-WE
-HQ
+vs
+tV
+tV
 aK
 vs
 vs
@@ -11359,9 +12621,9 @@ aY
 aY
 qS
 qS
-kQ
-HQ
-kQ
+rs
+tV
+rs
 qS
 aY
 aY
@@ -12462,7 +13724,7 @@ qS
 qS
 qS
 qS
-dU
+KP
 og
 vs
 vs
@@ -12617,11 +13879,11 @@ aY
 aY
 qS
 Jr
-kQ
-kQ
+RI
+rs
 dU
 HI
-HQ
+Hf
 vs
 aY
 aY
@@ -12771,14 +14033,14 @@ aY
 aY
 aY
 aY
-aY
+vs
 vs
 dU
 kQ
 HQ
 WE
 bn
-HQ
+Sc
 vs
 vs
 aY
@@ -12928,15 +14190,15 @@ aY
 aY
 aY
 aY
-aY
 Kr
+RZ
 fH
-kQ
+dY
 HQ
-WE
-HQ
-HQ
-HQ
+zu
+Ke
+wC
+Hf
 vs
 aY
 aY
@@ -13085,10 +14347,10 @@ aY
 aY
 aY
 aY
-aY
+vs
 vs
 XX
-kQ
+IF
 HQ
 WE
 HQ
@@ -13245,13 +14507,13 @@ aY
 aY
 vs
 vs
-kQ
-HQ
-WE
+Kc
+Xm
+zu
 JK
 rD
-HQ
-HQ
+wC
+Hf
 vs
 aY
 aY
@@ -13401,14 +14663,14 @@ aY
 aY
 aY
 aY
-IB
-IB
+vs
+vs
 QW
 cT
 Wr
 Wu
 QU
-HQ
+FR
 vs
 vs
 aY
@@ -13559,12 +14821,12 @@ aY
 aY
 aY
 aY
-IB
-HQ
-HQ
+vs
+tV
+tV
 CY
 tV
-cF
+FL
 HQ
 yW
 vs
@@ -13716,13 +14978,13 @@ aY
 aY
 aY
 aY
-IB
+vs
 VP
 aY
 aY
 aY
-cF
-HQ
+HM
+Ke
 tQ
 vs
 vs
@@ -13877,7 +15139,7 @@ aY
 aY
 aY
 aY
-Ec
+tV
 cF
 HQ
 tQ
@@ -14033,10 +15295,10 @@ aY
 aY
 aY
 aY
-Ec
+tV
 Ec
 cF
-HQ
+Ke
 tQ
 yW
 vs
@@ -14190,7 +15452,7 @@ aY
 aY
 aY
 vs
-Ec
+ar
 xf
 cF
 HQ
@@ -14350,7 +15612,7 @@ vs
 vs
 Ec
 cF
-HQ
+Yt
 sI
 VO
 VO
@@ -14662,20 +15924,20 @@ aY
 aY
 aY
 Tw
-UR
+QL
 yR
-UR
+yn
 eq
 jF
 Vy
-oT
-Ap
+pF
+gk
 Ap
 aY
-iq
+Ap
 aY
 IR
-FB
+iS
 FB
 ad
 FB
@@ -14684,16 +15946,16 @@ FB
 FB
 ad
 FB
-XD
-FB
+jy
+UX
 FB
 ad
 FB
 UP
-bU
-bU
-Wv
-bU
+FB
+FB
+ad
+zL
 Rp
 Ch
 qS
@@ -14821,7 +16083,7 @@ aY
 Tw
 UR
 yR
-UR
+ZS
 eq
 St
 Mh
@@ -14832,7 +16094,7 @@ fD
 Ok
 iq
 IR
-FB
+Df
 Ry
 oO
 Bu
@@ -14850,7 +16112,7 @@ dF
 BX
 BX
 Zg
-bU
+SC
 Rp
 Pb
 qS
@@ -14978,7 +16240,7 @@ aY
 Tw
 UR
 yR
-UR
+wy
 eq
 kX
 AO
@@ -14989,25 +16251,25 @@ Qx
 dM
 dM
 IR
-FB
+Df
 Jm
-FB
-FB
+bU
+KY
 mp
-OP
-FB
-FB
-FB
-rs
-FB
-FB
-FB
+Zv
+cv
+cv
+cv
+AE
+cv
+cv
+XD
 OP
 UP
-bU
+fo
 bU
 Rt
-bU
+SC
 Rp
 FE
 qS
@@ -15148,8 +16410,8 @@ eq
 IR
 wo
 Jm
-FB
-FB
+Eh
+Ai
 IR
 IR
 IR
@@ -15161,10 +16423,10 @@ IR
 IR
 IR
 IR
-bU
-bU
-Rt
-bU
+cd
+ii
+Fx
+SC
 Rp
 gu
 ah
@@ -15175,7 +16437,7 @@ aY
 YA
 qS
 qS
-zn
+fv
 xH
 xn
 JQ
@@ -15319,7 +16581,7 @@ Sb
 Sb
 Sb
 IR
-bU
+Df
 Rt
 sC
 Rp
@@ -15332,7 +16594,7 @@ aY
 aY
 qS
 oA
-zn
+Li
 JV
 CJ
 bB
@@ -15447,22 +16709,22 @@ aY
 aY
 aY
 Tw
-AM
 sd
-AM
+yR
+wy
 eq
 oT
-oT
+pF
 TN
 Lz
 Xu
 oT
-fJ
+oC
 mP
 IR
-Gc
-SH
-ee
+Df
+Jm
+oZ
 IR
 Sb
 Sb
@@ -15604,12 +16866,12 @@ aY
 aY
 aY
 Tw
-UR
-yR
-UR
+AM
+bR
+AM
 eq
 oT
-wD
+aJ
 gz
 Bz
 oT
@@ -15619,7 +16881,7 @@ fJ
 IR
 HC
 Ib
-FB
+SC
 IR
 Sb
 Sb
@@ -15635,7 +16897,7 @@ Sb
 IR
 vQ
 UH
-gK
+ia
 qS
 aY
 aY
@@ -15652,12 +16914,12 @@ CJ
 Di
 Rp
 AU
-DI
+ow
 WN
-DI
-DI
+ow
+Px
 HR
-Mm
+to
 Mm
 hL
 Tb
@@ -15775,8 +17037,8 @@ eq
 eq
 IR
 Tn
-Gg
-FB
+SH
+yu
 IR
 Sb
 Sb
@@ -15792,7 +17054,7 @@ Fp
 IR
 HF
 Dm
-gK
+ia
 qS
 aY
 aY
@@ -15803,13 +17065,13 @@ aY
 qS
 SQ
 Pg
-zn
+Li
 Kb
 CJ
 Ll
 Rp
 Zr
-DI
+NG
 SD
 Ea
 Ea
@@ -15819,8 +17081,8 @@ DJ
 WA
 qS
 qS
-DX
-DX
+YQ
+YQ
 DX
 HR
 ap
@@ -15918,22 +17180,22 @@ aY
 aY
 aY
 Tw
-UR
+sd
 yR
-UR
+wy
 QE
-BK
+QB
 dx
-BK
+yc
 RQ
-BK
+yc
 nw
-BK
+yc
 BK
 IR
-FB
+mq
 Gg
-FB
+fL
 IR
 Sb
 Sb
@@ -15948,7 +17210,7 @@ PF
 Yu
 gS
 gK
-Dm
+gN
 qS
 qS
 aY
@@ -15958,7 +17220,7 @@ aY
 aY
 YA
 aY
-zn
+Xr
 rB
 zn
 jC
@@ -15969,16 +17231,16 @@ GV
 UU
 tb
 WR
-DI
+uU
 HR
 Rb
 aZ
 nm
-DX
+YQ
 SR
 rq
 aZ
-aZ
+OB
 HR
 mo
 mf
@@ -16079,9 +17341,9 @@ VT
 ug
 Fk
 GU
-TU
-TU
 om
+TU
+TU
 xP
 Cw
 JF
@@ -16090,7 +17352,7 @@ Cw
 UC
 ps
 Wm
-FB
+SC
 IR
 Sb
 Sb
@@ -16117,7 +17379,7 @@ YA
 qS
 tJ
 rB
-zn
+pM
 qf
 CJ
 vU
@@ -16126,7 +17388,7 @@ Hp
 DI
 yC
 DI
-DI
+lH
 HR
 eJ
 Pj
@@ -16137,11 +17399,11 @@ Pj
 eJ
 Pj
 HR
-hH
+oK
 hH
 lN
 tC
-gL
+CH
 BY
 ap
 ap
@@ -16234,20 +17496,20 @@ aY
 Tw
 UR
 hz
-UR
+wy
 QE
-BK
+zv
 kK
 vu
 xN
-BK
+vu
 PU
-BK
-BK
+Dn
+Gx
 IR
-FB
+bA
 rp
-FB
+Zu
 IR
 Sb
 Sb
@@ -16261,7 +17523,7 @@ wr
 gT
 wr
 CM
-AF
+ia
 qS
 aY
 aY
@@ -16295,7 +17557,7 @@ HR
 HR
 HR
 vm
-hH
+WZ
 ip
 yg
 ME
@@ -16389,9 +17651,9 @@ aY
 aY
 aY
 Tw
-Kz
+oM
 hz
-LL
+Nr
 US
 US
 US
@@ -16403,8 +17665,8 @@ US
 US
 IR
 du
-rp
-FB
+Rq
+yu
 IR
 Sb
 Sb
@@ -16418,7 +17680,7 @@ WC
 Sb
 cj
 IR
-gK
+ia
 Wi
 qS
 qS
@@ -16429,34 +17691,34 @@ aY
 qS
 tY
 tY
-tY
+nR
 aL
 Bp
-nR
+Hx
 Wy
 tk
-nR
+Hx
 nR
 nR
 ZE
 EC
-nR
+Hx
 nR
 OH
 nR
-hZ
+Io
 Wy
 nR
+Hx
 nR
-nR
-nR
+JO
 rK
 NW
-hH
+RU
 sx
-hH
-hH
-hH
+Bh
+VD
+So
 hH
 zG
 ZY
@@ -16548,7 +17810,7 @@ aY
 Tw
 AM
 Ey
-Ah
+AM
 US
 jU
 sV
@@ -16584,7 +17846,7 @@ aY
 aY
 qS
 qS
-id
+Gc
 id
 tA
 jd
@@ -16593,14 +17855,14 @@ Or
 pX
 Or
 Or
-Or
+JE
 Or
 ae
 kZ
 Or
 Or
 KQ
-Or
+JE
 Or
 pX
 Or
@@ -16613,7 +17875,7 @@ MY
 fM
 fg
 he
-hH
+oK
 TO
 RM
 ZY
@@ -16705,19 +17967,19 @@ aY
 Tw
 UR
 hz
-UR
+wy
 US
 Je
 jX
 Qe
 Bj
 bS
-oa
+gd
 bu
-oa
+gd
 IR
-Gc
-Rq
+Df
+rp
 SC
 IR
 Sb
@@ -16744,34 +18006,34 @@ JM
 gF
 Tg
 MB
-gF
-Bp
-nR
-li
+py
+da
+Pc
+Dd
 wi
-nR
-nR
-nR
+Pc
+Pc
+VY
 Lh
 Gl
 hZ
 Ut
-nR
+VY
 py
-nR
+Pc
 li
-nR
+Pc
 py
-nR
-nR
+VY
+ss
 rK
 ZO
-hH
+RU
 aQ
 hH
-hH
-hH
-hH
+GN
+bG
+Bh
 Iv
 ZY
 aY
@@ -16861,7 +18123,7 @@ aY
 aY
 Tw
 Vq
-TB
+iA
 Sq
 US
 Kj
@@ -16871,7 +18133,7 @@ sg
 bS
 gM
 Bg
-Mf
+Rj
 IR
 Eb
 LN
@@ -16922,12 +18184,12 @@ kS
 kS
 kS
 kS
-hH
+oK
 gW
-hH
-hH
+RU
+WZ
 SB
-hH
+Bh
 mF
 ap
 ap
@@ -17019,7 +18281,7 @@ aY
 Tw
 Kz
 hz
-UR
+AF
 US
 je
 Wn
@@ -17032,8 +18294,8 @@ gd
 IR
 ws
 zb
-bU
-bU
+Gd
+zL
 IR
 IR
 IR
@@ -17045,7 +18307,7 @@ IR
 IR
 IR
 IR
-gK
+ia
 qS
 qS
 qS
@@ -17056,7 +18318,7 @@ qS
 qS
 Ff
 zp
-HL
+aa
 Vv
 bT
 ES
@@ -17065,7 +18327,7 @@ LH
 ha
 Ff
 lT
-rE
+nG
 LI
 Ca
 kS
@@ -17079,8 +18341,8 @@ sO
 sO
 sO
 kS
-hH
-hH
+oK
+Bh
 Dc
 KB
 gL
@@ -17174,34 +18436,34 @@ aY
 aY
 aY
 Tw
-UR
+sd
 hz
-UR
+wy
 US
-Lq
+sj
 ZF
 sV
-Te
+AZ
 bS
 UB
 Mn
 DW
 IR
-bU
+Df
 zb
 bU
 aO
 UP
 Eo
-bU
-bU
-bU
+FB
+FB
+FB
 jy
-bU
-bU
-bU
+FB
+UX
+FB
 Yh
-gK
+ia
 qS
 qS
 aY
@@ -17227,8 +18489,8 @@ md
 Vl
 kS
 Wa
-yO
-gk
+ee
+iN
 yO
 jx
 bW
@@ -17333,7 +18595,7 @@ aY
 Tw
 UR
 hz
-UR
+ZS
 US
 Lq
 sV
@@ -17344,20 +18606,20 @@ aY
 aY
 aY
 aY
-gK
+kl
 Wk
 ZU
 mW
 wn
 mW
 mW
-mW
+Iy
 mW
 wI
 mW
+Iy
 mW
-mW
-mW
+df
 qS
 qS
 aY
@@ -17367,13 +18629,13 @@ aY
 qS
 qS
 qS
-bU
+Cj
 Ff
 yB
 Qa
 hB
 pI
-HL
+Wd
 Ff
 qd
 pj
@@ -17488,9 +18750,9 @@ aY
 aY
 aY
 Tw
-UR
+Pn
 hz
-UR
+IW
 US
 SO
 XS
@@ -17503,18 +18765,18 @@ aY
 aY
 aY
 aY
-gK
-gK
+eO
+eO
 UP
-bU
-EZ
-bU
-bU
+cv
+kg
+cv
+XD
 AE
-bU
-EZ
-bU
-gK
+cv
+kg
+XD
+ia
 qS
 aY
 aY
@@ -17524,19 +18786,19 @@ aY
 aY
 aY
 qS
-bU
+Cj
 Ff
-HL
+Qv
 dE
 Tr
 ai
-HL
+qo
 Ff
 QK
 pj
 Ff
 lT
-rE
+gp
 Eq
 WD
 kS
@@ -17681,7 +18943,7 @@ aY
 YA
 qS
 qS
-bU
+Cj
 Ff
 ln
 HL
@@ -17689,7 +18951,7 @@ cp
 HL
 kH
 SP
-pj
+KJ
 pj
 Ff
 yj
@@ -17802,10 +19064,10 @@ qS
 aY
 aY
 oG
-Lr
+Wv
 EH
-Lr
-Lr
+xB
+fy
 US
 gX
 US
@@ -17838,13 +19100,13 @@ aY
 qS
 qS
 gJ
-bU
+SC
 Ff
 JY
 HL
 HL
 HL
-HL
+qo
 Ff
 pj
 uu
@@ -17959,10 +19221,10 @@ aY
 aY
 aY
 qS
-tz
+QA
 uW
-Lr
-Lr
+Xy
+hi
 US
 US
 US
@@ -17995,10 +19257,10 @@ aY
 aY
 qS
 EZ
-bU
+Ai
 Ff
 zI
-HL
+zP
 zX
 zX
 BU
@@ -18119,7 +19381,7 @@ qS
 qS
 SW
 Lr
-Lr
+gG
 mn
 oG
 oG
@@ -18275,9 +19537,9 @@ aY
 qS
 qS
 qS
-tz
-tz
-tz
+QA
+QA
+ty
 oG
 aY
 aY
@@ -19838,7 +21100,7 @@ aY
 aY
 oG
 tz
-tz
+QA
 QA
 qS
 qS
@@ -20150,13 +21412,13 @@ aY
 aY
 oG
 oG
-Lr
-Lr
+Ah
+Wf
 Ku
 bX
 et
-tz
-tz
+QA
+QA
 aY
 aY
 aY
@@ -20304,15 +21566,15 @@ aY
 aY
 aY
 aY
-aY
 oG
-Lr
-Lr
+oG
+Wv
+Wf
 Lr
 Ku
+Xy
 Lr
-Lr
-Lr
+hi
 oG
 oG
 aY
@@ -20461,15 +21723,15 @@ aY
 aY
 aY
 aY
-aY
 iE
+oa
 Dh
 Lr
-Lr
+Xy
 Ku
 Lr
-Lr
-Lr
+cB
+bC
 oG
 aY
 aY
@@ -20618,7 +21880,7 @@ aY
 aY
 aY
 aY
-aY
+oG
 oG
 NL
 Lr
@@ -20775,14 +22037,14 @@ aY
 aY
 aY
 aY
-aY
 iE
+oa
 FD
-Lr
+Xy
 Lr
 Ku
-Lr
-Lr
+cB
+bC
 oG
 aY
 aY
@@ -20932,13 +22194,13 @@ aY
 aY
 aY
 aY
-aY
+oG
 oG
 Bt
+Xy
 Lr
-Lr
-Ku
-Lr
+uI
+tW
 oG
 oG
 aY
@@ -21089,13 +22351,13 @@ aY
 aY
 aY
 aY
-aY
 iE
+oa
 WM
 xO
 xO
 uH
-Lr
+bC
 oG
 aY
 aY
@@ -21246,12 +22508,12 @@ aY
 aY
 aY
 aY
-aY
+oG
 oG
 Bt
 Lr
-Lr
-Lr
+Xy
+hi
 oG
 oG
 aY
@@ -21403,12 +22665,12 @@ aY
 aY
 aY
 aY
-aY
 iE
+oa
 FD
-Lr
-Lr
-Lr
+Xy
+cB
+bC
 oG
 aY
 aY
@@ -21560,13 +22822,13 @@ aY
 aY
 aY
 aY
-aY
 oG
-NL
+oG
+IB
 Lr
-oJ
+ZN
 oG
-uU
+oG
 aY
 aY
 aY
@@ -21717,11 +22979,11 @@ aY
 aY
 aY
 aY
-aY
 iE
+oa
 uH
-Lr
-Lr
+tZ
+bC
 oG
 aY
 aY
@@ -21874,7 +23136,7 @@ aY
 aY
 aY
 aY
-aY
+oG
 oG
 oG
 oG

--- a/maps/away/away_site/idris_wreck/idris_wreck.dmm
+++ b/maps/away/away_site/idris_wreck/idris_wreck.dmm
@@ -4,7 +4,7 @@
 	color = "#4B7A73";
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "ad" = (
 /obj/machinery/light{
@@ -40,7 +40,7 @@
 "ai" = (
 /obj/structure/table/wood/mahogany,
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/idris,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "ap" = (
 /turf/simulated/wall/shuttle/idris,
@@ -50,12 +50,6 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/starbthrust)
-"ax" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/full,
-/area/idris_wreck/central)
 "aC" = (
 /obj/machinery/anti_bluespace,
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -237,13 +231,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/idris_wreck/bridge)
-"bH" = (
-/obj/effect/floor_decal/corner{
-	color = "#4B7A73";
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/idris_wreck/central)
 "bJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -290,7 +277,7 @@
 	color = "#4B7A73";
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "bU" = (
 /turf/simulated/floor/tiled/airless,
@@ -337,7 +324,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "cv" = (
 /obj/effect/floor_decal/corner{
@@ -386,12 +373,6 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/airless,
 /area/idris_wreck/starbthrust)
-"cV" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/full,
-/area/idris_wreck/armory)
 "da" = (
 /obj/machinery/door/firedoor/noid/closed,
 /obj/effect/floor_decal/corner{
@@ -441,7 +422,7 @@
 /obj/item/paper_bin,
 /obj/item/pen/fountain/captain,
 /obj/item/stamp/idris,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "dF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -534,7 +515,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/idris_wreck/engi)
 "eO" = (
 /obj/effect/landmark/scorcher,
@@ -753,7 +734,7 @@
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/industrial/warning/cee,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/idris_wreck/engi)
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -879,6 +860,12 @@
 /obj/effect/landmark/corpse/idris,
 /turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/cryo)
+"hQ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
+/area/idris_wreck/armory)
 "hT" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 32;
@@ -944,16 +931,6 @@
 /obj/effect/landmark/scorcher,
 /turf/simulated/floor/reinforced/airless,
 /area/idris_wreck/atmos)
-"it" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner{
-	color = "#4B7A73";
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/idris_wreck/central)
 "iu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
@@ -1140,7 +1117,7 @@
 	color = "#4B7A73";
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "kK" = (
 /obj/machinery/light{
@@ -1191,7 +1168,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "lH" = (
 /obj/effect/floor_decal/corner/full{
@@ -1498,9 +1475,6 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
-"oW" = (
-/turf/simulated/floor/tiled,
-/area/idris_wreck/central)
 "oZ" = (
 /obj/structure/sign/flag/idris/large/south{
 	pixel_y = -32
@@ -1572,7 +1546,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/captain)
 "pJ" = (
 /obj/structure/cable{
@@ -1641,7 +1615,7 @@
 	color = "#4B7A73";
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "qt" = (
 /obj/structure/sign/flag/idris/large/north{
@@ -1711,13 +1685,6 @@
 /obj/effect/landmark/scorcher,
 /turf/simulated/floor/airless,
 /area/idris_wreck/starbthrust)
-"ru" = (
-/obj/effect/floor_decal/corner/full{
-	color = "#4B7A73";
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/idris_wreck/central)
 "ry" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1871,13 +1838,6 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/plating,
 /area/idris_wreck/cryoentrance)
-"tf" = (
-/obj/effect/floor_decal/corner{
-	color = "#4B7A73";
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/idris_wreck/central)
 "tk" = (
 /mob/living/simple_animal/hostile/icarus_drone/malf,
 /obj/effect/floor_decal/corner{
@@ -1935,12 +1895,6 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor/airless,
 /area/idris_wreck/forehall)
-"tB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/full,
-/area/idris_wreck/central)
 "tC" = (
 /obj/machinery/computer/ship/engines{
 	dir = 4
@@ -2102,6 +2056,13 @@
 /obj/effect/landmark/corpse/idris,
 /turf/simulated/floor/airless,
 /area/idris_wreck/portthrust)
+"vh" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "vm" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -2282,13 +2243,6 @@
 	},
 /turf/simulated/floor/tiled/full,
 /area/idris_wreck/central)
-"xb" = (
-/obj/effect/floor_decal/corner{
-	color = "#4B7A73";
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/idris_wreck/central)
 "xf" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/closet/crate,
@@ -2311,6 +2265,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/starbthrust)
+"xA" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "xB" = (
 /obj/effect/floor_decal/corner{
 	color = "#4B7A73";
@@ -2318,6 +2279,9 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/portthrust)
+"xE" = (
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "xH" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 9
@@ -2433,7 +2397,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "yC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2514,7 +2478,7 @@
 	color = "#4B7A73";
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "zu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -2561,7 +2525,7 @@
 	color = "#4B7A73";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "zL" = (
 /obj/effect/floor_decal/corner/full{
@@ -2576,7 +2540,7 @@
 	dir = 6
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "zR" = (
 /obj/structure/cable/green{
@@ -2599,7 +2563,7 @@
 	color = "#4B7A73";
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "Ah" = (
 /obj/effect/floor_decal/corner/full{
@@ -2827,7 +2791,7 @@
 	color = "#4B7A73";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "BX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3021,7 +2985,7 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/idris_wreck/engi)
 "DX" = (
 /obj/effect/landmark/scorcher,
@@ -3061,7 +3025,7 @@
 	color = "#4B7A73";
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "Eh" = (
 /obj/effect/floor_decal/corner{
@@ -3161,7 +3125,7 @@
 /obj/effect/floor_decal/corner/full{
 	color = "#4B7A73"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "EZ" = (
 /obj/machinery/light{
@@ -3436,7 +3400,7 @@
 /turf/simulated/floor/tiled/full,
 /area/idris_wreck/armory)
 "HL" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "HM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3497,7 +3461,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "Io" = (
 /obj/effect/landmark/corpse/idris,
@@ -3510,6 +3474,13 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/forehall)
+"Ip" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "Iv" = (
 /obj/machinery/computer/ship/sensors,
 /obj/effect/floor_decal/corner/full{
@@ -3539,6 +3510,14 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/airless,
 /area/idris_wreck/portthrust)
+"ID" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "IF" = (
 /obj/effect/landmark/scorcher,
 /obj/effect/floor_decal/corner{
@@ -3561,6 +3540,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/idris_wreck/mainthall)
+"Jc" = (
+/obj/machinery/door/firedoor/noid/closed,
+/turf/simulated/floor/tiled/full,
+/area/idris_wreck/central)
 "Je" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -3594,13 +3577,6 @@
 /obj/effect/landmark/scorcher,
 /turf/simulated/floor/airless,
 /area/idris_wreck/starbthrust)
-"Jz" = (
-/obj/effect/floor_decal/corner{
-	color = "#4B7A73";
-	dir = 5
-	},
-/turf/simulated/floor/tiled,
-/area/idris_wreck/central)
 "JE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3676,7 +3652,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "Kb" = (
 /obj/effect/floor_decal/spline/plain{
@@ -3862,6 +3838,12 @@
 "Lr" = (
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/portthrust)
+"Lt" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/full,
+/area/idris_wreck/central)
 "Lz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -3928,7 +3910,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/idris_wreck/engi)
 "Mh" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/blue,
@@ -4245,7 +4227,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/full,
+/turf/simulated/floor/tiled/full/airless,
 /area/idris_wreck/captain)
 "Qe" = (
 /obj/structure/cable/green{
@@ -4266,7 +4248,7 @@
 	color = "#4B7A73";
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "Qw" = (
 /obj/random/civgun/rifle,
@@ -4372,6 +4354,12 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/starbthrust)
+"Ra" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/full,
+/area/idris_wreck/central)
 "Rb" = (
 /obj/structure/cable/green{
 	icon_state = "0-8"
@@ -4389,7 +4377,7 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/idris_wreck/engi)
 "Rn" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -4520,14 +4508,6 @@
 /obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /turf/simulated/floor/airless,
 /area/idris_wreck/captain)
-"Sj" = (
-/obj/effect/floor_decal/corner{
-	color = "#4B7A73";
-	dir = 9
-	},
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled,
-/area/idris_wreck/central)
 "So" = (
 /obj/effect/floor_decal/corner{
 	color = "#4B7A73";
@@ -4659,7 +4639,7 @@
 "Tr" = (
 /obj/structure/table/wood/mahogany,
 /obj/item/modular_computer/laptop/preset/command,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "Tt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4739,7 +4719,7 @@
 	},
 /obj/machinery/power/portgen/basic/fusion,
 /obj/effect/floor_decal/industrial/warning/cee,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/idris_wreck/engi)
 "UC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4789,6 +4769,16 @@
 "US" = (
 /turf/simulated/wall/shuttle/idris,
 /area/idris_wreck/engi)
+"UT" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "UU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/random/dirt_75,
@@ -4825,7 +4815,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/airless,
 /area/idris_wreck/captain)
 "Vy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -4911,7 +4901,7 @@
 	dir = 10
 	},
 /obj/random/dirt_75,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/airless,
 /area/idris_wreck/captain)
 "Wf" = (
 /obj/effect/floor_decal/corner{
@@ -4963,14 +4953,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/idris_wreck/engi)
-"Wo" = (
-/obj/effect/floor_decal/corner{
-	color = "#4B7A73";
-	dir = 6
-	},
-/obj/random/dirt_75,
-/turf/simulated/floor/tiled,
-/area/idris_wreck/central)
 "Wr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -5073,6 +5055,13 @@
 /obj/random/dirt_75,
 /turf/simulated/floor/airless,
 /area/idris_wreck/kitchen)
+"Xt" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "Xu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -5105,6 +5094,13 @@
 /obj/item/stack/rods,
 /turf/template_noop,
 /area/space)
+"XO" = (
+/obj/effect/floor_decal/corner/full{
+	color = "#4B7A73";
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "XS" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -5139,6 +5135,14 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/starbthrust)
+"XY" = (
+/obj/effect/floor_decal/corner{
+	color = "#4B7A73";
+	dir = 6
+	},
+/obj/random/dirt_75,
+/turf/simulated/floor/tiled,
+/area/idris_wreck/central)
 "Yb" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -5191,10 +5195,6 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/idris_wreck/atmos)
-"YK" = (
-/obj/machinery/door/firedoor/noid/closed,
-/turf/simulated/floor/tiled/full,
-/area/idris_wreck/central)
 "YO" = (
 /obj/effect/shuttle_landmark/idris_wreck/nav3,
 /turf/template_noop,
@@ -16038,20 +16038,20 @@ Ap
 aY
 IR
 iS
-bH
-it
-bH
+xA
+UT
+xA
 mp
-bH
-bH
-it
-bH
-ax
-Sj
-bH
-it
-bH
-YK
+xA
+xA
+UT
+xA
+Ra
+ID
+xA
+UT
+xA
+Jc
 FB
 FB
 ad
@@ -16194,7 +16194,7 @@ fD
 Ok
 iq
 IR
-Jz
+Ip
 Ry
 oO
 Bu
@@ -16351,21 +16351,21 @@ Qx
 dM
 dM
 IR
-Jz
+Ip
 Jm
-oW
+xE
 KY
 mp
 Zv
-tf
-tf
-tf
-tB
-tf
-tf
-Wo
+Xt
+Xt
+Xt
+Lt
+Xt
+Xt
+XY
 OP
-YK
+Jc
 fo
 bU
 Rt
@@ -16511,7 +16511,7 @@ IR
 wo
 Jm
 Eh
-ru
+XO
 IR
 IR
 IR
@@ -16822,7 +16822,7 @@ oT
 oC
 mP
 IR
-Jz
+Ip
 Jm
 oZ
 IR
@@ -16981,7 +16981,7 @@ fJ
 IR
 HC
 Ib
-xb
+vh
 IR
 Sb
 Sb
@@ -17452,7 +17452,7 @@ Cw
 UC
 ps
 Wm
-xb
+vh
 IR
 Sb
 Sb
@@ -17921,7 +17921,7 @@ eL
 AN
 Mf
 IR
-Jz
+Ip
 Hi
 oZ
 IR
@@ -18078,9 +18078,9 @@ gd
 bu
 gd
 IR
-Jz
+Ip
 rp
-xb
+vh
 IR
 Sb
 Sb
@@ -18590,7 +18590,7 @@ Vl
 kS
 Wa
 ee
-cV
+hQ
 yO
 jx
 bW


### PR DESCRIPTION
Changes the Idris Wreck away site to look a bit nicer, using various techniques developed for making ships that have come around since this was added. Along with some minor mapping tweaks, fixing bugs with misplaced fixtures, uneven design, so on.