### PR TITLE
Fixed gremorian cocoon verb

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -375,12 +375,12 @@
 		src.visible_message("\The [src] begins to secrete a sticky substance around \the [P].")
 		if(!do_after(src, 80))
 			return
-		if(P && isturf(P) && get_dist(src,P) <= 1)
-			var/obj/effect/spider/cocoon/C = new(P.loc)
+		if(P && isturf(get_turf(P)) && get_dist(src,P) <= 1)
+			var/obj/effect/spider/cocoon/C = new(get_turf(P))
 			var/large_cocoon = FALSE
 			C.pixel_x = P.pixel_x
 			C.pixel_y = P.pixel_y
-			for(P in C.loc)
+			for(P in get_turf(C))
 				if(istype(P, /mob/living/simple_animal/hostile/giant_spider))
 					continue
 				large_cocoon = TRUE

--- a/html/changelogs/fluffyghost-fixgremoriancocoonverb.yml
+++ b/html/changelogs/fluffyghost-fixgremoriancocoonverb.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed gremorian cocoon verb."
+  - code_imp: "Slight cleanup with usage of get_turf() in the cocoon verb, instead of the loc variable."


### PR DESCRIPTION
Fixed gremorian cocoon verb.
Slight cleanup with usage of get_turf() in the cocoon verb, instead of the loc variable.