### PR TITLE
Improves Sani'Orios base and Hadiist missile silo

### DIFF
--- a/html/changelogs/Hollyhock - sanioriosmedbay.yml
+++ b/html/changelogs/Hollyhock - sanioriosmedbay.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Hollyhock
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Gives the Sani'Orios base a medbay, jetpacks, a tool belt, and a fuel tank for refuelling their fellows in the DPRA."
+  - qol: "Gives the poor Hadiist silo guard some rations, cigarettes, a radio, and a Hadiist manifesto. Hadii's grace."

--- a/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost.dmm
+++ b/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost.dmm
@@ -1,4 +1,13 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"as" = (
+/obj/machinery/body_scanconsole,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "at" = (
 /obj/structure/ship_weapon_dummy,
 /obj/effect/floor_decal/industrial/warning{
@@ -7,6 +16,14 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/saniorios_outpost/gun)
+"au" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "av" = (
 /obj/machinery/porta_turret/ballistic,
 /obj/effect/decal/warning_stripes,
@@ -27,6 +44,19 @@
 	},
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost)
+"aS" = (
+/obj/effect/floor_decal/corner/white/full{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/saniorios_outpost)
 "bt" = (
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost/hangar)
@@ -37,8 +67,16 @@
 /obj/effect/floor_decal/spline/plain/grey{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
+"bB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
+/turf/simulated/floor/plating/cooled,
+/area/saniorios_outpost/hangar)
 "bI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -63,6 +101,24 @@
 	},
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost)
+"cc" = (
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
+	dir = 8;
+	frequency = 1441;
+	id_tag = "saniorios_co2_out"
+	},
+/turf/simulated/floor/reinforced/carbon_dioxide,
+/area/saniorios_outpost/hangar)
+"ck" = (
+/obj/effect/floor_decal/corner/green/full{
+	dir = 8
+	},
+/obj/machinery/iv_drip,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "cw" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
@@ -95,7 +151,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
 	},
-/turf/simulated/wall/shuttle/raider,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/saniorios_outpost)
 "cE" = (
 /obj/machinery/atmospherics/pipe/tank/air{
@@ -105,7 +161,7 @@
 /area/saniorios_outpost/atmos)
 "cG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/wall/shuttle/raider,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/saniorios_outpost)
 "cI" = (
 /obj/machinery/door/airlock{
@@ -164,7 +220,7 @@
 /area/saniorios_outpost)
 "dE" = (
 /obj/machinery/button/remote/blast_door{
-	id = "saniorios_gun";
+	id = "saniorios_shuttle_torpedo";
 	name = "Missile Hangar Blastdoor";
 	req_access = list(214);
 	dir = 1;
@@ -356,7 +412,9 @@
 	req_access = list(214)
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "fO" = (
 /obj/structure/bed/stool/chair/shuttle{
@@ -429,7 +487,9 @@
 /obj/effect/floor_decal/spline/plain/grey{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "gB" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
@@ -444,24 +504,16 @@
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost/atmos)
 "hz" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
+/obj/machinery/door/airlock{
+	req_access = list(209);
+	name = "Operating Room"
 	},
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca/frag{
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white{
 	temperature = 278.15
 	},
-/area/saniorios_outpost/gun)
+/area/saniorios_outpost/medbay)
 "hE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -524,6 +576,12 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/mob/living/heavy_vehicle/premade/ripley/loader,
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/structure/sign/flag/dpra{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -539,6 +597,29 @@
 	},
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost)
+"it" = (
+/obj/structure/table/standard,
+/obj/structure/closet/walllocker/medical/secure{
+	pixel_x = -31
+	},
+/obj/item/reagent_containers/hypospray,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/reagent_containers/glass/bottle/inaprovaline,
+/obj/item/auto_cpr,
+/obj/item/tank/oxygen,
+/obj/item/tank/oxygen,
+/obj/item/tank/oxygen,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/effect/floor_decal/corner/green/full,
+/obj/item/storage/belt/medical/first_responder,
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "ix" = (
 /obj/structure/ship_weapon_dummy{
 	is_barrel = 1
@@ -560,7 +641,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
 	},
-/turf/simulated/wall/shuttle/raider,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/saniorios_outpost)
 "iD" = (
 /obj/effect/map_effect/marker/airlock{
@@ -638,6 +719,33 @@
 	temperature = 278.15
 	},
 /area/saniorios_outpost)
+"jr" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 6
+	},
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/structure/closet/walllocker/medical/secure{
+	name = "O- Blood Locker";
+	pixel_x = 32;
+	req_access = null
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "jx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -656,16 +764,18 @@
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost)
 "jE" = (
-/obj/effect/floor_decal/industrial/outline/engineering,
-/obj/machinery/mech_recharger,
-/mob/living/heavy_vehicle/premade/ripley/loader,
-/obj/structure/sign/flag/dpra{
-	pixel_y = 32
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/saniorios_outpost/medbay)
+"jI" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
 	},
-/turf/simulated/floor/tiled{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white{
 	temperature = 278.15
 	},
-/area/saniorios_outpost/gun)
+/area/saniorios_outpost/medbay)
 "jU" = (
 /obj/machinery/door/airlock{
 	req_access = list(214);
@@ -786,28 +896,18 @@
 	},
 /area/saniorios_outpost/hangar)
 "lV" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
+/obj/effect/floor_decal/corner/green/full{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca,
-/obj/item/ship_ammunition/francisca/frag{
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white{
 	temperature = 278.15
 	},
-/area/saniorios_outpost/gun)
+/area/saniorios_outpost/medbay)
 "lY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -821,8 +921,9 @@
 	},
 /area/saniorios_outpost)
 "lZ" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/binary/pump/high_power{
+	name = "Fuel Tank to Connector";
+	dir = 1
 	},
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost/hangar)
@@ -837,6 +938,29 @@
 	temperature = 278.15
 	},
 /area/saniorios_outpost)
+"mU" = (
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 1;
+	icon_state = "rwindow"
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	icon_state = "rwindow"
+	},
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/gun)
 "nh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -863,7 +987,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "nz" = (
 /obj/structure/closet/cabinet,
@@ -878,6 +1004,19 @@
 "nD" = (
 /turf/simulated/wall/shuttle/raider,
 /area/space)
+"nG" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/structure/bed/roller,
+/obj/structure/curtain/open/medical,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "nZ" = (
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(214);
@@ -900,19 +1039,17 @@
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost)
 "or" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	req_access = list(214);
-	name = "gun cabinet (bayonets)"
-	},
 /obj/effect/floor_decal/industrial/outline/security,
-/obj/item/clothing/accessory/storage/bayonet,
-/obj/item/clothing/accessory/storage/bayonet,
-/obj/item/clothing/accessory/storage/bayonet,
-/obj/item/clothing/accessory/storage/bayonet,
-/obj/item/clothing/accessory/storage/bayonet,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/guncabinet{
+	req_access = list(214);
+	name = "gun cabinet (pistol)"
+	},
+/obj/item/gun/projectile/silenced,
+/obj/item/gun/projectile/silenced,
+/obj/item/gun/projectile/silenced,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -924,7 +1061,7 @@
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost/hangar)
 "oG" = (
-/obj/effect/map_effect/window_spawner/reinforced,
+/obj/effect/map_effect/window_spawner/full/shuttle/raider,
 /turf/simulated/floor/plating,
 /area/space)
 "oJ" = (
@@ -946,7 +1083,9 @@
 /obj/machinery/atmospherics/portables_connector/aux,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "ph" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -969,7 +1108,9 @@
 /area/saniorios_outpost/crew_section)
 "pj" = (
 /obj/structure/bed/stool/chair/shuttle,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "ps" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -979,7 +1120,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "pt" = (
 /obj/structure/cable/green{
@@ -991,18 +1134,22 @@
 /area/saniorios_outpost/hangar)
 "pI" = (
 /obj/effect/floor_decal/industrial/outline/security,
-/obj/structure/closet/secure_closet/guncabinet{
-	req_access = list(214);
-	name = "gun cabinet (pistol ammo)"
-	},
-/obj/item/ammo_magazine/d762,
-/obj/item/ammo_magazine/d762,
 /obj/machinery/power/apc/high/north{
 	req_access = list(214)
 	},
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
+/obj/structure/closet/secure_closet/guncabinet{
+	req_access = list(214);
+	name = "gun cabinet (rifle ammo)"
+	},
+/obj/item/ammo_magazine/boltaction,
+/obj/item/ammo_magazine/boltaction,
+/obj/item/ammo_magazine/boltaction,
+/obj/item/ammo_magazine/boltaction,
+/obj/item/ammo_magazine/boltaction,
+/obj/item/ammo_magazine/boltaction,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1019,20 +1166,39 @@
 	},
 /area/saniorios_outpost/barracks)
 "pO" = (
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 20
+/obj/effect/floor_decal/corner/green{
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/white{
-	dir = 6
+/obj/machinery/sleeper{
+	dir = 1
 	},
-/turf/simulated/floor/tiled{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white{
 	temperature = 278.15
 	},
-/area/saniorios_outpost/crew_section)
+/area/saniorios_outpost/medbay)
+"pX" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/machinery/vending/wallmed2{
+	req_access = null;
+	pixel_x = -28
+	},
+/obj/structure/sink/kitchen{
+	name = "surgical sink";
+	dir = 4;
+	pixel_x = -20
+	},
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "pZ" = (
 /obj/effect/landmark/entry_point/port,
-/turf/simulated/wall/shuttle/raider,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/saniorios_outpost)
 "qf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
@@ -1080,21 +1246,31 @@
 	},
 /area/saniorios_outpost/gun)
 "qH" = (
-/obj/structure/closet/secure_closet/guncabinet{
-	req_access = list(214);
-	name = "gun cabinet (rifle ammo)"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/item/ammo_magazine/boltaction,
-/obj/item/ammo_magazine/boltaction,
-/obj/item/ammo_magazine/boltaction,
-/obj/item/ammo_magazine/boltaction,
-/obj/item/ammo_magazine/boltaction,
-/obj/item/ammo_magazine/boltaction,
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
+/turf/simulated/floor/plating/cooled,
+/area/saniorios_outpost/hangar)
+"qI" = (
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 1;
+	icon_state = "rwindow"
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
-/area/saniorios_outpost/armory)
+/area/saniorios_outpost/gun)
 "qO" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
@@ -1115,21 +1291,23 @@
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost/atmos)
 "rk" = (
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
 /obj/structure/table/standard,
-/obj/item/device/gps,
-/obj/item/device/gps,
-/obj/item/device/gps,
-/obj/item/device/gps,
-/obj/item/device/gps,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/device/gps,
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost)
 "rw" = (
@@ -1182,8 +1360,35 @@
 	icon_state = "1-2"
 	},
 /obj/effect/map_effect/marker/airlock/shuttle/saniorios_outpost,
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/floor/tiled/dark/full{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
+"rR" = (
+/obj/effect/floor_decal/corner/green/full{
+	dir = 1
+	},
+/obj/machinery/iv_drip,
+/obj/machinery/alarm/cold/north{
+	req_one_access = list(209)
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
+"rT" = (
+/obj/effect/floor_decal/industrial/outline/security,
+/obj/structure/closet/secure_closet/guncabinet{
+	req_access = list(214);
+	name = "gun cabinet (marksman ammo)"
+	},
+/obj/item/ammo_magazine/d762,
+/obj/item/ammo_magazine/d762,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/armory)
 "se" = (
 /obj/structure/bed/stool/bar/padded/black,
 /obj/structure/sign/painting_frame/nated{
@@ -1217,11 +1422,20 @@
 	},
 /obj/effect/map_effect/marker/airlock/shuttle/saniorios_outpost,
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "su" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/saniorios_outpost/barracks)
+"sv" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
+/turf/simulated/floor/plating/cooled,
+/area/saniorios_outpost/hangar)
 "sw" = (
 /obj/effect/floor_decal/industrial/outline/security,
 /obj/structure/closet/secure_closet/guncabinet{
@@ -1256,7 +1470,9 @@
 /obj/effect/floor_decal/spline/plain/grey{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "ty" = (
 /obj/machinery/light{
@@ -1391,6 +1607,10 @@
 	temperature = 278.15
 	},
 /area/saniorios_outpost/crew_section)
+"vR" = (
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/plating/cooled,
+/area/saniorios_outpost/hangar)
 "vU" = (
 /obj/effect/step_trigger/teleporter,
 /turf/space/transit/north,
@@ -1429,6 +1649,21 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/unsimulated/floor/asteroid/ash,
 /area/space)
+"wp" = (
+/obj/machinery/door/airlock/glass_medical{
+	req_access = list(209);
+	name = "Medbay";
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/saniorios_outpost)
 "wM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 8
@@ -1436,7 +1671,9 @@
 /obj/effect/floor_decal/spline/plain/grey{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "wZ" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1454,7 +1691,9 @@
 	},
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/mask/breath,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "xe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -1465,6 +1704,30 @@
 	temperature = 278.15
 	},
 /area/saniorios_outpost)
+"xg" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
+/turf/simulated/floor/plating/cooled,
+/area/saniorios_outpost/hangar)
+"xo" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/machinery/iv_drip,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/alarm/cold/north{
+	req_one_access = list(209)
+	},
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "xy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1547,6 +1810,23 @@
 /area/saniorios_outpost/gun)
 "za" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/ap,
+/obj/item/ship_ammunition/francisca/frag{
+	pixel_y = 4
+	},
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	icon_state = "rwindow"
+	},
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1582,7 +1862,9 @@
 	icon_state = "1-4"
 	},
 /obj/effect/overmap/visitable/ship/landable/saniorios_outpost,
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/floor/tiled/dark/full{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "zq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1637,14 +1919,12 @@
 	},
 /area/saniorios_outpost)
 "AN" = (
+/obj/effect/floor_decal/industrial/outline/security,
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(214);
-	name = "gun cabinet (pistol)"
+	name = "gun cabinet (marksman)"
 	},
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/item/gun/projectile/silenced,
-/obj/item/gun/projectile/silenced,
-/obj/item/gun/projectile/silenced,
+/obj/item/gun/projectile/dragunov,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1665,6 +1945,14 @@
 	temperature = 278.15
 	},
 /area/saniorios_outpost)
+"AR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "AT" = (
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -1699,6 +1987,12 @@
 	temperature = 278.15
 	},
 /area/saniorios_outpost/armory)
+"Bc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor/plating/cooled,
+/area/saniorios_outpost/hangar)
 "Bd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
@@ -1753,7 +2047,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "CD" = (
 /obj/structure/ship_weapon_dummy,
@@ -1774,6 +2070,24 @@
 	temperature = 278.15
 	},
 /area/saniorios_outpost/barracks)
+"CV" = (
+/obj/effect/floor_decal/corner/green/full,
+/obj/structure/table/rack,
+/obj/item/storage/box/masks{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/clothing/gloves/latex/nitrile/tajara,
+/obj/item/clothing/gloves/latex/nitrile/tajara,
+/obj/item/clothing/gloves/latex/nitrile/tajara,
+/obj/item/clothing/suit/storage/hooded/tajaran/surgery,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "Df" = (
 /obj/effect/landmark/entry_point/aft{
 	name = "aft engines, asteroid'"
@@ -1812,6 +2126,20 @@
 	},
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost/hangar)
+"DX" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/structure/table/standard,
+/obj/item/storage/box/bodybags,
+/obj/item/defibrillator,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "El" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1857,27 +2185,17 @@
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost)
 "Ez" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
+/obj/effect/floor_decal/corner/green{
+	dir = 10
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/ship_ammunition/francisca/ap,
-/obj/item/ship_ammunition/francisca/ap,
-/obj/item/ship_ammunition/francisca/ap,
-/obj/item/ship_ammunition/francisca/ap,
-/obj/item/ship_ammunition/francisca/ap,
-/obj/item/ship_ammunition/francisca/frag{
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled{
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white{
 	temperature = 278.15
 	},
-/area/saniorios_outpost/gun)
+/area/saniorios_outpost/medbay)
 "EC" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1900,7 +2218,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "Fa" = (
 /obj/machinery/ammunition_loader/francisca{
@@ -1949,12 +2269,6 @@
 /turf/simulated/floor/reinforced/airless,
 /area/saniorios_outpost/gun)
 "Fw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -1963,6 +2277,11 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 9
 	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -1974,11 +2293,13 @@
 /obj/effect/floor_decal/spline/plain/grey{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "Fy" = (
 /obj/effect/landmark/entry_point/aft,
-/turf/simulated/wall/shuttle/raider,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/saniorios_outpost)
 "FF" = (
 /obj/structure/lattice/catwalk,
@@ -2043,7 +2364,9 @@
 /obj/effect/floor_decal/spline/plain/grey{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "Gt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -2119,6 +2442,15 @@
 	temperature = 278.15
 	},
 /area/space)
+"Hk" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "Hl" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /turf/simulated/floor/tiled{
@@ -2145,7 +2477,9 @@
 	},
 /obj/effect/map_effect/marker/airlock/shuttle/saniorios_outpost,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "Hp" = (
 /obj/structure/cable/green{
@@ -2248,12 +2582,28 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/floor/tiled/dark/full{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "IB" = (
 /obj/item/storage/toolbox/syndicate,
 /turf/unsimulated/floor/asteroid/ash,
 /area/space)
+"IE" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	use_power = 1;
+	frequency = 1441;
+	id = "saniorios_co2_in";
+	dir = 8
+	},
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "saniorios_co2_sensor";
+	pixel_y = 16
+	},
+/turf/simulated/floor/reinforced/carbon_dioxide,
+/area/saniorios_outpost/hangar)
 "IF" = (
 /obj/structure/bed/stool/bar/padded/black,
 /obj/effect/floor_decal/corner/white/diagonal,
@@ -2263,7 +2613,7 @@
 /area/saniorios_outpost/crew_section)
 "IJ" = (
 /obj/effect/landmark/entry_point/starboard,
-/turf/simulated/wall/shuttle/raider,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/saniorios_outpost)
 "IS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2302,8 +2652,20 @@
 /obj/machinery/computer/ship/helm/terminal{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
+"Jb" = (
+/obj/effect/floor_decal/corner/green/full{
+	dir = 8
+	},
+/obj/item/storage/box/fancy/tray,
+/obj/structure/table/glass,
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "Jq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -2320,7 +2682,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 1
 	},
-/turf/simulated/wall/shuttle/raider,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/saniorios_outpost)
 "JQ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -2332,6 +2694,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/item/storage/belt/utility,
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost)
 "Kb" = (
@@ -2381,7 +2744,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
 	},
-/turf/simulated/wall/shuttle/raider,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/saniorios_outpost)
 "LK" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -2430,10 +2793,19 @@
 	},
 /turf/template_noop,
 /area/space)
+"MQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
+/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
+/turf/simulated/floor/plating/cooled,
+/area/saniorios_outpost/hangar)
 "Nd" = (
 /obj/machinery/atmospherics/binary/pump/fuel/on,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "Nj" = (
 /obj/machinery/door/blast/regular{
@@ -2443,12 +2815,16 @@
 /turf/template_noop,
 /area/saniorios_outpost/hangar)
 "Nt" = (
+/obj/effect/floor_decal/industrial/outline/security,
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(214);
-	name = "gun cabinet (marksman)"
+	name = "gun cabinet (bayonets)"
 	},
-/obj/effect/floor_decal/industrial/outline/security,
-/obj/item/gun/projectile/dragunov,
+/obj/item/clothing/accessory/storage/bayonet,
+/obj/item/clothing/accessory/storage/bayonet,
+/obj/item/clothing/accessory/storage/bayonet,
+/obj/item/clothing/accessory/storage/bayonet,
+/obj/item/clothing/accessory/storage/bayonet,
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
@@ -2565,7 +2941,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "Qo" = (
 /obj/machinery/pipedispenser,
@@ -2614,7 +2992,9 @@
 	pixel_y = 28;
 	pixel_x = 6
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "RO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2631,6 +3011,16 @@
 /obj/machinery/light/small,
 /turf/unsimulated/floor/asteroid/ash,
 /area/space)
+"Se" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/structure/curtain/open/medical,
+/obj/structure/bed/roller,
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "Sk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -2655,6 +3045,30 @@
 	},
 /turf/space/transit/north,
 /area/space)
+"TQ" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/machinery/bodyscanner{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
+"TS" = (
+/obj/effect/floor_decal/corner/green/full{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "Uf" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 6
@@ -2689,6 +3103,14 @@
 	temperature = 278.15
 	},
 /area/saniorios_outpost)
+"UI" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Atmos";
+	req_access = list(214);
+	dir = 4
+	},
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/saniorios_outpost)
 "UK" = (
 /obj/structure/ship_weapon_dummy,
 /obj/effect/floor_decal/industrial/warning{
@@ -2706,6 +3128,15 @@
 	temperature = 278.15
 	},
 /area/saniorios_outpost/barracks)
+"UQ" = (
+/obj/machinery/computer/general_air_control/large_tank_control/terminal{
+	name = "Carbon Dioxide Supply Monitor";
+	sensors = list(""saniorios_co2_sensor""="Tank");
+	input_tag = "saniorios_co2_in";
+	output_tag = "saniorios_co2_out"
+	},
+/turf/simulated/floor/plating/cooled,
+/area/saniorios_outpost/hangar)
 "Vn" = (
 /obj/machinery/light/small/emergency{
 	dir = 4
@@ -2724,8 +3155,18 @@
 /obj/machinery/computer/shuttle_control/explore/terminal/saniorios_outpost{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
+"VA" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "VB" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2774,6 +3215,24 @@
 	temperature = 278.15
 	},
 /area/saniorios_outpost/gun)
+"Wm" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/turf/simulated/floor/plating/cooled,
+/area/saniorios_outpost/hangar)
+"Wp" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/machinery/optable,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "Ws" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2878,11 +3337,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
 	},
-/obj/machinery/alarm/east{
-	req_one_access = null
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/alarm/cold/east,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
 /area/shuttle/saniorios_outpost)
 "Xs" = (
 /obj/machinery/cryopod{
@@ -2902,6 +3361,10 @@
 	tag_door = "saniorios_dock_doors";
 	dir = 1;
 	pixel_y = -25
+	},
+/obj/machinery/atmospherics/binary/pump/high_power{
+	name = "Connector to Fuel Tank";
+	dir = 4
 	},
 /turf/simulated/floor/plating/cooled,
 /area/saniorios_outpost/hangar)
@@ -2940,7 +3403,7 @@
 /turf/simulated/mineral,
 /area/space)
 "Zd" = (
-/turf/simulated/wall/shuttle/raider,
+/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/saniorios_outpost)
 "Zf" = (
 /obj/effect/floor_decal/corner/white/full{
@@ -2955,6 +3418,33 @@
 /obj/effect/step_trigger/teleporter,
 /turf/space/transit/north,
 /area/space)
+"Zi" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -4
+	},
+/obj/item/storage/firstaid/o2{
+	pixel_x = 5
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/large/adv,
+/obj/effect/floor_decal/corner/green/full{
+	dir = 1
+	},
+/obj/machinery/power/apc/north{
+	req_access = list(209)
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/saniorios_outpost/medbay)
 "Zp" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/brown,
@@ -23145,10 +23635,10 @@ Kn
 Kn
 SL
 SL
-SL
-SL
-SL
-lz
+jE
+jE
+jE
+jE
 lz
 lz
 AG
@@ -23402,11 +23892,11 @@ SL
 SL
 SL
 SL
-SL
-SL
-SL
+jE
+ck
+pX
+it
 lz
-Ez
 za
 Wd
 Zr
@@ -23656,15 +24146,15 @@ Kn
 Kn
 Kn
 SL
-SL
-SL
-SL
-SL
-SL
-SL
+jE
+jE
+jE
+jE
+Se
+AR
+DX
 lz
-hz
-yg
+qI
 go
 yg
 dt
@@ -23913,15 +24403,15 @@ Kn
 SL
 SL
 SL
-SL
-SL
-SL
-SL
-SL
-SL
+jE
+Jb
+CV
+jE
+xo
+as
+TQ
 lz
-lV
-yg
+mU
 go
 yg
 qu
@@ -24170,14 +24660,14 @@ Kn
 SL
 SL
 SL
-SL
-SL
-SL
-SL
-SL
-SL
-lz
 jE
+Wp
+Ez
+jE
+nG
+au
+pO
+lz
 ij
 bI
 PO
@@ -24427,13 +24917,13 @@ SL
 SL
 SL
 SL
-SL
-SL
-SL
-SL
-SL
-SL
-lz
+jE
+rR
+TS
+hz
+jI
+Hk
+VA
 lz
 lz
 gg
@@ -24688,11 +25178,11 @@ gB
 gB
 gB
 gB
-SL
-SL
-SL
-mz
-ks
+Zi
+jr
+lV
+wp
+aS
 Fw
 eK
 WE
@@ -25714,7 +26204,7 @@ gB
 BV
 Qq
 HJ
-Qq
+WC
 su
 zt
 VB
@@ -25726,7 +26216,7 @@ XD
 WE
 fb
 iy
-pO
+iy
 Gx
 WE
 SL
@@ -25971,7 +26461,7 @@ gB
 xL
 Qq
 kQ
-WC
+Qq
 su
 UO
 hE
@@ -27525,7 +28015,7 @@ Zf
 mz
 SL
 gS
-qH
+En
 Nv
 AN
 gS
@@ -27764,7 +28254,7 @@ mz
 mz
 mz
 mz
-mz
+UI
 mz
 mz
 mz
@@ -27782,7 +28272,7 @@ NR
 NR
 SL
 gS
-En
+rT
 Fi
 Nt
 gS
@@ -29063,7 +29553,7 @@ Jq
 WK
 pt
 ec
-bt
+Tn
 NR
 Kn
 Kn
@@ -29318,9 +29808,9 @@ dE
 bt
 bt
 bt
-lZ
-EC
 bt
+EC
+Wm
 NR
 Kn
 Zd
@@ -29574,8 +30064,8 @@ SL
 NR
 Pg
 NR
-NR
-NR
+bt
+bt
 EC
 XA
 NR
@@ -29831,10 +30321,10 @@ SL
 NR
 xJ
 NR
-SL
-NR
-EC
+UQ
 bt
+EC
+bB
 NR
 Zd
 JG
@@ -30088,10 +30578,10 @@ SL
 NR
 WU
 NR
-SL
-NR
+ow
+bt
 WK
-pt
+xg
 HU
 Hn
 ry
@@ -30345,10 +30835,10 @@ SL
 NR
 WU
 NR
-SL
-NR
-bt
-Tn
+vR
+lZ
+Bc
+sv
 NR
 Fy
 iz
@@ -30602,10 +31092,10 @@ SL
 NR
 qO
 NR
-SL
 NR
-bt
-bt
+NR
+MQ
+qH
 NR
 kL
 cB
@@ -30859,10 +31349,10 @@ SL
 NR
 Es
 NR
-SL
 NR
-bt
-bt
+NR
+cc
+IE
 NR
 Kn
 Zd

--- a/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost.dmm
+++ b/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost.dmm
@@ -1297,13 +1297,11 @@
 	},
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
 /obj/item/device/radio,
 /obj/item/device/radio,
 /obj/item/device/radio,
 /obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/gps,
 /obj/item/device/gps,
 /obj/item/device/gps,
 /obj/item/device/gps,
@@ -3102,14 +3100,6 @@
 /turf/simulated/floor/tiled{
 	temperature = 278.15
 	},
-/area/saniorios_outpost)
-"UI" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Atmos";
-	req_access = list(214);
-	dir = 4
-	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/saniorios_outpost)
 "UK" = (
 /obj/structure/ship_weapon_dummy,
@@ -28254,7 +28244,7 @@ mz
 mz
 mz
 mz
-UI
+mz
 mz
 mz
 mz

--- a/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost.dmm
+++ b/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost.dmm
@@ -3121,7 +3121,7 @@
 "UQ" = (
 /obj/machinery/computer/general_air_control/large_tank_control/terminal{
 	name = "Carbon Dioxide Supply Monitor";
-	sensors = list(""saniorios_co2_sensor""="Tank");
+	sensors = list("saniorios_co2_sensor"="Tank");
 	input_tag = "saniorios_co2_in";
 	output_tag = "saniorios_co2_out"
 	},

--- a/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost_zones.dm
+++ b/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost_zones.dm
@@ -31,6 +31,10 @@
 	name = "Sani'Orios Asteroid Outpost Armory"
 	icon_state = "armory"
 
+	/area/saniorios_outpost/medbay
+	name = "Sani'Orios Asteroid Outpost Armory"
+	icon_state = "medbay"
+
 //Shuttle
 /area/shuttle/saniorios_outpost
 	name = "Sani'Orios Shuttle"

--- a/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost_zones.dm
+++ b/maps/away/away_site/tajara/saniorios_outpost/saniorios_outpost_zones.dm
@@ -31,7 +31,7 @@
 	name = "Sani'Orios Asteroid Outpost Armory"
 	icon_state = "armory"
 
-	/area/saniorios_outpost/medbay
+/area/saniorios_outpost/medbay
 	name = "Sani'Orios Asteroid Outpost Armory"
 	icon_state = "medbay"
 

--- a/maps/random_ruins/exoplanets/adhomai/adhomai_silo.dmm
+++ b/maps/random_ruins/exoplanets/adhomai/adhomai_silo.dmm
@@ -36,6 +36,22 @@
 	},
 /turf/simulated/floor/concrete,
 /area/adhomai_silo)
+"h" = (
+/obj/effect/floor_decal/concrete/large{
+	dir = 4
+	},
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/shot,
+/obj/item/storage/field_ration/army,
+/obj/item/storage/box/fancy/cigarettes/pra,
+/obj/item/flame/lighter/adhomai,
+/obj/item/storage/field_ration/army,
+/obj/item/storage/firstaid/regular,
+/obj/item/book/manual/pra_manifesto,
+/turf/simulated/floor/concrete{
+	temperature = 268.15
+	},
+/area/adhomai_silo/cabin)
 "i" = (
 /turf/simulated/floor/concrete/square,
 /area/adhomai_silo)
@@ -46,6 +62,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/shovel,
 /turf/simulated/floor/concrete,
 /area/adhomai_silo)
 "k" = (
@@ -94,6 +111,15 @@
 	},
 /turf/simulated/floor/concrete,
 /area/adhomai_silo)
+"q" = (
+/obj/effect/floor_decal/concrete/large{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/concrete,
+/area/adhomai_silo)
 "s" = (
 /obj/structure/blocker/steel/fence{
 	dir = 4
@@ -134,11 +160,8 @@
 /turf/simulated/floor/concrete,
 /area/adhomai_silo)
 "B" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/floor_decal/concrete{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/concrete{
 	temperature = 268.15
@@ -150,7 +173,6 @@
 	icon_state = "rwindow"
 	},
 /obj/structure/table/steel,
-/obj/item/material/ashtray/bronze,
 /obj/item/handcuffs,
 /obj/effect/floor_decal/concrete/large{
 	dir = 8
@@ -252,8 +274,8 @@
 	},
 /area/adhomai_silo/cabin)
 "S" = (
-/obj/effect/floor_decal/concrete/large{
-	dir = 4
+/obj/effect/floor_decal/concrete{
+	dir = 10
 	},
 /turf/simulated/floor/concrete{
 	temperature = 268.15
@@ -271,6 +293,30 @@
 	},
 /turf/simulated/floor/concrete,
 /area/adhomai_silo)
+"X" = (
+/obj/effect/floor_decal/concrete/large{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/steel,
+/obj/item/lore_radio{
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/obj/item/deck/cards{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/material/ashtray/bronze{
+	pixel_y = -3;
+	pixel_x = -7
+	},
+/turf/simulated/floor/concrete{
+	temperature = 268.15
+	},
+/area/adhomai_silo/cabin)
 "Y" = (
 /obj/structure/blocker/steel/fence,
 /turf/simulated/floor/exoplanet/snow/cold,
@@ -823,8 +869,8 @@ c
 (18,1,1) = {"
 c
 U
-U
-U
+X
+h
 U
 O
 f
@@ -854,11 +900,11 @@ c
 "}
 (19,1,1) = {"
 c
-s
-b
-N
-N
-y
+U
+U
+U
+U
+A
 f
 f
 f
@@ -887,10 +933,10 @@ c
 (20,1,1) = {"
 c
 s
-A
-f
-f
-f
+q
+N
+N
+y
 f
 f
 f


### PR DESCRIPTION
Gives the Sani'Orios base a toolbelt, a medbay, jetpacks, and a fuel tank for supplying their fellow DPRA.

Makes the Hadiist missile silo slightly less miserable (should still be plenty miserable) by giving them food, a Hadiist manifesto, an analog radio, and some cigarettes to smoke. Hadii's grrrace.