### PR TITLE
Shuttle manifest update

### DIFF
--- a/code/__DEFINES/shuttle.dm
+++ b/code/__DEFINES/shuttle.dm
@@ -13,3 +13,5 @@
 //Landmarks.
 #define SLANDMARK_FLAG_AUTOSET 1    // If set, will set base area and turf type to same as where it was spawned at
 #define SLANDMARK_FLAG_ZERO_G  2    // Zero-G shuttles moved here will lose gravity unless the area has ambient gravity.
+
+#define HORIZON_SHUTTLES list("SCCV Canary", "SCCV Intrepid", "SCCV Spark")

--- a/code/__DEFINES/shuttle.dm
+++ b/code/__DEFINES/shuttle.dm
@@ -15,3 +15,4 @@
 #define SLANDMARK_FLAG_ZERO_G  2    // Zero-G shuttles moved here will lose gravity unless the area has ambient gravity.
 
 #define HORIZON_SHUTTLES list("SCCV Canary", "SCCV Intrepid", "SCCV Spark")
+#define SHUTTLE_MISSIONS list("Exploration", "Research", "Prospecting", "Transport", "Combat", "Rescue", "Training")

--- a/code/__DEFINES/shuttle.dm
+++ b/code/__DEFINES/shuttle.dm
@@ -13,6 +13,3 @@
 //Landmarks.
 #define SLANDMARK_FLAG_AUTOSET 1    // If set, will set base area and turf type to same as where it was spawned at
 #define SLANDMARK_FLAG_ZERO_G  2    // Zero-G shuttles moved here will lose gravity unless the area has ambient gravity.
-
-#define HORIZON_SHUTTLES list("SCCV Canary", "SCCV Intrepid", "SCCV Spark")
-#define SHUTTLE_MISSIONS list("Exploration", "Research", "Prospecting", "Transport", "Combat", "Rescue", "Training")

--- a/code/controllers/subsystems/records.dm
+++ b/code/controllers/subsystems/records.dm
@@ -37,7 +37,7 @@ SUBSYSTEM_DEF(records)
 	viruses = list()
 	shuttle_assignments = list()
 	for(var/shuttle in HORIZON_SHUTTLES)
-		var/datum/record/shuttle/assignment/A = new /datum/record/shuttle/assignment/A(src, shuttle)
+		var/datum/record/shuttle_assignment/A = new /datum/record/shuttle_assignment(shuttle)
 		shuttle_assignments += A
 	shuttle_manifests = list()
 	excluded_fields = list()
@@ -111,9 +111,9 @@ SUBSYSTEM_DEF(records)
 			warrants += record
 		if(/datum/record/virus)
 			viruses += record
-		if(/datum/record/shuttle/manifest)
+		if(/datum/record/shuttle_manifest)
 			shuttle_manifests += record
-		if(/datum/record/shuttle/assignment)
+		if(/datum/record/shuttle_assignment)
 			shuttle_assignments += record
 	onCreate(record)
 
@@ -128,9 +128,9 @@ SUBSYSTEM_DEF(records)
 			warrants |= record
 		if(/datum/record/virus)
 			viruses |= record
-		if(/datum/record/shuttle/manifest)
+		if(/datum/record/shuttle_manifest)
 			shuttle_manifests |= record
-		if(/datum/record/shuttle/assignment)
+		if(/datum/record/shuttle_assignment)
 			shuttle_assignments |= record
 	onModify(record)
 
@@ -145,9 +145,9 @@ SUBSYSTEM_DEF(records)
 			warrants -= record
 		if(/datum/record/virus)
 			viruses *= record
-		if(/datum/record/shuttle/manifest)
+		if(/datum/record/shuttle_manifest)
 			shuttle_manifests -= record
-		if(/datum/record/shuttle/assignment)
+		if(/datum/record/shuttle_assignment)
 			shuttle_assignments -= record
 	onDelete(record)
 	qdel(record)

--- a/code/controllers/subsystems/records.dm
+++ b/code/controllers/subsystems/records.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(records)
 
 	var/list/warrants
 	var/list/viruses
+	var/list/shuttle_assignments
 	var/list/shuttle_manifests
 
 	var/list/excluded_fields
@@ -34,6 +35,10 @@ SUBSYSTEM_DEF(records)
 	records_locked = list()
 	warrants = list()
 	viruses = list()
+	shuttle_assignments = list()
+	for(var/shuttle in HORIZON_SHUTTLES)
+		var/datum/record/shuttle/assignment/A = new /datum/record/shuttle/assignment/A(src, shuttle)
+		shuttle_assignments += A
 	shuttle_manifests = list()
 	excluded_fields = list()
 	localized_fields = list()
@@ -106,8 +111,10 @@ SUBSYSTEM_DEF(records)
 			warrants += record
 		if(/datum/record/virus)
 			viruses += record
-		if(/datum/record/shuttle_manifest)
+		if(/datum/record/shuttle/manifest)
 			shuttle_manifests += record
+		if(/datum/record/shuttle/assignment)
+			shuttle_assignments += record
 	onCreate(record)
 
 /datum/controller/subsystem/records/proc/update_record(var/datum/record/record)
@@ -121,8 +128,10 @@ SUBSYSTEM_DEF(records)
 			warrants |= record
 		if(/datum/record/virus)
 			viruses |= record
-		if(/datum/record/shuttle_manifest)
+		if(/datum/record/shuttle/manifest)
 			shuttle_manifests |= record
+		if(/datum/record/shuttle/assignment)
+			shuttle_assignments |= record
 	onModify(record)
 
 /datum/controller/subsystem/records/proc/remove_record(var/datum/record/record)
@@ -136,8 +145,10 @@ SUBSYSTEM_DEF(records)
 			warrants -= record
 		if(/datum/record/virus)
 			viruses *= record
-		if(/datum/record/shuttle_manifest)
+		if(/datum/record/shuttle/manifest)
 			shuttle_manifests -= record
+		if(/datum/record/shuttle/assignment)
+			shuttle_assignments -= record
 	onDelete(record)
 	qdel(record)
 

--- a/code/controllers/subsystems/records.dm
+++ b/code/controllers/subsystems/records.dm
@@ -24,6 +24,10 @@ SUBSYSTEM_DEF(records)
 	for(var/type in localized_fields)
 		localized_fields[type] = compute_localized_field(type)
 
+	for(var/shuttle in SSatlas.current_map.shuttle_manifests)
+		var/datum/record/shuttle_assignment/A = new /datum/record/shuttle_assignment(shuttle)
+		shuttle_assignments += A
+
 	InitializeCitizenships()
 	InitializeReligions()
 	InitializeAccents()
@@ -36,9 +40,6 @@ SUBSYSTEM_DEF(records)
 	warrants = list()
 	viruses = list()
 	shuttle_assignments = list()
-	for(var/shuttle in HORIZON_SHUTTLES)
-		var/datum/record/shuttle_assignment/A = new /datum/record/shuttle_assignment(shuttle)
-		shuttle_assignments += A
 	shuttle_manifests = list()
 	excluded_fields = list()
 	localized_fields = list()

--- a/code/datums/records.dm
+++ b/code/datums/records.dm
@@ -254,10 +254,27 @@ var/warrant_uid = 0
 //Manifest record
 /datum/record/shuttle_manifest
 	name = "Unknown"
-	var/shuttle = "Unknown"
 	cmp_field = "name"
+	var/shuttle = "Unknown"
+	var/pilot = FALSE
+	var/lead = FALSE
 
 var/shuttle_uid = 0
 /datum/record/shuttle_manifest/New()
 	..()
 	id = shuttle_uid++
+
+/datum/record/shuttle_assignment
+	var/shuttle
+	var/destination = "Unknown"
+	var/heading = 0
+	var/mission = "Exploration"
+	var/departure_time
+	var/return_time
+	cmp_field = "destination"
+
+/datum/record/shuttle_assignment/New(var/for_shuttle)
+	. = ..()
+	shuttle = for_shuttle
+	departure_time = worldtime2text()
+	return_time = worldtime2text(world.time + 1 HOUR)

--- a/code/datums/records.dm
+++ b/code/datums/records.dm
@@ -276,5 +276,3 @@ var/shuttle_uid = 0
 /datum/record/shuttle_assignment/New(var/for_shuttle)
 	. = ..()
 	shuttle = for_shuttle
-	departure_time = worldtime2text()
-	return_time = worldtime2text(world.time + 1 HOUR)

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -176,3 +176,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	wrist_radio = /obj/item/device/radio/headset/wrist/command
 	clipon_radio = /obj/item/device/radio/headset/wrist/clip/command
 	messengerbag = /obj/item/storage/backpack/messenger/com
+
+	tab_pda = /obj/item/modular_computer/handheld/pda/bridge
+	wristbound = /obj/item/modular_computer/handheld/wristbound/preset/pda/bridge
+	tablet = /obj/item/modular_computer/handheld/preset/bridge

--- a/code/modules/modular_computers/computers/subtypes/preset_handheld.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_handheld.dm
@@ -135,6 +135,9 @@
 
 // Command / Misc
 
+/obj/item/modular_computer/handheld/preset/bridge
+	_app_preset_type = /datum/modular_computer_app_presets/bridge
+
 /obj/item/modular_computer/handheld/preset/command
 	_app_preset_type = /datum/modular_computer_app_presets/command
 

--- a/code/modules/modular_computers/computers/subtypes/preset_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_pda.dm
@@ -130,6 +130,9 @@
 
 // Command / Misc
 
+/obj/item/modular_computer/handheld/pda/bridge
+	_app_preset_type = /datum/modular_computer_app_presets/bridge
+
 /obj/item/modular_computer/handheld/pda/command
 	_app_preset_type = /datum/modular_computer_app_presets/command
 	icon_add = "h"

--- a/code/modules/modular_computers/computers/subtypes/preset_wristbound.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_wristbound.dm
@@ -55,6 +55,9 @@
 	_app_preset_type = /datum/modular_computer_app_presets/research
 	icon_state = "wristbound-tox"
 
+/obj/item/modular_computer/handheld/wristbound/preset/advanced/bridge
+	_app_preset_type = /datum/modular_computer_app_presets/bridge
+
 /obj/item/modular_computer/handheld/wristbound/preset/advanced/command
 	_app_preset_type = /datum/modular_computer_app_presets/command
 	icon_state = "wristbound-h"
@@ -219,6 +222,9 @@
 	icon_add = "hos"
 
 // Command / Misc
+
+/obj/item/modular_computer/handheld/wristbound/preset/pda/bridge
+	_app_preset_type = /datum/modular_computer_app_presets/bridge
 
 /obj/item/modular_computer/handheld/wristbound/preset/pda/command
 	_app_preset_type = /datum/modular_computer_app_presets/command

--- a/code/modules/modular_computers/file_system/programs/app_presets_crew.dm
+++ b/code/modules/modular_computers/file_system/programs/app_presets_crew.dm
@@ -106,6 +106,20 @@
 	)
 	return flatten_list(_prg_list)
 
+/datum/modular_computer_app_presets/bridge
+	name = "bridge"
+	display_name = "Bridge"
+	description = "Contains the most common bridge programs"
+	available = TRUE
+
+/datum/modular_computer_app_presets/bridge/return_install_programs(obj/item/modular_computer/comp)
+	var/list/_prg_list = list(
+		COMPUTER_APP_PRESET_SYSTEM,
+		COMPUTER_APP_PRESET_HORIZON_CIVILIAN,
+		new /datum/computer_file/program/away_manifest(comp),
+	)
+	return flatten_list(_prg_list)
+
 /datum/modular_computer_app_presets/command
 	name = "command"
 	display_name = "Command"

--- a/code/modules/modular_computers/file_system/programs/command/away_manifest.dm
+++ b/code/modules/modular_computers/file_system/programs/command/away_manifest.dm
@@ -34,7 +34,11 @@
 				"pilot" = m.pilot,
 				"lead" = m.lead
 			))
-		for(var/datum/record/shuttle_assignment/a in SSrecord.shuttle_assignments)
+		for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
+			if(!a.departure_time)
+				a.departure_time = worldtime2text()
+			if(!a.return_time)
+				a.return_time = worldtime2text(world.time + 1 HOUR)
 			allassignments += list(list(
 				"shuttle" = a.shuttle,
 				"destination" = a.destination,
@@ -120,7 +124,7 @@
 
 		if("editentryshuttle")
 			. = TRUE
-			var/newshuttle = sanitize(input("Please enter shuttle.") as null|anything in list("SCCV Canary", "SCCV Intrepid", "SCCV Spark"))
+			var/newshuttle = sanitize(input("Please enter shuttle.") as null|anything in HORIZON_SHUTTLES)
 			if(!computer.use_check_and_message(usr))
 				if(!newshuttle)
 					return
@@ -138,7 +142,7 @@
 		if("editheading")
 			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
 				if(a.shuttle == params["editheading"])
-					var/new_head = floor(input(usr, "Please enter heading.") as null|number)
+					var/new_head = floor(input(usr, "Please enter heading.") as null|num)
 					if(new_head < 0 || new_head > 359 || !new_head)
 						new_head = 0
 					if(!computer.use_check_and_message(usr))
@@ -146,8 +150,8 @@
 
 		if("editmission")
 			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
-				if(a.shuttle == params["editdestination"])
-					var/new_mis = sanitize(input(usr, "Please select mission.") as null|anything in list("Exploration", "Research", "Prospecting", "Transport", "Combat", "Rescue", "Training"))
+				if(a.shuttle == params["editmission"])
+					var/new_mis = sanitize(input(usr, "Please select primary mission.") as null|anything in list("Exploration", "Research", "Prospecting", "Transport", "Combat", "Rescue", "Training"))
 					if(!computer.use_check_and_message(usr))
 						if(!new_mis)
 							return
@@ -155,7 +159,7 @@
 
 		if("editdeparturetime")
 			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
-				if(a.shuttle === params["editdeparturetime"])
+				if(a.shuttle == params["editdeparturetime"])
 					var/new_depart = sanitize(input(usr, "Please enter new departure time.") as null|text)
 					if(!computer.use_check_and_message(usr))
 						if(!new_depart)
@@ -164,7 +168,7 @@
 
 		if("editreturntime")
 			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
-				if(a.shuttle === params["editreturntime"])
+				if(a.shuttle == params["editreturntime"])
 					var/new_return = sanitize(input(usr, "Please enter new return time.") as null|text)
 					if(!computer.use_check_and_message(usr))
 						if(!new_return)

--- a/code/modules/modular_computers/file_system/programs/command/away_manifest.dm
+++ b/code/modules/modular_computers/file_system/programs/command/away_manifest.dm
@@ -18,18 +18,33 @@
 	if(active_record)
 		data["active_record"] = list(
 			"name" = active_record.name,
+			"id" = active_record.id,
 			"shuttle" = active_record.shuttle,
-			"id" = active_record.id
+			"pilot" = active_record.pilot,
+			"lead" = active_record.lead
 		)
 	else
 		var/list/allshuttles = list()
+		var/list/allassignments = list()
 		for (var/datum/record/shuttle_manifest/m in SSrecords.shuttle_manifests)
 			allshuttles += list(list(
 				"name" = m.name,
+				"id" = m.id,
 				"shuttle" = m.shuttle,
-				"id" = m.id
+				"pilot" = m.pilot,
+				"lead" = m.lead
+			))
+		for(var/datum/record/shuttle_assignment/a in SSrecord.shuttle_assignments)
+			allassignments += list(list(
+				"shuttle" = a.shuttle,
+				"destination" = a.destination,
+				"heading" = a.heading,
+				"mission" = a.mission,
+				"departure_time" = a.departure_time,
+				"return_time" = a.return_time
 			))
 		data["shuttle_manifest"] = allshuttles
+		data["shuttle_assignments"] = allassignments
 		data["active_record"] = null
 	return data
 
@@ -102,6 +117,7 @@
 				if(!newname)
 					return
 				active_record.name = newname
+
 		if("editentryshuttle")
 			. = TRUE
 			var/newshuttle = sanitize(input("Please enter shuttle.") as null|anything in list("SCCV Canary", "SCCV Intrepid", "SCCV Spark"))
@@ -109,3 +125,66 @@
 				if(!newshuttle)
 					return
 				active_record.shuttle = newshuttle
+
+		if("editdestination")
+			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
+				if(a.shuttle == params["editdestination"])
+					var/new_dest = sanitize(input(usr, "Please enter destination.") as null|text)
+					if(!computer.use_check_and_message(usr))
+						if(!new_dest)
+							return
+						a.destination = new_dest
+
+		if("editheading")
+			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
+				if(a.shuttle == params["editheading"])
+					var/new_head = floor(input(usr, "Please enter heading.") as null|number)
+					if(new_head < 0 || new_head > 359 || !new_head)
+						new_head = 0
+					if(!computer.use_check_and_message(usr))
+						a.heading = new_head
+
+		if("editmission")
+			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
+				if(a.shuttle == params["editdestination"])
+					var/new_mis = sanitize(input(usr, "Please select mission.") as null|anything in list("Exploration", "Research", "Prospecting", "Transport", "Combat", "Rescue", "Training"))
+					if(!computer.use_check_and_message(usr))
+						if(!new_mis)
+							return
+						a.mission = new_mis
+
+		if("editdeparturetime")
+			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
+				if(a.shuttle === params["editdeparturetime"])
+					var/new_depart = sanitize(input(usr, "Please enter new departure time.") as null|text)
+					if(!computer.use_check_and_message(usr))
+						if(!new_depart)
+							return
+						a.departure_time = new_depart
+
+		if("editreturntime")
+			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
+				if(a.shuttle === params["editreturntime"])
+					var/new_return = sanitize(input(usr, "Please enter new return time.") as null|text)
+					if(!computer.use_check_and_message(usr))
+						if(!new_return)
+							return
+						a.return_time = new_return
+
+		if("editlead")
+			for(var/datum/record/shuttle_manifest/m in SSrecords.shuttle_manifests)
+				if(m.id == text2num(params["editlead"]))
+					m.lead = !m.lead
+					if(m.lead)
+						for(var/datum/record/shuttle_manifest/other in SSrecords.shuttle_manifests) // There can be only one
+							if(other.shuttle == m.shuttle && other.lead && other != m)
+								other.lead = FALSE
+
+		if("editpilot")
+			for(var/datum/record/shuttle_manifest/m in SSrecords.shuttle_manifests)
+				if(m.id == text2num(params["editpilot"]))
+					m.pilot = !m.pilot
+					if(m.pilot)
+						for(var/datum/record/shuttle_manifest/other in SSrecords.shuttle_manifests)
+							if(other.shuttle == m.shuttle && other.pilot && other != m)
+								other.pilot = FALSE

--- a/code/modules/modular_computers/file_system/programs/command/away_manifest.dm
+++ b/code/modules/modular_computers/file_system/programs/command/away_manifest.dm
@@ -47,6 +47,7 @@
 				"departure_time" = a.departure_time,
 				"return_time" = a.return_time
 			))
+		data["shuttles"] = SSatlas.current_map.shuttle_manifests
 		data["shuttle_manifest"] = allshuttles
 		data["shuttle_assignments"] = allassignments
 		data["active_record"] = null
@@ -124,7 +125,7 @@
 
 		if("editentryshuttle")
 			. = TRUE
-			var/newshuttle = tgui_input_list(usr, "Please select shuttle.", "Shuttle select", HORIZON_SHUTTLES, active_record.shuttle)
+			var/newshuttle = tgui_input_list(usr, "Please select shuttle.", "Shuttle select", SSatlas.current_map.shuttle_manifests, active_record.shuttle)
 			if(!computer.use_check_and_message(usr))
 				if(!newshuttle)
 					return
@@ -151,7 +152,7 @@
 		if("editmission")
 			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
 				if(a.shuttle == params["editmission"])
-					var/new_mis = tgui_input_list(usr, "Please select mission.", "Mission select", SHUTTLE_MISSIONS, a.mission)
+					var/new_mis = tgui_input_list(usr, "Please select mission.", "Mission select", SSatlas.current_map.shuttle_missions, a.mission)
 					if(!computer.use_check_and_message(usr))
 						if(!new_mis)
 							return

--- a/code/modules/modular_computers/file_system/programs/command/away_manifest.dm
+++ b/code/modules/modular_computers/file_system/programs/command/away_manifest.dm
@@ -108,7 +108,7 @@
 			var/names = list()
 			for(var/datum/record/general/r in SSrecords.records)
 				names += r.name
-			var/newname = sanitize(input(usr, "Please enter name.") as null|anything in names)
+			var/newname = sanitize(tgui_input_list(usr, "Please select name.", "Name select", names, active_record.name))
 			if(!computer.use_check_and_message(usr))
 				if(!newname)
 					return
@@ -116,7 +116,7 @@
 
 		if("editentrynamecustom")
 			. = TRUE
-			var/newname = sanitize(input("Please enter name.") as null|text)
+			var/newname = sanitize(tgui_input_text(usr, "Please enter name.", "Name entry", active_record.name))
 			if(!computer.use_check_and_message(usr))
 				if(!newname)
 					return
@@ -124,7 +124,7 @@
 
 		if("editentryshuttle")
 			. = TRUE
-			var/newshuttle = sanitize(input("Please enter shuttle.") as null|anything in HORIZON_SHUTTLES)
+			var/newshuttle = tgui_input_list(usr, "Please select shuttle.", "Shuttle select", HORIZON_SHUTTLES, active_record.shuttle)
 			if(!computer.use_check_and_message(usr))
 				if(!newshuttle)
 					return
@@ -133,7 +133,7 @@
 		if("editdestination")
 			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
 				if(a.shuttle == params["editdestination"])
-					var/new_dest = sanitize(input(usr, "Please enter destination.") as null|text)
+					var/new_dest = sanitize(tgui_input_text(usr, "Please enter destination.", "Destination entry", a.destination))
 					if(!computer.use_check_and_message(usr))
 						if(!new_dest)
 							return
@@ -142,7 +142,7 @@
 		if("editheading")
 			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
 				if(a.shuttle == params["editheading"])
-					var/new_head = floor(input(usr, "Please enter heading.") as null|num)
+					var/new_head = floor(tgui_input_number(usr, "Please enter heading.", "Heading entry", a.heading, 359, 0))
 					if(new_head < 0 || new_head > 359 || !new_head)
 						new_head = 0
 					if(!computer.use_check_and_message(usr))
@@ -151,7 +151,7 @@
 		if("editmission")
 			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
 				if(a.shuttle == params["editmission"])
-					var/new_mis = sanitize(input(usr, "Please select primary mission.") as null|anything in list("Exploration", "Research", "Prospecting", "Transport", "Combat", "Rescue", "Training"))
+					var/new_mis = tgui_input_list(usr, "Please select mission.", "Mission select", SHUTTLE_MISSIONS, a.mission)
 					if(!computer.use_check_and_message(usr))
 						if(!new_mis)
 							return
@@ -160,7 +160,7 @@
 		if("editdeparturetime")
 			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
 				if(a.shuttle == params["editdeparturetime"])
-					var/new_depart = sanitize(input(usr, "Please enter new departure time.") as null|text)
+					var/new_depart = sanitize(tgui_input_text(usr, "Please enter new departure time.", "Departure time entry", a.departure_time))
 					if(!computer.use_check_and_message(usr))
 						if(!new_depart)
 							return
@@ -169,7 +169,7 @@
 		if("editreturntime")
 			for(var/datum/record/shuttle_assignment/a in SSrecords.shuttle_assignments)
 				if(a.shuttle == params["editreturntime"])
-					var/new_return = sanitize(input(usr, "Please enter new return time.") as null|text)
+					var/new_return = sanitize(tgui_input_text(usr, "Please enter new return time.", "Return time entry", a.departure_time))
 					if(!computer.use_check_and_message(usr))
 						if(!new_return)
 							return

--- a/html/changelogs/shuttlemanifestexpansion.yml
+++ b/html/changelogs/shuttlemanifestexpansion.yml
@@ -1,58 +1,7 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes:
-#   bugfix
-#     - (fixes bugs)
-#   wip
-#     - (work in progress)
-#   qol
-#     - (quality of life)
-#   soundadd
-#     - (adds a sound)
-#   sounddel
-#     - (removes a sound)
-#   rscadd
-#     - (adds a feature)
-#   rscdel
-#     - (removes a feature)
-#   imageadd
-#     - (adds an image or sprite)
-#   imagedel
-#     - (removes an image or sprite)
-#   spellcheck
-#     - (fixes spelling or grammar)
-#   experiment
-#     - (experimental change)
-#   balance
-#     - (balance changes)
-#   code_imp
-#     - (misc internal code change)
-#   refactor
-#     - (refactors code)
-#   config
-#     - (makes a change to the config files)
-#   admin
-#     - (makes changes to administrator tools)
-#   server
-#     - (miscellaneous changes to server)
-#################################
-
-# Your name.
 author: Sparky_hotdog
 
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
 
-# Any changes you've made.  See valid prefix list above.
-# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-# SCREW THIS UP AND IT WON'T WORK.
-# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
-# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Updated the shuttle manifest program to include extra details such as shuttle destination, heading, mission and departure & return times, as well as the assignment of a mission leader and shuttle pilot."
+  - rscadd: "Added the shuttle manifest program to Bridge Crew PDAs at round start."

--- a/html/changelogs/shuttlemanifestexpansion.yml
+++ b/html/changelogs/shuttlemanifestexpansion.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Sparky_hotdog
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Updated the shuttle manifest program to include extra details such as shuttle destination, heading, mission and departure & return times, as well as the assignment of a mission leader and shuttle pilot."

--- a/maps/_common/mapsystem/map.dm
+++ b/maps/_common/mapsystem/map.dm
@@ -123,6 +123,17 @@
 	var/allow_borgs_to_leave = FALSE //this controls if borgs can leave the station or ship without exploding
 	var/area/warehouse_basearea //this controls where the cargospawner tries to populate warehouse items
 
+	/**
+	 * A list of the shuttles on this map, used by the Shuttle Manifest program to populate itself.
+	 * Formatted with the shuttle name as an index, followed by a list containing the color and icon to be used for the shuttle's drop down
+	 * On the manifest. i.e. "SCCV Intrepid" = list("color" = "purple", "icon" = "compass")
+	 */
+	var/list/shuttle_manifests = list()
+	/**
+	 * A list of the missions shuttles can select for their assignment in the Shuttle Manifest program.
+	 */
+	var/list/shuttle_missions = list()
+
 /datum/map/New()
 	if(!map_levels)
 		map_levels = station_levels.Copy()

--- a/maps/sccv_horizon/code/sccv_horizon.dm
+++ b/maps/sccv_horizon/code/sccv_horizon.dm
@@ -141,6 +141,12 @@
 
 	warehouse_basearea = /area/operations/storage
 
+	shuttle_manifests = list(
+		"SCCV Canary" = list("color" = "blue", "icon" = "binoculars"),
+		"SCCV Intrepid" = list("color" = "purple", "icon" = "compass"),
+		"SCCV Spark" = list("color" = "brown", "icon" = "gem"))
+	shuttle_missions = list("Exploration", "Research", "Prospecting", "Transport", "Combat", "Rescue", "Training")
+
 /datum/map/sccv_horizon/send_welcome()
 	var/obj/effect/overmap/visitable/ship/horizon = SSshuttle.ship_by_type(/obj/effect/overmap/visitable/ship/sccv_horizon)
 

--- a/tgui/packages/tgui/interfaces/AwayShuttleManifest.tsx
+++ b/tgui/packages/tgui/interfaces/AwayShuttleManifest.tsx
@@ -5,13 +5,25 @@ import { NtosWindow } from '../layouts';
 export type AwayShuttleData = {
   shuttle_manifest: ShuttleCrew[];
   active_record: ShuttleCrew;
+  shuttle_assignments: ShuttleAssignment[];
 };
 
 type ShuttleCrew = {
   name: string;
   shuttle: string;
+  pilot: Boolean;
+  lead: Boolean;
   id: number;
 };
+
+type ShuttleAssignment = {
+  shuttle: string;
+  destination: string;
+  heading: number;
+  mission: string;
+  departure_time: string;
+  return_time: string;
+}
 
 export const AwayShuttleManifest = (props, context) => {
   const { act, data } = useBackend<AwayShuttleData>(context);
@@ -85,6 +97,48 @@ export const AllShuttles = (props, context) => {
           buttons={
             <Button icon="plus" color="green" onClick={() => act('addentry')} />
           }>
+          {data.shuttle_assignments.filter((m => m.shuttle === 'SCCV Canary')).map((ShuttleAssignment) => (
+          <Table.Row key={ShuttleAssignment.shuttle}>
+            <Table.Cell>
+              <Flex.Item>
+                Destination:
+                <Button
+                  content={ShuttleAssignment.destination}
+                  onClick={() =>
+                    act('editdestination', { editdestination: ShuttleAssignment.shuttle })
+                  }
+                />
+                Heading:
+                <Button
+                  content={ShuttleAssignment.heading}
+                  onClick={() =>
+                    act('editheading', { editheading: ShuttleAssignment.shuttle })
+                  }
+                />
+                Mission:
+                <Button
+                  content={ShuttleAssignment.mission}
+                  onClick={() =>
+                    act('editmission', { editmission: ShuttleAssignment.shuttle })
+                  }
+                />
+                Departure Time:
+                <Button
+                  content={ShuttleAssignment.departure_time}
+                  onClick={() =>
+                    act('editdeparturetime', { editdeparturetime: ShuttleAssignment.shuttle })
+                  }
+                />
+                Return Time:
+                <Button
+                  content={ShuttleAssignment.return_time}
+                  onClick={() =>
+                    act('editreturntime', { editreturntime: ShuttleAssignment.shuttle })
+                  }
+                />
+              </Flex.Item>
+            </Table.Cell>
+          </Table.Row>))}
           {data.shuttle_manifest && data.shuttle_manifest.length ? (
             <Flex>
               <Table>
@@ -98,9 +152,23 @@ export const AllShuttles = (props, context) => {
                       <Table.Cell>
                         <Flex.Item>
                           <Button
+                            icon = {ShuttleCrew.lead ? "star" : null}
+                            color={ShuttleCrew.lead ? 'green' : 'blue'}
+                            onClick={() =>
+                              act('editlead', { editlead: ShuttleCrew.id })
+                            }
+                          />
+                          <Button
                             content={ShuttleCrew.name}
                             onClick={() =>
                               act('editentry', { editentry: ShuttleCrew.id })
+                            }
+                          />
+                          <Button
+                            content={ShuttleCrew.pilot ? 'P' : 'O'}
+                            color={ShuttleCrew.pilot ? 'green' : 'blue'}
+                            onClick={() =>
+                              act('editpilot', { editpilot: ShuttleCrew.id })
                             }
                           />
                         </Flex.Item>
@@ -120,6 +188,48 @@ export const AllShuttles = (props, context) => {
           buttons={
             <Button icon="plus" color="green" onClick={() => act('addentry')} />
           }>
+          {data.shuttle_assignments.filter((m => m.shuttle === 'SCCV Intrepid')).map((ShuttleAssignment) => (
+          <Table.Row key={ShuttleAssignment.shuttle}>
+            <Table.Cell>
+              <Flex.Item>
+              Destination:
+                <Button
+                  content={ShuttleAssignment.destination}
+                  onClick={() =>
+                    act('editdestination', { editdestination: ShuttleAssignment.shuttle })
+                  }
+                />
+                Heading:
+                <Button
+                  content={ShuttleAssignment.heading}
+                  onClick={() =>
+                    act('editheading', { editheading: ShuttleAssignment.shuttle })
+                  }
+                />
+                Mission:
+                <Button
+                  content={ShuttleAssignment.mission}
+                  onClick={() =>
+                    act('editmission', { editmission: ShuttleAssignment.shuttle })
+                  }
+                />
+                Departure Time:
+                <Button
+                  content={ShuttleAssignment.departure_time}
+                  onClick={() =>
+                    act('editdeparturetime', { editdeparturetime: ShuttleAssignment.shuttle })
+                  }
+                />
+                Return Time:
+                <Button
+                  content={ShuttleAssignment.return_time}
+                  onClick={() =>
+                    act('editreturntime', { editreturntime: ShuttleAssignment.shuttle })
+                  }
+                />
+              </Flex.Item>
+            </Table.Cell>
+          </Table.Row>))}
           {data.shuttle_manifest && data.shuttle_manifest.length ? (
             <Flex>
               <Table>
@@ -133,9 +243,23 @@ export const AllShuttles = (props, context) => {
                       <Table.Cell>
                         <Flex.Item>
                           <Button
+                            icon = {ShuttleCrew.lead ? "star" : null}
+                            color={ShuttleCrew.lead ? 'green' : 'blue'}
+                            onClick={() =>
+                              act('editlead', { editlead: ShuttleCrew.id })
+                            }
+                          />
+                          <Button
                             content={ShuttleCrew.name}
                             onClick={() =>
                               act('editentry', { editentry: ShuttleCrew.id })
+                            }
+                          />
+                          <Button
+                            content={ShuttleCrew.pilot ? 'P' : 'O'}
+                            color={ShuttleCrew.pilot ? 'green' : 'blue'}
+                            onClick={() =>
+                              act('editpilot', { editpilot: ShuttleCrew.id })
                             }
                           />
                         </Flex.Item>
@@ -155,6 +279,48 @@ export const AllShuttles = (props, context) => {
           buttons={
             <Button icon="plus" color="green" onClick={() => act('addentry')} />
           }>
+          {data.shuttle_assignments.filter((m => m.shuttle === 'SCCV Spark')).map((ShuttleAssignment) => (
+          <Table.Row key={ShuttleAssignment.shuttle}>
+            <Table.Cell>
+              <Flex.Item>
+              Destination:
+                <Button
+                  content={ShuttleAssignment.destination}
+                  onClick={() =>
+                    act('editdestination', { editdestination: ShuttleAssignment.shuttle })
+                  }
+                />
+                Heading:
+                <Button
+                  content={ShuttleAssignment.heading}
+                  onClick={() =>
+                    act('editheading', { editheading: ShuttleAssignment.shuttle })
+                  }
+                />
+                Mission:
+                <Button
+                  content={ShuttleAssignment.mission}
+                  onClick={() =>
+                    act('editmission', { editmission: ShuttleAssignment.shuttle })
+                  }
+                />
+                Departure Time:
+                <Button
+                  content={ShuttleAssignment.departure_time}
+                  onClick={() =>
+                    act('editdeparturetime', { editdeparturetime: ShuttleAssignment.shuttle })
+                  }
+                />
+                Return Time:
+                <Button
+                  content={ShuttleAssignment.return_time}
+                  onClick={() =>
+                    act('editreturntime', { editreturntime: ShuttleAssignment.shuttle })
+                  }
+                />
+              </Flex.Item>
+            </Table.Cell>
+          </Table.Row>))}
           {data.shuttle_manifest && data.shuttle_manifest.length ? (
             <Flex>
               <Table>
@@ -168,9 +334,23 @@ export const AllShuttles = (props, context) => {
                       <Table.Cell>
                         <Flex.Item>
                           <Button
+                            icon = {ShuttleCrew.lead ? "star" : null}
+                            color={ShuttleCrew.lead ? 'green' : 'blue'}
+                            onClick={() =>
+                              act('editlead', { editlead: ShuttleCrew.id })
+                            }
+                          />
+                          <Button
                             content={ShuttleCrew.name}
                             onClick={() =>
                               act('editentry', { editentry: ShuttleCrew.id })
+                            }
+                          />
+                          <Button
+                            content={ShuttleCrew.pilot ? 'P' : 'O'}
+                            color={ShuttleCrew.pilot ? 'green' : 'blue'}
+                            onClick={() =>
+                              act('editpilot', { editpilot: ShuttleCrew.id })
                             }
                           />
                         </Flex.Item>

--- a/tgui/packages/tgui/interfaces/AwayShuttleManifest.tsx
+++ b/tgui/packages/tgui/interfaces/AwayShuttleManifest.tsx
@@ -23,7 +23,15 @@ type ShuttleAssignment = {
   mission: string;
   departure_time: string;
   return_time: string;
-}
+};
+
+const num2bearing = function (num) {
+  let bearing = '000';
+  if (num < 10) bearing = '00' + num;
+  else if (num < 100) bearing = '0' + num;
+  else bearing = num;
+  return bearing;
+};
 
 export const AwayShuttleManifest = (props, context) => {
   const { act, data } = useBackend<AwayShuttleData>(context);
@@ -91,59 +99,101 @@ export const AllShuttles = (props, context) => {
 
   return (
     <>
-      <Collapsible title="SCCV Canary" color="blue">
+      <Collapsible title="SCCV Canary" color="blue" icon="binoculars">
+        <Section title="SCCV Canary">
+          <Flex>
+            <Table>
+              <Table.Row header>
+                <Table.Cell>Shuttle Assignment: </Table.Cell>
+              </Table.Row>
+              {data.shuttle_assignments
+                .filter((m) => m.shuttle === 'SCCV Canary')
+                .map((ShuttleAssignment) => (
+                  <Table.Row key={ShuttleAssignment.shuttle}>
+                    <Table.Cell>
+                      <Flex.Item>
+                        Destination:
+                        <Button
+                          content={ShuttleAssignment.destination}
+                          onClick={() =>
+                            act('editdestination', {
+                              editdestination: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                      </Flex.Item>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <Flex.Item>
+                        Heading:
+                        <Button
+                          content={num2bearing(ShuttleAssignment.heading)}
+                          onClick={() =>
+                            act('editheading', {
+                              editheading: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                      </Flex.Item>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <Flex.Item>
+                        Mission:
+                        <Button
+                          content={ShuttleAssignment.mission}
+                          onClick={() =>
+                            act('editmission', {
+                              editmission: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                      </Flex.Item>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <Flex.Item>
+                        Departure Time:
+                        <Button
+                          content={ShuttleAssignment.departure_time}
+                          onClick={() =>
+                            act('editdeparturetime', {
+                              editdeparturetime: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                      </Flex.Item>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <Flex.Item>
+                        Return Time:
+                        <Button
+                          content={ShuttleAssignment.return_time}
+                          onClick={() =>
+                            act('editreturntime', {
+                              editreturntime: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                      </Flex.Item>
+                    </Table.Cell>
+                  </Table.Row>
+                ))}
+            </Table>
+          </Flex>
+        </Section>
         <Section
-          title="SCCV Canary"
+          title="Shuttle Manifest"
           buttons={
-            <Button icon="plus" color="green" onClick={() => act('addentry')} />
+            <Button
+              icon="user-plus"
+              color="green"
+              onClick={() => act('addentry')}
+            />
           }>
-          {data.shuttle_assignments.filter((m => m.shuttle === 'SCCV Canary')).map((ShuttleAssignment) => (
-          <Table.Row key={ShuttleAssignment.shuttle}>
-            <Table.Cell>
-              <Flex.Item>
-                Destination:
-                <Button
-                  content={ShuttleAssignment.destination}
-                  onClick={() =>
-                    act('editdestination', { editdestination: ShuttleAssignment.shuttle })
-                  }
-                />
-                Heading:
-                <Button
-                  content={ShuttleAssignment.heading}
-                  onClick={() =>
-                    act('editheading', { editheading: ShuttleAssignment.shuttle })
-                  }
-                />
-                Mission:
-                <Button
-                  content={ShuttleAssignment.mission}
-                  onClick={() =>
-                    act('editmission', { editmission: ShuttleAssignment.shuttle })
-                  }
-                />
-                Departure Time:
-                <Button
-                  content={ShuttleAssignment.departure_time}
-                  onClick={() =>
-                    act('editdeparturetime', { editdeparturetime: ShuttleAssignment.shuttle })
-                  }
-                />
-                Return Time:
-                <Button
-                  content={ShuttleAssignment.return_time}
-                  onClick={() =>
-                    act('editreturntime', { editreturntime: ShuttleAssignment.shuttle })
-                  }
-                />
-              </Flex.Item>
-            </Table.Cell>
-          </Table.Row>))}
           {data.shuttle_manifest && data.shuttle_manifest.length ? (
             <Flex>
               <Table>
                 <Table.Row header>
-                  <Table.Cell>Name</Table.Cell>
+                  <Table.Cell>Crew Onboard: </Table.Cell>
                 </Table.Row>
                 {data.shuttle_manifest
                   .filter((m) => m.shuttle === 'SCCV Canary')
@@ -152,7 +202,13 @@ export const AllShuttles = (props, context) => {
                       <Table.Cell>
                         <Flex.Item>
                           <Button
-                            icon = {ShuttleCrew.lead ? "star" : null}
+                            icon={
+                              ShuttleCrew.lead ? 'star-half-stroke' : 'user'
+                            }
+                            tooltip={
+                              (ShuttleCrew.lead ? 'Remove' : 'Set') +
+                              ' Expedition Leader'
+                            }
                             color={ShuttleCrew.lead ? 'green' : 'blue'}
                             onClick={() =>
                               act('editlead', { editlead: ShuttleCrew.id })
@@ -165,7 +221,12 @@ export const AllShuttles = (props, context) => {
                             }
                           />
                           <Button
-                            content={ShuttleCrew.pilot ? 'P' : 'O'}
+                            icon={
+                              ShuttleCrew.pilot ? 'rocket' : 'suitcase-rolling'
+                            }
+                            tooltip={
+                              (ShuttleCrew.pilot ? 'Remove' : 'Set') + ' Pilot'
+                            }
                             color={ShuttleCrew.pilot ? 'green' : 'blue'}
                             onClick={() =>
                               act('editpilot', { editpilot: ShuttleCrew.id })
@@ -182,59 +243,89 @@ export const AllShuttles = (props, context) => {
           )}
         </Section>
       </Collapsible>
-      <Collapsible title="SCCV Intrepid" color="purple">
+      <Collapsible title="SCCV Intrepid" color="purple" icon="compass">
+        <Section title="SCCV Intrepid">
+          <Flex>
+            <Table>
+              <Table.Row header>
+                <Table.Cell>Shuttle Assignment: </Table.Cell>
+              </Table.Row>
+              {data.shuttle_assignments
+                .filter((m) => m.shuttle === 'SCCV Intrepid')
+                .map((ShuttleAssignment) => (
+                  <Table.Row key={ShuttleAssignment.shuttle}>
+                    <Table.Cell>
+                      <Flex.Item>
+                        Destination:
+                        <Button
+                          content={ShuttleAssignment.destination}
+                          onClick={() =>
+                            act('editdestination', {
+                              editdestination: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                        {'\t'}
+                        Heading:
+                        <Button
+                          content={num2bearing(ShuttleAssignment.heading)}
+                          onClick={() =>
+                            act('editheading', {
+                              editheading: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                        {'\t'}
+                        Mission:
+                        <Button
+                          content={ShuttleAssignment.mission}
+                          onClick={() =>
+                            act('editmission', {
+                              editmission: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                        {'\n'}
+                        Departure Time:
+                        <Button
+                          content={ShuttleAssignment.departure_time}
+                          onClick={() =>
+                            act('editdeparturetime', {
+                              editdeparturetime: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                        {'\t'}
+                        Return Time:
+                        <Button
+                          content={ShuttleAssignment.return_time}
+                          onClick={() =>
+                            act('editreturntime', {
+                              editreturntime: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                      </Flex.Item>
+                    </Table.Cell>
+                  </Table.Row>
+                ))}
+            </Table>
+          </Flex>
+        </Section>
         <Section
-          title="SCCV Intrepid"
+          title="Shuttle Manifest"
           buttons={
-            <Button icon="plus" color="green" onClick={() => act('addentry')} />
+            <Button
+              icon="user-plus"
+              color="green"
+              onClick={() => act('addentry')}
+            />
           }>
-          {data.shuttle_assignments.filter((m => m.shuttle === 'SCCV Intrepid')).map((ShuttleAssignment) => (
-          <Table.Row key={ShuttleAssignment.shuttle}>
-            <Table.Cell>
-              <Flex.Item>
-              Destination:
-                <Button
-                  content={ShuttleAssignment.destination}
-                  onClick={() =>
-                    act('editdestination', { editdestination: ShuttleAssignment.shuttle })
-                  }
-                />
-                Heading:
-                <Button
-                  content={ShuttleAssignment.heading}
-                  onClick={() =>
-                    act('editheading', { editheading: ShuttleAssignment.shuttle })
-                  }
-                />
-                Mission:
-                <Button
-                  content={ShuttleAssignment.mission}
-                  onClick={() =>
-                    act('editmission', { editmission: ShuttleAssignment.shuttle })
-                  }
-                />
-                Departure Time:
-                <Button
-                  content={ShuttleAssignment.departure_time}
-                  onClick={() =>
-                    act('editdeparturetime', { editdeparturetime: ShuttleAssignment.shuttle })
-                  }
-                />
-                Return Time:
-                <Button
-                  content={ShuttleAssignment.return_time}
-                  onClick={() =>
-                    act('editreturntime', { editreturntime: ShuttleAssignment.shuttle })
-                  }
-                />
-              </Flex.Item>
-            </Table.Cell>
-          </Table.Row>))}
           {data.shuttle_manifest && data.shuttle_manifest.length ? (
             <Flex>
               <Table>
                 <Table.Row header>
-                  <Table.Cell>Name</Table.Cell>
+                  <Table.Cell>Crew Onboard: </Table.Cell>
                 </Table.Row>
                 {data.shuttle_manifest
                   .filter((m) => m.shuttle === 'SCCV Intrepid')
@@ -243,7 +334,13 @@ export const AllShuttles = (props, context) => {
                       <Table.Cell>
                         <Flex.Item>
                           <Button
-                            icon = {ShuttleCrew.lead ? "star" : null}
+                            icon={
+                              ShuttleCrew.lead ? 'star-half-stroke' : 'user'
+                            }
+                            tooltip={
+                              (ShuttleCrew.lead ? 'Remove' : 'Set') +
+                              ' Expedition Leader'
+                            }
                             color={ShuttleCrew.lead ? 'green' : 'blue'}
                             onClick={() =>
                               act('editlead', { editlead: ShuttleCrew.id })
@@ -256,7 +353,12 @@ export const AllShuttles = (props, context) => {
                             }
                           />
                           <Button
-                            content={ShuttleCrew.pilot ? 'P' : 'O'}
+                            icon={
+                              ShuttleCrew.pilot ? 'rocket' : 'suitcase-rolling'
+                            }
+                            tooltip={
+                              (ShuttleCrew.pilot ? 'Remove' : 'Set') + ' Pilot'
+                            }
                             color={ShuttleCrew.pilot ? 'green' : 'blue'}
                             onClick={() =>
                               act('editpilot', { editpilot: ShuttleCrew.id })
@@ -273,59 +375,89 @@ export const AllShuttles = (props, context) => {
           )}
         </Section>
       </Collapsible>
-      <Collapsible title="SCCV Spark" color="brown">
+      <Collapsible title="SCCV Spark" color="brown" icon="gem">
+        <Section title="SCCV Spark">
+          <Flex>
+            <Table>
+              <Table.Row header>
+                <Table.Cell>Shuttle Assignment: </Table.Cell>
+              </Table.Row>
+              {data.shuttle_assignments
+                .filter((m) => m.shuttle === 'SCCV Spark')
+                .map((ShuttleAssignment) => (
+                  <Table.Row key={ShuttleAssignment.shuttle}>
+                    <Table.Cell>
+                      <Flex.Item>
+                        Destination:
+                        <Button
+                          content={ShuttleAssignment.destination}
+                          onClick={() =>
+                            act('editdestination', {
+                              editdestination: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                        {'\t'}
+                        Heading:
+                        <Button
+                          content={num2bearing(ShuttleAssignment.heading)}
+                          onClick={() =>
+                            act('editheading', {
+                              editheading: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                        {'\t'}
+                        Mission:
+                        <Button
+                          content={ShuttleAssignment.mission}
+                          onClick={() =>
+                            act('editmission', {
+                              editmission: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                        {'\n'}
+                        Departure Time:
+                        <Button
+                          content={ShuttleAssignment.departure_time}
+                          onClick={() =>
+                            act('editdeparturetime', {
+                              editdeparturetime: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                        {'\t'}
+                        Return Time:
+                        <Button
+                          content={ShuttleAssignment.return_time}
+                          onClick={() =>
+                            act('editreturntime', {
+                              editreturntime: ShuttleAssignment.shuttle,
+                            })
+                          }
+                        />
+                      </Flex.Item>
+                    </Table.Cell>
+                  </Table.Row>
+                ))}
+            </Table>
+          </Flex>
+        </Section>
         <Section
-          title="SCCV Spark"
+          title="Shuttle Manifest"
           buttons={
-            <Button icon="plus" color="green" onClick={() => act('addentry')} />
+            <Button
+              icon="user-plus"
+              color="green"
+              onClick={() => act('addentry')}
+            />
           }>
-          {data.shuttle_assignments.filter((m => m.shuttle === 'SCCV Spark')).map((ShuttleAssignment) => (
-          <Table.Row key={ShuttleAssignment.shuttle}>
-            <Table.Cell>
-              <Flex.Item>
-              Destination:
-                <Button
-                  content={ShuttleAssignment.destination}
-                  onClick={() =>
-                    act('editdestination', { editdestination: ShuttleAssignment.shuttle })
-                  }
-                />
-                Heading:
-                <Button
-                  content={ShuttleAssignment.heading}
-                  onClick={() =>
-                    act('editheading', { editheading: ShuttleAssignment.shuttle })
-                  }
-                />
-                Mission:
-                <Button
-                  content={ShuttleAssignment.mission}
-                  onClick={() =>
-                    act('editmission', { editmission: ShuttleAssignment.shuttle })
-                  }
-                />
-                Departure Time:
-                <Button
-                  content={ShuttleAssignment.departure_time}
-                  onClick={() =>
-                    act('editdeparturetime', { editdeparturetime: ShuttleAssignment.shuttle })
-                  }
-                />
-                Return Time:
-                <Button
-                  content={ShuttleAssignment.return_time}
-                  onClick={() =>
-                    act('editreturntime', { editreturntime: ShuttleAssignment.shuttle })
-                  }
-                />
-              </Flex.Item>
-            </Table.Cell>
-          </Table.Row>))}
           {data.shuttle_manifest && data.shuttle_manifest.length ? (
             <Flex>
               <Table>
                 <Table.Row header>
-                  <Table.Cell>Name</Table.Cell>
+                  <Table.Cell>Crew Onboard: </Table.Cell>
                 </Table.Row>
                 {data.shuttle_manifest
                   .filter((m) => m.shuttle === 'SCCV Spark')
@@ -334,7 +466,13 @@ export const AllShuttles = (props, context) => {
                       <Table.Cell>
                         <Flex.Item>
                           <Button
-                            icon = {ShuttleCrew.lead ? "star" : null}
+                            icon={
+                              ShuttleCrew.lead ? 'star-half-stroke' : 'user'
+                            }
+                            tooltip={
+                              (ShuttleCrew.lead ? 'Remove' : 'Set') +
+                              ' Expedition Leader'
+                            }
                             color={ShuttleCrew.lead ? 'green' : 'blue'}
                             onClick={() =>
                               act('editlead', { editlead: ShuttleCrew.id })
@@ -347,7 +485,12 @@ export const AllShuttles = (props, context) => {
                             }
                           />
                           <Button
-                            content={ShuttleCrew.pilot ? 'P' : 'O'}
+                            icon={
+                              ShuttleCrew.pilot ? 'rocket' : 'suitcase-rolling'
+                            }
+                            tooltip={
+                              (ShuttleCrew.pilot ? 'Remove' : 'Set') + ' Pilot'
+                            }
                             color={ShuttleCrew.pilot ? 'green' : 'blue'}
                             onClick={() =>
                               act('editpilot', { editpilot: ShuttleCrew.id })

--- a/tgui/packages/tgui/interfaces/AwayShuttleManifest.tsx
+++ b/tgui/packages/tgui/interfaces/AwayShuttleManifest.tsx
@@ -3,9 +3,15 @@ import { Button, LabeledList, NoticeBox, Section, Flex, Table, Collapsible } fro
 import { NtosWindow } from '../layouts';
 
 export type AwayShuttleData = {
+  shuttles: { name: Shuttle[] };
   shuttle_manifest: ShuttleCrew[];
   active_record: ShuttleCrew;
   shuttle_assignments: ShuttleAssignment[];
+};
+
+type Shuttle = {
+  color: string;
+  icon: string;
 };
 
 type ShuttleCrew = {
@@ -99,414 +105,166 @@ export const AllShuttles = (props, context) => {
 
   return (
     <>
-      <Collapsible title="SCCV Canary" color="blue" icon="binoculars">
-        <Section title="SCCV Canary">
-          <Flex>
-            <Table>
-              <Table.Row header>
-                <Table.Cell>Shuttle Assignment: </Table.Cell>
-              </Table.Row>
-              {data.shuttle_assignments
-                .filter((m) => m.shuttle === 'SCCV Canary')
-                .map((ShuttleAssignment) => (
-                  <Table.Row key={ShuttleAssignment.shuttle}>
-                    <Table.Cell>
-                      <Flex.Item>
-                        Destination:
-                        <Button
-                          content={ShuttleAssignment.destination}
-                          onClick={() =>
-                            act('editdestination', {
-                              editdestination: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                      </Flex.Item>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Flex.Item>
-                        Heading:
-                        <Button
-                          content={num2bearing(ShuttleAssignment.heading)}
-                          onClick={() =>
-                            act('editheading', {
-                              editheading: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                      </Flex.Item>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Flex.Item>
-                        Mission:
-                        <Button
-                          content={ShuttleAssignment.mission}
-                          onClick={() =>
-                            act('editmission', {
-                              editmission: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                      </Flex.Item>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Flex.Item>
-                        Departure Time:
-                        <Button
-                          content={ShuttleAssignment.departure_time}
-                          onClick={() =>
-                            act('editdeparturetime', {
-                              editdeparturetime: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                      </Flex.Item>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Flex.Item>
-                        Return Time:
-                        <Button
-                          content={ShuttleAssignment.return_time}
-                          onClick={() =>
-                            act('editreturntime', {
-                              editreturntime: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                      </Flex.Item>
-                    </Table.Cell>
+      {Object.keys(data.shuttles).map((name) => {
+        const Shuttle = data.shuttles[name];
+        return (
+          <Collapsible
+            title={name}
+            color={Shuttle.color}
+            icon={Shuttle.icon}
+            key={name}>
+            <Section title={name}>
+              <Flex>
+                <Table>
+                  <Table.Row header>
+                    <Table.Cell>Shuttle Assignment: </Table.Cell>
                   </Table.Row>
-                ))}
-            </Table>
-          </Flex>
-        </Section>
-        <Section
-          title="Shuttle Manifest"
-          buttons={
-            <Button
-              icon="user-plus"
-              color="green"
-              onClick={() => act('addentry')}
-            />
-          }>
-          {data.shuttle_manifest && data.shuttle_manifest.length ? (
-            <Flex>
-              <Table>
-                <Table.Row header>
-                  <Table.Cell>Crew Onboard: </Table.Cell>
-                </Table.Row>
-                {data.shuttle_manifest
-                  .filter((m) => m.shuttle === 'SCCV Canary')
-                  .map((ShuttleCrew) => (
-                    <Table.Row key={ShuttleCrew.id}>
-                      <Table.Cell>
-                        <Flex.Item>
-                          <Button
-                            icon={
-                              ShuttleCrew.lead ? 'star-half-stroke' : 'user'
-                            }
-                            tooltip={
-                              (ShuttleCrew.lead ? 'Remove' : 'Set') +
-                              ' Expedition Leader'
-                            }
-                            color={ShuttleCrew.lead ? 'green' : 'blue'}
-                            onClick={() =>
-                              act('editlead', { editlead: ShuttleCrew.id })
-                            }
-                          />
-                          <Button
-                            content={ShuttleCrew.name}
-                            onClick={() =>
-                              act('editentry', { editentry: ShuttleCrew.id })
-                            }
-                          />
-                          <Button
-                            icon={
-                              ShuttleCrew.pilot ? 'rocket' : 'suitcase-rolling'
-                            }
-                            tooltip={
-                              (ShuttleCrew.pilot ? 'Remove' : 'Set') + ' Pilot'
-                            }
-                            color={ShuttleCrew.pilot ? 'green' : 'blue'}
-                            onClick={() =>
-                              act('editpilot', { editpilot: ShuttleCrew.id })
-                            }
-                          />
-                        </Flex.Item>
-                      </Table.Cell>
+                  {data.shuttle_assignments
+                    .filter((m) => m.shuttle === name)
+                    .map((ShuttleAssignment) => (
+                      <Table.Row key={ShuttleAssignment.shuttle}>
+                        <Table.Cell>
+                          <Flex.Item>
+                            Destination:
+                            <Button
+                              content={ShuttleAssignment.destination}
+                              onClick={() =>
+                                act('editdestination', {
+                                  editdestination: ShuttleAssignment.shuttle,
+                                })
+                              }
+                            />
+                          </Flex.Item>
+                        </Table.Cell>
+                        <Table.Cell>
+                          <Flex.Item>
+                            Heading:
+                            <Button
+                              content={num2bearing(ShuttleAssignment.heading)}
+                              onClick={() =>
+                                act('editheading', {
+                                  editheading: ShuttleAssignment.shuttle,
+                                })
+                              }
+                            />
+                          </Flex.Item>
+                        </Table.Cell>
+                        <Table.Cell>
+                          <Flex.Item>
+                            Mission:
+                            <Button
+                              content={ShuttleAssignment.mission}
+                              onClick={() =>
+                                act('editmission', {
+                                  editmission: ShuttleAssignment.shuttle,
+                                })
+                              }
+                            />
+                          </Flex.Item>
+                        </Table.Cell>
+                        <Table.Cell>
+                          <Flex.Item>
+                            Departure Time:
+                            <Button
+                              content={ShuttleAssignment.departure_time}
+                              onClick={() =>
+                                act('editdeparturetime', {
+                                  editdeparturetime: ShuttleAssignment.shuttle,
+                                })
+                              }
+                            />
+                          </Flex.Item>
+                        </Table.Cell>
+                        <Table.Cell>
+                          <Flex.Item>
+                            Return Time:
+                            <Button
+                              content={ShuttleAssignment.return_time}
+                              onClick={() =>
+                                act('editreturntime', {
+                                  editreturntime: ShuttleAssignment.shuttle,
+                                })
+                              }
+                            />
+                          </Flex.Item>
+                        </Table.Cell>
+                      </Table.Row>
+                    ))}
+                </Table>
+              </Flex>
+            </Section>
+            <Section
+              title="Shuttle Manifest"
+              buttons={
+                <Button
+                  icon="user-plus"
+                  color="green"
+                  onClick={() => act('addentry')}
+                />
+              }>
+              {data.shuttle_manifest && data.shuttle_manifest.length ? (
+                <Flex>
+                  <Table>
+                    <Table.Row header>
+                      <Table.Cell>Crew Onboard: </Table.Cell>
                     </Table.Row>
-                  ))}
-              </Table>
-            </Flex>
-          ) : (
-            <NoticeBox>No crew detected.</NoticeBox>
-          )}
-        </Section>
-      </Collapsible>
-      <Collapsible title="SCCV Intrepid" color="purple" icon="compass">
-        <Section title="SCCV Intrepid">
-          <Flex>
-            <Table>
-              <Table.Row header>
-                <Table.Cell>Shuttle Assignment: </Table.Cell>
-              </Table.Row>
-              {data.shuttle_assignments
-                .filter((m) => m.shuttle === 'SCCV Intrepid')
-                .map((ShuttleAssignment) => (
-                  <Table.Row key={ShuttleAssignment.shuttle}>
-                    <Table.Cell>
-                      <Flex.Item>
-                        Destination:
-                        <Button
-                          content={ShuttleAssignment.destination}
-                          onClick={() =>
-                            act('editdestination', {
-                              editdestination: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                        {'\t'}
-                        Heading:
-                        <Button
-                          content={num2bearing(ShuttleAssignment.heading)}
-                          onClick={() =>
-                            act('editheading', {
-                              editheading: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                        {'\t'}
-                        Mission:
-                        <Button
-                          content={ShuttleAssignment.mission}
-                          onClick={() =>
-                            act('editmission', {
-                              editmission: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                        {'\n'}
-                        Departure Time:
-                        <Button
-                          content={ShuttleAssignment.departure_time}
-                          onClick={() =>
-                            act('editdeparturetime', {
-                              editdeparturetime: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                        {'\t'}
-                        Return Time:
-                        <Button
-                          content={ShuttleAssignment.return_time}
-                          onClick={() =>
-                            act('editreturntime', {
-                              editreturntime: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                      </Flex.Item>
-                    </Table.Cell>
-                  </Table.Row>
-                ))}
-            </Table>
-          </Flex>
-        </Section>
-        <Section
-          title="Shuttle Manifest"
-          buttons={
-            <Button
-              icon="user-plus"
-              color="green"
-              onClick={() => act('addentry')}
-            />
-          }>
-          {data.shuttle_manifest && data.shuttle_manifest.length ? (
-            <Flex>
-              <Table>
-                <Table.Row header>
-                  <Table.Cell>Crew Onboard: </Table.Cell>
-                </Table.Row>
-                {data.shuttle_manifest
-                  .filter((m) => m.shuttle === 'SCCV Intrepid')
-                  .map((ShuttleCrew) => (
-                    <Table.Row key={ShuttleCrew.id}>
-                      <Table.Cell>
-                        <Flex.Item>
-                          <Button
-                            icon={
-                              ShuttleCrew.lead ? 'star-half-stroke' : 'user'
-                            }
-                            tooltip={
-                              (ShuttleCrew.lead ? 'Remove' : 'Set') +
-                              ' Expedition Leader'
-                            }
-                            color={ShuttleCrew.lead ? 'green' : 'blue'}
-                            onClick={() =>
-                              act('editlead', { editlead: ShuttleCrew.id })
-                            }
-                          />
-                          <Button
-                            content={ShuttleCrew.name}
-                            onClick={() =>
-                              act('editentry', { editentry: ShuttleCrew.id })
-                            }
-                          />
-                          <Button
-                            icon={
-                              ShuttleCrew.pilot ? 'rocket' : 'suitcase-rolling'
-                            }
-                            tooltip={
-                              (ShuttleCrew.pilot ? 'Remove' : 'Set') + ' Pilot'
-                            }
-                            color={ShuttleCrew.pilot ? 'green' : 'blue'}
-                            onClick={() =>
-                              act('editpilot', { editpilot: ShuttleCrew.id })
-                            }
-                          />
-                        </Flex.Item>
-                      </Table.Cell>
-                    </Table.Row>
-                  ))}
-              </Table>
-            </Flex>
-          ) : (
-            <NoticeBox>No crew detected.</NoticeBox>
-          )}
-        </Section>
-      </Collapsible>
-      <Collapsible title="SCCV Spark" color="brown" icon="gem">
-        <Section title="SCCV Spark">
-          <Flex>
-            <Table>
-              <Table.Row header>
-                <Table.Cell>Shuttle Assignment: </Table.Cell>
-              </Table.Row>
-              {data.shuttle_assignments
-                .filter((m) => m.shuttle === 'SCCV Spark')
-                .map((ShuttleAssignment) => (
-                  <Table.Row key={ShuttleAssignment.shuttle}>
-                    <Table.Cell>
-                      <Flex.Item>
-                        Destination:
-                        <Button
-                          content={ShuttleAssignment.destination}
-                          onClick={() =>
-                            act('editdestination', {
-                              editdestination: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                        {'\t'}
-                        Heading:
-                        <Button
-                          content={num2bearing(ShuttleAssignment.heading)}
-                          onClick={() =>
-                            act('editheading', {
-                              editheading: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                        {'\t'}
-                        Mission:
-                        <Button
-                          content={ShuttleAssignment.mission}
-                          onClick={() =>
-                            act('editmission', {
-                              editmission: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                        {'\n'}
-                        Departure Time:
-                        <Button
-                          content={ShuttleAssignment.departure_time}
-                          onClick={() =>
-                            act('editdeparturetime', {
-                              editdeparturetime: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                        {'\t'}
-                        Return Time:
-                        <Button
-                          content={ShuttleAssignment.return_time}
-                          onClick={() =>
-                            act('editreturntime', {
-                              editreturntime: ShuttleAssignment.shuttle,
-                            })
-                          }
-                        />
-                      </Flex.Item>
-                    </Table.Cell>
-                  </Table.Row>
-                ))}
-            </Table>
-          </Flex>
-        </Section>
-        <Section
-          title="Shuttle Manifest"
-          buttons={
-            <Button
-              icon="user-plus"
-              color="green"
-              onClick={() => act('addentry')}
-            />
-          }>
-          {data.shuttle_manifest && data.shuttle_manifest.length ? (
-            <Flex>
-              <Table>
-                <Table.Row header>
-                  <Table.Cell>Crew Onboard: </Table.Cell>
-                </Table.Row>
-                {data.shuttle_manifest
-                  .filter((m) => m.shuttle === 'SCCV Spark')
-                  .map((ShuttleCrew) => (
-                    <Table.Row key={ShuttleCrew.id}>
-                      <Table.Cell>
-                        <Flex.Item>
-                          <Button
-                            icon={
-                              ShuttleCrew.lead ? 'star-half-stroke' : 'user'
-                            }
-                            tooltip={
-                              (ShuttleCrew.lead ? 'Remove' : 'Set') +
-                              ' Expedition Leader'
-                            }
-                            color={ShuttleCrew.lead ? 'green' : 'blue'}
-                            onClick={() =>
-                              act('editlead', { editlead: ShuttleCrew.id })
-                            }
-                          />
-                          <Button
-                            content={ShuttleCrew.name}
-                            onClick={() =>
-                              act('editentry', { editentry: ShuttleCrew.id })
-                            }
-                          />
-                          <Button
-                            icon={
-                              ShuttleCrew.pilot ? 'rocket' : 'suitcase-rolling'
-                            }
-                            tooltip={
-                              (ShuttleCrew.pilot ? 'Remove' : 'Set') + ' Pilot'
-                            }
-                            color={ShuttleCrew.pilot ? 'green' : 'blue'}
-                            onClick={() =>
-                              act('editpilot', { editpilot: ShuttleCrew.id })
-                            }
-                          />
-                        </Flex.Item>
-                      </Table.Cell>
-                    </Table.Row>
-                  ))}
-              </Table>
-            </Flex>
-          ) : (
-            <NoticeBox>No crew detected.</NoticeBox>
-          )}
-        </Section>
-      </Collapsible>
+                    {data.shuttle_manifest
+                      .filter((m) => m.shuttle === name)
+                      .map((ShuttleCrew) => (
+                        <Table.Row key={ShuttleCrew.id}>
+                          <Table.Cell>
+                            <Flex.Item>
+                              <Button
+                                icon={
+                                  ShuttleCrew.lead ? 'star-half-stroke' : 'user'
+                                }
+                                tooltip={
+                                  (ShuttleCrew.lead ? 'Remove' : 'Set') +
+                                  ' Expedition Leader'
+                                }
+                                color={ShuttleCrew.lead ? 'green' : 'blue'}
+                                onClick={() =>
+                                  act('editlead', { editlead: ShuttleCrew.id })
+                                }
+                              />
+                              <Button
+                                content={ShuttleCrew.name}
+                                onClick={() =>
+                                  act('editentry', {
+                                    editentry: ShuttleCrew.id,
+                                  })
+                                }
+                              />
+                              <Button
+                                icon={
+                                  ShuttleCrew.pilot
+                                    ? 'rocket'
+                                    : 'suitcase-rolling'
+                                }
+                                tooltip={
+                                  (ShuttleCrew.pilot ? 'Remove' : 'Set') +
+                                  ' Pilot'
+                                }
+                                color={ShuttleCrew.pilot ? 'green' : 'blue'}
+                                onClick={() =>
+                                  act('editpilot', {
+                                    editpilot: ShuttleCrew.id,
+                                  })
+                                }
+                              />
+                            </Flex.Item>
+                          </Table.Cell>
+                        </Table.Row>
+                      ))}
+                  </Table>
+                </Flex>
+              ) : (
+                <NoticeBox>No crew detected.</NoticeBox>
+              )}
+            </Section>
+          </Collapsible>
+        );
+      })}
     </>
   );
 };


### PR DESCRIPTION
Adds some new fields to the shuttle manifest:
- Destination (Per shuttle)
- Heading (Per shuttle)
- Mission (Per shuttle)
- Departure Time (Per Shuttle)
- Return Time (Per Shuttle)
- Expedition/Mission Leader (One per shuttle)
- Shuttle Pilot (One per shuttle)

Also adds the shuttle manifest to Bridge Crew PDAs by default.

<img width="458" alt="image" src="https://github.com/Aurorastation/Aurora.3/assets/26849270/802d9a8d-9c43-4883-a5a7-d23967616766">
