### PR TITLE
Gremorian Warriors/Workers Use Simple Melee AI

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -112,6 +112,7 @@
 	armor_penetration = 15
 	poison_per_bite = 5
 	move_to_delay = 4
+	smart_melee = TRUE
 
 /mob/living/simple_animal/hostile/giant_spider/emp
 	name = "greimorian jackal"
@@ -127,6 +128,7 @@
 	poison_type = /singleton/reagent/perconol // mildly beneficial for organics
 	poison_per_bite = 2
 	move_to_delay = 5
+	smart_melee = TRUE
 
 /mob/living/simple_animal/hostile/giant_spider/bombardier
 	name = "greimorian bombardier"
@@ -144,6 +146,7 @@
 	poison_type = /singleton/reagent/capsaicin/condensed
 	poison_per_bite = 2
 	move_to_delay = 5
+	smart_melee = TRUE
 
 /mob/living/simple_animal/hostile/giant_spider/bombardier/Shoot(var/target, var/start, var/mob/user, var/bullet = 0)
 	if(target == start)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -44,6 +44,7 @@
 	move_to_delay = 6
 	speed = 3
 	mob_size = 6
+	smart_melee = FALSE
 
 	attacktext = "bitten"
 	attack_emote = "skitters toward"
@@ -67,6 +68,7 @@
 	var/atom/cocoon_target
 	poison_type = /singleton/reagent/soporific
 	var/fed = 0
+	smart_melee = FALSE
 
 /mob/living/simple_animal/hostile/giant_spider/nurse/servant
 	name = "greimorian servant"

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -68,8 +68,7 @@
 	var/atom/cocoon_target
 	poison_type = /singleton/reagent/soporific
 	var/fed = 0
-	smart_melee = FALSE
-
+	
 /mob/living/simple_animal/hostile/giant_spider/nurse/servant
 	name = "greimorian servant"
 	desc = "A greimorian with a startling intelligence to its bulbous yellow eyes. Its needle-like mandibles look like they could easily punch through armor - or flesh."

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -68,7 +68,7 @@
 	var/atom/cocoon_target
 	poison_type = /singleton/reagent/soporific
 	var/fed = 0
-	
+
 /mob/living/simple_animal/hostile/giant_spider/nurse/servant
 	name = "greimorian servant"
 	desc = "A greimorian with a startling intelligence to its bulbous yellow eyes. Its needle-like mandibles look like they could easily punch through armor - or flesh."

--- a/html/changelogs/gremsoul_wickedcybs.yml
+++ b/html/changelogs/gremsoul_wickedcybs.yml
@@ -1,0 +1,6 @@
+author: WickedCybs
+
+delete-after: True
+
+changes:
+  - balance: "Gremorian warriors and workers now have simpler melee AI. The former relies on raw strength over strategy and the latter is single-minded in its pursuit of spreading infestation."


### PR DESCRIPTION
Changes their smart melee var with the idea that warriors go for brute strength over strategy and the workers are more simple in how they want to spread the infestation. Makes the former a little different from most of the usual greimorians and the latter less punishing when it comes to spread.
