### PR TITLE
PDA Chat Improvements

### DIFF
--- a/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
+++ b/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
@@ -157,7 +157,11 @@ var/global/ntnrc_uid = 0
 	if(newPassword)
 		password = newPassword
 	else
-		password = FALSE
+		password = null
+
+	var/datum/ntnet_message/new_password/msg = new()
+	msg.nuser = operator
+	process_message(msg)
 
 /datum/ntnet_conversation/proc/cl_kick(var/datum/computer_file/program/chat_client/Cl, var/datum/ntnet_user/target)
 	if(!istype(Cl) || !istype(Cl.my_user) || !can_manage(Cl) || !(target in users) || direct)

--- a/code/modules/modular_computers/NTNet/NTNRC/message.dm
+++ b/code/modules/modular_computers/NTNet/NTNRC/message.dm
@@ -36,7 +36,10 @@
 	. = "<b>([sanitize(Conv.get_title(Cl))]) <i>[nuser.username]</i>:</b> [sanitize(message)] (<a href='byond://?src=\ref[Cl]&Reply=\ref[Conv]'>Reply</a>)"
 
 /datum/ntnet_message/message/format_chat_log(var/datum/ntnet_conversation/Conv)
-	. = "[worldtime2text()] [nuser.username]: [message]"
+	var/conversation_message_length = length(Conv.messages)
+	var/last_message = conversation_message_length ? Conv.messages[conversation_message_length] : null
+	var/should_add_spacer = last_message ? !findtext(last_message, nuser.username + ":") : FALSE
+	. = "[should_add_spacer ? "\n" : ""][worldtime2text()] [nuser.username]: [message]"
 
 /datum/ntnet_message/message/format_admin_log(var/datum/ntnet_conversation/Conv)
 	. = message
@@ -50,7 +53,7 @@
 	. = FONT_SMALL("<b>([sanitize(Conv.get_title(Cl))]) <i>[nuser.username]</i> has entered the chat.</b>")
 
 /datum/ntnet_message/join/format_chat_log(var/datum/ntnet_conversation/Conv)
-	. = "[worldtime2text()] -!- [nuser.username] has entered the chat."
+	. = "\n[worldtime2text()] -!- [nuser.username] has entered the chat."
 
 
 
@@ -58,20 +61,22 @@
 	. = FONT_SMALL("<b>([sanitize(Conv.get_title(Cl))]) <i>[nuser.username]</i> has left the chat.</b>")
 
 /datum/ntnet_message/leave/format_chat_log(var/datum/ntnet_conversation/Conv)
-	. = "[worldtime2text()] -!- [nuser.username] has left the chat."
+	. = "\n[worldtime2text()] -!- [nuser.username] has left the chat."
 
 
 
 /datum/ntnet_message/new_op/format_chat_log(var/datum/ntnet_conversation/Conv)
-	. = "[worldtime2text()] -!- [nuser.username] has become operator."
+	. = "\n[worldtime2text()] -!- [nuser.username] has become operator."
 
+/datum/ntnet_message/new_password/format_chat_log(var/datum/ntnet_conversation/Conv)
+	. = "\n[worldtime2text()] -!- [nuser.username] has [Conv.password ? "updated" : "removed"] the channel's password."
 
 
 /datum/ntnet_message/new_title
 	var/title = ""
 
 /datum/ntnet_message/new_title/format_chat_log(var/datum/ntnet_conversation/Conv)
-	. = "[worldtime2text()] -!- [nuser.username] has changed channel title from [Conv.get_title()] to [title]"
+	. = "\n[worldtime2text()] -!- [nuser.username] has changed channel title from [Conv.get_title()] to [title]"
 
 /datum/ntnet_message/new_title/format_chat_notification(var/datum/ntnet_conversation/Conv, var/datum/computer_file/program/chat_client/Cl)
 	. = FONT_SMALL("<b>([sanitize(Conv.get_title(Cl))]) <i>[nuser.username]</i> has changed the channel title to <i>[sanitize(title)].</i></b>")
@@ -82,7 +87,7 @@
 	var/datum/ntnet_user/target
 
 /datum/ntnet_message/kick/format_chat_log(var/datum/ntnet_conversation/Conv)
-	. = "[worldtime2text()] -!- [nuser.username] has kicked [target.username] from conversation."
+	. = "\n[worldtime2text()] -!- [nuser.username] has kicked [target.username] from conversation."
 
 /datum/ntnet_message/kick/format_chat_notification(var/datum/ntnet_conversation/Conv, var/datum/computer_file/program/chat_client/Cl)
 	. = FONT_SMALL("<b>([sanitize(Conv.get_title(Cl))]) <i>[nuser.username]</i> has kicked <i>[target.username]</i> from conversation.</b>")
@@ -90,7 +95,7 @@
 
 
 /datum/ntnet_message/direct/format_chat_log(var/datum/ntnet_conversation/Conv)
-	. = "[worldtime2text()] -!- [nuser.username] has opened direct conversation."
+	. = "\n[worldtime2text()] -!- [nuser.username] has opened direct conversation."
 
 /datum/ntnet_message/direct/format_chat_notification(var/datum/ntnet_conversation/Conv, var/datum/computer_file/program/chat_client/Cl)
 	. = FONT_SMALL("<b>([sanitize(Conv.get_title(Cl))]) <i>[nuser.username]</i> has opened direct conversation with you.</b>")

--- a/code/modules/modular_computers/NTNet/NTNRC/ntnrc.dm
+++ b/code/modules/modular_computers/NTNet/NTNRC/ntnrc.dm
@@ -26,3 +26,5 @@
 
 	var/datum/ntnet_message/direct/msg = new(Cl)
 	Conv.process_message(msg)
+
+	return Conv

--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -254,6 +254,7 @@
 			else
 				conv.cl_join(src)
 		computer.update_static_data_for_all_viewers()
+		active = conv
 		. = TRUE
 
 	if(action == "set_active")
@@ -298,8 +299,9 @@
 		. = TRUE
 
 	if(action == "new_channel")
-		GLOB.ntnet_global.begin_conversation(src, sanitize(params["new_channel"]))
+		var/datum/ntnet_conversation/conversation = GLOB.ntnet_global.begin_conversation(src, sanitize(params["new_channel"]))
 		computer.update_static_data_for_all_viewers()
+		active = conversation
 		. = TRUE
 
 	if(action == "delete")
@@ -312,8 +314,9 @@
 
 	if(action == "direct")
 		var/datum/ntnet_user/tUser = locate(params["direct"])
-		GLOB.ntnet_global.begin_direct(src, tUser)
+		var/datum/ntnet_conversation/conversation = GLOB.ntnet_global.begin_direct(src, tUser)
 		computer.update_static_data_for_all_viewers()
+		active = conversation
 		. = TRUE
 
 	if(action == "toggleadmin")

--- a/html/changelogs/geeves-pda_chat_improvements.yml
+++ b/html/changelogs/geeves-pda_chat_improvements.yml
@@ -1,0 +1,9 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - qol: "Made a bunch of improvements to the PDA chat program. Clicking on someone or a channel's name will now immediately open the chat. Text inputs will now not input unless you press enter."
+  - qol: "PDA chat messages will now have spaces between them, unless it's the same person sending multiple messages in a row."
+  - qol: "Updating a PDA chat channel's password will now output that it changed into the chat."
+  - bugfix: "Killed innocent kittens."

--- a/html/changelogs/geeves-pda_chat_improvements.yml
+++ b/html/changelogs/geeves-pda_chat_improvements.yml
@@ -6,4 +6,3 @@ changes:
   - qol: "Made a bunch of improvements to the PDA chat program. Clicking on someone or a channel's name will now immediately open the chat. Text inputs will now not input unless you press enter."
   - qol: "PDA chat messages will now have spaces between them, unless it's the same person sending multiple messages in a row."
   - qol: "Updating a PDA chat channel's password will now output that it changed into the chat."
-  - bugfix: "Killed innocent kittens."

--- a/tgui/packages/tgui/interfaces/ChatClient.tsx
+++ b/tgui/packages/tgui/interfaces/ChatClient.tsx
@@ -106,16 +106,15 @@ export const Users = (props, context) => {
   return (
     <Section>
       <Section fitted>
-        <Tabs>
+        <Tabs pl="15px" pr="15px">
           <Tabs.Tab
             height="20%"
             selected={!data.active}
             onClick={() => act('set_active', { set_active: null })}>
             All
           </Tabs.Tab>
-          {data.channels &&
-            data.channels.length &&
-            data.channels
+          {data.channels?.length
+            ? data.channels
               .filter((chn) => chn.can_interact)
               .map((channel) => (
                 <Tabs.Tab
@@ -127,7 +126,8 @@ export const Users = (props, context) => {
                   }>
                   {channel.title}
                 </Tabs.Tab>
-              ))}
+              ))
+            : null}
         </Tabs>
       </Section>
       {data.active && data.active.can_interact ? <Chat /> : <AllUsers />}
@@ -183,11 +183,25 @@ export const Chat = (props, context) => {
     `newMessage`,
     ``
   );
+
+  const [creatingJoinPassword, setCreatingJoinPassword] = useLocalState(
+    context,
+    'creatingJoinPassword',
+    0
+  );
+
   const [password, setPassword] = useLocalState<string>(
     context,
     `password`,
     ``
   );
+
+  const [creatingTitle, setCreatingTitle] = useLocalState(
+    context,
+    'creatingTitle',
+    0
+  );
+
   const [title, setTitle] = useLocalState<string>(context, `title`, ``);
 
   return (
@@ -199,40 +213,49 @@ export const Chat = (props, context) => {
             <>
               <Button
                 key={data.active.ref}
-                content={password ? 'Close Menu' : 'Set Password'}
-                onClick={() => setPassword(password ? '' : 'New Password')}
+                content={creatingJoinPassword ? 'Close Menu' : 'Set Password'}
+                onClick={() => {
+                  setPassword('');
+                  setCreatingJoinPassword(creatingJoinPassword ? 0 : 1);
+                }}
               />
-              {password ? (
+              {creatingJoinPassword ? (
                 <Input
-                  placeholder={password}
+                  placeholder="New Password"
                   value={password}
+                  strict
                   onInput={(e, v) => setPassword(v)}
-                  onChange={(e, v) =>
+                  onChange={(e, v) => {
                     act('set_password', {
                       password: password,
                       target: data.active ? data.active.ref : '',
-                    })
-                  }
+                    });
+                    setCreatingJoinPassword(0);
+                  }}
                 />
               ) : (
                 ''
               )}
               <Button
                 key={data.active.ref}
-                content={title ? 'Close Menu' : 'Set Title'}
-                onClick={() => setTitle(title ? '' : 'New Title')}
+                content={creatingTitle ? 'Close Menu' : 'Set Title'}
+                onClick={() => {
+                  setTitle('');
+                  setCreatingTitle(creatingTitle ? 0 : 1);
+                }}
               />
-              {title ? (
+              {creatingTitle ? (
                 <Input
-                  placeholder={title}
+                  placeholder="New Title"
                   value={title}
                   onInput={(e, v) => setTitle(v)}
-                  onChange={(e, v) =>
+                  onChange={(e, v) => {
                     act('change_title', {
                       title: title,
                       target: data.active ? data.active.ref : '',
-                    })
-                  }
+                    });
+                    setCreatingTitle(0);
+                  }}
                 />
               ) : (
                 ''
@@ -327,11 +350,25 @@ export const ChannelsWindow = (props, context) => {
     `channelSearchTerm`,
     ``
   );
+
+  const [creatingChannelName, setCreatingChannelName] = useLocalState(
+    context,
+    'creatingChannelName',
+    0
+  );
+
   const [channelName, setChannelName] = useLocalState(
     context,
     'channelName',
     ''
   );
+
+  const [enteringJoinPassword, setEnteringJoinPassword] = useLocalState(
+    context,
+    'enteringJoinPassword',
+    0
+  );
+
   const [joinPassword, setJoinPassword] = useLocalState(
     context,
     'joinPassword',
@@ -344,17 +381,22 @@ export const ChannelsWindow = (props, context) => {
       buttons={
         <>
           <Button
-            content="New Channel"
-            onClick={() =>
-              setChannelName(channelName ? '' : 'New Channel Name')
-            }
+            content={creatingChannelName ? 'Close Menu' : 'New Channel'}
+            onClick={() => {
+              setChannelName('');
+              setCreatingChannelName(creatingChannelName ? 0 : 1);
+            }}
           />
-          {channelName ? (
+          {creatingChannelName ? (
             <Input
-              placeholder={channelName}
+              placeholder="New Channel Name"
               value={channelName}
+              strict
               onInput={(e, v) => setChannelName(v)}
-              onChange={() => act('new_channel', { new_channel: channelName })}
+              onChange={() => {
+                act('new_channel', { new_channel: channelName });
+                setCreatingChannelName(0);
+              }}
             />
           ) : (
             ''
@@ -374,9 +416,8 @@ export const ChannelsWindow = (props, context) => {
           }}
           value={channelSearchTerm}
         />
-        {data.channels &&
-          data.channels.length &&
-          data.channels
+        {data.channels?.length
+          ? data.channels
             .filter(
               (chn) =>
                 chn.title
@@ -389,18 +430,24 @@ export const ChannelsWindow = (props, context) => {
                   <>
                     <Button
                       content={channel.title}
-                      onClick={() => setJoinPassword('Password')}
+                      onClick={() => {
+                        setJoinPassword('');
+                        setEnteringJoinPassword(enteringJoinPassword ? 0 : 1);
+                      }}
                     />
-                    {joinPassword ? (
+                    {enteringJoinPassword ? (
                       <Input
+                        placeholder="Enter Password"
                         value={joinPassword}
+                        strict
                         onInput={(e, v) => setJoinPassword(v)}
-                        onChange={(e, v) =>
+                        onChange={(e, v) => {
                           act('join', {
                             target: channel.ref,
                             password: joinPassword,
-                          })
-                        }
+                          });
+                          setEnteringJoinPassword(0);
+                        }}
                       />
                     ) : (
                       ''
@@ -413,7 +460,8 @@ export const ChannelsWindow = (props, context) => {
                   />
                 )}
               </Stack.Item>
-            ))}
+            ))
+          : null}
       </Stack>
     </Section>
   );


### PR DESCRIPTION
* Made a bunch of improvements to the PDA chat program. Clicking on someone or a channel's name will now immediately open the chat. Text inputs will now not input unless you press enter.
* PDA chat messages will now have spaces between them, unless it's the same person sending multiple messages in a row.
* Updating a PDA chat channel's password will now output that it changed into the chat.