### PR TITLE
Hegemony Corvette/Kataphract Chapter Ship Minor Fixes/Additions

### DIFF
--- a/html/changelogs/changelog.yml
+++ b/html/changelogs/changelog.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: not-a-gonk
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Revised the armoury and infirmary for the Hegemony Corvette and Kataphract Chapter ship, along with adding some extra equipment and gear."
+  - qol: "Minor additions and modifications of fluff items on the Hegemony Corvette and Kataphract Chapter Ship."

--- a/html/changelogs/changelog.yml
+++ b/html/changelogs/changelog.yml
@@ -56,4 +56,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - balance: "Revised the armoury and infirmary for the Hegemony Corvette and Kataphract Chapter ship, along with adding some extra equipment and gear."
-  - qol: "Minor additions and modifications of fluff items on the Hegemony Corvette and Kataphract Chapter Ship."
+  - qol: "Hegemony Corvette Gunnery room remap; minor additions and modifications of fluff items on the Hegemony Corvette and Kataphract Chapter Ship."

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
@@ -262,8 +262,16 @@
 /obj/item/clothing/accessory/holster/hip,
 /obj/item/clothing/accessory/holster/hip,
 /obj/item/clothing/accessory/holster/hip,
-/obj/item/clothing/accessory/holster/hip,
-/obj/item/clothing/accessory/holster/hip,
+/obj/item/clothing/accessory/storage/pouches/black,
+/obj/item/clothing/accessory/storage/pouches/black,
+/obj/item/clothing/accessory/storage/pouches/black,
+/obj/item/clothing/accessory/storage/pouches/black,
+/obj/item/clothing/accessory/storage/pouches/black,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
 /turf/simulated/floor/plating,
 /area/hegemony_ship/armory)
 "bw" = (
@@ -278,9 +286,6 @@
 	},
 /obj/structure/table/reinforced/steel,
 /obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 10
-	},
 /obj/effect/floor_decal/corner/yellow/full,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
@@ -305,18 +310,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/crew_quarters)
-"bO" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline_straight/yellow{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hegemony_ship)
 "bU" = (
 /obj/effect/landmark/entry_point/aft,
 /turf/simulated/wall/shuttle/space_ship/mercenary,
@@ -350,15 +343,12 @@
 /turf/simulated/floor/carpet/rubber,
 /area/hegemony_ship/aux_cic)
 "ce" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/obj/machinery/light{
+/obj/effect/floor_decal/corner/red/diagonal{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline_straight/yellow{
-	dir = 1
-	},
+/obj/structure/table/rack,
+/obj/item/clothing/gloves/boxing,
+/obj/item/clothing/gloves/boxing/yellow,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "co" = (
@@ -765,7 +755,9 @@
 "eO" = (
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/light,
-/obj/machinery/suit_cycler/offship/hegemony/specialist,
+/obj/machinery/suit_cycler/offship/hegemony/specialist{
+	mask = /obj/item/clothing/mask/gas/half
+	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/eva_storage)
 "eQ" = (
@@ -1184,16 +1176,6 @@
 /obj/machinery/light/small/emergency,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
-"gX" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline_straight/yellow,
-/turf/simulated/floor/tiled,
-/area/hegemony_ship)
 "ha" = (
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#5b5b5b";
@@ -1462,6 +1444,9 @@
 	dir = 5
 	},
 /obj/machinery/light/small/emergency,
+/obj/machinery/recharger{
+	pixel_y = 3
+	},
 /turf/simulated/floor/carpet/rubber,
 /area/hegemony_ship/tcomms)
 "iG" = (
@@ -1553,7 +1538,7 @@
 "jz" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/unathi/izharshan,
-/obj/item/nullrod/shaman,
+/obj/item/nullrod/skakh_warrior,
 /obj/item/storage/box/fancy/matches,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -1562,6 +1547,7 @@
 /obj/item/clothing/under/unathi/mogazali/green,
 /obj/item/clothing/suit/unathi/robe/robe_coat/red,
 /obj/item/clothing/suit/unathi/robe/robe_coat/blue,
+/obj/item/clothing/under/unathi/skakh/warrior,
 /turf/simulated/floor/wood,
 /area/hegemony_ship/warpriests_quarters)
 "jC" = (
@@ -1621,6 +1607,12 @@
 /obj/item/clothing/head/helmet/unathi/hegemony,
 /obj/item/clothing/head/helmet/unathi/hegemony,
 /obj/item/clothing/head/helmet/unathi/hegemony,
+/obj/item/clothing/glasses/safety/goggles/tactical/generic,
+/obj/item/clothing/glasses/safety/goggles/tactical/generic,
+/obj/item/clothing/glasses/safety/goggles/tactical/generic,
+/obj/item/clothing/glasses/safety/goggles/tactical/generic,
+/obj/item/clothing/glasses/safety/goggles/tactical/generic,
+/obj/item/clothing/glasses/safety/goggles/tactical/generic,
 /turf/simulated/floor/plating,
 /area/hegemony_ship/armory)
 "kd" = (
@@ -1682,11 +1674,9 @@
 /obj/effect/floor_decal/corner_wide/lime{
 	dir = 6
 	},
-/obj/item/storage/firstaid/adv{
-	pixel_x = 5;
-	pixel_y = 5
+/obj/item/storage/firstaid/large/adv{
+	pixel_y = 4
 	},
-/obj/item/storage/firstaid/fire,
 /obj/machinery/firealarm/east,
 /turf/simulated/floor/tiled/white,
 /area/hegemony_ship/medbay)
@@ -1872,7 +1862,6 @@
 	dir = 9
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/sign/flag/hegemony/large/west,
 /turf/simulated/floor/holofloor/desert,
 /area/hegemony_ship)
 "lz" = (
@@ -2154,10 +2143,11 @@
 	dir = 4
 	},
 /obj/item/gun/energy/rifle/hegemony,
-/obj/item/gun/energy/rifle/hegemony,
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(113)
 	},
+/obj/item/gun/energy/rifle/hegemony,
+/obj/item/gun/energy/rifle/hegemony,
 /obj/item/gun/energy/rifle/hegemony,
 /turf/simulated/floor/tiled/dark/full,
 /area/hegemony_ship/armory)
@@ -2491,9 +2481,6 @@
 /area/hegemony_ship/canteen)
 "oP" = (
 /obj/structure/table/rack,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 10
-	},
 /obj/item/storage/toolbox/mechanical,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
@@ -2614,6 +2601,9 @@
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
 /obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
 /turf/simulated/floor/tiled/white,
 /area/hegemony_ship/medbay)
 "pq" = (
@@ -2662,7 +2652,9 @@
 /area/hegemony_ship/starboard_propulsion)
 "pH" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/suit_cycler/offship/hegemony/priest,
+/obj/machinery/suit_cycler/offship/hegemony/priest{
+	mask = /obj/item/clothing/mask/gas/half
+	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/eva_storage)
 "pI" = (
@@ -2760,7 +2752,9 @@
 /obj/item/reagent_containers/spray/cleaner{
 	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
 	icon_state = "sterilesprayblue";
-	name = "surgery cleaner"
+	name = "surgery cleaner";
+	pixel_y = 14;
+	pixel_x = 6
 	},
 /obj/machinery/light{
 	dir = 4
@@ -2841,7 +2835,9 @@
 /area/hegemony_ship/warpriests_quarters)
 "qL" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/suit_cycler/offship/hegemony,
+/obj/machinery/suit_cycler/offship/hegemony{
+	mask = /obj/item/clothing/mask/gas/half
+	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/eva_storage)
 "qO" = (
@@ -2962,9 +2958,16 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
 "rt" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/white,
-/area/hegemony_ship/medbay)
+/obj/effect/floor_decal/corner/dark_blue/diagonal,
+/obj/structure/table/rack,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/turf/simulated/floor/tiled,
+/area/hegemony_ship/eva_storage)
 "rx" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_y = -30;
@@ -3026,9 +3029,6 @@
 	},
 /obj/effect/floor_decal/industrial/outline_straight/yellow{
 	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline_straight/yellow{
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -3422,7 +3422,7 @@
 	dir = 1
 	},
 /obj/item/storage/toolbox/electrical{
-	pixel_y = 10
+	pixel_y = 5
 	},
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled,
@@ -3514,11 +3514,12 @@
 /obj/item/spacecash/c10,
 /obj/item/spacecash/c10,
 /obj/item/spacecash/c10,
-/obj/item/melee/energy/sword/hegemony,
 /obj/item/clothing/under/unathi/mogazali,
 /obj/item/clothing/accessory/holster/hip,
-/obj/item/gun/energy/pistol/hegemony,
-/obj/item/shield/energy/hegemony,
+/obj/item/clothing/suit/unathi/robe/robe_coat/orange,
+/obj/item/clothing/suit/unathi/robe/robe_coat/blue,
+/obj/item/clothing/accessory/storage/pouches/black,
+/obj/item/storage/belt/military,
 /turf/simulated/floor/carpet/lightblue,
 /area/hegemony_ship/captains_quarters)
 "uz" = (
@@ -3537,7 +3538,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/outline_straight/yellow,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "uE" = (
@@ -3720,7 +3720,7 @@
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/item/clothing/suit/space/void/sol/sfa,
 /obj/item/clothing/head/helmet/space/void/sol/sfa,
-/obj/item/gun/projectile/pistol/sol,
+/obj/item/melee/ceremonial_sword/marine,
 /turf/simulated/floor/plating,
 /area/hegemony_ship/trophy_room)
 "vB" = (
@@ -3820,12 +3820,7 @@
 /obj/item/ammo_casing/slugger,
 /obj/item/ammo_casing/slugger,
 /obj/item/gun/projectile/heavysniper/unathi,
-/obj/item/gun/projectile/heavysniper/unathi,
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/item/ammo_casing/slugger,
-/obj/item/ammo_casing/slugger,
-/obj/item/ammo_casing/slugger,
-/obj/item/ammo_casing/slugger,
 /obj/structure/closet/secure_closet/guncabinet{
 	req_access = list(113)
 	},
@@ -4089,6 +4084,15 @@
 /obj/structure/table/rack,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/item/gun/energy/pistol/hegemony,
+/obj/item/shield/energy/hegemony{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/item/melee/energy/sword/hegemony{
+	pixel_y = 2;
+	pixel_x = 7
 	},
 /turf/simulated/floor/wood,
 /area/hegemony_ship/captains_quarters)
@@ -4419,7 +4423,7 @@
 	name = "igs - hegemony_klax";
 	identifier = "hegemony_klax"
 	},
-/obj/structure/sign/flag/sedantis{
+/obj/structure/sign/flag/klax{
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
@@ -4442,6 +4446,14 @@
 /obj/machinery/alarm/west{
 	req_one_access = null;
 	req_access = list(113)
+	},
+/obj/machinery/recharger{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/machinery/recharger{
+	pixel_x = 5;
+	pixel_y = 3
 	},
 /turf/simulated/floor/carpet/rubber,
 /area/hegemony_ship/aux_cic)
@@ -4772,6 +4784,7 @@
 	pixel_y = 5
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/recharger,
 /turf/simulated/floor/plating,
 /area/hegemony_ship/engineering)
 "Bo" = (
@@ -4966,8 +4979,11 @@
 /obj/item/gun/energy/pistol/hegemony,
 /obj/item/gun/energy/pistol/hegemony,
 /obj/item/gun/energy/pistol/hegemony,
-/obj/item/gun/energy/pistol/hegemony,
-/obj/item/gun/energy/pistol/hegemony,
+/obj/item/shield/energy/hegemony,
+/obj/item/shield/energy/hegemony,
+/obj/item/shield/energy/hegemony,
+/obj/item/shield/energy/hegemony,
+/obj/item/shield/energy/hegemony,
 /turf/simulated/floor/plating,
 /area/hegemony_ship/armory)
 "CK" = (
@@ -4985,6 +5001,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
+/obj/item/storage/box/zipties,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/brig)
 "CM" = (
@@ -4996,10 +5013,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "CN" = (
@@ -5542,18 +5557,6 @@
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/hegemony)
-"Gn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/effect/floor_decal/industrial/outline_straight/yellow,
-/turf/simulated/floor/tiled,
-/area/hegemony_ship)
 "Go" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -5799,9 +5802,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
-/obj/effect/floor_decal/industrial/outline_straight/yellow{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "Hn" = (
@@ -5839,7 +5839,9 @@
 /area/hegemony_ship/trophy_room)
 "Hq" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/suit_cycler/offship/hegemony,
+/obj/machinery/suit_cycler/offship/hegemony{
+	mask = /obj/item/clothing/mask/gas/half
+	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/eva_storage)
 "Hz" = (
@@ -5892,8 +5894,6 @@
 /obj/effect/floor_decal/spline/fancy/wood/cee{
 	dir = 8
 	},
-/obj/item/clothing/suit/unathi/robe/robe_coat/blue,
-/obj/item/clothing/suit/unathi/robe/robe_coat/orange,
 /turf/simulated/floor/wood,
 /area/hegemony_ship/captains_quarters)
 "HT" = (
@@ -6206,10 +6206,7 @@
 /obj/machinery/light/colored/red{
 	dir = 8
 	},
-/obj/item/shield/energy/hegemony,
-/obj/item/shield/energy/hegemony,
-/obj/item/shield/energy/hegemony,
-/obj/item/shield/energy/hegemony,
+/obj/item/recharger_backpack/high,
 /obj/item/recharger_backpack/high,
 /obj/item/recharger_backpack/high,
 /turf/simulated/floor/plating,
@@ -6349,10 +6346,13 @@
 /area/hegemony_ship/canteen)
 "KL" = (
 /obj/structure/table/steel,
-/obj/item/storage/box/zipties,
 /obj/machinery/alarm/north{
 	req_one_access = null;
 	req_access = list(113)
+	},
+/obj/machinery/recharger{
+	pixel_x = 7;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/brig)
@@ -6754,13 +6754,13 @@
 /area/hegemony_ship)
 "MM" = (
 /obj/structure/closet/cabinet,
-/obj/item/reagent_containers/food/snacks/phoroncandy,
+/obj/item/reagent_containers/food/snacks/koisbar_clean,
 /obj/item/clothing/suit/vaurca/silver,
-/obj/item/vaurca/box,
-/obj/item/skrell_projector/vaurca_projector,
+/obj/item/clothing/under/unathi/zazali{
+	color = #373C0E
+	},
 /obj/item/clothing/mask/gas/vaurca/filter,
 /obj/item/melee/energy/vaurca,
-/obj/item/clothing/under/vaurca/gearharness/black,
 /obj/item/clothing/under/vaurca/gearharness,
 /obj/effect/floor_decal/corner/yellow/diagonal,
 /obj/effect/floor_decal/corner/red/diagonal{
@@ -6922,7 +6922,12 @@
 	dir = 4
 	},
 /obj/structure/table/steel,
-/obj/item/device/binoculars,
+/obj/item/device/binoculars{
+	pixel_x = -10
+	},
+/obj/machinery/recharger{
+	pixel_x = 4
+	},
 /turf/simulated/floor/tiled,
 /area/shuttle/hegemony)
 "Nk" = (
@@ -6978,6 +6983,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/oxygen,
 /turf/simulated/floor/tiled/white,
 /area/hegemony_ship/medbay)
 "NG" = (
@@ -7128,9 +7135,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/noid,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "OF" = (
@@ -7341,7 +7346,18 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/item/storage/firstaid/radiation,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/storage/firstaid/fire{
+	pixel_y = 5;
+	pixel_x = -5
+	},
+/obj/item/storage/firstaid/combat{
+	pixel_x = -5;
+	pixel_y = 2
+	},
 /turf/simulated/floor/tiled/white,
 /area/hegemony_ship/medbay)
 "Qh" = (
@@ -7437,7 +7453,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/suit_cycler/offship/hegemony,
+/obj/machinery/suit_cycler/offship/hegemony{
+	name = "captain";
+	helmet = /obj/item/clothing/head/helmet/space/void/hegemony/captain;
+	suit = /obj/item/clothing/suit/space/void/hegemony/captain;
+	mask = /obj/item/clothing/mask/gas/half
+	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/eva_storage)
 "QM" = (
@@ -7541,10 +7562,11 @@
 	dir = 5
 	},
 /obj/structure/table/reinforced/steel,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 10
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 4;
+	pixel_x = 1
 	},
-/obj/item/storage/toolbox/mechanical,
+/obj/item/device/multitool,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
 "RK" = (
@@ -7717,13 +7739,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
-/area/hegemony_ship)
-"Sy" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/outline_straight/yellow,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "Sz" = (
@@ -8087,14 +8102,18 @@
 "Um" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/masks{
-	pixel_y = 10
+	pixel_y = 8
 	},
 /obj/item/storage/box/gloves{
-	pixel_y = -4
+	pixel_y = 1
 	},
 /obj/effect/floor_decal/corner_wide/lime/full,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 11;
+	pixel_y = 3
 	},
 /turf/simulated/floor/tiled/white,
 /area/hegemony_ship/medbay)
@@ -8410,7 +8429,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/aux{
 	dir = 6
 	},
-/obj/effect/floor_decal/industrial/outline_straight/yellow,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "VS" = (
@@ -8776,7 +8794,6 @@
 /obj/effect/floor_decal/industrial/outline_straight/yellow{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline_straight/yellow,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "Yw" = (
@@ -8853,7 +8870,7 @@
 	req_access = list(113);
 	dir = 1
 	},
-/obj/item/device/gps,
+/obj/item/clothing/mask/gas/vaurca/tactical,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -18405,13 +18422,13 @@ Qp
 mX
 eC
 Nu
-gX
-ll
-lw
+Ay
+rE
+rE
 Sf
-Sy
-ll
-ce
+rE
+rE
+Ay
 KB
 Ev
 cD
@@ -18567,13 +18584,13 @@ oe
 fh
 zs
 Av
-Gn
+OA
 OA
 mv
 Yw
 TQ
-kh
-dU
+os
+os
 Dr
 PG
 fk
@@ -18729,13 +18746,13 @@ ii
 ml
 eC
 Ex
-Th
-mr
+Ej
+IH
 rU
 WO
 Yu
-mr
-bO
+IH
+Ej
 FS
 Ev
 Wl
@@ -21343,7 +21360,7 @@ Xa
 nl
 Xa
 wQ
-dz
+ce
 Ml
 Ml
 wZ
@@ -22490,7 +22507,7 @@ WH
 wo
 IE
 lP
-hn
+rt
 CX
 vm
 Hq
@@ -22626,7 +22643,7 @@ nG
 qY
 nG
 GH
-rt
+ZX
 ZX
 tA
 ZX
@@ -24561,8 +24578,8 @@ bo
 KD
 oB
 uA
-Pp
-lw
+Ay
+rE
 Su
 cX
 Cx

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
@@ -6757,7 +6757,7 @@
 /obj/item/reagent_containers/food/snacks/koisbar_clean,
 /obj/item/clothing/suit/vaurca/silver,
 /obj/item/clothing/under/unathi/zazali{
-	color = #373C0E
+	color = "#373C0E"
 	},
 /obj/item/clothing/mask/gas/vaurca/filter,
 /obj/item/melee/energy/vaurca,

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
@@ -29,12 +29,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/blast/regular/open{
-	id = "hegemony2";
-	name = "blast door"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "hegemony2"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -57,12 +56,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/blast/regular/open{
-	id = "hegemony1";
-	name = "blast door"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "hegemony1"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -518,9 +516,7 @@
 	pixel_y = 0
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/bridge)
@@ -695,10 +691,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/blast/regular/open{
-	id = "hegemony_cic";
-	name = "blast door"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/hegemony_ship/aux_cic)
 "er" = (
@@ -708,6 +700,11 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing/mapped,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
 "eu" = (
@@ -732,11 +729,6 @@
 /turf/simulated/floor/plating,
 /area/hegemony_ship/engineering)
 "eI" = (
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "headmaster_bridge";
-	icon_state = "pdoor0"
-	},
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, captains quarters"
 	},
@@ -745,6 +737,9 @@
 	frame_color = "#5b5b5b";
 	spawn_firedoor = 1;
 	spawn_grille = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "hegemony_window"
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/captains_quarters)
@@ -947,8 +942,7 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony3";
-	name = "blast door"
+	id = "hegemony3"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -1116,6 +1110,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/noid,
+/obj/machinery/door/blast/regular/open{
+	id = "hegemony_bridge";
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/bridge)
 "gC" = (
@@ -1449,9 +1447,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
@@ -1507,8 +1502,7 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony5";
-	name = "blast door"
+	id = "hegemony5"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -1697,12 +1691,14 @@
 /obj/machinery/button/remote/blast_door{
 	name = "Ship Lockdown";
 	pixel_y = 8;
-	pixel_x = -5
+	pixel_x = -5;
+	id = "hegemony1", "hegemony2", "hegemony3", "hegemony4", "hegemony5"
 	},
 /obj/machinery/button/remote/blast_door{
 	name = "Bridge Blastdoors";
 	pixel_x = 5;
-	pixel_y = 8
+	pixel_y = 8;
+	id = "hegemony_bridge"
 	},
 /obj/machinery/button/remote/blast_door{
 	pixel_x = -5;
@@ -1712,7 +1708,8 @@
 /obj/machinery/button/remote/blast_door{
 	name = "Auxiliary CIC Blastdoors";
 	pixel_x = 5;
-	pixel_y = -1
+	pixel_y = -1;
+	id = "hegemony_cic"
 	},
 /obj/item/clothing/head/helmet/pilot{
 	pixel_y = 4
@@ -1815,6 +1812,10 @@
 	frame_color = "#5b5b5b";
 	spawn_firedoor = 1;
 	spawn_grille = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "hegemony_window";
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/bridge)
@@ -2030,9 +2031,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/floor_decal/industrial/outline_straight/yellow{
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship)
 "mw" = (
@@ -2326,10 +2324,6 @@
 	dir = 1;
 	icon_state = "rwindow"
 	},
-/obj/machinery/door/window/brigdoor/northleft{
-	dir = 2;
-	req_access = list(113)
-	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
@@ -2346,6 +2340,10 @@
 /obj/item/ship_ammunition/francisca/frag,
 /obj/item/ship_ammunition/francisca/frag{
 	pixel_y = 4
+	},
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access = list(113);
+	dir = 2
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_flak)
@@ -2449,11 +2447,6 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/hegemony_ship/warpriests_quarters)
 "oG" = (
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "headmaster_bridge";
-	icon_state = "pdoor0"
-	},
 /obj/effect/landmark/entry_point/starboard{
 	name = "starboard, center"
 	},
@@ -2462,6 +2455,9 @@
 	frame_color = "#5b5b5b";
 	spawn_firedoor = 1;
 	spawn_grille = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "hegemony_window"
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship)
@@ -2523,13 +2519,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/sign/flag/hegemony/large/north{
 	pixel_y = 32
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/bridge)
@@ -2562,8 +2558,7 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony3";
-	name = "blast door"
+	id = "hegemony3"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -2933,16 +2928,16 @@
 	dir = 5
 	},
 /obj/machinery/firealarm/west,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/black/full{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
@@ -3147,6 +3142,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/bridge)
 "sK" = (
@@ -3254,8 +3254,7 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony4";
-	name = "blast door"
+	id = "hegemony4"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -3357,8 +3356,7 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony4";
-	name = "blast door"
+	id = "hegemony4"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -3453,9 +3451,6 @@
 /obj/structure/railing/mapped,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/bridge)
@@ -3565,8 +3560,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony2";
-	name = "blast door"
+	id = "hegemony2"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -3769,6 +3763,11 @@
 	dir = 1
 	},
 /obj/structure/railing/mapped,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
 "wi" = (
@@ -4126,8 +4125,7 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony5";
-	name = "blast door"
+	id = "hegemony5"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -4655,8 +4653,7 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony4";
-	name = "blast door"
+	id = "hegemony4"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -4906,8 +4903,7 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony5";
-	name = "blast door"
+	id = "hegemony5"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -6110,14 +6106,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/bridge)
-"Jp" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/hegemony_ship/gun_deck_bruiser)
 "Jt" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -6220,8 +6208,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony1";
-	name = "blast door"
+	id = "hegemony1"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -6442,16 +6429,14 @@
 /turf/simulated/floor/tiled/white,
 /area/hegemony_ship/restroom)
 "Lp" = (
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "headmaster_bridge";
-	icon_state = "pdoor0"
-	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#5b5b5b";
 	frame_color = "#5b5b5b";
 	spawn_firedoor = 1;
 	spawn_grille = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "hegemony_window"
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship)
@@ -6895,10 +6880,17 @@
 	},
 /obj/structure/table/steel,
 /obj/item/device/binoculars{
-	pixel_x = -10
+	pixel_x = -7;
+	pixel_y = 7
 	},
 /obj/machinery/recharger{
 	pixel_x = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	name = "Shuttle Blastdoors";
+	pixel_x = -7;
+	pixel_y = -2;
+	id = "hegemony_shuttle"
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/hegemony)
@@ -6974,16 +6966,14 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "NI" = (
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "headmaster_bridge";
-	icon_state = "pdoor0"
-	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#5b5b5b";
 	frame_color = "#5b5b5b";
 	spawn_firedoor = 1;
 	spawn_grille = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "hegemony_window"
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/captains_quarters)
@@ -7719,7 +7709,9 @@
 	dir = 8
 	},
 /obj/structure/table/steel,
-/obj/item/storage/bag/inflatable,
+/obj/item/storage/bag/inflatable{
+	pixel_y = 4
+	},
 /turf/simulated/floor/tiled,
 /area/shuttle/hegemony)
 "SB" = (
@@ -7902,6 +7894,10 @@
 	spawn_firedoor = 1;
 	spawn_grille = 1
 	},
+/obj/machinery/door/blast/regular/open{
+	id = "hegemony_window";
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/bridge)
 "Th" = (
@@ -8011,20 +8007,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/hegemony)
-"TQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/floor_decal/industrial/outline_straight/yellow,
-/turf/simulated/floor/plating,
-/area/hegemony_ship)
 "TW" = (
 /obj/machinery/alarm/north{
 	req_one_access = null;
@@ -8187,8 +8169,7 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony3";
-	name = "blast door"
+	id = "hegemony3"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -8206,6 +8187,10 @@
 	frame_color = "#5b5b5b";
 	spawn_firedoor = 1;
 	spawn_grille = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "hegemony_shuttle"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/hegemony)
@@ -8403,10 +8388,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/machinery/door/blast/regular/open{
-	id = "hegemony_cic";
-	name = "blast door"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hegemony_ship/aux_cic)
@@ -8634,6 +8615,10 @@
 /obj/effect/landmark/entry_point/fore{
 	name = "fore, bridge"
 	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "hegemony_shuttle"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/hegemony)
 "XM" = (
@@ -8719,16 +8704,14 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/hegemony_ship/brig)
 "Yq" = (
-/obj/machinery/door/blast/regular{
-	dir = 2;
-	id = "headmaster_bridge";
-	icon_state = "pdoor0"
-	},
 /obj/effect/map_effect/window_spawner/full/shuttle{
 	color = "#5b5b5b";
 	frame_color = "#5b5b5b";
 	spawn_firedoor = 1;
 	spawn_grille = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "hegemony_window"
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/trophy_room)
@@ -8815,6 +8798,9 @@
 	spawn_firedoor = 1;
 	spawn_grille = 1
 	},
+/obj/machinery/door/blast/regular/open{
+	id = "hegemony_window"
+	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/gun_deck_flak)
 "YG" = (
@@ -8896,8 +8882,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony1";
-	name = "blast door"
+	id = "hegemony1"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -9020,8 +9005,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony2";
-	name = "blast door"
+	id = "hegemony2"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -18544,7 +18528,7 @@ OA
 OA
 mv
 Yw
-TQ
+Bo
 os
 os
 Dr
@@ -18718,7 +18702,7 @@ aK
 hV
 Ev
 iG
-Jp
+BO
 LZ
 QM
 AH

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
@@ -1697,8 +1697,8 @@
 	name = "Ship Lockdown";
 	pixel_y = 8;
 	pixel_x = -5;
-	id = "hegemony1","hegemony2","hegemony3","hegemony4","hegemony5";
-	req_one_access = list(113)
+	req_one_access = list(113);
+	desc = "It controls blast doors, remotely. This button looks to be non-functional."
 	},
 /obj/machinery/button/remote/blast_door{
 	name = "Bridge Blastdoors";
@@ -1711,7 +1711,8 @@
 	pixel_x = -5;
 	pixel_y = -1;
 	name = "Ship Window Shields";
-	req_one_access = list(113)
+	req_one_access = list(113);
+	id = "hegemony_window"
 	},
 /obj/machinery/button/remote/blast_door{
 	name = "Auxiliary CIC Blastdoors";

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
@@ -315,12 +315,8 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/hegemony_ship/warpriests_quarters)
 "bZ" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/computer/ship/navigation,
-/turf/simulated/floor/plating,
+/obj/structure/ship_weapon_dummy,
+/turf/template_noop,
 /area/hegemony_ship/gun_deck_bruiser)
 "cc" = (
 /obj/structure/closet/secure_closet/guncabinet{
@@ -706,12 +702,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/hegemony_ship/aux_cic)
 "er" = (
-/obj/structure/railing/mapped,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/railing/mapped,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
 "eu" = (
@@ -1692,6 +1688,7 @@
 	},
 /obj/machinery/power/apc/east,
 /obj/structure/cable/green,
+/obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
 "kF" = (
@@ -2062,10 +2059,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/hegemony_ship/bridge)
 "mB" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark/full,
+/obj/structure/grille,
+/turf/template_noop,
 /area/hegemony_ship/gun_deck_bruiser)
 "mG" = (
 /obj/effect/floor_decal/corner_wide/red/diagonal,
@@ -2694,12 +2689,6 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/white,
 /area/hegemony_ship/medbay)
-"pP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/hegemony_ship/gun_deck_bruiser)
 "pU" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /turf/simulated/floor/tiled/white,
@@ -3038,9 +3027,7 @@
 /area/hegemony_ship/tcomms)
 "sg" = (
 /obj/structure/lattice/catwalk/indoor/grate,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/computer/ship/navigation,
 /turf/simulated/floor/plating,
 /area/hegemony_ship/gun_deck_bruiser)
 "sl" = (
@@ -3302,18 +3289,6 @@
 "tn" = (
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/bridge)
-"tw" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hegemony_ship/gun_deck_bruiser)
 "tx" = (
 /obj/machinery/computer/ship/sensors,
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -3793,6 +3768,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/railing/mapped,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
 "wi" = (
@@ -3954,8 +3930,9 @@
 	dir = 1;
 	icon_state = "rwindow"
 	},
-/obj/machinery/door/window/brigdoor/southright{
-	req_access = list(113)
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access = list(113);
+	dir = 2
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
@@ -3974,12 +3951,13 @@
 /turf/simulated/floor/plating,
 /area/hegemony_ship)
 "xt" = (
-/obj/structure/window/reinforced,
-/obj/structure/ship_weapon_dummy,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
 /obj/effect/floor_decal/spline/plain,
+/obj/machinery/ship_weapon/bruiser{
+	weapon_id = "Hegemony Corvette Bruiser";
+	pixel_x = -32;
+	pixel_y = -128
+	},
+/obj/structure/ship_weapon_dummy,
 /turf/simulated/floor/tiled/dark/full,
 /area/hegemony_ship/gun_deck_bruiser)
 "xu" = (
@@ -5500,7 +5478,7 @@
 /area/hegemony_ship)
 "FU" = (
 /turf/simulated/floor/foamedmetal,
-/area/space)
+/area/hegemony_ship/bridge)
 "FW" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/wood,
@@ -5648,11 +5626,16 @@
 /turf/simulated/floor/plating,
 /area/shuttle/hegemony)
 "GL" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 6
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/floor_decal/spline/plain,
-/turf/simulated/floor/tiled,
+/obj/structure/table/rack,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/glasses/safety/goggles,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/head/hardhat,
+/turf/simulated/floor/plating,
 /area/hegemony_ship/gun_deck_bruiser)
 "GM" = (
 /obj/machinery/door/airlock/external{
@@ -5871,9 +5854,12 @@
 /turf/simulated/floor/plating,
 /area/hegemony_ship/bridge)
 "HI" = (
-/obj/structure/viewport/unathi,
-/obj/structure/ship_weapon_dummy,
-/turf/simulated/floor/tiled/dark/full,
+/obj/structure/lattice/catwalk/indoor/grate,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/machinery/computer/ship/targeting,
+/turf/simulated/floor/plating,
 /area/hegemony_ship/gun_deck_bruiser)
 "HJ" = (
 /obj/structure/grille,
@@ -6073,13 +6059,11 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/hegemony)
 "Je" = (
-/obj/structure/railing/mapped{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9;
+	icon_state = "warning"
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/hegemony_ship/gun_deck_bruiser)
 "Jj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6127,22 +6111,11 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/bridge)
 "Jp" = (
-/obj/structure/railing/mapped,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
-/area/hegemony_ship/gun_deck_bruiser)
-"Jq" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/obj/structure/sign/flag/hegemony/large/west,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
 "Jt" = (
@@ -6681,9 +6654,8 @@
 /turf/simulated/floor/tiled/white,
 /area/hegemony_ship/medbay)
 "Mr" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
+/obj/structure/bed/stool/chair/office/bridge,
+/obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled,
 /area/hegemony_ship/gun_deck_bruiser)
 "Mt" = (
@@ -7571,10 +7543,10 @@
 /area/hegemony_ship/gun_deck_bruiser)
 "RK" = (
 /obj/structure/ship_weapon_dummy,
-/obj/machinery/ship_weapon/bruiser{
-	weapon_id = "Hegemony Corvette Bruiser";
-	pixel_x = -32;
-	pixel_y = -128
+/obj/structure/viewport/unathi,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/hegemony_ship/gun_deck_bruiser)
@@ -8124,11 +8096,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/port_propulsion)
-"Up" = (
-/obj/item/hullbeacon/red,
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
-/area/space)
 "Ut" = (
 /obj/effect/floor_decal/corner/yellow/full{
 	dir = 4
@@ -8271,23 +8238,12 @@
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
 "Vd" = (
-/obj/structure/window/reinforced,
-/obj/structure/railing/mapped{
-	dir = 4
+/obj/structure/ship_weapon_dummy,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10;
+	icon_state = "warning"
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9
-	},
-/obj/effect/floor_decal/spline/plain,
-/obj/structure/sign/deathsposal{
-	name = "\improper SPENT MUNITIONS EJECTION CHUTE sign";
-	pixel_x = -32
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark/full,
 /area/hegemony_ship/gun_deck_bruiser)
 "Ve" = (
 /obj/item/modular_computer/console/preset/civilian,
@@ -8354,8 +8310,6 @@
 	},
 /obj/item/reagent_containers/hypospray/autoinjector/coagzolug,
 /obj/item/reagent_containers/hypospray/autoinjector/coagzolug,
-/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline,
-/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline,
 /obj/item/storage/pill_bottle/mortaphenyl,
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
@@ -8365,6 +8319,8 @@
 /obj/item/reagent_containers/inhaler/pneumalin,
 /obj/item/reagent_containers/inhaler/pneumalin,
 /obj/item/storage/belt/medical/paramedic/combat/full,
+/obj/item/reagent_containers/glass/bottle/inaprovaline,
+/obj/item/reagent_containers/glass/bottle/inaprovaline,
 /turf/simulated/floor/tiled/white,
 /area/hegemony_ship/medbay)
 "VG" = (
@@ -18281,8 +18237,8 @@ aJ
 aJ
 aJ
 aJ
-aJ
-aJ
+xh
+xh
 aJ
 aJ
 aJ
@@ -18442,11 +18398,11 @@ Ev
 GD
 Ev
 Ev
-pP
+Ev
+Ev
 xh
-aJ
-aJ
-aJ
+xh
+pC
 aJ
 aJ
 aJ
@@ -18602,12 +18558,12 @@ zq
 rs
 we
 Je
-Jq
-tw
+fQ
+CN
 Vd
-xh
-xh
-pC
+Ev
+aJ
+aJ
 aJ
 aJ
 aJ
@@ -18763,13 +18719,13 @@ hV
 Ev
 iG
 Jp
-mB
-fQ
-CN
+LZ
+QM
+AH
 xt
-aJ
-aJ
-aJ
+bZ
+UV
+WG
 aJ
 aJ
 aJ
@@ -18924,14 +18880,14 @@ hX
 Ev
 Ev
 RI
-BO
-LZ
-QM
-AH
+er
+hg
+ye
+Jz
 RK
-UV
-UV
-WG
+mB
+aJ
+aJ
 aJ
 aJ
 aJ
@@ -19086,15 +19042,15 @@ Ev
 Ev
 Ev
 xo
-er
-hg
-ye
-Jz
+BO
+qX
 HI
-aJ
-aJ
-aJ
-aJ
+Ev
+Ev
+fS
+xh
+xh
+pC
 aJ
 aJ
 aJ
@@ -19250,12 +19206,12 @@ Ev
 yO
 BO
 Mr
-qX
-bZ
-fS
+sg
+Ev
+Ev
+Ev
 xh
-xh
-Up
+aJ
 aJ
 aJ
 aJ
@@ -19413,10 +19369,10 @@ sT
 vW
 kB
 GL
-sg
+Ev
 Ev
 xh
-aJ
+xh
 aJ
 aJ
 aJ
@@ -19576,8 +19532,8 @@ Ev
 Ev
 Ev
 Ev
-Ev
-xh
+aJ
+aJ
 aJ
 aJ
 aJ
@@ -22519,7 +22475,7 @@ Ep
 Ep
 Ep
 Ep
-uz
+Ep
 HJ
 HJ
 HJ
@@ -22680,8 +22636,8 @@ tn
 vj
 Ep
 FU
-uz
-uz
+Ep
+Ep
 HJ
 HJ
 HJ
@@ -22842,8 +22798,8 @@ OG
 mA
 Ep
 FU
-uz
-uz
+Ep
+Ep
 HJ
 HJ
 aJ
@@ -23004,8 +22960,8 @@ HM
 yN
 Ep
 FU
-uz
-uz
+Ep
+Ep
 HJ
 aJ
 aJ
@@ -23165,8 +23121,8 @@ Ku
 Ku
 Ku
 Ep
-uz
-uz
+Ep
+Ep
 HJ
 HJ
 HJ
@@ -23327,7 +23283,7 @@ hA
 Ep
 Ep
 Ep
-uz
+Ep
 HJ
 HJ
 aJ

--- a/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
+++ b/maps/away/ships/hegemony/hegemony_corvette/hegemony_corvette.dmm
@@ -33,7 +33,8 @@
 	dir = 4
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony2"
+	id = "hegemony2";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -60,7 +61,8 @@
 	dir = 4
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony1"
+	id = "hegemony1";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -691,6 +693,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/blast/regular/open{
+	name = "blast door";
+	id = "hegemony_cic"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hegemony_ship/aux_cic)
 "er" = (
@@ -739,7 +745,8 @@
 	spawn_grille = 1
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony_window"
+	id = "hegemony_window";
+	name = "blast door"
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/captains_quarters)
@@ -942,7 +949,8 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony3"
+	id = "hegemony3";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -1110,10 +1118,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/noid,
-/obj/machinery/door/blast/regular/open{
-	id = "hegemony_bridge";
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/bridge)
 "gC" = (
@@ -1502,7 +1506,8 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony5"
+	id = "hegemony5";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -1692,24 +1697,28 @@
 	name = "Ship Lockdown";
 	pixel_y = 8;
 	pixel_x = -5;
-	id = "hegemony1", "hegemony2", "hegemony3", "hegemony4", "hegemony5"
+	id = "hegemony1","hegemony2","hegemony3","hegemony4","hegemony5";
+	req_one_access = list(113)
 	},
 /obj/machinery/button/remote/blast_door{
 	name = "Bridge Blastdoors";
 	pixel_x = 5;
 	pixel_y = 8;
-	id = "hegemony_bridge"
+	id = "hegemony_bridge";
+	req_one_access = list(113)
 	},
 /obj/machinery/button/remote/blast_door{
 	pixel_x = -5;
 	pixel_y = -1;
-	name = "Ship Window Shields"
+	name = "Ship Window Shields";
+	req_one_access = list(113)
 	},
 /obj/machinery/button/remote/blast_door{
 	name = "Auxiliary CIC Blastdoors";
 	pixel_x = 5;
 	pixel_y = -1;
-	id = "hegemony_cic"
+	id = "hegemony_cic";
+	req_one_access = list(113)
 	},
 /obj/item/clothing/head/helmet/pilot{
 	pixel_y = 4
@@ -1815,7 +1824,8 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	id = "hegemony_window";
-	dir = 4
+	dir = 4;
+	name = "blast door"
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/bridge)
@@ -2457,7 +2467,8 @@
 	spawn_grille = 1
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony_window"
+	id = "hegemony_window";
+	name = "blast door"
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship)
@@ -2558,7 +2569,8 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony3"
+	id = "hegemony3";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -3254,7 +3266,8 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony4"
+	id = "hegemony4";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -3356,7 +3369,8 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony4"
+	id = "hegemony4";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -3560,7 +3574,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony2"
+	id = "hegemony2";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -4125,7 +4140,8 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony5"
+	id = "hegemony5";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -4653,7 +4669,8 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony4"
+	id = "hegemony4";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -4903,7 +4920,8 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony5"
+	id = "hegemony5";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -6208,7 +6226,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony1"
+	id = "hegemony1";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -6436,7 +6455,8 @@
 	spawn_grille = 1
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony_window"
+	id = "hegemony_window";
+	name = "blast door"
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship)
@@ -6890,7 +6910,8 @@
 	name = "Shuttle Blastdoors";
 	pixel_x = -7;
 	pixel_y = -2;
-	id = "hegemony_shuttle"
+	id = "hegemony_shuttle";
+	req_one_access = list(113)
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/hegemony)
@@ -6973,7 +6994,8 @@
 	spawn_grille = 1
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony_window"
+	id = "hegemony_window";
+	name = "blast door"
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/captains_quarters)
@@ -7896,7 +7918,8 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	id = "hegemony_window";
-	dir = 4
+	dir = 4;
+	name = "blast door"
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/bridge)
@@ -8169,7 +8192,8 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony3"
+	id = "hegemony3";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -8190,7 +8214,8 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony_shuttle"
+	id = "hegemony_shuttle";
+	name = "blast door"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/hegemony)
@@ -8388,6 +8413,10 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	name = "blast door";
+	id = "hegemony_cic"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hegemony_ship/aux_cic)
@@ -8617,7 +8646,8 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
-	id = "hegemony_shuttle"
+	id = "hegemony_shuttle";
+	name = "blast door"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/hegemony)
@@ -8710,9 +8740,6 @@
 	spawn_firedoor = 1;
 	spawn_grille = 1
 	},
-/obj/machinery/door/blast/regular/open{
-	id = "hegemony_window"
-	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/trophy_room)
 "Yt" = (
@@ -8799,7 +8826,8 @@
 	spawn_grille = 1
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony_window"
+	id = "hegemony_window";
+	name = "blast door"
 	},
 /turf/simulated/floor/plating,
 /area/hegemony_ship/gun_deck_flak)
@@ -8882,7 +8910,8 @@
 	pixel_y = -32
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony1"
+	id = "hegemony1";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)
@@ -9005,7 +9034,8 @@
 	pixel_y = -32
 	},
 /obj/machinery/door/blast/regular/open{
-	id = "hegemony2"
+	id = "hegemony2";
+	name = "blast door"
 	},
 /turf/simulated/floor/tiled,
 /area/hegemony_ship)

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -7524,6 +7524,8 @@
 /obj/effect/floor_decal/corner/green/full,
 /obj/item/reagent_containers/inhaler/pneumalin,
 /obj/item/reagent_containers/inhaler/pneumalin,
+/obj/item/reagent_containers/glass/bottle/inaprovaline,
+/obj/item/reagent_containers/glass/bottle/inaprovaline,
 /turf/simulated/floor/tiled/white{
 	temperature = 278.15
 	},

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -2673,7 +2673,7 @@
 /obj/item/flag/hegemony/l,
 /obj/item/toy/mech/marauder,
 /obj/item/clothing/accessory/poncho/unathimantle/forest{
-	color = #6D2B1A
+	color = "#6D2B1A"
 	},
 /obj/item/clothing/accessory/storage/pouches/brown,
 /obj/item/storage/belt/military,
@@ -3071,7 +3071,7 @@
 /obj/item/clothing/head/helmet/unathi/klax,
 /obj/item/clothing/shoes/magboots/vaurca,
 /obj/item/clothing/glasses/sunglasses/blinders{
-	color = #423509
+	color = "#423509"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -3790,7 +3790,7 @@
 /obj/item/clothing/accessory/storage/pouches/brown,
 /obj/item/clothing/under/vaurca/gearharness,
 /obj/item/clothing/under/unathi/zazali{
-	color = #373C0E
+	color = "#373C0E"
 	},
 /obj/item/clothing/suit/unathi/robe/beige,
 /obj/item/clothing/head/unathi/dark,

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -418,6 +418,9 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/item/folder/red{
+	pixel_x = 4
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/kataphract_chapter/cic)
 "bq" = (
@@ -660,6 +663,12 @@
 "cC" = (
 /obj/machinery/computer/ship/sensors/terminal{
 	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	name = "Shuttle Blast Doors";
+	id = "kataphract_shuttle_shutters";
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/full,
 /area/shuttle/kataphract_shuttle/main_compartment)
@@ -1680,6 +1689,8 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/item/melee/energy/glaive/hegemony,
+/obj/item/melee/energy/glaive/hegemony,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/armoury)
 "gb" = (
@@ -1921,6 +1932,8 @@
 /obj/item/clothing/head/unathi/deco/dark/orange,
 /obj/item/material/hatchet/unathiknife,
 /obj/item/clothing/accessory/storage/pouches/brown,
+/obj/item/clothing/head/unathi/dark,
+/obj/item/storage/belt/military,
 /obj/item/clothing/accessory/badge/passport/hegemony,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -1971,7 +1984,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/closet/crate/bin,
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
@@ -2437,7 +2449,9 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/kataphract_chapter/armoury)
 "iU" = (
-/obj/machinery/suit_cycler/offship/kataphract,
+/obj/machinery/suit_cycler/offship/kataphract{
+	mask = /obj/item/clothing/mask/gas/half
+	},
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
@@ -2471,6 +2485,12 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
+/obj/item/tank/jetpack/oxygen,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/armoury)
 "iX" = (
@@ -2652,7 +2672,11 @@
 /obj/item/flag/hegemony,
 /obj/item/flag/hegemony/l,
 /obj/item/toy/mech/marauder,
-/obj/item/clothing/accessory/poncho/unathimantle/fighter,
+/obj/item/clothing/accessory/poncho/unathimantle/forest{
+	color = #6D2B1A
+	},
+/obj/item/clothing/accessory/storage/pouches/brown,
+/obj/item/storage/belt/military,
 /obj/item/clothing/suit/unathi/robe/robe_coat,
 /obj/item/clothing/suit/unathi/robe/robe_coat/blue,
 /obj/item/clothing/suit/unathi/robe/robe_coat/orange,
@@ -2703,12 +2727,10 @@
 /area/kataphract_chapter/medical)
 "kf" = (
 /obj/structure/table/standard,
-/obj/item/reagent_containers/glass/bottle/inaprovaline,
 /obj/item/storage/belt/medical/paramedic,
 /obj/item/storage/belt/medical,
 /obj/item/reagent_containers/hypospray,
 /obj/item/reagent_containers/hypospray,
-/obj/item/reagent_containers/glass/bottle/inaprovaline,
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
@@ -2735,6 +2757,9 @@
 /obj/effect/floor_decal/corner/green/full{
 	dir = 1
 	},
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
 /turf/simulated/floor/tiled/white,
 /area/kataphract_chapter/medical)
 "ki" = (
@@ -3044,8 +3069,10 @@
 /obj/structure/table/rack,
 /obj/item/clothing/suit/armor/unathi/klax,
 /obj/item/clothing/head/helmet/unathi/klax,
-/obj/item/clothing/shoes/magboots/hegemony,
-/obj/item/clothing/glasses/sunglasses/blinders,
+/obj/item/clothing/shoes/magboots/vaurca,
+/obj/item/clothing/glasses/sunglasses/blinders{
+	color = #423509
+	},
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
@@ -3053,6 +3080,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/clothing/mask/gas/vaurca/tactical,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/armoury)
 "lc" = (
@@ -3761,7 +3789,12 @@
 /obj/item/material/hatchet/unathiknife,
 /obj/item/clothing/accessory/storage/pouches/brown,
 /obj/item/clothing/under/vaurca/gearharness,
-/obj/item/clothing/under/vaurca,
+/obj/item/clothing/under/unathi/zazali{
+	color = #373C0E
+	},
+/obj/item/clothing/suit/unathi/robe/beige,
+/obj/item/clothing/head/unathi/dark,
+/obj/item/storage/belt/military,
 /obj/item/clothing/mask/gas/vaurca/filter,
 /obj/item/reagent_containers/food/snacks/koisbar,
 /obj/item/clothing/accessory/badge/passport/hegemony,
@@ -4610,7 +4643,8 @@
 /area/kataphract_chapter/main_ring)
 "uA" = (
 /obj/machinery/suit_cycler/offship/kataphract/lead{
-	req_access = list(113)
+	req_access = list(113);
+	mask = /obj/item/clothing/mask/gas/half
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -4676,6 +4710,8 @@
 /obj/item/clothing/head/unathi/deco/dark/orange,
 /obj/item/material/hatchet/unathiknife,
 /obj/item/clothing/accessory/storage/pouches/brown,
+/obj/item/clothing/head/unathi/dark,
+/obj/item/storage/belt/military,
 /obj/item/clothing/accessory/badge/passport/hegemony,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -4801,7 +4837,6 @@
 /area/kataphract_chapter/atmospherics)
 "wT" = (
 /obj/structure/table/reinforced/steel,
-/obj/item/folder/red,
 /obj/item/reagent_containers/food/drinks/drinkingglass/newglass/coffeecup/hegemony{
 	pixel_y = 6;
 	pixel_x = 10
@@ -4818,14 +4853,6 @@
 /area/kataphract_chapter/cic)
 "wU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/shuttle/kataphract_shuttle/main_compartment)
-"xd" = (
-/obj/machinery/button/remote/blast_door{
-	dir = 6;
-	name = "Shuttle Blast Doors";
-	id = "kataphract_shuttle_shutters"
-	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/shuttle/kataphract_shuttle/main_compartment)
 "xz" = (
@@ -5626,7 +5653,8 @@
 /area/kataphract_chapter/mess)
 "FC" = (
 /obj/machinery/suit_cycler/offship/kataphract/specialist{
-	req_access = list(113)
+	req_access = list(113);
+	mask = /obj/item/clothing/mask/gas/half
 	},
 /obj/machinery/light{
 	dir = 4
@@ -5876,6 +5904,7 @@
 /area/kataphract_chapter/hangar)
 "Iq" = (
 /obj/effect/floor_decal/corner/green/full,
+/obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/white,
 /area/kataphract_chapter/medical)
 "Iz" = (
@@ -6219,7 +6248,6 @@
 "Mm" = (
 /obj/structure/table/rack,
 /obj/item/material/twohanded/pike/flag/hegemony,
-/obj/item/material/twohanded/pike/flag/hegemony,
 /obj/item/shield/energy/hegemony/kataphract,
 /obj/item/shield/energy/hegemony/kataphract,
 /obj/item/shield/energy/hegemony/kataphract,
@@ -6252,8 +6280,9 @@
 /area/kataphract_chapter/main_ring)
 "Mw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/closet/crate/bin,
+/obj/structure/table/rack,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/rig/unathi/fancy/equipped,
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/armoury)
 "MD" = (
@@ -6362,12 +6391,9 @@
 /obj/item/clothing/head/helmet/unathi/hegemony,
 /obj/item/clothing/head/helmet/unathi/hegemony,
 /obj/item/clothing/head/helmet/unathi/hegemony,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/clothing/glasses/sunglasses,
+/obj/item/clothing/glasses/safety/goggles/tactical/generic,
+/obj/item/clothing/glasses/safety/goggles/tactical/generic,
+/obj/item/clothing/glasses/safety/goggles/tactical/generic,
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
@@ -6452,6 +6478,8 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/item/clothing/accessory/badge/passport/hegemony,
 /obj/machinery/light,
+/obj/item/clothing/accessory/storage/pouches/brown,
+/obj/item/clothing/accessory/storage/pouches/white,
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/specoffice)
 "Oi" = (
@@ -7101,7 +7129,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/frankie)
 "TM" = (
-/obj/machinery/suit_cycler/offship/kataphract,
+/obj/machinery/suit_cycler/offship/kataphract{
+	mask = /obj/item/clothing/mask/gas/half
+	},
 /obj/effect/floor_decal/corner_wide/red/full,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
@@ -7240,6 +7270,8 @@
 /obj/item/clothing/head/unathi/deco/dark/orange,
 /obj/item/material/hatchet/unathiknife,
 /obj/item/clothing/accessory/storage/pouches/brown,
+/obj/item/clothing/head/unathi/dark,
+/obj/item/storage/belt/military,
 /obj/item/clothing/accessory/badge/passport/hegemony,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -7480,7 +7512,6 @@
 	pixel_x = -32;
 	req_access = list(113)
 	},
-/obj/item/clothing/mask/breath/medical,
 /obj/item/auto_cpr,
 /obj/item/tank/oxygen,
 /obj/item/tank/oxygen,
@@ -33346,7 +33377,7 @@ iT
 fZ
 Su
 NG
-Td
+NG
 lb
 CB
 iT
@@ -36855,7 +36886,7 @@ iB
 iB
 iB
 bH
-xd
+Bi
 cC
 cr
 kQ


### PR DESCRIPTION
The armouries/EVA prep rooms in both ships had some equipment upgrades and fixes, their infirmaries had some minor equipment revisions that should make item management more convenient, and a litany of smaller changes such as more clothing options and some rechargers placed around both ships. When I figure out how to fix the forever-tinted windows on the Hegemony Corvette that will be added too.