### PR TITLE
Stuff burns for longer

### DIFF
--- a/code/game/objects/items/weapons/candle.dm
+++ b/code/game/objects/items/weapons/candle.dm
@@ -1,6 +1,6 @@
 /obj/item/flame/candle
 	name = "red candle"
-	desc = "a small pillar candle. Its specially-formulated fuel-oxidizer wax mixture allows continued combustion in airless environments."
+	desc = "A small pillar candle. Its specially-formulated fuel-oxidizer wax mixture allows continued combustion in airless environments."
 	icon = 'icons/obj/storage/fancy/candle.dmi'
 	icon_state = "candle1"
 	item_state = "candle1"
@@ -8,20 +8,20 @@
 	pickup_sound = 'sound/items/pickup/gloves.ogg'
 	w_class = WEIGHT_CLASS_TINY
 	light_color = "#E09D37"
-	var/wax = 2000
+	var/wax = 3200
 	var/start_lit = FALSE
 
 /obj/item/flame/candle/Initialize()
 	. = ..()
-	wax = rand(1600, 2000)
+	wax = rand(2800, 3400)
 	if(start_lit)
 		light()
 
 /obj/item/flame/candle/update_icon()
 	var/i
-	if(wax > 1500)
+	if(wax > 2000)
 		i = 1
-	else if(wax > 800)
+	else if(wax > 1200)
 		i = 2
 	else i = 3
 	icon_state = "candle[i][lit ? "_lit" : ""]"

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -306,7 +306,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	has_blood_overlay = FALSE
 	type_butt = /obj/item/trash/cigbutt
 	chem_volume = 30
-	burn_rate = 0.006 //Lasts ~166 seconds)
+	burn_rate = 0.003 //Lasts ~353 seconds)
 	surgerysound = 'sound/items/surgery/cautery.ogg'
 	matchmes = SPAN_NOTICE("USER lights their NAME with their FLAME.")
 	lightermes = SPAN_NOTICE("USER manages to light their NAME with FLAME.")
@@ -374,11 +374,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 
 /obj/item/clothing/mask/smokable/cigarette/vanilla
-	burn_rate = 0.015
 	reagents_to_add = list(/singleton/reagent/toxin/tobacco = 15)
 
 /obj/item/clothing/mask/smokable/cigarette/acmeco
-	burn_rate = 0.015
 	reagents_to_add = list(
 		/singleton/reagent/toxin/tobacco = 5,
 		/singleton/reagent/mental/nicotine = 5,
@@ -387,7 +385,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	)
 
 /obj/item/clothing/mask/smokable/cigarette/blank
-	burn_rate = 0.015
 	chem_volume = 15
 	reagents_to_add = null
 
@@ -466,7 +463,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	item_state = "cigaroff"
 	type_butt = /obj/item/trash/cigbutt/cigarbutt
 	throw_speed = 0.5
-	burn_rate = 0.015
 	chem_volume = 60
 	matchmes = SPAN_NOTICE("USER lights their NAME with their FLAME.")
 	lightermes = SPAN_NOTICE("USER manages to offend their NAME by lighting it with FLAME.")
@@ -586,7 +582,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	item_state = "pipeoff"
 	icon_on = "pipeon"
 	icon_off = "pipeoff"
-	burn_rate = 0.015
 	w_class = WEIGHT_CLASS_TINY
 	chem_volume = 30
 	matchmes = SPAN_NOTICE("USER lights their NAME with their FLAME.")

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -165,7 +165,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/weldermes = "USER lights NAME with FLAME"
 	var/ignitermes = "USER lights NAME with FLAME"
 	var/initial_volume = 0
-	var/burn_rate = 0 // Do not make lower than MINIMUM_CHEMICAL_VOLUME 0.01
+	var/burn_rate = 0
 	var/last_drag = 0 //Spam limiter for audio/message when taking a drag of cigarette.
 	drop_sound = 'sound/items/drop/food.ogg'
 	pickup_sound = 'sound/items/pickup/food.ogg'

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -32,7 +32,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		slot_l_hand_str = 'icons/mob/items/lefthand_cigs_lighters.dmi',
 		slot_r_hand_str = 'icons/mob/items/righthand_cigs_lighters.dmi',
 		)
-	var/smoketime = 5
+	var/smoketime = 10
 	var/type_burnt = /obj/item/trash/match
 	w_class = WEIGHT_CLASS_TINY
 	origin_tech = list(TECH_MATERIAL = 1)

--- a/html/changelogs/hazelmouse-500cigarettes.yml
+++ b/html/changelogs/hazelmouse-500cigarettes.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Cigarettes, candles, and matches now burn for substantially longer before going out."


### PR DESCRIPTION
This makes candles, matches, and cigarettes burn for longer than they currently do. Matches burn for twice as long, candles for about +1/3 as long, and cigarettes around twice as long. 

Code note: I don't see any problems with this for matches and candles, but there's a comment in the current code warning strictly not to lower the smokable burn_rate below 0.01, see the changes. I haven't been able to hunt down exactly why this is, and it seems like the burn_rate for the parent type was already lowered down to 0.006 a few years ago by a previous PR intended to extend cigarette burn times. From what I can tell reagents are still being absorbed below 0.01 by having the cigarette on your mask slot, so if there is a serious issue with this it can be removed under review, but I'm not certain what it would be. I've removed every subtype modification to burn_rate, which seems to have been left a setting substantially higher than the parent, causing pipes and cigars in live to seem to burn out very quickly - like in a little over a minute.