### PR TITLE
Cryo heals below and to 60% BA instead of healing only at above 50% BA

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -241,7 +241,7 @@
 			for(var/obj/item/organ/internal/I in H.internal_organs)
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
-						if(I.damage < I.max_damage/2.6) //will only treat brain activity below 60% brain activity
+						if(I.damage < I.max_damage*0.6) //will only treat brain activity below 60% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)
@@ -273,7 +273,7 @@
 			for(var/obj/item/organ/internal/I in H.internal_organs)
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
-						if(I.damage < I.max_damage/2.6) //will only treat brain activity below 60% brain activity
+						if(I.damage < I.max_damage*0.6) //will only treat brain activity below 60% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -241,7 +241,8 @@
 			for(var/obj/item/organ/internal/I in H.internal_organs)
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
-						if(I.damage < I.max_damage*0.38) //will only treat brain activity below 62% brain activity
+						var/brain_activity = 100 - ((I.damage / I.max_damage) * 100) //converts brain damage to a percentage, to calculate BA
+                        if(brain_activity < 61) //will only treat brain activity below 61% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)
@@ -273,7 +274,8 @@
 			for(var/obj/item/organ/internal/I in H.internal_organs)
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
-						if(I.damage < I.max_damage*0.38) //will only treat brain activity below 62% brain activity
+						var/brain_activity = 100 - ((I.damage / I.max_damage) * 100) //converts brain damage to a percentage, to calculate BA
+                        if(brain_activity < 61) //will only treat brain activity below 61% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -242,7 +242,7 @@
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
 						var/brain_activity = 100 - ((I.damage / I.max_damage) * 100) //converts brain damage to a percentage, to calculate BA
-						if(brain_activity > 60) //will only treat brain activity below 61% brain activity
+						if(brain_activity >= 60) //will only treat brain activity below 61% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)
@@ -275,7 +275,7 @@
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
 						var/brain_activity = 100 - ((I.damage / I.max_damage) * 100) //converts brain damage to a percentage, to calculate BA
-						if(brain_activity > 60) //will only treat brain activity below 61% brain activity
+						if(brain_activity >= 60) //will only treat brain activity below 61% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -242,7 +242,7 @@
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
 						var/brain_activity = 100 - ((I.damage / I.max_damage) * 100) //converts brain damage to a percentage, to calculate BA
-                        (brain_activity < 61) //will only treat brain activity below 61% brain activity
+						if(brain_activity < 61) //will only treat brain activity below 61% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)
@@ -275,7 +275,7 @@
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
 						var/brain_activity = 100 - ((I.damage / I.max_damage) * 100) //converts brain damage to a percentage, to calculate BA
-                        (brain_activity < 61) //will only treat brain activity below 61% brain activity
+						if(brain_activity < 61) //will only treat brain activity below 61% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -242,7 +242,7 @@
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
 						var/brain_activity = 100 - ((I.damage / I.max_damage) * 100) //converts brain damage to a percentage, to calculate BA
-                        if(brain_activity < 61) //will only treat brain activity below 61% brain activity
+                        (brain_activity < 61) //will only treat brain activity below 61% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)
@@ -275,7 +275,7 @@
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
 						var/brain_activity = 100 - ((I.damage / I.max_damage) * 100) //converts brain damage to a percentage, to calculate BA
-                        if(brain_activity < 61) //will only treat brain activity below 61% brain activity
+                        (brain_activity < 61) //will only treat brain activity below 61% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -242,7 +242,7 @@
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
 						var/brain_activity = 100 - ((I.damage / I.max_damage) * 100) //converts brain damage to a percentage, to calculate BA
-						if(brain_activity >= 60) //will only treat brain activity below 61% brain activity
+						if(brain_activity > 60) //will only treat brain activity below 61% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)
@@ -275,7 +275,7 @@
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
 						var/brain_activity = 100 - ((I.damage / I.max_damage) * 100) //converts brain damage to a percentage, to calculate BA
-						if(brain_activity >= 60) //will only treat brain activity below 61% brain activity
+						if(brain_activity > 60) //will only treat brain activity below 61% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -242,7 +242,7 @@
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
 						var/brain_activity = 100 - ((I.damage / I.max_damage) * 100) //converts brain damage to a percentage, to calculate BA
-						if(brain_activity < 61) //will only treat brain activity below 61% brain activity
+						if(brain_activity > 60) //will only treat brain activity below 61% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)
@@ -275,7 +275,7 @@
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
 						var/brain_activity = 100 - ((I.damage / I.max_damage) * 100) //converts brain damage to a percentage, to calculate BA
-						if(brain_activity < 61) //will only treat brain activity below 61% brain activity
+						if(brain_activity > 60) //will only treat brain activity below 61% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -242,7 +242,7 @@
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
 						var/brain_activity = 100 - ((I.damage / I.max_damage) * 100) //converts brain damage to a percentage, to calculate BA
-						if(brain_activity > 60) //will only treat brain activity below 61% brain activity
+						if(brain_activity >= 61) //will only treat brain activity below 61% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)
@@ -275,7 +275,7 @@
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
 						var/brain_activity = 100 - ((I.damage / I.max_damage) * 100) //converts brain damage to a percentage, to calculate BA
-						if(brain_activity > 60) //will only treat brain activity below 61% brain activity
+						if(brain_activity >= 61) //will only treat brain activity below 61% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -241,7 +241,7 @@
 			for(var/obj/item/organ/internal/I in H.internal_organs)
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
-						if(I.damage < I.max_damage*0.6) //will only treat brain activity below 60% brain activity
+						if(I.damage < I.max_damage*0.38) //will only treat brain activity below 62% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)
@@ -273,7 +273,7 @@
 			for(var/obj/item/organ/internal/I in H.internal_organs)
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
-						if(I.damage < I.max_damage*0.6) //will only treat brain activity below 60% brain activity
+						if(I.damage < I.max_damage*0.38) //will only treat brain activity below 62% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -241,7 +241,7 @@
 			for(var/obj/item/organ/internal/I in H.internal_organs)
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
-						if(I.damage > I.max_damage/2) //will only treat brain activity above 50% brain activity
+						if(I.damage < I.max_damage/2.6) //will only treat brain activity below 60% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)
@@ -273,7 +273,7 @@
 			for(var/obj/item/organ/internal/I in H.internal_organs)
 				if(!BP_IS_ROBOTIC(I))
 					if(I.organ_tag == BP_BRAIN)
-						if(I.damage > I.max_damage/2) //will only treat brain activity above 50% brain activity
+						if(I.damage < I.max_damage/2.6) //will only treat brain activity below 60% brain activity
 							continue
 					I.heal_damage(4*removed)
 	else if(M.is_diona() && M.bodytemperature < 170)

--- a/html/changelogs/shimmeristaken - braiouchie.yml
+++ b/html/changelogs/shimmeristaken - braiouchie.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: shimmeristaken
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/shimmeristaken - braiouchie.yml
+++ b/html/changelogs/shimmeristaken - braiouchie.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed cryo healing the brain only if it is above 50% brain activity, which made it functionally useless."


### PR DESCRIPTION
Allows cryogenics to heal the brain to 60% brain activity, at which point natural healing brings it to where inaprovaline can take the wheel.

This was intended initially by Kermit when she made the cryo PRs, however by mistake the opposite was implemented, wherein cryo could only heal when brain damage was above 50%. It was useless for it's original, niche goal - allowing physicians to restore brain damage when no surgeons or pharmacists are available.