### PR TITLE
Intrepid Transport and Expedition Prep Tweaks

### DIFF
--- a/html/changelogs/DreamySkrell-intrepid-transport-tweaks.yml
+++ b/html/changelogs/DreamySkrell-intrepid-transport-tweaks.yml
@@ -1,0 +1,8 @@
+
+author: DreamySkrell
+
+delete-after: True
+
+changes:
+  - rscadd: "Expands Intrepid passenger seating."
+  - rscadd: "Expands expedition supplies in the Intrepid hangar."


### PR DESCRIPTION
changes:
  - rscadd: "Expands Intrepid passenger seating."
  - rscadd: "Expands expedition supplies in the Intrepid hangar."

![image](https://github.com/user-attachments/assets/34cdc5a1-afac-48f1-b952-c08658054a47)
![image](https://github.com/user-attachments/assets/ec051f63-9bbf-46f2-bd98-33b82790fae7)
![image](https://github.com/user-attachments/assets/5d21b94b-a834-42b2-ba66-0ed371adca56)

