### PR TITLE
Buffs maglights + energy weapons force

### DIFF
--- a/code/game/objects/items/devices/lighting/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/flashlight.dm
@@ -343,7 +343,7 @@
 	desc = "A heavy flashlight, designed for security personnel."
 	icon_state = "maglight"
 	item_state = "maglight"
-	force = 11
+	force = 9
 	brightness_on = 5
 	efficiency_modifier = 0.8
 	w_class = ITEMSIZE_NORMAL

--- a/code/game/objects/items/devices/lighting/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/flashlight.dm
@@ -343,7 +343,7 @@
 	desc = "A heavy flashlight, designed for security personnel."
 	icon_state = "maglight"
 	item_state = "maglight"
-	force = 5
+	force = 11
 	brightness_on = 5
 	efficiency_modifier = 0.8
 	w_class = ITEMSIZE_NORMAL

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -134,7 +134,7 @@
 	icon_state = "eglaive0"
 	force = 25
 	throwforce = 30
-	active_force = 40
+	active_force = 44
 	active_throwforce = 60
 	active_w_class = ITEMSIZE_HUGE
 	armor_penetration = 20
@@ -226,7 +226,7 @@
 	to block projectiles and melee attacks while it is on and being held.  The sword can be toggled on or off by using it in your hand.  While it is off, \
 	it can be concealed in your pocket or bag."
 	icon_state = "sword0"
-	active_force = 30
+	active_force = 33
 	armor_penetration = 25
 	active_throwforce = 20
 	active_w_class = ITEMSIZE_LARGE
@@ -318,7 +318,7 @@
 
 /obj/item/melee/energy/sword/pirate/generic
 	desc = "An energy with a curved output, useful for defense and intimidation."
-	active_force = 20 // 20 damage per hit, seems more balanced for what it can do
+	active_force = 25
 
 /obj/item/melee/energy/glaive/hegemony
 	name = "hegemony energy glaive"
@@ -358,7 +358,7 @@
 	icon_state = "edagger0"
 	base_reflectchance = 10
 	base_block_chance = 10
-	active_force = 20
+	active_force = 25
 	force = 15
 	origin_tech = list(TECH_MAGNET = 3)
 
@@ -372,7 +372,7 @@
 	icon_state = "sol_edagger0"
 	base_reflectchance = 10
 	base_block_chance = 10
-	active_force = 20
+	active_force = 25
 	force = 15
 	origin_tech = list(TECH_MAGNET = 3)
 
@@ -392,7 +392,7 @@
 	item_state = "runesword0" //same icon, lol
 	contained_sprite = TRUE
 	base_reflectchance = 65
-	active_force = 40
+	active_force = 44
 	base_block_chance = 65
 	active_w_class = ITEMSIZE_NORMAL
 	w_class = ITEMSIZE_NORMAL
@@ -424,7 +424,7 @@
 	desc = "A concentrated beam of energy in the shape of a blade. Very stylish... and lethal."
 	icon_state = "blade"
 	force = 30
-	active_force = 40 //Normal attacks deal very high damage - about the same as wielded fire axe
+	active_force = 44 //Normal attacks deal very high damage - about the same as wielded fire axe
 	sharp = TRUE
 	edge = TRUE
 	anchored = 1    // Never spawned outside of inventory, should be fine.

--- a/code/game/objects/items/weapons/vaurca_items.dm
+++ b/code/game/objects/items/weapons/vaurca_items.dm
@@ -104,7 +104,7 @@
 	icon = 'icons/obj/vaurca_items.dmi'
 	icon_state = "eknife0"
 	item_state = "eknife0"
-	active_force = 20
+	active_force = 25
 	active_throwforce = 20
 	active_w_class = ITEMSIZE_HUGE
 	force = 11
@@ -381,7 +381,7 @@
 	icon = 'icons/obj/vaurca_items.dmi'
 	icon_state = "greatblade0"
 	item_state = "greatblade0"
-	active_force = 30
+	active_force = 33
 	armor_penetration = 30
 	active_throwforce = 20
 	active_w_class = ITEMSIZE_HUGE

--- a/html/changelogs/pirouette-force-adjustments.yml
+++ b/html/changelogs/pirouette-force-adjustments.yml
@@ -2,4 +2,4 @@ author: Pirouette
 delete-after: True
 changes:
   - balance: "Buffed the force of energy melee weapons in line with prior buffs to non-energy weapons."
-  - balance: "Buffed the force of maglights to be in line with other items of similar caliber."
+  - balance: "Buffed the force of maglights."

--- a/html/changelogs/pirouette-force-adjustments.yml
+++ b/html/changelogs/pirouette-force-adjustments.yml
@@ -1,0 +1,5 @@
+author: Pirouette
+delete-after: True
+changes:
+  - balance: "Buffed the force of energy melee weapons in line with prior buffs to non-energy weapons."
+  - balance: "Buffed the force of maglights to be in line with other items of similar caliber."


### PR DESCRIPTION
Trying to bring both in line with this PR: https://github.com/Aurorastation/Aurora.3/pull/18708

Maglights have the same force as binoculars, multitools, etc - other formerly 5-force items. They are still outclassed by crowbars and guns in melee, so they shouldn't revert to being the default weapon of choice.

Energy weapons were not buffed in the above PR, so I've simply adjusted active_force by the formula above.