### PR TITLE
Fixes Tumors Not Being Able To Be Removed with Surgery

### DIFF
--- a/code/modules/organs/subtypes/parasite/_parasite.dm
+++ b/code/modules/organs/subtypes/parasite/_parasite.dm
@@ -87,11 +87,11 @@
 			switch(parasite_type) //such a shitty way to do this but i couldnt get a better alternative to work in a sane amount of time :/
 				if("malignant tumour")
 					var/obj/item/organ/internal/parasite/malignant_tumour/P = new()
-					P.parent_organ = organ_to_infest
+					P.parent_organ = organ_to_infest.limb_name
 					P.replaced(H, organ_to_infest)
 					P.generate_name()
 				if("benign tumour")
 					var/obj/item/organ/internal/parasite/benign_tumour/P = new()
-					P.parent_organ = organ_to_infest
+					P.parent_organ = organ_to_infest.limb_name
 					P.replaced(H, organ_to_infest)
 					P.generate_name()

--- a/html/changelogs/Evandorf-Tumorsurgeryfix.yml
+++ b/html/changelogs/Evandorf-Tumorsurgeryfix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Evandorf
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Creating tumors will now set the correct 'parent_organ' variable to allow for surgical removal."


### PR DESCRIPTION
The 'infest_with_parasite' proc was setting the 'parent_organ' variable of new tumors to the src organ reference. Changed to set the 'parent_organ' variable to the 'limb_name' of the src which allows surgery code to find it.