### PR TITLE
Hivebot Spawn Effect Tweak

### DIFF
--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -4,7 +4,6 @@
 /obj/effect/effect/smoke/chem
 	icon = 'icons/effects/chemsmoke.dmi'
 	opacity = 0
-	layer = ABOVE_PROJECTILE_LAYER
 	time_to_live = 300
 	pass_flags = PASSTABLE | PASSGRILLE | PASSGLASS //PASSGLASS is fine here, it's just so the visual effect can "flow" around glass
 	var/splash_amount = 10 //atoms moving through a smoke cloud get splashed with up to 10 units of reagent

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -97,6 +97,7 @@ steam.start() -- spawns the effect
 	name = "smoke"
 	icon_state = "smoke"
 	opacity = 1
+	layer = ABOVE_PROJECTILE_LAYER
 	anchored = 0.0
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/amount = 6.0

--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot.dm
@@ -55,8 +55,7 @@
 		linked_parent = hivebotbeacon
 
 	if(!mapload)
-		new /obj/effect/effect/smoke(src.loc,30)
-		playsound(src.loc, 'sound/effects/EMPulse.ogg', 25, 1)
+		spark(get_turf(src), 2, GLOB.alldirs)
 
 /mob/living/simple_animal/hostile/hivebot/Destroy()
 	if(linked_parent)

--- a/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_harvester.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebots/hivebot_harvester.dm
@@ -52,15 +52,13 @@
 	.=..()
 	set_light(3,2,LIGHT_COLOR_RED)
 	if(!mapload)
-		new /obj/effect/effect/smoke(src.loc,30)
-		playsound(src.loc, 'sound/effects/EMPulse.ogg', 25, 1)
+		spark(get_turf(src), 3, GLOB.alldirs)
 
 /mob/living/simple_animal/hostile/retaliate/hivebotharvester/death()
 	..(null,"teleports away!")
 	if(linked_parent)
 		linked_parent.harvester_amt --
-	new /obj/effect/effect/smoke(src.loc,30)
-	playsound(src.loc, 'sound/effects/EMPulse.ogg', 25, 1)
+	spark(get_turf(src), 3, GLOB.alldirs)
 	qdel(src)
 
 /mob/living/simple_animal/hostile/retaliate/hivebotharvester/Destroy()

--- a/html/changelogs/geeves-hivebot_spawn_effect_tweak.yml
+++ b/html/changelogs/geeves-hivebot_spawn_effect_tweak.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Most hivebots now create sparks when they teleport in, instead of smoke. The smokescreen created by beacons remain."
+  - bugfix: "Smoke now renders over mobs again."


### PR DESCRIPTION
* Most hivebots now create sparks when they teleport in, instead of smoke. The smokescreen created by beacons remain.
* Smoke now renders over mobs again.