### PR TITLE
Produce can now be given Descriptions (+ Adhomai produce descs)

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -44,9 +44,9 @@
 	/// Graffiti decal
 	var/splat_type = /obj/effect/decal/cleanable/fruit_smudge
 	var/product_type = /obj/item/reagent_containers/food/snacks/grown
-	/// If set, overrides the description of the product
+	/// If set, overrides the description of the product (What the produce looks like for example)
 	var/product_desc
-	/// If set, overrides the extended scription of the product
+	/// If set, overrides the extended scription of the product (Useful to describe the 'lore')
 	var/product_desc_extended
 
 	var/force_layer

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -1,27 +1,54 @@
 /datum/plantgene
-	var/genetype    // Label used when applying trait.
-	var/list/values // Values to copy into the target seed datum.
+	/// Label used when applying trait.
+	var/genetype
+	/// Values to copy into the target seed datum.
+	var/list/values
 
 /datum/seed
 	//Tracking.
-	var/uid                        // Unique identifier.
-	var/name                       // Index for global list.
-	var/seed_name                  // Plant name for seed packet.
-	var/seed_noun = SEED_NOUN_SEEDS        // Descriptor for packet.
-	var/display_name               // Prettier name.
-	var/roundstart                 // If set, seed will not display variety number.
-	var/mysterious                 // Only used for the random seed packets.
-	var/can_self_harvest = 0       // Mostly used for living mobs.
-	var/growth_stages = 0          // Number of stages the plant passes through before it is mature.
-	var/list/traits = list()       // Initialized in New()
-	var/list/mutants               // Possible predefined mutant varieties, if any.
-	var/list/chems                 // Chemicals that plant produces in products/injects into victim.
-	var/list/consume_gasses        // The plant will absorb these gasses during its life.
-	var/list/exude_gasses          // The plant will exude these gasses during its life.
-	var/kitchen_tag                // Used by the reagent grinder.
-	var/trash_type                 // Garbage item produced when eaten.
-	var/splat_type = /obj/effect/decal/cleanable/fruit_smudge // Graffiti decal.
+	/// Unique identifier
+	var/uid
+	/// Index for global list
+	var/name
+	/// Plant name for seed packet
+	var/seed_name
+	/// Descriptor for packet
+	var/seed_noun = SEED_NOUN_SEEDS
+	/// Prettier name
+	var/display_name
+
+	/// If set, seed will not display variety number
+	var/roundstart
+	/// Only used for the random seed packets.
+	var/mysterious
+	/// Mostly used for living mobs
+	var/can_self_harvest = 0
+	/// Number of stages the plant passes through before it is mature
+	var/growth_stages = 0
+
+	/// Initialized in New()
+	var/list/traits = list()
+	/// Possible predefined mutant varieties, if any
+	var/list/mutants
+	/// Chemicals that plant produces in products/injects into victim
+	var/list/chems
+	/// The plant will absorb these gasses during its life
+	var/list/consume_gasses
+	/// The plant will exude these gasses during its life
+	var/list/exude_gasses
+
+	/// Used by the reagent grinder
+	var/kitchen_tag
+	/// Garbage item produced when eaten
+	var/trash_type
+	/// Graffiti decal
+	var/splat_type = /obj/effect/decal/cleanable/fruit_smudge
 	var/product_type = /obj/item/reagent_containers/food/snacks/grown
+	/// If set, overrides the description of the product
+	var/product_desc
+	/// If set, overrides the extended scription of the product
+	var/product_desc_extended
+
 	var/force_layer
 	var/hydrotray_only
 
@@ -744,6 +771,12 @@
 
 /datum/seed/proc/spawn_seed(var/turf/spawning_loc)
 	var/obj/item/product = new product_type(spawning_loc, name)
+	// Set descriptions
+	if(product_desc)
+		product.desc = product_desc
+	if(product_desc_extended)
+		product.desc_extended = product_desc_extended
+
 	if(get_trait(TRAIT_PRODUCT_COLOUR))
 		if(istype(product, /obj/item/reagent_containers/food))
 			var/obj/item/reagent_containers/food/food = product

--- a/code/modules/hydroponics/seed_datums/adhomai.dm
+++ b/code/modules/hydroponics/seed_datums/adhomai.dm
@@ -5,7 +5,7 @@
 	name = "shand"
 	seed_name = "S'rendarr's hand"
 	display_name = "S'rendarr's hand leaves"
-	product_desc_extended = "A dark green bush that grows above ground in areas around bodies of water. S'rendarr's hand, or Alyad'al S'rendarr, are typically found in the equatorial region along the coasts where many bushes grow together but also are often planted on church properties as well as plantations. These bushes are prolific due to their medicinal fruits which are both eaten and used in salves. Another use that is prolific among Tajara is to dry them out and stuff them in pipes or roll them into cigars for smoking. S'rendarr's hand's smokables are still popular despite the growing popularity of alien tobacco. Tajara who worship the Suns become extremely offended when these plants are placed in rubbish bins or with refuse in general."
+	product_desc_extended = "A dark green bush that grows above ground in areas around bodies of water. S'rendarr's hand, or Alyad'al S'rendarr, are typically planted on church properties as well as plantations. These bushes are prolific due to their medicinal fruits which are both eaten and used in salves. Another use that is prolific among Tajara is to dry them out and stuff them in pipes or roll them into cigars for smoking. S'rendarr's hand's smokables are still popular despite the growing popularity of alien tobacco."
 	chems = list(/singleton/reagent/toxin/tobacco = list(1, 5), /singleton/reagent/bicaridine = list(3, 5), /singleton/reagent/mental/nicotine = list(1, 3))
 	kitchen_tag = "shand"
 
@@ -54,7 +54,7 @@
 	seed_name = "earthen-root"
 	display_name = "earthen-roots"
 	product_desc = "A sweet and firm blue-colored vegetable with no visible soft areas."
-	product_desc_extended = "The Earthen-Root, or Binajr-nab'at, is a herbaceous plant native to the region of the Northern Harr'masir. The herb is highly adapted to the rough and cold climate of the New Kingdom of Adhomai, being able to survive the rigorous winter that other agricultural products can not stand. Being cultivated by farmers in the region since immemorial times, it is considered a symbol of the regional culture of Northern Harr'masir. Common uses for the Earth-Root, besides being used in dishes, include distillation to brew alcoholic beverages, extraction of the blue pigment for the fabrication of dyes, and the production of sugar, even if the plant is not efficient as the sugar trees."
+	product_desc_extended = "The Earthen-Root, or Binajr-nab'at, is a herbaceous plant native to the region of the Northern Harr'masir, and is popular in the New Kingdom of Adhomai due to it's resilience in harsh environments. Common uses for the Earth-Root, besides being used in dishes, include distillation to brew alcoholic beverages, extraction of the blue pigment for the fabrication of dyes, and the production of sugar."
 	chems = list(/singleton/reagent/nutriment = list(0, 5), /singleton/reagent/sugar = list(1, 5), /singleton/reagent/drink/earthenrootjuice = list(4, 8))
 	kitchen_tag = "earthenroot"
 
@@ -78,7 +78,7 @@
 	name = "nifberries"
 	seed_name = "dirt berries"
 	display_name = "dirt berries shrub"
-	product_desc_extended = "An above-ground evergreen shrub that grows sweet, starchy legumes underground in thick pods, in a huge profusion. 'Dirt Berries', or Zhu'hagha Nifs, grow like peanuts but bear several nuts like peas in a pod, typically around 8 thumb-sized nifs in each pod. Their flavor is rich, fatty, and savory, and they are used to produce oil. Each pod when matured produces runners that grow out of the soil and extend like strawberry runners, typically around a foot or so, and are woody, hardy vines."
+	product_desc_extended = "An above-ground evergreen shrub that grows sweet, starchy legumes underground in thick pods. 'Dirt Berries', or Zhu'hagha Nifs, grow like peanuts but bear several nuts like peas in a pod, typically around 8 thumb-sized nifs in each pod. Their flavor is rich, fatty, and savory, and they are used to produce oil."
 	chems = list(/singleton/reagent/nutriment = list(0, 15), /singleton/reagent/nutriment/triglyceride/oil = list(1, 5), /singleton/reagent/drink/dirtberryjuice = list(10,10))
 	kitchen_tag = "nifberries"
 
@@ -134,7 +134,7 @@
 	name = "nmshaan"
 	seed_name = "sugar tree"
 	display_name = "sugar trees"
-	product_desc_extended = "Sugar Tree, or Nm'shaan, are hardy snow bamboo invaluable for sugar production on the planet. They are unique in that on every stem it bears a single spherical fruit at the very top, surrounded by a white woolly rind. Short stems which end in thick-leafed fronds grow along the length of the 'trunk', giving it an appearance like Terran bamboo. The stalks tend to be as thick as one's thigh with very hard, protective woody shells around its vulnerable interior. They grow in giant groves like the bamboo forests on Earth and can be applied in similar uses."
+	product_desc_extended = "Sugar Tree, or Nm'shaan, are hardy snow bamboo invaluable for sugar production on the planet. They are unique in that on every stem it bears a single spherical fruit at the very top, surrounded by a white woolly rind. Short stems which end in thick-leafed fronds grow along the length of the 'trunk', giving it an appearance like Terran bamboo. The stalks tend to be as thick as one's thigh with very hard, protective woody shells around its vulnerable interior."
 	seed_noun = SEED_NOUN_SEEDS
 	mutants = null
 	chems = list(/singleton/reagent/sugar = list(2, 10), /singleton/reagent/nutriment/gelatin = list(2, 5))

--- a/code/modules/hydroponics/seed_datums/adhomai.dm
+++ b/code/modules/hydroponics/seed_datums/adhomai.dm
@@ -3,8 +3,9 @@
 /////////////////////////////
 /datum/seed/shand
 	name = "shand"
-	seed_name = "S'Rendarr's hand"
-	display_name = "S'Rendarr's hand leaves"
+	seed_name = "S'rendarr's hand"
+	display_name = "S'rendarr's hand leaves"
+	product_desc_extended = "A dark green bush that grows above ground in areas around bodies of water. S'rendarr's hand, or Alyad'al S'rendarr, are typically found in the equatorial region along the coasts where many bushes grow together but also are often planted on church properties as well as plantations. These bushes are prolific due to their medicinal fruits which are both eaten and used in salves. Another use that is prolific among Tajara is to dry them out and stuff them in pipes or roll them into cigars for smoking. S'rendarr's hand's smokables are still popular despite the growing popularity of alien tobacco. Tajara who worship the Suns become extremely offended when these plants are placed in rubbish bins or with refuse in general."
 	chems = list(/singleton/reagent/toxin/tobacco = list(1, 5), /singleton/reagent/bicaridine = list(3, 5), /singleton/reagent/mental/nicotine = list(1, 3))
 	kitchen_tag = "shand"
 
@@ -28,6 +29,7 @@
 	name = "mtear"
 	seed_name = "Messa's tear"
 	display_name = "Messa's tear leaves"
+	product_desc_extended = "Growing in patches in many places in the Adhomai wilderness, this grassy medicinal herb can also be found on many church properties much like S'rendarr's Hand. These plants grow to heights between 50 and 75 centimeters and are harvested by scythes. The harvested plants can be eaten, but more typically are ground up and used as ointments for burn treatments."
 	chems = list(/singleton/reagent/nutriment/honey = list(1, 10), /singleton/reagent/kelotane = list(3, 5))
 	kitchen_tag = "mtear"
 
@@ -51,6 +53,8 @@
 	name = "earthenroot"
 	seed_name = "earthen-root"
 	display_name = "earthen-roots"
+	product_desc = "A sweet and firm blue-colored vegetable with no visible soft areas."
+	product_desc_extended = "The Earthen-Root, or Binajr-nab'at, is a herbaceous plant native to the region of the Northern Harr'masir. The herb is highly adapted to the rough and cold climate of the New Kingdom of Adhomai, being able to survive the rigorous winter that other agricultural products can not stand. Being cultivated by farmers in the region since immemorial times, it is considered a symbol of the regional culture of Northern Harr'masir. Common uses for the Earth-Root, besides being used in dishes, include distillation to brew alcoholic beverages, extraction of the blue pigment for the fabrication of dyes, and the production of sugar, even if the plant is not efficient as the sugar trees."
 	chems = list(/singleton/reagent/nutriment = list(0, 5), /singleton/reagent/sugar = list(1, 5), /singleton/reagent/drink/earthenrootjuice = list(4, 8))
 	kitchen_tag = "earthenroot"
 
@@ -74,6 +78,7 @@
 	name = "nifberries"
 	seed_name = "dirt berries"
 	display_name = "dirt berries shrub"
+	product_desc_extended = "An above-ground evergreen shrub that grows sweet, starchy legumes underground in thick pods, in a huge profusion. 'Dirt Berries', or Zhu'hagha Nifs, grow like peanuts but bear several nuts like peas in a pod, typically around 8 thumb-sized nifs in each pod. Their flavor is rich, fatty, and savory, and they are used to produce oil. Each pod when matured produces runners that grow out of the soil and extend like strawberry runners, typically around a foot or so, and are woody, hardy vines."
 	chems = list(/singleton/reagent/nutriment = list(0, 15), /singleton/reagent/nutriment/triglyceride/oil = list(1, 5), /singleton/reagent/drink/dirtberryjuice = list(10,10))
 	kitchen_tag = "nifberries"
 
@@ -101,6 +106,8 @@
 	seed_name = "blizzard ears"
 	seed_noun = SEED_NOUN_NODES
 	display_name = "blizzard ear stalks"
+	product_desc = "A large, meaty, tough fungus with an earthy taste, resembling a more savory jicama."
+	product_desc_extended = "Blizard ears, or N'fri-hi, are a flour-producing plant that forms a meal that can be dried and stored for a long period of time. It grows underground with a thick starchy rind, which is peeled off and is not edible raw. The rind dries, and is pounded into flour, which dries to a fine meal, and has similar usage to potato flour. The raw peeled lobes can be dried, and ground into a more hearty, coarse meal, used like both cornmeal and whole-wheat flour."
 	mutants = null
 	chems = list(/singleton/reagent/nutriment/flour/nfrihi = list(10, 10))
 	splat_type = /obj/effect/plant
@@ -127,6 +134,7 @@
 	name = "nmshaan"
 	seed_name = "sugar tree"
 	display_name = "sugar trees"
+	product_desc_extended = "Sugar Tree, or Nm'shaan, are hardy snow bamboo invaluable for sugar production on the planet. They are unique in that on every stem it bears a single spherical fruit at the very top, surrounded by a white woolly rind. Short stems which end in thick-leafed fronds grow along the length of the 'trunk', giving it an appearance like Terran bamboo. The stalks tend to be as thick as one's thigh with very hard, protective woody shells around its vulnerable interior. They grow in giant groves like the bamboo forests on Earth and can be applied in similar uses."
 	seed_noun = SEED_NOUN_SEEDS
 	mutants = null
 	chems = list(/singleton/reagent/sugar = list(2, 10), /singleton/reagent/nutriment/gelatin = list(2, 5))

--- a/code/modules/hydroponics/seed_datums/adhomai.dm
+++ b/code/modules/hydroponics/seed_datums/adhomai.dm
@@ -5,6 +5,7 @@
 	name = "shand"
 	seed_name = "S'rendarr's hand"
 	display_name = "S'rendarr's hand leaves"
+	product_desc = "a medicinal brush traditionally smoked by the Tajara."
 	product_desc_extended = "A dark green bush that grows above ground in areas around bodies of water. S'rendarr's hand, or Alyad'al S'rendarr, are typically planted on church properties as well as plantations. These bushes are prolific due to their medicinal fruits which are both eaten and used in salves. Another use that is prolific among Tajara is to dry them out and stuff them in pipes or roll them into cigars for smoking. S'rendarr's hand's smokables are still popular despite the growing popularity of alien tobacco."
 	chems = list(/singleton/reagent/toxin/tobacco = list(1, 5), /singleton/reagent/bicaridine = list(3, 5), /singleton/reagent/mental/nicotine = list(1, 3))
 	kitchen_tag = "shand"
@@ -29,6 +30,7 @@
 	name = "mtear"
 	seed_name = "Messa's tear"
 	display_name = "Messa's tear leaves"
+	product_desc = "a medicinal Adhomian leaf used to treat burns."
 	product_desc_extended = "Growing in patches in many places in the Adhomai wilderness, this grassy medicinal herb can also be found on many church properties much like S'rendarr's Hand. These plants grow to heights between 50 and 75 centimeters and are harvested by scythes. The harvested plants can be eaten, but more typically are ground up and used as ointments for burn treatments."
 	chems = list(/singleton/reagent/nutriment/honey = list(1, 10), /singleton/reagent/kelotane = list(3, 5))
 	kitchen_tag = "mtear"
@@ -53,7 +55,7 @@
 	name = "earthenroot"
 	seed_name = "earthen-root"
 	display_name = "earthen-roots"
-	product_desc = "A sweet and firm blue-colored vegetable with no visible soft areas."
+	product_desc = "a sweet and firm blue-colored vegetable with no visible soft areas."
 	product_desc_extended = "The Earthen-Root, or Binajr-nab'at, is a herbaceous plant native to the region of the Northern Harr'masir, and is popular in the New Kingdom of Adhomai due to it's resilience in harsh environments. Common uses for the Earth-Root, besides being used in dishes, include distillation to brew alcoholic beverages, extraction of the blue pigment for the fabrication of dyes, and the production of sugar."
 	chems = list(/singleton/reagent/nutriment = list(0, 5), /singleton/reagent/sugar = list(1, 5), /singleton/reagent/drink/earthenrootjuice = list(4, 8))
 	kitchen_tag = "earthenroot"
@@ -78,6 +80,7 @@
 	name = "nifberries"
 	seed_name = "dirt berries"
 	display_name = "dirt berries shrub"
+	product_desc = "a pile of Adhomian berries used by the Tajara for its oil."
 	product_desc_extended = "An above-ground evergreen shrub that grows sweet, starchy legumes underground in thick pods. 'Dirt Berries', or Zhu'hagha Nifs, grow like peanuts but bear several nuts like peas in a pod, typically around 8 thumb-sized nifs in each pod. Their flavor is rich, fatty, and savory, and they are used to produce oil."
 	chems = list(/singleton/reagent/nutriment = list(0, 15), /singleton/reagent/nutriment/triglyceride/oil = list(1, 5), /singleton/reagent/drink/dirtberryjuice = list(10,10))
 	kitchen_tag = "nifberries"
@@ -106,7 +109,7 @@
 	seed_name = "blizzard ears"
 	seed_noun = SEED_NOUN_NODES
 	display_name = "blizzard ear stalks"
-	product_desc = "A large, meaty, tough fungus with an earthy taste, resembling a more savory jicama."
+	product_desc = "a large, meaty, tough fungus with an earthy taste, resembling a more savory jicama."
 	product_desc_extended = "Blizard ears, or N'fri-hi, are a flour-producing plant that forms a meal that can be dried and stored for a long period of time. It grows underground with a thick starchy rind, which is peeled off and is not edible raw. The rind dries, and is pounded into flour, which dries to a fine meal, and has similar usage to potato flour. The raw peeled lobes can be dried, and ground into a more hearty, coarse meal, used like both cornmeal and whole-wheat flour."
 	mutants = null
 	chems = list(/singleton/reagent/nutriment/flour/nfrihi = list(10, 10))
@@ -134,6 +137,7 @@
 	name = "nmshaan"
 	seed_name = "sugar tree"
 	display_name = "sugar trees"
+	product_desc = "the fruit of the Sugar Tree, native to Adhomai. It is sweet and commonly used in candies."
 	product_desc_extended = "Sugar Tree, or Nm'shaan, are hardy snow bamboo invaluable for sugar production on the planet. They are unique in that on every stem it bears a single spherical fruit at the very top, surrounded by a white woolly rind. Short stems which end in thick-leafed fronds grow along the length of the 'trunk', giving it an appearance like Terran bamboo. The stalks tend to be as thick as one's thigh with very hard, protective woody shells around its vulnerable interior."
 	seed_noun = SEED_NOUN_SEEDS
 	mutants = null

--- a/code/modules/hydroponics/seed_datums/misc.dm
+++ b/code/modules/hydroponics/seed_datums/misc.dm
@@ -44,6 +44,7 @@
 	name = "grass"
 	seed_name = "grass"
 	display_name = "grass"
+	product_desc = "You should probably touch some of this sometime."
 	chems = list(/singleton/reagent/nutriment = list(1,20))
 	kitchen_tag = "grass"
 

--- a/html/changelogs/Ben10083 - Seed Description.yml
+++ b/html/changelogs/Ben10083 - Seed Description.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - code_imp: "Produce from gardening can now be given descriptions and extended descriptions, for when we want lore to write about potatos."
+  - code_imp: "DMdocing seeds."


### PR DESCRIPTION
Seed code DMdoc'ed and code added to allow for custom descriptions and extended descriptions for produce.

Adhomai plants given descriptions as proof of concept (maybe)

- [x] Foundation code
- [x] Assassinate Almrah Harrlala
- [x] Adhomai Plants descriptions