### PR TITLE
Restricts Wildlands flagpatches from Command

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/factions.dm
+++ b/code/modules/client/preference_setup/loadout/items/factions.dm
@@ -445,10 +445,11 @@
 
 /datum/gear/faction/wildlands_flagpatches
 	display_name = "wildlands flagpatch selection"
-	description = "A selection of flagpatches from the now defunct groups of the Human Wildlands."
+	description = "A selection of flagpatches from the defunct groups of the Human Wildlands."
 	path = /obj/item/clothing/accessory/flagpatch/fsf
 	slot = slot_tie
 	faction = "Private Military Contracting Group"
+	allowed_roles = list("Physician", "Surgeon", "Pharmacist", "Paramedic", "Psychiatrist", "Medical Intern", "Medical Personnel", "Security Cadet", "Security Officer", "Investigator", "Warden", "Security Personnel",  "Bridge Crew")
 	flags = null
 
 /datum/gear/faction/wildlands_flagpatches/New()

--- a/html/changelogs/Dessysalta-flagpatchfix.yml
+++ b/html/changelogs/Dessysalta-flagpatchfix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Dessysalta
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Command members (excl. crewmen) can no longer wear flagpatches from the Wildlands."


### PR DESCRIPTION
Heads of Staff can't wear Wildlands flagpatches. Matt said there are probably inoffensive ones out of the four you can pick, but this is a band-aid change because I don't want to learn how to restrict certain items out of a selection in the loadout to command.

I figured that liaisons and consuls can't wear them either, on account of consuls that would wear them probably being Solarian (and thus not allowed to be on ship in the first place) and liaisons being inherently corporate/generally anti-Sol.