### PR TITLE
Adds a small combustion turbine to Atmos maintenance.

### DIFF
--- a/html/changelogs/furrycactus - atmos turbine.yml
+++ b/html/changelogs/furrycactus - atmos turbine.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Furrycactus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a single turbine to maintenance near Atmospherics. Try your hand at combustion without setting fire to the ship!"

--- a/maps/sccv_horizon/code/sccv_horizon_areas.dm
+++ b/maps/sccv_horizon/code/sccv_horizon_areas.dm
@@ -19,6 +19,9 @@
 /area/engineering/engine_room/rust
 	name = "Engineering - INDRA Engine"
 
+/area/engineering/engine_room/combustion
+	name = "Engineering - Combustion Turbine"
+
 /area/engineering/smes
 	name = "Engineering - SM SMES"
 	icon_state = "engine_smes"


### PR DESCRIPTION
Repurposes a little bit of maintenance to give Atmospherics a singular turbine to play around with. Lockers/crates/maint loot that already existed in that room have been shifted to adjacent maintenance areas as to not disturb the overall balance of goodies.

The rationale behind this is that it'll give Atmos Techs something to do and to play with once thrusters are set up, while being completely optional. Messing around with it is never the expectation, hence the dim lighting, its tucked away nature, and how it totally lacks prior setup beyond necessary construction. (The SMES is empty and not upgraded, no canisters are in place and need to be manually found and filled elsewhere, all the pumps and computers are unconfigured, etc.)

Not really intended to replace the SM or INDRA, as combustion requires more maintenance and upkeep due to faster cooling, and actively burns fuel to run - plus it's only a single turbine. But it does give bored or curious Atmos Techs something else they can play with if they feel like it, once all the round-start stuff is done.


![image](https://github.com/user-attachments/assets/546a00dc-980c-4809-a0e2-16074eee76ac)


In conclusion:

![ezgif-1-bbc246f85f](https://github.com/user-attachments/assets/9be9735f-8431-4a2a-94c1-52badf8898b0)
