### PR TITLE
Offship Cameras

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -109,8 +109,8 @@
 		return 1
 
 /obj/machinery/computer/security/attack_hand(var/mob/user as mob)
-	if (src.z > 6)
-		to_chat(user, "<span class='danger'>Unable to establish a connection:</span> You're too far away from the station!")
+	if (!(src.z in GetConnectedZlevels(starting_z_level)))
+		to_chat(user, "Unable to establish a connection.")
 		return
 	if(stat & (NOPOWER|BROKEN))	return
 
@@ -135,7 +135,7 @@
 		return 0
 	set_current(C)
 
-	if(!is_contact_area(get_area(C)))
+	if (!(C.z in GetConnectedZlevels(starting_z_level)))
 		to_chat(user, SPAN_NOTICE("This camera is too far away to connect to!"))
 		return FALSE
 
@@ -314,3 +314,14 @@
 /obj/machinery/computer/security/nuclear/Initialize()
 	. = ..()
 	req_access = list(150)
+
+/obj/machinery/computer/security/terminal
+	name = "camera monitor terminal"
+	icon = 'icons/obj/machinery/modular_terminal.dmi'
+	icon_screen = "cameras"
+	icon_keyboard = "security_key"
+	icon_keyboard_emis = "security_key_mask"
+	is_connected = TRUE
+	has_off_keyboards = TRUE
+	can_pass_under = FALSE
+	light_power_on = 1

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -25,9 +25,13 @@
 	var/has_off_keyboards = FALSE
 	var/can_pass_under = TRUE
 
+	// The zlevel that this computer is spawned on.
+	var/starting_z_level = null
+
 /obj/machinery/computer/Initialize()
 	. = ..()
 	overlay_layer = layer
+	starting_z_level = src.z
 	power_change()
 	update_icon()
 

--- a/html/changelogs/DreamySkrell-offship-cameras.yml
+++ b/html/changelogs/DreamySkrell-offship-cameras.yml
@@ -1,0 +1,7 @@
+
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - rscadd: "Offship cameras."


### PR DESCRIPTION
tl;dr: instead of just checking if the computer/camera are on map defined "contact" zlevels (1,2,3 for horizon), computers save the zlevel they were initialized on, and check for that (check connected zlevels)

so a offship camera works on offship zlevel, but not when brought outside of it like on a shuttle, and only connects to cameras that are on that offship zlevel, and same thing, not if flown outside on a shuttle

this affects only the computer cameras - horizon generally uses camera program on modular computers (but it works correctly on horizon too)