### PR TITLE
Shuttle atmos-to-atmos fixes + correctly coloured windows for some ships

### DIFF
--- a/html/changelogs/hazelmouse-shuttleandwindowfixes.yml
+++ b/html/changelogs/hazelmouse-shuttleandwindowfixes.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "A variety of shuttle airlocks should now correctly cycle from atmosphere to atmosphere."
+  - rsadd: "Added prettier windows to the Idris, IAC, Sadar, and Hephaestus ERT offships."

--- a/html/changelogs/hazelmouse-shuttleandwindowfixes.yml
+++ b/html/changelogs/hazelmouse-shuttleandwindowfixes.yml
@@ -56,4 +56,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "A variety of shuttle airlocks should now correctly cycle from atmosphere to atmosphere."
-  - rsadd: "Added prettier windows to the Idris, IAC, Sadar, and Hephaestus ERT offships."
+  - rscadd: "Added prettier windows to the Idris, IAC, Sadar, and Hephaestus ERT offships."

--- a/maps/away/away_site/uueoaesa/tret/tret_industrial_complex_.dm
+++ b/maps/away/away_site/uueoaesa/tret/tret_industrial_complex_.dm
@@ -110,3 +110,4 @@
 	master_tag = "airlock_tret_industrial_shuttle"
 	req_one_access = null
 	req_access = null
+	cycle_to_external_air = TRUE

--- a/maps/away/ships/coc/coc_ranger/coc_ship.dmm
+++ b/maps/away/ships/coc/coc_ranger/coc_ship.dmm
@@ -168,12 +168,6 @@
 /area/ship/ranger_corvette/engine1)
 "aFp" = (
 /obj/machinery/computer/ship/sensors,
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	pixel_y = 21;
-	pixel_x = -4;
-	id_tag = "ranger_shuttle_dock";
-	name = "Ranger Shuttle docking port controller"
-	},
 /turf/simulated/floor/tiled/full,
 /area/shuttle/ranger_shuttle)
 "aHv" = (
@@ -302,7 +296,8 @@
 	name = "ranger_shuttle_dock2";
 	master_tag = "ranger_shuttle_dock2";
 	shuttle_tag = "Ranger Shuttle";
-	req_one_access = null
+	req_one_access = null;
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/ranger_shuttle)
@@ -1170,6 +1165,17 @@
 "eGi" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/ranger_corvette/janitor)
+"eJh" = (
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#5b5b5b";
+	frame_color = "#5b5b5b";
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
+/turf/simulated/floor/plating{
+	temperature = 278.15
+	},
+/area/shuttle/ranger_shuttle)
 "eJp" = (
 /obj/item/clothing/accessory/flagpatch/vysoka,
 /obj/item/clothing/head/vysoka,
@@ -1445,7 +1451,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/north{
-	req_access = null;
+	req_access = null
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/ranger_corvette/engine1)
@@ -1699,7 +1705,8 @@
 	name = "ranger_shuttle_dock2";
 	master_tag = "ranger_shuttle_dock2";
 	shuttle_tag = "Ranger Shuttle";
-	req_one_access = null
+	req_one_access = null;
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/ranger_shuttle)
@@ -2098,7 +2105,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/north{
-	req_access = null;
+	req_access = null
 	},
 /obj/machinery/autolathe,
 /turf/simulated/floor/tiled/dark,
@@ -2466,7 +2473,8 @@
 	name = "ranger_shuttle_dock2";
 	master_tag = "ranger_shuttle_dock2";
 	shuttle_tag = "Ranger Shuttle";
-	req_one_access = null
+	req_one_access = null;
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/tiled/full,
 /area/shuttle/ranger_shuttle)
@@ -3331,16 +3339,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "ranger_shuttle_dock2";
-	master_tag = "ranger_shuttle_dock2";
-	shuttle_tag = "Ranger Shuttle";
-	req_one_access = null
-	},
 /obj/machinery/access_button{
 	pixel_x = 12;
 	pixel_y = -28;
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "ranger_shuttle_dock2";
+	master_tag = "ranger_shuttle_dock2";
+	shuttle_tag = "Ranger Shuttle";
+	req_one_access = null;
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/tiled/full,
 /area/shuttle/ranger_shuttle)
@@ -5519,7 +5528,8 @@
 	name = "ranger_shuttle_dock2";
 	master_tag = "ranger_shuttle_dock2";
 	shuttle_tag = "Ranger Shuttle";
-	req_one_access = null
+	req_one_access = null;
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/tiled/full,
 /area/shuttle/ranger_shuttle)
@@ -5953,7 +5963,8 @@
 	name = "ranger_shuttle_dock2";
 	master_tag = "ranger_shuttle_dock2";
 	shuttle_tag = "Ranger Shuttle";
-	req_one_access = null
+	req_one_access = null;
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/tiled/full,
 /area/shuttle/ranger_shuttle)
@@ -6271,12 +6282,6 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "ranger_shuttle_dock2";
-	master_tag = "ranger_shuttle_dock2";
-	shuttle_tag = "Ranger Shuttle";
-	req_one_access = null
-	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	dir = 2;
 	pixel_y = 28;
@@ -6289,6 +6294,13 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "ranger_shuttle_dock2";
+	master_tag = "ranger_shuttle_dock2";
+	shuttle_tag = "Ranger Shuttle";
+	req_one_access = null;
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/ranger_shuttle)
@@ -6307,6 +6319,12 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/bag/inflatable{
 	pixel_y = 4
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	pixel_x = 24;
+	id_tag = "ranger_shuttle_dock";
+	name = "Ranger Shuttle docking port controller";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/full,
 /area/shuttle/ranger_shuttle)
@@ -40686,7 +40704,7 @@ gJZ
 xRX
 xRX
 xRX
-xRX
+kYm
 yau
 yau
 yau
@@ -40943,7 +40961,7 @@ gJZ
 xRX
 xRX
 xRX
-kYm
+yau
 yau
 nVM
 tbY
@@ -41200,7 +41218,7 @@ gJZ
 xRX
 xRX
 xRX
-yau
+eJh
 lvN
 nZU
 tcC
@@ -41714,7 +41732,7 @@ xRX
 xRX
 xRX
 xRX
-yau
+eJh
 aFp
 xCw
 xCw
@@ -41971,7 +41989,7 @@ xRX
 xRX
 xRX
 xRX
-oBx
+yau
 yau
 xHi
 jzV
@@ -42228,7 +42246,7 @@ xRX
 xRX
 xRX
 xRX
-xRX
+oBx
 yau
 yau
 yau

--- a/maps/away/ships/coc/coc_ranger/coc_ship.dmm
+++ b/maps/away/ships/coc/coc_ranger/coc_ship.dmm
@@ -504,6 +504,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/ship/ranger_corvette/engine1)
+"bLh" = (
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#5b5b5b";
+	frame_color = "#5b5b5b";
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/ranger_shuttle)
 "bMK" = (
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 1
@@ -845,9 +854,7 @@
 /obj/effect/landmark/entry_point/south{
 	name = "fore, bridge"
 	},
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
+/turf/simulated/floor/plating,
 /area/shuttle/ranger_shuttle)
 "dwE" = (
 /turf/simulated/floor/plating,
@@ -1165,17 +1172,6 @@
 "eGi" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/ranger_corvette/janitor)
-"eJh" = (
-/obj/effect/map_effect/window_spawner/full/shuttle{
-	color = "#5b5b5b";
-	frame_color = "#5b5b5b";
-	spawn_firedoor = 1;
-	spawn_grille = 1
-	},
-/turf/simulated/floor/plating{
-	temperature = 278.15
-	},
-/area/shuttle/ranger_shuttle)
 "eJp" = (
 /obj/item/clothing/accessory/flagpatch/vysoka,
 /obj/item/clothing/head/vysoka,
@@ -41218,7 +41214,7 @@ gJZ
 xRX
 xRX
 xRX
-eJh
+bLh
 lvN
 nZU
 tcC
@@ -41732,7 +41728,7 @@ xRX
 xRX
 xRX
 xRX
-eJh
+bLh
 aFp
 xCw
 xCw

--- a/maps/away/ships/coc/coc_scarab/coc_scarab_deck_1.dmm
+++ b/maps/away/ships/coc/coc_scarab/coc_scarab_deck_1.dmm
@@ -133,7 +133,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "airlock_scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/coc_scarab/central)
@@ -189,7 +190,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "airlock_scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
@@ -1431,7 +1433,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "airlock_scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
@@ -1685,7 +1688,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "airlock_scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/coc_scarab/central)
@@ -1760,7 +1764,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "airlock_scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
@@ -1878,7 +1883,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "airlock_scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
@@ -1905,7 +1911,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "airlock_scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
@@ -2034,7 +2041,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "airlock_scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
@@ -2210,7 +2218,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "airlock_scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/coc_scarab/central)
@@ -2562,7 +2571,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "airlock_scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)
@@ -2587,7 +2597,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_scarab_shuttle";
 	master_tag = "airlock_scarab_shuttle";
-	shuttle_tag = "Scarab Shuttle"
+	shuttle_tag = "Scarab Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/coc_scarab/central)

--- a/maps/away/ships/dominia/dominian_corvette/dominian_corvette.dmm
+++ b/maps/away/ships/dominia/dominian_corvette/dominian_corvette.dmm
@@ -1060,12 +1060,6 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_dominian_shuttle";
-	master_tag = "airlock_dominian_shuttle";
-	shuttle_tag = "Dominian Shuttle";
-	req_one_access = list(212)
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1075,6 +1069,13 @@
 	pixel_x = 32;
 	pixel_y = 9;
 	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "airlock_dominian_shuttle";
+	master_tag = "airlock_dominian_shuttle";
+	shuttle_tag = "Dominian Shuttle";
+	req_one_access = list(212);
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/dominian_shuttle)
@@ -1176,12 +1177,6 @@
 "dHA" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_dominian_shuttle";
-	master_tag = "airlock_dominian_shuttle";
-	shuttle_tag = "Dominian Shuttle";
-	req_one_access = list(212)
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1189,6 +1184,13 @@
 	dir = 5
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "airlock_dominian_shuttle";
+	master_tag = "airlock_dominian_shuttle";
+	shuttle_tag = "Dominian Shuttle";
+	req_one_access = list(212);
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_shuttle)
 "dIe" = (
@@ -2755,7 +2757,8 @@
 	name = "airlock_dominian_shuttle";
 	master_tag = "airlock_dominian_shuttle";
 	shuttle_tag = "Dominian Shuttle";
-	req_one_access = list(212)
+	req_one_access = list(212);
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/dominian_shuttle)
@@ -3193,7 +3196,8 @@
 	name = "airlock_dominian_shuttle";
 	master_tag = "airlock_dominian_shuttle";
 	shuttle_tag = "Dominian Shuttle";
-	req_one_access = list(212)
+	req_one_access = list(212);
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/dominian_shuttle)
@@ -3219,7 +3223,8 @@
 	name = "airlock_dominian_shuttle";
 	master_tag = "airlock_dominian_shuttle";
 	shuttle_tag = "Dominian Shuttle";
-	req_one_access = list(212)
+	req_one_access = list(212);
+	cycle_to_external_air = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/airless,
@@ -4680,7 +4685,8 @@
 	name = "airlock_dominian_shuttle";
 	master_tag = "airlock_dominian_shuttle";
 	shuttle_tag = "Dominian Shuttle";
-	req_one_access = list(212)
+	req_one_access = list(212);
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/dominian_shuttle)
@@ -5429,14 +5435,15 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux,
 /obj/effect/map_effect/marker_helper/airlock/out,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_dominian_shuttle";
 	master_tag = "airlock_dominian_shuttle";
 	shuttle_tag = "Dominian Shuttle";
-	req_one_access = list(212)
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+	req_one_access = list(212);
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/dominian_shuttle)
@@ -5975,12 +5982,6 @@
 "uYP" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_dominian_shuttle";
-	master_tag = "airlock_dominian_shuttle";
-	shuttle_tag = "Dominian Shuttle";
-	req_one_access = list(212)
-	},
 /obj/machinery/access_button{
 	pixel_x = -28;
 	dir = 2
@@ -5991,6 +5992,13 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, airlock"
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "airlock_dominian_shuttle";
+	master_tag = "airlock_dominian_shuttle";
+	shuttle_tag = "Dominian Shuttle";
+	req_one_access = list(212);
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/dominian_shuttle)
@@ -6369,16 +6377,17 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_dominian_shuttle";
-	master_tag = "airlock_dominian_shuttle";
-	shuttle_tag = "Dominian Shuttle";
-	req_one_access = list(212)
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/airlock_sensor{
 	pixel_x = 24;
 	pixel_y = 6
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "airlock_dominian_shuttle";
+	master_tag = "airlock_dominian_shuttle";
+	shuttle_tag = "Dominian Shuttle";
+	req_one_access = list(212);
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/dominian_shuttle)
@@ -6550,14 +6559,15 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_dominian_shuttle";
 	master_tag = "airlock_dominian_shuttle";
 	shuttle_tag = "Dominian Shuttle";
-	req_one_access = list(212)
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+	req_one_access = list(212);
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/dominian_shuttle)

--- a/maps/away/ships/freebooter/freebooter_ship.dmm
+++ b/maps/away/ships/freebooter/freebooter_ship.dmm
@@ -74,15 +74,16 @@
 /area/ship/freebooter_ship/thruster2)
 "afL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_freebooter_shuttle";
-	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
-	},
 /obj/effect/map_effect/marker_helper/airlock/out,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk/indoor,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle";
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "ahD" = (
@@ -2072,13 +2073,14 @@
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
 	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_freebooter_shuttle";
 	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
+	shuttle_tag = "Freebooter Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -4216,15 +4218,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/freebooter_ship/gunnery)
-"kmP" = (
-/obj/effect/decal/fake_object{
-	desc = "A lightweight support lattice.";
-	icon = 'icons/obj/smooth/lattice.dmi';
-	icon_state = "lattice";
-	name = "lattice"
-	},
-/turf/simulated/floor,
-/area/ship/freebooter_ship/pod4)
 "knE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4472,7 +4465,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_freebooter_shuttle";
 	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
+	shuttle_tag = "Freebooter Shuttle";
+	cycle_to_external_air = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -4931,11 +4925,6 @@
 /obj/structure/bed/stool/chair/shuttle{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_freebooter_shuttle";
-	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
-	},
 /obj/structure/sign/vacuum{
 	pixel_y = 30
 	},
@@ -4945,6 +4934,12 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = -27;
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
@@ -5222,13 +5217,14 @@
 "mkb" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_freebooter_shuttle";
 	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
+	shuttle_tag = "Freebooter Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "moJ" = (
@@ -6681,15 +6677,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/ship/freebooter_ship/thruster2)
-"ppp" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/ship/freebooter_ship/exterior)
 "prU" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/spline/plain/corner{
@@ -7779,11 +7766,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_freebooter_shuttle";
-	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/access_button{
 	pixel_x = 27;
@@ -7795,6 +7777,12 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle";
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "rEb" = (
@@ -7938,16 +7926,17 @@
 	name = "aft, engines"
 	},
 /obj/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_freebooter_shuttle";
-	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle";
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
 "rYv" = (
@@ -8184,13 +8173,14 @@
 /area/ship/freebooter_ship/pod5)
 "syX" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/lattice/catwalk/indoor,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_freebooter_shuttle";
 	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
+	shuttle_tag = "Freebooter Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice/catwalk/indoor,
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "szY" = (
@@ -8381,11 +8371,6 @@
 	pixel_x = -27;
 	pixel_y = -2
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_freebooter_shuttle";
-	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 5
@@ -8395,6 +8380,12 @@
 	pixel_y = -3
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle";
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor/airless,
 /area/shuttle/freebooter_shuttle)
 "sWG" = (
@@ -8438,11 +8429,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_freebooter_shuttle";
-	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
-	},
 /obj/machinery/light{
 	dir = 4;
 	inserted_light = /obj/item/light/tube/colored/blue;
@@ -8450,6 +8436,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk/indoor,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle";
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "tcY" = (
@@ -10177,11 +10169,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "airlock_freebooter_shuttle";
-	name = "airlock_freebooter_shuttle";
-	shuttle_tag = "Freebooter Shuttle"
-	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	pixel_x = 23;
 	dir = 8
@@ -10190,6 +10177,12 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk/indoor,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "airlock_freebooter_shuttle";
+	name = "airlock_freebooter_shuttle";
+	shuttle_tag = "Freebooter Shuttle";
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor,
 /area/shuttle/freebooter_shuttle)
 "xal" = (
@@ -39263,7 +39256,7 @@ wUi
 vZW
 gwg
 pUP
-kmP
+qAl
 qDn
 kev
 jcX
@@ -44395,10 +44388,10 @@ jhL
 vZW
 okU
 sUX
-ppp
-ppp
-ppp
-ppp
+wtm
+wtm
+wtm
+wtm
 jrC
 kQs
 jrC

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
@@ -1092,13 +1092,14 @@
 	pixel_x = -12;
 	pixel_y = 28
 	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
 	req_one_access = list(113);
-	shuttle_tag = "Hegemony Shuttle"
+	shuttle_tag = "Hegemony Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/hegemony)
 "gm" = (
@@ -1852,7 +1853,8 @@
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
 	req_one_access = list(113);
-	shuttle_tag = "Hegemony Shuttle"
+	shuttle_tag = "Hegemony Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/hegemony)
@@ -1899,7 +1901,8 @@
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
 	req_one_access = list(113);
-	shuttle_tag = "Hegemony Shuttle"
+	shuttle_tag = "Hegemony Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/airless,
 /area/shuttle/hegemony)
@@ -3077,19 +3080,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/brig)
-"ss" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/hegemony_ship)
 "sv" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/ship_weapon_dummy,
@@ -3149,13 +3139,14 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
 	req_one_access = list(113);
-	shuttle_tag = "Hegemony Shuttle"
+	shuttle_tag = "Hegemony Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/hegemony)
 "sJ" = (
@@ -4078,15 +4069,16 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/simple/hidden/aux{
+	dir = 10
+	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
 	req_one_access = list(113);
-	shuttle_tag = "Hegemony Shuttle"
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/atmospherics/pipe/simple/hidden/aux{
-	dir = 10
+	shuttle_tag = "Hegemony Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/hegemony)
@@ -5447,13 +5439,14 @@
 	pixel_x = 12;
 	pixel_y = -28
 	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
 	req_one_access = list(113);
-	shuttle_tag = "Hegemony Shuttle"
+	shuttle_tag = "Hegemony Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/plating,
 /area/shuttle/hegemony)
 "FQ" = (
@@ -5646,7 +5639,8 @@
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
 	req_one_access = list(113);
-	shuttle_tag = "Hegemony Shuttle"
+	shuttle_tag = "Hegemony Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/hegemony)
@@ -7406,14 +7400,15 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 8
 	},
+/obj/effect/map_effect/marker_helper/airlock/out,
+/obj/machinery/light,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
 	req_one_access = list(113);
-	shuttle_tag = "Hegemony Shuttle"
+	shuttle_tag = "Hegemony Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/out,
-/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/shuttle/hegemony)
 "Qv" = (
@@ -7617,13 +7612,14 @@
 	pixel_x = 6;
 	pixel_y = 28
 	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_hegemony_shuttle";
 	name = "airlock_hegemony_shuttle";
 	req_one_access = list(113);
-	shuttle_tag = "Hegemony Shuttle"
+	shuttle_tag = "Hegemony Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/shuttle/hegemony)
 "Se" = (
@@ -21684,7 +21680,7 @@ Qt
 Oo
 Lu
 Ck
-ss
+ZW
 IK
 Jt
 aS

--- a/maps/away/ships/heph/heph_security/heph_security.dmm
+++ b/maps/away/ships/heph/heph_security/heph_security.dmm
@@ -2770,7 +2770,12 @@
 	id = "heph_shuttle_shutters"
 	},
 /obj/machinery/door/firedoor/noid,
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "sz" = (
@@ -3400,8 +3405,13 @@
 /turf/simulated/floor/tiled,
 /area/heph_security_ship)
 "xU" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid,
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "xW" = (
@@ -3549,9 +3559,14 @@
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/medbay)
 "zP" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
 /obj/machinery/door/firedoor/noid{
 	dir = 4
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/heph_security)
@@ -4087,7 +4102,12 @@
 /obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "ES" = (
@@ -6070,7 +6090,12 @@
 	name = "fore"
 	},
 /obj/machinery/door/firedoor/noid,
-/obj/effect/map_effect/window_spawner/full/reinforced/grille,
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "Uz" = (

--- a/maps/away/ships/heph/heph_security/heph_security.dmm
+++ b/maps/away/ships/heph/heph_security/heph_security.dmm
@@ -2769,7 +2769,6 @@
 /obj/machinery/door/blast/shutters/open{
 	id = "heph_shuttle_shutters"
 	},
-/obj/machinery/door/firedoor/noid,
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#BDB6AE";
 	frame_color = "#BDB6AE";
@@ -3404,16 +3403,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/heph_security_ship)
-"xU" = (
-/obj/machinery/door/firedoor/noid,
-/obj/effect/map_effect/window_spawner/full/shuttle{
-	color = "#BDB6AE";
-	frame_color = "#BDB6AE";
-	spawn_firedoor = 1;
-	spawn_grille = 1
-	},
-/turf/simulated/floor,
-/area/shuttle/heph_security)
 "xW" = (
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/medbay)
@@ -3559,9 +3548,6 @@
 /turf/simulated/floor/tiled/white,
 /area/heph_security_ship/medbay)
 "zP" = (
-/obj/machinery/door/firedoor/noid{
-	dir = 4
-	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#BDB6AE";
 	frame_color = "#BDB6AE";
@@ -4097,9 +4083,6 @@
 "EJ" = (
 /obj/machinery/door/blast/shutters/open{
 	id = "heph_shuttle_shutters";
-	dir = 4
-	},
-/obj/machinery/door/firedoor/noid{
 	dir = 4
 	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
@@ -6089,7 +6072,6 @@
 /obj/effect/landmark/entry_point/aft{
 	name = "fore"
 	},
-/obj/machinery/door/firedoor/noid,
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#BDB6AE";
 	frame_color = "#BDB6AE";
@@ -38296,7 +38278,7 @@ Zb
 cV
 TG
 xz
-xU
+zP
 Fb
 fF
 Zb

--- a/maps/away/ships/heph/heph_security/heph_security.dmm
+++ b/maps/away/ships/heph/heph_security/heph_security.dmm
@@ -472,13 +472,14 @@
 	pixel_x = -28;
 	pixel_y = 12
 	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_heph_shuttle";
 	name = "airlock_heph_shuttle";
 	req_one_access = list(216);
-	shuttle_tag = "Hephaestus Security Shuttle"
+	shuttle_tag = "Hephaestus Security Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "dA" = (
@@ -2073,7 +2074,8 @@
 	master_tag = "airlock_heph_shuttle";
 	name = "airlock_heph_shuttle";
 	req_one_access = list(216);
-	shuttle_tag = "Hephaestus Security Shuttle"
+	shuttle_tag = "Hephaestus Security Shuttle";
+	cycle_to_external_air = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
 /obj/structure/bed/handrail{
@@ -2343,7 +2345,8 @@
 	master_tag = "airlock_heph_shuttle";
 	name = "airlock_heph_shuttle";
 	req_one_access = list(216);
-	shuttle_tag = "Hephaestus Security Shuttle"
+	shuttle_tag = "Hephaestus Security Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/heph_security)
@@ -2834,15 +2837,16 @@
 "tH" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/manifold/hidden/red,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/landmark/entry_point/fore{
+	name = "aft"
+	},
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_heph_shuttle";
 	name = "airlock_heph_shuttle";
 	req_one_access = list(216);
-	shuttle_tag = "Hephaestus Security Shuttle"
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/landmark/entry_point/fore{
-	name = "aft"
+	shuttle_tag = "Hephaestus Security Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/heph_security)
@@ -3276,7 +3280,8 @@
 	master_tag = "airlock_heph_shuttle";
 	name = "airlock_heph_shuttle";
 	req_one_access = list(216);
-	shuttle_tag = "Hephaestus Security Shuttle"
+	shuttle_tag = "Hephaestus Security Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/heph_security)
@@ -3829,13 +3834,14 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/effect/map_effect/marker_helper/airlock/out,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_heph_shuttle";
 	name = "airlock_heph_shuttle";
 	req_one_access = list(216);
-	shuttle_tag = "Hephaestus Security Shuttle"
+	shuttle_tag = "Hephaestus Security Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "Cg" = (
@@ -4335,13 +4341,14 @@
 /obj/machinery/access_button{
 	pixel_x = -28
 	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_heph_shuttle";
 	name = "airlock_heph_shuttle";
 	req_one_access = list(216);
-	shuttle_tag = "Hephaestus Security Shuttle"
+	shuttle_tag = "Hephaestus Security Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "Hf" = (
@@ -5180,13 +5187,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_heph_shuttle";
 	name = "airlock_heph_shuttle";
 	req_one_access = list(216);
-	shuttle_tag = "Hephaestus Security Shuttle"
+	shuttle_tag = "Hephaestus Security Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "MK" = (
@@ -6793,13 +6801,14 @@
 	pixel_x = 20;
 	pixel_y = -6
 	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "airlock_heph_shuttle";
 	name = "airlock_heph_shuttle";
 	req_one_access = list(216);
-	shuttle_tag = "Hephaestus Security Shuttle"
+	shuttle_tag = "Hephaestus Security Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor,
 /area/shuttle/heph_security)
 "ZZ" = (

--- a/maps/away/ships/iac/iac_rescue_ship.dmm
+++ b/maps/away/ships/iac/iac_rescue_ship.dmm
@@ -21,7 +21,6 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/hangar)
 "aac" = (
-/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
 /obj/machinery/door/blast/shutters/open{
 	dir = 4;
 	id = "chemwindowIAC";
@@ -31,6 +30,12 @@
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/pharmacy)
@@ -70,11 +75,16 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/hangar)
 "adW" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/afthallway)
@@ -247,11 +257,16 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/starboardengine)
 "aqo" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/kitchen)
@@ -1609,7 +1624,6 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/centralhallway)
 "dbG" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
@@ -1617,6 +1631,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 8
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/iac_shuttle)
@@ -2215,11 +2235,16 @@
 /turf/space/transit/north,
 /area/space)
 "euz" = (
-/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
 /obj/machinery/door/blast/shutters/open{
 	dir = 4;
 	id = "chemwindowIAC";
 	name = "Window Shutter"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/pharmacy)
@@ -2557,7 +2582,6 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/medical)
 "fhX" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, bridge"
 	},
@@ -2570,6 +2594,12 @@
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/bridge)
@@ -2810,11 +2840,16 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/hangar)
 "fFU" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/medical)
@@ -3549,7 +3584,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/coord)
 "hoH" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
@@ -3559,6 +3593,12 @@
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/afthallway)
@@ -3690,12 +3730,6 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/bed/handrail,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_iac_rescue_shuttle";
-	req_one_access = list(211);
-	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle"
-	},
 /obj/effect/map_effect/marker_helper/airlock/out,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	pixel_x = -6;
@@ -3704,6 +3738,13 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = 6;
 	pixel_y = 24
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "airlock_iac_rescue_shuttle";
+	req_one_access = list(211);
+	master_tag = "airlock_iac_rescue_shuttle";
+	shuttle_tag = "IAC Ambulance Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
@@ -4020,17 +4061,18 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_iac_rescue_shuttle";
-	req_one_access = list(211);
-	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/access_button{
 	pixel_x = 10;
 	pixel_y = -26;
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "airlock_iac_rescue_shuttle";
+	req_one_access = list(211);
+	master_tag = "airlock_iac_rescue_shuttle";
+	shuttle_tag = "IAC Ambulance Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
@@ -4053,13 +4095,14 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_iac_rescue_shuttle";
 	req_one_access = list(211);
 	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle"
+	shuttle_tag = "IAC Ambulance Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "iuU" = (
@@ -4245,13 +4288,14 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_iac_rescue_shuttle";
 	req_one_access = list(211);
 	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle"
+	shuttle_tag = "IAC Ambulance Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "iJs" = (
@@ -4338,13 +4382,14 @@
 /obj/structure/bed/handrail{
 	dir = 1
 	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_iac_rescue_shuttle";
 	req_one_access = list(211);
 	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle"
+	shuttle_tag = "IAC Ambulance Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "iTS" = (
@@ -4473,7 +4518,8 @@
 	name = "airlock_iac_rescue_shuttle";
 	req_one_access = list(211);
 	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle"
+	shuttle_tag = "IAC Ambulance Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
@@ -4825,11 +4871,16 @@
 /turf/simulated/floor/tiled/freezer,
 /area/ship/iac_rescue_ship/bathroom)
 "kak" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/coord)
@@ -4997,11 +5048,16 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "kFO" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/portengine)
@@ -5272,7 +5328,6 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/hangar)
 "llg" = (
-/obj/effect/map_effect/window_spawner/full/borosilicate/reinforced/firedoor,
 /obj/machinery/door/blast/shutters/open{
 	dir = 4;
 	id = "chemwindowIAC";
@@ -5285,6 +5340,12 @@
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/pharmacy)
@@ -5592,7 +5653,6 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/kitchen)
 "mpX" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
@@ -5600,6 +5660,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 8
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/iac_shuttle)
@@ -5673,11 +5739,16 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/starboardengine)
 "mGf" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "iac_shuttle_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/iac_shuttle)
@@ -5916,11 +5987,16 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/portengine)
 "ntN" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/starboarddocking)
@@ -6453,7 +6529,6 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/portengine)
 "oLN" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/south{
 	name = "fore, bridge"
 	},
@@ -6461,6 +6536,12 @@
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "iac_shuttle_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/iac_shuttle)
@@ -6651,11 +6732,16 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/hangar)
 "pkG" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/dorms)
@@ -6855,7 +6941,8 @@
 	name = "airlock_iac_rescue_shuttle";
 	req_one_access = list(211);
 	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle"
+	shuttle_tag = "IAC Ambulance Shuttle";
+	cycle_to_external_air = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /turf/simulated/floor/tiled/white,
@@ -6922,11 +7009,16 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/hangar)
 "pPY" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/bathroom)
@@ -7050,13 +7142,14 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	name = "airlock_iac_rescue_shuttle";
 	req_one_access = list(211);
 	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle"
+	shuttle_tag = "IAC Ambulance Shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "qjc" = (
@@ -7082,7 +7175,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/hydro)
 "qkm" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
@@ -7092,6 +7184,12 @@
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/bridge)
@@ -7309,17 +7407,18 @@
 	},
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_iac_rescue_shuttle";
-	req_one_access = list(211);
-	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/airlock_sensor{
 	dir = 4;
 	pixel_x = 12;
 	pixel_y = 40
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	name = "airlock_iac_rescue_shuttle";
+	req_one_access = list(211);
+	master_tag = "airlock_iac_rescue_shuttle";
+	shuttle_tag = "IAC Ambulance Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/iac_shuttle)
@@ -7500,7 +7599,6 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/mainstorage)
 "reH" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
@@ -7510,6 +7608,12 @@
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/bridge)
@@ -8462,11 +8566,16 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/starboardengine)
 "tGp" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/hydro)
@@ -8532,11 +8641,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/bridge)
 "tQC" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/portdocking)
@@ -8624,11 +8738,16 @@
 /turf/simulated/floor/carpet/lightblue,
 /area/ship/iac_rescue_ship/dorms)
 "uef" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "iac_windows_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/starboardengine)
@@ -8698,11 +8817,16 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/ship/iac_rescue_ship/starboardengine)
 "upe" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "iac_shuttle_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/iac_shuttle)
@@ -8751,12 +8875,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/ship/iac_rescue_ship/bathroom)
-"uyt" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/ship/iac_rescue_ship/hangar)
 "uBm" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -9488,7 +9606,8 @@
 	name = "airlock_iac_rescue_shuttle";
 	req_one_access = list(211);
 	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle"
+	shuttle_tag = "IAC Ambulance Shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
@@ -41361,7 +41480,7 @@ wrJ
 wrJ
 jar
 aab
-uyt
+sDt
 aaa
 aAY
 mpX
@@ -41618,7 +41737,7 @@ iCT
 wrJ
 jar
 aab
-uyt
+sDt
 jJx
 aAY
 mLN
@@ -43160,7 +43279,7 @@ eCO
 wrJ
 hwr
 jqj
-uyt
+sDt
 jJx
 aAY
 xHP
@@ -43417,7 +43536,7 @@ wrJ
 wrJ
 jar
 fkL
-uyt
+sDt
 fpQ
 aAY
 mGf

--- a/maps/away/ships/idris/idris_cruiser.dmm
+++ b/maps/away/ships/idris/idris_cruiser.dmm
@@ -16,13 +16,16 @@
 /turf/simulated/floor/carpet/green,
 /area/ship/idris_cruiser/corridor/lobby)
 "ab" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_shuttle_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/idris_cruiser_shuttle/bridge)
@@ -185,13 +188,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/idris_cruiser/corridor/dockingarm/port)
 "aB" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/hydroponics)
@@ -903,9 +909,6 @@
 /turf/simulated/floor/plating,
 /area/ship/idris_cruiser/engineering/disposals)
 "dT" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
@@ -913,6 +916,12 @@
 	},
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, starboard docking arm"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/corridor/dockingarm/starboard)
@@ -1224,13 +1233,16 @@
 /turf/simulated/wall/shuttle/idris,
 /area/ship/idris_cruiser/brig)
 "fn" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/bridge)
@@ -1910,13 +1922,16 @@
 /turf/simulated/floor/reinforced/airless,
 /area/ship/idris_cruiser/bridge)
 "hV" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/bridge)
@@ -1932,13 +1947,16 @@
 /turf/simulated/floor/reinforced/airless,
 /area/ship/idris_cruiser/bridge)
 "ia" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/kitchen)
@@ -2114,9 +2132,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/idris_cruiser/corridor/dockingarm/starboard)
 "iU" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
@@ -2124,6 +2139,12 @@
 	},
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, port docking arm"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/corridor/dockingarm/port)
@@ -2229,13 +2250,16 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/idris_cruiser/suite/suite_4)
 "jh" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/corridor/port_lobby)
@@ -2457,9 +2481,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/idris_cruiser_shuttle/bridge)
 "jR" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
@@ -2467,6 +2488,12 @@
 	},
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, bridge"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/bridge)
@@ -2518,13 +2545,16 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "ku" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/great_room)
@@ -2555,13 +2585,16 @@
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/corridor/dockingarm/port)
 "ky" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/corridor/dockingarm/starboard)
@@ -3030,13 +3063,16 @@
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/corridor/lobby)
 "ml" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/cargo_bay)
@@ -3568,9 +3604,6 @@
 /turf/simulated/floor/carpet/green,
 /area/ship/idris_cruiser/corridor/civ_fore)
 "nI" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
@@ -3579,12 +3612,15 @@
 /obj/effect/map_effect/map_helper/ruler_tiles_3{
 	dir = 4
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/pool)
 "nO" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
@@ -3592,6 +3628,12 @@
 	},
 /obj/effect/landmark/entry_point/port{
 	name = "port, great room"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/great_room)
@@ -3933,13 +3975,16 @@
 /turf/simulated/floor/plating,
 /area/ship/idris_cruiser/engineering)
 "pa" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/corridor/suites_a)
@@ -4025,11 +4070,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	shuttle_tag = "Idris Runabout";
-	master_tag = "airlock_idris_cruiser_shuttle";
-	name = "airlock_idris_cruiser_shuttle"
-	},
 /obj/structure/bed/handrail{
 	dir = 4
 	},
@@ -4043,6 +4083,12 @@
 	pixel_x = -22;
 	pixel_y = 10;
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "Idris Runabout";
+	master_tag = "airlock_idris_cruiser_shuttle";
+	name = "airlock_idris_cruiser_shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/idris_cruiser_shuttle/main)
@@ -4157,9 +4203,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/idris_cruiser/hydroponics)
 "pO" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
@@ -4168,6 +4211,12 @@
 /obj/effect/landmark/entry_point/starboard{
 	dir = 1;
 	name = "starboard, main compartment"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/idris_cruiser_shuttle/main)
@@ -4265,13 +4314,16 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/idris_cruiser/bridge)
 "qq" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/corridor/starboard_lobby)
@@ -4577,13 +4629,16 @@
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/crew_quarters)
 "rc" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_shuttle_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/idris_cruiser_shuttle/main)
@@ -4634,9 +4689,6 @@
 /turf/simulated/floor/exoplanet/water/shallow/konyang/no_smooth,
 /area/ship/idris_cruiser/pool)
 "rm" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
@@ -4644,6 +4696,12 @@
 	},
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, great room"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/great_room)
@@ -4661,13 +4719,16 @@
 /turf/simulated/floor/plating,
 /area/shuttle/idris_cruiser_shuttle/engineering)
 "rp" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/engineering)
@@ -4734,9 +4795,6 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "rI" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
@@ -4745,6 +4803,12 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, cockpit";
 	dir = 8
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/idris_cruiser_shuttle/bridge)
@@ -5538,13 +5602,16 @@
 /area/ship/idris_cruiser/corridor/dockingarm/port)
 "un" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_shuttle_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/idris_cruiser_shuttle/main)
@@ -7029,13 +7096,16 @@
 /turf/simulated/floor/plating,
 /area/ship/idris_cruiser/corridor/dockingarm/starboard)
 "zT" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_shuttle_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/idris_cruiser_shuttle/bridge)
@@ -7148,13 +7218,16 @@
 /turf/simulated/floor/plating,
 /area/ship/idris_cruiser/corridor/maintenance_foyer)
 "Ar" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/spa)
@@ -7700,16 +7773,17 @@
 /obj/machinery/access_button{
 	pixel_x = 28
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	shuttle_tag = "Idris Runabout";
-	master_tag = "airlock_idris_cruiser_shuttle";
-	name = "airlock_idris_cruiser_shuttle"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 5
 	},
 /obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "Idris Runabout";
+	master_tag = "airlock_idris_cruiser_shuttle";
+	name = "airlock_idris_cruiser_shuttle";
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/idris_cruiser_shuttle/main)
 "CB" = (
@@ -7908,13 +7982,16 @@
 /turf/simulated/floor/carpet/purple,
 /area/ship/idris_cruiser/lounge)
 "Do" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/lounge)
@@ -7953,13 +8030,16 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/idris_cruiser/breakroom)
 "Dt" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/breakroom)
@@ -8105,14 +8185,15 @@
 /obj/structure/bed/handrail{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	shuttle_tag = "Idris Runabout";
-	master_tag = "airlock_idris_cruiser_shuttle";
-	name = "airlock_idris_cruiser_shuttle"
-	},
 /obj/effect/map_effect/marker_helper/airlock/out,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "Idris Runabout";
+	master_tag = "airlock_idris_cruiser_shuttle";
+	name = "airlock_idris_cruiser_shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/idris_cruiser_shuttle/main)
@@ -8322,9 +8403,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/idris_cruiser/bridge)
 "EL" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/effect/landmark/entry_point/port{
 	dir = 2;
 	name = "port, main compartment"
@@ -8333,6 +8411,12 @@
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_shuttle_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/idris_cruiser_shuttle/main)
@@ -8343,18 +8427,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	shuttle_tag = "Idris Runabout";
 	master_tag = "airlock_idris_cruiser_shuttle";
-	name = "airlock_idris_cruiser_shuttle"
+	name = "airlock_idris_cruiser_shuttle";
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/idris_cruiser_shuttle/main)
 "ES" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
@@ -8362,6 +8444,12 @@
 	},
 /obj/effect/landmark/entry_point/port{
 	name = "port, kitchen"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/kitchen)
@@ -8593,9 +8681,6 @@
 /turf/simulated/floor/wood,
 /area/ship/idris_cruiser/great_room)
 "FM" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
@@ -8603,6 +8688,12 @@
 	},
 /obj/effect/landmark/entry_point/aft{
 	name = "aft, starboard docking arm"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/corridor/starboard_lobby)
@@ -9807,7 +9898,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	shuttle_tag = "Idris Runabout";
 	master_tag = "airlock_idris_cruiser_shuttle";
-	name = "airlock_idris_cruiser_shuttle"
+	name = "airlock_idris_cruiser_shuttle";
+	cycle_to_external_air = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/structure/bed/handrail{
@@ -11238,13 +11330,16 @@
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/crew_quarters)
 "OW" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/security)
@@ -11291,14 +11386,15 @@
 	pixel_x = -28;
 	pixel_y = 12
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	shuttle_tag = "Idris Runabout";
-	master_tag = "airlock_idris_cruiser_shuttle";
-	name = "airlock_idris_cruiser_shuttle"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/external,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	shuttle_tag = "Idris Runabout";
+	master_tag = "airlock_idris_cruiser_shuttle";
+	name = "airlock_idris_cruiser_shuttle";
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/idris_cruiser_shuttle/main)
 "Pf" = (
@@ -11880,13 +11976,16 @@
 /turf/simulated/floor/plating,
 /area/ship/idris_cruiser/corridor/dockingarm/port)
 "Rg" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/corridor/dockingarm/port)
@@ -12245,13 +12344,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/idris_cruiser/crew_quarters)
 "SN" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/medbay)
@@ -12380,7 +12482,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	shuttle_tag = "Idris Runabout";
 	master_tag = "airlock_idris_cruiser_shuttle";
-	name = "airlock_idris_cruiser_shuttle"
+	name = "airlock_idris_cruiser_shuttle";
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/idris_cruiser_shuttle/main)
@@ -12507,13 +12610,16 @@
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/corridor/crew_aft)
 "Uc" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/laundromat)
@@ -12665,13 +12771,16 @@
 /turf/simulated/floor/reinforced/airless,
 /area/ship/idris_cruiser/engineering)
 "UP" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/pool)
@@ -12992,7 +13101,12 @@
 /turf/simulated/floor/plating,
 /area/ship/idris_cruiser/corridor/dockingarm/port)
 "Wb" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/firedoor,
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
+	},
 /turf/simulated/floor/tiled/full,
 /area/ship/idris_cruiser/cargo_bay)
 "We" = (
@@ -13453,9 +13567,6 @@
 /turf/simulated/floor/lino,
 /area/ship/idris_cruiser/bar)
 "Xy" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	name = "Safety Blast Doors";
@@ -13463,6 +13574,12 @@
 	},
 /obj/effect/landmark/entry_point/aft{
 	name = "aft, port docking arm"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/corridor/dockingarm/port)
@@ -13528,9 +13645,6 @@
 /turf/simulated/floor/reinforced/airless,
 /area/ship/idris_cruiser/engineering)
 "XM" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
@@ -13538,6 +13652,12 @@
 	},
 /obj/effect/map_effect/map_helper/ruler_tiles_3{
 	dir = 4
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/great_room)
@@ -13730,9 +13850,6 @@
 /turf/simulated/floor/carpet/green,
 /area/ship/idris_cruiser/corridor/port_lobby)
 "YB" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
@@ -13740,6 +13857,12 @@
 	},
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, custodial closet"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/custodial)
@@ -13854,9 +13977,6 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/idris_cruiser/restroom/suite_3)
 "Zb" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
@@ -13864,6 +13984,12 @@
 	},
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, lounge"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/lounge)
@@ -14058,13 +14184,16 @@
 /turf/simulated/floor/carpet/darkblue,
 /area/ship/idris_cruiser/spa/spa1)
 "ZU" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor{
-	req_one_access = list(220)
-	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
 	name = "Safety Blast Doors";
 	id = "idriscruiser_bridge_blast"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#4B7A73";
+	frame_color = "#4B7A73";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ship/idris_cruiser/corridor/suites_b)

--- a/maps/away/ships/kataphracts/kataphract_ship.dm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dm
@@ -134,6 +134,7 @@
 	name = "Kataphract Transport"
 	shuttle_tag = "Kataphract Transport"
 	master_tag = "airlock_kataphract_transport"
+	cycle_to_external_air = TRUE
 
 /obj/effect/shuttle_landmark/kataphract_transport/hangar
 	name = "Kataphract Transport Shuttle Hangar"

--- a/maps/away/ships/orion/orion_express_ship.dmm
+++ b/maps/away/ships/orion/orion_express_ship.dmm
@@ -401,11 +401,6 @@
 	dir = 2;
 	id_tag = "orion_shuttle_in"
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "orion_shuttle";
-	shuttle_tag = "Orion Express Shuttle";
-	req_one_access = list(201)
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -425,6 +420,12 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "orion_shuttle";
+	shuttle_tag = "Orion Express Shuttle";
+	req_one_access = list(201);
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle/storage)
 "bvf" = (
@@ -436,13 +437,14 @@
 	dir = 2;
 	id_tag = "orion_shuttle_ex"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/green,
+/obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "orion_shuttle";
 	shuttle_tag = "Orion Express Shuttle";
-	req_one_access = list(201)
+	req_one_access = list(201);
+	cycle_to_external_air = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/green,
-/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle/storage)
 "bAQ" = (
@@ -708,16 +710,17 @@
 /turf/simulated/floor/plating,
 /area/ship/orion/mainhall)
 "cvK" = (
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "orion_shuttle";
-	shuttle_tag = "Orion Express Shuttle";
-	req_one_access = list(201)
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "orion_shuttle";
+	shuttle_tag = "Orion Express Shuttle";
+	req_one_access = list(201);
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/orion_shuttle/storage)
@@ -1074,7 +1077,8 @@
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "orion_shuttle";
 	shuttle_tag = "Orion Express Shuttle";
-	req_one_access = list(201)
+	req_one_access = list(201);
+	cycle_to_external_air = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8
@@ -1621,14 +1625,15 @@
 	name = "exterior access button";
 	pixel_x = -27
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "orion_shuttle";
-	shuttle_tag = "Orion Express Shuttle";
-	req_one_access = list(201)
-	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 5
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "orion_shuttle";
+	shuttle_tag = "Orion Express Shuttle";
+	req_one_access = list(201);
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/orion_shuttle/storage)
@@ -1653,11 +1658,6 @@
 	pixel_x = -20;
 	frequency = 1380
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "orion_shuttle";
-	shuttle_tag = "Orion Express Shuttle";
-	req_one_access = list(201)
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1380
 	},
@@ -1666,6 +1666,12 @@
 	pixel_x = -22;
 	dir = 4;
 	pixel_y = -6
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "orion_shuttle";
+	shuttle_tag = "Orion Express Shuttle";
+	req_one_access = list(201);
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/orion_shuttle/storage)
@@ -2019,16 +2025,17 @@
 	dir = 2;
 	id_tag = "orion_shuttle_in"
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "orion_shuttle";
-	shuttle_tag = "Orion Express Shuttle";
-	req_one_access = list(201)
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "orion_shuttle";
+	shuttle_tag = "Orion Express Shuttle";
+	req_one_access = list(201);
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/orion_shuttle/storage)
 "ilT" = (
@@ -3467,16 +3474,17 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/orion/cargo)
 "oAK" = (
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "orion_shuttle";
-	shuttle_tag = "Orion Express Shuttle";
-	req_one_access = list(201)
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
 	},
 /obj/structure/sign/vacuum{
 	pixel_x = -30
+	},
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "orion_shuttle";
+	shuttle_tag = "Orion Express Shuttle";
+	req_one_access = list(201);
+	cycle_to_external_air = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/orion_shuttle/storage)
@@ -4398,12 +4406,13 @@
 	pixel_y = -1;
 	dir = 4
 	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/effect/map_effect/marker/airlock/shuttle{
 	master_tag = "orion_shuttle";
 	shuttle_tag = "Orion Express Shuttle";
-	req_one_access = list(201)
+	req_one_access = list(201);
+	cycle_to_external_air = 1
 	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/airless,
 /area/shuttle/orion_shuttle/storage)
 "spv" = (
@@ -6112,15 +6121,16 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	master_tag = "orion_shuttle";
-	shuttle_tag = "Orion Express Shuttle";
-	req_one_access = list(201)
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1380
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
+/obj/effect/map_effect/marker/airlock/shuttle{
+	master_tag = "orion_shuttle";
+	shuttle_tag = "Orion Express Shuttle";
+	req_one_access = list(201);
+	cycle_to_external_air = 1
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/orion_shuttle/storage)
 "yko" = (

--- a/maps/away/ships/pra/database_freighter/database_freighter.dm
+++ b/maps/away/ships/pra/database_freighter/database_freighter.dm
@@ -118,3 +118,4 @@
 	shuttle_tag = "Database Freighter Shuttle"
 	master_tag = "airlock_database_freighter_shuttle"
 	req_one_access = list(209)
+	cycle_to_external_air = TRUE

--- a/maps/away/ships/sadar_scout/sadar_scout.dmm
+++ b/maps/away/ships/sadar_scout/sadar_scout.dmm
@@ -650,7 +650,6 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/ship/sadar_scout/eva)
 "eD" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_bridge_blast";
 	dir = 4
@@ -658,6 +657,7 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, bridge"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/sadar_scout/bridge)
 "eE" = (
@@ -707,7 +707,6 @@
 /turf/simulated/floor/plating,
 /area/ship/sadar_scout/cic)
 "eM" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, primary armament"
 	},
@@ -715,13 +714,14 @@
 	id = "sadar_weapon_blast";
 	dir = 4
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/reinforced,
 /area/ship/sadar_scout/wep)
 "eT" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_bridge_blast"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/sadar_scout/bridge)
 "eV" = (
@@ -1174,10 +1174,10 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/sadar_scout/mainhall)
 "iA" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_tool_blast"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/sadar_scout/tools)
 "iC" = (
@@ -1224,11 +1224,11 @@
 /turf/simulated/floor/plating,
 /area/ship/sadar_scout/wep)
 "jb" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_weapon_blast";
 	dir = 4
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/reinforced,
 /area/ship/sadar_scout/wep)
 "jd" = (
@@ -1252,13 +1252,18 @@
 /turf/simulated/floor/airless,
 /area/ship/sadar_scout/exterior)
 "jj" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_shuttle_shutters";
 	dir = 4
 	},
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, cockpit"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/sadar_shuttle)
@@ -1288,10 +1293,15 @@
 /turf/simulated/floor/plating,
 /area/ship/sadar_scout/forehall)
 "jp" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_shuttle_shutters";
 	dir = 4
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/sadar_shuttle)
@@ -2008,11 +2018,11 @@
 /turf/space/transit/north,
 /area/space)
 "oK" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_bridge_blast";
 	dir = 4
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/sadar_scout/bridge)
 "oL" = (
@@ -4622,13 +4632,13 @@
 /turf/space,
 /area/ship/sadar_scout/exterior)
 "Jn" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_bridge_blast"
 	},
 /obj/effect/landmark/entry_point/port{
 	name = "port, bridge"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/sadar_scout/bridge)
 "Jr" = (
@@ -4761,10 +4771,10 @@
 /turf/simulated/wall/shuttle/space_ship,
 /area/shuttle/sadar_shuttle)
 "Kb" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_mess_blast"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/sadar_scout/mess)
 "Ke" = (
@@ -4984,10 +4994,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/sadar_scout/eva)
 "Lu" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_weapon_blast"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/reinforced,
 /area/ship/sadar_scout/wep)
 "Lw" = (
@@ -5318,10 +5328,10 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/sadar_scout/forehall)
 "NX" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_hydro_blast"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/sadar_scout/hydro)
 "On" = (
@@ -5377,13 +5387,13 @@
 /turf/simulated/floor/reinforced/airless,
 /area/shuttle/sadar_shuttle)
 "Oz" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, hydroponics"
 	},
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_hydro_blast"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/sadar_scout/hydro)
 "OF" = (
@@ -5654,9 +5664,14 @@
 /turf/simulated/floor/lino,
 /area/ship/sadar_scout/mess)
 "Qn" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_shuttle_shutters"
+	},
+/obj/effect/map_effect/window_spawner/full/shuttle{
+	color = "#BDB6AE";
+	frame_color = "#BDB6AE";
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/sadar_shuttle)
@@ -5709,13 +5724,13 @@
 /turf/simulated/floor/carpet/rubber,
 /area/ship/sadar_scout/cic)
 "QE" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, tool storage"
 	},
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_tool_blast"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/sadar_scout/tools)
 "QI" = (
@@ -6438,10 +6453,10 @@
 /turf/simulated/floor/airless,
 /area/ship/sadar_scout/exterior)
 "VO" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_utility_blast"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/sadar_scout/utility)
 "VX" = (
@@ -6681,13 +6696,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/sadar_scout/eva)
 "Xl" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
 /obj/effect/landmark/entry_point/port{
 	name = "port, utility storage"
 	},
 /obj/machinery/door/blast/regular/open{
 	id = "sadar_utility_blast"
 	},
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary,
 /turf/simulated/floor/plating,
 /area/ship/sadar_scout/utility)
 "Xm" = (

--- a/maps/away/ships/scc/scc_scout_ship.dm
+++ b/maps/away/ships/scc/scc_scout_ship.dm
@@ -110,3 +110,4 @@
 	name = "SCC Scout Shuttle"
 	shuttle_tag = "SCC Scout Shuttle"
 	master_tag = "airlock_scc_scout_shuttle"
+	cycle_to_external_air = TRUE

--- a/maps/away/ships/sol/sol_ssmd/ssmd_ship.dm
+++ b/maps/away/ships/sol/sol_ssmd/ssmd_ship.dm
@@ -185,6 +185,7 @@
 	name = "SSMD Shuttle"
 	shuttle_tag = "SSMD Shuttle"
 	master_tag = "airlock_ssmd_shuttle"
+	cycle_to_external_air = TRUE
 
 /obj/effect/shuttle_landmark/ssmd_shuttle/hangar
 	name = "SSMD Shuttle Hangar"

--- a/maps/away/ships/sol/sol_ssmd/ssmd_ship.dmm
+++ b/maps/away/ships/sol/sol_ssmd/ssmd_ship.dmm
@@ -417,6 +417,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle/ssmd_shuttle{
 	req_one_access = list(13,203)
 	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/shuttle/ssmd_shuttle)
 "aUQ" = (
@@ -2895,6 +2896,7 @@
 /obj/effect/map_effect/marker/airlock/shuttle/ssmd_shuttle{
 	req_one_access = list(13,203)
 	},
+/obj/effect/map_effect/marker_helper/airlock/out,
 /turf/simulated/floor/plating,
 /area/shuttle/ssmd_shuttle)
 "hGn" = (
@@ -4316,7 +4318,7 @@
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/effect/map_effect/marker_helper/airlock/out,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /turf/simulated/floor/plating,
 /area/shuttle/ssmd_shuttle)
 "moE" = (

--- a/maps/away/ships/tramp_freighter/tramp_freighter_landmarks.dm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter_landmarks.dm
@@ -117,3 +117,4 @@
 	name = "airlock_tramp_shuttle"
 	master_tag = "airlock_tramp_shuttle"
 	shuttle_tag = "Freight Shuttle"
+	cycle_to_external_air = TRUE


### PR DESCRIPTION
- Set cycle_to_external_air to true for every shuttle I could find that lacked it, in code if they were already defined in code, and in the .dmm otherwise. This means they should cycle air to air correctly, previously they were not actually making use of their out vents.
- Adds coloured windows to the Idris, IAC, Sadar, and Hephaestus Security offships where missing.