### PR TITLE
Chatlog tweaks: fix-chat/reconnects no longer wipe log; and a higher max message limit

### DIFF
--- a/html/changelogs/lly-log_stuff.yml
+++ b/html/changelogs/lly-log_stuff.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Llywelwyn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Increased the upper limit for max messages saved in the chatlog."
+  - rscadd: "Chat log pruning and rebuilding now uses the max messages value, so reconnects and the fix-chat verb will no longer wipe most of the chatlog."

--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -4,7 +4,6 @@
  * @license MIT
  */
 
-export const MAX_PERSISTED_MESSAGES = 1000;
 export const MESSAGE_SAVE_INTERVAL = 10000;
 export const MESSAGE_PRUNE_INTERVAL = 60000;
 export const COMBINE_MAX_MESSAGES = 5;

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -7,7 +7,7 @@
 import { EventEmitter } from 'common/events';
 import { classes } from 'common/react';
 import { createLogger } from 'tgui/logging';
-import { COMBINE_MAX_MESSAGES, COMBINE_MAX_TIME_WINDOW, IMAGE_RETRY_DELAY, IMAGE_RETRY_LIMIT, IMAGE_RETRY_MESSAGE_AGE, MAX_PERSISTED_MESSAGES, MESSAGE_TYPES, MESSAGE_TYPE_INTERNAL, MESSAGE_TYPE_UNKNOWN } from './constants';
+import { COMBINE_MAX_MESSAGES, COMBINE_MAX_TIME_WINDOW, IMAGE_RETRY_DELAY, IMAGE_RETRY_LIMIT, IMAGE_RETRY_MESSAGE_AGE, MESSAGE_TYPES, MESSAGE_TYPE_INTERNAL, MESSAGE_TYPE_UNKNOWN } from './constants';
 import { render } from 'inferno';
 import { canPageAcceptType, createMessage, isSameMessage } from './model';
 import { highlightNode, linkifyNode } from './replaceInTextNode';
@@ -468,7 +468,7 @@ class ChatRenderer {
     }
   }
 
-  pruneMessagesTo(max_visible_messages, max_persisted_messages) {
+  pruneMessagesTo(max_visible_messages) {
     if (!this.isReady()) {
       return;
     }
@@ -502,7 +502,7 @@ class ChatRenderer {
     {
       const fromIndex = Math.max(
         0,
-        this.messages.length - max_persisted_messages
+        this.messages.length - max_visible_messages
       );
       if (fromIndex > 0) {
         this.messages = this.messages.slice(fromIndex);
@@ -511,15 +511,12 @@ class ChatRenderer {
     }
   }
 
-  rebuildChat() {
+  rebuildChat(max_visible_messages) {
     if (!this.isReady()) {
       return;
     }
     // Make a copy of messages
-    const fromIndex = Math.max(
-      0,
-      this.messages.length - MAX_PERSISTED_MESSAGES
-    );
+    const fromIndex = Math.max(0, this.messages.length - max_visible_messages);
     const messages = this.messages.slice(fromIndex);
     // Remove existing nodes
     for (let message of messages) {

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -582,7 +582,7 @@ class ChatRenderer {
   }
 
   clear() {
-    this.pruneMessagesTo(0, 0);
+    this.pruneMessagesTo(0);
   }
 }
 

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -182,6 +182,7 @@ export const SettingsGeneral = (props, context) => {
 
 const TextHighlightSettings = (props, context) => {
   const highlightSettings = useSelector(context, selectHighlightSettings);
+  const settings = useSelector(context, selectSettings);
   const dispatch = useDispatch(context);
   return (
     <Section fill scrollable height="200px">
@@ -210,7 +211,9 @@ const TextHighlightSettings = (props, context) => {
       </Section>
       <Divider />
       <Box>
-        <Button icon="check" onClick={() => dispatch(rebuildChat())}>
+        <Button
+          icon="check"
+          onClick={() => dispatch(rebuildChat(settings.maxMessages))}>
           Apply now
         </Button>
         <Box inline fontSize="0.9em" ml={1} color="label">

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -156,7 +156,7 @@ export const SettingsGeneral = (props, context) => {
             step={50}
             stepPixelSize={2}
             minValue={2000}
-            maxValue={16000}
+            maxValue={32000}
             value={maxMessages}
             format={(value) => toFixed(value)}
             onChange={(e, value) =>


### PR DESCRIPTION
tg chatlog stored a very low number of `persisted messages` (stuff from the last time chat got saved) and the significantly higher settings value of how much stuff the player wants to save. when rebuilding chat for any reason, the current msgs get saved to persisted, and everything else is deleted. 

e.g. any unexpected chat rebuilds means losing pretty much your entire chatlog irrecoverably

  - rscadd: "Increased the upper limit for max messages saved in the chatlog."
  - rscadd: "Chat log pruning and rebuilding now uses the max messages value, so reconnects and the fix-chat verb will no longer wipe most of the chatlog."

this means the player has the option to persist more messages which might cause issues on PCs from 1970 but otherwise i see no issues