### PR TITLE
Full Xenoarchaeology Belt

### DIFF
--- a/code/modules/research/xenoarchaeology/tools/gearbelt.dm
+++ b/code/modules/research/xenoarchaeology/tools/gearbelt.dm
@@ -16,6 +16,7 @@
 		/obj/item/pickaxe,
 		/obj/item/device/depth_scanner,
 		/obj/item/device/camera,
+		/obj/item/device/camera_film,
 		/obj/item/paper,
 		/obj/item/photo,
 		/obj/item/folder,

--- a/code/modules/research/xenoarchaeology/tools/gearbelt.dm
+++ b/code/modules/research/xenoarchaeology/tools/gearbelt.dm
@@ -1,4 +1,3 @@
-
 /obj/item/storage/belt/archaeology
 	name = "excavation gear-belt"
 	desc = "Can hold various excavation gear."
@@ -11,6 +10,7 @@
 		/obj/item/device/beacon_locator,
 		/obj/item/device/radio/beacon,
 		/obj/item/device/gps,
+		/obj/item/device/radio,
 		/obj/item/device/measuring_tape,
 		/obj/item/device/flashlight,
 		/obj/item/pickaxe,
@@ -20,7 +20,7 @@
 		/obj/item/photo,
 		/obj/item/folder,
 		/obj/item/pen,
-		/obj/item/folder,
+		/obj/item/reagent_containers/glass/beaker
 		/obj/item/clipboard,
 		/obj/item/anodevice,
 		/obj/item/clothing/glasses,
@@ -31,3 +31,16 @@
 		/obj/item/ore_detector,
 		/obj/item/device/spaceflare
 		)
+
+/obj/item/storage/belt/archaeology/full
+	starts_with = list(
+		/obj/item/device/core_sampler = 1,
+		/obj/item/device/gps = 1,
+		/obj/item/device/measuring_tape = 1,
+		/obj/item/pickaxe/hand = 1,
+		/obj/item/storage/box/excavation = 1,
+		/obj/item/device/depth_scanner = 1,
+		/obj/item/device/ano_scanner = 1,
+		/obj/item/ore_detector = 1,
+		/obj/item/wrench = 1,
+	)

--- a/code/modules/research/xenoarchaeology/tools/gearbelt.dm
+++ b/code/modules/research/xenoarchaeology/tools/gearbelt.dm
@@ -21,7 +21,7 @@
 		/obj/item/photo,
 		/obj/item/folder,
 		/obj/item/pen,
-		/obj/item/reagent_containers/glass/beaker
+		/obj/item/reagent_containers/glass/beaker,
 		/obj/item/clipboard,
 		/obj/item/anodevice,
 		/obj/item/clothing/glasses,

--- a/code/modules/research/xenoarchaeology/tools/gearbelt.dm
+++ b/code/modules/research/xenoarchaeology/tools/gearbelt.dm
@@ -43,5 +43,5 @@
 		/obj/item/device/depth_scanner = 1,
 		/obj/item/device/ano_scanner = 1,
 		/obj/item/ore_detector = 1,
-		/obj/item/wrench = 1,
+		/obj/item/wrench = 1
 		)

--- a/code/modules/research/xenoarchaeology/tools/gearbelt.dm
+++ b/code/modules/research/xenoarchaeology/tools/gearbelt.dm
@@ -44,4 +44,4 @@
 		/obj/item/device/ano_scanner = 1,
 		/obj/item/ore_detector = 1,
 		/obj/item/wrench = 1,
-	)
+		)

--- a/html/changelogs/Lavillastrangiato - new belt.yml
+++ b/html/changelogs/Lavillastrangiato - new belt.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Lavillastrangiato
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds a full variant of the xenoarchaeology belt, and adds more items that can be stored in it."


### PR DESCRIPTION
* Adds a "full" variant of the xenoarchaeology belt that starts with a GPS, hand pickaxe, wrench, excavation picks, depth scanner, Alden-Saraspova scanner, ore detector, core sampler, and wrench.
* Makes radios and camera film able to be stored in a xenoarchaeology belt.
* This PR is dedicated to the brave coders of events, RustingWithYou.
