### PR TITLE
SCCV Spark fixes and QoL

### DIFF
--- a/html/changelogs/hazelmouse-sparkfixes.yml
+++ b/html/changelogs/hazelmouse-sparkfixes.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Spark hangar is now vacuum, allowing the shuttle to use its sensors while docked."
+  - rscadd: "Spark airlock optimised to cycle more efficiently, and to handle air-to-air cycling without flooding the shuttle with foreign gas. Merge valve now starts disabled. Fuel connector now pumps into the fuel tank, rather than directly into the thrusters."

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -5967,6 +5967,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos)
+"eiF" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/hullbeacon/red,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/hangar/operations)
 "ejL" = (
 /obj/machinery/power/smes/buildable/substation{
 	RCon_tag = "Substation - Engineering Lower Deck"
@@ -7097,7 +7108,8 @@
 	shuttle_tag = "Spark";
 	cycle_to_external_air = 1
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch/grey,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/mining)
 "eVk" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -19989,7 +20001,8 @@
 	shuttle_tag = "Spark";
 	cycle_to_external_air = 1
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch/grey,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/mining)
 "nJB" = (
 /turf/simulated/wall/shuttle/unique/scc/research{
@@ -25885,7 +25898,8 @@
 	cycle_to_external_air = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch/grey,
+/turf/simulated/floor/tiled/dark/full,
 /area/shuttle/mining)
 "rNe" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -35036,17 +35050,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/shuttle/intrepid/crew_compartment)
-"xRK" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/hullbeacon/red,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/airless,
-/area/hangar/operations)
 "xRN" = (
 /obj/machinery/door/blast/regular{
 	id = "iso_b_purge";
@@ -50764,7 +50767,7 @@ gyo
 gyo
 gyo
 gyo
-xRK
+eiF
 jEx
 kiw
 kVe

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -5474,10 +5474,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
-"dMx" = (
-/obj/effect/map_effect/marker_helper/airlock/out,
-/turf/simulated/wall,
-/area/horizon/stairwell/central)
 "dMS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -10997,17 +10993,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hangar/canary)
-"hxI" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/hullbeacon/red,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/airless,
-/area/hangar/operations)
 "hxL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
@@ -16135,7 +16120,7 @@
 	name = "Fuel Tank to Thrusters"
 	},
 /obj/effect/floor_decal/industrial/outline/engineering,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
 "liB" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -24570,16 +24555,6 @@
 "qPV" = (
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
-"qPY" = (
-/obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
-	master_tag = "airlock_shuttle_intrepid";
-	name = "airlock_shuttle_intrepid";
-	req_one_access = null;
-	shuttle_tag = "Intrepid"
-	},
-/turf/simulated/wall,
-/area/horizon/stairwell/central)
 "qQa" = (
 /obj/machinery/alarm/west,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -35061,6 +35036,17 @@
 	},
 /turf/simulated/floor/lino,
 /area/shuttle/intrepid/crew_compartment)
+"xRK" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/hullbeacon/red,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/hangar/operations)
 "xRN" = (
 /obj/machinery/door/blast/regular{
 	id = "iso_b_purge";
@@ -50778,7 +50764,7 @@ gyo
 gyo
 gyo
 gyo
-hxI
+xRK
 jEx
 kiw
 kVe
@@ -53608,9 +53594,9 @@ aAe
 wKW
 mBx
 qju
-qPY
 qju
-dMx
+qju
+qju
 qju
 nWF
 dQH

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -174,6 +174,16 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/assembly/chargebay)
+"agG" = (
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_shuttle_intrepid";
+	name = "airlock_shuttle_intrepid";
+	req_one_access = null;
+	shuttle_tag = "Intrepid"
+	},
+/turf/simulated/wall,
+/area/horizon/stairwell/central)
 "agI" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 9
@@ -2802,10 +2812,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/machinery/access_button{
 	pixel_x = -25;
 	pixel_y = 20
@@ -2814,13 +2820,18 @@
 	pixel_x = -25;
 	pixel_y = 27
 	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
+	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_shuttle_spark";
 	name = "airlock_shuttle_spark";
 	req_one_access = list(31,48,67);
-	shuttle_tag = "Spark"
+	shuttle_tag = "Spark";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
 "bZR" = (
@@ -4489,6 +4500,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
 /turf/simulated/wall/shuttle/unique/scc/mining{
 	icon_state = "4,9"
 	},
@@ -4553,7 +4567,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/hangar/operations)
 "dip" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -7080,17 +7094,18 @@
 /obj/effect/landmark/entry_point/aft{
 	name = "aft, airlock"
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_shuttle_spark";
-	name = "airlock_shuttle_spark";
-	req_one_access = list(31,48,67);
-	shuttle_tag = "Spark"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/access_button{
 	dir = 1;
 	pixel_x = 28;
 	pixel_y = 12
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_shuttle_spark";
+	name = "airlock_shuttle_spark";
+	req_one_access = list(31,48,67);
+	shuttle_tag = "Spark";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/mining)
@@ -7389,9 +7404,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 5
-	},
 /turf/simulated/wall/shuttle/unique/scc/research{
 	icon_state = "11,17"
 	},
@@ -7415,13 +7427,14 @@
 	},
 /obj/item/reagent_containers/inhaler/pneumalin,
 /obj/item/reagent_containers/inhaler/pneumalin,
-/obj/machinery/atmospherics/portables_connector/fuel{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/item/device/radio/intercom/expedition/hailing/north{
 	pixel_x = -8;
 	pixel_y = 18
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
@@ -8172,21 +8185,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/hangar/intrepid)
 "fFb" = (
-/obj/structure/shuttle_part/scc/mining{
-	icon_state = "thrustermount";
-	opacity = 1;
-	outside_part = 0
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced{
-	blocks_air = 1;
-	density = 1;
-	name = "thruster mount";
-	opacity = 1
-	},
-/area/shuttle/mining)
+/turf/simulated/floor/airless,
+/area/hangar/operations)
 "fFf" = (
 /obj/machinery/atmospherics/binary/pump/fuel{
 	name = "Fuel Tank to Thrusters"
@@ -9633,7 +9633,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/hangar/operations)
 "gyx" = (
 /obj/effect/floor_decal/corner/brown{
@@ -11412,7 +11412,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/hangar/operations)
 "hPC" = (
 /obj/structure/tank_wall{
@@ -11988,6 +11988,13 @@
 	},
 /area/shuttle/intrepid/engine_compartment)
 "inM" = (
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_shuttle_intrepid";
+	name = "airlock_shuttle_intrepid";
+	req_one_access = null;
+	shuttle_tag = "Intrepid"
+	},
 /turf/simulated/wall/shuttle/unique/scc/research{
 	icon_state = "11,25"
 	},
@@ -12190,7 +12197,7 @@
 	c_tag = "Operations - Mining Shuttle Dock Starboard";
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/hangar/operations)
 "iyV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13419,7 +13426,12 @@
 /area/outpost/mining_main/refinery)
 "jpU" = (
 /obj/machinery/bluespace_beacon,
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
 "jqc" = (
@@ -13993,6 +14005,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
+"jHj" = (
+/obj/effect/map_effect/marker_helper/airlock/out,
+/turf/simulated/wall,
+/area/horizon/stairwell/central)
 "jHp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
@@ -15685,7 +15701,6 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/obj/machinery/door/window/northleft,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/reinforced,
 /area/shuttle/mining)
@@ -15852,11 +15867,13 @@
 	master_tag = "airlock_shuttle_spark";
 	name = "airlock_shuttle_spark";
 	req_one_access = list(31,48,67);
-	shuttle_tag = "Spark"
+	shuttle_tag = "Spark";
+	cycle_to_external_air = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/aux{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
 	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/shuttle/mining)
 "kVv" = (
@@ -16119,10 +16136,12 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
-	dir = 4
+/obj/machinery/atmospherics/binary/pump/fuel{
+	dir = 1;
+	name = "Fuel Tank to Thrusters"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/engineering,
+/turf/simulated/floor/plating,
 /area/shuttle/mining)
 "liB" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -16583,6 +16602,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
+"lAn" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/hullbeacon/red,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/hangar/operations)
 "lAU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -16718,6 +16748,7 @@
 /area/medical/morgue/lower)
 "lFa" = (
 /obj/machinery/hologram/holopad/long_range,
+/obj/effect/overmap/visitable/ship/landable/mining_shuttle,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
 "lFD" = (
@@ -19199,7 +19230,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/hangar/operations)
 "nhw" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -19842,6 +19873,21 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_shuttle_spark";
+	name = "airlock_shuttle_spark";
+	req_one_access = list(31,48,67);
+	shuttle_tag = "Spark";
+	cycle_to_external_air = 1
+	},
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	pixel_x = -25
+	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/mining)
 "nBK" = (
@@ -19967,13 +20013,14 @@
 	dir = 1;
 	icon_state = "door_locked"
 	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_shuttle_spark";
 	name = "airlock_shuttle_spark";
 	req_one_access = list(31,48,67);
-	shuttle_tag = "Spark"
+	shuttle_tag = "Spark";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/mining)
 "nJB" = (
@@ -21142,15 +21189,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/custodial/disposals)
 "ozA" = (
-/obj/machinery/atmospherics/valve/digital/open{
-	dir = 4;
-	name = "airlock shutoff valve"
-	},
-/obj/machinery/atmospherics/binary/pump/fuel{
-	dir = 1;
-	name = "Fuel Tank to Thrusters"
-	},
 /obj/effect/floor_decal/industrial/outline/engineering,
+/obj/machinery/atmospherics/valve/digital{
+	dir = 4;
+	name = "Airlock to Distribution Merge"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/mining)
 "ozE" = (
@@ -22021,7 +22067,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/hangar/operations)
 "phg" = (
 /obj/structure/shuttle_part/scc/research{
@@ -23866,12 +23912,12 @@
 /turf/simulated/floor/tiled,
 /area/operations/loading)
 "qqS" = (
-/obj/machinery/atmospherics/portables_connector/aux{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/closet/walllocker/firecloset{
 	pixel_x = -25
+	},
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
@@ -24920,12 +24966,12 @@
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
 	},
-/obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/machinery/light/spot,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled,
 /area/hangar/operations)
 "rcA" = (
@@ -24958,6 +25004,10 @@
 "rcY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9;
+	icon_state = "intact"
 	},
 /turf/simulated/wall/shuttle/unique/scc/mining{
 	icon_state = "4,8"
@@ -25548,10 +25598,13 @@
 /turf/space/dynamic,
 /area/horizon/exterior)
 "rAa" = (
-/obj/effect/overmap/visitable/ship/landable/mining_shuttle,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+/obj/machinery/atmospherics/binary/pump/fuel{
+	name = "Canister to Fuel Tank";
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
@@ -25815,7 +25868,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/hullbeacon/red,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/hangar/operations)
 "rLd" = (
 /obj/structure/shuttle_part/scc/research{
@@ -25851,20 +25904,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_shuttle_spark";
-	name = "airlock_shuttle_spark";
-	req_one_access = list(31,48,67);
-	shuttle_tag = "Spark"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 10
-	},
 /obj/machinery/door/airlock/external{
 	dir = 1;
 	icon_state = "door_locked"
 	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_shuttle_spark";
+	name = "airlock_shuttle_spark";
+	req_one_access = list(31,48,67);
+	shuttle_tag = "Spark";
+	cycle_to_external_air = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/shuttle/mining)
 "rNe" = (
@@ -26257,8 +26309,17 @@
 	master_tag = "airlock_shuttle_spark";
 	name = "airlock_shuttle_spark";
 	req_one_access = list(31,48,67);
-	shuttle_tag = "Spark"
+	shuttle_tag = "Spark";
+	cycle_to_external_air = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/marker_helper/airlock/out,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/shuttle/mining)
 "rZu" = (
@@ -27006,7 +27067,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/shuttle/mining)
 "sEw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -27577,15 +27638,22 @@
 	pixel_x = 25;
 	pixel_y = -7
 	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_shuttle_spark";
 	name = "airlock_shuttle_spark";
 	req_one_access = list(31,48,67);
-	shuttle_tag = "Spark"
+	shuttle_tag = "Spark";
+	cycle_to_external_air = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	icon_state = "map"
 	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/shuttle/mining)
 "sYf" = (
@@ -30213,10 +30281,6 @@
 	},
 /obj/structure/bed/handrail,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/binary/pump/fuel{
-	dir = 4;
-	name = "Canister to Thrusters"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/mining)
 "uNH" = (
@@ -30386,22 +30450,11 @@
 	},
 /area/shuttle/intrepid/atmos_compartment)
 "uUP" = (
-/obj/structure/shuttle_part/scc/mining{
-	icon_state = "thrustermount";
-	opacity = 1;
-	outside_part = 0
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 5
 	},
-/turf/simulated/floor/reinforced{
-	blocks_air = 1;
-	density = 1;
-	name = "thruster mount";
-	opacity = 1
+/turf/simulated/wall/shuttle/unique/scc/mining{
+	icon_state = "6,2"
 	},
 /area/shuttle/mining)
 "uUZ" = (
@@ -31556,9 +31609,13 @@
 	master_tag = "airlock_shuttle_spark";
 	name = "airlock_shuttle_spark";
 	req_one_access = list(31,48,67);
-	shuttle_tag = "Spark"
+	shuttle_tag = "Spark";
+	cycle_to_external_air = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor/plating,
 /area/shuttle/mining)
 "vFL" = (
@@ -32051,7 +32108,6 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/obj/machinery/door/window/northright,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/reinforced,
 /area/shuttle/mining)
@@ -34374,7 +34430,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced/airless,
 /area/shuttle/mining)
 "xwA" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -50729,7 +50785,7 @@ gyo
 gyo
 gyo
 gyo
-suw
+lAn
 jEx
 kiw
 kVe
@@ -50932,7 +50988,7 @@ oDr
 vHW
 fja
 kZP
-mwO
+fFb
 tNp
 eSV
 eSV
@@ -51135,7 +51191,7 @@ vkB
 tuL
 tVI
 xwo
-mwO
+fFb
 tNp
 eSV
 eSV
@@ -51338,7 +51394,7 @@ sOc
 tqs
 sxP
 sDN
-mwO
+fFb
 tNp
 eSV
 eSV
@@ -51541,7 +51597,7 @@ osc
 tuy
 vhg
 pfs
-mwO
+fFb
 qSF
 eSV
 eSV
@@ -51735,7 +51791,7 @@ rcA
 kKc
 kNN
 nBA
-fFb
+rZh
 ucE
 lhE
 ozA
@@ -51743,8 +51799,8 @@ byb
 sVu
 cWa
 tCA
-mwO
-mwO
+fFb
+fFb
 tNp
 eSV
 eSV
@@ -51946,8 +52002,8 @@ ePy
 xpX
 rZh
 qhG
-mwO
-mwO
+fFb
+fFb
 tNp
 eSV
 eSV
@@ -52149,8 +52205,8 @@ bZR
 iZi
 oSA
 hMj
-mwO
-mwO
+fFb
+fFb
 tNp
 eSV
 eSV
@@ -53559,9 +53615,9 @@ aAe
 wKW
 mBx
 qju
+agG
 qju
-qju
-qju
+jHj
 qju
 nWF
 dQH

--- a/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
+++ b/maps/sccv_horizon/sccv_horizon-1_deck_1.dmm
@@ -174,16 +174,6 @@
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/assembly/chargebay)
-"agG" = (
-/obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
-	master_tag = "airlock_shuttle_intrepid";
-	name = "airlock_shuttle_intrepid";
-	req_one_access = null;
-	shuttle_tag = "Intrepid"
-	},
-/turf/simulated/wall,
-/area/horizon/stairwell/central)
 "agI" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 9
@@ -5484,6 +5474,10 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos)
+"dMx" = (
+/obj/effect/map_effect/marker_helper/airlock/out,
+/turf/simulated/wall,
+/area/horizon/stairwell/central)
 "dMS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11003,6 +10997,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/hangar/canary)
+"hxI" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/hullbeacon/red,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/airless,
+/area/hangar/operations)
 "hxL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
@@ -11988,13 +11993,6 @@
 	},
 /area/shuttle/intrepid/engine_compartment)
 "inM" = (
-/obj/effect/map_effect/marker/airlock/shuttle{
-	cycle_to_external_air = 1;
-	master_tag = "airlock_shuttle_intrepid";
-	name = "airlock_shuttle_intrepid";
-	req_one_access = null;
-	shuttle_tag = "Intrepid"
-	},
 /turf/simulated/wall/shuttle/unique/scc/research{
 	icon_state = "11,25"
 	},
@@ -14005,10 +14003,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenoarch_atrium)
-"jHj" = (
-/obj/effect/map_effect/marker_helper/airlock/out,
-/turf/simulated/wall,
-/area/horizon/stairwell/central)
 "jHp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 9
@@ -16602,17 +16596,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/atmos/propulsion)
-"lAn" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/hullbeacon/red,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/airless,
-/area/hangar/operations)
 "lAU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -24587,6 +24570,16 @@
 "qPV" = (
 /turf/simulated/floor/plating,
 /area/maintenance/research_port)
+"qPY" = (
+/obj/effect/map_effect/marker/airlock/shuttle{
+	cycle_to_external_air = 1;
+	master_tag = "airlock_shuttle_intrepid";
+	name = "airlock_shuttle_intrepid";
+	req_one_access = null;
+	shuttle_tag = "Intrepid"
+	},
+/turf/simulated/wall,
+/area/horizon/stairwell/central)
 "qQa" = (
 /obj/machinery/alarm/west,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -50785,7 +50778,7 @@ gyo
 gyo
 gyo
 gyo
-lAn
+hxI
 jEx
 kiw
 kVe
@@ -53615,9 +53608,9 @@ aAe
 wKW
 mBx
 qju
-agG
+qPY
 qju
-jHj
+dMx
 qju
 nWF
 dQH


### PR DESCRIPTION
- Makes the Spark hangar fully vacuum, so it can use its sensors while docked again like it used to.
- Swaps the fuel line around so the fuel connector pumps into the fuel tank, rather than into the thrusters directly.
- Airlock to distro merger valve starts disabled and the shuttle begins with an airlock air canister. Distro is very high pressure, so the airlock always relying on it made cycling very slow. Should cycle faster now. Air canister in the hangar has been replaced with a PAP.
- Spark airlock now cycles air-to-air by fully emptying foreign gas on an inward cycle, and then refilling with air from the canister. Landing on planets with toxic atmospheres shouldn't flood the shuttle with their atmospheres, or contaminate the airlock canister.
- Windoors on front of the Spark cargo bay have been removed so the out vent works properly.
- Spark airlock has catwalks to match the Intrepid.
- Replaced the odd half-walls at the back of the cargo bay of the Spark with full walls pulled from the front of the spark.
