### PR TITLE
Allow Wireless Firing Pins (Disruptors) To Fire On Code Blue

### DIFF
--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -305,7 +305,7 @@ var/list/wireless_firing_pins = list() //A list of all initialized wireless firi
 			var/obj/item/gun/energy/EG = gun
 			if(EG.required_firemode_auth[EG.sel_mode] == WIRELESS_PIN_STUN)
 				return TRUE
-			else if (GLOB.security_level == SEC_LEVEL_YELLOW || GLOB.security_level == SEC_LEVEL_RED || GLOB.security_level == SEC_LEVEL_BLUE)
+			else if (GLOB.security_level == SEC_LEVEL_YELLOW || GLOB.security_level >= SEC_LEVEL_BLUE)
 				return TRUE
 			else
 				fail_message = SPAN_WARNING("Unable to fire: insufficient security level.")

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -305,13 +305,13 @@ var/list/wireless_firing_pins = list() //A list of all initialized wireless firi
 			var/obj/item/gun/energy/EG = gun
 			if(EG.required_firemode_auth[EG.sel_mode] == WIRELESS_PIN_STUN)
 				return TRUE
-			else if (GLOB.security_level == SEC_LEVEL_YELLOW || GLOB.security_level == SEC_LEVEL_RED)
+			else if (GLOB.security_level == SEC_LEVEL_YELLOW || GLOB.security_level == SEC_LEVEL_RED || GLOB.security_level == SEC_LEVEL_BLUE)
 				return TRUE
 			else
 				fail_message = SPAN_WARNING("Unable to fire: insufficient security level.")
 				return FALSE
 		else
-			if (GLOB.security_level == SEC_LEVEL_YELLOW || GLOB.security_level == SEC_LEVEL_RED)
+			if (GLOB.security_level == SEC_LEVEL_YELLOW || GLOB.security_level == SEC_LEVEL_RED || GLOB.security_level == SEC_LEVEL_BLUE)
 				return TRUE
 			else
 				fail_message = SPAN_WARNING("Unable to fire: insufficient security level.")

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -305,13 +305,13 @@ var/list/wireless_firing_pins = list() //A list of all initialized wireless firi
 			var/obj/item/gun/energy/EG = gun
 			if(EG.required_firemode_auth[EG.sel_mode] == WIRELESS_PIN_STUN)
 				return TRUE
-			else if (GLOB.security_level == SEC_LEVEL_YELLOW || GLOB.security_level >= SEC_LEVEL_BLUE)
+			else if (GLOB.security_level >= SEC_LEVEL_YELLOW)
 				return TRUE
 			else
 				fail_message = SPAN_WARNING("Unable to fire: insufficient security level.")
 				return FALSE
 		else
-			if (GLOB.security_level == SEC_LEVEL_YELLOW || GLOB.security_level == SEC_LEVEL_RED || GLOB.security_level == SEC_LEVEL_BLUE)
+			if (GLOB.security_level >= SEC_LEVEL_YELLOW)
 				return TRUE
 			else
 				fail_message = SPAN_WARNING("Unable to fire: insufficient security level.")

--- a/html/changelogs/crosarius - blasterqol.yml
+++ b/html/changelogs/crosarius - blasterqol.yml
@@ -1,0 +1,4 @@
+author: crosarius
+delete-after: True
+changes:
+  - qol: "Changes the wireless firing pin (disruptor pistols) to be able to fire on lethal mode during code blue"


### PR DESCRIPTION
This adds code blue to the list of alert levels that allow wireless firing pins to fire on lethal mode.

There's a cultural thing on Aurora where Code Red is never used, because it stops the vote from being called. This means that during most high intensity interactions, we stay on Code Blue, and the disruptor pistol can't be used on lethal mode. 

This simply adds code blue to the list of permissible codes for lethal. 