### PR TITLE
Coalition Ship Purge from Badlands

### DIFF
--- a/html/changelogs/Ben10083-No_More-CoC.yml
+++ b/html/changelogs/Ben10083-No_More-CoC.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Some Tajaran ships have different spawn weights in certain allied sectors."
+  - rscdel: "Coalition Ships removed from Badlands pool."

--- a/maps/away/away_site/tajara/peoples_station/peoples_station.dm
+++ b/maps/away/away_site/tajara/peoples_station/peoples_station.dm
@@ -6,7 +6,7 @@
 	suffixes = list("peoples_station.dmm")
 
 	sectors = list(SECTOR_SRANDMARR)
-	spawn_weight = 1
+	spawn_weight = 2.5
 	spawn_cost = 1
 	id = "peoples_station"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/peoples_station_fang, /datum/shuttle/autodock/overmap/peoples_station_transport)

--- a/maps/away/ships/coc/coc_ranger/coc_ship.dm
+++ b/maps/away/ships/coc/coc_ranger/coc_ship.dm
@@ -5,8 +5,7 @@
 	prefix = "ships/coc/coc_ranger/"
 	suffixes = list("coc_ship.dmm")
 
-	sectors = list(SECTOR_BADLANDS, ALL_COALITION_SECTORS)
-	spawn_weight_sector_dependent = list(ALL_BADLAND_SECTORS = 0.5)
+	sectors = list(ALL_COALITION_SECTORS)
 	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA)
 	spawn_weight = 1
 	ship_cost = 1

--- a/maps/away/ships/coc/coc_surveyor/coc_surveyor.dm
+++ b/maps/away/ships/coc/coc_surveyor/coc_surveyor.dm
@@ -5,8 +5,7 @@
 	prefix = "ships/coc/coc_surveyor/"
 	suffixes = list("coc_surveyor.dmm")
 
-	sectors = list(SECTOR_BADLANDS, ALL_COALITION_SECTORS, ALL_VOID_SECTORS)
-	spawn_weight_sector_dependent = list(ALL_BADLAND_SECTORS = 0.5)
+	sectors = list(ALL_COALITION_SECTORS, ALL_VOID_SECTORS)
 	sectors_blacklist = list(SECTOR_HANEUNIM, SECTOR_BURZSIA)
 	spawn_weight = 1
 	ship_cost = 1

--- a/maps/away/ships/dpra/hailstorm/hailstorm_ship.dm
+++ b/maps/away/ships/dpra/hailstorm/hailstorm_ship.dm
@@ -9,6 +9,7 @@
 	ship_cost = 1
 	spawn_weight = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/hailstorm_shuttle)
+	spawn_weight_sector_dependent = list(SECTOR_SRANDMARR = 2, SECTOR_GAKAL = 2)
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_GAKAL)
 	unit_test_groups = list(1)
 

--- a/maps/away/ships/nka/nka_merchant/nka_merchant.dm
+++ b/maps/away/ships/nka/nka_merchant/nka_merchant.dm
@@ -9,6 +9,7 @@
 	ship_cost = 1
 	spawn_weight = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/nka_merchant_shuttle)
+	spawn_weight_sector_dependent = list(SECTOR_SRANDMARR = 2)
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_VALLEY_HALE, SECTOR_CORP_ZONE, SECTOR_TAU_CETI)
 
 	unit_test_groups = list(3)

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dm
@@ -9,6 +9,7 @@
 	ship_cost = 1
 	spawn_weight = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/headmaster_shuttle)
+	spawn_weight_sector_dependent = list(SECTOR_SRANDMARR = 2, SECTOR_NRRAHRAHUL = 2)
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL)
 
 	unit_test_groups = list(3)

--- a/maps/away/ships/xanu/xanu_frigate.dm
+++ b/maps/away/ships/xanu/xanu_frigate.dm
@@ -7,8 +7,8 @@
 	prefix = "ships/xanu/"
 	suffixes = list("xanu_frigate.dmm")
 
-	sectors = list(ALL_COALITION_SECTORS, SECTOR_BADLANDS)
-	spawn_weight_sector_dependent = list(SECTOR_LIBERTYS_CRADLE = 3, ALL_BADLAND_SECTORS = 0.5)
+	sectors = list(ALL_COALITION_SECTORS)
+	spawn_weight_sector_dependent = list(SECTOR_LIBERTYS_CRADLE = 3)
 	spawn_weight = 1
 	ship_cost = 1
 	id = "xanu_frigate"


### PR DESCRIPTION
The Badlands sector has alot of available awaysites/ships, but some don't fit as well as others.

Coalition Gunship: Badlands far away from Coalition, while anti-pirate activity could be argued as the reason, the Badlands has a variety of military ships from other nations, that are seen far less often. For this reason, this will not be set to spawn
Xanu Frigate: Same as above
Coalition Surveyor: The Badlands is indeed a place with unusual fauna, but this should be handled by other survey vessels that could arrive, the Coalition is focused on the 'northern' frontier far more than the south.