### PR TITLE
Raskara Okon 001 Tweaks and Fixes

### DIFF
--- a/html/changelogs/Ben10083 - Okon.yml
+++ b/html/changelogs/Ben10083 - Okon.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - spellcheck: "Fixed incorrect mentions of 'Okon 011' instead of 'Okon 001'."
+  - rscadd: "Adds delivery point and holopad to Okon 001."
+  - bugfix: "Adds missing airlock for Okon 001."

--- a/maps/random_ruins/exoplanets/raskara/raskara_okon.dm
+++ b/maps/random_ruins/exoplanets/raskara/raskara_okon.dm
@@ -1,5 +1,5 @@
 /datum/map_template/ruin/exoplanet/raskara_okon
-	name = "Okon 011"
+	name = "Okon 001"
 	id = "raskara_okon"
 	description = "A People's Republic observation outpost on the Moon."
 
@@ -12,7 +12,7 @@
 	unit_test_groups = list(1)
 
 /area/raskara_okon
-	name = "Okon 011"
+	name = "Okon 001"
 	icon_state = "bluenew"
 	requires_power = TRUE
 	dynamic_lighting = TRUE
@@ -22,39 +22,39 @@
 	ambience = AMBIENCE_EXPOUTPOST
 
 /area/raskara_okon/observatory
-	name = "Okon 011 Observatory"
+	name = "Okon 001 Observatory"
 	icon_state = "bridge"
 
 /area/raskara_okon/mess_hall
-	name = "Okon 011 Mess Hall"
+	name = "Okon 001 Mess Hall"
 	icon_state = "bridge"
 
 /area/raskara_okon/barracks
-	name = "Okon 011 Barracks"
+	name = "Okon 001 Barracks"
 	icon_state = "crew_quarters"
 
 /area/raskara_okon/mining
-	name = "Okon 011 Mining"
+	name = "Okon 001 Mining"
 	icon_state = "mining"
 
 /area/raskara_okon/entry
-	name = "Okon 011 Entry"
+	name = "Okon 001 Entry"
 	icon_state = "thunder"
 
 /area/raskara_okon/eva
-	name = "Okon 011 EVA Storage"
+	name = "Okon 001 EVA Storage"
 	icon_state = "machinist_workshop"
 
 /area/raskara_okon/engineer
-	name = "Okon 011 Engineer"
+	name = "Okon 001 Engineer"
 	icon_state = "outpost_engine"
 
 /area/raskara_okon/laboratory
-	name = "Okon 011 Laboratory"
+	name = "Okon 001 Laboratory"
 	icon_state = "anolab"
 
 /area/raskara_okon/medbay
-	name = "Okon 011 Medbay"
+	name = "Okon 001 Medbay"
 	icon_state = "medbay"
 
 //ghost roles
@@ -62,7 +62,7 @@
 /datum/ghostspawner/human/okon_crew
 	short_name = "okon_crew"
 	name = "Okon Crewmember"
-	desc = "Man the Okon 011 observation outpost on Raskara."
+	desc = "Man the Okon 001 observation outpost on Raskara."
 	tags = list("External")
 
 	spawnpoints = list("okon_crew")

--- a/maps/random_ruins/exoplanets/raskara/raskara_okon.dm
+++ b/maps/random_ruins/exoplanets/raskara/raskara_okon.dm
@@ -27,7 +27,7 @@
 
 /area/raskara_okon/mess_hall
 	name = "Okon 001 Mess Hall"
-	icon_state = "bridge"
+	icon_state = "lounge"
 
 /area/raskara_okon/barracks
 	name = "Okon 001 Barracks"

--- a/maps/random_ruins/exoplanets/raskara/raskara_okon.dm
+++ b/maps/random_ruins/exoplanets/raskara/raskara_okon.dm
@@ -39,7 +39,7 @@
 
 /area/raskara_okon/entry
 	name = "Okon 001 Entry"
-	icon_state = "thunder"
+	icon_state = "exit"
 
 /area/raskara_okon/eva
 	name = "Okon 001 EVA Storage"

--- a/maps/random_ruins/exoplanets/raskara/raskara_okon.dm
+++ b/maps/random_ruins/exoplanets/raskara/raskara_okon.dm
@@ -43,7 +43,7 @@
 
 /area/raskara_okon/eva
 	name = "Okon 001 EVA Storage"
-	icon_state = "machinist_workshop"
+	icon_state = "eva"
 
 /area/raskara_okon/engineer
 	name = "Okon 001 Engineer"

--- a/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
+++ b/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
@@ -992,8 +992,7 @@
 /area/raskara_okon/mess_hall)
 "lO" = (
 /obj/machinery/light/small/emergency{
-	dir = 8;
-	pixel_x = 16
+	dir = 8
 	},
 /turf/simulated/floor/airless,
 /area/raskara_okon/entry)

--- a/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
+++ b/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
@@ -3650,10 +3650,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/mess_hall)
-"VT" = (
-/obj/effect/map_effect/airlock/long/square,
-/turf/simulated/wall/shuttle/raider,
-/area/raskara_okon/entry)
 "VV" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/bodybags,
@@ -4573,7 +4569,7 @@ yR
 RF
 RF
 RF
-VT
+RF
 Vr
 "}
 (16,1,1) = {"

--- a/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
+++ b/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
@@ -359,6 +359,18 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/medbay)
+"eL" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "eP" = (
 /obj/structure/table/standard,
 /obj/item/material/ashtray,
@@ -639,6 +651,23 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/observatory)
+"iH" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = -25;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "iN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -696,6 +725,23 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/eva)
+"jm" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 4;
+	pixel_x = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "jr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -1177,6 +1223,18 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/eva)
+"pu" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "pD" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -1698,6 +1756,19 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/engineer)
+"wu" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "wx" = (
 /obj/structure/table/stone/marble,
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -1785,6 +1856,17 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/mess_hall)
+"xI" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cargo_receptacle{
+	min_spawn = 1;
+	payment_modifier = 1.4;
+	override_name = "Raskara - Okon 001"
+	},
+/turf/simulated/floor/airless,
+/area/raskara_okon/entry)
 "xY" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/warning{
@@ -2407,6 +2489,22 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/laboratory)
+"Fx" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = 28;
+	pixel_y = -9
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "Fz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2508,7 +2606,8 @@
 "GW" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
-	req_one_access = null
+	req_one_access = list(209);
+	department = "Okon 001 Observation Outpost"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -2670,6 +2769,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/hologram/holopad/long_range,
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -2850,6 +2950,14 @@
 "Me" = (
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -3701,6 +3809,19 @@
 	},
 /area/raskara_okon/medbay)
 "Xk" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = 11;
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -4412,7 +4533,7 @@ HB
 TG
 YN
 RF
-UC
+xI
 Sg
 Sg
 HX
@@ -4480,9 +4601,9 @@ dg
 NG
 aX
 Xk
-Xk
-Xk
-Xk
+iH
+jm
+eL
 HX
 "}
 (17,1,1) = {"
@@ -4513,10 +4634,10 @@ Vn
 VH
 wK
 dg
-Xk
-Xk
+pu
+wu
 Me
-Xk
+Fx
 HX
 "}
 (18,1,1) = {"

--- a/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
+++ b/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
@@ -219,6 +219,23 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/medbay)
+"cH" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = -25;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "de" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -233,6 +250,23 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/observatory)
+"df" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 4;
+	pixel_x = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "dg" = (
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -605,19 +639,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/eva)
-"ie" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "is" = (
 /obj/structure/table/stone/marble,
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -1030,7 +1051,7 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 1
 	},
-/turf/template_noop,
+/turf/simulated/floor/airless,
 /area/raskara_okon/mining)
 "mF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
@@ -1081,18 +1102,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/eva)
-"ny" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "nJ" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/black,
@@ -1114,6 +1123,18 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/medbay)
+"nW" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "ob" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1269,7 +1290,7 @@
 	id = "okon_base_belt"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/template_noop,
+/turf/simulated/floor/airless,
 /area/raskara_okon/mining)
 "pY" = (
 /obj/structure/table/steel,
@@ -1586,6 +1607,10 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/barracks)
+"ul" = (
+/obj/effect/landmark/clear,
+/turf/template_noop,
+/area/exoplanet/barren/raskara)
 "uN" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -1979,18 +2004,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/eva)
-"zm" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "zn" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/black,
@@ -2133,6 +2146,18 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
+"As" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/raskara_okon/entry)
@@ -2386,23 +2411,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/engineer)
-"DI" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/machinery/airlock_sensor{
-	pixel_x = -25;
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "DP" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
 /turf/simulated/floor/tiled/dark{
@@ -2472,6 +2480,22 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/laboratory)
+"EW" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = 28;
+	pixel_y = -9
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "Fz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2796,24 +2820,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/mess_hall)
-"KD" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/door/airlock/external,
-/obj/machinery/access_button{
-	pixel_x = -28;
-	pixel_y = 11;
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "KV" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/monkeycubes/farwacubes{
@@ -2836,23 +2842,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/raskara_okon/laboratory)
-"KZ" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 4;
-	pixel_x = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "Ld" = (
 /obj/machinery/optable,
 /obj/machinery/light/small,
@@ -3267,6 +3256,19 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/engineer)
+"Pt" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "PA" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 10
@@ -3816,12 +3818,14 @@
 	name = "airlock_okon";
 	frequency = 1004
 	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
-	pixel_x = 28;
-	pixel_y = -9
+	pixel_x = -28;
+	pixel_y = 11;
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -4468,7 +4472,7 @@ qg
 qg
 qg
 lO
-HX
+ul
 "}
 (13,1,1) = {"
 HX
@@ -4502,7 +4506,7 @@ qg
 Sg
 Sg
 Sg
-HX
+ul
 "}
 (14,1,1) = {"
 HX
@@ -4536,7 +4540,7 @@ RF
 xI
 Sg
 Sg
-HX
+ul
 "}
 (15,1,1) = {"
 HX
@@ -4570,7 +4574,7 @@ RF
 RF
 RF
 VT
-HX
+ul
 "}
 (16,1,1) = {"
 HX
@@ -4600,11 +4604,11 @@ Lw
 dg
 NG
 aX
-KD
-DI
-KZ
-zm
-HX
+Xk
+cH
+df
+nW
+ul
 "}
 (17,1,1) = {"
 HX
@@ -4634,11 +4638,11 @@ Vn
 VH
 wK
 dg
-ny
-ie
+As
+Pt
 Me
-Xk
-HX
+EW
+ul
 "}
 (18,1,1) = {"
 HX
@@ -4672,7 +4676,7 @@ RF
 RF
 RF
 RF
-HX
+ul
 "}
 (19,1,1) = {"
 HX
@@ -4706,7 +4710,7 @@ RF
 UC
 Sg
 Sg
-HX
+ul
 "}
 (20,1,1) = {"
 HX
@@ -4740,7 +4744,7 @@ Yw
 Sg
 Sg
 Sg
-HX
+ul
 "}
 (21,1,1) = {"
 HX
@@ -4774,10 +4778,10 @@ Yw
 Yw
 Yw
 Hc
-HX
+ul
 "}
 (22,1,1) = {"
-HX
+ul
 Av
 oc
 xn
@@ -4811,7 +4815,7 @@ Yw
 HX
 "}
 (23,1,1) = {"
-HX
+ul
 Av
 vC
 Av
@@ -4913,7 +4917,7 @@ Yw
 HX
 "}
 (26,1,1) = {"
-HX
+ul
 Av
 Av
 pY
@@ -4947,8 +4951,8 @@ Yw
 HX
 "}
 (27,1,1) = {"
-HX
-HX
+ul
+ul
 Av
 Av
 Av

--- a/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
+++ b/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
@@ -39,6 +39,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -70,6 +73,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 8;
+	req_one_access = list(24,11,67,209)
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -202,7 +209,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "cE" = (
 /obj/machinery/body_scanconsole{
 	dir = 1
@@ -529,7 +536,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "hj" = (
 /obj/item/sign/painting_frame/hadii{
 	pixel_y = 32
@@ -568,7 +575,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "hA" = (
 /obj/effect/map_effect/marker/airlock{
 	master_tag = "airlock_okon";
@@ -768,6 +775,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
+	},
 /turf/simulated/floor/tiled/white{
 	temperature = 278.15
 	},
@@ -805,6 +815,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -1211,7 +1224,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "pH" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced{
@@ -1237,7 +1250,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "pP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1251,11 +1264,13 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
-/obj/structure/sign/flag/pra/large/north,
+/obj/structure/sign/flag/pra/large/north{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "pV" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "okon_base_belt"
@@ -1374,7 +1389,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "rf" = (
 /obj/structure/table/stone/marble,
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -1424,7 +1439,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "so" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -1454,6 +1469,20 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/barracks)
+"sR" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/high/north{
+	req_access = list(209)
+	},
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/raskara_okon)
 "sS" = (
 /obj/structure/bed/stool/bar/padded/red,
 /obj/effect/floor_decal/corner/brown/diagonal,
@@ -1491,7 +1520,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "tF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -1516,7 +1545,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "tJ" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1562,7 +1591,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "uj" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/black,
@@ -1629,7 +1658,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "vA" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 9
@@ -1678,6 +1707,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 8;
+	req_one_access = list(24,11,67,209)
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -1874,7 +1907,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "yB" = (
 /turf/simulated/floor/plating{
 	temperature = 278.15
@@ -2101,6 +2134,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor{
+	dir = 8;
+	req_one_access = list(24,11,67,209)
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -2115,7 +2152,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "Av" = (
 /turf/simulated/wall/shuttle/raider,
 /area/raskara_okon/mining)
@@ -2158,7 +2195,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "AK" = (
 /obj/effect/floor_decal/corner/mauve/full{
 	dir = 4
@@ -2214,7 +2251,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "Br" = (
 /obj/effect/map_effect/marker/airlock{
 	master_tag = "airlock_okon";
@@ -2239,6 +2276,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -2326,7 +2366,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "Cp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark{
@@ -2501,15 +2541,22 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "Gh" = (
 /obj/machinery/door/airlock/glass_medical{
 	req_access = list(209);
 	name = "Medbay";
 	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 8;
+	req_one_access = list(24,11,67,209)
 	},
 /turf/simulated/floor/tiled/white{
 	temperature = 278.15
@@ -2814,6 +2861,9 @@
 	name = "Restroom";
 	dir = 1
 	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
+	},
 /turf/simulated/floor/tiled/freezer{
 	temperature = 278.15
 	},
@@ -2866,6 +2916,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -3025,7 +3078,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "Na" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 10
@@ -3150,7 +3203,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "Os" = (
 /obj/machinery/power/apc/high/north{
 	req_access = list(209)
@@ -3356,6 +3409,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor{
+	dir = 8;
+	req_one_access = list(24,11,67,209)
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -3379,7 +3436,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "Rw" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor{
@@ -3396,7 +3453,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "RF" = (
 /turf/simulated/wall/shuttle/raider,
 /area/raskara_okon/entry)
@@ -3545,7 +3602,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "Ud" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -3560,7 +3617,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "Ux" = (
 /obj/effect/map_effect/marker/airlock{
 	master_tag = "airlock_okon";
@@ -3700,7 +3757,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "Wp" = (
 /obj/machinery/artifact_analyser,
 /obj/effect/floor_decal/spline/plain/cee/black{
@@ -3750,7 +3807,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "WG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -3842,7 +3899,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "XF" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 9
@@ -3910,7 +3967,7 @@
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
-/area/raskara_okon/entry)
+/area/raskara_okon)
 "Yr" = (
 /obj/machinery/door/airlock{
 	req_access = list(209);
@@ -3923,6 +3980,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -3985,6 +4045,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 8;
+	req_one_access = list(24,11,67,209)
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -4582,7 +4646,7 @@ AS
 jg
 Ph
 gs
-tl
+sR
 Xv
 Oc
 hj

--- a/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
+++ b/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
@@ -359,18 +359,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/medbay)
-"eL" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "eP" = (
 /obj/structure/table/standard,
 /obj/item/material/ashtray,
@@ -617,6 +605,19 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/eva)
+"ie" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "is" = (
 /obj/structure/table/stone/marble,
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -651,23 +652,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/observatory)
-"iH" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/machinery/airlock_sensor{
-	pixel_x = -25;
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "iN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -725,23 +709,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/eva)
-"jm" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 4;
-	pixel_x = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "jr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -1114,6 +1081,18 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/eva)
+"ny" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "nJ" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/black,
@@ -1223,18 +1202,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/eva)
-"pu" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "pD" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -1756,19 +1723,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/engineer)
-"wu" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "wx" = (
 /obj/structure/table/stone/marble,
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -2025,6 +1979,18 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/eva)
+"zm" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "zn" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/black,
@@ -2420,6 +2386,23 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/engineer)
+"DI" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = -25;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "DP" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
 /turf/simulated/floor/tiled/dark{
@@ -2489,22 +2472,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/laboratory)
-"Fx" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/door/airlock/external,
-/obj/machinery/access_button{
-	pixel_x = 28;
-	pixel_y = -9
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "Fz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2829,6 +2796,24 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/mess_hall)
+"KD" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = 11;
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "KV" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/monkeycubes/farwacubes{
@@ -2851,6 +2836,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/raskara_okon/laboratory)
+"KZ" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 4;
+	pixel_x = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "Ld" = (
 /obj/machinery/optable,
 /obj/machinery/light/small,
@@ -3814,14 +3816,12 @@
 	name = "airlock_okon";
 	frequency = 1004
 	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
-	pixel_x = -28;
-	pixel_y = 11;
-	dir = 1
+	pixel_x = 28;
+	pixel_y = -9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -4600,10 +4600,10 @@ Lw
 dg
 NG
 aX
-Xk
-iH
-jm
-eL
+KD
+DI
+KZ
+zm
 HX
 "}
 (17,1,1) = {"
@@ -4634,10 +4634,10 @@ Vn
 VH
 wK
 dg
-pu
-wu
+ny
+ie
 Me
-Fx
+Xk
 HX
 "}
 (18,1,1) = {"

--- a/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
+++ b/maps/random_ruins/exoplanets/raskara/raskara_okon.dmm
@@ -219,23 +219,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/medbay)
-"cH" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/machinery/airlock_sensor{
-	pixel_x = -25;
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "de" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -250,23 +233,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/observatory)
-"df" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	dir = 4;
-	pixel_x = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "dg" = (
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -600,6 +566,23 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
+"hA" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	dir = 4;
+	pixel_x = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/raskara_okon/entry)
@@ -1008,8 +991,9 @@
 	},
 /area/raskara_okon/mess_hall)
 "lO" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/light/small/emergency{
+	dir = 8;
+	pixel_x = 16
 	},
 /turf/simulated/floor/airless,
 /area/raskara_okon/entry)
@@ -1123,18 +1107,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/medbay)
-"nW" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "ob" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1607,10 +1579,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/barracks)
-"ul" = (
-/obj/effect/landmark/clear,
-/turf/template_noop,
-/area/exoplanet/barren/raskara)
 "uN" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 5
@@ -1836,7 +1804,7 @@
 	},
 /area/raskara_okon/mess_hall)
 "xI" = (
-/obj/machinery/light/small{
+/obj/machinery/light/small/emergency{
 	dir = 1
 	},
 /obj/structure/cargo_receptacle{
@@ -2149,18 +2117,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/entry)
-"As" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "Av" = (
 /turf/simulated/wall/shuttle/raider,
 /area/raskara_okon/mining)
@@ -2236,9 +2192,39 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/mess_hall)
+"AU" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = 11;
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "Bp" = (
 /obj/effect/floor_decal/corner/red/full,
 /turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
+"Br" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/raskara_okon/entry)
@@ -2259,6 +2245,19 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/eva)
+"BU" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "BW" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced{
@@ -2480,22 +2479,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/laboratory)
-"EW" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/door/airlock/external,
-/obj/machinery/access_button{
-	pixel_x = 28;
-	pixel_y = -9
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "Fz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2550,6 +2533,22 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/laboratory)
+"Gy" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button{
+	pixel_x = 28;
+	pixel_y = -9
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "GF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2608,7 +2607,7 @@
 	},
 /area/raskara_okon/observatory)
 "Hc" = (
-/obj/machinery/light/small{
+/obj/machinery/light/small/emergency{
 	dir = 4
 	},
 /turf/simulated/floor/airless,
@@ -3256,19 +3255,6 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/engineer)
-"Pt" = (
-/obj/effect/map_effect/marker/airlock{
-	master_tag = "airlock_okon";
-	name = "airlock_okon";
-	frequency = 1004
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/raskara_okon/entry)
 "PA" = (
 /obj/effect/floor_decal/corner/mauve{
 	dir = 10
@@ -3576,8 +3562,25 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/entry)
+"Ux" = (
+/obj/effect/map_effect/marker/airlock{
+	master_tag = "airlock_okon";
+	name = "airlock_okon";
+	frequency = 1004
+	},
+/obj/machinery/airlock_sensor{
+	pixel_x = -25;
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/raskara_okon/entry)
 "UC" = (
-/obj/machinery/light/small{
+/obj/machinery/light/small/emergency{
 	dir = 1
 	},
 /turf/simulated/floor/airless,
@@ -3609,6 +3612,10 @@
 	temperature = 278.15
 	},
 /area/raskara_okon/entry)
+"Vr" = (
+/obj/effect/landmark/clear,
+/turf/template_noop,
+/area/exoplanet/barren/raskara)
 "VA" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/freezer{
@@ -3818,14 +3825,8 @@
 	name = "airlock_okon";
 	frequency = 1004
 	},
-/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
 /obj/machinery/door/airlock/external,
-/obj/machinery/access_button{
-	pixel_x = -28;
-	pixel_y = 11;
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -4472,7 +4473,7 @@ qg
 qg
 qg
 lO
-ul
+Vr
 "}
 (13,1,1) = {"
 HX
@@ -4506,7 +4507,7 @@ qg
 Sg
 Sg
 Sg
-ul
+Vr
 "}
 (14,1,1) = {"
 HX
@@ -4540,7 +4541,7 @@ RF
 xI
 Sg
 Sg
-ul
+Vr
 "}
 (15,1,1) = {"
 HX
@@ -4574,7 +4575,7 @@ RF
 RF
 RF
 VT
-ul
+Vr
 "}
 (16,1,1) = {"
 HX
@@ -4604,11 +4605,11 @@ Lw
 dg
 NG
 aX
+AU
+Ux
+hA
 Xk
-cH
-df
-nW
-ul
+Vr
 "}
 (17,1,1) = {"
 HX
@@ -4638,11 +4639,11 @@ Vn
 VH
 wK
 dg
-As
-Pt
+Br
+BU
 Me
-EW
-ul
+Gy
+Vr
 "}
 (18,1,1) = {"
 HX
@@ -4676,7 +4677,7 @@ RF
 RF
 RF
 RF
-ul
+Vr
 "}
 (19,1,1) = {"
 HX
@@ -4710,7 +4711,7 @@ RF
 UC
 Sg
 Sg
-ul
+Vr
 "}
 (20,1,1) = {"
 HX
@@ -4744,7 +4745,7 @@ Yw
 Sg
 Sg
 Sg
-ul
+Vr
 "}
 (21,1,1) = {"
 HX
@@ -4778,10 +4779,10 @@ Yw
 Yw
 Yw
 Hc
-ul
+Vr
 "}
 (22,1,1) = {"
-ul
+Vr
 Av
 oc
 xn
@@ -4815,7 +4816,7 @@ Yw
 HX
 "}
 (23,1,1) = {"
-ul
+Vr
 Av
 vC
 Av
@@ -4917,7 +4918,7 @@ Yw
 HX
 "}
 (26,1,1) = {"
-ul
+Vr
 Av
 Av
 pY
@@ -4951,8 +4952,8 @@ Yw
 HX
 "}
 (27,1,1) = {"
-ul
-ul
+Vr
+Vr
 Av
 Av
 Av


### PR DESCRIPTION
For Okon 001 on Raskara:

- Adds holopad and delivery point (good luck delivering...)
- Adds missing airlock
- Fixes misspells of 'Okon 011' instead of Okon 001
- Increased Hadiism by aprox. 11%