### PR TITLE
Barbed Wire Barricades Fixes

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -107,7 +107,11 @@
 		return ..()
 
 /obj/structure/proc/can_climb(var/mob/living/user, post_climb_check=0)
-	if (!climbable || !can_touch(user) || (!post_climb_check && (user in climbers)))
+	if (!climbable)
+		to_chat(user, SPAN_WARNING("\The [src] cannot be climbed!"))
+		return FALSE
+
+	if (!can_touch(user) || (!post_climb_check && (user in climbers)))
 		return FALSE
 
 	if (!user.Adjacent(src))

--- a/code/game/objects/structures/barricades/_barricade.dm
+++ b/code/game/objects/structures/barricades/_barricade.dm
@@ -46,7 +46,8 @@
 			. += SPAN_WARNING("It's crumbling apart, just a few more blows will tear it apart!")
 
 /obj/structure/barricade/update_icon()
-	overlays.Cut()
+	CutOverlays()
+
 	if(!closed)
 		if(can_change_dmg_state)
 			icon_state = "[barricade_type]_[damage_state]"
@@ -70,9 +71,9 @@
 
 	if(is_wired)
 		if(!closed)
-			overlays += image('icons/obj/barricades.dmi', icon_state = "[src.barricade_type]_wire")
+			AddOverlays(image('icons/obj/barricades.dmi', icon_state = "[src.barricade_type]_wire"))
 		else
-			overlays += image('icons/obj/barricades.dmi', icon_state = "[src.barricade_type]_closed_wire")
+			AddOverlays(image('icons/obj/barricades.dmi', icon_state = "[src.barricade_type]_closed_wire"))
 
 	..()
 
@@ -110,6 +111,12 @@
 		return !density
 	else
 		return TRUE
+
+/obj/structure/barricade/can_climb(var/mob/living/user, post_climb_check=0)
+	if(is_wired)
+		to_chat(user, SPAN_WARNING("\The [src] has barbed wire over it, restricting you from climbing over!"))
+		return FALSE
+	return ..()
 
 /obj/structure/barricade/attack_robot(mob/user)
 	return attack_hand(user)

--- a/html/changelogs/geeves-obvious_wire.yml
+++ b/html/changelogs/geeves-obvious_wire.yml
@@ -1,0 +1,7 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "Barricades will now send a chat message if you can't climb them due to there being barbed wire."
+  - bugfix: "Fixed barbed wire overlays not appearing on barricades."


### PR DESCRIPTION
* Barricades will now send a chat message if you can't climb them due to there being barbed wire.
* Fixed barbed wire overlays not appearing on barricades.