### PR TITLE
Smaller sip volumes.

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -22,7 +22,16 @@ If you add a drink with an empty icon sprite, ensure it is in the same folder, e
 	volume = 50
 	var/shaken = 0
 	var/drink_flags
-	possible_transfer_amounts = list(1,2,3,4,5,10,15,25,30)
+	possible_transfer_amounts = list(
+									1,
+									2,
+									3,
+									4,
+									5,
+									10,
+									15,
+									25,
+									30)
 
 /obj/item/reagent_containers/food/drinks/Initialize()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -22,16 +22,7 @@ If you add a drink with an empty icon sprite, ensure it is in the same folder, e
 	volume = 50
 	var/shaken = 0
 	var/drink_flags
-	possible_transfer_amounts = list(
-									1,
-									2,
-									3,
-									4,
-									5,
-									10,
-									15,
-									25,
-									30)
+	possible_transfer_amounts = list(1, 2, 3, 4, 5, 10, 15, 25, 30)
 
 /obj/item/reagent_containers/food/drinks/Initialize()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -22,6 +22,7 @@ If you add a drink with an empty icon sprite, ensure it is in the same folder, e
 	volume = 50
 	var/shaken = 0
 	var/drink_flags
+	possible_transfer_amounts = list(1,2,3,4,5,10,15,25,30)
 
 /obj/item/reagent_containers/food/drinks/Initialize()
 	. = ..()

--- a/html/changelogs/sip.yml
+++ b/html/changelogs/sip.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - rscadd: "Drinks can now select a transfer rate as low as 1 unit, allowing for smaller sips."


### PR DESCRIPTION
Allows drinks to select smaller transfer amounts, as low as 1 unit, to allow smaller sips.
