### PR TITLE
Barista QoL Expansion

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -51,6 +51,8 @@ var/list/mimic_defines = list(
 #define ATOM_FLAG_HTML_USE_INITIAL_ICON FLAG(6)
 /// If a dense atom like a platform does not allow movement through it like a window pane BUT allows pickup.
 #define ATOM_FLAG_ALWAYS_ALLOW_PICKUP FLAG(7)
+/// A reagent container that can dispense when being attacked by another container.
+#define ATOM_FLAG_DISPENSER FLAG(8)
 
 #define ATOM_AWAITING_OVERLAY_UPDATE FLAG(10)
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -328,6 +328,9 @@
 
 	// Ensure we don't splash beakers and similar containers.
 	if(!target.is_open_container() && istype(target, /obj/item/reagent_containers))
+		if(istype(target, /obj/item/reagent_containers/glass/bottle/syrup))
+			var/obj/item/reagent_containers/glass/bottle/syrup/dispenser = target
+			return dispenser.standard_pour_into(user, src)
 		to_chat(user, SPAN_NOTICE("\The [target] is closed."))
 		return 1
 	// Otherwise don't care about splashing.

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -327,9 +327,9 @@
 		return 0
 
 	// Ensure we don't splash beakers and similar containers.
-	if(!target.is_open_container() && istype(target, /obj/item/reagent_containers))
-		if(istype(target, /obj/item/reagent_containers/glass/bottle/syrup))
-			var/obj/item/reagent_containers/glass/bottle/syrup/dispenser = target
+	if(!target.is_open_container())
+		if(target.atom_flags & ATOM_FLAG_DISPENSER && istype(target, /obj/item/reagent_containers))
+			var/obj/item/reagent_containers/dispenser = target
 			return dispenser.standard_pour_into(user, src)
 		to_chat(user, SPAN_NOTICE("\The [target] is closed."))
 		return 1

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -299,6 +299,31 @@ If you add a drink with an empty icon sprite, ensure it is in the same folder, e
 	pickup_sound = 'sound/items/pickup/papercup.ogg'
 	possible_transfer_amounts = null
 	volume = 30
+	/**
+	 * Details written on the cup, a la IRL coffee places
+	 */
+	var/list/details = list("Customer" = null, "Order" = null)
+
+/obj/item/reagent_containers/food/drinks/takeaway_cup_idris/attackby(obj/item/attacking_item, mob/user)
+	if(attacking_item.ispen())
+		var/choice = tgui_input_list(user, "Which detail to edit?", "Detail edit", list("Customer", "Order"))
+		switch(choice)
+			if("Customer")
+				details["Customer"] = tgui_input_text(user, "Enter customer name", "Enter name")
+			if("Order")
+				details["Order"] = tgui_input_text(user, "Enter ordered drink", "Enter order")
+		name = initial(name)
+		if(details["Order"])
+			name += " - [details["Order"]]"
+		if(details["Customer"])
+			name += " ([details["Customer"]])"
+		return
+	return ..()
+
+/obj/item/reagent_containers/food/drinks/takeaway_cup_idris/get_examine_text(mob/user, distance, is_adjacent, infix, suffix, get_extended)
+	. = ..()
+	. += "Order: [details["Order"]]"
+	. += "For: [details["Customer"]]"
 
 //////////////////////////drinkingglass and shaker//
 //Note by Darem: This code handles the mixing of drinks. New drinks go in three places: In Chemistry-Reagents.dm (for the drink

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -305,18 +305,13 @@ If you add a drink with an empty icon sprite, ensure it is in the same folder, e
 	var/list/details = list("Customer" = null, "Order" = null)
 
 /obj/item/reagent_containers/food/drinks/takeaway_cup_idris/attackby(obj/item/attacking_item, mob/user)
-	if(attacking_item.ispen())
-		var/choice = tgui_input_list(user, "Which detail to edit?", "Detail edit", list("Customer", "Order"))
+	if(attacking_item.ispen() && !use_check_and_message(user))
+		var/choice = tgui_input_list(user, "Which detail do you want to edit?", "Detail Editor", list("Customer", "Order"))
 		switch(choice)
 			if("Customer")
-				details["Customer"] = tgui_input_text(user, "Enter customer name", "Enter name")
+				details["Customer"] = sanitize(tgui_input_text(user, "What is the customer's name?", "Enter Customer Name"))
 			if("Order")
-				details["Order"] = tgui_input_text(user, "Enter ordered drink", "Enter order")
-		name = initial(name)
-		if(details["Order"])
-			name += " - [details["Order"]]"
-		if(details["Customer"])
-			name += " ([details["Customer"]])"
+				details["Order"] = sanitize(tgui_input_text(user, "What is the ordered drink?", "Enter Ordered Drink"))
 		return
 	return ..()
 

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -245,7 +245,7 @@
 	desc = "A small bottle dispenser."
 	icon_state = "syrup"
 	filling_states = "20;40;60;80;100"
-	atom_flags = ATOM_FLAG_POUR_CONTAINER
+	atom_flags = ATOM_FLAG_POUR_CONTAINER | ATOM_FLAG_DISPENSER
 	volume = 50
 
 /obj/item/reagent_containers/glass/bottle/syrup/chocolate

--- a/html/changelogs/barista-expansion.yml
+++ b/html/changelogs/barista-expansion.yml
@@ -1,0 +1,8 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - rscadd: "You can now use pens to add customer names and their orders to takeaway cups."
+  - qol: "Moved the chemical heater to the front of the bar."
+  - qol: "You can now use reagent containers on closed syrup dispensers to dispense syrup into the container without picking up the syrup."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -254,11 +254,11 @@
 /turf/simulated/floor/tiled,
 /area/horizon/hallway/deck_two/fore)
 "aec" = (
-/obj/effect/floor_decal/corner/grey{
-	dir = 10
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey{
+	dir = 8
 	},
 /turf/simulated/floor/lino,
 /area/horizon/bar)
@@ -14883,7 +14883,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
-/obj/machinery/vending/dinnerware/bar,
+/obj/machinery/chem_heater,
 /turf/simulated/floor/wood,
 /area/horizon/bar)
 "gHV" = (
@@ -30269,6 +30269,9 @@
 /obj/item/reagent_containers/glass/bottle/syrup/vanilla{
 	pixel_x = 9;
 	pixel_y = 4
+	},
+/obj/machinery/vending/dinnerware/bar{
+	pixel_y = 16
 	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/bar)
@@ -47281,12 +47284,7 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 6
 	},
-/obj/machinery/chem_master/condimaster,
-/obj/effect/floor_decal/corner/grey{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/hatch/grey,
-/turf/simulated/floor/tiled/dark/full,
+/turf/simulated/floor/lino,
 /area/horizon/bar)
 "vUK" = (
 /obj/structure/bed/stool/chair/office/light{
@@ -51541,8 +51539,9 @@
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/xenobiology/dissection)
 "xPY" = (
-/obj/machinery/chem_heater,
 /obj/effect/floor_decal/industrial/hatch/grey,
+/obj/machinery/chem_master/condimaster,
+/obj/effect/floor_decal/corner/grey/full,
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/bar)
 "xQj" = (
@@ -71803,8 +71802,8 @@ uZh
 nxI
 uws
 bKX
-exU
 vUm
+exU
 sKJ
 gHV
 uTY


### PR DESCRIPTION
Adds the ability to use pens to write names and orders on takeaway cups.

Allows you to click on syrup dispensers with a cup to dispense the syrup, rather than having to pick them up.

Moves the chemical heater from the bar backroom to the front, so bartenders don't need to walk away and come back every time they need to make steamed milk.