### PR TITLE
IPC antenna bugfixes: lockable when in the headslot, and antennae -> antennas

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/xeno/machine.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/machine.dm
@@ -60,15 +60,15 @@
 	bracers["arm chains, ruby"] = /obj/item/clothing/wrists/goldbracer/ruby
 	gear_tweaks += new /datum/gear_tweak/path(bracers)
 
-/datum/gear/ears/antennae
-	display_name = "antennae"
+/datum/gear/ears/antennas
+	display_name = "antennas"
 	path = /obj/item/clothing/ears/antenna
 	cost = 1
 	whitelisted = list(SPECIES_IPC, SPECIES_IPC_G1, SPECIES_IPC_G2, SPECIES_IPC_XION, SPECIES_IPC_ZENGHU, SPECIES_IPC_BISHOP, SPECIES_IPC_SHELL)
 	sort_category = "Xenowear - IPC"
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION
 
-/datum/gear/ears/antennae/New()
+/datum/gear/ears/antennas/New()
 	..()
 	var/list/antenna = list()
 	antenna["antenna, curved"] = /obj/item/clothing/ears/antenna/curved

--- a/code/modules/clothing/ears/antennae.dm
+++ b/code/modules/clothing/ears/antennae.dm
@@ -8,9 +8,9 @@
 	drop_sound = 'sound/items/drop/component.ogg'
 	pickup_sound = 'sound/items/pickup/component.ogg'
 
-/obj/item/clothing/ears/antenna/verb/lock_antennae()
-	set name = "Lock Antenna(e)"
-	set desc = "Lock your antenna(e) in place."
+/obj/item/clothing/ears/antenna/verb/lock_antennas()
+	set name = "Lock Antenna(s)"
+	set desc = "Lock your antenna(s) in place."
 	set category = "Object"
 	set src in usr
 
@@ -27,64 +27,64 @@
 		return
 
 	if(user.r_ear != src && user.l_ear != src && user.head != src)
-		to_chat(user, SPAN_WARNING("Your antennae must be on your head for the locking mechanism to work."))
+		to_chat(user, SPAN_WARNING("Your antennas must be on your head for the locking mechanism to work."))
 		return
 
-	to_chat(user, SPAN_NOTICE("You [canremove ? "enable" : "disable"] the locking mechanism on your antennae."))
+	to_chat(user, SPAN_NOTICE("You [canremove ? "enable" : "disable"] the locking mechanism on your antennas."))
 	playsound(user, canremove ? 'sound/machines/hatch_close.ogg' : 'sound/machines/hatch_open.ogg', 25)
 	canremove = !canremove
 
 /obj/item/clothing/ears/antenna/curved
-	name = "curved antennae"
-	desc = "A set of decorative antennae. This particular pair is curved in the middle point, arcing upwards. Unfortunately, it doesn't get FM here."
+	name = "curved antennas"
+	desc = "A set of decorative antennas. This particular pair is curved in the middle point, arcing upwards. Unfortunately, it doesn't get FM here."
 	icon_state = "curvedantennae"
 	item_state = "curvedantennae"
 
 /obj/item/clothing/ears/antenna/straight
-	name = "straight antennae"
-	desc = "A set of decorative antennae. This particular pair is straight, jutting out to what is reasonably shoulder width. They don't seem to plug into anything."
+	name = "straight antennas"
+	desc = "A set of decorative antennas. This particular pair is straight, jutting out to what is reasonably shoulder width. They don't seem to plug into anything."
 	icon_state = "straightantennae"
 	item_state = "straightantennae"
 
 /obj/item/clothing/ears/antenna/circle
-	name = "circle antennae"
-	desc = "A set of decorative antennae. This particular pair is circular, mimicking a sattelite dish. Still better than cable, though."
+	name = "circle antennas"
+	desc = "A set of decorative antennas. This particular pair is circular, mimicking a sattelite dish. Still better than cable, though."
 	icon_state = "circleantennae"
 	item_state = "circleantennae"
 
 /obj/item/clothing/ears/antenna/tusk
-	name = "tusk antennae"
-	desc = "A set of decorative antennae. This particular pair is stylized like animal tusks, for combat down the runway, of course."
+	name = "tusk antennas"
+	desc = "A set of decorative antennas. This particular pair is stylized like animal tusks, for combat down the runway, of course."
 	icon_state = "tusk"
 	item_state = "tusk"
 
 /obj/item/clothing/ears/antenna/horncrown
-	name = "horn crown antennae"
-	desc = "A set of decorative antennae. This particular pair is in a spring shape, attached to a large chassis. Careful for doorways."
+	name = "horn crown antennas"
+	desc = "A set of decorative antennas. This particular pair is in a spring shape, attached to a large chassis. Careful for doorways."
 	icon_state = "horncrown"
 	item_state = "horncrown"
 
 /obj/item/clothing/ears/antenna/horn
-	name = "horn antennae"
-	desc = "A set of decorative antennae. This particular pair is in a spring shape, mimicking animal horns."
+	name = "horn antennas"
+	desc = "A set of decorative antennas. This particular pair is in a spring shape, mimicking animal horns."
 	icon_state = "dual_horn"
 	item_state = "dual_horn"
 
 /obj/item/clothing/ears/antenna/horn/single
 	name = "horn antenna"
-	desc = "A set of decorative antennae. This particular one is in a spring shape, mimicking an animal's horn."
+	desc = "A decorative antenna. This particular one is in a spring shape, mimicking an animal's horn."
 	icon_state = "horn"
 	item_state = "horn"
 
 /obj/item/clothing/ears/antenna/dish
 	name = "antenna dishes"
-	desc = "A set of decorative antennae. This particular one is stylized as two tiny dishes, intended to hold excess wiring in a very specific manner. If only they picked up holodramas."
+	desc = "A decorative antenna. This particular one is stylized as two tiny dishes, intended to hold excess wiring in a very specific manner. If only they picked up holodramas."
 	icon_state = "dual_dish"
 	item_state = "dual_dish"
 
 /obj/item/clothing/ears/antenna/whip
-	name = "whip antennae"
-	desc = "A set of decorative antennae. Despite being commonly seen on Shells, nobody knows what these actually do."
+	name = "whip antennas"
+	desc = "A set of decorative antennas. Despite being commonly seen on Shells, nobody knows what these actually do."
 	icon_state = "dual_whip"
 	item_state = "dual_whip"
 

--- a/code/modules/clothing/ears/antennae.dm
+++ b/code/modules/clothing/ears/antennae.dm
@@ -26,7 +26,7 @@
 		to_chat(user, SPAN_WARNING("The locking mechanism refuses to work!"))
 		return
 
-	if(user.r_ear != src && user.l_ear != src)
+	if(user.r_ear != src && user.l_ear != src && user.head != src)
 		to_chat(user, SPAN_WARNING("Your antennae must be on your head for the locking mechanism to work."))
 		return
 

--- a/html/changelogs/llywelwyn-antennafix.yml
+++ b/html/changelogs/llywelwyn-antennafix.yml
@@ -55,4 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "Antennae can now be locked when equipped on the head slot."
+  - bugfix: "Antennas can now be locked when equipped on the head slot."
+  - spellcheck: "Corrected the name of IPC antennae to antennas."

--- a/html/changelogs/llywelwyn-antennafix.yml
+++ b/html/changelogs/llywelwyn-antennafix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Llywelwyn
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Antennae can now be locked when equipped on the head slot."


### PR DESCRIPTION
  - bugfix: "Antennas can now be locked when equipped on the head slot."
  - spellcheck: "Corrected the name of IPC antennae to antennas."

`the plural, antennas, is used to refer to electrical instruments, and antennae, to the protuberances found on the heads of insects.`