### PR TITLE
Fixes SMES hacking

### DIFF
--- a/code/datums/wires/smes.dm
+++ b/code/datums/wires/smes.dm
@@ -25,7 +25,7 @@
 	var/obj/machinery/power/smes/buildable/S = holder
 	. += ..()
 	. += "The green light is [(S.input_cut || S.input_pulsed || S.output_cut || S.output_pulsed) ? "off" : "on"]."
-	. += "The red light is [(S.safeties_enabled || S.grounding) ? "off" : "blinking"]."
+	. += "The red light is [(S.safeties_enabled && S.grounding) ? "off" : "blinking"]."
 	. += "The blue light is [S.RCon ? "on" : "off"]."
 
 /datum/wires/smes/on_cut(wire, mend, source)

--- a/code/modules/modular_computers/file_system/programs/engineering/rcon.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/rcon.dm
@@ -21,7 +21,7 @@
 
 	var/list/smeslist = list()
 	for(var/obj/machinery/power/smes/buildable/SMES in SSmachinery.rcon_smes_units)
-		if(SMES.RCon == TRUE)
+		if(SMES.RCon)
 			smeslist.Add(list(list(
 			"charge" = round(SMES.Percentage()),
 			"input_set" = SMES.input_attempt,

--- a/code/modules/modular_computers/file_system/programs/engineering/rcon.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/rcon.dm
@@ -21,17 +21,18 @@
 
 	var/list/smeslist = list()
 	for(var/obj/machinery/power/smes/buildable/SMES in SSmachinery.rcon_smes_units)
-		smeslist.Add(list(list(
-		"charge" = round(SMES.Percentage()),
-		"input_set" = SMES.input_attempt,
-		"input_val" = round(SMES.input_level),
-		"output_set" = SMES.output_attempt,
-		"output_val" = round(SMES.output_level),
-		"input_level_max" = SMES.input_level_max,
-		"output_level_max" = SMES.output_level_max,
-		"output_load" = round(SMES.output_used),
-		"RCON_tag" = SMES.RCon_tag
-		)))
+		if(SMES.RCon == TRUE)
+			smeslist.Add(list(list(
+			"charge" = round(SMES.Percentage()),
+			"input_set" = SMES.input_attempt,
+			"input_val" = round(SMES.input_level),
+			"output_set" = SMES.output_attempt,
+			"output_val" = round(SMES.output_level),
+			"input_level_max" = SMES.input_level_max,
+			"output_level_max" = SMES.output_level_max,
+			"output_load" = round(SMES.output_used),
+			"RCON_tag" = SMES.RCon_tag
+			)))
 
 	data["smes_info"] = smeslist
 	// BREAKER DATA (simplified view)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -225,7 +225,7 @@
 	var/goal = (delta_power < 0) ? (charge) : (capacity - charge)
 	time = world.time + (delta_power ? ((goal / abs(delta_power)) * (world.time - last_time)) : 0)
 
-	if(input_cut == TRUE) // Cannot charge if input wire cut
+	if(input_cut) // Cannot charge if input wire cut
 		charge_mode = 0
 	else if(delta_power < 0) // If we are negative - we are discharging
 		charge_mode = 0

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -224,8 +224,10 @@
 
 	var/goal = (delta_power < 0) ? (charge) : (capacity - charge)
 	time = world.time + (delta_power ? ((goal / abs(delta_power)) * (world.time - last_time)) : 0)
-	// If it is negative - we are discharging
-	if(delta_power < 0)
+
+	if(input_cut == TRUE) // Cannot charge if input wire cut
+		charge_mode = 0
+	else if(delta_power < 0) // If we are negative - we are discharging
 		charge_mode = 0
 	else if(delta_power != 0)
 		charge_mode = 1

--- a/html/changelogs/flaminglily - smesfix.yml
+++ b/html/changelogs/flaminglily - smesfix.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FlamingLily
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The RCON wire in a SMES now actually disconnects a SMES from RCON (before it only prevented AI control)."
+  - bugfix: "When the input wire of a SMES is cut, it will now correctly report that the SMES is not charging on the UI."
+  - bugfix: "The Failsafe and Grounding wires of a SMES now correctly trigger the red light when only one is cut, instead of both needing to be triggered."


### PR DESCRIPTION
~~In preparation for my grand political strategy to get SMES hacking wires added to the aurora wiki, I made sure they were working.~~

It's on the wiki now so you have to merge this it's canon 🫡 

Changes:
* The RCON wire in a SMES now actually disconnects a SMES from RCON (before it only prevented AI control).
* When the input wire is cut in a SMES, it will now correctly report that the SMES is not charging on the UI.
* The Failsafe and Grounding wires of a SMES now correctly trigger the red light when only one is cut, instead of both needing to be triggered.
