### PR TITLE
Hivebot Gib Reduction

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot.dm
@@ -91,9 +91,23 @@
 
 /mob/living/simple_animal/hostile/hivebot/death()
 	..(null,"blows apart!")
-	var/T = get_turf(src)
-	new /obj/effect/gibspawner/robot(T)
-	spark(T, 1, GLOB.alldirs)
+
+	var/turf/current_turf = get_turf(src)
+	if(!current_turf)
+		qdel(src)
+		return
+
+	var/robot_gib_type = /obj/effect/decal/cleanable/blood/gibs/robot
+	var/atom/turf_gibs = locate(robot_gib_type) in current_turf
+	if(turf_gibs) // we only want to spawn gibs here if there aren't any already
+		return
+
+	var/list/gib_types = typesof(robot_gib_type)
+	var/selected_gib_type = pick(gib_types)
+	new selected_gib_type(current_turf)
+
+	spark(current_turf, 1, GLOB.alldirs)
+
 	qdel(src)
 
 /mob/living/simple_animal/hostile/hivebot/think()

--- a/html/changelogs/geeves-fuel_spill_cap.yml
+++ b/html/changelogs/geeves-fuel_spill_cap.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscdel: "Killed hivebots now only drop a single robot gib onto the turf beneath it, and only if there isn't one on that turf already."


### PR DESCRIPTION
* Killed hivebots now only drop a single robot gib onto the turf beneath it, and only if there isn't one on that turf already.