### PR TITLE
Slime core mob selection fix

### DIFF
--- a/code/modules/mob/living/simple_animal/aquatic.dm
+++ b/code/modules/mob/living/simple_animal/aquatic.dm
@@ -1,5 +1,7 @@
 //For things that swim and don't do much else.
 /mob/living/simple_animal/aquatic
+	abstract_type = /mob/living/simple_animal/aquatic
+
 	name = "aquatic animal"
 	desc = DESC_PARENT
 	icon = 'icons/mob/npc/fish.dmi'

--- a/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
+++ b/code/modules/mob/living/simple_animal/hostile/commanded/commanded.dm
@@ -1,4 +1,6 @@
 /mob/living/simple_animal/hostile/commanded
+	abstract_type = /mob/living/simple_animal/hostile/commanded
+
 	name = "commanded"
 	var/short_name = null
 	stance = COMMANDED_STOP

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -1,4 +1,6 @@
 /mob/living/simple_animal/hostile
+	abstract_type = /mob/living/simple_animal/hostile
+
 	faction = "hostile"
 	var/stance = HOSTILE_STANCE_IDLE	//Used to determine behavior
 	var/mob/living/target_mob

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/aquatic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/aquatic.dm
@@ -1,5 +1,7 @@
 //For things that swim and don't do much else, but also bite!
 /mob/living/simple_animal/hostile/retaliate/aquatic
+	abstract_type = /mob/living/simple_animal/hostile/retaliate/aquatic
+
 	name = "aquatic animal"
 	desc = DESC_PARENT
 	icon = 'icons/mob/npc/fish.dmi'

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -1,4 +1,6 @@
 /mob/living/simple_animal/hostile/retaliate
+	abstract_type = /mob/living/simple_animal/hostile/retaliate
+
 	var/list/enemies = list()
 
 /mob/living/simple_animal/hostile/retaliate/Destroy()

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1243,6 +1243,7 @@
 	required = /obj/item/slime_extract/gold
 
 /datum/chemical_reaction/slime/crit/on_reaction(var/datum/reagents/holder)
+	//exclusion list for things you don't want the reaction to create
 	var/blocked = list(
 		/mob/living/simple_animal/hostile,
 		/mob/living/simple_animal/hostile/pirate,
@@ -1255,10 +1256,8 @@
 		/mob/living/simple_animal/hostile/syndicate/ranged,
 		/mob/living/simple_animal/hostile/syndicate/ranged/space,
 		/mob/living/simple_animal/hostile/faithless,
-		/mob/living/simple_animal/hostile/retaliate,
 		/mob/living/simple_animal/hostile/retaliate/clown,
 		/mob/living/simple_animal/hostile/true_changeling,
-		/mob/living/simple_animal/hostile/commanded,
 		/mob/living/simple_animal/hostile/commanded/dog,
 		/mob/living/simple_animal/hostile/commanded/dog/amaskan,
 		/mob/living/simple_animal/hostile/commanded/dog/columbo,
@@ -1281,7 +1280,7 @@
 		/mob/living/simple_animal/hostile/cavern_geist/augmented,
 		/mob/living/simple_animal/hostile/retaliate/pra_exploration_drone
 	)
-	//exclusion list for things you don't want the reaction to create.
+
 	var/list/critters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
 	var/turf/location = get_turf(holder.my_atom)
 	playsound(location, 'sound/effects/phasein.ogg', 100, 1)
@@ -1290,6 +1289,15 @@
 
 	for(var/i = 1, i <= 5, i++)
 		var/chosen = pick(critters)
+		//No abstract mobs
+		while(is_abstract(chosen))
+			critters -= chosen
+			if(!length(critters))
+				crash_with("No critters left to pick from!")
+				return
+
+			chosen = pick(critters)
+
 		var/mob/living/simple_animal/hostile/C = new chosen
 		C.faction = "slimesummon"
 		C.forceMove(location)

--- a/html/changelogs/fluffyghost-fixslimecorespawn.yml
+++ b/html/changelogs/fluffyghost-fixslimecorespawn.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - code_imp: "Marked some mobs that were not meant to be spawned as abstracts."
+  - bugfix: "Updated the reaction of the slime core to not spawn abstract mobs."


### PR DESCRIPTION
Marked some mobs that were not meant to be spawned as abstracts.
Updated the reaction of the slime core to not spawn abstract mobs.

Fixes #19276 