### PR TITLE
Luthien Pact origin fix

### DIFF
--- a/code/modules/background/origins/origins/unathi/autakh.dm
+++ b/code/modules/background/origins/origins/unathi/autakh.dm
@@ -6,6 +6,7 @@
 		/singleton/origin_item/origin/autakh/undercity,
 		/singleton/origin_item/origin/autakh/eridani,
 		/singleton/origin_item/origin/autakh/razortail,
+		/singleton/origin_item/origin/autakh/luthien,
 		/singleton/origin_item/origin/autakh/hidden
 	)
 

--- a/html/changelogs/luthien-pact-fix.yml
+++ b/html/changelogs/luthien-pact-fix.yml
@@ -1,0 +1,6 @@
+author: Sparky_hotdog
+
+delete-after: True
+
+changes:
+  - bugfix: "The Aut'akh Luthien Pact origin is now correctly selectable."


### PR DESCRIPTION
Fixes the Luthien Pact origin not being selectable. This was a mistake according to Unathi Lore.
