### PR TITLE
Adds method for choosing friends that psi ability mirror shades won't attack

### DIFF
--- a/code/modules/psionics/abilities/mirror_shade.dm
+++ b/code/modules/psionics/abilities/mirror_shade.dm
@@ -1,7 +1,7 @@
 /singleton/psionic_power/mirror_shade
 	name = "Mirror Shade"
 	desc = "Activate this spell to generate two psionic copies of yourself that will attack nearby mobs. These clones are not dense, will deal pain damage, and disappear \
-			after thirty seconds."
+			after thirty seconds. Clicking mobs before casting protects them from your clones."
 	icon_state = "wiz_jaunt"
 	point_cost = 2
 	ability_flags = PSI_FLAG_EVENT
@@ -11,21 +11,42 @@
 	name = "mirror shade"
 	desc = "Photocopy yourself."
 	icon_state = "darkness"
-	cast_methods = CAST_USE
+	cast_methods = CAST_RANGED|CAST_USE
 	aspect = ASPECT_PSIONIC
 	cooldown = 100
 	psi_cost = 20
+	var/list/mob/living/chosen_friends = list()
 
 /obj/item/spell/mirror_shade/on_use_cast(mob/user)
+	cooldown = 100
 	. = ..()
 	if(!.)
 		return
 	if(do_after(user, 1 SECOND))
 		to_chat(user, SPAN_WARNING("You weave your psionic force into two copies of yourself!"))
 		for(var/i = 1 to 2)
-			var/mob/living/simple_animal/hostile/mirror_shade/MS = new(pick(get_adjacent_open_turfs(user)), user)
+			var/mob/living/simple_animal/hostile/mirror_shade/MS = new(pick(get_adjacent_open_turfs(user)), user, chosen_friends)
 			MS.appearance = user.appearance
 			MS.name = user.name
+
+/obj/item/spell/mirror_shade/on_ranged_cast(atom/hit_atom, mob/user, bypass_psi_check = TRUE)
+	cooldown = 0
+	if(!isliving(hit_atom))
+		return
+	. = ..()
+	if(!.)
+		return
+
+	var/mob/living/M = hit_atom
+	if(istype(M, /mob/living/simple_animal/hostile/mirror_shade)) return
+
+	if(!(M in chosen_friends))
+		chosen_friends.Add(M)
+		to_chat(user, SPAN_INFO("Your clones will no longer target [M]!"))
+	else
+		chosen_friends.Remove(M)
+		to_chat(user, SPAN_INFO("Your clones will now target [M]!"))
+
 
 /mob/living/simple_animal/hostile/mirror_shade
 	damage_type = DAMAGE_PAIN
@@ -37,14 +58,16 @@
 	attacktext = "phases its arms through"
 	var/mob/living/carbon/human/owner
 
-/mob/living/simple_animal/hostile/mirror_shade/Initialize(mapload, var/mob/set_owner)
+/mob/living/simple_animal/hostile/mirror_shade/Initialize(mapload, var/mob/set_owner, var/list/mob/living/chosen_friends)
 	. = ..()
 	if(set_owner)
 		owner = set_owner
 		friends += owner
-		var/brain_worm = owner.has_brain_worms()
-		if(brain_worm)
-			friends += brain_worm
+		friends |= chosen_friends
+		for(var/mob/friend in friends)
+			var/brain_worm = friend.has_brain_worms()
+			if(brain_worm)
+				friends += brain_worm
 	QDEL_IN(src, 30 SECONDS)
 
 /mob/living/simple_animal/hostile/mirror_shade/examine(mob/user, distance, is_adjacent, infix, suffix, show_extended)

--- a/code/modules/psionics/abilities/mirror_shade.dm
+++ b/code/modules/psionics/abilities/mirror_shade.dm
@@ -47,6 +47,9 @@
 		chosen_friends.Remove(M)
 		to_chat(user, SPAN_INFO("Your clones will now target [M]!"))
 
+/obj/item/spell/mirror_shade/Destroy()
+	chosen_friends = null
+	return ..()
 
 /mob/living/simple_animal/hostile/mirror_shade
 	damage_type = DAMAGE_PAIN

--- a/html/changelogs/alaunuslux-pick-mirror-shade-friends.yml
+++ b/html/changelogs/alaunuslux-pick-mirror-shade-friends.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: AlaunusLux
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added a method for choosing friends that mirror shades won't attack."


### PR DESCRIPTION
This allows friends to be designated before casting the psi power mirror shade, so that you and another psychic psycho don't kill each other on accident.