### PR TITLE
Away Ship Bugfix - Kataphract ship lacking chargers

### DIFF
--- a/html/changelogs/Courier Bravo-kataphractbugfix.yml
+++ b/html/changelogs/Courier Bravo-kataphractbugfix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: CourierBravo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Added chargers throughout the Kataphract ship and its shuttle."

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -1577,6 +1577,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/cell_charger{
+	pixel_y = 9
+	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/engineering)
 "fG" = (
@@ -2125,6 +2128,15 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
+	},
+/obj/machinery/recharger{
+	pixel_y = 3;
+	pixel_x = 7
+	},
+/obj/machinery/recharger/wallcharger{
+	layer = 3.3;
+	pixel_x = 5;
+	pixel_y = 21
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/kataphract_shuttle/main_compartment)
@@ -4794,6 +4806,10 @@
 /obj/effect/floor_decal/corner_wide/dark_blue{
 	dir = 10
 	},
+/obj/machinery/recharger{
+	pixel_x = -7;
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/kataphract_chapter/cic)
 "wU" = (
@@ -6723,6 +6739,16 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
+/obj/machinery/recharger/wallcharger{
+	layer = 3.3;
+	pixel_x = 5;
+	pixel_y = 23
+	},
+/obj/machinery/recharger/wallcharger{
+	layer = 3.3;
+	pixel_x = 5;
+	pixel_y = 34
+	},
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/armoury)
 "Rv" = (
@@ -7311,6 +7337,10 @@
 "Ws" = (
 /obj/structure/table/reinforced/steel,
 /obj/effect/floor_decal/corner_wide/dark_blue/full,
+/obj/machinery/recharger{
+	pixel_y = 7;
+	pixel_x = -6
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/kataphract_chapter/bridge)
 "WI" = (


### PR DESCRIPTION
adds chargers throughout the kataphract ship and its shuttle. This is a fix for issue #19200