### PR TITLE
Fixes borer progress bars and internal borers being attacked by mirror shades

### DIFF
--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -134,8 +134,6 @@
 		return
 	last_progress = progress
 	bar.icon_state = "prog_bar_[round(((progress / goal) * 100), 5)]"
-	if(progress == goal)
-		end_progress()
 
 
 ///Called on progress end, be it successful or a failure. Wraps up things to delete the datum and bar.

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -134,6 +134,8 @@
 		return
 	last_progress = progress
 	bar.icon_state = "prog_bar_[round(((progress / goal) * 100), 5)]"
+	if(progress == goal)
+		end_progress()
 
 
 ///Called on progress end, be it successful or a failure. Wraps up things to delete the datum and bar.

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -40,7 +40,6 @@
 		add_verb(player.current.client, /mob/living/proc/write_ambition)
 
 	to_chat(player.current, SPAN_NOTICE("Once you decide on a goal to pursue, you can optionally display it to everyone at the end of the shift with the <b>Set Ambition</b> verb, located in the IC tab.  You can change this at any time, and it otherwise has no bearing on your round."))
-	add_verb(player.current.client, /mob/living/proc/write_ambition)
 
 	// Handle only adding a mind and not bothering with gear etc.
 	if(nonstandard_role_type)

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -87,7 +87,12 @@
 			host.emote(pick(controlling_emotes))
 	..()
 	if(!QDELETED(ability_bar))
-		ability_bar.update(world.time - ability_start_time)
+		var/borer_progress = world.time - ability_start_time
+		borer_progress = clamp(borer_progress, 0, ability_bar.goal)
+		ability_bar.update(borer_progress)
+
+		if(borer_progress == ability_bar.goal)
+			ability_bar.end_progress()
 
 /mob/living/simple_animal/borer/proc/start_ability(var/atom/target, var/time)
 	if(!QDELETED(ability_bar))

--- a/code/modules/psionics/abilities/mirror_shade.dm
+++ b/code/modules/psionics/abilities/mirror_shade.dm
@@ -42,6 +42,9 @@
 	if(set_owner)
 		owner = set_owner
 		friends += owner
+		var/brain_worm = owner.has_brain_worms()
+		if(brain_worm)
+			friends += brain_worm
 	QDEL_IN(src, 30 SECONDS)
 
 /mob/living/simple_animal/hostile/mirror_shade/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)

--- a/html/changelogs/alaunuslux-fix-borer-progress-bars.yml
+++ b/html/changelogs/alaunuslux-fix-borer-progress-bars.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Borers will no longer get stuck in progress bar purgatory upon bestowing psionic powers to their host."
+  - bugfix: "The Mirror Shade psi power will no longer target the host's internal borer."


### PR DESCRIPTION
This fixes borers being permanently mid-ability after first awakening their host's psionic powers, and thus unable to do anything else for the remainder of the round.

I also found an issue with the psi ability mirror shade: somehow the shades target internal borers, including the hosts. I'd like a more generic fix for this so that they don't attack any internal borers, but I'm not well versed in mob code.

Also removed an `add_verb` for `write_ambition` that I should've removed in my last borer-based PR, as it's done above inside a client check, and could cause RTEs in some circumstances.
