### PR TITLE
Premade exosuits now spawn with power cores

### DIFF
--- a/code/modules/heavy_vehicle/premade/combat.dm
+++ b/code/modules/heavy_vehicle/premade/combat.dm
@@ -4,7 +4,7 @@
 	icon_state = "durand"
 
 	e_head = /obj/item/mech_component/sensors/combat
-	e_body = /obj/item/mech_component/chassis/combat
+	e_body = /obj/item/mech_component/chassis/combat/cell
 	e_arms = /obj/item/mech_component/manipulators/combat
 	e_legs = /obj/item/mech_component/propulsion/combat
 	e_color = COLOR_DARK_GUNMETAL
@@ -77,11 +77,17 @@
 
 	. = ..()
 
+/obj/item/mech_component/chassis/combat/cell
+	cell_type = /obj/item/cell/mecha
+
+/obj/item/mech_component/chassis/combat/nuclear
+	cell_type = /obj/item/cell/mecha/nuclear
+
 /mob/living/heavy_vehicle/premade/combat/tcaf
 	name = "\improper Vigilance combat exosuit"
 	desc = "A heavy-duty combat exosuit manufactured by Zavodskoi Interstellar, and issued to the Tau Ceti Armed Forces."
 	e_head = /obj/item/mech_component/sensors/combat
-	e_body = /obj/item/mech_component/chassis/combat
+	e_body = /obj/item/mech_component/chassis/combat/nuclear
 	e_arms = /obj/item/mech_component/manipulators/heavy
 	e_legs = /obj/item/mech_component/propulsion/combat
 	e_color = COLOR_TCFL
@@ -95,7 +101,7 @@
 	name = "\improper Vigilance-C combat exosuit"
 	desc = "A heavy combat exosuit manufactured by Zavodskoi Interstellar, licensed to and slightly modified by the All-Xanu Armed Forces. Used by proponents of the combined Coalition of Colonies military."
 	e_head = /obj/item/mech_component/sensors/combat
-	e_body = /obj/item/mech_component/chassis/combat
+	e_body = /obj/item/mech_component/chassis/combat/nuclear
 	e_arms = /obj/item/mech_component/manipulators/heavy
 	e_legs = /obj/item/mech_component/propulsion/combat
 	e_color = COLOR_COALITION

--- a/code/modules/heavy_vehicle/premade/heavy.dm
+++ b/code/modules/heavy_vehicle/premade/heavy.dm
@@ -4,7 +4,7 @@
 	icon_state = "durand"
 
 	e_head = /obj/item/mech_component/sensors/heavy
-	e_body = /obj/item/mech_component/chassis/heavy
+	e_body = /obj/item/mech_component/chassis/heavy/cell
 	e_arms = /obj/item/mech_component/manipulators/heavy
 	e_legs = /obj/item/mech_component/propulsion/heavy
 	e_color = COLOR_TITANIUM
@@ -65,3 +65,8 @@
 	. = ..()
 	mech_armor = new /obj/item/robot_parts/robot_component/armor/mech/combat(src)
 
+/obj/item/mech_component/chassis/heavy/cell
+	cell_type = /obj/item/cell/mecha
+
+/obj/item/mech_component/chassis/heavy/nuclear
+	cell_type = /obj/item/cell/mecha/nuclear

--- a/code/modules/heavy_vehicle/premade/light.dm
+++ b/code/modules/heavy_vehicle/premade/light.dm
@@ -4,7 +4,7 @@
 	icon_state = "odysseus"
 
 	e_head = /obj/item/mech_component/sensors/light
-	e_body = /obj/item/mech_component/chassis/light
+	e_body = /obj/item/mech_component/chassis/light/cell
 	e_arms = /obj/item/mech_component/manipulators/light
 	e_legs = /obj/item/mech_component/propulsion/light
 	e_color = COLOR_OFF_WHITE
@@ -78,6 +78,9 @@
 
 /obj/item/mech_component/chassis/light/nuclear
 	cell_type = /obj/item/cell/mecha/nuclear
+
+/obj/item/mech_component/chassis/light/cell
+	cell_type = /obj/item/cell/mecha
 
 /mob/living/heavy_vehicle/premade/light/legion
 	name = "legion support exosuit"

--- a/code/modules/heavy_vehicle/premade/miner.dm
+++ b/code/modules/heavy_vehicle/premade/miner.dm
@@ -3,7 +3,7 @@
 	desc = "A mining mecha of custom design, a closed cockpit with powerloader appendages."
 
 	e_head = /obj/item/mech_component/sensors/ripley
-	e_body = /obj/item/mech_component/chassis/combat
+	e_body = /obj/item/mech_component/chassis/combat/cell
 	e_arms = /obj/item/mech_component/manipulators/ripley
 	e_legs = /obj/item/mech_component/propulsion/ripley
 	e_color = COLOR_RIPLEY
@@ -27,7 +27,7 @@
 	name = "salvage exosuit"
 	desc = "An exosuit of unknown design, with a closed cockpit and quadruped motivators."
 	e_head = /obj/item/mech_component/sensors/ripley
-	e_body = /obj/item/mech_component/chassis/combat
+	e_body = /obj/item/mech_component/chassis/combat/nuclear
 	e_arms = /obj/item/mech_component/manipulators/ripley
 	e_legs = /obj/item/mech_component/propulsion/spider
 	e_color = "#b07f0c"

--- a/code/modules/heavy_vehicle/premade/powerloader.dm
+++ b/code/modules/heavy_vehicle/premade/powerloader.dm
@@ -3,7 +3,7 @@
 	desc = "An ancient but well-liked cargo handling exosuit."
 
 	e_head = /obj/item/mech_component/sensors/ripley
-	e_body = /obj/item/mech_component/chassis/ripley
+	e_body = /obj/item/mech_component/chassis/ripley/cell
 	e_arms = /obj/item/mech_component/manipulators/ripley
 	e_legs = /obj/item/mech_component/propulsion/ripley
 	e_color = COLOR_RIPLEY
@@ -80,6 +80,12 @@
 	. = ..()
 	mech_armor = new /obj/item/robot_parts/robot_component/armor/mech(src)
 
+/obj/item/mech_component/chassis/ripley/cell
+	cell_type = /obj/item/cell/mecha
+
+/obj/item/mech_component/chassis/ripley/nuclear
+	cell_type = /obj/item/cell/mecha/nuclear
+
 /obj/item/mech_component/chassis/ripley/Initialize()
 	pilot_positions = list(
 		list(
@@ -115,7 +121,7 @@
 	icon_state = "firefighter"
 
 	e_head = /obj/item/mech_component/sensors/ripley
-	e_body = /obj/item/mech_component/chassis/ripley
+	e_body = /obj/item/mech_component/chassis/ripley/cell
 	e_arms = /obj/item/mech_component/manipulators/ripley
 	e_legs = /obj/item/mech_component/propulsion/ripley
 	e_color = "#385b3c"
@@ -143,7 +149,7 @@
 	decal = "ripley_legion"
 
 	e_head = /obj/item/mech_component/sensors/combatripley
-	e_body = /obj/item/mech_component/chassis/ripley
+	e_body = /obj/item/mech_component/chassis/ripley/nuclear
 	e_arms = /obj/item/mech_component/manipulators/ripley
 	e_legs = /obj/item/mech_component/propulsion/ripley
 	e_color = COLOR_TCFL

--- a/code/modules/heavy_vehicle/premade/pra.dm
+++ b/code/modules/heavy_vehicle/premade/pra.dm
@@ -4,7 +4,7 @@
 	icon_state = "durand"
 
 	e_head = /obj/item/mech_component/sensors/pra_egg
-	e_body = /obj/item/mech_component/chassis/pra_egg
+	e_body = /obj/item/mech_component/chassis/pra_egg/nuclear
 	e_arms = /obj/item/mech_component/manipulators/pra_egg
 	e_legs = /obj/item/mech_component/propulsion/pra_egg
 	e_color = COLOR_STEEL
@@ -59,6 +59,9 @@
 	max_damage = 150
 	power_use = 250
 
+/obj/item/mech_component/chassis/pra_egg/nuclear
+	cell_type = /obj/item/cell/mecha/nuclear
+
 /obj/item/mech_component/chassis/pra_egg/prebuild()
 	. = ..()
 	mech_armor = new /obj/item/robot_parts/robot_component/armor/mech(src)
@@ -68,7 +71,7 @@
 	icon_state = "durand"
 
 	e_head = /obj/item/mech_component/sensors/pra_egg/armored
-	e_body = /obj/item/mech_component/chassis/pra_egg/armored
+	e_body = /obj/item/mech_component/chassis/pra_egg/armored/nuclear
 	e_arms = /obj/item/mech_component/manipulators/pra_egg/armored
 
 /obj/item/mech_component/manipulators/pra_egg/armored
@@ -86,7 +89,7 @@
 	icon_state = "strong_egg_head"
 	max_damage = 120
 
-/obj/item/mech_component/chassis/pra_egg/armored
+/obj/item/mech_component/chassis/pra_egg/armored/nuclear
 	name = "armored P'kus-3 chassis"
 	exosuit_desc_string = "an armored chassis"
 	desc = "A armored composite frame keeps the armor of this chassis respectable, but the interior spacious."

--- a/html/changelogs/RustingWithYou - geevesmoment.yml
+++ b/html/changelogs/RustingWithYou - geevesmoment.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: RustingWithYou
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Premade exosuits now spawn with power cores."


### PR DESCRIPTION
Premade exosuits weren't spawning with power cores, which meant that mapped-in mechs off the Horizon were effectively unusable. All premade mechs will now spawn with an appropriate power core.