### PR TITLE
Hegemony Energy Rifle Bugfix

### DIFF
--- a/code/modules/projectiles/guns/energy/rifle.dm
+++ b/code/modules/projectiles/guns/energy/rifle.dm
@@ -251,10 +251,13 @@
 	fire_sound = 'sound/weapons/laser1.ogg'
 	slot_flags = SLOT_BELT|SLOT_BACK
 	max_shots = 15
-	can_switch_modes = FALSE
 	can_turret = TRUE
 	turret_is_lethal = TRUE
 	projectile_type = /obj/item/projectile/beam/midlaser/hegemony
+	can_switch_modes = 0
+	secondary_projectile_type = null
+	firemodes = list()
+	modifystate = null
 	origin_tech = list(TECH_COMBAT = 6, TECH_MAGNET = 4)
 	is_wieldable = TRUE
 	modifystate = "hegemonyrifle"

--- a/code/modules/projectiles/guns/energy/rifle.dm
+++ b/code/modules/projectiles/guns/energy/rifle.dm
@@ -254,7 +254,7 @@
 	can_turret = TRUE
 	turret_is_lethal = TRUE
 	projectile_type = /obj/item/projectile/beam/midlaser/hegemony
-	can_switch_modes = 0
+	can_switch_modes = FALSE
 	secondary_projectile_type = null
 	firemodes = list()
 	modifystate = null

--- a/html/changelogs/crosarius-hegemonyriflefix.yml
+++ b/html/changelogs/crosarius-hegemonyriflefix.yml
@@ -1,0 +1,6 @@
+author: Crosarius
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes the Hegemony Energy Rifle so you can't break the sprite by trying to change firemodes anymore."


### PR DESCRIPTION
Fixes Bug #19648

The Hegemony Energy Rifle has the E-Gun as a parent, instead of the laser rifle, so it doesn't inherit all the single-fire-mode stuff that the laser rifle has. I gave it all those attributes to make sure you can't accidentally change the fire mode.

Edit: To clarify, this fixes the bug where you can change the fire mode and it causes the gun to vanish.