### PR TITLE
Unrestricts Sk'akh and Si'akh robes in loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/xeno/unathi.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/unathi.dm
@@ -462,7 +462,7 @@
 	display_name = "Skakh robes selection"
 	path = /obj/item/clothing/under/unathi/skakh
 	cost = 1
-	whitelisted = list(SPECIES_UNATHI, SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI)
+	whitelisted = list(SPECIES_UNATHI)
 	sort_category = "Xenowear - Unathi"
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
@@ -479,6 +479,6 @@
 	display_name = "Siakh robes"
 	path = /obj/item/clothing/under/unathi/siakh
 	cost = 1
-	whitelisted = list(SPECIES_UNATHI, SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI)
+	whitelisted = list(SPECIES_UNATHI)
 	sort_category = "Xenowear - Unathi"
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION

--- a/code/modules/client/preference_setup/loadout/items/xeno/unathi.dm
+++ b/code/modules/client/preference_setup/loadout/items/xeno/unathi.dm
@@ -462,9 +462,8 @@
 	display_name = "Skakh robes selection"
 	path = /obj/item/clothing/under/unathi/skakh
 	cost = 1
-	whitelisted = list(SPECIES_UNATHI)
+	whitelisted = list(SPECIES_UNATHI, SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI)
 	sort_category = "Xenowear - Unathi"
-	allowed_roles = list("Chaplain", "Off-Duty Crew Member")
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION
 
 /datum/gear/uniform/unathi/skakh/New()
@@ -480,7 +479,6 @@
 	display_name = "Siakh robes"
 	path = /obj/item/clothing/under/unathi/siakh
 	cost = 1
-	whitelisted = list(SPECIES_UNATHI)
+	whitelisted = list(SPECIES_UNATHI, SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_SKRELL_AXIORI)
 	sort_category = "Xenowear - Unathi"
-	allowed_roles = list("Chaplain", "Off-Duty Crew Member")
 	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION

--- a/html/changelogs/crosarius-UnrestrictedSintaRobes.yml
+++ b/html/changelogs/crosarius-UnrestrictedSintaRobes.yml
@@ -1,0 +1,6 @@
+author: Crosarius
+
+delete-after: True
+
+changes:
+  - qol: "Unrestricts the Sk'akh and Si'akh robes from only Chaplain and Off-Duty Crew, and allows them to be taken by Humans, and Skrell also."

--- a/html/changelogs/crosarius-UnrestrictedSintaRobes.yml
+++ b/html/changelogs/crosarius-UnrestrictedSintaRobes.yml
@@ -3,4 +3,4 @@ author: Crosarius
 delete-after: True
 
 changes:
-  - qol: "Unrestricts the Sk'akh and Si'akh robes from only Chaplain and Off-Duty Crew, and allows them to be taken by Humans, and Skrell also."
+  - qol: "Unrestricts the Sk'akh and Si'akh robes from only Chaplain and Off-Duty Crew"


### PR DESCRIPTION
This PR unrestricts the Sk'akh and Si'akh robes so that they can be taken by any job, not just Off-Duty and Chaplain. It also allows it to be taken by Humans and Skrell, on the off chance someone would like to play an Ouerean Xeno or something.

![image](https://github.com/Aurorastation/Aurora.3/assets/30341877/1325f0a3-ef92-4bab-b05b-63f8068799ed)
![image](https://github.com/Aurorastation/Aurora.3/assets/30341877/10b57d58-6bc5-4cab-87a8-18aba5675fd1)
![image](https://github.com/Aurorastation/Aurora.3/assets/30341877/2d48b610-d77c-4878-af58-2107e045b5d1)
