### PR TITLE
Altered Trawler Crewman Whitelist Requirements

### DIFF
--- a/html/changelogs/Evandorf-TrawlerTweaks.yml
+++ b/html/changelogs/Evandorf-TrawlerTweaks.yml
@@ -56,4 +56,6 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Altered the Crewman ghostrole to allow for non-listed players."
+  - bugfix: "Added the Uueoaesa sector to list of sectors."
+
 

--- a/html/changelogs/Evandorf-Trawlerwhitelistchange.yml
+++ b/html/changelogs/Evandorf-Trawlerwhitelistchange.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Evandorf
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Altered the Crewman ghostrole to allow for non-listed players."
+

--- a/maps/away/ships/hegemony/fishing_trawler/fishing_league_trawler.dm
+++ b/maps/away/ships/hegemony/fishing_trawler/fishing_league_trawler.dm
@@ -5,7 +5,7 @@
 	prefix = "ships/hegemony/fishing_trawler/"
 	suffixes = list("fishing_league_trawler.dmm")
 
-	sectors = list(SECTOR_BADLANDS)
+	sectors = list(SECTOR_BADLANDS, SECTOR_UUEOAESA)
 	spawn_weight_sector_dependent = list(SECTOR_UUEOAESA = 3)
 	spawn_weight = 1
 	ship_cost = 1

--- a/maps/away/ships/hegemony/fishing_trawler/fishing_league_trawler_ghostroles.dm
+++ b/maps/away/ships/hegemony/fishing_trawler/fishing_league_trawler_ghostroles.dm
@@ -10,7 +10,7 @@
 
 	outfit = /obj/outfit/admin/fishing_trawler_crewman
 	possible_species = list(SPECIES_UNATHI, SPECIES_VAURCA_WARRIOR, SPECIES_VAURCA_WORKER)
-	uses_species_whitelist = TRUE
+	uses_species_whitelist = FALSE
 	allow_appearance_change = APPEARANCE_PLASTICSURGERY
 
 	assigned_role = "Fishing League Trawler Crewman"


### PR DESCRIPTION
Trawler Crewmen no longer need a whitelist to join. The original whitelist restriction was an oversight on my part. The Captain will still remain behind the whitelist.
