### PR TITLE
Tyrant tweaks

### DIFF
--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -173,13 +173,15 @@
 	deployed = FALSE
 	time_to_escape = 3 // Minutes
 	can_buckle = list(/mob/living)
+	health = 100
+	can_astar_pass = CANASTARPASS_ALWAYS_PROC
+
 	var/breakout = FALSE
 	var/last_shake = 0
 	var/list/allowed_mobs = list(/mob/living/simple_animal/rat, /mob/living/simple_animal/chick, /mob/living/simple_animal/lizard)
 	var/release_time = 0
 	var/list/resources = list(rods = 6)
 	var/spider = TRUE
-	health = 100
 	var/datum/weakref/captured = null
 
 /obj/item/trap/animal/MouseDrop_T(atom/dropping, mob/user)
@@ -527,6 +529,10 @@
 
 /obj/item/trap/animal/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	return TRUE
+
+/obj/item/trap/animal/CanAStarPass(to_dir, datum/can_pass_info/pass_info)
+	return TRUE
+
 
 /**
  * # Animal trap (Medium)

--- a/code/modules/heavy_vehicle/mecha.dm
+++ b/code/modules/heavy_vehicle/mecha.dm
@@ -2,7 +2,6 @@
 /mob/living/heavy_vehicle
 	name = "exosuit"
 	density = TRUE
-	opacity = TRUE
 	anchored = TRUE
 	status_flags = PASSEMOTES
 	a_intent = I_HURT

--- a/code/modules/mob/living/simple_animal/hostile/moghes.dm
+++ b/code/modules/mob/living/simple_animal/hostile/moghes.dm
@@ -19,8 +19,8 @@
 	response_disarm = "shoves"
 	response_harm   = "harmlessly punches"
 	blood_overlay_icon = null
-	maxHealth = 500
-	health = 500
+	maxHealth = 400
+	health = 400
 	harm_intent_damage = 0
 	melee_damage_lower = 40
 	melee_damage_upper = 40
@@ -49,7 +49,34 @@
 
 /mob/living/simple_animal/hostile/biglizard/Life()
 	..()
-	adjustBruteLoss(-5)
+
+	//It's a predator, supposedly it shouldn't always alert his victims to be nearby
+	//(also saves some processing)
+	if(prob(30))
+		for(var/mob/living/poor_soul_approaching in get_hearers_in_range(world.view*1.8, src))
+			//No point in sending a message if there's no client
+			if(!poor_soul_approaching.client)
+				continue
+
+			var/message
+
+			var/poor_soul_distance_from_tyrant = get_dist(src, poor_soul_approaching)
+			//They can see us, no point
+			if(poor_soul_distance_from_tyrant <= world.view)
+				continue
+
+			//RUN FOR YOUR LIFE
+			else if(poor_soul_distance_from_tyrant <= world.view*1.4)
+				message = SPAN_HIGHDANGER(SPAN_BOLD("YOU HEAR LOUD STOMPING NEARBY, SOMETHING TERRIFYINGLY LARGE IS NEARBY!"))
+
+			//Fairly close, a normal warning should suffice
+			else
+				message = SPAN_DANGER("You hear a bone-chilling roar in the distance!")
+
+			poor_soul_approaching.notify_message(message, 10 SECONDS, key = "biglizard-[REF(src)]")
+
+
+	adjustBruteLoss(-1)
 
 /mob/living/simple_animal/hostile/biglizard/verb/devour(mob/living/target as mob in oview())
 	set category = "Plains Tyrant"

--- a/code/modules/mob/living/simple_animal/hostile/moghes.dm
+++ b/code/modules/mob/living/simple_animal/hostile/moghes.dm
@@ -67,7 +67,7 @@
 
 			//RUN FOR YOUR LIFE
 			else if(poor_soul_distance_from_tyrant <= world.view*1.4)
-				message = SPAN_HIGHDANGER(SPAN_BOLD("YOU HEAR LOUD STOMPING NEARBY, SOMETHING TERRIFYINGLY LARGE IS NEARBY!"))
+				message = SPAN_HIGHDANGER(SPAN_BOLD("You hear loud stomping nearby!"))
 
 			//Fairly close, a normal warning should suffice
 			else

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -741,21 +741,22 @@
 	apply_damage(damage, DAMAGE_BRUTE, damage_flags = DAMAGE_FLAG_EXPLODE)
 
 /mob/living/simple_animal/proc/SA_attackable(target_mob)
-	if (isliving(target_mob))
+	if(isliving(target_mob))
 		var/mob/living/L = target_mob
 		if(!L.stat)
-			return (0)
-	if (istype(target_mob, /obj/machinery/bot))
+			return FALSE
+	else if(istype(target_mob, /obj/machinery/bot))
 		var/obj/machinery/bot/B = target_mob
 		if(B.health > 0)
-			return (0)
-	if(istype(target_mob, /obj/machinery/porta_turret/))
+			return FALSE
+	else if(istype(target_mob, /obj/machinery/porta_turret))
 		var/obj/machinery/porta_turret/T = target_mob
 		if(T.health > 0)
-			return (0)
-	if(istype(target_mob, /obj/effect/energy_field))
-		return (0)
-	return 1
+			return FALSE
+	else if(istype(target_mob, /obj/effect/energy_field))
+		return FALSE
+
+	return TRUE
 
 /mob/living/simple_animal/proc/make_noise(var/make_sound = TRUE)
 	set name = "Make Sound"

--- a/html/changelogs/fluffyghost-tyrantexosuittweak.yml
+++ b/html/changelogs/fluffyghost-tyrantexosuittweak.yml
@@ -1,0 +1,62 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added some notifications of proximity to the plains tyrant."
+  - balance: "Reduced health and auto-brute-healing of the plains tyrant."
+  - bugfix: "Fixed traps pathing so that mobs should now pass in them."
+  - code_imp: "Optimized SA_attackable proc."
+  - bugfix: "Mechs are no longer opaque, this fixes the simplemobs not attacking them (because the line of sight check fails as the turf they stand on is opaque if they are opaque too) as well as avoid lighting recomputing on every step."


### PR DESCRIPTION
Added some notifications of proximity to the plains tyrant.
Reduced health and auto-brute-healing of the plains tyrant.
Fixed traps pathing so that mobs should now pass in them.
Optimized SA_attackable proc.
Mechs are no longer opaque, this fixes the simplemobs not attacking them (because the line of sight check fails as the turf they stand on is opaque if they are opaque too) as well as avoid lighting recomputing on every step.