### PR TITLE
Fix limb targeted explosive implant

### DIFF
--- a/code/game/objects/items/weapons/implants/implants/explosive.dm
+++ b/code/game/objects/items/weapons/implants/implants/explosive.dm
@@ -123,7 +123,6 @@
 		return
 	if(findtext(sanitizePhrase(msg),phrase))
 		activate()
-		qdel(src)
 
 /obj/item/implant/explosive/exposed()
 	if(warning_message)

--- a/code/game/objects/items/weapons/implants/implants/explosive.dm
+++ b/code/game/objects/items/weapons/implants/implants/explosive.dm
@@ -186,7 +186,7 @@
 									SPAN_DANGER("Your [part.name] bursts open with a horrible ripping noise!"),
 									SPAN_WARNING("You hear a horrible ripping noise."))
 		else
-			part.droplimb(0,DROPLIMB_BLUNT)
+			part.droplimb(0,DROPLIMB_EDGE)
 		playsound(get_turf(imp_in), BP_IS_ROBOTIC(part) ? 'sound/effects/meteorimpact.ogg' : 'sound/effects/splat.ogg', 70)
 	else if(ismob(imp_in))
 		var/mob/M = imp_in

--- a/html/changelogs/alaunuslux-fix-limb-targeted-explosive-implant.yml
+++ b/html/changelogs/alaunuslux-fix-limb-targeted-explosive-implant.yml
@@ -1,0 +1,12 @@
+author: AlaunusLux
+
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Explosive Implants targeting the Localized Limb no longer fail to remove the limb."
+  - bugfix: "Exploded limbs will now bleed and cause pain."


### PR DESCRIPTION
The removed `qdel` seemed extraneous from what I could gather. There may be a niche instance that the `qdel` caught, but from what I read of the code and testing it, the `qdel`s in `activate()` and `small_countdown()` are sufficient. I could have put it behind an if statement, and still could, but it looked messy and seemed unnecessary.

I have some small gripe with `DROPLIMB_BLUNT` somehow not causing injury or a bleeding wound. If someone gets their hand hit so hard with a baseball bat that they no longer have their hand, I doubt it would be bloodless. I struggle to think of a scenario where the loss of a limb does not involve heavy bleeding. 

Anyway, I settled for changing it to a `DROPLIMB_EDGE.` I was considering adding an instant bloodloss (5-10% depending on which limb was exploded), but that felt a bit much.

Additionally, I would like to make the change from `_BLUNT` to `_EDGE` for [Greimorian egg-bursting limb loss](https://github.com/Aurorastation/Aurora.3/blob/5e69bf50bc9fd3c27284029bfd0eff8f4fbfc138/code/game/objects/effects/spiders.dm#L322), but I worried it would muddle this PR too much.

Below image shows what a health analyzer scan prints with the new `_EDGE` limb loss. When `_BLUNT` there is simply no wound, bleeding, or pain.

![image](https://github.com/user-attachments/assets/c6a43744-cc94-49c0-9c34-51c342318204)
