### PR TITLE
Fixes attempting surgery firing instead of normal actions

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -104,3 +104,5 @@ var/list/mimic_defines = list(
 #define ITEM_FLAG_HELD_MAP_TEXT FLAG(11)
 /// Cannot be moved from its current inventory slot. Mostly for augments, modules, and other "attached" items.
 #define ITEM_FLAG_NO_MOVE FLAG(12)
+/// Can be used for surgery, giving the "You're not sure what you can do with this." message if no surgery is available.
+#define ITEM_FLAG_SURGERY FLAG(13)

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -18,6 +18,10 @@
 	pickup_sound = 'sound/items/pickup/weldingtool.ogg'
 	recyclable = TRUE
 
+/obj/item/surgery/Initialize(mapload, ...)
+	. = ..()
+	item_flags |= ITEM_FLAG_SURGERY
+
 /*
  * Retractor
  */

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -92,31 +92,6 @@
 	if(!istype(M) || user.a_intent == I_HURT)
 		return FALSE
 
-	var/static/list/safety_check_exceptions = list(
-		/obj/item/auto_cpr,
-		/obj/item/device/healthanalyzer,
-		/obj/item/modular_computer,
-		/obj/item/reagent_containers,
-		/obj/item/device/advanced_healthanalyzer,
-		/obj/item/device/robotanalyzer,
-		/obj/item/stack/medical,
-		/obj/item/stack/nanopaste,
-		/obj/item/device/breath_analyzer,
-		/obj/item/personal_inhaler,
-		/obj/item/clothing/accessory/stethoscope,
-		/obj/item/autopsy_scanner,
-		/obj/item/device/flashlight/pen,
-		/obj/item/spell/resurrect,
-		/obj/item/spell/mend_organs,
-		/obj/item/spell/modifier/mend_life,
-		/obj/item/spell/modifier/mend_synthetic,
-		/obj/item/grab,
-
-		//Defibrillator stuffs
-		/obj/item/defibrillator,
-		/obj/item/shockpaddles,
-
-		)
 	// Check for multi-surgery drifting.
 	var/zone = user.zone_sel.selecting
 	if(zone in M.op_stage.in_progress)
@@ -148,10 +123,10 @@
 
 	// We didn't find a surgery, or decided not to perform one.
 	if(!istype(S))
-		if(is_type_in_list(tool, safety_check_exceptions))
-			return FALSE//These tools are safe to bypass hippocratic oath
-		to_chat(user, SPAN_WARNING("You aren't sure what you could do to \the [M] with \the [tool]."))
-		return TRUE
+		if(tool.item_flags & ITEM_FLAG_SURGERY) //Is this supposed to be used for surgery?
+			to_chat(user, SPAN_WARNING("You aren't sure what you could do to \the [M] with \the [tool]."))
+			return TRUE
+		return FALSE //Just do the normal use for the tool instead
 
 	// Otherwise we can make a start on surgery!
 	else if(istype(M) && !QDELETED(M) && tool)

--- a/html/changelogs/cuffs-arent-surgery.yml
+++ b/html/changelogs/cuffs-arent-surgery.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes attempting surgery with every item while someone is on a bed getting in the way of normal item uses. Surgery will now only stop you using surgical tools at the wrong time."


### PR DESCRIPTION
Fixes surgery code from hijacking any attempt to use an item while someone is on a bed. Rather than checking for a few allowed items, it will now check for if the tool is meant for surgery, and only say "You don't know what you can do" if so.