### PR TITLE
Ranger Gunboat Fixes and qol

### DIFF
--- a/html/changelogs/example copy.yml
+++ b/html/changelogs/example copy.yml
@@ -1,0 +1,61 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Tzui5020
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes the Aft Airlock on the Ranger Gunship not working."
+  - qol: "Adds an Autolathe to the Ranger Gunship."
+  - qol: "Adds more navpoints for Boarding actions or anything else"
+  - qol: "Adds some Lights to the Thrusters too so you can see"

--- a/maps/away/ships/coc/coc_ranger/coc_ship.dm
+++ b/maps/away/ships/coc/coc_ranger/coc_ship.dm
@@ -109,7 +109,9 @@
 
 	initial_generic_waypoints = list(
 		"nav_ranger_corvette_1",
-		"nav_ranger_corvette_2"
+		"nav_ranger_corvette_2",
+		"nav_ranger_corvette_3",
+		"nav_ranger_corvette_4"
 	)
 
 	invisible_until_ghostrole_spawn = TRUE
@@ -133,6 +135,18 @@
 /obj/effect/shuttle_landmark/ranger_corvette/nav2
 	name = "Ranger Gunboat - Dock Airlock"
 	landmark_tag = "nav_ranger_corvette_2"
+	base_turf = /turf/space/dynamic
+	base_area = /area/space
+
+/obj/effect/shuttle_landmark/ranger_corvette/nav3
+	name = "Ranger Gunboat - Starboard Side"
+	landmark_tag = "nav_ranger_corvette_3"
+	base_turf = /turf/space/dynamic
+	base_area = /area/space
+
+/obj/effect/shuttle_landmark/ranger_corvette/nav4
+	name = "Ranger Gunboat - Aft side"
+	landmark_tag = "nav_ranger_corvette_4"
 	base_turf = /turf/space/dynamic
 	base_area = /area/space
 

--- a/maps/away/ships/coc/coc_ranger/coc_ship.dmm
+++ b/maps/away/ships/coc/coc_ranger/coc_ship.dmm
@@ -385,6 +385,9 @@
 /area/ship/ranger_corvette/engine1)
 "bph" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/ship/ranger_corvette/engine2)
 "brx" = (
@@ -724,7 +727,7 @@
 	pixel_x = -13
 	},
 /turf/simulated/floor/plating,
-/area/ship/ranger_corvette)
+/area/ship/ranger_corvette/atmospherics)
 "cZV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
@@ -892,7 +895,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
-/area/ship/ranger_corvette)
+/area/ship/ranger_corvette/atmospherics)
 "dGE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -936,7 +939,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate/dark,
 /turf/simulated/floor/plating,
-/area/ship/ranger_corvette)
+/area/ship/ranger_corvette/atmospherics)
 "dMX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4;
@@ -1476,6 +1479,9 @@
 /area/ship/ranger_corvette/foyer)
 "fVq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/ship/ranger_corvette/engine1)
 "gec" = (
@@ -1718,8 +1724,11 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/ranger_corvette/voidsuits)
 "gNW" = (
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/ship/ranger_corvette)
+/obj/effect/shuttle_landmark/ranger_corvette/nav3{
+	name = "Ranger Gunboat - Starboard Side"
+	},
+/turf/template_noop,
+/area/space)
 "gOp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10;
@@ -2099,6 +2108,7 @@
 	req_access = null;
 	cell_type = /obj/item/cell/hyper
 	},
+/obj/machinery/autolathe,
 /turf/simulated/floor/tiled/dark,
 /area/ship/ranger_corvette/engine2)
 "iDh" = (
@@ -2682,7 +2692,7 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
-/area/ship/ranger_corvette)
+/area/ship/ranger_corvette/atmospherics)
 "lpY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -5085,6 +5095,10 @@
 /obj/item/storage/box/masks,
 /turf/simulated/floor/tiled/white,
 /area/ship/ranger_corvette/medbay)
+"tJG" = (
+/obj/effect/shuttle_landmark/ranger_corvette/nav4,
+/turf/template_noop,
+/area/space)
 "tLA" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/ranger_corvette/gunnery)
@@ -6039,7 +6053,7 @@
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
-/area/ship/ranger_corvette)
+/area/ship/ranger_corvette/atmospherics)
 "wMK" = (
 /obj/structure/extinguisher_cabinet/west,
 /turf/simulated/floor/tiled/dark,
@@ -6067,7 +6081,7 @@
 	pixel_x = 14
 	},
 /turf/simulated/floor/plating,
-/area/ship/ranger_corvette)
+/area/ship/ranger_corvette/atmospherics)
 "wPe" = (
 /obj/structure/bed/stool/bar/padded/brown,
 /obj/structure/noticeboard{
@@ -29133,7 +29147,7 @@ xRX
 xRX
 xRX
 xRX
-xRX
+gNW
 xRX
 xRX
 xRX
@@ -36829,9 +36843,9 @@ xRX
 xRX
 xRX
 xRX
-gNW
-gNW
-gNW
+vFS
+vFS
+vFS
 vFS
 exg
 stX
@@ -37066,7 +37080,7 @@ xRX
 xRX
 xRX
 xRX
-xRX
+tJG
 xRX
 xRX
 xRX
@@ -37599,10 +37613,10 @@ xRX
 xRX
 xRX
 xRX
-gNW
-gNW
-gNW
-gNW
+vFS
+vFS
+vFS
+vFS
 vFS
 riA
 aXC


### PR DESCRIPTION
- Fixes the Aft Airlock not working
- Added the autolathe because all other Ships have it and the Ranger gunboat was missing one.
- The lights are so the Engine rooms look a bit better instead of looking like an entryway into the Void.
- Added more navpoints so you can board from diffrent Directions.
![StrongDMM-2024-05-18 18 18 09](https://github.com/Aurorastation/Aurora.3/assets/167625846/6ccb50be-5ceb-4fca-8393-b161e3160742)
