### PR TITLE
Welding Tool Surgery Fuel Usage Fix

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -201,7 +201,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(tool.iswelder())
 		var/obj/item/weldingtool/welder = tool
-		if(!welder.isOn() || !welder.use(2,user))
+		if(!welder.isOn() || welder.get_fuel() < 2)
 			return FALSE
 	return affected && affected.open == ORGAN_ENCASED_RETRACTED && affected.brute_dam > 0 && target_zone != BP_MOUTH
 
@@ -214,7 +214,7 @@
 /singleton/surgery_step/robotics/repair_brute/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(tool.iswelder())
 		var/obj/item/weldingtool/welder = tool
-		if(!welder.isOn())
+		if(!welder.isOn() && !welder.use(2, user))
 			user.visible_message(SPAN_WARNING("[user]'s [tool] shut off before the procedure was finished."), \
 			SPAN_WARNING("Your [tool] is shut off!"))
 			return

--- a/html/changelogs/geeves-welding_fuel_usage_fix.yml
+++ b/html/changelogs/geeves-welding_fuel_usage_fix.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed welding tools using fuel in prosthetic repairs during the check to see if it CAN do the surgery. Instead, the fuel when be consumed once the surgery completes."


### PR DESCRIPTION
* Fixed welding tools using fuel in prosthetic repairs during the check to see if it CAN do the surgery. Instead, the fuel when be consumed once the surgery completes.

I _think_ this fixes the issue where welding fuel usage for prosthetic surgery is bonkers, but I wasn't able to reproduce the bug on my local, so keep an eye out for it still.