### PR TITLE
Intent-based sink/reagent dispenser filling

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -1,7 +1,8 @@
 /obj/structure/reagent_dispensers
 	name = "strange dispenser"
 	desc = "What the fuck is this?"
-	desc_info = "You can right-click this and change the amount transferred per use."
+	desc_info = "Use HELP intent to fill a container in your hand from this, and use any other intent to empty the container into this. \
+	You can right-click this and change the amount transferred per use."
 	icon = 'icons/obj/reagent_dispensers.dmi'
 	icon_state = "watertank"
 	density = 1
@@ -42,27 +43,23 @@
 /obj/structure/reagent_dispensers/attackby(obj/item/attacking_item, mob/user)
 
 	var/obj/item/reagent_containers/RG = attacking_item
-	if (istype(RG) && RG.is_open_container())
-
-		var/atype
-		if(accept_any_reagent)
-			atype = alert(user, "Do you want to fill or empty \the [RG] at \the [src]?", "Fill or Empty", "Fill", "Empty", "Cancel")
-		else
-			atype = alert(user, "Do you want to fill \the [RG] at \the [src]?", "Fill", "Fill", "Cancel")
-
+	if (istype(RG))
 		if(!user.Adjacent(src)) return
 		if(RG.loc != user && !isrobot(user)) return
-
-		switch(atype)
-			if ("Fill")
-				RG.standard_dispenser_refill(user,src)
-				playsound(src.loc, 'sound/machines/reagent_dispense.ogg', 25, 1)
-			if ("Empty")
-				if(is_open_container())
-					RG.standard_pour_into(user,src)
-				else
-					to_chat(user,SPAN_NOTICE("The inlet cap on \the [src] is wrenched on tight!"))
-		return
+		if(!(RG.is_open_container()))
+			to_chat(usr, SPAN_WARNING("The [RG.name]'s lid is on!"))
+			return
+		if (usr.a_intent == I_HELP)
+			RG.standard_dispenser_refill(user,src)
+			playsound(src.loc, 'sound/machines/reagent_dispense.ogg', 25, 1)
+		else
+			if(!accept_any_reagent)
+				to_chat(user,SPAN_WARNING("You can't refill \the [src]."))
+				return
+			if(is_open_container())
+				RG.standard_pour_into(user,src)
+			else
+				to_chat(user,SPAN_NOTICE("The inlet cap on \the [src] is wrenched on tight!"))
 
 	if (attacking_item.iswrench())
 		if(use_check(user, USE_DISALLOW_SPECIALS))

--- a/html/changelogs/nauticall-sink_qol.yml
+++ b/html/changelogs/nauticall-sink_qol.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: nauticall
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Sinks and reagent dispensers now have intent-based filling/emptying of containers like beakers/buckets. Use help intent to fill a container in your hand from a sink/tank/dispenser, any other intent to empty."


### PR DESCRIPTION
Changes the sink/reagent dispenser (i.e. water tanks)' filling system to be intent-based rather than opening a window every time. Should make filling/emptying containers at least 10x quicker. :)

Use **HELP** intent to fill from a container. Any other intent (i.e. HARM) will have you try to empty the container into the dispenser/sink instead.

Additional examination info has been added to both the sink and reagent dispensers to give such information.