### PR TITLE
Horizon Mapping - Minor Tweaks

### DIFF
--- a/html/changelogs/CourierBravo - Horizon Map Tweaks.yml
+++ b/html/changelogs/CourierBravo - Horizon Map Tweaks.yml
@@ -1,0 +1,62 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: CourierBravo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Moves a floor light in the science wing that breaks the pattern of floor lights in the hallway."
+  - qol: "Moves a floor light in the deck 3 central primary hallway, to maintain the pattern of floor lights being spaced 4 tiles apart."
+  - bugfix: "Removes an access level door helper effect, which I believe is causing the Consular Office B door to be accessible to anyone with that access."
+  - balence: "Replaces a table in the CIC with a charger, allowing for IPC members of command or command support to charge safely in the bunker."
+  - rscadd: "Places another rubber ducky... somewhere."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -19414,6 +19414,9 @@
 	pixel_x = 20;
 	pixel_y = 4
 	},
+/obj/item/bikehorn/rubberducky{
+	pixel_y = 5
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
 "nqp" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -5019,6 +5019,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/machinery/light/floor{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)
 "cdq" = (
@@ -30608,9 +30611,6 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
-	},
-/obj/machinery/light/floor{
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/hallway)

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -1909,7 +1909,7 @@
 /turf/simulated/floor/tiled/full,
 /area/horizon/security/evidence_storage)
 "bnG" = (
-/obj/structure/table/steel,
+/obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/dark/full,
 /area/bridge/aibunker)
 "boM" = (
@@ -2997,8 +2997,8 @@
 /obj/effect/floor_decal/corner/dark_green{
 	dir = 10
 	},
-/obj/machinery/light/floor,
 /obj/structure/railing/mapped,
+/obj/machinery/light/floor,
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_three/primary/central)
 "cii" = (
@@ -4965,7 +4965,6 @@
 	name = "Consular Office B";
 	req_access = list(72)
 	},
-/obj/effect/map_effect/door_helper/level_access/command_foyer,
 /turf/simulated/floor/tiled,
 /area/lawoffice/consular_two)
 "dRo" = (
@@ -13768,9 +13767,6 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -28;
 	pixel_y = -10
-	},
-/obj/machinery/recharger{
-	pixel_y = 11
 	},
 /obj/machinery/light/small/emergency{
 	dir = 8
@@ -33978,6 +33974,10 @@
 /obj/random/pottedplant_small{
 	pixel_x = 6;
 	pixel_y = 1
+	},
+/obj/machinery/recharger{
+	pixel_y = 8;
+	pixel_x = -5
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/bridge/aibunker)
@@ -56402,7 +56402,7 @@ nCP
 kTE
 tzY
 fDJ
-cid
+vOV
 oZv
 lJJ
 swR
@@ -56604,7 +56604,7 @@ nCP
 dHs
 dHr
 vyx
-vOV
+cid
 kwr
 iBY
 lEP


### PR DESCRIPTION
-Moves a floor light in the science wing that breaks the pattern of floor lights in the hallway.
-Moves a floor light in the deck 3 central primary hallway, to maintain the pattern of floor lights being spaced 4 tiles apart.
-Removes an access level door helper effect, which I believe is causing the Consular Office B door to be accessible to anyone with that access.
-Replaces a table in the CIC with a charger, allowing for IPC members of command or command support to charge safely in the bunker.
-Places another rubber ducky... somewhere :)