### PR TITLE
Honor, fire, burn thy fear: Adds a simple animal knockout technique to the Kis-Khan martial art

### DIFF
--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -163,6 +163,12 @@
 
 	return TRUE
 
+/datum/martial_art/proc/simple_animal_basic_disarm(var/mob/living/carbon/human/A, var/mob/living/simple_animal/D)
+	if(A.a_intent == I_DISARM)
+		A.visible_message("<b>\The [A]</b> [D.response_disarm] \the [D]")
+		A.do_attack_animation(D)
+		D.poke(1)
+		D.handle_attack_by(A)
 
 /datum/martial_art/proc/teach(var/mob/living/carbon/human/H)
 	if(help_verb)

--- a/code/modules/martial_arts/martial.dm
+++ b/code/modules/martial_arts/martial.dm
@@ -165,7 +165,7 @@
 
 /datum/martial_art/proc/simple_animal_basic_disarm(var/mob/living/carbon/human/A, var/mob/living/simple_animal/D)
 	if(A.a_intent == I_DISARM)
-		A.visible_message("<b>\The [A]</b> [D.response_disarm] \the [D]")
+		A.visible_message("[SPAN_BOLD("\The [A]")] [D.response_disarm] \the [D]")
 		A.do_attack_animation(D)
 		D.poke(1)
 		D.handle_attack_by(A)

--- a/code/modules/martial_arts/unathi.dm
+++ b/code/modules/martial_arts/unathi.dm
@@ -47,19 +47,18 @@
 		return 1
 	if(istype(D, /mob/living/simple_animal))
 		simple_animal_basic_disarm(A,D)
-		return 1
 	else
 		basic_hit(A,D)
-		return 1
+	return 1
 
 /datum/martial_art/kis_khan/simple_animal_basic_disarm(var/mob/living/carbon/human/A, var/mob/living/simple_animal/D)
 	if(!D.paralysis)
-		A.visible_message("<b>[A]</b> delivers a blow to \the <b>[D]</b>'s head, making [D.get_pronoun("him")] fall unconscious!")
+		A.visible_message("[SPAN_BOLD("[A]")] delivers a blow to \the [SPAN_BOLD("[D]")]'s head, making [D.get_pronoun("him")] fall unconscious!")
 		A.do_attack_animation(D)
-		playsound(D.loc, /singleton/sound_category/punch_sound, 25, 1, -1)
+		playsound(D.loc, /singleton/sound_category/punch_sound, 25, TRUE, MEDIUM_RANGE_SOUND_EXTRARANGE+4)
 		D.AdjustParalysis(5)
 	else
-		to_chat(A, SPAN_WARNING("\The <b>[D]</b> is already unconscious!"))
+		to_chat(A, SPAN_WARNING("\The [SPAN_BOLD("[D]")] is already unconscious!"))
 		return
 
 /datum/martial_art/kis_khan/proc/tail_sweep(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)

--- a/code/modules/martial_arts/unathi.dm
+++ b/code/modules/martial_arts/unathi.dm
@@ -45,8 +45,22 @@
 	add_to_streak("D",D)
 	if(check_streak(A,D))
 		return 1
-	basic_hit(A,D)
-	return 1
+	if(istype(D, /mob/living/simple_animal))
+		simple_animal_basic_disarm(A,D)
+		return 1
+	else
+		basic_hit(A,D)
+		return 1
+
+/datum/martial_art/kis_khan/simple_animal_basic_disarm(var/mob/living/carbon/human/A, var/mob/living/simple_animal/D)
+	if(!D.paralysis)
+		A.visible_message("<b>[A]</b> delivers a blow to \the <b>[D]</b>'s head, making [D.get_pronoun("him")] fall unconscious!")
+		A.do_attack_animation(D)
+		playsound(D.loc, /singleton/sound_category/punch_sound, 25, 1, -1)
+		D.AdjustParalysis(5)
+	else
+		to_chat(A, SPAN_WARNING("\The <b>[D]</b> is already unconscious!"))
+		return
 
 /datum/martial_art/kis_khan/proc/tail_sweep(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	if(D.stat || D.weakened)
@@ -97,6 +111,7 @@
 	to_chat(usr, "<span class='notice'>Tail Sweep</span>: Harm Harm Disarm. Trips the victim with your tail, rendering them prone and unable to move for a short time.")
 	to_chat(usr, "<span class='notice'>Swift Disarm</span>: Disarm Disarm Grab. Strikes your target's weapon, trying to disarm it from their hands.")
 	to_chat(usr, "<span class='notice'>Hammering Strike</span>: Disarm Harm Disarm. Delivers a strikes that will push the target away from you.")
+	to_chat(usr, "<span class='notice'>You can also deal a knockout blow to non-sapient animals by using disarm.</span>")
 
 /obj/item/martial_manual/unathi
 	name = "kis khan scroll"

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -500,6 +500,7 @@
 
 /mob/living/simple_animal/attack_hand(mob/living/carbon/human/M as mob)
 	..()
+	var/datum/martial_art/attacker_style = M.primary_martial_art
 	switch(M.a_intent)
 
 		if(I_HELP)
@@ -508,6 +509,8 @@
 				poke()
 
 		if(I_DISARM)
+			if(attacker_style && attacker_style.disarm_act(M, src))
+				return TRUE
 			M.visible_message("<b>\The [M]</b> [response_disarm] \the [src]")
 			M.do_attack_animation(src)
 			poke(1)

--- a/html/changelogs/SimpleMaroon-martialrefactor.yml
+++ b/html/changelogs/SimpleMaroon-martialrefactor.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: SimpleMaroon
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a 'knockout blow' technique to the Kis-Khan martial art that renders a simple animal temporarily paralyzed. It can be performed with disarm intent."
+  - code_imp: "Adjusted disarm intent on simple mobs to be compatible with martial arts."


### PR DESCRIPTION
Implements a disarm technique to Kis-Khan that "knocks out" simple animals for a few seconds, allowing you to follow up with other attacks. This is because shriekers are easy to encounter in the Untouched Lands as a Kis-Khan master and are too difficult to get away from with Unathi sprint, making it easy to get overwhelmed by multiple of them, especially if you're in water. And dying to shriekers is, unfortunately, not badass as a martial arts master.

Could also pave the way for other simple animal-based attacks for Kis-Khan or other martial arts, if people are interested in that.