### PR TITLE
Removes camera gun from research

### DIFF
--- a/html/changelogs/cameragunremoval.yml
+++ b/html/changelogs/cameragunremoval.yml
@@ -1,0 +1,4 @@
+author: Pirouette
+delete-after: True
+changes:
+  - bugfix: "Replaced a camera gun mapped into research with an actual camera."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -22934,7 +22934,6 @@
 /area/horizon/zat)
 "kwS" = (
 /obj/structure/table/standard,
-/obj/item/gun/projectile/shotgun/foldable/cameragun,
 /obj/effect/floor_decal/corner/mauve{
 	dir = 9
 	},
@@ -22944,6 +22943,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/item/device/camera,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/foyer)
 "kwW" = (


### PR DESCRIPTION
Hi. Research spawned with a gun instead of a camera. I thought I'd go ahead and change that.