### PR TITLE
Reduces explosion radius of standstill landmines

### DIFF
--- a/code/game/objects/items/weapons/landmines.dm
+++ b/code/game/objects/items/weapons/landmines.dm
@@ -391,7 +391,7 @@
 		for(var/mob/living/person_in_range in get_hearers_in_LOS(world.view, src))
 			to_chat(person_in_range, SPAN_HIGHDANGER("[victim] does a sudden move, releasing the feet from the trigger..."))
 
-		explosion(loc, 2, 5, 7, world.view)
+		explosion(loc, 2, 3, 5, world.view)
 		qdel(src)
 
 /obj/item/landmine/standstill/deactivate(mob/user)

--- a/html/changelogs/hazelmouse - standstills_tweak.yml
+++ b/html/changelogs/hazelmouse - standstills_tweak.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "The explosion radius of standstill landmines has been reduced."


### PR DESCRIPTION
This reduces the explosion radius of standstills. Currently, standstill landmines blow a hole in the ship so large that it can take engineering an extremely long time to fix it, even with full staffing. If a standstill goes off inside service, for instance, nobody is using service for a very large portion of the round, if ever - between the venting, the broken floors, walling, windows, furniture, and machines. I think it'd benefit as a tool without its users having to worry about the insane blast radius disrupting more than they intended.

This reduces the heavy and light impact ranges, so they'll do less structural damage, but maintains their devastation range - so, if you're caught at the epicentre of the blast, you should still be about as immediately critical as before. Lethality shouldn't be strongly influenced, just structural damage. The blast radius is still large enough that, in my testing, it's impossible to fully escape the blast.

Current blast radius:
![image](https://github.com/user-attachments/assets/0d3aa191-bf04-4fd8-98f6-a9e7cd08e836)

PR blast radius:
![image](https://github.com/user-attachments/assets/44499f07-f866-4626-9d51-c1fb604daf17)

