### PR TITLE
Allows custom background color highlights in chat

### DIFF
--- a/html/changelogs/alaunuslux-add-custom-background-highlight-colors.yml
+++ b/html/changelogs/alaunuslux-add-custom-background-highlight-colors.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: AlaunusLux
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds option to use a custom background color for highlighted text."

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -453,7 +453,7 @@ class ChatRenderer {
             );
             if (highlighted && parser.highlightWholeMessage) {
               const backgroundColor =
-                parser.backgroundHighlightColor || 'rgba(255, 221, 68, 0.1)';
+                parser.backgroundHighlightColor || 'rgba(255, 221, 68)';
               const backgroundColorAlpha = changeAlpha(backgroundColor, 0.1);
 
               node.className += ' ChatMessage--highlighted';

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -232,6 +232,7 @@ const TextHighlightSetting = (props, context) => {
     highlightColor,
     highlightText,
     highlightWholeMessage,
+    backgroundHighlightColor,
     matchWord,
     matchCase,
   } = highlightSettingById[id];
@@ -252,11 +253,33 @@ const TextHighlightSetting = (props, context) => {
             }
           />
         </Flex.Item>
+        <Flex.Item shrink={0}>
+          {highlightWholeMessage && (
+            <>
+              <ColorBox mr={1} color={backgroundHighlightColor} />
+              <Input
+                mr={1}
+                width="5em"
+                monospace
+                placeholder="#ffdd44"
+                value={backgroundHighlightColor}
+                onInput={(e, value) =>
+                  dispatch(
+                    updateHighlightSetting({
+                      id: id,
+                      backgroundHighlightColor: value,
+                    })
+                  )
+                }
+              />
+            </>
+          )}
+        </Flex.Item>
         <Flex.Item>
           <Button.Checkbox
             checked={highlightWholeMessage}
             content="Whole Message"
-            tooltip="If this option is selected, the entire message will be highlighted in yellow."
+            tooltip="If this option is selected, the entire message will be highlighted in the color defined to the left."
             mr="5px"
             onClick={() =>
               dispatch(

--- a/tgui/packages/tgui-panel/settings/model.js
+++ b/tgui/packages/tgui-panel/settings/model.js
@@ -8,6 +8,7 @@ export const createHighlightSetting = (obj) => ({
   highlightText: '',
   highlightColor: '#ffdd44',
   highlightWholeMessage: true,
+  backgroundHighlightColor: '#ffdd44',
   matchWord: false,
   matchCase: false,
   ...obj,

--- a/tgui/packages/tgui-panel/styles/components/Chat.scss
+++ b/tgui/packages/tgui-panel/styles/components/Chat.scss
@@ -85,16 +85,16 @@ $color-bg-section: base.$color-bg-section !default;
   position: relative;
   border-left: math.div(1em, 6) solid rgba(255, 221, 68);
   padding-left: 0.5em;
+}
 
-  &:after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(255, 221, 68, 0.1);
-    // Make this click-through since this is an overlay
-    pointer-events: none;
-  }
+.ChatMessage-highlight-overlay {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgba(255, 221, 68, 0.1);
+  // Make this click-through since this is an overlay
+  pointer-events: none;
 }


### PR DESCRIPTION
I disliked the background highlight color always being yellow, so I did this as an experiment to see what it would look like if we could change it, and I like it, so hopefully others will too.

This could have been implemented more cleanly if CSS vars worked in Dream Seeker's/IE's rendering engine, but since they don't, I had to change the highlight structure - it's now an appended span instead of an :after pseudo-element, since JavaScript can't modify pesudo-elements.

Inputs will be blank for existing settings, but will default to yellow highlighting. Attempts to set this variable at run-time led to unintended consequences, and I'd rather users have to set a color than have code that becomes obsolete after the first load. I'm always open to ideas, of course. New highlight settings added via the button will have their default values set, like the existing input for the word highlight.

Example image. Note that in the case of multiple highlight rules being hit for one message, the left border color will be the color of the rule that comes later in the text highlights list, and the background will be a combination of all triggered highlight colors.

![image](https://github.com/Aurorastation/Aurora.3/assets/89751433/7da67f32-3f6b-4a7f-886e-587909c0e089)