### PR TITLE
Exoplanet Forcing & Banning

### DIFF
--- a/code/modules/background/space_sectors/space_sector.dm
+++ b/code/modules/background/space_sectors/space_sector.dm
@@ -12,6 +12,8 @@
 	var/list/possible_exoplanets = list(/obj/effect/overmap/visitable/sector/exoplanet/snow, /obj/effect/overmap/visitable/sector/exoplanet/desert)
 	///Guaranteed planets to spawn. This ignores the map exoplanet limit, so don't put too many planets in here.
 	var/list/guaranteed_exoplanets = list()
+	///Banned exoplanets. These will be removed from the possible exoplanets list.
+	var/list/banned_exoplanets = list()
 	var/list/cargo_price_coef = list("nt" = 1, "hpi" = 1, "zhu" = 1, "een" = 1, "get" = 1, "arz" = 1, "blm" = 1,
 								"iac" = 1, "zsc" = 1, "vfc" = 1, "bis" = 1, "xmg" = 1, "npi" = 1) //how much the space sector afffects how expensive is ordering from that cargo supplier
 	var/skybox_icon = "ceti"

--- a/code/modules/maps/planet_types/lore/uueoaesa.dm
+++ b/code/modules/maps/planet_types/lore/uueoaesa.dm
@@ -141,6 +141,7 @@
 	ruin_type_whitelist = list(/datum/map_template/ruin/exoplanet/moghes_village) //defaults to village bc for some reason nothing spawns if this is empty
 	place_near_main = list(2,2)
 	actors = list("reptilian humanoid", "three-faced reptilian humanoid", "a statue", "a sword", "an unidentifiable object", "an Unathi skull", "a staff", "a fishing spear", "reptilian humanoids", "unusual devices", "a pyramid")
+	banned_exoplanets = list(/obj/effect/overmap/visitable/sector/exoplanet/ouerea)
 	var/landing_region
 
 /obj/effect/overmap/visitable/sector/exoplanet/moghes/pre_ruin_preparation()
@@ -293,6 +294,7 @@
 		/datum/map_template/ruin/exoplanet/ouerea_threshbeast_herd
 	)
 	place_near_main = list(2,2)
+	banned_exoplanets = list(/obj/effect/overmap/visitable/sector/exoplanet/moghes)
 
 /obj/effect/overmap/visitable/sector/exoplanet/ouerea/generate_habitability()
 	return HABITABILITY_IDEAL

--- a/code/modules/overmap/exoplanets/exoplanet.dm
+++ b/code/modules/overmap/exoplanets/exoplanet.dm
@@ -83,6 +83,10 @@
 	///A list of groups, as strings, that this exoplanet belongs to. When adding new map templates, try to keep this balanced on the CI execution time, or consider adding a new one
 	///ONLY IF IT'S THE LONGEST RUNNING CI POD AND THEY ARE ALREADY BALANCED
 	var/list/unit_test_groups = list()
+	///For mutually exclusive exoplanet types
+	var/list/banned_exoplanets = list()
+	///For guaranteed exoplanet types
+	var/list/guaranteed_exoplanets = list()
 
 
 /obj/effect/overmap/visitable/sector/exoplanet/proc/generate_habitability()

--- a/html/changelogs/RustingWithYou - planetbanning.yml
+++ b/html/changelogs/RustingWithYou - planetbanning.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Exoplanets can now prevent or force other exoplanets to spawn."
+  - qol: "Away sites can now force or ban exoplanets from spawning."

--- a/maps/away/away_sites.dm
+++ b/maps/away/away_sites.dm
@@ -9,6 +9,10 @@
 	/// Should be assoc map of `/turf/unsimulated/marker/...` path to `/datum/exoplanet_theme/...` path,
 	/// where exoplanet generation with the map value is applied only on marker turfs of the applicable map key.
 	var/list/exoplanet_themes = null
+	///Exoplanets that this site will force to spawn. Useful for on-planet away sites such as Point Verdant or other ports of call.
+	var/list/force_exoplanets = list()
+	///Exoplanets that this site will prohibit from spawning. Useful for fake planet away sites intended to replace normal exoplanets.
+	var/list/ban_exoplanets = list()
 
 /datum/map_template/ruin/away_site/New(var/list/paths = null, rename = null)
 


### PR DESCRIPTION
Exoplanets can now force or prevent other exoplanets from spawning. Currently this is only used for Moghes and Ouerea.

Away sites can now force or prevent exoplanets from spawning. Currently unused