### PR TITLE
Fixed the message server PDA messages logging

### DIFF
--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -148,6 +148,20 @@
 				dat += "<br><hr><dd><span class='warning'>Reg, #514 forbids sending messages to a Head of Staff containing Erotic Rendering Properties.</span>"
 
 		//Message Logs
+		if(1)
+			if(src.linkedServer?.stat & (NOPOWER|BROKEN))
+				dat += "<br><hr><dd><span class='notice'>Server is currently not accepting connections, or is down.</span>"
+			else
+				var/index = 3000
+				dat += "<br><hr><dd>" + SPAN_ALERT("Only the last [index] messages are stored!") + "</span>"
+
+				dat += "<center><A href='?src=\ref[src];back=1'>Back</a> - <A href='?src=\ref[src];refresh=1'>Refresh</center><hr></a>"
+
+				for(var/datum/data_pda_msg/message in src.linkedServer.pda_msgs)
+					if(index-- <= 0)
+						break
+					dat += "<br><hr><dd><span class='notice'>[message.sender] --> [message.recipient]:</span> [message.message]"
+
 		//Hacking screen.
 		if(2)
 			if(istype(user, /mob/living/silicon/ai) || istype(user, /mob/living/silicon/robot))

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -1,7 +1,9 @@
 #define MESSAGE_SERVER_SPAM_REJECT 1
 #define MESSAGE_SERVER_DEFAULT_SPAM_LIMIT 10
 
-// Log datums stored by the message server.
+/**
+ * Log datums stored by the message server
+ */
 /datum/data_pda_msg
 	var/sender = "Unspecified"
 	var/recipient = "Unspecified"
@@ -175,7 +177,8 @@
 	frequency = PUB_FREQ
 	server_type = /obj/machinery/telecomms/message_server
 
-/datum/signal/subspace/pda/New(source, data)
+/datum/signal/subspace/pda/New(obj/source, data)
+	. = ..(source, frequency, data = data)
 	src.source = source
 	src.data = data
 	var/turf/T = get_turf(source)

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -307,3 +307,7 @@
 	network = "tcommsat"
 	produces_heat = 0
 	autolinkers = list("broadcasterCent")
+
+/obj/machinery/telecomms/message_server/preset
+	network = "tcommsat"
+	autolinkers = list("processor1", "processor2", "processor3", "processor4")

--- a/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
+++ b/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
@@ -107,6 +107,26 @@ var/global/ntnrc_uid = 0
 	var/datum/ntnet_message/message/msg = new(Cl)
 	msg.message = message
 	msg.user = user
+
+	//[signal.data["name"]] ([signal.data["job"]])", signal.data["message"], signal.data["photo"]
+	var/list/signal_data = list()
+	signal_data["name"] = user.GetVoice()
+	signal_data["job"] = user.job
+	signal_data["message"] = message
+	signal_data["photo"] = null
+
+	// If the channel has a title, use the title, otherwise add the users
+	if(title != initial(title))
+		signal_data["targets"] = list("[title] (Channel)")
+	else
+		signal_data["targets"] = list()
+		for(var/datum/ntnet_user/U in users)
+			if(U != Cl.my_user)
+				signal_data["targets"] += U.username
+
+	var/datum/signal/subspace/pda/signal = new(Cl.computer, signal_data)
+	signal.send_to_receivers()
+
 	process_message(msg)
 
 /datum/ntnet_conversation/proc/cl_join(var/datum/computer_file/program/chat_client/Cl)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -122,7 +122,7 @@
 /obj/item/paper/proc/can_read(var/mob/user, var/forceshow = FALSE)
 	var/can_read = (istype(user, /mob/living/carbon/human) || isobserver(user) || istype(user, /mob/living/silicon)) || forceshow
 	if(!forceshow && istype(user,/mob/living/silicon/ai))
-		var/mob/living/silicon/ai/AI
+		var/mob/living/silicon/ai/AI = user
 		can_read = get_dist(src, AI.camera) < 2
 	return can_read
 

--- a/html/changelogs/fluffyghost-fixmessageserverpdalogging.yml
+++ b/html/changelogs/fluffyghost-fixmessageserverpdalogging.yml
@@ -1,0 +1,61 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed the message server PDA messages logging."
+  - bugfix: "Fixed the message monitoring console for the aforementioned use."
+  - bugfix: "Fixed a runtime for AI distance check on trying to read papers."
+  - bugfix: "Created a preset for the message server so it's autolinked on the horizon."

--- a/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
+++ b/maps/sccv_horizon/sccv_horizon-3_deck_3.dmm
@@ -20357,7 +20357,7 @@
 /turf/simulated/floor,
 /area/bridge/upperdeck)
 "nMa" = (
-/obj/machinery/telecomms/message_server,
+/obj/machinery/telecomms/message_server/preset,
 /turf/simulated/floor/bluegrid,
 /area/tcommsat/chamber)
 "nMz" = (


### PR DESCRIPTION
Fixed the message server PDA messages logging.
Fixed the message monitoring console for the aforementioned use.
Fixed a runtime for AI distance check on trying to read papers.
Created a preset for the message server so it's autolinked on the horizon.

Fixes #11701 (For the Message Logs part)