### PR TITLE
Expands the hivebot hub to all sectors

### DIFF
--- a/html/changelogs/hazelmouse_total_hivebot_victory.yml
+++ b/html/changelogs/hazelmouse_total_hivebot_victory.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Adds the Hivebot Hub offsite to all sectors."

--- a/maps/away/away_site/hivebot_hub/hivebot_hub.dm
+++ b/maps/away/away_site/hivebot_hub/hivebot_hub.dm
@@ -7,7 +7,7 @@
 	prefix = "away_site/hivebot_hub/"
 	suffixes = list("hivebot_hub.dmm")
 
-	sectors = list(SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_NEW_ANKARA, SECTOR_BADLANDS, SECTOR_AEMAQ, ALL_COALITION_SECTORS)
+	sectors = ALL_POSSIBLE_SECTORS
 	spawn_weight = 1
 	spawn_cost = 1
 

--- a/maps/away/away_site/hivebot_hub/hivebot_hub.dm
+++ b/maps/away/away_site/hivebot_hub/hivebot_hub.dm
@@ -133,7 +133,8 @@
 		It cost the skipper a lot, I know. Sold off whatever was left of our shuttle for it. <br>\
 		No easy way off this tincan til it's sold. But if we can sell this at a decent price, maybe it'll be over? <br>\
 		No more living on the edge of space. No more darkness, and silence, and worrying for the next buyer that'll find us. <br>\
-		I could go home. See grass again. Trees. You never realise how much you miss them. <br>\
+		I could go home. See grass again. Trees. You never do realise how much you miss them. <br>\
 		This needs to work. <br>\
 		~ HB <br>\
 		"
+


### PR DESCRIPTION
Uueoa-Esa in particular has a lack of hostile offsites, and quite lacking variety generally. This means offships, and especially combat-oriented offships, don't have very much to do right now. This expands the hivebot hub to all possible sectors to help remedy this problem. Hivebots are an apparently omnipresent threat and the map is totally generic, besides being presumably human.