### PR TITLE
Alien Sleep Updates - Allows upright sleeping, and indefinite sleep.

### DIFF
--- a/code/modules/emotes/definitions/audible.dm
+++ b/code/modules/emotes/definitions/audible.dm
@@ -43,6 +43,7 @@
 	key ="chirp"
 	emote_message_3p = "USER chirps!"
 	emote_sound = 'sound/misc/nymphchirp.ogg'
+	conscious = 0
 
 /singleton/emote/audible/multichirp
 	key ="mchirp"
@@ -65,6 +66,7 @@
 	key = "chitter"
 	emote_message_3p = "USER chitters."
 	emote_sound = list('sound/voice/chitter1.ogg', 'sound/voice/chitter2.ogg', 'sound/voice/chitter3.ogg')
+	conscious = 0
 
 /singleton/emote/audible/click
 	key = "click"

--- a/code/modules/emotes/definitions/synthetics.dm
+++ b/code/modules/emotes/definitions/synthetics.dm
@@ -2,6 +2,7 @@
 	key = "beep"
 	emote_message_3p = "USER beeps."
 	emote_sound = 'sound/machines/twobeep.ogg'
+	conscious = 0
 
 /singleton/emote/audible/synth/check_user(var/mob/living/user)
 	if(istype(user) && user.isSynthetic())

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -393,7 +393,7 @@
 	set category = "IC"
 
 	sleeping_indefinitely = !sleeping_indefinitely
-	to_chat(M, SPAN_NOTICE("You will [sleeping_indefinitely ? "now" : "no longer"] sleep indefinitely."))
+	to_chat(usr, SPAN_NOTICE("You will [sleeping_indefinitely ? "now" : "no longer"] sleep indefinitely."))
 
 	if(!sleeping_indefinitely)
 		AdjustSleeping(-1*sleep_buffer)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -7,6 +7,9 @@
 
 	. = ..()
 
+	if(species && species.indefinite_sleep)
+		add_verb(client, /mob/verb/toggle_indefinite_sleep)
+
 /mob/living/carbon/Life()
 	if(!..())
 		return
@@ -273,8 +276,11 @@
 					M.visible_message(SPAN_NOTICE("[M] shakes [src] trying to wake [get_pronoun("him")] up!"), \
 										SPAN_NOTICE("You shake [src], but they do not respond... Maybe they have S.S.D?"))
 			else if(lying)
-				if(src.sleeping)
-					src.sleeping = max(0,src.sleeping-5)
+				if(sleeping)
+					if(sleeping_indefinitely)
+						sleep_buffer += 5
+					else
+						AdjustSleeping(-5)
 					M.visible_message(SPAN_NOTICE("[M] shakes [src] trying to wake [get_pronoun("him")] up!"), \
 										SPAN_NOTICE("You shake [src] trying to wake [get_pronoun("him")] up!"))
 				else
@@ -376,6 +382,22 @@
 		willfully_sleeping = TRUE
 		usr.sleeping = 20 // Short nap.
 		usr.eye_blurry = 20
+
+/mob/living/carbon/sleeps_horizontal()
+	if(species && species.sleeps_upright)
+		return FALSE
+	return ..()
+
+/mob/verb/toggle_indefinite_sleep()
+	set name = "Toggle Indefinite Sleep"
+	set category = "IC"
+
+	sleeping_indefinitely = !sleeping_indefinitely
+	to_chat(M, SPAN_NOTICE("You will [sleeping_indefinitely ? "now" : "no longer"] sleep indefinitely."))
+
+	if(!sleeping_indefinitely)
+		AdjustSleeping(-1*sleep_buffer)
+		sleep_buffer = 0
 
 /mob/living/carbon/Collide(atom/A)
 	if(now_pushing)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -272,6 +272,8 @@
 		have_client = bg.client
 		inactivity =  have_client ? bg.client.inactivity : null
 
+	if(sleeping)
+		msg += species.sleep_examine_msg(src)
 
 	if(species.show_ssd && (!species.has_organ[BP_BRAIN] || has_brain()) && stat != DEAD && !(status_flags & FAKEDEATH))
 		if(!vr_mob && !key)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -732,6 +732,9 @@
 	if(status_flags & GODMODE)
 		return 0
 
+	if(recently_slept)
+		recently_slept -= 1
+
 	//SSD check, if a logged player is awake put them back to sleep!
 	if(species.show_ssd && (!client && !vr_mob) && !teleop && ((world.realtime - disconnect_time) >= 5 MINUTES)) //only sleep after 5 minutes, should help those with intermittent internet connections
 		Sleeping(2)
@@ -758,7 +761,8 @@
 
 		if(paralysis || sleeping || InStasis())
 			blinded = TRUE
-			if(sleeping)
+			if(sleeping && !stat)
+				species.sleep_msg(src)
 				set_stat(UNCONSCIOUS)
 				if(!sleeping_msg_debounce)
 					sleeping_msg_debounce = TRUE
@@ -778,10 +782,13 @@
 			if(mind)
 				//Are they SSD? If so we'll keep them asleep but work off some of that sleep var in case of stoxin or similar.
 				if(client || sleeping > 3 || istype(bg))
-					AdjustSleeping(-1)
-			if(prob(2) && health && !failed_last_breath && !isSynthetic() && !InStasis())
+					if(sleeping_indefinitely)
+						sleep_buffer++
+					else
+						AdjustSleeping(-1)
+			if(prob(2) && health && !failed_last_breath && !InStasis())
 				if(!paralysis)
-					emote("snore")
+					emote(species.snore_key)
 
 		//CONSCIOUS
 		else if(!InStasis())

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -64,7 +64,7 @@
 	var/race_key = 0       	                             // Used for mob icon cache string.
 	var/icon/icon_template                               // Used for mob icon generation for non-32x32 species.
 	var/mob_size	= MOB_MEDIUM
-	var/show_ssd = "fast asleep"
+	var/show_ssd = "in a deep slumber"
 	var/short_sighted
 	var/bald = 0
 
@@ -309,6 +309,20 @@
 	var/psi_deaf = FALSE
 	///Which species-unique robolimb types can this species take?
 	var/list/valid_prosthetics
+
+	//Sleeping stuff
+	/**
+	 * Does this species sleep standing up?
+	 */
+	var/sleeps_upright = FALSE
+	/**
+	 * The key of the emote to play when this species is sleeping
+	 */
+	var/snore_key = "snore"
+	/**
+	 * Whether this species can choose to sleep indefinitely
+	 */
+	var/indefinite_sleep = FALSE
 
 /datum/species/proc/get_eyes(var/mob/living/carbon/human/H)
 	return
@@ -881,3 +895,16 @@
 
 /datum/species/proc/get_species_record_sex(var/mob/living/carbon/human/H)
 	return H.gender
+
+/**
+ * The message which displays when this species falls asleep
+ */
+/datum/species/proc/sleep_msg(var/mob/M)
+	M.visible_message(SPAN_NOTICE("\The [M] lies down, falling asleep."))
+	to_chat(M, SPAN_NOTICE("You lie down, falling asleep."))
+
+/**
+ * Shown when this species is asleep and examined
+ */
+/datum/species/proc/sleep_examine_msg(var/mob/M)
+	return SPAN_NOTICE("[M.get_pronoun("He")] appears to be fast asleep.\n")

--- a/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
+++ b/code/modules/mob/living/carbon/human/species/station/diona/diona.dm
@@ -131,6 +131,9 @@
 	alterable_internal_organs = list()
 	psi_deaf = TRUE
 
+	sleeps_upright = TRUE
+	snore_key = "chirp"
+
 /datum/species/diona/can_understand(var/mob/other)
 	var/mob/living/carbon/alien/diona/D = other
 	if(istype(D))
@@ -190,3 +193,10 @@
 
 /datum/species/diona/bypass_food_fullness(var/mob/living/carbon/human/H)
 	return TRUE
+
+/datum/species/diona/sleep_msg(var/mob/M)
+	M.visible_message(SPAN_NOTICE("\The [M] creaks, entering an introspective state."))
+	to_chat(M, SPAN_NOTICE("You creak, entering an introspective state."))
+
+/datum/species/diona/sleep_examine_msg(var/mob/M)
+	return SPAN_NOTICE("[M.get_pronoun("He")] sways and creaks, in a dormant state.\n")

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
@@ -144,6 +144,9 @@
 	use_alt_hair_layer = TRUE
 	psi_deaf = TRUE
 
+	sleeps_upright = TRUE
+	snore_key = "beep"
+
 /datum/species/machine/handle_post_spawn(var/mob/living/carbon/human/H)
 	. = ..()
 	check_tag(H, H.client)
@@ -391,3 +394,10 @@
 	var/obj/item/organ/internal/cell/C = human.internal_organs_by_name[BP_CELL]
 	if(C)
 		C.use(stamina_cost * 8)
+
+/datum/species/machine/sleep_msg(var/mob/M)
+	M.visible_message(SPAN_NOTICE("\The [M] locks [M.get_pronoun("his")] chassis into place, entering standby."))
+	to_chat(M, SPAN_NOTICE("You lock your chassis into place, entering standby."))
+
+/datum/species/machine/sleep_examine_msg(var/mob/M)
+	return SPAN_NOTICE("[M.get_pronoun("He")] appears to be in standby.\n")

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -150,6 +150,9 @@
 	possible_speech_bubble_types = list("robot", "default")
 	valid_prosthetics = list(PROSTHETIC_VAURCA)
 
+	sleeps_upright = TRUE
+	snore_key = "chitter"
+
 /datum/species/bug/before_equip(var/mob/living/carbon/human/H)
 	. = ..()
 	H.gender = NEUTER
@@ -174,3 +177,9 @@
 		return TRUE
 	return FALSE
 
+/datum/species/bug/sleep_msg(var/mob/M)
+	M.visible_message(SPAN_NOTICE("\The [M] locks [M.get_pronoun("his")] carrapace in place, becoming completely still."))
+	to_chat(M, SPAN_NOTICE("You lock your carrapace into place, becoming completely still."))
+
+/datum/species/bug/sleep_examine_msg(var/mob/M)
+	return SPAN_NOTICE("[M.get_pronoun("He")] has locked [M.get_pronoun("his")] carrapace in place, and is standing completely still.\n")

--- a/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
+++ b/code/modules/mob/living/carbon/human/species/station/vaurca/vaurca.dm
@@ -178,8 +178,8 @@
 	return FALSE
 
 /datum/species/bug/sleep_msg(var/mob/M)
-	M.visible_message(SPAN_NOTICE("\The [M] locks [M.get_pronoun("his")] carrapace in place, becoming completely still."))
-	to_chat(M, SPAN_NOTICE("You lock your carrapace into place, becoming completely still."))
+	M.visible_message(SPAN_NOTICE("\The [M] locks [M.get_pronoun("his")] carapace in place, becoming completely still."))
+	to_chat(M, SPAN_NOTICE("You lock your carapace into place, becoming completely still."))
 
 /datum/species/bug/sleep_examine_msg(var/mob/M)
-	return SPAN_NOTICE("[M.get_pronoun("He")] has locked [M.get_pronoun("his")] carrapace in place, and is standing completely still.\n")
+	return SPAN_NOTICE("[M.get_pronoun("He")] has locked [M.get_pronoun("his")] carapace in place, and is standing completely still.\n")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -858,8 +858,12 @@
 			lying = TRUE
 			lying_is_intentional = TRUE
 			canmove = TRUE
+		else if(sleeping)
+			lying = lying && MOB_IS_INCAPACITATED(INCAPACITATION_KNOCKDOWN) && sleeps_horizontal() // Vaurca, IPCs and Diona sleep standing up, unless they were already lying down
+			lying_is_intentional = FALSE
+			canmove = !MOB_IS_INCAPACITATED(INCAPACITATION_KNOCKOUT) && !weakened
 		else
-			lying = MOB_IS_INCAPACITATED(INCAPACITATION_KNOCKDOWN)
+			lying = MOB_IS_INCAPACITATED(INCAPACITATION_KNOCKDOWN) && !recently_slept
 			lying_is_intentional = FALSE
 			canmove = !MOB_IS_INCAPACITATED(INCAPACITATION_KNOCKOUT) && !weakened
 
@@ -891,6 +895,9 @@
 
 	return canmove
 
+
+/mob/proc/sleeps_horizontal()
+	return TRUE
 
 /mob/proc/facedir(var/ndir, var/force_change = FALSE)
 	if(!canface() || (client && client.moving))
@@ -992,6 +999,8 @@
 
 /mob/proc/AdjustSleeping(amount)
 	sleeping = max(sleeping + amount,0)
+	if(!sleeping)
+		recently_slept = 10
 	return
 
 /mob/proc/Resting(amount)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -97,6 +97,9 @@
 	var/phoron = null
 	var/sleeping = 0					//Carbon
 	var/sleeping_msg_debounce = FALSE	//Carbon - Used to show a message once every time someone falls asleep.
+	var/recently_slept = 0				//Carbon - Used to avoid falling over after waking up
+	var/sleeping_indefinitely = FALSE
+	var/sleep_buffer = 0				//Used for indefinite sleeping
 	var/resting = 0						//Carbon
 	var/lying = 0	// Is the mob lying down?
 	var/lying_prev = 0	// Was the mob lying down before?

--- a/html/changelogs/alien_sleep.yml
+++ b/html/changelogs/alien_sleep.yml
@@ -1,0 +1,9 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - rscadd: "Vaurcae, IPCs & Dionae will now all remain upright when sleeping."
+  - rscadd: "Added unique messages when entering sleep for alien species, as well as unique sleep examine text."
+  - rscadd: "Added unique different snoring replacements for alien species."
+  - rscadd: "Varcae, IPCs & Dionae can now all choose to remain asleep indefinitely."


### PR DESCRIPTION
This allows certain alien species (Currently Vaurcae, IPCs and Dionae) to sleep while standing, and gives them a verb to let them choose to sleep indefinitely. 

It also adds custom messages for enter sleep and examining, as well as changing the snoring emote for the above aliens too.
