### PR TITLE
Fixes Arterials Not Applying Bloodloss

### DIFF
--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -10,10 +10,13 @@
 
 /mob/living/carbon/human/proc/recheck_bad_external_organs()
 	var/damage_this_tick = getToxLoss()
+	var/arterial_check = 0
 	for(var/obj/item/organ/external/O in organs)
 		damage_this_tick += O.burn_dam + O.brute_dam
+		if(O.status & ORGAN_ARTERY_CUT)
+			arterial_check = 1
 
-	if(damage_this_tick > last_dam)
+	if(damage_this_tick > last_dam || arterial_check != 0)
 		. = TRUE
 	last_dam = damage_this_tick
 

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -131,7 +131,7 @@
 		var/blood_max = 0
 		var/open_wound
 		var/list/do_spray = list()
-		for(var/obj/item/organ/external/temp in owner.organs)
+		for(var/obj/item/organ/external/temp in owner.bad_external_organs)
 			if((temp.status & ORGAN_BLEEDING) && !BP_IS_ROBOTIC(temp))
 				for(var/datum/wound/W in temp.wounds)
 					if(W.bleeding())

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -131,7 +131,7 @@
 		var/blood_max = 0
 		var/open_wound
 		var/list/do_spray = list()
-		for(var/obj/item/organ/external/temp in owner.bad_external_organs)
+		for(var/obj/item/organ/external/temp in owner.organs)
 			if((temp.status & ORGAN_BLEEDING) && !BP_IS_ROBOTIC(temp))
 				for(var/datum/wound/W in temp.wounds)
 					if(W.bleeding())
@@ -146,7 +146,7 @@
 							blood_max += ((W.damage / 40) * species.bleed_mod)
 
 			if(temp.status & ORGAN_ARTERY_CUT)
-				var/bleed_amount = FLOOR((owner.vessel.total_volume / (temp.applied_pressure || !open_wound ? 450 : 250)) * temp.arterial_bleed_severity, 1)
+				var/bleed_amount = FLOOR((owner.vessel.total_volume / (temp.applied_pressure || !open_wound ? 450 : 250)) * temp.arterial_bleed_severity, 0.1)
 				if(bleed_amount)
 					if((CE_BLOODCLOT in owner.chem_effects) && !(owner.chem_effects[CE_BLOODTHIN]))
 						bleed_amount *= 0.8 // won't do much, but it'll help

--- a/html/changelogs/Evandorf-Arterialbleedfix.yml
+++ b/html/changelogs/Evandorf-Arterialbleedfix.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Evandorf
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The handle_blood proc will now check all organs, not just damaged ones, and apply bloodloss accurately; including arterials where the external wounds are healed."
+  - bugfix: "Arterial severity which applies less than 1u of bloodloss is now accounted for properly and is no longer rounded down to 0."

--- a/html/changelogs/Evandorf-Arterialbleedfix.yml
+++ b/html/changelogs/Evandorf-Arterialbleedfix.yml
@@ -55,5 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "The handle_blood proc will now check all organs, not just damaged ones, and apply bloodloss accurately; including arterials where the external wounds are healed."
+  - bugfix: "Added an arterial check to the proc which determines which external organs are damaged so that the handle_blood proc will correctly remove blood for external organs with arterial bleeds with no damage."
   - bugfix: "Arterial severity which applies less than 1u of bloodloss is now accounted for properly and is no longer rounded down to 0."


### PR DESCRIPTION
- ~~The handle_blood proc will now check all organs, not just damaged ones, and apply bloodloss accurately; including arterials where the external wounds are healed.~~

- Added an arterial check to the proc which determines which external organs are damaged so that the handle_blood proc will correctly remove blood for external organs with arterial bleeds with no damage. 

- Arterial severity which applies less than 1u of bloodloss is now accounted for properly and is no longer rounded down to 0.

Fixes: https://github.com/Aurorastation/Aurora.3/issues/17807