### PR TITLE
Revert "Accessory Weight Handling"

### DIFF
--- a/code/__DEFINES/accessories.dm
+++ b/code/__DEFINES/accessories.dm
@@ -1,5 +1,3 @@
-// Accesssory Slots
-
 #define ACCESSORY_SLOT_GENERIC			"decor"
 #define ACCESSORY_SLOT_UTILITY			"utility"
 #define ACCESSORY_SLOT_UTILITY_MINOR	"minor utility"
@@ -11,14 +9,3 @@
 #define ACCESSORY_SLOT_ARMOR_PIN		"armor pin"
 #define ACCESSORY_SLOT_ARMOR_POCKETS 	"armor pockets"
 #define ACCESSORY_SLOT_HEAD             "head"
-
-// Accessory Weight Classes
-
-/// Doesn't increase size
-#define ACCESSORY_WEIGHT_NONE 0
-
-/// Two accessories can be attached but will only increase size by one
-#define ACCESSORY_WEIGHT_HALF_UNIT 0.5
-
-// This accessory will increase the size by one
-#define ACCESSORY_WEIGHT_ONE_UNIT 1

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -115,7 +115,6 @@
 	update_clothing_icon()
 	update_accessory_slowdown()
 	recalculate_body_temperature_change()
-	recalculate_item_size()
 
 /obj/item/clothing/proc/remove_accessory(mob/user, obj/item/clothing/accessory/A)
 	if(!(A in accessories))
@@ -126,15 +125,6 @@
 	update_clothing_icon()
 	update_accessory_slowdown()
 	recalculate_body_temperature_change()
-	recalculate_item_size()
-
-/obj/item/clothing/proc/recalculate_item_size()
-	w_class = initial(w_class)
-
-	for(var/obj/item/clothing/accessory/accessory as anything in accessories)
-		w_class += accessory.accessory_w_class_adjustment
-
-	w_class = Clamp(Ceil(w_class), ITEMSIZE_TINY, ITEMSIZE_IMMENSE)
 
 /obj/item/clothing/proc/removetie_verb()
 	set name = "Remove Accessory"

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -7,12 +7,7 @@
 	overlay_state = null
 	slot_flags = SLOT_TIE
 	w_class = ITEMSIZE_SMALL
-
 	var/slot = ACCESSORY_SLOT_GENERIC
-
-	/// When attached to another piece of clothing, it'll increase the size by this amount. Accepts the ACCESSORY_WEIGHT_* define, which can be found in code/__DEFINES/accessories.dm. The final result is rounded up
-	var/accessory_w_class_adjustment = ACCESSORY_WEIGHT_NONE
-
 	var/obj/item/clothing/has_suit = null		//the suit the tie may be attached to
 	var/image/inv_overlay = null	//overlay used when attached to clothing.
 	var/overlay_in_inventory = TRUE // Whether the worn_overlay should apply when attached to an item of clothing.

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -8,7 +8,6 @@
 	item_state = "legguards_sec"
 	contained_sprite = TRUE
 	slot = ACCESSORY_SLOT_LEG_GUARDS
-	accessory_w_class_adjustment = ACCESSORY_WEIGHT_HALF_UNIT
 	w_class = ITEMSIZE_NORMAL
 	armor = list(
 		melee = ARMOR_MELEE_KEVLAR,
@@ -149,7 +148,6 @@
 	item_state = "armguards_sec"
 	contained_sprite = TRUE
 	slot = ACCESSORY_SLOT_ARM_GUARDS
-	accessory_w_class_adjustment = ACCESSORY_WEIGHT_HALF_UNIT
 	body_parts_covered = HANDS|ARMS
 	armor = list(
 		melee = ARMOR_MELEE_KEVLAR,

--- a/html/changelogs/fluffyghost-revertaccessoryweighthandling.yml
+++ b/html/changelogs/fluffyghost-revertaccessoryweighthandling.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Reverts the accessory weight handling, ontop of being exploitable as easily as attaching the accessories after the clothe is in the bag, it doesn't make sense that you can store the pieces singularly but not once put together (for the modular armor, that is), and is ultimately just an hassle to have to disassemble and reassemble it over and over every time you have to pull the armor in the backpack and back out."


### PR DESCRIPTION
Reverts accessory weight handling, ontop of being exploitable as easily as attaching the accessories after the clothe is in the bag, it doesn't make sense that you can store the pieces singularly but not once put together (for the modular armor, that is), and is ultimately just an hassle to have to disassemble and reassemble it over and over every time you have to pull the armor in the backpack and back out