### PR TITLE
Progress Bar Darkness Fix

### DIFF
--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -36,7 +36,8 @@
 	bar_loc = target
 	location_type = bar_loc.type
 	bar = image('icons/effects/progressbar.dmi', bar_loc, "prog_bar_0")
-	bar.layer = 21 //TODO: Move this to a proper plane and layer when that PR is finished
+	bar.layer = HUD_ABOVE_ITEM_LAYER
+	bar.plane = HUD_PLANE
 	bar.appearance_flags = RESET_COLOR|RESET_TRANSFORM|NO_CLIENT_COLOR|RESET_ALPHA|PIXEL_SCALE
 	user = User
 

--- a/html/changelogs/geeves-emissive_do_after.yml
+++ b/html/changelogs/geeves-emissive_do_after.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Progress bars now render on the HUD layer, meaning it won't be affected by darkness."


### PR DESCRIPTION
* Progress bars now render on the HUD layer, meaning it won't be affected by darkness.