### PR TITLE
Hadiist Satellite Fixes

### DIFF
--- a/html/changelogs/Ben10083 - PRA Satellite.yml
+++ b/html/changelogs/Ben10083 - PRA Satellite.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: President Hadii
+author: President Njadrasanukii Hadii
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/Ben10083 - PRA Satellite.yml
+++ b/html/changelogs/Ben10083 - PRA Satellite.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: Ben10083
+author: President Hadii
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -55,4 +55,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "Replaces depreciated Airlock markers in Hadiist Satellite with '''modern''' equivalent."
+  - bugfix: "Replaces depreciated Airlock markers in Hadiist Satellite with Hadiist modern equivalent."

--- a/html/changelogs/Ben10083 - PRA Satellite.yml
+++ b/html/changelogs/Ben10083 - PRA Satellite.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Ben10083
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Replaces depreciated Airlock markers in Hadiist Satellite with '''modern''' equivalent."

--- a/maps/away/away_site/tajara/pra_satellite/pra_satellite.dm
+++ b/maps/away/away_site/tajara/pra_satellite/pra_satellite.dm
@@ -50,6 +50,22 @@
 	name = "Hadiist Satellite Navpoint #3"
 	landmark_tag = "nav_hadiist_satellite_3"
 
+// Airlock Markers
+/obj/effect/map_effect/marker/airlock/pra_satellite
+	frequency = 1004
+
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard
+	name = "airlock_pra_satellite_starboard"
+	master_tag = "airlock_pra_satellite_starboard"
+
+/obj/effect/map_effect/marker/airlock/pra_satellite/port
+	name = "airlock_pra_satellite_port"
+	master_tag = "airlock_pra_satellite_port"
+
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft
+	name = "airlock_pra_satellite_aft"
+	master_tag = "airlock_pra_satellite_aft"
+
 /area/pra_satellite
 	name = "Hadiist Satellite"
 	icon_state = "research"

--- a/maps/away/away_site/tajara/pra_satellite/pra_satellite.dmm
+++ b/maps/away/away_site/tajara/pra_satellite/pra_satellite.dmm
@@ -240,7 +240,8 @@
 "cw" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
-	req_one_access = list(209)
+	department = "PRA Survey Satellite";
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1

--- a/maps/away/away_site/tajara/pra_satellite/pra_satellite.dmm
+++ b/maps/away/away_site/tajara/pra_satellite/pra_satellite.dmm
@@ -1,7 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/map_effect/window_spawner/full/shuttle/raider{
+	spawn_firedoor = 1;
+	req_one_access = list(209);
+	spawn_grille = 1
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -96,8 +99,9 @@
 	},
 /area/pra_satellite)
 "aR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -120,6 +124,16 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"bm" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/airlock_sensor{
+	pixel_y = 25
+	},
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -172,30 +186,11 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"bI" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "bU" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/multi,
 /turf/simulated/floor/wood{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"bY" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	pixel_y = 25
-	},
-/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -232,6 +227,17 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"db" = (
+/obj/effect/floor_decal/corner/black{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -308,6 +314,16 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"eu" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	pixel_y = 25
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "eB" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -315,16 +331,6 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red/full,
 /turf/simulated/floor/tiled/dark{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"eC" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -341,6 +347,14 @@
 "eL" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"eY" = (
+/obj/machinery/light/small,
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -398,11 +412,13 @@
 	},
 /area/pra_satellite)
 "gb" = (
-/obj/effect/map_effect/window_spawner/full/shuttle/raider{
-	spawn_firedoor = 1;
-	req_one_access = list(209);
-	spawn_grille = 1
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = -9
 	},
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -448,6 +464,9 @@
 /obj/effect/floor_decal/corner/black{
 	dir = 6
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -484,18 +503,6 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"hs" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/access_button{
-	pixel_x = -28;
-	pixel_y = -9
-	},
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "hD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6;
@@ -528,16 +535,6 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"hR" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/machinery/airlock_sensor{
-	pixel_y = 25
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "hX" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -550,14 +547,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"id" = (
-/obj/machinery/light/small,
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -600,6 +589,17 @@
 "jb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"jd" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/machinery/airlock_sensor{
+	pixel_x = 20;
+	dir = 8;
+	frequency = 2137
+	},
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -674,7 +674,9 @@
 /area/pra_satellite)
 "lo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -685,25 +687,21 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"lp" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/machinery/airlock_sensor{
-	pixel_y = 25
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "lu" = (
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/space)
-"lH" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/external,
+"lK" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button/airlock_exterior{
+	pixel_x = -8;
+	pixel_y = 30;
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -733,7 +731,9 @@
 	},
 /area/pra_satellite)
 "mb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -769,19 +769,6 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"mw" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "nn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 9
@@ -800,10 +787,9 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"nZ" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+"ov" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -874,20 +860,6 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"px" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	pixel_y = 6;
-	pixel_x = 20;
-	dir = 8
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "pR" = (
 /obj/effect/shuttle_landmark/pra_satellite/nav2,
 /turf/template_noop,
@@ -942,11 +914,34 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"rl" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "sc" = (
 /obj/effect/shuttle_landmark/pra_satellite/nav3,
 /turf/template_noop,
 /area/space)
-"ss" = (
+"sn" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_y = 6;
+	pixel_x = 20;
+	dir = 8
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"sp" = (
 /obj/effect/map_effect/marker/airlock/pra_satellite/aft,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
@@ -977,6 +972,16 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"sP" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1034,11 +1039,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1;
+	icon_state = "map-supply"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/full{
 	dir = 8
@@ -1064,7 +1070,7 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"uy" = (
+"uB" = (
 /obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
 /obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1167,16 +1173,6 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"xT" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	pixel_y = 25
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "yh" = (
 /turf/simulated/floor/tiled{
 	temperature = 278.15
@@ -1194,6 +1190,19 @@
 "yx" = (
 /obj/effect/floor_decal/corner/black/full,
 /turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"yC" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -1232,6 +1241,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -1276,6 +1291,14 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"AG" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "AS" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor{
@@ -1312,31 +1335,6 @@
 "Bu" = (
 /obj/machinery/light{
 	dir = 8
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"Bz" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"BG" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/access_button/airlock_exterior{
-	pixel_x = 8;
-	pixel_y = 30;
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	dir = 4
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -1393,6 +1391,15 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"DQ" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "Fc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/red{
@@ -1402,18 +1409,21 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"Fe" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "Ff" = (
 /obj/effect/floor_decal/corner/black/full{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"Fg" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -1536,6 +1546,16 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"Hv" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/airlock_sensor{
+	pixel_y = 25
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "HE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/red{
@@ -1548,10 +1568,8 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"HI" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/door/airlock/external{
+"HG" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -1563,6 +1581,13 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/carpet/art{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"IE" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -1599,12 +1624,28 @@
 "Kn" = (
 /turf/template_noop,
 /area/space)
-"KR" = (
+"Ky" = (
 /obj/effect/map_effect/marker/airlock/pra_satellite/port,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"KA" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	pixel_y = 25
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"Lb" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1661,6 +1702,13 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"MC" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "ME" = (
 /obj/structure/bed/padded,
 /obj/structure/curtain/open/bed,
@@ -1685,21 +1733,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"Nk" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/access_button/airlock_exterior{
-	pixel_x = -8;
-	pixel_y = 30;
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -1754,6 +1787,15 @@
 /area/pra_satellite)
 "Qk" = (
 /obj/machinery/atmospherics/binary/pump/on,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"Qn" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/external,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1842,6 +1884,16 @@
 /obj/effect/shuttle_landmark/pra_satellite/nav1,
 /turf/template_noop,
 /area/space)
+"Vc" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "Vh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -1882,12 +1934,16 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"Wu" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
-/obj/machinery/airlock_sensor{
-	pixel_x = 20;
-	dir = 8;
-	frequency = 2137
+"Wx" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button/airlock_exterior{
+	pixel_x = 8;
+	pixel_y = 30;
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -1934,6 +1990,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4;
+	icon_state = "map_scrubber_on"
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1988,6 +2048,12 @@
 /obj/machinery/door/airlock/engineering{
 	req_access = list(209);
 	name = "Power";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark{
@@ -26051,8 +26117,8 @@ wc
 wc
 Kn
 wc
-Nk
-HI
+lK
+Vc
 wc
 Kn
 Kn
@@ -26308,8 +26374,8 @@ da
 wc
 Kn
 wc
-hR
-nZ
+bm
+rl
 wc
 Kn
 Kn
@@ -26565,8 +26631,8 @@ ma
 wc
 Kn
 wc
-xT
-id
+KA
+eY
 wc
 Kn
 Kn
@@ -26813,7 +26879,7 @@ wc
 lL
 lL
 lL
-ww
+Lb
 zF
 wc
 kP
@@ -26822,8 +26888,8 @@ Gu
 wc
 Kn
 wc
-eC
-uy
+Fe
+uB
 wc
 Kn
 Kn
@@ -27323,7 +27389,7 @@ Kn
 Kn
 Kn
 Kn
-gb
+aa
 bU
 by
 vA
@@ -27580,7 +27646,7 @@ Kn
 Kn
 Kn
 Kn
-gb
+aa
 JL
 fG
 Nh
@@ -27846,13 +27912,13 @@ aN
 AA
 wc
 wc
-gb
-gb
-gb
-gb
-gb
-gb
-gb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 wc
 wc
 PQ
@@ -28363,12 +28429,12 @@ wg
 wg
 wg
 wc
-gb
-gb
+aa
+aa
 wc
 Kn
 Kn
-gb
+aa
 Jy
 wD
 wc
@@ -28625,7 +28691,7 @@ eB
 wc
 wc
 wg
-gb
+aa
 Jy
 aK
 wc
@@ -28865,7 +28931,7 @@ Kn
 Kn
 Kn
 Kn
-gb
+aa
 eg
 vF
 dB
@@ -28873,22 +28939,22 @@ wc
 aO
 AA
 wc
-gb
-gb
+aa
+aa
 wc
 Gq
 LU
 Yt
 cw
-gb
+aa
 Kn
-gb
+aa
 Jy
 fU
 yx
 wc
 Ly
-ss
+sp
 wc
 Kn
 Kn
@@ -29122,7 +29188,7 @@ lu
 lu
 lu
 lu
-gb
+aa
 Km
 vF
 TQ
@@ -29137,16 +29203,16 @@ hX
 Hd
 qy
 oP
-gb
+aa
 Kn
 wc
 fa
 Zr
 Qv
-lH
-aa
-Fg
-hs
+Qn
+MC
+IE
+gb
 lu
 lu
 lu
@@ -29379,7 +29445,7 @@ Kn
 Kn
 Kn
 Kn
-gb
+aa
 fm
 jb
 Gw
@@ -29387,22 +29453,22 @@ wc
 GK
 AA
 wc
-gb
-gb
+aa
+aa
 wc
 NK
 di
 uw
 CM
-gb
+aa
 Kn
-gb
+aa
 Jy
 Wy
 Av
 wc
-Wu
-px
+jd
+sn
 wc
 Kn
 Kn
@@ -29636,7 +29702,7 @@ Kn
 Kn
 Kn
 Kn
-gb
+aa
 vy
 yh
 hb
@@ -29653,7 +29719,7 @@ gY
 wc
 wc
 wg
-gb
+aa
 Jy
 aK
 wc
@@ -29905,12 +29971,12 @@ wg
 wg
 wg
 wc
-gb
-gb
+aa
+aa
 wc
 Kn
 Kn
-gb
+aa
 Jy
 AA
 wc
@@ -30410,19 +30476,19 @@ Kn
 wc
 jP
 ww
-ww
+HG
 wc
 aR
-AA
+db
 wc
 wc
-gb
-gb
-gb
-gb
-gb
-gb
-gb
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 wc
 wc
 Jy
@@ -31438,8 +31504,8 @@ Kn
 wc
 AS
 OH
-fT
-ww
+AG
+ov
 ww
 Bu
 ww
@@ -31448,8 +31514,8 @@ sW
 wc
 Kn
 wc
-Bz
-mw
+Ky
+yC
 wc
 Kn
 Kn
@@ -31705,7 +31771,7 @@ ww
 wc
 Kn
 wc
-bY
+eu
 FB
 wc
 Kn
@@ -31962,8 +32028,8 @@ NO
 wc
 Kn
 wc
-lp
-bI
+Hv
+DQ
 wc
 Kn
 Kn
@@ -32219,8 +32285,8 @@ wc
 wc
 Kn
 wc
-BG
-KR
+Wx
+sP
 wc
 Kn
 Kn

--- a/maps/away/away_site/tajara/pra_satellite/pra_satellite.dmm
+++ b/maps/away/away_site/tajara/pra_satellite/pra_satellite.dmm
@@ -1,7 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/obj/effect/map_effect/airlock/long/square/wide,
-/turf/simulated/wall/shuttle/raider,
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
 /area/pra_satellite)
 "aE" = (
 /obj/structure/table/glass,
@@ -32,7 +35,7 @@
 /area/pra_satellite)
 "aH" = (
 /obj/machinery/atmospherics/portables_connector{
-	dir = 1;
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -169,6 +172,15 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"bI" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "bU" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -177,10 +189,20 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"bY" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	pixel_y = 25
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "cw" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
-	req_one_access = null
+	req_one_access = list(209)
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -296,6 +318,16 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"eC" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "eF" = (
 /obj/machinery/power/rtg/advanced,
 /obj/structure/cable/green{
@@ -366,7 +398,11 @@
 	},
 /area/pra_satellite)
 "gb" = (
-/obj/effect/map_effect/window_spawner/full/reinforced/grille/firedoor,
+/obj/effect/map_effect/window_spawner/full/shuttle/raider{
+	spawn_firedoor = 1;
+	req_one_access = list(209);
+	spawn_grille = 1
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -448,6 +484,18 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"hs" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = -9
+	},
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "hD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6;
@@ -480,6 +528,16 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"hR" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/airlock_sensor{
+	pixel_y = 25
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "hX" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -492,6 +550,14 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"id" = (
+/obj/machinery/light/small,
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -619,10 +685,29 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"lp" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/airlock_sensor{
+	pixel_y = 25
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "lu" = (
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/space)
+"lH" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "lL" = (
 /obj/machinery/power/rtg/advanced,
 /obj/structure/cable/green{
@@ -684,6 +769,19 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"mw" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "nn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 9
@@ -699,6 +797,15 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"nZ" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -724,7 +831,7 @@
 /area/pra_satellite)
 "oR" = (
 /obj/machinery/atmospherics/portables_connector{
-	dir = 1;
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -764,6 +871,20 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"px" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_y = 6;
+	pixel_x = 20;
+	dir = 8
+	},
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -825,6 +946,15 @@
 /obj/effect/shuttle_landmark/pra_satellite/nav3,
 /turf/template_noop,
 /area/space)
+"ss" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "sB" = (
 /obj/effect/floor_decal/corner/red/full{
 	dir = 1
@@ -934,6 +1064,19 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"uy" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "vd" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/food/drinks/bottle/victorygin,
@@ -1021,6 +1164,16 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"xT" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	pixel_y = 25
+	},
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -1164,6 +1317,31 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"Bz" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"BG" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button/airlock_exterior{
+	pixel_x = 8;
+	pixel_y = 30;
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "CM" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -1183,7 +1361,9 @@
 /obj/machinery/turretid{
 	req_access = list(209);
 	dir = 8;
-	pixel_x = 32
+	pixel_x = 32;
+	check_arrest = 0;
+	check_records = 0
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -1213,14 +1393,6 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"Eb" = (
-/obj/effect/map_effect/airlock/w_to_e/long/square,
-/turf/simulated/wall/shuttle/raider,
-/area/pra_satellite)
-"ED" = (
-/obj/effect/map_effect/airlock/e_to_w/long/square,
-/turf/simulated/wall/shuttle/raider,
-/area/pra_satellite)
 "Fc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/red{
@@ -1238,6 +1410,13 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"Fg" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "Fx" = (
 /obj/effect/floor_decal/corner/black{
 	dir = 8
@@ -1251,6 +1430,8 @@
 /area/pra_satellite)
 "FB" = (
 /obj/machinery/light/small,
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1367,6 +1548,16 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"HI" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "HQ" = (
 /obj/structure/sign/flag/pra/large/west{
 	pixel_x = -32
@@ -1408,6 +1599,16 @@
 "Kn" = (
 /turf/template_noop,
 /area/space)
+"KR" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "Lc" = (
 /obj/structure/extinguisher_cabinet/west,
 /obj/effect/floor_decal/corner/red{
@@ -1436,6 +1637,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1483,6 +1685,21 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"Nk" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button/airlock_exterior{
+	pixel_x = -8;
+	pixel_y = 30;
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -1660,6 +1877,17 @@
 "Wr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 10
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"Wu" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/machinery/airlock_sensor{
+	pixel_x = 20;
+	dir = 8;
+	frequency = 2137
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -25823,9 +26051,9 @@ wc
 wc
 Kn
 wc
-ww
-ww
-ED
+Nk
+HI
+wc
 Kn
 Kn
 Kn
@@ -26080,8 +26308,8 @@ da
 wc
 Kn
 wc
-ww
-ww
+hR
+nZ
 wc
 Kn
 Kn
@@ -26337,8 +26565,8 @@ ma
 wc
 Kn
 wc
-ww
-FB
+xT
+id
 wc
 Kn
 Kn
@@ -26594,8 +26822,8 @@ Gu
 wc
 Kn
 wc
-ww
-ww
+eC
+uy
 wc
 Kn
 Kn
@@ -28404,7 +28632,7 @@ wc
 wc
 wc
 wc
-aa
+wc
 gg
 Kn
 Kn
@@ -28660,7 +28888,7 @@ fU
 yx
 wc
 Ly
-ww
+ss
 wc
 Kn
 Kn
@@ -28915,10 +29143,10 @@ wc
 fa
 Zr
 Qv
-ww
-ww
-ww
-ww
+lH
+aa
+Fg
+hs
 lu
 lu
 lu
@@ -29173,8 +29401,8 @@ Jy
 Wy
 Av
 wc
-ww
-ww
+Wu
+px
 wc
 Kn
 Kn
@@ -31220,9 +31448,9 @@ sW
 wc
 Kn
 wc
-ww
-ww
-Eb
+Bz
+mw
+wc
 Kn
 Kn
 Kn
@@ -31477,7 +31705,7 @@ ww
 wc
 Kn
 wc
-ww
+bY
 FB
 wc
 Kn
@@ -31734,8 +31962,8 @@ NO
 wc
 Kn
 wc
-ww
-ww
+lp
+bI
 wc
 Kn
 Kn
@@ -31991,8 +32219,8 @@ wc
 wc
 Kn
 wc
-ww
-ww
+BG
+KR
 wc
 Kn
 Kn

--- a/maps/away/away_site/tajara/pra_satellite/pra_satellite.dmm
+++ b/maps/away/away_site/tajara/pra_satellite/pra_satellite.dmm
@@ -1,11 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/obj/effect/map_effect/window_spawner/full/shuttle/raider{
-	spawn_firedoor = 1;
-	req_one_access = list(209);
-	spawn_grille = 1
+/obj/effect/floor_decal/corner/red{
+	dir = 6
 	},
-/turf/simulated/floor{
+/obj/structure/extinguisher_cabinet/east,
+/turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -127,11 +126,29 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"bm" = (
+"bh" = (
 /obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/machinery/airlock_sensor{
-	pixel_y = 25
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"bp" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button/airlock_exterior{
+	pixel_x = 8;
+	pixel_y = 30;
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -151,6 +168,19 @@
 /obj/machinery/porta_turret/ballistic,
 /turf/simulated/floor/airless,
 /area/pra_satellite)
+"bv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/black{
+	dir = 9
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "bw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -163,6 +193,9 @@
 	req_access = list(209);
 	name = "Bridge";
 	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -191,6 +224,16 @@
 /obj/item/paper_bin,
 /obj/item/pen/multi,
 /turf/simulated/floor/wood{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"ci" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/airlock_sensor{
+	pixel_y = 25
+	},
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -227,17 +270,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"db" = (
-/obj/effect/floor_decal/corner/black{
-	dir = 10
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -314,16 +346,6 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"eu" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	pixel_y = 25
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "eB" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -350,19 +372,22 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"eY" = (
-/obj/machinery/light/small,
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "fa" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
 /obj/structure/hadii_statue,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"fe" = (
+/obj/effect/floor_decal/corner/black{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -412,13 +437,11 @@
 	},
 /area/pra_satellite)
 "gb" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/access_button{
-	pixel_x = -28;
-	pixel_y = -9
+/obj/effect/map_effect/window_spawner/full/shuttle/raider{
+	spawn_firedoor = 1;
+	req_one_access = list(209);
+	spawn_grille = 1
 	},
-/obj/machinery/door/airlock/external,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -592,17 +615,6 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"jd" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
-/obj/machinery/airlock_sensor{
-	pixel_x = 20;
-	dir = 8;
-	frequency = 2137
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "jp" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /turf/simulated/floor{
@@ -631,6 +643,9 @@
 	req_access = list(209);
 	name = "Sleeping Quarters";
 	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -691,21 +706,6 @@
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/space)
-"lK" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/access_button/airlock_exterior{
-	pixel_x = -8;
-	pixel_y = 30;
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "lL" = (
 /obj/machinery/power/rtg/advanced,
 /obj/structure/cable/green{
@@ -749,6 +749,9 @@
 	name = "Crew Area";
 	dir = 1
 	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
+	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -765,7 +768,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/firedoor{
+	dir = 8;
+	req_one_access = list(24,11,67,209)
+	},
 /turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"my" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -787,9 +807,16 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"ov" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+"on" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button/airlock_exterior{
+	pixel_x = -8;
+	pixel_y = 30;
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	dir = 4
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -875,6 +902,14 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"qi" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "qw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -902,6 +937,15 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"qF" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "qH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/alarm/cold/west{
@@ -914,6 +958,16 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"qW" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "rl" = (
 /obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -923,33 +977,21 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"rH" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/machinery/airlock_sensor{
+	pixel_x = 20;
+	dir = 8;
+	frequency = 2137
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "sc" = (
 /obj/effect/shuttle_landmark/pra_satellite/nav3,
 /turf/template_noop,
 /area/space)
-"sn" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	pixel_y = 6;
-	pixel_x = 20;
-	dir = 8
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"sp" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "sB" = (
 /obj/effect/floor_decal/corner/red/full{
 	dir = 1
@@ -976,9 +1018,9 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"sP" = (
+"sS" = (
 /obj/effect/map_effect/marker/airlock/pra_satellite/port,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker_helper/airlock/interior,
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
@@ -1033,6 +1075,20 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"tV" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	pixel_y = 6;
+	pixel_x = 20;
+	dir = 8
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "ug" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1067,19 +1123,6 @@
 	},
 /obj/effect/floor_decal/corner/red,
 /turf/simulated/floor/tiled/dark{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"uB" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -1193,19 +1236,6 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"yC" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "yE" = (
 /obj/structure/sign/flag/pra/large/south{
 	pixel_y = -32
@@ -1252,6 +1282,16 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"zP" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/airlock_sensor{
+	pixel_y = 25
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "Ab" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/corner/black/full{
@@ -1291,9 +1331,11 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"AG" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+"AP" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/door/airlock/external{
+	dir = 4
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -1335,6 +1377,16 @@
 "Bu" = (
 /obj/machinery/light{
 	dir = 8
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"CB" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	pixel_y = 25
 	},
 /turf/simulated/floor{
 	temperature = 278.15
@@ -1391,31 +1443,12 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"DQ" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "Fc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"Fe" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -1529,10 +1562,13 @@
 	},
 /area/pra_satellite)
 "GU" = (
-/obj/structure/extinguisher_cabinet/east,
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
 	},
@@ -1543,16 +1579,6 @@
 /obj/effect/floor_decal/corner_wide/black/diagonal,
 /obj/effect/overmap/visitable/sector/pra_satellite,
 /turf/simulated/floor/tiled/dark{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"Hv" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/machinery/airlock_sensor{
-	pixel_y = 25
-	},
-/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -1568,14 +1594,6 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"HG" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "HQ" = (
 /obj/structure/sign/flag/pra/large/west{
 	pixel_x = -32
@@ -1584,9 +1602,10 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"IE" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
-/obj/machinery/atmospherics/pipe/manifold/hidden,
+"HV" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1624,28 +1643,10 @@
 "Kn" = (
 /turf/template_noop,
 /area/space)
-"Ky" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"KA" = (
+"Ks" = (
+/obj/machinery/light/small,
 /obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume,
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	pixel_y = 25
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"Lb" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1683,6 +1684,13 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"LD" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "LU" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 1
@@ -1699,13 +1707,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"MC" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -1733,6 +1734,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"Nu" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -1765,6 +1775,18 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"Pp" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/access_button{
+	pixel_x = -28;
+	pixel_y = -9
+	},
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "PQ" = (
 /obj/structure/sign/flag/pra/large/north{
 	pixel_y = 32
@@ -1787,15 +1809,6 @@
 /area/pra_satellite)
 "Qk" = (
 /obj/machinery/atmospherics/binary/pump/on,
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
-"Qn" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
-/obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/airlock/external,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1823,6 +1836,15 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"QG" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -1857,6 +1879,26 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"Sd" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	pixel_y = 25
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"Su" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/port,
+/obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "SX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
@@ -1884,12 +1926,8 @@
 /obj/effect/shuttle_landmark/pra_satellite/nav1,
 /turf/template_noop,
 /area/space)
-"Vc" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/starboard,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
+"UO" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -1934,24 +1972,29 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
-"Wx" = (
-/obj/effect/map_effect/marker/airlock/pra_satellite/port,
-/obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/machinery/access_button/airlock_exterior{
-	pixel_x = 8;
-	pixel_y = 30;
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	dir = 4
-	},
-/turf/simulated/floor{
-	temperature = 278.15
-	},
-/area/pra_satellite)
 "Wy" = (
 /obj/effect/floor_decal/corner/black,
 /turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"Wz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/black{
+	dir = 6
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"WI" = (
+/obj/effect/map_effect/marker/airlock/pra_satellite/aft,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor{
 	temperature = 278.15
 	},
 /area/pra_satellite)
@@ -1968,6 +2011,14 @@
 "WT" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor{
+	temperature = 278.15
+	},
+/area/pra_satellite)
+"Xp" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /turf/simulated/floor{
 	temperature = 278.15
 	},
@@ -2028,6 +2079,18 @@
 	temperature = 278.15
 	},
 /area/pra_satellite)
+"YJ" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark{
+	temperature = 278.15
+	},
+/area/pra_satellite)
 "Zg" = (
 /obj/machinery/light{
 	dir = 4
@@ -2055,6 +2118,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 8;
+	req_one_access = list(24,11,67,209)
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -2090,6 +2157,9 @@
 	req_access = list(209);
 	name = "Atmospherics";
 	dir = 1
+	},
+/obj/machinery/door/firedoor{
+	req_one_access = list(24,11,67,209)
 	},
 /turf/simulated/floor/tiled/dark{
 	temperature = 278.15
@@ -26117,8 +26187,8 @@ wc
 wc
 Kn
 wc
-lK
-Vc
+on
+qW
 wc
 Kn
 Kn
@@ -26374,7 +26444,7 @@ da
 wc
 Kn
 wc
-bm
+zP
 rl
 wc
 Kn
@@ -26631,8 +26701,8 @@ ma
 wc
 Kn
 wc
-KA
-eY
+CB
+Ks
 wc
 Kn
 Kn
@@ -26879,7 +26949,7 @@ wc
 lL
 lL
 lL
-Lb
+UO
 zF
 wc
 kP
@@ -26888,8 +26958,8 @@ Gu
 wc
 Kn
 wc
-Fe
-uB
+AP
+bh
 wc
 Kn
 Kn
@@ -27389,7 +27459,7 @@ Kn
 Kn
 Kn
 Kn
-aa
+gb
 bU
 by
 vA
@@ -27399,7 +27469,7 @@ ZV
 lo
 ds
 yQ
-yQ
+YJ
 Lc
 pw
 AT
@@ -27646,7 +27716,7 @@ Kn
 Kn
 Kn
 Kn
-aa
+gb
 JL
 fG
 Nh
@@ -27656,7 +27726,7 @@ Wy
 gC
 tc
 RO
-RO
+Wz
 Bt
 Fc
 Fc
@@ -27912,13 +27982,13 @@ aN
 AA
 wc
 wc
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+gb
+gb
+gb
+gb
+gb
+gb
+gb
 wc
 wc
 PQ
@@ -28429,12 +28499,12 @@ wg
 wg
 wg
 wc
-aa
-aa
+gb
+gb
 wc
 Kn
 Kn
-aa
+gb
 Jy
 wD
 wc
@@ -28691,7 +28761,7 @@ eB
 wc
 wc
 wg
-aa
+gb
 Jy
 aK
 wc
@@ -28931,7 +29001,7 @@ Kn
 Kn
 Kn
 Kn
-aa
+gb
 eg
 vF
 dB
@@ -28939,22 +29009,22 @@ wc
 aO
 AA
 wc
-aa
-aa
+gb
+gb
 wc
 Gq
 LU
 Yt
 cw
-aa
+gb
 Kn
-aa
+gb
 Jy
 fU
 yx
 wc
 Ly
-sp
+qF
 wc
 Kn
 Kn
@@ -29188,7 +29258,7 @@ lu
 lu
 lu
 lu
-aa
+gb
 Km
 vF
 TQ
@@ -29203,16 +29273,16 @@ hX
 Hd
 qy
 oP
-aa
+gb
 Kn
 wc
 fa
 Zr
 Qv
-Qn
-MC
-IE
-gb
+Nu
+LD
+WI
+Pp
 lu
 lu
 lu
@@ -29445,7 +29515,7 @@ Kn
 Kn
 Kn
 Kn
-aa
+gb
 fm
 jb
 Gw
@@ -29453,22 +29523,22 @@ wc
 GK
 AA
 wc
-aa
-aa
+gb
+gb
 wc
 NK
 di
 uw
 CM
-aa
+gb
 Kn
-aa
+gb
 Jy
 Wy
 Av
 wc
-jd
-sn
+rH
+tV
 wc
 Kn
 Kn
@@ -29702,7 +29772,7 @@ Kn
 Kn
 Kn
 Kn
-aa
+gb
 vy
 yh
 hb
@@ -29719,7 +29789,7 @@ gY
 wc
 wc
 wg
-aa
+gb
 Jy
 aK
 wc
@@ -29971,12 +30041,12 @@ wg
 wg
 wg
 wc
-aa
-aa
+gb
+gb
 wc
 Kn
 Kn
-aa
+gb
 Jy
 AA
 wc
@@ -30476,19 +30546,19 @@ Kn
 wc
 jP
 ww
-HG
+HV
 wc
 aR
-db
+fe
 wc
 wc
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+gb
+gb
+gb
+gb
+gb
+gb
+gb
 wc
 wc
 Jy
@@ -30740,7 +30810,7 @@ ks
 VX
 VX
 VX
-VX
+bv
 HE
 ym
 ym
@@ -30996,7 +31066,7 @@ sB
 CW
 RC
 CW
-CW
+aa
 GU
 ox
 Zg
@@ -31504,8 +31574,8 @@ Kn
 wc
 AS
 OH
-AG
-ov
+Xp
+qi
 ww
 Bu
 ww
@@ -31514,8 +31584,8 @@ sW
 wc
 Kn
 wc
-Ky
-yC
+sS
+my
 wc
 Kn
 Kn
@@ -31771,7 +31841,7 @@ ww
 wc
 Kn
 wc
-eu
+Sd
 FB
 wc
 Kn
@@ -32028,8 +32098,8 @@ NO
 wc
 Kn
 wc
-Hv
-DQ
+ci
+QG
 wc
 Kn
 Kn
@@ -32285,8 +32355,8 @@ wc
 wc
 Kn
 wc
-Wx
-sP
+bp
+Su
 wc
 Kn
 Kn


### PR DESCRIPTION
For Hadiist Satellite:
- Replace smelly depreciated airlock with cutting-edge new airlock
- Replaced windows with raider equivalent
- Adds missing scrubbers/vents
- Adds missing firelocks