### PR TITLE
Cult buff

### DIFF
--- a/aurorastation.dme
+++ b/aurorastation.dme
@@ -686,6 +686,7 @@
 #include "code\game\gamemodes\cult\runes\convert.dm"
 #include "code\game\gamemodes\cult\runes\create_construct.dm"
 #include "code\game\gamemodes\cult\runes\create_talisman.dm"
+#include "code\game\gamemodes\cult\runes\cult_mech.dm"
 #include "code\game\gamemodes\cult\runes\deafen_others.dm"
 #include "code\game\gamemodes\cult\runes\emp.dm"
 #include "code\game\gamemodes\cult\runes\free_cultist.dm"

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -670,7 +670,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
  *
  */
 /proc/do_after(mob/user, delay, atom/target, do_flags = DO_DEFAULT, incapacitation_flags = INCAPACITATION_DEFAULT, datum/callback/extra_checks)
-	return !do_after_detailed(user, delay, target, do_flags, incapacitation_flags)
+	return !do_after_detailed(user, delay, target, do_flags, incapacitation_flags, extra_checks)
 
 /**
  * See [/proc/do_after]

--- a/code/game/gamemodes/cult/runes/_rune_datum.dm
+++ b/code/game/gamemodes/cult/runes/_rune_datum.dm
@@ -1,12 +1,20 @@
-#define NO_TALISMAN                  1
-#define CAN_MEMORIZE                  2
-#define HAS_SPECIAL_TALISMAN_ACTION  4
+#define NO_TALISMAN	BITFLAG(1)
+#define CAN_MEMORIZE	BITFLAG(2)
+#define HAS_SPECIAL_TALISMAN_ACTION	BITFLAG(3)
 
 /datum/rune
-	var/name            	  // The rune's name.
-	var/desc         		  // The rune's description. This and the name are used in the guide.
-	var/rune_flags   		  // Things like if it can be a talisman or not.
-	var/max_number_allowed    // Maximum number allowed of this rune.
+	///The rune's name
+	var/name
+
+	///The rune's description; this and the name are used in the guide
+	var/desc
+
+	///Things like if it can be a talisman or not, see defines in `code\game\gamemodes\cult\runes\_rune_datum.dm`
+	var/rune_flags
+
+	///Maximum number allowed of this rune
+	var/max_number_allowed
+
 	var/atom/movable/parent
 
 /datum/rune/New(atom/owner)

--- a/code/game/gamemodes/cult/runes/cult_mech.dm
+++ b/code/game/gamemodes/cult/runes/cult_mech.dm
@@ -1,0 +1,62 @@
+/datum/rune/cult_mech
+	name = "cult mech rune"
+	desc = "This rune is used to convert a mech into a cult mech."
+	max_number_allowed = 1
+
+	///How many times it was used
+	var/times_used = 0
+
+/datum/rune/cult_mech/do_rune_action(mob/living/user, atom/movable/A)
+	if(times_used >= 1)
+		to_chat(user, SPAN_WARNING("You have already used this rune to its full potential!"))
+		return
+
+	var/mob/living/heavy_vehicle/mech_on_us = locate() in get_turf(A)
+
+	if(!mech_on_us)
+		to_chat(user, SPAN_WARNING("\The [A] fizzles, dark mechanical energy tentacles try to find a mech to convert on the rune, but in vain..."))
+		return
+
+	if(istype(mech_on_us, /mob/living/heavy_vehicle/premade/cult))
+		to_chat(user, SPAN_WARNING("The rune fizzles... This offering is already ours, why are you offering to the Geometer of Blood what is already his?"))
+		return
+
+	if(!ishuman(user))
+		to_chat(user, SPAN_WARNING("Your form is too simple to convert a mech into a cult mech!"))
+		return
+
+	var/mob/living/carbon/human/human_user = user
+
+	to_chat(human_user, SPAN_NOTICE("You start to orchestrate the dark mechanical energy tentacles in a quasi-simphony, to convert \the [mech_on_us] into a cult mech!"))
+	to_chat(human_user, SPAN_INFO("This action will take approximately 2 minutes to perform."))
+
+
+
+	if(!do_after(human_user, 2 MINUTES, mech_on_us, extra_checks = CALLBACK(src, PROC_REF(check_conversion_possible), mech_on_us, A, human_user)))
+		to_chat(human_user, SPAN_WARNING("The rune fizzles... You have failed to convert the mech into a cult mech!"))
+		return
+
+
+	//Conversion successful, give a message, delete the old mech, put down a cult mech, increment the rune's use count
+	to_chat(human_user, SPAN_NOTICE("You have converted \the [mech_on_us] into a cult mech! The Geometer of Blood is pleased with your offering!"))
+
+	qdel(mech_on_us)
+
+	//20% chance of a super cult mech
+	var/cult_mech_type = prob(80) ? /mob/living/heavy_vehicle/premade/cult : /mob/living/heavy_vehicle/premade/cult/super
+
+	new cult_mech_type(get_turf(A))
+
+	times_used += 1
+
+/datum/rune/cult_mech/proc/check_conversion_possible(mob/living/heavy_vehicle/mech_on_us, atom/movable/A, mob/living/carbon/human/user)
+	//In case someone steals or moves it while it's being converted
+	if(get_turf(mech_on_us) != get_turf(A))
+		to_chat(user, SPAN_WARNING("The rune fizzles... You have failed to convert the mech into a cult mech! The mech was moved!"))
+		return FALSE
+
+	if(length(mech_on_us.pilots))
+		to_chat(user, SPAN_WARNING("The rune fizzles... The mech isn't pure, a living being is inside it. The offerings must be separated..."))
+		return FALSE
+
+	return TRUE

--- a/code/game/gamemodes/cult/runes/cult_mech.dm
+++ b/code/game/gamemodes/cult/runes/cult_mech.dm
@@ -27,7 +27,7 @@
 
 	var/mob/living/carbon/human/human_user = user
 
-	to_chat(human_user, SPAN_NOTICE("You start to orchestrate the dark mechanical energy tentacles in a quasi-simphony, to convert \the [mech_on_us] into a cult mech!"))
+	to_chat(human_user, SPAN_NOTICE("You start to orchestrate the dark mechanical energy tentacles in a quasi-symphony, to convert \the [mech_on_us] into a cult mech!"))
 	to_chat(human_user, SPAN_INFO("This action will take approximately 2 minutes to perform."))
 
 

--- a/code/game/gamemodes/cult/runes/cult_mech.dm
+++ b/code/game/gamemodes/cult/runes/cult_mech.dm
@@ -47,7 +47,7 @@
 
 	new cult_mech_type(get_turf(A))
 
-	times_used += 1
+	times_used++
 
 /datum/rune/cult_mech/proc/check_conversion_possible(mob/living/heavy_vehicle/mech_on_us, atom/movable/A, mob/living/carbon/human/user)
 	//In case someone steals or moves it while it's being converted

--- a/code/game/gamemodes/cult/structures/pylon.dm
+++ b/code/game/gamemodes/cult/structures/pylon.dm
@@ -7,7 +7,8 @@
 	name = "pylon"
 	desc = "A floating crystal that hums with an unearthly energy."
 	desc_antag = "A pylon can be upgraded into a magical defensive turret that shoots anyone opposing the cult\
-	</br>Upgrading a pylon requires a sacrifice. Bring it a small organic creature, like a monkey or rat. Use the creature on the pylon, or drag and drop to present it.\
+	</br>Upgrading a pylon requires a sacrifice. Bring it a small organic creature, like a monkey or rat. Use the creature on the pylon, or drag and drop to present it,\
+	</br>Alternatively, you can attack it with disarm intent to sacrifice some of your blood for the upgrade.\
 	</br>Once the sacrifice is accepted, kill it to complete the process. This will gib its body and make a very visible mess. After this point the pylon is fixed to the floor and cant be moved\
 	</br>The pylon will fire weak beams that are harmless to the cult. In addition it can be upgraded even more by shooting it with a laser, which will give it a limited number of extra-power shots."
 
@@ -359,7 +360,7 @@
 			return
 
 		if(cultist_upgrader.get_blood_volume() < BLOOD_VOLUME_OKAY)
-			to_chat(cultist_upgrader, SPAN_WARNING("You do not have enought blood to do this, the Geometer values you being alive more... For now."))
+			to_chat(cultist_upgrader, SPAN_WARNING("You do not have enough blood to do this, the Geometer values you being alive more... For now."))
 			return
 
 		cultist_upgrader.remove_blood_simple((DEFAULT_BLOOD_AMOUNT / 100) * 20) //20% of the default blood volume

--- a/code/game/gamemodes/cult/structures/pylon.dm
+++ b/code/game/gamemodes/cult/structures/pylon.dm
@@ -18,20 +18,31 @@
 	var/pylonmode = PYLON_IDLE
 
 	var/damagetaken = 0
-	var/empowered = FALSE //Number of empowered, higher-damage shots remaining
+
+	///Number of empowered, higher-damage shots remaining
+	var/empowered = 0
+
 	var/mob/living/sacrifice //Holds a reference to a mob that is a pending sacrifice
 	var/mob/living/sacrificer //A reference to the last mob that attempted to sacrifice something. So we can message them
 	//Sacrifier is also used in target handling. the pylon will not bite the hand that feeds it. Noncultist colleagues are fair game though
 
-	var/next_shot = 0 //Absolute world time when we're allowed to fire again
-	var/shot_delay = 5 //Minimum delay between shots, in deciseconds
+	///Absolute world time when we're allowed to fire again
+	var/next_shot = 0
+
+	///Minimum delay between shots, in deciseconds
+	var/shot_delay = 5
+
 	var/mob/living/target
 
-	var/notarget //Number of times handle_firing has been called without finding anything to shoot at
-	//This is used for switching to lower-intensity processing
+	/**
+	 * Number of times handle_firing has been called without finding anything to shoot at
+	 *
+	 * This is used for switching to lower-intensity processing
+	 */
+	var/notarget
 
+	///An instance of the cult language datum. Used to scramble speech when speaking to noncultists
 	var/datum/language/cultcommon/lang
-	//An instance of the cult language datum. Used to scramble speech when speaking to noncultists
 
 	var/turf/last_target_loc
 
@@ -45,12 +56,17 @@
 /obj/structure/cult/pylon/turret
 	pylonmode = PYLON_TURRET
 
-/obj/structure/cult/pylon/turret/New()
-	..()
+/obj/structure/cult/pylon/turret/Initialize()
+	. = ..()
 	start_process()
 
 /obj/structure/cult/pylon/Destroy()
 	STOP_PROCESSING(SSprocessing, src)
+	last_target_loc = null
+	target = null
+	sacrifice = null
+	sacrificer = null
+
 	return ..()
 
 //Another subtype which starts with infinite empower shots. For empowered adminbus
@@ -259,7 +275,7 @@
 	//Stuffcache holds a list of things found by a dview call, so we only need to do it once per proc.
 
 	if(target && target.stat != DEAD)
-		if(target.loc == last_target_loc)
+		if(get_turf(target) == last_target_loc)
 		//To minimise expensive DVIEW calls, if the target hasnt moved since the last shot we'll assume they're still in sight
 		//This could cause problems in some edge cases (like lowering firelocks or shutters without moving)
 		//But it has a major performance gain that makes it worth it
@@ -308,9 +324,7 @@
 
 
 /obj/structure/cult/pylon/proc/fire_at(var/atom/target)
-	//Only store loc if target is on a turf. Otherwise this bugs out with people in exosuits
-	if(istype(target.loc, /turf))
-		last_target_loc = target.loc
+	last_target_loc = get_turf(target.loc)
 
 	process_interval = 1 //Instantly wake up if we found a target
 	var/obj/item/projectile/beam/cult/A
@@ -329,11 +343,32 @@
 	A = null //So projectiles can GC
 	addtimer(CALLBACK(src, PROC_REF(handle_firing)), shot_delay + 1)
 
-/obj/structure/cult/pylon/attack_hand(mob/M)
-	if (M.a_intent == "help")
-		to_chat(M, SPAN_WARNING("The pylon feels warm to the touch..."))
+/obj/structure/cult/pylon/attack_hand(mob/living/user)
+	if (user.a_intent == I_HELP)
+		to_chat(user, SPAN_WARNING("The pylon feels warm to the touch..."))
+
+	else if((user.a_intent == I_DISARM) && (pylonmode != PYLON_TURRET))
+		if(!iscultist(user))
+			return
+
+		var/mob/living/carbon/human/cultist_upgrader = user
+		if(!istype(cultist_upgrader))
+			return
+
+		if(tgui_alert(user, "Do you wish to sacrifice some of your blood to upgrade this pylon?", "Upgrade Pylon", list("Yes", "No")) != "Yes")
+			return
+
+		if(cultist_upgrader.get_blood_volume() < BLOOD_VOLUME_OKAY)
+			to_chat(cultist_upgrader, SPAN_WARNING("You do not have enought blood to do this, the Geometer values you being alive more... For now."))
+			return
+
+		cultist_upgrader.remove_blood_simple((DEFAULT_BLOOD_AMOUNT / 100) * 20) //20% of the default blood volume
+		pylonmode = PYLON_TURRET
+		update_icon()
+		start_process()
+
 	else
-		attackpylon(M, 4, M)
+		attackpylon(user, 4, user)
 
 /obj/structure/cult/pylon/attack_generic(mob/user, damage)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -522,6 +522,7 @@
 
 /obj/item/projectile/bullet/shard/heavy
 	damage = 30
+	armor_penetration = 15
 
 /obj/item/projectile/bullet/recoilless_rifle
 	name = "anti-tank warhead"

--- a/html/changelogs/fluffyghost-cultbuff.yml
+++ b/html/changelogs/fluffyghost-cultbuff.yml
@@ -1,0 +1,61 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a single-use-per-round rune that can convert a mech into a cultist mech, needs 2 minutes to do so and is single use, so max 1 cult mech per round."
+  - balance: "Added the ability to upgrade a pylon into turret mode using the cultist blood, by clicking on the pylon with help intent."
+  - bugfix: "Fixed do_after not using the callbacks at all (because it never passed the parameter to do_after_detailed)."
+  - code_imp: "Some improvements to the pylons and runes code, DMDocs."

--- a/html/changelogs/fluffyghost-cultbuff.yml
+++ b/html/changelogs/fluffyghost-cultbuff.yml
@@ -56,6 +56,6 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - rscadd: "Added a single-use-per-round rune that can convert a mech into a cultist mech, needs 2 minutes to do so and is single use, so max 1 cult mech per round."
-  - balance: "Added the ability to upgrade a pylon into turret mode using the cultist blood, by clicking on the pylon with help intent."
+  - balance: "Added the ability to upgrade a pylon into turret mode using the cultist blood, by clicking on the pylon with disarm intent."
   - bugfix: "Fixed do_after not using the callbacks at all (because it never passed the parameter to do_after_detailed)."
   - code_imp: "Some improvements to the pylons and runes code, DMDocs."


### PR DESCRIPTION
Added a single-use-per-round rune that can convert a mech into a cultist mech, needs 2 minutes to do so and is single use, so max 1 cult mech per round.
Added the ability to upgrade a pylon into turret mode using the cultist blood, by clicking on the pylon with disarm intent.
Fixed do_after not using the callbacks at all (because it never passed the parameter to do_after_detailed).
Some improvements to the pylons and runes code, DMDocs.