### PR TITLE
Hephaestus Asset Protection offship tweaks & fixes

### DIFF
--- a/html/changelogs/hazelmouse - hapt_fixes.yml
+++ b/html/changelogs/hazelmouse - hapt_fixes.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added air alarms to the Hephaestus Security Vessel offship, in addition to a few quality-of-life additions."

--- a/maps/away/ships/heph/heph_security/heph_security.dm
+++ b/maps/away/ships/heph/heph_security/heph_security.dm
@@ -10,7 +10,6 @@
 	ship_cost = 1
 	id = "Hephaestus Security Vessel"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/hephsec_shuttle)
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 	unit_test_groups = list(2)
 

--- a/maps/away/ships/heph/heph_security/heph_security.dm
+++ b/maps/away/ships/heph/heph_security/heph_security.dm
@@ -10,6 +10,7 @@
 	ship_cost = 1
 	id = "Hephaestus Security Vessel"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/hephsec_shuttle)
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 	unit_test_groups = list(2)
 

--- a/maps/away/ships/heph/heph_security/heph_security.dmm
+++ b/maps/away/ships/heph/heph_security/heph_security.dmm
@@ -160,13 +160,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/armory)
-"bc" = (
-/obj/effect/floor_decal/corner_wide/black/diagonal,
-/obj/machinery/computer/ship/targeting{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/heph_security_ship/bridge)
 "be" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 6
@@ -748,12 +741,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/heph_security_ship/grauwolf)
 "fd" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, port thruster"
-	},
-/turf/simulated/floor,
-/area/heph_security_ship/thrusterport)
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/wall/shuttle/raider,
+/area/heph_security_ship/thrusterstarb)
 "ff" = (
 /obj/effect/floor_decal/corner_wide/orange{
 	dir = 4
@@ -776,13 +766,17 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/heph_security_ship/bathroom)
+"fj" = (
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/wood,
+/area/heph_security_ship/kitchen)
 "fk" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, starboard thruster"
+/obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/machinery/computer/ship/targeting{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/heph_security_ship/thrusterstarb)
+/turf/simulated/floor/tiled,
+/area/heph_security_ship/bridge)
 "fl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -887,6 +881,13 @@
 	dir = 10
 	},
 /turf/simulated/floor/airless,
+/area/heph_security_ship/bridge)
+"gc" = (
+/obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
 /area/heph_security_ship/bridge)
 "gg" = (
 /obj/structure/ship_weapon_dummy,
@@ -1540,7 +1541,7 @@
 /obj/item/gun/projectile/automatic/wt550/lethal,
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(216);
-	name = "ballistics"
+	name = "firearms"
 	},
 /obj/item/gun/projectile/automatic/wt550/lethal,
 /obj/item/gun/projectile/sec/lethal,
@@ -1555,6 +1556,10 @@
 	magazine_type = /obj/item/ammo_magazine/a556/carbine
 	},
 /obj/item/gun/projectile/shotgun/pump/combat,
+/obj/item/gun/energy/rifle,
+/obj/item/gun/energy/rifle,
+/obj/item/gun/energy/gun,
+/obj/item/gun/energy/gun,
 /turf/simulated/floor/tiled/dark/full,
 /area/heph_security_ship/armory)
 "kO" = (
@@ -1693,15 +1698,9 @@
 /turf/simulated/floor/carpet/rubber,
 /area/heph_security_ship/brig)
 "lN" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/space/dynamic,
-/area/space)
+/obj/machinery/atmospherics/unary/engine,
+/turf/simulated/floor,
+/area/heph_security_ship/thrusterstarb)
 "lW" = (
 /obj/structure/railing/mapped,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -2178,6 +2177,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/medbay)
+"pf" = (
+/obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/machinery/computer/ship/helm{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/heph_security_ship/bridge)
 "pg" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/nosmoking_1{
@@ -2216,13 +2222,6 @@
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/shuttle/heph_security)
-"pu" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/computer/ship/sensors{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/heph_security_ship/bridge)
 "pv" = (
 /obj/structure/viewport,
 /obj/effect/landmark/entry_point/fore{
@@ -2258,9 +2257,12 @@
 /turf/simulated/floor/wood,
 /area/heph_security_ship)
 "pD" = (
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/white,
-/area/heph_security_ship/medbay)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/turf/space/dynamic,
+/area/space)
 "pE" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -2298,6 +2300,12 @@
 	},
 /turf/simulated/floor,
 /area/heph_security_ship/thrusterport)
+"pK" = (
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/heph_security_ship)
 "pO" = (
 /turf/simulated/floor/tiled/dark,
 /area/heph_security_ship/francisca)
@@ -2325,9 +2333,10 @@
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/brig)
 "qf" = (
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/wood,
-/area/heph_security_ship/kitchen)
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/photocopier,
+/turf/simulated/floor,
+/area/heph_security_ship/bridge)
 "qg" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -2446,11 +2455,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/heph_security_ship/grauwolf)
-"qN" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor,
-/area/shuttle/heph_security)
 "qP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
@@ -2887,6 +2891,9 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
 /turf/space/dynamic,
 /area/space)
 "tU" = (
@@ -3024,19 +3031,20 @@
 /turf/simulated/floor,
 /area/heph_security_ship/grauwolf)
 "uN" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light,
-/obj/structure/table/reinforced/steel,
-/obj/machinery/button/distress{
-	pixel_y = 8
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/securearea{
+	name = "\improper WARNING: HAZARD sign";
+	pixel_y = -32
 	},
-/turf/simulated/floor,
-/area/heph_security_ship/bridge)
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/turf/space/dynamic,
+/area/space)
 "vi" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/table/reinforced/steel,
+/obj/machinery/atmospherics/unary/engine,
 /turf/simulated/floor,
-/area/heph_security_ship/bridge)
+/area/heph_security_ship/thrusterport)
 "vj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
@@ -3070,6 +3078,13 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/heph_security)
+"vn" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/computer/ship/sensors{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/heph_security_ship/bridge)
 "vq" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 9
@@ -3308,17 +3323,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/heph_security_ship/crew)
-"xq" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/papershredder{
-	pixel_x = 6
-	},
-/obj/structure/filingcabinet/filingcabinet{
-	pixel_x = -9;
-	pixel_y = 1
-	},
-/turf/simulated/floor,
-/area/heph_security_ship/bridge)
 "xz" = (
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
@@ -3438,15 +3442,34 @@
 /turf/simulated/floor/tiled,
 /area/heph_security_ship)
 "yy" = (
-/obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(216);
-	name = "energy weapons"
+	name = "armor"
 	},
-/obj/item/gun/energy/gun,
-/obj/item/gun/energy/gun,
-/obj/item/gun/energy/rifle,
-/obj/item/gun/energy/rifle,
+/obj/item/clothing/suit/armor/carrier/ablative,
+/obj/item/clothing/suit/armor/carrier/ablative,
+/obj/item/clothing/glasses/safety/goggles/tactical{
+	brand_name = "Hephaestus Industries"
+	},
+/obj/item/clothing/glasses/safety/goggles/tactical{
+	brand_name = "Hephaestus Industries"
+	},
+/obj/item/clothing/glasses/safety/goggles/tactical{
+	brand_name = "Hephaestus Industries"
+	},
+/obj/item/clothing/glasses/safety/goggles/tactical{
+	brand_name = "Hephaestus Industries"
+	},
+/obj/item/clothing/glasses/safety/goggles/tactical{
+	brand_name = "Hephaestus Industries"
+	},
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/suit/armor/carrier/ballistic,
+/obj/item/clothing/suit/armor/carrier/ballistic,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/heph_security_ship/armory)
 "yF" = (
@@ -3530,11 +3553,12 @@
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/medbay)
 "zP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, port thruster"
 	},
-/turf/simulated/wall/shuttle/space_ship,
-/area/shuttle/heph_security)
+/turf/simulated/floor,
+/area/heph_security_ship/thrusterport)
 "zQ" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/airless,
@@ -3620,6 +3644,10 @@
 /obj/structure/lattice/catwalk,
 /turf/space/dynamic,
 /area/space)
+"Am" = (
+/obj/structure/closet/secure_closet/freezer/kois,
+/turf/template_noop,
+/area/space)
 "Au" = (
 /obj/machinery/telecomms/allinone/ship,
 /obj/machinery/light{
@@ -3652,21 +3680,6 @@
 	},
 /turf/simulated/floor,
 /area/heph_security_ship/atmos)
-"AU" = (
-/obj/effect/floor_decal/corner/orange{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/alarm/west{
-	req_one_access = null;
-	req_access = list(216)
-	},
-/turf/simulated/floor/tiled,
-/area/heph_security_ship)
 "AV" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3751,19 +3764,12 @@
 /turf/space/transit/north,
 /area/space)
 "BA" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/sign/securearea{
-	name = "\improper WARNING: HAZARD sign";
-	pixel_y = -32
-	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/space/dynamic,
-/area/space)
-"BB" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/photocopier,
+/obj/machinery/light,
+/obj/structure/table/reinforced/steel,
+/obj/machinery/photocopier/faxmachine{
+	department = "Hephaestus Asset Protection Vessel"
+	},
 /turf/simulated/floor,
 /area/heph_security_ship/bridge)
 "BF" = (
@@ -3854,6 +3860,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/heph_security_ship/kitchen)
+"Cl" = (
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/tiled/white,
+/area/heph_security_ship/medbay)
 "Cv" = (
 /obj/structure/toilet,
 /obj/structure/curtain/open/shower,
@@ -3914,11 +3924,12 @@
 /turf/simulated/floor/tiled/ramp,
 /area/shuttle/heph_security)
 "CV" = (
-/obj/machinery/door/firedoor/noid{
-	dir = 4
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, starboard thruster"
 	},
-/turf/simulated/floor/tiled,
-/area/heph_security_ship)
+/turf/simulated/floor,
+/area/heph_security_ship/thrusterstarb)
 "Dc" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/pipe/tank{
@@ -4165,6 +4176,16 @@
 /obj/effect/floor_decal/spline/plain/black,
 /turf/simulated/floor/carpet/rubber,
 /area/heph_security_ship/grauwolf)
+"FG" = (
+/obj/structure/closet/crate{
+	name = "Emergency Fuel"
+	},
+/obj/item/tank/hydrogen/shuttle,
+/obj/item/tank/hydrogen/shuttle,
+/obj/item/tank/hydrogen/shuttle,
+/obj/item/tank/hydrogen/shuttle,
+/turf/simulated/floor,
+/area/shuttle/heph_security)
 "FJ" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 6
@@ -4262,9 +4283,15 @@
 /turf/simulated/floor,
 /area/heph_security_ship/atmos)
 "Gf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/wall/shuttle/raider,
-/area/heph_security_ship/thrusterstarb)
+/obj/effect/floor_decal/corner/orange{
+	dir = 5
+	},
+/obj/machinery/alarm/north{
+	req_one_access = null;
+	req_access = list(216)
+	},
+/turf/simulated/floor/tiled,
+/area/heph_security_ship)
 "Gj" = (
 /obj/structure/table/glass,
 /obj/machinery/chemical_dispenser/coffee/full,
@@ -4519,11 +4546,15 @@
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "If" = (
-/obj/effect/floor_decal/corner_wide/black/diagonal,
-/obj/machinery/computer/ship/helm{
-	dir = 1
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/papershredder{
+	pixel_x = 6
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/filingcabinet/filingcabinet{
+	pixel_x = -9;
+	pixel_y = 1
+	},
+/turf/simulated/floor,
 /area/heph_security_ship/bridge)
 "Ig" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -4719,10 +4750,6 @@
 /obj/effect/shuttle_landmark/heph_security/nav4,
 /turf/template_noop,
 /area/space)
-"Jm" = (
-/obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor,
-/area/heph_security_ship/thrusterstarb)
 "Jn" = (
 /turf/simulated/floor/tiled/freezer{
 	name = "cooled tiles";
@@ -4812,6 +4839,11 @@
 	},
 /turf/simulated/floor,
 /area/heph_security_ship/atmos)
+"Kg" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/table/reinforced/steel,
+/turf/simulated/floor,
+/area/heph_security_ship/bridge)
 "Kn" = (
 /obj/effect/floor_decal/corner/dark_blue/diagonal,
 /obj/effect/floor_decal/industrial/warning{
@@ -5308,6 +5340,21 @@
 "NC" = (
 /turf/simulated/floor/airless,
 /area/heph_security_ship/grauwolf)
+"ND" = (
+/obj/effect/floor_decal/corner/orange{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/alarm/west{
+	req_one_access = null;
+	req_access = list(216)
+	},
+/turf/simulated/floor/tiled,
+/area/heph_security_ship)
 "NE" = (
 /obj/effect/floor_decal/spline/plain/black,
 /obj/effect/floor_decal/industrial/outline/security,
@@ -5474,6 +5521,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/dock)
+"OY" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor,
+/area/shuttle/heph_security)
 "Pb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -5481,6 +5533,15 @@
 	},
 /turf/simulated/floor,
 /area/heph_security_ship/engineering)
+"Pd" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light,
+/obj/structure/table/reinforced/steel,
+/obj/machinery/button/distress{
+	pixel_y = 8
+	},
+/turf/simulated/floor,
+/area/heph_security_ship/bridge)
 "Ph" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
@@ -5554,13 +5615,6 @@
 	},
 /turf/simulated/floor,
 /area/heph_security_ship/atmos)
-"PG" = (
-/obj/effect/floor_decal/corner_wide/black/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/heph_security_ship/bridge)
 "PL" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 1
@@ -5652,38 +5706,11 @@
 /turf/simulated/floor/airless,
 /area/space)
 "QJ" = (
+/obj/effect/floor_decal/corner/dark_blue/diagonal,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/guncabinet{
-	req_access = list(216);
-	name = "armor"
-	},
-/obj/item/clothing/suit/armor/carrier/ablative,
-/obj/item/clothing/suit/armor/carrier/ablative,
-/obj/item/clothing/glasses/safety/goggles/tactical{
-	brand_name = "Hephaestus Industries"
-	},
-/obj/item/clothing/glasses/safety/goggles/tactical{
-	brand_name = "Hephaestus Industries"
-	},
-/obj/item/clothing/glasses/safety/goggles/tactical{
-	brand_name = "Hephaestus Industries"
-	},
-/obj/item/clothing/glasses/safety/goggles/tactical{
-	brand_name = "Hephaestus Industries"
-	},
-/obj/item/clothing/glasses/safety/goggles/tactical{
-	brand_name = "Hephaestus Industries"
-	},
-/obj/item/clothing/head/helmet/ablative,
-/obj/item/clothing/head/helmet/ablative,
-/obj/item/clothing/head/helmet/ballistic,
-/obj/item/clothing/head/helmet/ballistic,
-/obj/item/clothing/suit/armor/carrier/ballistic,
-/obj/item/clothing/suit/armor/carrier/ballistic,
-/obj/effect/floor_decal/industrial/hatch/red,
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/floor/tiled,
 /area/heph_security_ship/armory)
 "QR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -5770,15 +5797,16 @@
 /turf/simulated/floor/tiled,
 /area/heph_security_ship)
 "RZ" = (
-/obj/effect/floor_decal/corner/orange{
-	dir = 5
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/mapped{
+	dir = 1
 	},
-/obj/machinery/alarm/north{
-	req_one_access = null;
-	req_access = list(216)
+/obj/structure/sign/securearea{
+	name = "\improper WARNING: HAZARD sign";
+	pixel_y = -32
 	},
-/turf/simulated/floor/tiled,
-/area/heph_security_ship)
+/turf/space/dynamic,
+/area/space)
 "Sb" = (
 /obj/effect/floor_decal/corner/green/full{
 	dir = 4
@@ -5789,16 +5817,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/medbay)
-"Sc" = (
-/obj/structure/closet/crate{
-	name = "Emergency Fuel"
-	},
-/obj/item/tank/hydrogen/shuttle,
-/obj/item/tank/hydrogen/shuttle,
-/obj/item/tank/hydrogen/shuttle,
-/obj/item/tank/hydrogen/shuttle,
-/turf/simulated/floor,
-/area/shuttle/heph_security)
 "Sh" = (
 /obj/machinery/door/blast/regular/open{
 	id = "heph_lockdown";
@@ -6001,16 +6019,11 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/heph_security)
 "TK" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/mapped{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
 	},
-/obj/structure/sign/securearea{
-	name = "\improper WARNING: HAZARD sign";
-	pixel_y = -32
-	},
-/turf/space/dynamic,
-/area/space)
+/turf/simulated/wall/shuttle/space_ship,
+/area/shuttle/heph_security)
 "TQ" = (
 /obj/machinery/door/blast/regular/open{
 	id = "heph_lockdown";
@@ -6591,15 +6604,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/armory)
-"Ym" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light,
-/obj/structure/table/reinforced/steel,
-/obj/machinery/photocopier/faxmachine{
-	department = "Hephaestus Asset Protection Vessel"
-	},
-/turf/simulated/floor,
-/area/heph_security_ship/bridge)
 "Yo" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/window/reinforced{
@@ -6617,10 +6621,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/dock)
-"Yy" = (
-/obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor,
-/area/heph_security_ship/thrusterport)
 "YC" = (
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -6692,10 +6692,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/heph_security_ship/francisca)
-"Zr" = (
-/obj/structure/closet/secure_closet/freezer/kois,
-/turf/template_noop,
-/area/space)
 "Zs" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/decal/cleanable/dirt,
@@ -35449,7 +35445,7 @@ CE
 CE
 CE
 CE
-TK
+RZ
 vZ
 vZ
 vZ
@@ -35707,8 +35703,8 @@ CE
 CE
 CE
 Ag
-Jm
-Gf
+lN
+fd
 aG
 mv
 pw
@@ -35964,8 +35960,8 @@ CE
 CE
 CE
 Ag
-fk
-Gf
+CV
+fd
 kd
 mv
 AT
@@ -35984,7 +35980,7 @@ bC
 Yk
 PC
 KC
-qf
+fj
 yR
 Lc
 Rd
@@ -36221,8 +36217,8 @@ CE
 CE
 CE
 Ag
-Jm
-Gf
+lN
+fd
 ru
 sc
 PF
@@ -36478,8 +36474,8 @@ CE
 CE
 CE
 Ag
-Jm
-Gf
+lN
+fd
 Nv
 mv
 rn
@@ -36734,7 +36730,7 @@ CE
 CE
 CE
 CE
-BA
+uN
 vZ
 vZ
 vZ
@@ -36992,10 +36988,10 @@ CE
 CE
 CE
 PR
-tT
+pD
 Ag
 qP
-tT
+pD
 Ag
 ed
 ed
@@ -37254,9 +37250,9 @@ CE
 CE
 CE
 PR
-tT
+pD
 qP
-tT
+pD
 Ag
 JH
 JH
@@ -37514,10 +37510,10 @@ CE
 CE
 CE
 CE
-lN
 tT
+pD
 qP
-tT
+pD
 Ag
 YC
 Ab
@@ -37525,7 +37521,7 @@ iU
 Ij
 hc
 hc
-AU
+ND
 RX
 gC
 oX
@@ -38277,14 +38273,14 @@ Zb
 cV
 TG
 xz
-qN
+OY
 Fb
 fF
 Zb
 wb
 BJ
 Xy
-zP
+TK
 DW
 QC
 CE
@@ -38302,13 +38298,13 @@ Nh
 Iz
 xN
 VE
-CV
+pK
 mz
 tn
 Wi
 ef
 jc
-vi
+Kg
 tn
 tn
 tn
@@ -38565,7 +38561,7 @@ tn
 SD
 eS
 YJ
-BB
+qf
 tn
 tn
 tn
@@ -38822,7 +38818,7 @@ tn
 Xn
 IC
 VZ
-Ym
+BA
 tn
 tn
 Ag
@@ -39079,7 +39075,7 @@ dU
 Wr
 aj
 Ns
-If
+pf
 tn
 Wj
 CQ
@@ -39334,9 +39330,9 @@ Kw
 LK
 Hw
 VZ
-PG
+gc
 Ns
-bc
+fk
 tn
 tn
 CQ
@@ -39593,7 +39589,7 @@ tn
 rg
 hr
 Vz
-uN
+Pd
 tn
 tn
 Ag
@@ -39825,8 +39821,8 @@ Zb
 Zb
 Kq
 Do
-Sc
-zP
+FG
+TK
 DW
 CE
 CE
@@ -39850,7 +39846,7 @@ tn
 WR
 Fh
 GD
-xq
+If
 tn
 tn
 tn
@@ -40106,8 +40102,8 @@ gG
 tn
 Wi
 fD
-pu
-vi
+vn
+Kg
 tn
 tn
 tn
@@ -40615,7 +40611,7 @@ dA
 ih
 Uc
 dA
-RZ
+Gf
 yw
 Sq
 dJ
@@ -41103,7 +41099,7 @@ CE
 CE
 CE
 CE
-TK
+RZ
 Nm
 Nm
 Nm
@@ -41361,7 +41357,7 @@ CE
 CE
 CE
 Ag
-Yy
+vi
 VK
 zW
 pI
@@ -41618,7 +41614,7 @@ CE
 CE
 CE
 Ag
-Yy
+vi
 VK
 xP
 Wl
@@ -41643,7 +41639,7 @@ dA
 dA
 dA
 dA
-CV
+pK
 mz
 Sq
 fK
@@ -41654,7 +41650,7 @@ mP
 oA
 Zn
 Ag
-tT
+pD
 Lv
 CE
 CE
@@ -41875,7 +41871,7 @@ CE
 CE
 CE
 Ag
-fd
+zP
 VK
 SO
 Nm
@@ -42132,7 +42128,7 @@ CE
 CE
 CE
 Ag
-Yy
+vi
 VK
 eo
 Nm
@@ -42151,7 +42147,7 @@ xW
 DU
 jZ
 WP
-pD
+Cl
 Bt
 jX
 nE
@@ -42388,7 +42384,7 @@ CE
 CE
 CE
 CE
-TK
+RZ
 Nm
 Nm
 Nm
@@ -42645,11 +42641,11 @@ CE
 CE
 CE
 CE
-lN
 tT
-tT
+pD
+pD
 qP
-tT
+pD
 Ag
 lm
 lm
@@ -42908,9 +42904,9 @@ CE
 CE
 CE
 PR
-tT
+pD
 qP
-tT
+pD
 Ag
 Zc
 gI
@@ -42932,11 +42928,11 @@ HO
 oi
 Ry
 Ag
-tT
-tT
+pD
+pD
 qP
-tT
-tT
+pD
+pD
 Lv
 CE
 CE
@@ -43169,9 +43165,9 @@ CE
 CE
 CE
 PR
-tT
+pD
 qP
-tT
+pD
 Ag
 rl
 rl
@@ -43181,8 +43177,8 @@ Sh
 rl
 rl
 Ag
-tT
-tT
+pD
+pD
 Ag
 DD
 VH
@@ -43430,13 +43426,13 @@ CE
 CE
 CE
 PR
-tT
-tT
-tT
+pD
+pD
+pD
 qP
-tT
-tT
-tT
+pD
+pD
+pD
 Lv
 CE
 CE
@@ -49339,7 +49335,7 @@ CE
 CE
 CE
 CE
-Zr
+Am
 CE
 CE
 CE

--- a/maps/away/ships/heph/heph_security/heph_security.dmm
+++ b/maps/away/ships/heph/heph_security/heph_security.dmm
@@ -766,17 +766,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/heph_security_ship/bathroom)
-"fj" = (
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/wood,
-/area/heph_security_ship/kitchen)
-"fk" = (
-/obj/effect/floor_decal/corner_wide/black/diagonal,
-/obj/machinery/computer/ship/targeting{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/heph_security_ship/bridge)
 "fl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -882,13 +871,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/heph_security_ship/bridge)
-"gc" = (
-/obj/effect/floor_decal/corner_wide/black/diagonal,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/heph_security_ship/bridge)
 "gg" = (
 /obj/structure/ship_weapon_dummy,
 /turf/simulated/floor/airless,
@@ -940,6 +922,13 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/heph_security)
+"gE" = (
+/obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/heph_security_ship/bridge)
 "gG" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 10
@@ -1571,6 +1560,13 @@
 /obj/structure/ship_weapon_dummy,
 /turf/simulated/floor/airless,
 /area/heph_security_ship/francisca)
+"kP" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/computer/ship/sensors{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/heph_security_ship/bridge)
 "kR" = (
 /obj/structure/railing/mapped,
 /obj/structure/table/reinforced/steel,
@@ -1658,6 +1654,17 @@
 /obj/machinery/door/firedoor/noid,
 /turf/simulated/floor,
 /area/heph_security_ship/engineering)
+"lu" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/papershredder{
+	pixel_x = 6
+	},
+/obj/structure/filingcabinet/filingcabinet{
+	pixel_x = -9;
+	pixel_y = 1
+	},
+/turf/simulated/floor,
+/area/heph_security_ship/bridge)
 "lv" = (
 /obj/structure/railing/mapped,
 /obj/structure/flora/ausbushes/brflowers,
@@ -1698,9 +1705,12 @@
 /turf/simulated/floor/carpet/rubber,
 /area/heph_security_ship/brig)
 "lN" = (
-/obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor,
-/area/heph_security_ship/thrusterstarb)
+/obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/machinery/computer/ship/helm{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/heph_security_ship/bridge)
 "lW" = (
 /obj/structure/railing/mapped,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -2177,13 +2187,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/medbay)
-"pf" = (
-/obj/effect/floor_decal/corner_wide/black/diagonal,
-/obj/machinery/computer/ship/helm{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/heph_security_ship/bridge)
 "pg" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/nosmoking_1{
@@ -2300,12 +2303,6 @@
 	},
 /turf/simulated/floor,
 /area/heph_security_ship/thrusterport)
-"pK" = (
-/obj/machinery/door/firedoor/noid{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/heph_security_ship)
 "pO" = (
 /turf/simulated/floor/tiled/dark,
 /area/heph_security_ship/francisca)
@@ -2333,10 +2330,11 @@
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/brig)
 "qf" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/photocopier,
-/turf/simulated/floor,
-/area/heph_security_ship/bridge)
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/heph_security_ship)
 "qg" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -3031,20 +3029,25 @@
 /turf/simulated/floor,
 /area/heph_security_ship/grauwolf)
 "uN" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/sign/securearea{
-	name = "\improper WARNING: HAZARD sign";
-	pixel_y = -32
+/obj/effect/floor_decal/corner/orange{
+	dir = 9
 	},
-/obj/structure/railing/mapped{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/turf/space/dynamic,
-/area/space)
+/obj/machinery/alarm/west{
+	req_one_access = null;
+	req_access = list(216)
+	},
+/turf/simulated/floor/tiled,
+/area/heph_security_ship)
 "vi" = (
-/obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor,
-/area/heph_security_ship/thrusterport)
+/obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/structure/bed/stool/chair/office/bridge/generic,
+/turf/simulated/floor/tiled,
+/area/heph_security_ship/bridge)
 "vj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
@@ -3078,13 +3081,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/heph_security)
-"vn" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/computer/ship/sensors{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/heph_security_ship/bridge)
 "vq" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 9
@@ -3403,9 +3399,7 @@
 /area/heph_security_ship)
 "xU" = (
 /obj/effect/map_effect/window_spawner/full/reinforced/grille,
-/obj/machinery/door/firedoor/noid{
-	dir = 4
-	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "xW" = (
@@ -3553,12 +3547,12 @@
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/medbay)
 "zP" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, port thruster"
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
 	},
 /turf/simulated/floor,
-/area/heph_security_ship/thrusterport)
+/area/shuttle/heph_security)
 "zQ" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/airless,
@@ -3644,10 +3638,15 @@
 /obj/structure/lattice/catwalk,
 /turf/space/dynamic,
 /area/space)
-"Am" = (
-/obj/structure/closet/secure_closet/freezer/kois,
-/turf/template_noop,
-/area/space)
+"Aj" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light,
+/obj/structure/table/reinforced/steel,
+/obj/machinery/photocopier/faxmachine{
+	department = "Hephaestus Asset Protection Vessel"
+	},
+/turf/simulated/floor,
+/area/heph_security_ship/bridge)
 "Au" = (
 /obj/machinery/telecomms/allinone/ship,
 /obj/machinery/light{
@@ -3764,14 +3763,9 @@
 /turf/space/transit/north,
 /area/space)
 "BA" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light,
-/obj/structure/table/reinforced/steel,
-/obj/machinery/photocopier/faxmachine{
-	department = "Hephaestus Asset Protection Vessel"
-	},
+/obj/machinery/atmospherics/unary/engine,
 /turf/simulated/floor,
-/area/heph_security_ship/bridge)
+/area/heph_security_ship/thrusterstarb)
 "BF" = (
 /obj/effect/floor_decal/corner/dark_blue/diagonal,
 /obj/structure/table/reinforced/steel,
@@ -3860,10 +3854,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/heph_security_ship/kitchen)
-"Cl" = (
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor/tiled/white,
-/area/heph_security_ship/medbay)
 "Cv" = (
 /obj/structure/toilet,
 /obj/structure/curtain/open/shower,
@@ -3924,12 +3914,10 @@
 /turf/simulated/floor/tiled/ramp,
 /area/shuttle/heph_security)
 "CV" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, starboard thruster"
-	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/table/reinforced/steel,
 /turf/simulated/floor,
-/area/heph_security_ship/thrusterstarb)
+/area/heph_security_ship/bridge)
 "Dc" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/pipe/tank{
@@ -4170,22 +4158,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship)
+"FB" = (
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, starboard thruster"
+	},
+/turf/simulated/floor,
+/area/heph_security_ship/thrusterstarb)
 "FF" = (
 /obj/machinery/computer/ship/targeting,
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/spline/plain/black,
 /turf/simulated/floor/carpet/rubber,
 /area/heph_security_ship/grauwolf)
-"FG" = (
-/obj/structure/closet/crate{
-	name = "Emergency Fuel"
-	},
-/obj/item/tank/hydrogen/shuttle,
-/obj/item/tank/hydrogen/shuttle,
-/obj/item/tank/hydrogen/shuttle,
-/obj/item/tank/hydrogen/shuttle,
-/turf/simulated/floor,
-/area/shuttle/heph_security)
 "FJ" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 6
@@ -4283,15 +4268,9 @@
 /turf/simulated/floor,
 /area/heph_security_ship/atmos)
 "Gf" = (
-/obj/effect/floor_decal/corner/orange{
-	dir = 5
-	},
-/obj/machinery/alarm/north{
-	req_one_access = null;
-	req_access = list(216)
-	},
-/turf/simulated/floor/tiled,
-/area/heph_security_ship)
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/wood,
+/area/heph_security_ship/kitchen)
 "Gj" = (
 /obj/structure/table/glass,
 /obj/machinery/chemical_dispenser/coffee/full,
@@ -4335,6 +4314,16 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/heph_security_ship)
+"GN" = (
+/obj/structure/closet/crate{
+	name = "Emergency Fuel"
+	},
+/obj/item/tank/hydrogen/shuttle,
+/obj/item/tank/hydrogen/shuttle,
+/obj/item/tank/hydrogen/shuttle,
+/obj/item/tank/hydrogen/shuttle,
+/turf/simulated/floor,
+/area/shuttle/heph_security)
 "Ha" = (
 /obj/effect/floor_decal/spline/plain/black,
 /turf/simulated/floor/wood,
@@ -4546,16 +4535,12 @@
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "If" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/papershredder{
-	pixel_x = 6
-	},
-/obj/structure/filingcabinet/filingcabinet{
-	pixel_x = -9;
-	pixel_y = 1
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, port thruster"
 	},
 /turf/simulated/floor,
-/area/heph_security_ship/bridge)
+/area/heph_security_ship/thrusterport)
 "Ig" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -4839,11 +4824,6 @@
 	},
 /turf/simulated/floor,
 /area/heph_security_ship/atmos)
-"Kg" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/table/reinforced/steel,
-/turf/simulated/floor,
-/area/heph_security_ship/bridge)
 "Kn" = (
 /obj/effect/floor_decal/corner/dark_blue/diagonal,
 /obj/effect/floor_decal/industrial/warning{
@@ -5134,6 +5114,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship)
+"LN" = (
+/obj/effect/floor_decal/corner/orange{
+	dir = 5
+	},
+/obj/machinery/alarm/north{
+	req_one_access = null;
+	req_access = list(216)
+	},
+/turf/simulated/floor/tiled,
+/area/heph_security_ship)
 "LY" = (
 /obj/structure/table/reinforced/steel,
 /obj/item/clothing/head/helmet/pilot{
@@ -5313,10 +5303,9 @@
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/medbay)
 "Ns" = (
-/obj/effect/floor_decal/corner_wide/black/diagonal,
-/obj/structure/bed/stool/chair/office/bridge/generic,
-/turf/simulated/floor/tiled,
-/area/heph_security_ship/bridge)
+/obj/machinery/atmospherics/unary/engine,
+/turf/simulated/floor,
+/area/heph_security_ship/thrusterport)
 "Nv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -5340,21 +5329,6 @@
 "NC" = (
 /turf/simulated/floor/airless,
 /area/heph_security_ship/grauwolf)
-"ND" = (
-/obj/effect/floor_decal/corner/orange{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/alarm/west{
-	req_one_access = null;
-	req_access = list(216)
-	},
-/turf/simulated/floor/tiled,
-/area/heph_security_ship)
 "NE" = (
 /obj/effect/floor_decal/spline/plain/black,
 /obj/effect/floor_decal/industrial/outline/security,
@@ -5521,11 +5495,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/dock)
-"OY" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
-/obj/machinery/door/firedoor/noid,
-/turf/simulated/floor,
-/area/shuttle/heph_security)
 "Pb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -5533,15 +5502,6 @@
 	},
 /turf/simulated/floor,
 /area/heph_security_ship/engineering)
-"Pd" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light,
-/obj/structure/table/reinforced/steel,
-/obj/machinery/button/distress{
-	pixel_y = 8
-	},
-/turf/simulated/floor,
-/area/heph_security_ship/bridge)
 "Ph" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
@@ -5626,6 +5586,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/heph_security_ship/kitchen)
+"PM" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/securearea{
+	name = "\improper WARNING: HAZARD sign";
+	pixel_y = -32
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/turf/space/dynamic,
+/area/space)
 "PN" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -5797,16 +5768,9 @@
 /turf/simulated/floor/tiled,
 /area/heph_security_ship)
 "RZ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/sign/securearea{
-	name = "\improper WARNING: HAZARD sign";
-	pixel_y = -32
-	},
-/turf/space/dynamic,
-/area/space)
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/tiled/white,
+/area/heph_security_ship/medbay)
 "Sb" = (
 /obj/effect/floor_decal/corner/green/full{
 	dir = 4
@@ -6180,6 +6144,13 @@
 "Vt" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/heph_security_ship/crew)
+"Vu" = (
+/obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/machinery/computer/ship/targeting{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/heph_security_ship/bridge)
 "Vy" = (
 /obj/effect/floor_decal/corner_wide/orange{
 	dir = 6
@@ -6286,6 +6257,17 @@
 	},
 /turf/simulated/floor,
 /area/heph_security_ship)
+"VR" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/structure/sign/securearea{
+	name = "\improper WARNING: HAZARD sign";
+	pixel_y = -32
+	},
+/turf/space/dynamic,
+/area/space)
 "VW" = (
 /obj/machinery/door/firedoor/noid{
 	dir = 4
@@ -6296,6 +6278,11 @@
 "VZ" = (
 /obj/effect/floor_decal/corner_wide/black/diagonal,
 /turf/simulated/floor/tiled,
+/area/heph_security_ship/bridge)
+"Wg" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/photocopier,
+/turf/simulated/floor,
 /area/heph_security_ship/bridge)
 "Wi" = (
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -6692,6 +6679,15 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/heph_security_ship/francisca)
+"Zq" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light,
+/obj/structure/table/reinforced/steel,
+/obj/machinery/button/distress{
+	pixel_y = 8
+	},
+/turf/simulated/floor,
+/area/heph_security_ship/bridge)
 "Zs" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/decal/cleanable/dirt,
@@ -35445,7 +35441,7 @@ CE
 CE
 CE
 CE
-RZ
+VR
 vZ
 vZ
 vZ
@@ -35703,7 +35699,7 @@ CE
 CE
 CE
 Ag
-lN
+BA
 fd
 aG
 mv
@@ -35960,7 +35956,7 @@ CE
 CE
 CE
 Ag
-CV
+FB
 fd
 kd
 mv
@@ -35980,7 +35976,7 @@ bC
 Yk
 PC
 KC
-fj
+Gf
 yR
 Lc
 Rd
@@ -36217,7 +36213,7 @@ CE
 CE
 CE
 Ag
-lN
+BA
 fd
 ru
 sc
@@ -36474,7 +36470,7 @@ CE
 CE
 CE
 Ag
-lN
+BA
 fd
 Nv
 mv
@@ -36730,7 +36726,7 @@ CE
 CE
 CE
 CE
-uN
+PM
 vZ
 vZ
 vZ
@@ -37521,7 +37517,7 @@ iU
 Ij
 hc
 hc
-ND
+uN
 RX
 gC
 oX
@@ -38273,7 +38269,7 @@ Zb
 cV
 TG
 xz
-OY
+xU
 Fb
 fF
 Zb
@@ -38298,13 +38294,13 @@ Nh
 Iz
 xN
 VE
-pK
+qf
 mz
 tn
 Wi
 ef
 jc
-Kg
+CV
 tn
 tn
 tn
@@ -38561,7 +38557,7 @@ tn
 SD
 eS
 YJ
-qf
+Wg
 tn
 tn
 tn
@@ -38788,8 +38784,8 @@ oR
 Ac
 rW
 Zb
-xU
-xU
+zP
+zP
 Zb
 MB
 dQ
@@ -38818,7 +38814,7 @@ tn
 Xn
 IC
 VZ
-BA
+Aj
 tn
 tn
 Ag
@@ -39074,8 +39070,8 @@ Af
 dU
 Wr
 aj
-Ns
-pf
+vi
+lN
 tn
 Wj
 CQ
@@ -39330,9 +39326,9 @@ Kw
 LK
 Hw
 VZ
-gc
-Ns
-fk
+gE
+vi
+Vu
 tn
 tn
 CQ
@@ -39589,7 +39585,7 @@ tn
 rg
 hr
 Vz
-Pd
+Zq
 tn
 tn
 Ag
@@ -39821,7 +39817,7 @@ Zb
 Zb
 Kq
 Do
-FG
+GN
 TK
 DW
 CE
@@ -39846,7 +39842,7 @@ tn
 WR
 Fh
 GD
-If
+lu
 tn
 tn
 tn
@@ -40102,8 +40098,8 @@ gG
 tn
 Wi
 fD
-vn
-Kg
+kP
+CV
 tn
 tn
 tn
@@ -40611,7 +40607,7 @@ dA
 ih
 Uc
 dA
-Gf
+LN
 yw
 Sq
 dJ
@@ -41099,7 +41095,7 @@ CE
 CE
 CE
 CE
-RZ
+VR
 Nm
 Nm
 Nm
@@ -41357,7 +41353,7 @@ CE
 CE
 CE
 Ag
-vi
+Ns
 VK
 zW
 pI
@@ -41614,7 +41610,7 @@ CE
 CE
 CE
 Ag
-vi
+Ns
 VK
 xP
 Wl
@@ -41639,7 +41635,7 @@ dA
 dA
 dA
 dA
-pK
+qf
 mz
 Sq
 fK
@@ -41871,7 +41867,7 @@ CE
 CE
 CE
 Ag
-zP
+If
 VK
 SO
 Nm
@@ -42128,7 +42124,7 @@ CE
 CE
 CE
 Ag
-vi
+Ns
 VK
 eo
 Nm
@@ -42147,7 +42143,7 @@ xW
 DU
 jZ
 WP
-Cl
+RZ
 Bt
 jX
 nE
@@ -42384,7 +42380,7 @@ CE
 CE
 CE
 CE
-RZ
+VR
 Nm
 Nm
 Nm
@@ -49335,7 +49331,7 @@ CE
 CE
 CE
 CE
-Am
+CE
 CE
 CE
 CE

--- a/maps/away/ships/heph/heph_security/heph_security.dmm
+++ b/maps/away/ships/heph/heph_security/heph_security.dmm
@@ -1,14 +1,16 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "af" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "heph_lockdown";
 	name = "blast door"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor,
 /area/heph_security_ship/kitchen)
 "aj" = (
-/obj/effect/floor_decal/corner_wide/black/diagonal,
 /obj/effect/overmap/visitable/ship/heph_security,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -19,9 +21,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/machinery/hologram/holopad/long_range{
-	pixel_x = 16
-	},
+/obj/machinery/hologram/holopad/long_range,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/bridge)
 "ao" = (
@@ -83,6 +84,10 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/south{
+	req_access = list(216)
+	},
+/obj/machinery/alarm/west{
+	req_one_access = null;
 	req_access = list(216)
 	},
 /turf/simulated/floor,
@@ -155,6 +160,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/armory)
+"bc" = (
+/obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/machinery/computer/ship/targeting{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/heph_security_ship/bridge)
 "be" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 6
@@ -199,6 +211,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/dock)
 "bz" = (
@@ -223,6 +238,7 @@
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/kitchen)
 "bC" = (
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/heph_security_ship/crew)
 "bF" = (
@@ -238,22 +254,11 @@
 /area/heph_security_ship/engineering)
 "bG" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
-/obj/machinery/door/window,
-/obj/structure/table/rack{
-	pixel_x = 32
-	},
-/obj/random/soap{
-	pixel_x = 32
-	},
-/obj/item/towel/random{
-	pixel_x = 32
-	},
-/obj/random/soap{
-	pixel_x = 32
-	},
-/obj/item/towel/random{
-	pixel_x = 32
-	},
+/obj/structure/table/rack,
+/obj/random/soap,
+/obj/random/soap,
+/obj/item/towel/random,
+/obj/item/towel/random,
 /turf/simulated/floor/tiled/freezer,
 /area/heph_security_ship/bathroom)
 "bH" = (
@@ -340,6 +345,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/grauwolf)
 "cq" = (
@@ -350,7 +356,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "cz" = (
 /obj/effect/landmark/entry_point/starboard{
@@ -390,6 +396,10 @@
 	},
 /obj/structure/sign/flag/heph/large/north{
 	pixel_y = 32
+	},
+/obj/machinery/alarm/west{
+	req_one_access = null;
+	req_access = list(216)
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/heph_security_ship/grauwolf)
@@ -442,6 +452,9 @@
 /obj/item/clothing/accessory/holster/hip/brown,
 /obj/item/clothing/accessory/holster/hip/brown,
 /obj/structure/closet/cabinet,
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
 /turf/simulated/floor/carpet,
 /area/heph_security_ship/crew)
 "dv" = (
@@ -497,6 +510,10 @@
 /obj/structure/sign/flag/heph/large/north{
 	pixel_y = 32
 	},
+/obj/machinery/alarm/west{
+	req_one_access = null;
+	req_access = list(216)
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/heph_security_ship/francisca)
 "dK" = (
@@ -513,6 +530,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -540,6 +560,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/bridge)
 "eb" = (
@@ -569,10 +590,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/heph_security_ship/francisca)
 "ef" = (
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/computer/ship/navigation{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/west{
+	req_access = list(216)
+	},
 /turf/simulated/floor,
 /area/heph_security_ship/bridge)
 "ej" = (
@@ -667,7 +694,6 @@
 /turf/simulated/floor/wood,
 /area/heph_security_ship/kitchen)
 "eQ" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "heph_lockdown";
 	name = "blast door"
@@ -675,6 +701,10 @@
 /obj/effect/landmark/entry_point/port{
 	name = "port, medical"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor,
 /area/heph_security_ship/medbay)
 "eR" = (
@@ -687,10 +717,13 @@
 /turf/simulated/floor/wood,
 /area/heph_security_ship/kitchen)
 "eS" = (
-/obj/structure/bed/stool/chair/office/bridge/generic{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/bed/handrail,
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/bridge)
 "eV" = (
@@ -716,9 +749,11 @@
 /area/heph_security_ship/grauwolf)
 "fd" = (
 /obj/machinery/atmospherics/unary/engine,
-/obj/structure/window/borosilicate/reinforced,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, port thruster"
+	},
 /turf/simulated/floor,
-/area/heph_security_ship/thrusterstarb)
+/area/heph_security_ship/thrusterport)
 "ff" = (
 /obj/effect/floor_decal/corner_wide/orange{
 	dir = 4
@@ -741,6 +776,13 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/heph_security_ship/bathroom)
+"fk" = (
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, starboard thruster"
+	},
+/turf/simulated/floor,
+/area/heph_security_ship/thrusterstarb)
 "fl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -756,7 +798,6 @@
 /turf/simulated/floor/wood,
 /area/heph_security_ship/kitchen)
 "fo" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "heph_lockdown";
 	name = "blast door"
@@ -764,6 +805,10 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, captain's quarters"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor,
 /area/heph_security_ship/captain)
 "fx" = (
@@ -785,10 +830,10 @@
 /turf/simulated/floor/wood,
 /area/heph_security_ship/kitchen)
 "fD" = (
-/obj/machinery/computer/ship/sensors{
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/computer/ship/targeting{
 	dir = 8
 	},
-/obj/structure/lattice/catwalk/indoor/grate,
 /turf/simulated/floor,
 /area/heph_security_ship/bridge)
 "fF" = (
@@ -1036,6 +1081,9 @@
 /turf/simulated/floor,
 /area/heph_security_ship/engineering)
 "hY" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/heph_security_ship/atmos)
 "ia" = (
@@ -1065,6 +1113,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/full,
@@ -1132,9 +1183,6 @@
 	pixel_y = 16
 	},
 /obj/item/bedsheet/orange,
-/obj/structure/sign/poster{
-	pixel_y = 32
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -1159,17 +1207,17 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/dock)
 "ix" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
 /obj/machinery/shower{
 	pixel_y = 20
 	},
+/obj/structure/curtain/open/shower,
 /turf/simulated/floor/tiled/freezer,
 /area/heph_security_ship/bathroom)
 "iD" = (
@@ -1237,6 +1285,9 @@
 /area/heph_security_ship/atmos)
 "jc" = (
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/computer/ship/engines{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/heph_security_ship/bridge)
 "jq" = (
@@ -1304,7 +1355,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "jR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1314,11 +1365,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/heph_security_ship/grauwolf)
 "jT" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "heph_lockdown";
 	name = "blast door"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor,
 /area/heph_security_ship)
 "jU" = (
@@ -1596,6 +1650,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor,
 /area/heph_security_ship/engineering)
 "lv" = (
@@ -1634,14 +1689,19 @@
 	id = "heph_lockdown";
 	name = "blast door"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/carpet/rubber,
 /area/heph_security_ship/brig)
 "lN" = (
-/obj/machinery/light{
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/heph_security_ship/crew)
+/turf/space/dynamic,
+/area/space)
 "lW" = (
 /obj/structure/railing/mapped,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -1751,6 +1811,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship)
 "mE" = (
@@ -1789,6 +1852,10 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/alarm/west{
+	req_one_access = null;
+	req_access = list(216)
+	},
 /turf/simulated/floor/wood,
 /area/heph_security_ship/crew)
 "nb" = (
@@ -1799,7 +1866,6 @@
 /turf/simulated/floor,
 /area/heph_security_ship/engineering)
 "nc" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "heph_lockdown";
 	name = "blast door"
@@ -1807,6 +1873,10 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, crew bunks"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor,
 /area/heph_security_ship/crew)
 "np" = (
@@ -1817,7 +1887,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/suit_cycler/offship/hephaestus,
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/armory)
 "nt" = (
@@ -1857,6 +1926,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor,
 /area/heph_security_ship/medbay)
 "nP" = (
@@ -1895,6 +1965,7 @@
 	id = "heph_lockdown";
 	name = "blast door"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/carpet/rubber,
 /area/heph_security_ship/brig)
 "ob" = (
@@ -1973,6 +2044,9 @@
 /obj/item/clothing/accessory/holster/hip/brown,
 /obj/item/clothing/accessory/holster/hip/brown,
 /obj/structure/closet/cabinet,
+/obj/structure/sign/poster{
+	pixel_y = 32
+	},
 /turf/simulated/floor/carpet,
 /area/heph_security_ship/crew)
 "oA" = (
@@ -2139,8 +2213,16 @@
 	dir = 1;
 	req_access = list(216)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/shuttle/heph_security)
+"pu" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/computer/ship/sensors{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/heph_security_ship/bridge)
 "pv" = (
 /obj/structure/viewport,
 /obj/effect/landmark/entry_point/fore{
@@ -2163,6 +2245,10 @@
 /obj/item/tank/oxygen,
 /obj/item/clothing/mask/breath/medical,
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/alarm/north{
+	req_one_access = null;
+	req_access = list(216)
+	},
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/medbay)
 "py" = (
@@ -2172,12 +2258,9 @@
 /turf/simulated/floor/wood,
 /area/heph_security_ship)
 "pD" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/turf/template_noop,
-/area/space)
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/tiled/white,
+/area/heph_security_ship/medbay)
 "pE" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -2199,6 +2282,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/armory)
@@ -2235,17 +2321,13 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/brig)
 "qf" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/structure/cable/green,
-/obj/machinery/power/apc/south{
-	req_access = list(216)
-	},
-/obj/machinery/light,
-/turf/simulated/floor,
-/area/heph_security_ship/bridge)
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor/wood,
+/area/heph_security_ship/kitchen)
 "qg" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -2272,6 +2354,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/heph_security_ship/crew)
 "ql" = (
@@ -2363,6 +2446,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/heph_security_ship/grauwolf)
+"qN" = (
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/firedoor/noid,
+/turf/simulated/floor,
+/area/shuttle/heph_security)
 "qP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped{
@@ -2411,6 +2499,7 @@
 	name = "Freezer"
 	},
 /obj/structure/plasticflaps/airtight,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/freezer{
 	name = "cooled tiles";
 	temperature = 253.15
@@ -2451,6 +2540,19 @@
 /obj/structure/sign/flag/heph{
 	pixel_y = 32;
 	stand_icon = null
+	},
+/obj/structure/table/reinforced/steel,
+/obj/item/paper_bin{
+	pixel_y = 4;
+	pixel_x = 4
+	},
+/obj/item/pen/black{
+	pixel_y = 4;
+	pixel_x = 3
+	},
+/obj/item/stamp/hephaestus{
+	pixel_x = -7;
+	pixel_y = 4
 	},
 /turf/simulated/floor,
 /area/heph_security_ship/bridge)
@@ -2507,9 +2609,6 @@
 /obj/item/bedsheet/orange,
 /obj/item/bedsheet/orange{
 	pixel_y = 16
-	},
-/obj/structure/sign/poster{
-	pixel_y = 32
 	},
 /obj/machinery/light{
 	dir = 1
@@ -2626,6 +2725,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor,
 /area/heph_security_ship/thrusterstarb)
 "sh" = (
@@ -2642,6 +2742,10 @@
 /obj/item/clothing/accessory/holster/hip/brown,
 /obj/item/clothing/under/rank/captain/hephaestus,
 /obj/structure/closet/cabinet,
+/obj/machinery/alarm/south{
+	req_one_access = null;
+	req_access = list(216)
+	},
 /turf/simulated/floor/carpet,
 /area/heph_security_ship/captain)
 "sw" = (
@@ -2663,10 +2767,11 @@
 /turf/simulated/floor,
 /area/heph_security_ship/engineering)
 "sx" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/shutters/open{
 	id = "heph_shuttle_shutters"
 	},
+/obj/machinery/door/firedoor/noid,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "sz" = (
@@ -2712,6 +2817,10 @@
 	},
 /obj/effect/floor_decal/corner/orange{
 	dir = 10
+	},
+/obj/machinery/alarm/south{
+	req_one_access = null;
+	req_access = list(216)
 	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/dock)
@@ -2768,6 +2877,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/dock)
 "tT" = (
@@ -2775,10 +2887,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "tU" = (
 /obj/structure/sign/securearea{
@@ -2902,7 +3011,7 @@
 	dir = 8
 	},
 /obj/structure/railing/mapped,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "uJ" = (
 /obj/machinery/computer/shuttle_control/explore/hephsec_shuttle,
@@ -2915,20 +3024,18 @@
 /turf/simulated/floor,
 /area/heph_security_ship/grauwolf)
 "uN" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/structure/window/borosilicate/reinforced,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, port thruster"
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light,
+/obj/structure/table/reinforced/steel,
+/obj/machinery/button/distress{
+	pixel_y = 8
 	},
 /turf/simulated/floor,
-/area/heph_security_ship/thrusterport)
+/area/heph_security_ship/bridge)
 "vi" = (
+/obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/table/reinforced/steel,
-/obj/effect/floor_decal/corner_wide/black/diagonal,
-/obj/machinery/photocopier/faxmachine{
-	department = "Hephaestus Asset Protection Vessel"
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor,
 /area/heph_security_ship/bridge)
 "vj" = (
 /obj/structure/lattice/catwalk,
@@ -2961,7 +3068,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/heph_security)
 "vq" = (
 /obj/effect/floor_decal/corner/black{
@@ -3005,6 +3112,7 @@
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 10
 	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor/wood,
 /area/heph_security_ship/kitchen)
 "vy" = (
@@ -3131,6 +3239,10 @@
 "wD" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/dispenser/oxygen,
+/obj/machinery/alarm/east{
+	req_one_access = null;
+	req_access = list(216)
+	},
 /turf/simulated/floor,
 /area/heph_security_ship/armory)
 "wG" = (
@@ -3196,6 +3308,17 @@
 	},
 /turf/simulated/floor/carpet,
 /area/heph_security_ship/crew)
+"xq" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/papershredder{
+	pixel_x = 6
+	},
+/obj/structure/filingcabinet/filingcabinet{
+	pixel_x = -9;
+	pixel_y = 1
+	},
+/turf/simulated/floor,
+/area/heph_security_ship/bridge)
 "xz" = (
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
@@ -3268,10 +3391,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/machinery/alarm/west{
+	req_one_access = null;
+	req_access = list(216)
+	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship)
 "xU" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "xW" = (
@@ -3344,6 +3474,10 @@
 	pixel_y = 32;
 	stand_icon = null
 	},
+/obj/machinery/alarm/west{
+	req_one_access = null;
+	req_access = list(216)
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/heph_security_ship/brig)
 "yM" = (
@@ -3370,7 +3504,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "zK" = (
 /obj/machinery/door/airlock/hatch{
@@ -3384,6 +3518,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor,
 /area/heph_security_ship)
 "zL" = (
@@ -3398,14 +3533,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
-/obj/structure/closet/crate{
-	name = "Emergency Fuel"
-	},
-/obj/item/tank/hydrogen/shuttle,
-/obj/item/tank/hydrogen/shuttle,
-/obj/item/tank/hydrogen/shuttle,
-/obj/item/tank/hydrogen/shuttle,
-/turf/simulated/floor,
+/turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/heph_security)
 "zQ" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -3416,6 +3544,10 @@
 /obj/structure/toilet{
 	dir = 8
 	},
+/obj/machinery/alarm/south{
+	req_one_access = null;
+	req_access = list(216)
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/heph_security_ship/bathroom)
 "zW" = (
@@ -3424,6 +3556,10 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/machinery/alarm/west{
+	req_one_access = null;
+	req_access = list(216)
 	},
 /turf/simulated/floor,
 /area/heph_security_ship/thrusterport)
@@ -3482,7 +3618,7 @@
 /area/heph_security_ship)
 "Ag" = (
 /obj/structure/lattice/catwalk,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "Au" = (
 /obj/machinery/telecomms/allinone/ship,
@@ -3509,8 +3645,28 @@
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/portables_connector{
+	layer = 2.8;
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/heph_security_ship/atmos)
+"AU" = (
+/obj/effect/floor_decal/corner/orange{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/alarm/west{
+	req_one_access = null;
+	req_access = list(216)
+	},
+/turf/simulated/floor/tiled,
+/area/heph_security_ship)
 "AV" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3570,6 +3726,10 @@
 /obj/item/reagent_containers/food/snacks/fish,
 /obj/item/reagent_containers/food/snacks/fish,
 /obj/item/reagent_containers/food/snacks/fish,
+/obj/machinery/alarm/freezer/west{
+	req_one_access = null;
+	req_access = list(216)
+	},
 /turf/simulated/floor/tiled/freezer{
 	name = "cooled tiles";
 	temperature = 253.15
@@ -3591,7 +3751,20 @@
 /turf/space/transit/north,
 /area/space)
 "BA" = (
-/turf/simulated/floor/foamedmetal,
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/securearea{
+	name = "\improper WARNING: HAZARD sign";
+	pixel_y = -32
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/turf/space/dynamic,
+/area/space)
+"BB" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/photocopier,
+/turf/simulated/floor,
 /area/heph_security_ship/bridge)
 "BF" = (
 /obj/effect/floor_decal/corner/dark_blue/diagonal,
@@ -3634,11 +3807,14 @@
 /turf/simulated/floor,
 /area/heph_security_ship/atmos)
 "BR" = (
-/obj/structure/table/wood,
-/obj/item/device/flashlight/lamp/lava/orange,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
+/obj/machinery/alarm/north{
+	req_one_access = null;
+	req_access = list(216)
+	},
+/obj/structure/undies_wardrobe,
 /turf/simulated/floor/carpet,
 /area/heph_security_ship/crew)
 "BU" = (
@@ -3726,7 +3902,7 @@
 "CQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "CT" = (
 /obj/effect/floor_decal/spline/plain/cee/black{
@@ -3738,16 +3914,11 @@
 /turf/simulated/floor/tiled/ramp,
 /area/shuttle/heph_security)
 "CV" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/sign/securearea{
-	name = "\improper WARNING: HAZARD sign";
-	pixel_y = -32
+/obj/machinery/door/firedoor/noid{
+	dir = 4
 	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/template_noop,
-/area/space)
+/turf/simulated/floor/tiled,
+/area/heph_security_ship)
 "Dc" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/pipe/tank{
@@ -3844,9 +4015,6 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/obj/structure/window/borosilicate/reinforced{
-	dir = 1
-	},
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "Ee" = (
@@ -3911,11 +4079,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/heph_security_ship/francisca)
 "EJ" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/shutters/open{
 	id = "heph_shuttle_shutters";
 	dir = 4
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "ES" = (
@@ -3972,10 +4143,8 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/heph_security)
 "Fh" = (
-/obj/structure/bed/stool/chair/office/bridge/generic{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/structure/bed/handrail,
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/bridge)
 "Fm" = (
@@ -4003,7 +4172,6 @@
 /turf/simulated/floor/carpet/rubber,
 /area/heph_security_ship/brig)
 "FK" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "heph_lockdown";
 	name = "blast door"
@@ -4011,6 +4179,10 @@
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, kitchen"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor,
 /area/heph_security_ship/kitchen)
 "FQ" = (
@@ -4020,6 +4192,7 @@
 	req_access = list(216)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/medbay)
 "FU" = (
@@ -4089,12 +4262,8 @@
 /turf/simulated/floor,
 /area/heph_security_ship/atmos)
 "Gf" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/structure/window/borosilicate/reinforced,
-/obj/effect/landmark/entry_point/aft{
-	name = "aft, starboard thruster"
-	},
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/wall/shuttle/raider,
 /area/heph_security_ship/thrusterstarb)
 "Gj" = (
 /obj/structure/table/glass,
@@ -4107,9 +4276,6 @@
 "Gl" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 10
-	},
-/obj/structure/sign/poster{
-	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4128,14 +4294,11 @@
 /turf/simulated/floor/wood,
 /area/heph_security_ship/kitchen)
 "GD" = (
-/obj/effect/floor_decal/corner/orange{
-	dir = 10
+/obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/structure/bed/stool/chair/office/bridge/generic{
+	dir = 4
 	},
-/obj/machinery/computer/ship/helm{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/heph_security_ship/bridge)
 "GG" = (
 /obj/effect/floor_decal/corner/orange{
@@ -4171,14 +4334,21 @@
 /area/shuttle/heph_security)
 "Hf" = (
 /obj/structure/closet/radiation,
+/obj/machinery/alarm/west{
+	req_one_access = null;
+	req_access = list(216)
+	},
 /turf/simulated/floor,
 /area/heph_security_ship/engineering)
 "Hn" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "heph_lockdown";
 	name = "blast door"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor,
 /area/heph_security_ship/crew)
 "Ho" = (
@@ -4205,6 +4375,7 @@
 	dir = 1;
 	req_access = list(216)
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/bridge)
 "Hx" = (
@@ -4303,6 +4474,9 @@
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 1
 	},
+/obj/machinery/alarm/north{
+	req_one_access = null
+	},
 /turf/simulated/floor/wood,
 /area/heph_security_ship/kitchen)
 "HV" = (
@@ -4310,23 +4484,16 @@
 /turf/simulated/floor/airless,
 /area/heph_security_ship/francisca)
 "HY" = (
-/obj/structure/table/rack{
-	pixel_x = 32
-	},
-/obj/item/towel/random{
-	pixel_x = 32
-	},
-/obj/item/towel/random{
-	pixel_x = 32
-	},
-/obj/random/soap{
-	pixel_x = 32
-	},
-/obj/random/soap{
-	pixel_x = 32
-	},
 /obj/structure/curtain/open/shower,
-/turf/simulated/floor/tiled,
+/obj/machinery/alarm/north{
+	req_one_access = null;
+	req_access = list(216)
+	},
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
 /area/heph_security_ship/brig)
 "Ib" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -4352,16 +4519,12 @@
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "If" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/mapped{
+/obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/machinery/computer/ship/helm{
 	dir = 1
 	},
-/obj/structure/sign/securearea{
-	name = "\improper WARNING: HAZARD sign";
-	pixel_y = -32
-	},
-/turf/template_noop,
-/area/space)
+/turf/simulated/floor/tiled,
+/area/heph_security_ship/bridge)
 "Ig" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/structure/cable{
@@ -4453,7 +4616,9 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/bridge)
@@ -4530,6 +4695,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/heph_security_ship/captain)
 "Je" = (
@@ -4551,6 +4719,10 @@
 /obj/effect/shuttle_landmark/heph_security/nav4,
 /turf/template_noop,
 /area/space)
+"Jm" = (
+/obj/machinery/atmospherics/unary/engine,
+/turf/simulated/floor,
+/area/heph_security_ship/thrusterstarb)
 "Jn" = (
 /turf/simulated/floor/tiled/freezer{
 	name = "cooled tiles";
@@ -4610,6 +4782,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/wood,
 /area/heph_security_ship/kitchen)
 "JO" = (
@@ -4632,6 +4805,10 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
+	},
+/obj/machinery/alarm/north{
+	req_one_access = null;
+	req_access = list(216)
 	},
 /turf/simulated/floor,
 /area/heph_security_ship/atmos)
@@ -4673,11 +4850,14 @@
 /turf/simulated/floor/carpet,
 /area/heph_security_ship/crew)
 "Kt" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "heph_lockdown";
 	name = "blast door"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor,
 /area/heph_security_ship/captain)
 "Kv" = (
@@ -4699,9 +4879,6 @@
 	},
 /obj/machinery/power/apc/north{
 	req_access = list(216)
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship)
@@ -4784,13 +4961,11 @@
 /turf/simulated/floor,
 /area/heph_security_ship/atmos)
 "KO" = (
-/obj/structure/closet/secure_closet/refrigerator/standard{
-	name = "k'ois freezer"
-	},
 /obj/item/reagent_containers/food/snacks/koiswaffles,
 /obj/item/reagent_containers/food/snacks/koissteak,
 /obj/item/reagent_containers/food/snacks/koissteak,
 /obj/item/reagent_containers/food/snacks/koismuffin,
+/obj/structure/closet/secure_closet/freezer/kois,
 /turf/simulated/floor/tiled/freezer{
 	name = "cooled tiles";
 	temperature = 253.15
@@ -4898,7 +5073,7 @@
 	dir = 4
 	},
 /obj/structure/railing/mapped,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "LJ" = (
 /obj/effect/floor_decal/corner/orange{
@@ -4937,6 +5112,10 @@
 /obj/item/clothing/head/helmet/pilot{
 	pixel_x = -6;
 	pixel_y = 7
+	},
+/obj/machinery/alarm/west{
+	req_one_access = null;
+	req_access = list(216)
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/shuttle/heph_security)
@@ -5048,6 +5227,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/heph_security_ship/kitchen)
 "Nd" = (
@@ -5099,15 +5281,8 @@
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/medbay)
 "Ns" = (
-/obj/structure/table/reinforced/steel,
 /obj/effect/floor_decal/corner_wide/black/diagonal,
-/obj/machinery/button/alternate{
-	id = "heph_lockdown";
-	name = "Ship Lockdown"
-	},
-/obj/machinery/button/distress{
-	pixel_y = 8
-	},
+/obj/structure/bed/stool/chair/office/bridge/generic,
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/bridge)
 "Nv" = (
@@ -5154,6 +5329,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor/tiled/dark,
 /area/heph_security_ship/francisca)
 "NP" = (
@@ -5280,12 +5456,13 @@
 /turf/simulated/floor/carpet,
 /area/heph_security_ship/captain)
 "OO" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	id = "heph_lockdown";
 	name = "blast door"
 	},
+/obj/machinery/door/firedoor/noid,
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor,
 /area/heph_security_ship/francisca)
 "OR" = (
@@ -5377,6 +5554,13 @@
 	},
 /turf/simulated/floor,
 /area/heph_security_ship/atmos)
+"PG" = (
+/obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/heph_security_ship/bridge)
 "PL" = (
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 1
@@ -5411,7 +5595,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "PW" = (
 /obj/effect/floor_decal/corner/red,
@@ -5450,7 +5634,8 @@
 	name = "Carbon Dioxide Supply Monitor";
 	output_tag = "hephsec_fuel";
 	sensors = list("hephsec_sensor"="Tank");
-	dir = 4
+	dir = 4;
+	input_tag = "hephsec_fuel_in"
 	},
 /turf/simulated/floor,
 /area/heph_security_ship/atmos)
@@ -5467,10 +5652,6 @@
 /turf/simulated/floor/airless,
 /area/space)
 "QJ" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8;
-	layer = 2.71
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
@@ -5501,6 +5682,7 @@
 /obj/item/clothing/head/helmet/ballistic,
 /obj/item/clothing/suit/armor/carrier/ballistic,
 /obj/item/clothing/suit/armor/carrier/ballistic,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/heph_security_ship/armory)
 "QR" = (
@@ -5546,6 +5728,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 4;
+	frequency = 0451;
+	icon_state = "map_injector";
+	id = "hephsec_fuel_in"
+	},
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/heph_security_ship/atmos)
 "Rw" = (
@@ -5582,9 +5770,15 @@
 /turf/simulated/floor/tiled,
 /area/heph_security_ship)
 "RZ" = (
-/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
-/turf/simulated/floor,
-/area/heph_security_ship/atmos)
+/obj/effect/floor_decal/corner/orange{
+	dir = 5
+	},
+/obj/machinery/alarm/north{
+	req_one_access = null;
+	req_access = list(216)
+	},
+/turf/simulated/floor/tiled,
+/area/heph_security_ship)
 "Sb" = (
 /obj/effect/floor_decal/corner/green/full{
 	dir = 4
@@ -5595,12 +5789,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/medbay)
+"Sc" = (
+/obj/structure/closet/crate{
+	name = "Emergency Fuel"
+	},
+/obj/item/tank/hydrogen/shuttle,
+/obj/item/tank/hydrogen/shuttle,
+/obj/item/tank/hydrogen/shuttle,
+/obj/item/tank/hydrogen/shuttle,
+/turf/simulated/floor,
+/area/shuttle/heph_security)
 "Sh" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "heph_lockdown";
 	name = "blast door"
 	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor,
 /area/heph_security_ship/medbay)
 "Si" = (
@@ -5627,6 +5834,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/noid{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/heph_security_ship/bathroom)
@@ -5655,11 +5865,20 @@
 	pixel_y = 1
 	},
 /obj/machinery/light,
+/obj/machinery/alarm/west{
+	req_one_access = null;
+	req_access = list(216)
+	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/brig)
 "SD" = (
-/obj/machinery/computer/ship/engines,
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/alarm/north{
+	req_one_access = null;
+	req_access = list(216)
+	},
+/obj/structure/table/reinforced/steel,
+/obj/machinery/recharger,
 /turf/simulated/floor,
 /area/heph_security_ship/bridge)
 "SM" = (
@@ -5683,12 +5902,13 @@
 /turf/simulated/floor,
 /area/heph_security_ship/thrusterport)
 "SQ" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	id = "heph_lockdown";
 	name = "blast door"
 	},
+/obj/machinery/door/firedoor/noid,
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor,
 /area/heph_security_ship/grauwolf)
 "SV" = (
@@ -5756,15 +5976,13 @@
 /turf/simulated/floor/tiled,
 /area/heph_security_ship)
 "TC" = (
-/obj/structure/closet/crate/bin{
-	dense_when_open = 0;
-	density = 0;
-	name = "trashbin";
-	pixel_y = 18
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table/rack,
+/obj/random/soap,
+/obj/item/towel/random,
+/obj/item/towel/random,
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/brig)
 "TD" = (
@@ -5783,21 +6001,32 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/heph_security)
 "TK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 10
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/mapped{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/shuttle/heph_security)
+/obj/structure/sign/securearea{
+	name = "\improper WARNING: HAZARD sign";
+	pixel_y = -32
+	},
+/turf/space/dynamic,
+/area/space)
 "TQ" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "heph_lockdown";
 	name = "blast door"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/heph_security_ship/dock)
 "Uc" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/heph_security_ship/brig)
 "Uh" = (
@@ -5855,13 +6084,14 @@
 /turf/simulated/floor/wood,
 /area/heph_security_ship/kitchen)
 "Uy" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/shutters/open{
 	id = "heph_shuttle_shutters"
 	},
 /obj/effect/landmark/entry_point/aft{
 	name = "fore"
 	},
+/obj/machinery/door/firedoor/noid,
+/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "Uz" = (
@@ -5952,22 +6182,13 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/heph_security)
 "Vz" = (
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light,
-/obj/structure/table/reinforced/steel,
-/obj/item/paper_bin{
-	pixel_y = 4;
-	pixel_x = 4
+/obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/machinery/button/remote/blast_door{
+	name = "Ship Lockdown";
+	id = "heph_lockdown";
+	pixel_y = -32
 	},
-/obj/item/pen/black{
-	pixel_y = 4;
-	pixel_x = 3
-	},
-/obj/item/stamp/hephaestus{
-	pixel_x = -7;
-	pixel_y = 4
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/heph_security_ship/bridge)
 "VA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6021,9 +6242,8 @@
 /turf/simulated/floor,
 /area/heph_security_ship)
 "VK" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/structure/window/borosilicate/reinforced,
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/wall/shuttle/raider,
 /area/heph_security_ship/thrusterport)
 "VM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6054,7 +6274,10 @@
 /turf/simulated/floor,
 /area/heph_security_ship)
 "VW" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/machinery/door/firedoor/noid{
+	dir = 4
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor,
 /area/heph_security_ship/kitchen)
 "VZ" = (
@@ -6066,6 +6289,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/table/reinforced/steel,
 /turf/simulated/floor,
 /area/heph_security_ship/bridge)
 "Wj" = (
@@ -6174,8 +6398,16 @@
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/medbay)
 "WR" = (
-/obj/item/modular_computer/console/preset/civilian,
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/table/reinforced/steel,
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 21;
+	pixel_x = 3
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 31;
+	pixel_x = 3
+	},
 /turf/simulated/floor,
 /area/heph_security_ship/bridge)
 "WT" = (
@@ -6219,12 +6451,13 @@
 /turf/simulated/floor,
 /area/heph_security_ship/atmos)
 "Xe" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	id = "heph_lockdown";
 	name = "blast door"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor,
 /area/heph_security_ship/dock)
 "Xi" = (
@@ -6239,6 +6472,7 @@
 	pixel_y = 32;
 	stand_icon = null
 	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor,
 /area/heph_security_ship/bridge)
 "Xr" = (
@@ -6357,6 +6591,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/armory)
+"Ym" = (
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light,
+/obj/structure/table/reinforced/steel,
+/obj/machinery/photocopier/faxmachine{
+	department = "Hephaestus Asset Protection Vessel"
+	},
+/turf/simulated/floor,
+/area/heph_security_ship/bridge)
 "Yo" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/window/reinforced{
@@ -6374,19 +6617,26 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled,
 /area/heph_security_ship/dock)
+"Yy" = (
+/obj/machinery/atmospherics/unary/engine,
+/turf/simulated/floor,
+/area/heph_security_ship/thrusterport)
 "YC" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	id = "heph_lockdown";
 	name = "blast door"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
+/obj/machinery/door/firedoor/noid,
 /turf/simulated/floor,
 /area/heph_security_ship)
 "YJ" = (
-/obj/machinery/computer/ship/targeting,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/obj/effect/floor_decal/corner_wide/black/diagonal,
+/obj/structure/bed/stool/chair/office/bridge/generic{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
 /area/heph_security_ship/bridge)
 "YO" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on/atmos{
@@ -6442,6 +6692,10 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/heph_security_ship/francisca)
+"Zr" = (
+/obj/structure/closet/secure_closet/freezer/kois,
+/turf/template_noop,
+/area/space)
 "Zs" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/decal/cleanable/dirt,
@@ -34938,9 +35192,9 @@ CE
 CE
 CE
 CE
-CE
 cq
 jQ
+Ag
 mp
 JH
 Ro
@@ -35195,8 +35449,8 @@ CE
 CE
 CE
 CE
-CE
-If
+TK
+vZ
 vZ
 vZ
 vZ
@@ -35452,12 +35706,12 @@ CE
 CE
 CE
 CE
-CE
 Ag
-fd
+Jm
+Gf
 aG
 mv
-RZ
+pw
 pw
 ed
 Kf
@@ -35709,8 +35963,8 @@ CE
 CE
 CE
 CE
-CE
 Ag
+fk
 Gf
 kd
 mv
@@ -35723,14 +35977,14 @@ vS
 ia
 iY
 mR
-lN
+Vt
 it
 xh
 bC
 Yk
 PC
 KC
-KH
+qf
 yR
 Lc
 Rd
@@ -35966,9 +36220,9 @@ CE
 CE
 CE
 CE
-CE
 Ag
-fd
+Jm
+Gf
 ru
 sc
 PF
@@ -36223,9 +36477,9 @@ CE
 CE
 CE
 CE
-CE
 Ag
-fd
+Jm
+Gf
 Nv
 mv
 rn
@@ -36480,8 +36734,8 @@ CE
 CE
 CE
 CE
-CE
-CV
+BA
+vZ
 vZ
 vZ
 vZ
@@ -36737,11 +36991,11 @@ CE
 CE
 CE
 CE
-CE
 PR
-pD
+tT
+Ag
 qP
-pD
+tT
 Ag
 ed
 ed
@@ -37000,9 +37254,9 @@ CE
 CE
 CE
 PR
-pD
+tT
 qP
-pD
+tT
 Ag
 JH
 JH
@@ -37260,10 +37514,10 @@ CE
 CE
 CE
 CE
+lN
 tT
-pD
 qP
-pD
+tT
 Ag
 YC
 Ab
@@ -37271,7 +37525,7 @@ iU
 Ij
 hc
 hc
-hc
+AU
 RX
 gC
 oX
@@ -38023,14 +38277,14 @@ Zb
 cV
 TG
 xz
-xU
+qN
 Fb
 fF
 Zb
 wb
 BJ
 Xy
-TK
+zP
 DW
 QC
 CE
@@ -38048,15 +38302,15 @@ Nh
 Iz
 xN
 VE
-lz
+CV
 mz
 tn
 Wi
 ef
 jc
+vi
 tn
-BA
-BA
+tn
 tn
 le
 CQ
@@ -38311,8 +38565,8 @@ tn
 SD
 eS
 YJ
+BB
 tn
-BA
 tn
 tn
 Ag
@@ -38567,9 +38821,9 @@ yw
 tn
 Xn
 IC
-qf
+VZ
+Ym
 tn
-BA
 tn
 Ag
 Lv
@@ -38819,14 +39073,14 @@ CL
 Ws
 kN
 VE
-nI
+Rk
 Af
 dU
 Wr
 aj
 Ns
+If
 tn
-BA
 Wj
 CQ
 CE
@@ -39080,10 +39334,10 @@ Kw
 LK
 Hw
 VZ
-hr
-vi
+PG
+Ns
+bc
 tn
-BA
 tn
 CQ
 CE
@@ -39337,10 +39591,10 @@ cO
 po
 tn
 rg
-VZ
+hr
 Vz
+uN
 tn
-BA
 tn
 Ag
 uF
@@ -39571,7 +39825,7 @@ Zb
 Zb
 Kq
 Do
-Xy
+Sc
 zP
 DW
 CE
@@ -39596,8 +39850,8 @@ tn
 WR
 Fh
 GD
+xq
 tn
-BA
 tn
 tn
 mp
@@ -39852,10 +40106,10 @@ gG
 tn
 Wi
 fD
-jc
+pu
+vi
 tn
-BA
-BA
+tn
 tn
 fT
 Ag
@@ -40357,11 +40611,11 @@ qo
 dA
 dA
 dA
-Uc
+dA
 ih
 Uc
 dA
-nI
+RZ
 yw
 Sq
 dJ
@@ -40592,8 +40846,8 @@ CE
 CE
 CE
 CE
-CE
 cq
+jQ
 jQ
 KK
 jQ
@@ -40849,8 +41103,8 @@ CE
 CE
 CE
 CE
-CE
-If
+TK
+Nm
 Nm
 Nm
 Nm
@@ -41106,8 +41360,8 @@ CE
 CE
 CE
 CE
-CE
 Ag
+Yy
 VK
 zW
 pI
@@ -41363,8 +41617,8 @@ CE
 CE
 CE
 CE
-CE
 Ag
+Yy
 VK
 xP
 Wl
@@ -41389,7 +41643,7 @@ dA
 dA
 dA
 dA
-lz
+CV
 mz
 Sq
 fK
@@ -41400,7 +41654,7 @@ mP
 oA
 Zn
 Ag
-pD
+tT
 Lv
 CE
 CE
@@ -41620,9 +41874,9 @@ CE
 CE
 CE
 CE
-CE
 Ag
-uN
+fd
+VK
 SO
 Nm
 dE
@@ -41877,8 +42131,8 @@ CE
 CE
 CE
 CE
-CE
 Ag
+Yy
 VK
 eo
 Nm
@@ -41897,7 +42151,7 @@ xW
 DU
 jZ
 WP
-xW
+pD
 Bt
 jX
 nE
@@ -42134,8 +42388,8 @@ CE
 CE
 CE
 CE
-CE
-If
+TK
+Nm
 Nm
 Nm
 Nm
@@ -42391,11 +42645,11 @@ CE
 CE
 CE
 CE
-CE
+lN
 tT
-pD
+tT
 qP
-pD
+tT
 Ag
 lm
 lm
@@ -42654,9 +42908,9 @@ CE
 CE
 CE
 PR
-pD
+tT
 qP
-pD
+tT
 Ag
 Zc
 gI
@@ -42678,11 +42932,11 @@ HO
 oi
 Ry
 Ag
-pD
-pD
+tT
+tT
 qP
-pD
-pD
+tT
+tT
 Lv
 CE
 CE
@@ -42915,9 +43169,9 @@ CE
 CE
 CE
 PR
-pD
+tT
 qP
-pD
+tT
 Ag
 rl
 rl
@@ -42927,8 +43181,8 @@ Sh
 rl
 rl
 Ag
-pD
-pD
+tT
+tT
 Ag
 DD
 VH
@@ -43176,13 +43430,13 @@ CE
 CE
 CE
 PR
-pD
-pD
-pD
+tT
+tT
+tT
 qP
-pD
-pD
-pD
+tT
+tT
+tT
 Lv
 CE
 CE
@@ -49085,7 +49339,7 @@ CE
 CE
 CE
 CE
-CE
+Zr
 CE
 CE
 CE


### PR DESCRIPTION
Quick PR. This gives the HAPT offship air alarms gated to its access, in addition to emergency shutters on every airlock and around every window. It also removes a stray suit cycler that presumably wasn't meant to be there, and expands the CIC so that it's big enough for the entire crew of the ship, plus some other QoL additions.