### PR TITLE
3 Second Timers

### DIFF
--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -11,7 +11,7 @@
 	secured = FALSE
 
 	var/timing = FALSE
-	var/time = 10
+	var/time = 3
 
 /obj/item/device/assembly/timer/activate()
 	. = ..()

--- a/html/changelogs/three-seconds.yml
+++ b/html/changelogs/three-seconds.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - rscadd: "Lowered the minimum timer time to 3 seconds, from 10, allowing shorter grenade fuses."


### PR DESCRIPTION
Lowers assembly timers to have a minimum time of 3 seconds, from 10. Allows practical grenade fuses.