### PR TITLE
Fixed Srom not working properly

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -155,7 +155,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/lobby_mobs_location)
 
 /obj/effect/landmark/skrell_srom/Initialize()
 	..()
-	dream_entries += get_turf(src)
+	GLOB.dream_entries |= get_turf(src)
 	return INITIALIZE_HINT_QDEL
 
 /**

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -60,7 +60,7 @@
 
 	// Try to translate with augment if it is installed and not broken.
 	var/obj/item/organ/internal/augment/translator/translator = internal_organs_by_name[BP_AUG_TRANSLATOR]
-	if(!translator?.is_broken() && (speaking.name in translator?.languages))
+	if(!translator?.is_broken() && (speaking?.name in translator?.languages))
 		return TRUE
 
 	return ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -88,7 +88,7 @@
 	zone_sel = null
 
 /mob/var/should_add_to_mob_list = TRUE
-/mob/Initialize()
+/mob/Initialize(mapload)
 	. = ..()
 	if(should_add_to_mob_list)
 		GLOB.mob_list += src

--- a/code/modules/shareddream/brainghost.dm
+++ b/code/modules/shareddream/brainghost.dm
@@ -12,10 +12,12 @@
 	. = ..()
 
 	body = loc
+	#if !defined(UNIT_TEST)
 	if(!istype(body))
 		stack_trace("No /mob/living/carbon/human found for brain ghost as loc!")
 		qdel(src)
 		return
+	#endif
 
 	name = body.real_name
 	old_mob = body

--- a/code/modules/shareddream/brainghost.dm
+++ b/code/modules/shareddream/brainghost.dm
@@ -8,16 +8,16 @@
 	var/mob/living/carbon/human/body = null
 
 
-/mob/living/brain_ghost/Initialize()
+/mob/living/brain_ghost/Initialize(mob/living/carbon/human/dreamer)
 	. = ..()
 
-	body = loc
-	#if !defined(UNIT_TEST)
+	body = dreamer
 	if(!istype(body))
-		stack_trace("No /mob/living/carbon/human found for brain ghost as loc!")
+		//This is to handle the unit tests
+		if(!isnull(body))
+			stack_trace("No /mob/living/carbon/human found for brain ghost as loc!")
 		qdel(src)
 		return
-	#endif
 
 	name = body.real_name
 	old_mob = body

--- a/code/modules/shareddream/brainghost.dm
+++ b/code/modules/shareddream/brainghost.dm
@@ -16,8 +16,7 @@
 		//This is to handle the unit tests
 		if(!isnull(body))
 			stack_trace("No /mob/living/carbon/human found for brain ghost as loc!")
-		qdel(src)
-		return
+		return INITIALIZE_HINT_QDEL
 
 	name = body.real_name
 	old_mob = body

--- a/code/modules/shareddream/brainghost.dm
+++ b/code/modules/shareddream/brainghost.dm
@@ -8,7 +8,7 @@
 	var/mob/living/carbon/human/body = null
 
 
-/mob/living/brain_ghost/Initialize(mob/living/carbon/human/dreamer)
+/mob/living/brain_ghost/Initialize(mapload, mob/living/carbon/human/dreamer)
 	. = ..()
 
 	body = dreamer

--- a/code/modules/shareddream/brainghost.dm
+++ b/code/modules/shareddream/brainghost.dm
@@ -5,25 +5,43 @@
 
 	alpha = 200
 
-	var/image/ghostimage = null
 	var/mob/living/carbon/human/body = null
 
 
 /mob/living/brain_ghost/Initialize()
 	. = ..()
-	var/mob/living/carbon/human/form = loc
-	if(!istype(form))
+
+	body = loc
+	if(!istype(body))
+		stack_trace("No /mob/living/carbon/human found for brain ghost as loc!")
 		qdel(src)
 		return
-	overlays += image(form.icon,form,form.icon_state)
-	overlays += form.overlays
-	name = form.real_name
-	loc = pick(dream_entries)
-	body = form
+
+	name = body.real_name
 	old_mob = body
 
+	var/mutable_appearance/MA = new(body)
+	MA.appearance_flags |= KEEP_APART | RESET_TRANSFORM
+	MA.transform = matrix() //Mutable appearances copy various vars, including transform, so we have to reset it here
+
+	AddOverlays(MA)
+
+
+	var/turf/T = pick(GLOB.dream_entries)
+	if(!T)
+		stack_trace("No dream entries found for Srom!")
+		awaken_impl(TRUE)
+		return
+
+	src.forceMove(T)
+
 	if(client)
-		client.screen |= body.healths
+		LateLogin()
+
+/mob/living/brain_ghost/Destroy()
+	body = null
+
+	. = ..()
 
 /mob/living/brain_ghost/LateLogin()
 	..()
@@ -79,3 +97,7 @@
 		body.set_stat(UNCONSCIOUS) // Toggled before anything else can happen. Ideally.
 
 	..(message, speaking, verb="says", alt_name="")
+
+
+/mob/living/brain_ghost/get_floating_chat_y_offset()
+	return 8

--- a/code/modules/shareddream/dream_entry.dm
+++ b/code/modules/shareddream/dream_entry.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_EMPTY_TYPED(dream_entries, /turf)
 	var/mob/living/carbon/human/srom_puller = srom_pulled_by?.resolve()
 	if((has_psionics() || (srom_puller && Adjacent(srom_puller))) && stat == UNCONSCIOUS && sleeping > 1)
 		if(!istype(bg) && client) // Don't spawn a brainghost if we're not logged in.
-			bg = new /mob/living/brain_ghost(src) // Generate a new brainghost.
+			bg = new /mob/living/brain_ghost(src, src) // Generate a new brainghost.
 			if(isnull(bg)) // Prevents you from getting kicked if the brain ghost didn't spawn - geeves
 				return
 			vr_mob = bg

--- a/code/modules/shareddream/dream_entry.dm
+++ b/code/modules/shareddream/dream_entry.dm
@@ -1,4 +1,5 @@
-var/list/dream_entries = list()
+///A list of `/turf` where the Srom is located, and people entering the shared dream (presumably Skrells sleeping) will be casted to
+GLOBAL_LIST_EMPTY_TYPED(dream_entries, /turf)
 
 /mob
 	var/mob/living/brain_ghost/bg
@@ -8,6 +9,8 @@ var/list/dream_entries = list()
 	var/datum/weakref/srom_pulling
 
 /mob/living/carbon/human/proc/handle_shared_dreaming(var/force_wakeup = FALSE)
+	SHOULD_NOT_SLEEP(TRUE)
+
 	// If they're an Unconsious person with the abillity to do Skrellepathy.
 	// If either changes, they should be nocked back to the real world.
 	var/mob/living/carbon/human/srom_puller = srom_pulled_by?.resolve()

--- a/html/changelogs/fluffyghost-fixsrom.yml
+++ b/html/changelogs/fluffyghost-fixsrom.yml
@@ -1,0 +1,61 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed srom not working properly."
+  - bugfix: "Fixed a runtime with translators implants."
+  - bugfix: "Aligned runechat correctly in srom mobs."
+  - code_imp: "Turned the srom entry points into a GLOB list."


### PR DESCRIPTION
Fixed srom not working properly.
Fixed a runtime with translators implants.
Aligned runechat correctly in srom mobs.
Turned the srom entry points into a GLOB list.

Fixes #19207 