### PR TITLE
Anomalist Alt Title For Xenoarchaeologist

### DIFF
--- a/code/game/jobs/faction/zavodskoi.dm
+++ b/code/game/jobs/faction/zavodskoi.dm
@@ -56,6 +56,7 @@
 		"Xenobotanist" = /obj/outfit/job/scientist/xenobotanist/zavodskoi,
 		"Lab Assistant" = /obj/outfit/job/intern_sci/zavodskoi,
 		"Xenoarchaeologist"= /obj/outfit/job/scientist/xenoarchaeologist/zavodskoi,
+		"Anomalist"= /obj/outfit/job/scientist/anomalist/zavodskoi,
 		"Engineer" = /obj/outfit/job/engineer/zavodskoi,
 		"Atmospheric Technician" = /obj/outfit/job/atmos/zavodskoi,
 		"Engineering Apprentice" = /obj/outfit/job/intern_eng/zavodskoi,
@@ -165,6 +166,19 @@
 	name = "Xenoarchaeologist - Zavodskoi Interstellar"
 
 	uniform = /obj/item/clothing/under/rank/scientist/xenoarchaeologist/zavod
+	suit = /obj/item/clothing/suit/storage/toggle/labcoat/zavodskoi
+	id = /obj/item/card/id/zavodskoi
+	shoes = /obj/item/clothing/shoes/sneakers/medsci/zavod
+
+	backpack_faction = /obj/item/storage/backpack/zavod
+	satchel_faction = /obj/item/storage/backpack/satchel/zavod
+	dufflebag_faction = /obj/item/storage/backpack/duffel/zavod
+	messengerbag_faction = /obj/item/storage/backpack/messenger/zavod
+
+/obj/outfit/job/scientist/anomalist/zavodskoi
+	name = "Anomalist - Zavodskoi Interstellar"
+
+	uniform = /obj/item/clothing/under/rank/scientist/anomalist/zavod
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/zavodskoi
 	id = /obj/item/card/id/zavodskoi
 	shoes = /obj/item/clothing/shoes/sneakers/medsci/zavod

--- a/code/game/jobs/faction/zeng_hu.dm
+++ b/code/game/jobs/faction/zeng_hu.dm
@@ -49,6 +49,7 @@
 		"Medical Intern" = /obj/outfit/job/intern_med/zeng_hu,
 		"Scientist" = /obj/outfit/job/scientist/zeng_hu,
 		"Xenobiologist" = /obj/outfit/job/scientist/xenobiologist/zeng_hu,
+		"Anomalist" = /obj/outfit/job/scientist/anomalist/zeng_hu,
 		"Xenobotanist" = /obj/outfit/job/scientist/xenobotanist/zeng_hu,
 		"Lab Assistant" = /obj/outfit/job/intern_sci/zeng_hu,
 		"Xenoarchaeologist"= /obj/outfit/job/scientist/xenoarchaeologist/zeng_hu,
@@ -183,6 +184,19 @@
 	name = "Xenoarchaeologist - Zeng-Hu"
 
 	uniform = /obj/item/clothing/under/rank/scientist/xenoarchaeologist/zeng
+	suit = /obj/item/clothing/suit/storage/toggle/labcoat/zeng/alt
+	id = /obj/item/card/id/zeng_hu
+	shoes = /obj/item/clothing/shoes/sneakers/medsci/zeng
+
+	backpack_faction = /obj/item/storage/backpack/zeng
+	satchel_faction = /obj/item/storage/backpack/satchel/zeng
+	dufflebag_faction = /obj/item/storage/backpack/duffel/zeng
+	messengerbag_faction = /obj/item/storage/backpack/messenger/zeng
+
+/obj/outfit/job/scientist/anomalist/zeng_hu
+	name = "Xenoarchaeologist - Zeng-Hu"
+
+	uniform = /obj/item/clothing/under/rank/scientist/anomalist/zeng
 	suit = /obj/item/clothing/suit/storage/toggle/labcoat/zeng/alt
 	id = /obj/item/card/id/zeng_hu
 	shoes = /obj/item/clothing/shoes/sneakers/medsci/zeng

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -118,6 +118,8 @@
 	departments = SIMPLEDEPT(DEPARTMENT_SCIENCE)
 	department_flag = MEDSCI
 	faction = "Station"
+	alt_titles = list("Anomalist")
+	alt_outfits = list("Anomalist" = "/obj/outfit/job/scientist/anomalist")
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the research director"
@@ -148,6 +150,18 @@
 	double_headset = /obj/item/device/radio/headset/alt/double/xenoarch
 	wrist_radio = /obj/item/device/radio/headset/wrist/xenoarch
 	clipon_radio = /obj/item/device/radio/headset/wrist/clip/xenoarch
+
+/obj/outfit/job/scientist/anomalist
+	name = "Anomalist"
+	jobtype = /datum/job/xenoarchaeologist
+
+	uniform = /obj/item/clothing/under/rank/scientist/anomalist
+
+	headset = /obj/item/device/radio/headset/headset_anom
+	bowman = /obj/item/device/radio/headset/headset_anom/alt
+	double_headset = /obj/item/device/radio/headset/alt/double/anom
+	wrist_radio = /obj/item/device/radio/headset/wrist/anom
+	clipon_radio = /obj/item/device/radio/headset/wrist/clip/anom
 
 /datum/job/xenobiologist
 	title = "Xenobiologist"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -609,6 +609,34 @@
 	item_state = "clip_sci"
 	ks2type = /obj/item/device/encryptionkey/headset_xenoarch
 
+/obj/item/device/radio/headset/headset_anom
+	name = "anomalist radio headset"
+	desc = "A sciency headset for Anomalists."
+	icon_state = "sci_headset"
+	ks2type = /obj/item/device/encryptionkey/headset_xenoarch
+
+/obj/item/device/radio/headset/headset_anom/alt
+	name = "anomalist bowman headset"
+	icon_state = "sci_headset_alt"
+
+/obj/item/device/radio/headset/alt/double/anom
+	name = "soundproof anomalist headset"
+	icon_state = "earset_sci"
+	item_state = "earset_sci"
+	ks2type = /obj/item/device/encryptionkey/headset_xenoarch
+
+/obj/item/device/radio/headset/wrist/anom
+	name = "wristbound anomalist radio"
+	icon_state = "wristset_sci"
+	item_state = "wristset_sci"
+	ks2type = /obj/item/device/encryptionkey/headset_xenoarch
+
+/obj/item/device/radio/headset/wrist/clip/anom
+	name = "clip-on anomalist radio"
+	icon_state = "clip_sci"
+	item_state = "clip_sci"
+	ks2type = /obj/item/device/encryptionkey/headset_xenoarch
+
 /obj/item/device/radio/headset/headset_rob
 	name = "robotics radio headset"
 	desc = "Made specifically for the roboticists who cannot decide between departments."

--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -105,6 +105,25 @@
 	icon_state = "zav_xenoarch"
 	item_state = "zav_xenoarch"
 
+/obj/item/clothing/under/rank/scientist/anomalist
+	name = "anomalist's jumpsuit"
+	desc = "It's made of a special fiber that provides minor protection against explosions. It has markings that denote the wearer as an anomalist."
+	icon_state = "nt_xenoarch"
+	item_state = "nt_xenoarch"
+	permeability_coefficient = 0.50
+	armor = list(
+		bomb = ARMOR_BOMB_MINOR
+	)
+
+/obj/item/clothing/under/rank/scientist/anomalist/zeng
+	icon_state = "zeng_xenoarch"
+	item_state = "zeng_xenoarch"
+
+/obj/item/clothing/under/rank/scientist/anomalist/zavod
+	icon_state = "zav_xenoarch"
+	item_state = "zav_xenoarch"
+
+
 /*
  * Medical
  */

--- a/html/changelogs/crosarius-anomalist.yml
+++ b/html/changelogs/crosarius-anomalist.yml
@@ -1,0 +1,6 @@
+author: Crosarius
+
+delete-after: True
+
+changes:
+  - qol: "Adds the Anomalist alt-title for Xenoarchaeologist."


### PR DESCRIPTION
This re-adds the Anomalist alt-title for Xenoarchaeologist, alongside some uniforms for them (They're just Xenoarch radios and uniforms which are renamed to say "Anomalist")

The justification for this is that Xenoarchaeology and Anomaly research are pretty distinct mechanically and lorewise. This isn't to say necessarily that a Xenoarchaeologist is incapable of doing research on anomalies or vise versa, and I don't want to tell people that they can't!

However, I would like to have a way for Science characters with specialisations in anomaly research to be able to distinguish themselves from Xenoarchaeology, because their field wouldn't really have much to do with doing anthropological research or fossils or archaeology, really.