### PR TITLE
AI Visible Emotes Fix

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -77,6 +77,8 @@ Possible to do for anyone motivated enough:
 
 	light_color = long_range ? rgb(225, 173, 125) : rgb(125, 180, 225)
 
+	GLOB.listening_objects += src
+
 /obj/machinery/hologram/holopad/proc/get_holopad_id()
 	var/area/A = get_area(src)
 	holopad_id = "[A.name] ([src.x]-[src.y]-[src.z])"
@@ -522,6 +524,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	clear_holos(TRUE)
 	SSmachinery.all_holopads -= src
 	linked_pdas.Cut()
+	GLOB.listening_objects -= src
 	return ..()
 
 /obj/effect/overlay/hologram

--- a/html/changelogs/geeves-ai_visible_emotes.yml
+++ b/html/changelogs/geeves-ai_visible_emotes.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed AIs not being able to see visible emotes through holopads."


### PR DESCRIPTION
* Fixed AIs not being able to see visible emotes through holopads.

This fix worked on my local, but I'd like a test merge just to be sure.