### PR TITLE
Spiderbots can pilot Exosuits again

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -143,6 +143,9 @@
 /// Mob does not need to breathe.
 #define TRAIT_NO_BREATHE "no_breathe"
 
+// Mob ignores size requirements to enter Mech
+#define TRAIT_MECH_PILOT "mech_pilot"
+
 /// Mob has pressure immunity.
 #define TRAIT_PRESSURE_IMMUNITY "pressure_immunity"
 

--- a/code/modules/heavy_vehicle/mech_interaction.dm
+++ b/code/modules/heavy_vehicle/mech_interaction.dm
@@ -1,7 +1,7 @@
 /mob/living/MouseDrop(atom/over)
 	if(usr == src && usr != over)
 		if(istype(over, /mob/living/heavy_vehicle))
-			if(usr.mob_size >= MOB_SMALL && usr.mob_size <= 14)
+			if((usr.mob_size >= MOB_SMALL && usr.mob_size <= 14) || istype(usr, /mob/living/simple_animal/spiderbot))
 				var/mob/living/heavy_vehicle/M = over
 				if(M.enter(src))
 					return

--- a/code/modules/heavy_vehicle/mech_interaction.dm
+++ b/code/modules/heavy_vehicle/mech_interaction.dm
@@ -1,7 +1,7 @@
 /mob/living/MouseDrop(atom/over)
 	if(usr == src && usr != over)
 		if(istype(over, /mob/living/heavy_vehicle))
-			if((usr.mob_size >= MOB_SMALL && usr.mob_size <= 14) || istype(usr, /mob/living/simple_animal/spiderbot))
+			if((usr.mob_size >= MOB_SMALL && usr.mob_size <= 14) || HAS_TRAIT(usr, TRAIT_MECH_PILOT))
 				var/mob/living/heavy_vehicle/M = over
 				if(M.enter(src))
 					return

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -67,6 +67,10 @@
 	camera.c_tag = "spiderbot-[real_name]"
 	camera.replace_networks(list("SS13"))
 
+/mob/living/simple_animal/spiderbot/New()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_MECH_PILOT, ROUNDSTART_TRAIT)
+
 /mob/living/simple_animal/spiderbot/Destroy()
 	eject_brain()
 	return ..()

--- a/html/changelogs/Ben10083 - Spiderbot Exosuits.yml
+++ b/html/changelogs/Ben10083 - Spiderbot Exosuits.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Spiderbots can now once again pilot exosuits."

--- a/html/changelogs/Ben10083 - Spiderbot Exosuits.yml
+++ b/html/changelogs/Ben10083 - Spiderbot Exosuits.yml
@@ -56,3 +56,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Spiderbots can now once again pilot exosuits."
+  - admin: "New Mech Pilot trait to allow for admins to allow any mob to pilot mechs if they wish."


### PR DESCRIPTION
Spiderbots were blocked from piloting exosuits inadvertently. This restores that functionality and adds a new trait so it can easily be done for other mobs