### PR TITLE
Nerfs Ethanol Toxicity To Unathi

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -175,10 +175,10 @@
 
 		var/obj/item/organ/internal/parasite/P = M.internal_organs_by_name["blackkois"]
 		if(!has_valid_aug && (alien == IS_VAURCA || (istype(P) && P.stage >= 3)))//Vaurca are damaged instead of getting nutrients, but they can still get drunk
-			M.adjustToxLoss(12 * removed * (strength / 100))
+			M.adjustToxLoss(3 * removed * (strength / 100))
 
 		if (!has_valid_aug && alien == IS_UNATHI) //unathi are poisoned by alcohol as well
-			M.adjustToxLoss(12 * removed * (strength / 100))
+			M.adjustToxLoss(3 * removed * (strength / 100))
 			if(!M.lastpuke)
 				to_chat(M, SPAN_WARNING("Your gizzard lurches as the alcohol burns its way down your gullet!"))//Make it clear that you should not be drinking this.
 			var/mob/living/carbon/human/H = M

--- a/html/changelogs/crosarius-ethanoltoxicity.yml
+++ b/html/changelogs/crosarius-ethanoltoxicity.yml
@@ -1,0 +1,6 @@
+author: Crosarius
+
+delete-after: True
+
+changes:
+  - qol: "Nerfs ethanol toxicity to Unathi and Vaurca."


### PR DESCRIPTION
When I made the recent alcohol toxicity changes to Unathi, I made ethanol much more toxic to Unathi, because previously it wasn't very damaging to them unless they drank a lot. 

However, when I buffed the toxicity, I forgot to take into account ethanol scrubber gas. I have discovered, quite rudely, that ethanol scrubber explosions cause Unathi to instantly go into full 100% organ damage on every organ, and collapse and die in 60 seconds even with immediate medical attention. Their organs just all go critical simultaneously.

This changes things back to the way they were. Unathi and Vaurca will still vomit up alcohol, but will only take 3 toxin damage per unit of ethanol instead of 12, which, in hindsight, was quite ridiculous.