### PR TITLE
Adds name-assigning functionality to secure lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/locker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/locker.dm
@@ -9,6 +9,20 @@
 	locked = TRUE
 	health = 200
 
+/obj/structure/closet/secure_closet/AltClick(mob/user)
+	. = ..()
+	var/obj/item/holding = user.get_active_hand()
+	if(!holding)
+		return
+	if(istype(holding, /obj/item/card/id))
+		var/obj/item/card/id/ID = holding
+		if(check_access(ID))
+			if(name == initial(name))
+				name += " ([ID.registered_name])"
+				to_chat(user, SPAN_NOTICE("You assign your name to \the [src] using \the [ID]."))
+		else
+			to_chat(user, SPAN_WARNING("Access denied."))
+
 /obj/structure/closet/emp_act(severity)
 	. = ..()
 
@@ -89,3 +103,25 @@
 		togglelock(usr)
 	else
 		to_chat(usr, SPAN_WARNING("This mob type can't use this verb."))
+
+/obj/structure/closet/secure_closet/verb/reset()
+	set src in oview(1) // One square distance
+	set category = "Object"
+	set name = "Reset Name"
+	if(!usr.canmove || usr.stat || usr.restrained()) // Don't use it if you're not able to! Checks for stuns, ghost and restrain
+		return
+	if(ishuman(usr))
+		add_fingerprint(usr)
+		if (locked || name == initial(name))
+			to_chat(usr, SPAN_WARNING("You need to unlock it first."))
+		else if(broken)
+			to_chat(usr, SPAN_WARNING("It appears to be broken."))
+		else
+			if(opened)
+				if(!close())
+					return
+			locked = 1
+			update_icon()
+			name = initial(name)
+			desc = initial(desc)
+	return

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -84,25 +84,3 @@
 		if(visual_feedback)
 			visible_message(SPAN_WARNING("[visual_feedback]"), SPAN_WARNING("[audible_feedback]"))
 		return 1
-
-/obj/structure/closet/secure_closet/personal/verb/reset()
-	set src in oview(1) // One square distance
-	set category = "Object"
-	set name = "Reset Lock"
-	if(!usr.canmove || usr.stat || usr.restrained()) // Don't use it if you're not able to! Checks for stuns, ghost and restrain
-		return
-	if(ishuman(usr))
-		add_fingerprint(usr)
-		if (locked || !registered_name)
-			to_chat(usr, SPAN_WARNING("You need to unlock it first."))
-		else if (broken)
-			to_chat(usr, SPAN_WARNING("It appears to be broken."))
-		else
-			if (opened)
-				if(!close())
-					return
-			locked = 1
-			update_icon()
-			registered_name = null
-			desc = "It's a secure locker for personnel. The first card swiped gains control."
-	return

--- a/html/changelogs/SimpleMaroon-lockernaming.yml
+++ b/html/changelogs/SimpleMaroon-lockernaming.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: SimpleMaroon
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added the ability to assign the name on your ID to secure lockers. To do this, alt-click the locker with your ID in hand. You can also reset the assigned name on the locker by right-clicking and using the Reset Name verb while the locker is unlocked."


### PR DESCRIPTION
Implements the suggestion mentioned in https://forums.aurorastation.org/topic/20630-allow-id-cards-to-tag-lockers-with-your-name/?do=findComment&comment=176214

Uses alt-clicking instead of mouse-dropping because MouseDrop_T was acting a bit zilly with ID cards when I tried.