### PR TITLE
Aim Intent Safety Fix

### DIFF
--- a/code/modules/projectiles/targeting/targeting_triggers.dm
+++ b/code/modules/projectiles/targeting/targeting_triggers.dm
@@ -23,6 +23,13 @@
 	return TRUE
 
 /obj/aiming_overlay/proc/trigger(var/perm)
+	if(!owner || !aiming_with || !aiming_at || !locked)
+		return FALSE
+	if(perm && (target_permissions & perm))
+		return FALSE
+	if(!owner.canClick())
+		return FALSE
+
 	var/obj/item/gun/G = aiming_with
 	if(istype(G) && G.safety())
 		if(owner.a_intent == I_HURT)
@@ -30,12 +37,6 @@
 		else
 			G.handle_click_empty(owner)
 			to_chat(owner, SPAN_WARNING("Your [G]'s safety prevents firing."))
-	if(!owner || !aiming_with || !aiming_at || !locked)
-		return FALSE
-	if(perm && (target_permissions & perm))
-		return FALSE
-	if(!owner.canClick())
-		return FALSE
 
 	owner.setClickCooldown(DEFAULT_QUICK_COOLDOWN) // Spam prevention, essentially.
 	owner.visible_message(

--- a/html/changelogs/geeves-aim_intent_safety_fix.yml
+++ b/html/changelogs/geeves-aim_intent_safety_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed aim intent triggering clicking messages if someone moves (despite being allowed to move) when you're not on harm intent."


### PR DESCRIPTION
* Fixed aim intent triggering clicking messages if someone moves (despite being allowed to move) when you're not on harm intent.

Fixes https://github.com/Aurorastation/Aurora.3/issues/19242