### PR TITLE
Mech Attacking Fix

### DIFF
--- a/code/modules/heavy_vehicle/mech_interaction.dm
+++ b/code/modules/heavy_vehicle/mech_interaction.dm
@@ -363,6 +363,7 @@
 					remote_type = RM.type
 					become_remote()
 					qdel(attacking_item)
+				return
 			else if(attacking_item.ismultitool())
 				if(hardpoints_locked)
 					to_chat(user, SPAN_WARNING("Hardpoint system access is disabled."))
@@ -405,7 +406,7 @@
 							qdel(pilot)
 							new remote_type(get_turf(src))
 					dismantle()
-					return
+				return
 			else if(attacking_item.iswelder())
 				if(!getBruteLoss())
 					return

--- a/html/changelogs/geeves-mech_attacking_fix.yml
+++ b/html/changelogs/geeves-mech_attacking_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Moving away from a mech while using a wrench or a remote upgrade will no longer hit it."


### PR DESCRIPTION
* Moving away from a mech while using a wrench or a remote upgrade will no longer hit it.