### PR TITLE
Revert "Colorable Scrubs"

### DIFF
--- a/code/modules/client/preference_setup/loadout/items/uniform.dm
+++ b/code/modules/client/preference_setup/loadout/items/uniform.dm
@@ -113,13 +113,6 @@
 
 	gear_tweaks += new /datum/gear_tweak/path(scrubs)
 
-/datum/gear/uniform/colorable_scrubs
-	display_name = "colorable scrubs"
-	description = "It's made of a special fiber that provides minor protection against biohazards."
-	path = /obj/item/clothing/under/rank/medical/generic
-	allowed_roles = list("Scientist", "Lab Assistant", "Chief Medical Officer", "Physician", "Surgeon", "Pharmacist", "Paramedic", "Medical Intern", "Xenobiologist", "Research Director", "Investigator", "Medical Personnel", "Science Personnel")
-	flags = GEAR_HAS_NAME_SELECTION | GEAR_HAS_DESC_SELECTION | GEAR_HAS_COLOR_SELECTION | GEAR_HAS_ACCENT_COLOR_SELECTION
-
 /datum/gear/uniform/dress
 	display_name = "dress selection"
 	description = "A selection of dresses."

--- a/html/changelogs/wezzy_revert_colorable_scrubs.yml
+++ b/html/changelogs/wezzy_revert_colorable_scrubs.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Wowzewow (Wezzy)
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscdel: "Removes recolorable scrubs. Scrubs selection unchanged."


### PR DESCRIPTION
Reverts the addition of "Recolorable Scrubs"

It's a job uniform, so it should *not* have a recolorable selection to prevent people from circumventing corporate uniform colors.

As a rule of thumb, if it has a selection already with corporate colors, there shouldn't be a recolorable version.

(this pr keeps the ability for the newly added lab-techs to select from the scrubs selection, though)