### PR TITLE
Butanol Fix

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -255,7 +255,7 @@
 
 	distillation_point = T0C + 117.7
 
-/singleton/reagent/alcohol/butanol/affect_ingest(var/mob/living/carbon/human/M, var/alien, var/removed, var/datum/reagents/holder)
+/singleton/reagent/alcohol/butanol/affect_ingest(mob/living/carbon/human/M, alien, removed, var/datum/reagents/holder)
 	if (alien == IS_UNATHI)
 		M.intoxication += (strength / 100) * removed * 6
 		if (druggy != 0)

--- a/html/changelogs/Crosarius-butanolfix.yml
+++ b/html/changelogs/Crosarius-butanolfix.yml
@@ -1,0 +1,6 @@
+author: crosarius
+
+delete-after: True
+
+changes:
+  - bugfix: "Attempts to correct butanol sometimes having no effect on Unathi."


### PR DESCRIPTION
At the moment, sometimes Unathi will randomly be unaffected by butanol, for unknown reasons. This seems to happen on a per-person basis, not per round. In my testing I've found that simply going to below decks and then respawning can change whether or not you're affected by butnaol. This problem is not able to be replicated on test servers, and only exists on live. This is an attempt to fix the problem by changing the way that variables are declared in butanol/affect_ingest() to make it more like alcohol/affect_ingest()

The code still works on my test server as-intended, so worst case scenario it just doesn't fix the bug. 

I probably need serious coder help with resolving this bug because I am completely stumped if this isn't the problem. 