### PR TITLE
Synthetic Loadout Stuff

### DIFF
--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -655,10 +655,13 @@ SUBSYSTEM_DEF(jobs)
 		log_loadout("EC/([H]): Abort: invalid arguments.")
 		return FALSE
 
-	switch (job.title)
-		if ("AI", "Cyborg")
-			log_loadout("EC/([H]): Abort: synthetic.")
-			return FALSE
+	// if it's for their preview mob, let them wear it
+	// so they can customize their loadout for their hologram
+	if(!istype(H, /mob/living/carbon/human/dummy/mannequin))
+		switch (job.title)
+			if ("AI", "Cyborg")
+				log_loadout("EC/([H]): Abort: synthetic.")
+				return FALSE
 
 	for(var/thing in prefs.gear)
 		var/datum/gear/G = gear_datums[thing]

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -147,7 +147,7 @@
 		H.drop_from_inventory(H.w_uniform)
 		qdel(H.w_uniform)
 
-	if(!(equip_preview_mob & EQUIP_PREVIEW_JOB_UNIFORM) && H.wear_suit && REF(H.wear_suit) != pre_suit_ref)
+	if(!(equip_preview_mob & EQUIP_PREVIEW_JOB_SUIT) && H.wear_suit && REF(H.wear_suit) != pre_suit_ref)
 		H.drop_from_inventory(H.wear_suit)
 		qdel(H.wear_suit)
 

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -50,10 +50,17 @@
 	economic_modifier = 0
 
 /datum/job/cyborg/equip(var/mob/living/carbon/human/H, var/alt_title)
-		if(!H)	return 0
-		return 1
+	if(!H)
+		return FALSE
+	return TRUE
 
-/datum/job/cyborg/equip_preview(mob/living/carbon/human/H)
-	H.equip_to_slot_or_del(new /obj/item/clothing/suit/cardborg(H), slot_wear_suit)
-	H.equip_to_slot_or_del(new /obj/item/clothing/head/cardborg(H), slot_head)
-	return 1
+/datum/job/cyborg/equip_preview(mob/living/carbon/human/H, datum/preferences/prefs, var/alt_title, var/faction_override)
+	var/equip_preview_mob = prefs.equip_preview_mob
+
+	if(equip_preview_mob & EQUIP_PREVIEW_JOB_HAT)
+		H.equip_to_slot_or_del(new /obj/item/clothing/head/cardborg(H), slot_head)
+
+	if(equip_preview_mob & EQUIP_PREVIEW_JOB_SUIT)
+		H.equip_to_slot_or_del(new /obj/item/clothing/suit/cardborg(H), slot_wear_suit)
+
+	return TRUE

--- a/code/modules/mob/abstract/new_player/preferences_setup.dm
+++ b/code/modules/mob/abstract/new_player/preferences_setup.dm
@@ -217,7 +217,7 @@
 		var/list/leftovers = list()
 		var/list/used_slots = list()
 
-		if((equip_preview_mob & EQUIP_PREVIEW_LOADOUT) && !(previewJob && (equip_preview_mob & EQUIP_PREVIEW_JOB) && (previewJob.type == /datum/job/ai || previewJob.type == /datum/job/cyborg)))
+		if((equip_preview_mob & EQUIP_PREVIEW_LOADOUT))
 			SSjobs.EquipCustom(mannequin, previewJob, src, leftovers, null, used_slots)
 
 		if((equip_preview_mob & EQUIP_PREVIEW_JOB) && previewJob)

--- a/html/changelogs/geeves-ai_loadout_fixes.yml
+++ b/html/changelogs/geeves-ai_loadout_fixes.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "AIs can now dress up their preview mob."
+  - rscadd: "Cyborgs now have the cardboard outfit in the loadout again. You can toggle it by deselecting the job suit and hat options."
+  - bugfix: "Job suits are now hidden correctly when the job suit is deselected."


### PR DESCRIPTION
* AIs can now dress up their preview mob.
* Cyborgs now have the cardboard outfit in the loadout again. You can toggle it by deselecting the job suit and hat options.
* Job suits are now hidden correctly when the job suit is deselected.