### PR TITLE
Bullet Marking Cap

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -629,24 +629,27 @@
 /atom/proc/create_bullethole(obj/item/projectile/Proj)
 	var/p_x = Proj.p_x + rand(-6, 6)
 	var/p_y = Proj.p_y + rand(-6, 6)
-	var/obj/effect/overlay/bmark/bullet_mark = new(src)
 
-	bullet_mark.pixel_x = p_x
-	bullet_mark.pixel_y = p_y
-
-	//Offset correction
-	bullet_mark.pixel_x--
-	bullet_mark.pixel_y--
-
-	if(Proj.damage_flags & DAMAGE_FLAG_BULLET)
-		bullet_mark.icon_state = "dent"
-	else if(Proj.damage_flags & DAMAGE_FLAG_LASER)
-		bullet_mark.name = "scorch mark"
+	var/bullet_mark_icon_state = "dent"
+	var/bullet_mark_dir = SOUTH
+	if(Proj.damage_flags & DAMAGE_FLAG_LASER)
 		if(Proj.damage >= 20)
-			bullet_mark.icon_state = "scorch"
-			bullet_mark.set_dir(pick(NORTH,SOUTH,EAST,WEST)) // Pick random scorch design
+			bullet_mark_icon_state = "scorch"
+			bullet_mark_dir = pick(GLOB.cardinal) // Pick random scorch design
 		else
-			bullet_mark.icon_state = "light_scorch"
+			bullet_mark_icon_state = "light_scorch"
+
+	var/obj/effect/overlay/bmark/bullet_mark = locate() in src
+	if(!bullet_mark)
+		bullet_mark = new(src)
+		bullet_mark.icon_state = bullet_mark_icon_state
+		bullet_mark.set_dir(bullet_mark_dir)
+		bullet_mark.pixel_x = p_x
+		bullet_mark.pixel_y = p_y
+	// we limit to to 2 overlays, so 3 holes, to prevent decals from lagging the game
+	else if(length(bullet_mark.overlays) < 2)
+		var/image/bullet_overlay = image(bullet_mark.icon, icon_state = bullet_mark_icon_state, dir = bullet_mark_dir, pixel_x = p_x - bullet_mark.pixel_x, pixel_y = p_y - bullet_mark.pixel_y)
+		bullet_mark.AddOverlays(bullet_overlay)
 
 /atom/proc/clear_bulletholes()
 	for(var/obj/effect/overlay/bmark/bullet_mark in src)

--- a/code/game/objects/effects/decals/bullet_holes.dm
+++ b/code/game/objects/effects/decals/bullet_holes.dm
@@ -1,5 +1,5 @@
 /obj/effect/overlay/bmark
-	name = "bullet hole"
+	name = "bullet mark"
 	desc = "Somebody's been shooting."
 	icon = 'icons/effects/effects.dmi'
 	layer = ABOVE_OBJ_LAYER

--- a/html/changelogs/geeves-bullet_marking.yml
+++ b/html/changelogs/geeves-bullet_marking.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscdel: "Limited the number of bullet holes in a wall to 3, to prevent the decals from lagging the game."


### PR DESCRIPTION
* Limited the number of bullet holes in a wall to 3, to prevent the decals from lagging the game.