### PR TITLE
Minor Map Tweaks (Mostly Science)

### DIFF
--- a/html/changelogs/Lavillastrangiato - sciencemaptweaks.yml
+++ b/html/changelogs/Lavillastrangiato - sciencemaptweaks.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Lavillastrangiato
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Tweaks some tile decorations in the science department."
+  - qol: "Moves some of the science equipment around to be more accessible or provide more table space."
+  - qol: "Adds a coat rack to the public garden."

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -14895,12 +14895,12 @@
 /turf/simulated/floor/wood,
 /area/horizon/bar)
 "gKG" = (
-/obj/effect/floor_decal/corner/mauve/full{
-	dir = 1
-	},
 /obj/machinery/power/apc/east,
 /obj/structure/cable/green{
 	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/foyer)
@@ -17126,6 +17126,7 @@
 /obj/structure/table/rack,
 /obj/item/trap/animal,
 /obj/item/trap/animal,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/rnd/xenobiology/foyer)
 "hLh" = (
@@ -26779,9 +26780,6 @@
 /turf/simulated/floor/tiled,
 /area/medical/paramedic)
 "mtp" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -32160,6 +32158,7 @@
 /obj/item/trap/animal/large,
 /obj/item/trap/animal/large,
 /obj/machinery/light,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/rnd/xenobiology/foyer)
 "oRF" = (
@@ -40318,9 +40317,6 @@
 /turf/simulated/floor/lino,
 /area/horizon/bar)
 "sOn" = (
-/obj/effect/floor_decal/corner/mauve/full{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -40343,6 +40339,9 @@
 	dir = 10;
 	pixel_x = 32;
 	desiredstate = 1
+	},
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/foyer)
@@ -41448,7 +41447,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/foyer)
 "tmO" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -43141,6 +43143,7 @@
 /obj/structure/table/rack,
 /obj/item/trap/animal/medium,
 /obj/item/trap/animal/medium,
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/rnd/xenobiology/foyer)
 "ubz" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -2645,6 +2645,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/mauve/full,
+/obj/item/book/manual/excavation,
+/obj/item/book/manual/materials_chemistry_analysis,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "blJ" = (
@@ -3659,13 +3661,6 @@
 /turf/simulated/wall/r_wall,
 /area/horizon/security/brig)
 "bDv" = (
-/obj/machinery/chemical_dispenser/coffee/full{
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup,
-/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup{
-	pixel_x = 7
-	},
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/mauve{
 	dir = 5
@@ -5223,13 +5218,6 @@
 /obj/machinery/power/apc/west,
 /obj/structure/cable/green{
 	icon_state = "0-4"
-	},
-/obj/machinery/microscope/science{
-	dir = 8;
-	pixel_y = 12
-	},
-/obj/item/storage/box/fancy/vials{
-	pixel_y = -12
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
@@ -10021,7 +10009,6 @@
 /area/rnd/xenobiology/xenoflora)
 "eHt" = (
 /obj/structure/platform,
-/obj/machinery/spectrophotometer,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/lab)
 "eHG" = (
@@ -24123,7 +24110,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "lcs" = (
-/obj/machinery/vending/coffee,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
@@ -31132,10 +31118,10 @@
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "oqm" = (
-/obj/structure/bookcase,
-/obj/item/book/manual/mass_spectrometry,
-/obj/item/book/manual/materials_chemistry_analysis,
-/obj/item/book/manual/excavation,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
+	},
+/obj/machinery/spectrophotometer,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "oqv" = (
@@ -38977,6 +38963,7 @@
 /obj/effect/floor_decal/corner/mauve{
 	dir = 10
 	},
+/obj/machinery/centrifuge,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "rZy" = (
@@ -39703,6 +39690,13 @@
 	dir = 8
 	},
 /obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup,
+/obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup{
+	pixel_x = 7
+	},
+/obj/machinery/chemical_dispenser/coffee/full{
+	pixel_y = 14
+	},
 /turf/simulated/floor/wood,
 /area/rnd/hallway/secondary)
 "suc" = (
@@ -40449,7 +40443,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/centrifuge,
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
 "sRe" = (
@@ -46974,12 +46967,17 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "vNg" = (
-/obj/item/paper_bin,
-/obj/item/pen/black,
 /obj/structure/table/standard,
 /obj/machinery/firealarm/east,
 /obj/effect/floor_decal/corner/mauve{
 	dir = 6
+	},
+/obj/machinery/microscope/science{
+	dir = 4;
+	pixel_y = 12
+	},
+/obj/item/storage/box/fancy/vials{
+	pixel_y = -12
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
@@ -48654,6 +48652,8 @@
 /obj/effect/floor_decal/corner/mauve/full{
 	dir = 4
 	},
+/obj/item/paper_bin,
+/obj/item/pen/black,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "wvn" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -19168,11 +19168,11 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/investigations_hallway)
 "iJq" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 5
-	},
 /obj/machinery/chem_master,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/rubber,
 /area/rnd/xenobiology/xenoflora)
 "iJv" = (
 /obj/structure/platform{
@@ -19621,10 +19621,6 @@
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
-	},
-/obj/machinery/microscope/science{
-	dir = 4;
-	pixel_y = 12
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
@@ -43305,8 +43301,15 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "ueF" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/structure/sink/kitchen{
+	dir = 8;
+	name = "sink";
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "ueH" = (
 /turf/simulated/floor/tiled/dark,
@@ -45358,16 +45361,9 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/full,
 /area/horizon/bar)
-"uZp" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/structure/sink/kitchen{
-	dir = 8;
-	name = "sink";
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled,
+"uZr" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "uZs" = (
 /obj/structure/table/wood,
@@ -47833,10 +47829,10 @@
 /area/hallway/primary/central_one)
 "wdn" = (
 /obj/machinery/chemical_dispenser,
-/obj/effect/floor_decal/corner/mauve{
-	dir = 5
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/carpet/rubber,
 /area/rnd/xenobiology/xenoflora)
 "wdw" = (
 /obj/structure/disposalpipe/segment,
@@ -49443,7 +49439,6 @@
 	pixel_x = 3;
 	pixel_y = -1
 	},
-/obj/item/sampler,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "wPb" = (
@@ -52602,6 +52597,8 @@
 /area/operations/office)
 "yhR" = (
 /obj/structure/table/standard,
+/obj/item/sampler,
+/obj/item/sampler,
 /turf/simulated/floor/tiled/dark/full,
 /area/rnd/xenobiology/foyer)
 "yig" = (
@@ -83567,7 +83564,7 @@ nnk
 atQ
 atQ
 aAR
-ueF
+uZr
 sPn
 xRv
 fLi
@@ -84375,7 +84372,7 @@ bLT
 fQM
 fQM
 xZJ
-uZp
+ueF
 wKP
 nir
 iRl

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -315,9 +315,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/bar/backroom)
 "ahm" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -2650,6 +2647,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/mauve/full,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "blJ" = (
@@ -3253,8 +3251,8 @@
 /turf/simulated/open/airless,
 /area/horizon/exterior)
 "bxM" = (
-/obj/effect/floor_decal/corner/mauve/full{
-	dir = 8
+/obj/effect/floor_decal/corner/mauve{
+	dir = 9
 	},
 /obj/machinery/disposal/small/east,
 /obj/structure/disposalpipe/trunk,
@@ -3672,7 +3670,10 @@
 	pixel_x = 7
 	},
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "bDO" = (
 /turf/simulated/floor/carpet/rubber,
@@ -5121,7 +5122,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "cjg" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -7225,9 +7228,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/central_one)
 "dpE" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 5
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "dpG" = (
@@ -7963,7 +7963,10 @@
 	network = list("Research","Xeno_Bio")
 	},
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "dJE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9646,7 +9649,9 @@
 /area/chapel/office)
 "eyI" = (
 /obj/structure/coatrack,
-/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 8
+	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -20311,7 +20316,10 @@
 	},
 /obj/structure/closet/crate,
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "jlp" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -23147,7 +23155,10 @@
 	pixel_y = 6
 	},
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "kEY" = (
 /obj/effect/floor_decal/corner/brown{
@@ -27161,9 +27172,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/hallway/engineering)
 "mAQ" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -29850,7 +29858,9 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/secure_ammunition_storage)
 "nKt" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -31020,9 +31030,6 @@
 /area/template_noop)
 "ooZ" = (
 /obj/structure/bed/stool/chair/office/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/mauve/full{
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -32984,9 +32991,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "pkA" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 6
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -33453,9 +33457,6 @@
 /turf/simulated/floor/wood,
 /area/hallway/primary/central_two)
 "pwv" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
@@ -38955,7 +38956,10 @@
 	desiredstate = 1
 	},
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "rZy" = (
 /obj/effect/floor_decal/corner/dark_green{
@@ -40995,7 +40999,9 @@
 /turf/simulated/floor/wood,
 /area/operations/lower/machinist/surgicalbay)
 "tcz" = (
-/obj/effect/floor_decal/corner/mauve/full,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "tcE" = (
@@ -45993,9 +45999,6 @@
 /area/rnd/telesci)
 "vsI" = (
 /obj/structure/bed/stool/chair/office/light,
-/obj/effect/floor_decal/corner/mauve/full{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -46950,7 +46953,10 @@
 /obj/item/pen/black,
 /obj/structure/table/standard,
 /obj/machinery/firealarm/east,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "vNF" = (
 /obj/structure/disposalpipe/segment{
@@ -48620,7 +48626,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "wvn" = (
 /obj/structure/disposalpipe/trunk{
@@ -51460,7 +51469,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenological)
 "xMQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -21785,7 +21785,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/structure/plasticflaps/airtight,
+/obj/structure/plasticflaps/airtight{
+	dir = 8
+	},
 /obj/machinery/door/window/westleft{
 	name = "Server Room"
 	},

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -12119,6 +12119,9 @@
 "fEI" = (
 /obj/machinery/power/apc/east,
 /obj/structure/cable/green,
+/obj/structure/coatrack{
+	pixel_x = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/horizon/hydroponics/garden)
 "fEO" = (

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -31720,7 +31720,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "oDV" = (
 /obj/structure/cable/green{
@@ -33484,7 +33485,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/xenobiology/xenoflora)
 "pxA" = (
@@ -43302,10 +43305,8 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "ueF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "ueH" = (
 /turf/simulated/floor/tiled/dark,
@@ -45357,6 +45358,17 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/full,
 /area/horizon/bar)
+"uZp" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/structure/sink/kitchen{
+	dir = 8;
+	name = "sink";
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "uZs" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger{
@@ -83153,7 +83165,7 @@ kDx
 ngG
 eUi
 pxt
-sGR
+tsf
 wUn
 wUn
 wUn
@@ -83354,8 +83366,8 @@ lEv
 lEv
 bjM
 oDz
-ueF
-tsf
+tbi
+xRv
 scH
 scH
 scH
@@ -83555,7 +83567,7 @@ nnk
 atQ
 atQ
 aAR
-tbi
+ueF
 sPn
 xRv
 fLi
@@ -84363,7 +84375,7 @@ bLT
 fQM
 fQM
 xZJ
-wKP
+uZp
 wKP
 nir
 iRl

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -10637,7 +10637,6 @@
 /obj/effect/floor_decal/spline/plain/cee{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/chemistry)
 "eWP" = (
@@ -36182,7 +36181,6 @@
 /obj/effect/floor_decal/spline/plain/cee{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/chemistry)
 "qLT" = (
@@ -37639,7 +37637,6 @@
 	req_access = list(7)
 	},
 /obj/effect/floor_decal/spline/plain/cee,
-/turf/simulated/floor/tiled/white,
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/chemistry)
 "rtF" = (
@@ -40447,6 +40444,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
+"sRb" = (
+/obj/effect/floor_decal/corner/lime{
+	dir = 6
+	},
+/obj/structure/sink/kitchen{
+	dir = 8;
+	name = "sink";
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/xenobiology/xenoflora)
 "sRe" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -43301,15 +43309,8 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/brig)
 "ueF" = (
-/obj/effect/floor_decal/corner/lime{
-	dir = 6
-	},
-/obj/structure/sink/kitchen{
-	dir = 8;
-	name = "sink";
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology/xenoflora)
 "ueH" = (
 /turf/simulated/floor/tiled/dark,
@@ -45361,10 +45362,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/full,
 /area/horizon/bar)
-"uZr" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/dark,
-/area/rnd/xenobiology/xenoflora)
 "uZs" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger{
@@ -50041,7 +50038,6 @@
 /obj/effect/floor_decal/spline/plain/cee{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
 /turf/simulated/floor/carpet/rubber,
 /area/rnd/chemistry)
 "xed" = (
@@ -83564,7 +83560,7 @@ nnk
 atQ
 atQ
 aAR
-uZr
+ueF
 sPn
 xRv
 fLi
@@ -84372,7 +84368,7 @@ bLT
 fQM
 fQM
 xZJ
-ueF
+sRb
 wKP
 nir
 iRl

--- a/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
+++ b/maps/sccv_horizon/sccv_horizon-2_deck_2.dmm
@@ -1026,9 +1026,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/atmos/storage)
 "axc" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 10
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "axl" = (
@@ -6855,7 +6852,9 @@
 /obj/item/storage/box/gloves,
 /obj/item/clothing/glasses/safety/goggles/science,
 /obj/item/clothing/glasses/safety/goggles/science,
-/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
+	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
@@ -7831,7 +7830,10 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "dGj" = (
 /turf/simulated/wall/r_wall,
@@ -9922,7 +9924,9 @@
 /obj/structure/bed/stool/chair/office/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/mauve/full,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "eGx" = (
@@ -10362,8 +10366,8 @@
 /turf/simulated/floor/tiled,
 /area/horizon/security/hallway)
 "eRp" = (
-/obj/effect/floor_decal/corner/mauve/full{
-	dir = 8
+/obj/effect/floor_decal/corner/mauve{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
@@ -10643,8 +10647,11 @@
 /obj/machinery/chem_master{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/carpet/rubber,
 /area/rnd/chemistry)
 "eWP" = (
 /obj/structure/cable{
@@ -12702,9 +12709,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/horizon/zat)
 "fSm" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
@@ -12715,6 +12719,9 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "fSw" = (
@@ -13567,7 +13574,9 @@
 /obj/structure/bed/stool/chair/office/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "gkh" = (
@@ -15531,7 +15540,9 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/xenobiology)
 "hbt" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 8
+	},
 /obj/structure/sink{
 	pixel_y = 28;
 	pixel_x = -10
@@ -15638,9 +15649,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/main_storage)
 "hep" = (
-/obj/effect/floor_decal/corner/mauve/full{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
@@ -19575,9 +19583,11 @@
 /turf/simulated/floor/plating,
 /area/horizon/security/hallway)
 "iSG" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
 /obj/structure/cable/green,
 /obj/machinery/power/apc/south,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "iTm" = (
@@ -22582,13 +22592,16 @@
 /obj/item/grenade/chem_grenade,
 /obj/item/grenade/chem_grenade,
 /obj/item/grenade/chem_grenade,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/gun/launcher/syringe,
 /obj/item/storage/box/syringegun,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "knH" = (
 /obj/structure/dispenser/oxygen,
@@ -23671,9 +23684,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/horizon/security/brig)
 "kRz" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 5
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -29220,9 +29230,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "ntg" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 10
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -29747,7 +29754,8 @@
 /area/engineering/smes/rust)
 "nGt" = (
 /obj/machinery/chem_heater,
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "nGI" = (
 /obj/effect/floor_decal/corner/dark_green/full{
@@ -33384,7 +33392,8 @@
 	pixel_y = 2;
 	pixel_x = -8
 	},
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "puN" = (
 /obj/structure/table/rack,
@@ -35490,7 +35499,10 @@
 "qvN" = (
 /obj/structure/table/standard,
 /obj/machinery/firealarm/south,
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/corner/mauve{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "qvO" = (
 /obj/effect/floor_decal/corner/dark_blue{
@@ -36179,8 +36191,11 @@
 /obj/machinery/chem_master{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/carpet/rubber,
 /area/rnd/chemistry)
 "qLT" = (
 /obj/effect/floor_decal/corner/dark_green{
@@ -37635,8 +37650,9 @@
 /obj/machinery/chemical_dispenser/full{
 	req_access = list(7)
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/spline/plain/cee,
+/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/carpet/rubber,
 /area/rnd/chemistry)
 "rtF" = (
 /obj/structure/cable/green{
@@ -38370,8 +38386,8 @@
 /obj/structure/bed/stool/chair/office/light{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/mauve/full{
-	dir = 1
+/obj/effect/floor_decal/corner/mauve{
+	dir = 5
 	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -38625,7 +38641,8 @@
 /obj/structure/table/standard,
 /obj/item/storage/box/fancy/vials,
 /obj/item/reagent_containers/dropper/electronic_pipette,
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/corner/mauve/full,
+/turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "rSD" = (
 /obj/effect/floor_decal/corner/dark_green{
@@ -40709,7 +40726,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/wing/starboard/far)
 "sXh" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 1
+	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
@@ -45219,7 +45238,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "uUJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -45654,7 +45674,10 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/east,
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "vgt" = (
 /obj/structure/disposaloutlet{
@@ -46337,9 +46360,6 @@
 /turf/simulated/floor/plating,
 /area/horizon/hallway/deck_two/fore)
 "vzO" = (
-/obj/effect/floor_decal/corner/mauve{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -50008,8 +50028,11 @@
 /obj/machinery/chemical_dispenser/full{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/full,
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/carpet/rubber,
 /area/rnd/chemistry)
 "xed" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -51874,7 +51897,9 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/engineering/engine_room/rust)
 "xVt" = (
-/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/effect/floor_decal/corner/mauve/full{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/chemistry)
 "xVu" = (


### PR DESCRIPTION
* Makes some tile tweaks that were bothering me to the science map; some of them are white now and not steel-tile grey.
* Moves the microscope, centrifuge, and spectrophotometer to the lab between botany/biology. Also puts the science samplers in the xenobiology foyer.
* Adds a coat rack to the public garden.
