### PR TITLE
Harvestable Carpotoxin

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/adhomai.dm
+++ b/code/modules/mob/living/simple_animal/friendly/adhomai.dm
@@ -88,7 +88,7 @@
 	mob_size = 15
 
 	canbrush = TRUE
-	has_udder = TRUE
+	can_be_milked = TRUE
 	milk_type = /singleton/reagent/drink/milk/adhomai
 
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/adhomai
@@ -102,7 +102,7 @@
 	icon_living = "fatshouter_m"
 	icon_dead = "fatshouter_m_dead"
 	gender = MALE
-	has_udder = FALSE
+	can_be_milked = FALSE
 
 /mob/living/simple_animal/hostile/retaliate/rafama
 	name = "steed of Mata'ke"

--- a/code/modules/mob/living/simple_animal/friendly/carp.dm
+++ b/code/modules/mob/living/simple_animal/friendly/carp.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/carp
-	name = "space carp"
+	name = "tame space carp"
 	desc = "A domesticated, floating space carp. Careful around the teeth."
 	icon = 'icons/mob/npc/animal.dmi'
 	icon_state = "carp"
@@ -9,10 +9,11 @@
 	icon_gib = "carp_gib"
 	icon_rest = "carp_rest"
 	can_nap = TRUE
-	speak = list("Glub!")
+	has_toxingland = TRUE
+	speak = list("Glub!", "Glub?", "Glub.")
 	speak_emote = list("glubs", "glibs")
 	emote_hear = list("glubs","glibs")
-	emote_see = list("floats steadily", "inflates its gills")
+	emote_see = list("floats steadily", "inflates its gills", "flaps its flippers", "wiggles", "waggles")
 	speak_chance = 1
 	turns_per_move = 5
 	meat_type = /obj/item/reagent_containers/food/snacks/fish/carpmeat
@@ -138,9 +139,11 @@
 
 	gender = FEMALE
 
-	emote_see = list("floats steadily", "inflates her gills")
+	emote_see = list("floats steadily", "inflates her gills", "flaps her flippers", "wiggles", "waggles")
 
 	can_nap = TRUE
+	has_toxingland = FALSE
+	is_Ginny = TRUE
 	mob_size = 3.5
 
 	befriend_job = "Chief Engineer"
@@ -159,6 +162,7 @@
 	icon_dead = "babycarp_dead"
 	icon_gib = null
 	can_nap = TRUE
+	has_toxingland = TRUE
 	gender = NEUTER
 	mob_size = 3.5
 	holder_type = /obj/item/holder/carp/baby

--- a/code/modules/mob/living/simple_animal/friendly/carp.dm
+++ b/code/modules/mob/living/simple_animal/friendly/carp.dm
@@ -9,7 +9,6 @@
 	icon_gib = "carp_gib"
 	icon_rest = "carp_rest"
 	can_nap = TRUE
-	has_toxingland = TRUE
 	speak = list("Glub!", "Glub?", "Glub.")
 	speak_emote = list("glubs", "glibs")
 	emote_hear = list("glubs","glibs")
@@ -25,6 +24,11 @@
 	gender = NEUTER
 	faction = "carp"
 	flying = TRUE
+
+	can_be_milked = TRUE
+	udder_size = 3
+	milk_type = /singleton/reagent/toxin/carpotoxin
+	milk_regeneration = list(1, 2)
 
 	//Space carp aren't affected by atmos.
 	min_oxy = 0
@@ -142,8 +146,13 @@
 	emote_see = list("floats steadily", "inflates her gills", "flaps her flippers", "wiggles", "waggles")
 
 	can_nap = TRUE
-	has_toxingland = TRUE
 	mob_size = 3.5
+
+	// Actually cannot be milked, but this way we get the error message.
+	can_be_milked = TRUE
+	udder_size = 2
+	milk_type = /singleton/reagent/toxin/carpotoxin
+	milk_regeneration = list(1, 1)
 
 	befriend_job = "Chief Engineer"
 	holder_type = /obj/item/holder/carp/baby
@@ -151,6 +160,9 @@
 /mob/living/simple_animal/carp/fluff/ginny/death()
 	.=..()
 	desc = "WHO KILLED GINNY?!"
+
+/mob/living/simple_animal/carp/fluff/ginny/handle_milking(mob/user, obj/item/reagent_containers/container)
+	user.visible_message("[SPAN_BOLD("Ginny")] shies away from the [container] and stares at [SPAN_BOLD("[user]")] judgementally.")
 
 /mob/living/simple_animal/carp/baby
 	name = "baby space carp"
@@ -161,7 +173,6 @@
 	icon_dead = "babycarp_dead"
 	icon_gib = null
 	can_nap = TRUE
-	has_toxingland = TRUE
 	gender = NEUTER
 	mob_size = 3.5
 	holder_type = /obj/item/holder/carp/baby

--- a/code/modules/mob/living/simple_animal/friendly/carp.dm
+++ b/code/modules/mob/living/simple_animal/friendly/carp.dm
@@ -162,7 +162,8 @@
 	desc = "WHO KILLED GINNY?!"
 
 /mob/living/simple_animal/carp/fluff/ginny/handle_milking(mob/user, obj/item/reagent_containers/container)
-	user.visible_message("[SPAN_BOLD("Ginny")] shies away from the [container] and stares at [SPAN_BOLD("[user]")] judgementally.")
+	//user.visible_message("[SPAN_BOLD("Ginny")] shies away from the [container] and stares at [SPAN_BOLD("[user]")] judgementally.")
+	user.visible_message("[pick("[SPAN_BOLD("Ginny")] shies away from the [container] and stares at [SPAN_BOLD("[user]")] judgementally.", "[SPAN_BOLD("Ginny")] recoils from [SPAN_BOLD("[user]")] with an indignant glub.", "[SPAN_BOLD("Ginny")] bares her tiny fangs and evades the [container].", "[SPAN_BOLD("Ginny")] stretches a flipper out and pushes the [container] away.")]")
 
 /mob/living/simple_animal/carp/baby
 	name = "baby space carp"

--- a/code/modules/mob/living/simple_animal/friendly/carp.dm
+++ b/code/modules/mob/living/simple_animal/friendly/carp.dm
@@ -142,8 +142,7 @@
 	emote_see = list("floats steadily", "inflates her gills", "flaps her flippers", "wiggles", "waggles")
 
 	can_nap = TRUE
-	has_toxingland = FALSE
-	is_Ginny = TRUE
+	has_toxingland = TRUE
 	mob_size = 3.5
 
 	befriend_job = "Chief Engineer"

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -27,7 +27,7 @@
 	udder = null
 	canbrush = TRUE
 	emote_sounds = list('sound/effects/creatures/goat.ogg')
-	has_udder = TRUE
+	can_be_milked = TRUE
 	hostile_nameable = TRUE
 
 	butchering_products = list(/obj/item/stack/material/animalhide = 3)
@@ -99,7 +99,7 @@
 	mob_size = 20//based on mass of holstein fresian dairy cattle, what the sprite is based on
 	emote_sounds = list('sound/effects/creatures/cow.ogg')
 	canbrush = TRUE
-	has_udder = TRUE
+	can_be_milked = TRUE
 	butchering_products = list(/obj/item/stack/material/animalhide = 8)
 	forbidden_foods = list(/obj/item/reagent_containers/food/snacks/egg)
 

--- a/code/modules/mob/living/simple_animal/friendly/hakhma.dm
+++ b/code/modules/mob/living/simple_animal/friendly/hakhma.dm
@@ -25,5 +25,5 @@
 
 	mob_size = 15
 
-	has_udder = TRUE
+	can_be_milked = TRUE
 	milk_type = /singleton/reagent/drink/milk/beetle

--- a/code/modules/mob/living/simple_animal/friendly/schlorrgo.dm
+++ b/code/modules/mob/living/simple_animal/friendly/schlorrgo.dm
@@ -26,7 +26,7 @@
 	maxHealth = 30
 	health = 30
 
-	has_udder = TRUE
+	can_be_milked = TRUE
 	milk_type = /singleton/reagent/drink/milk/schlorrgo
 
 	friendly = "bumped"
@@ -235,7 +235,7 @@
 	maxHealth = 80
 	health = 80
 
-	has_udder = FALSE
+	can_be_milked = FALSE
 
 	organ_names = list("head", "chest", "augmented core", "augmented torso", "robotic centre", "left leg", "right leg")
 	butchering_products = list(/obj/item/reagent_containers/food/snacks/spreads/lard = 1)

--- a/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
@@ -17,11 +17,15 @@
 	response_help = "pets the"
 	response_disarm = "gently pushes aside the"
 	response_harm = "hits the"
-	has_toxingland = TRUE
 	speed = 4
 	maxHealth = 25
 	health = 25
 	mob_size = 10
+
+	can_be_milked = TRUE
+	udder_size = 3
+	milk_type = /singleton/reagent/toxin/carpotoxin
+	milk_regeneration = list(1, 2)
 
 	blood_overlay_icon = 'icons/mob/npc/blood_overlay_carp.dmi'
 	harm_intent_damage = 4

--- a/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_fauna.dm
@@ -17,6 +17,7 @@
 	response_help = "pets the"
 	response_disarm = "gently pushes aside the"
 	response_harm = "hits the"
+	has_toxingland = TRUE
 	speed = 4
 	maxHealth = 25
 	health = 25

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -139,16 +139,17 @@
 
 	var/flying = FALSE //if they can fly, which stops them from falling down and allows z-space travel
 
-	var/has_udder = FALSE
+	/// Whether this animal can be milked or not.
+	var/can_be_milked = FALSE
+	/// The reagent storage for the animal's milking product.
 	var/datum/reagents/udder = null
+	/// The size of the udder's reagent storage.
+	var/udder_size = 50
+	/// The minimum and upper floor of the per-tick milk regeneration to feed into rand(). This list should always have both minimum and upper floor.
+	/// This is also how much milk is taken from the animal at once.
+	var/list/milk_regeneration = list(5, 10)
+	/// What the animal's milking product is.
 	var/milk_type = /singleton/reagent/drink/milk
-
-	var/has_toxingland = FALSE
-	/// Defines whether or not this creature has a carpotoxin gland.
-	var/datum/reagents/toxingland = null
-	/// The contents of the toxin gland should always be carpotoxin.
-	var/toxin_type = /singleton/reagent/toxin/carpotoxin
-
 
 	var/list/butchering_products	//if anything else is created when butchering this creature, like bones and leather
 
@@ -188,13 +189,9 @@
 		reagents = new/datum/reagents(20, src)
 	nutrition = max_nutrition
 
-	if(has_udder)
-		udder = new(50)
+	if(can_be_milked)
+		udder = new(udder_size)
 		udder.my_atom = src
-
-	if(has_toxingland)
-		toxingland = new(2)
-		toxingland.my_atom = src
 
 	if(LAZYLEN(natural_armor))
 		AddComponent(armor_type, natural_armor)
@@ -322,14 +319,10 @@
 	if(!atmos_suitable)
 		apply_damage(unsuitable_atoms_damage, DAMAGE_OXY, used_weapon = "Atmosphere")
 
-	if(has_udder)
+	if(can_be_milked)
 		if(stat == CONSCIOUS)
 			if(udder && prob(5))
-				udder.add_reagent(milk_type, rand(5, 10))
-
-	if(has_toxingland && (stat == CONSCIOUS) && toxingland)
-		if(prob(3))
-			toxingland.add_reagent(toxin_type, rand(1, 2))
+				udder.add_reagent(milk_type, rand(milk_regeneration[1], milk_regeneration[2]))
 
 	return 1
 
@@ -592,37 +585,13 @@
 		qdel(attacking_item)
 		qdel(src)
 
-	if(istype(attacking_item, /obj/item/reagent_containers/glass/rag)) //You can't milk an udder with a rag.
-		attacked_with_item(attacking_item, user)
-		return
-	if(has_udder)
+	if(can_be_milked)
 		var/obj/item/reagent_containers/glass/G = attacking_item
+		if(istype(G, /obj/item/reagent_containers/glass/rag)) //You can't milk an udder with a rag.
+			attacked_with_item(attacking_item, user)
+			return
 		if(stat == CONSCIOUS && istype(G) && G.is_open_container())
-			if(udder.total_volume <= 0)
-				to_chat(user, SPAN_WARNING("The udder is dry."))
-				return
-			if(G.reagents.total_volume >= G.volume)
-				to_chat(user, SPAN_WARNING("The [attacking_item] is full."))
-				return
-			user.visible_message("<b>\The [user]</b> milks \the [src] using \the [attacking_item].")
-			udder.trans_type_to(G, milk_type, rand(5, 10))
-			return
-
-	if(has_toxingland && stat == CONSCIOUS)
-		var/obj/item/reagent_containers/glass/ctcontainer = attacking_item
-		if(istype(src, /mob/living/simple_animal/carp/fluff/ginny) && istype(ctcontainer) && ctcontainer.is_open_container())
-			user.visible_message("[SPAN_BOLD("Ginny")] shies away from the [attacking_item] and stares at [SPAN_BOLD("The [user]")] judgementally.")
-			return
-		if(stat == CONSCIOUS && istype(ctcontainer) && ctcontainer.is_open_container())
-			if(toxingland.total_volume <= 0)
-				to_chat(user, SPAN_WARNING("There is no toxin left to harvest."))
-				return
-			if(ctcontainer.reagents.total_volume >= ctcontainer.volume)
-				to_chat(user, SPAN_WARNING("The [attacking_item] is full."))
-				return
-			user.visible_message("[SPAN_BOLD("The [user]")] extracts some toxin from \the [src].")
-			toxingland.trans_type_to(ctcontainer, toxin_type, rand(1, 2))
-			return
+			handle_milking(user, G)
 
 	if(istype(attacking_item, /obj/item/reagent_containers) || istype(attacking_item, /obj/item/stack/medical) || istype(attacking_item,/obj/item/gripper/))
 		..()
@@ -1048,6 +1017,16 @@
 
 /mob/living/simple_animal/InStasis()
 	return in_stasis
+
+/mob/living/simple_animal/proc/handle_milking(mob/user, obj/item/reagent_containers/container)
+	if(udder.total_volume <= 0)
+		to_chat(user, SPAN_WARNING("The udder is dry."))
+		return
+	if(container.reagents.total_volume >= container.volume)
+		to_chat(user, SPAN_WARNING("The [container] is full."))
+		return
+	user.visible_message("<b>\The [user]</b> milks \the [src] using \the [container].")
+	udder.trans_type_to(container, milk_type, rand(milk_regeneration[1], milk_regeneration[2]))
 
 #undef BLOOD_NONE
 #undef BLOOD_LIGHT

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -144,8 +144,10 @@
 	var/milk_type = /singleton/reagent/drink/milk
 
 	var/has_toxingland = FALSE
+	/// Defines whether or not this creature has a carpotoxin gland.
 	var/datum/reagents/toxingland = null
 	var/toxin_type = /singleton/reagent/toxin/carpotoxin
+	/// The contents of the toxin gland should always be carpotoxin.
 
 
 	var/list/butchering_products	//if anything else is created when butchering this creature, like bones and leather
@@ -325,10 +327,9 @@
 			if(udder && prob(5))
 				udder.add_reagent(milk_type, rand(5, 10))
 
-	if(has_toxingland)
-		if(stat == CONSCIOUS)
-			if(toxingland && prob(3))
-				toxingland.add_reagent(toxin_type, rand(1, 2))
+	if(has_toxingland && (stat == CONSCIOUS) && toxingland)
+		if(prob(3))
+			toxingland.add_reagent(toxin_type, rand(1, 2))
 
 	return 1
 
@@ -607,10 +608,10 @@
 			udder.trans_type_to(G, milk_type, rand(5, 10))
 			return
 
-	if(has_toxingland)
+	if(has_toxingland && stat == CONSCIOUS)
 		var/obj/item/reagent_containers/glass/ctcontainer = attacking_item
-		if(istype(src, /mob/living/simple_animal/carp/fluff/ginny))
-			user.visible_message("[SPAN_BOLD("Ginny")] shies away from the [attacking_item] and stares at <b>\The [user]</b> judgementally.")
+		if(istype(src, /mob/living/simple_animal/carp/fluff/ginny) && istype(ctcontainer) && ctcontainer.is_open_container())
+			user.visible_message("[SPAN_BOLD("Ginny")] shies away from the [attacking_item] and stares at [SPAN_BOLD("The [user]")] judgementally.")
 			return
 		if(stat == CONSCIOUS && istype(ctcontainer) && ctcontainer.is_open_container())
 			if(toxingland.total_volume <= 0)
@@ -619,7 +620,7 @@
 			if(ctcontainer.reagents.total_volume >= ctcontainer.volume)
 				to_chat(user, SPAN_WARNING("The [attacking_item] is full."))
 				return
-			user.visible_message("<b>\The [user]</b> extracts some toxin from \the [src].")
+			user.visible_message("[SPAN_BOLD("The [user]")] extracts some toxin from \the [src].")
 			toxingland.trans_type_to(ctcontainer, toxin_type, rand(1, 2))
 			return
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -1020,7 +1020,7 @@
 
 /mob/living/simple_animal/proc/handle_milking(mob/user, obj/item/reagent_containers/container)
 	if(udder.total_volume <= 0)
-		to_chat(user, SPAN_WARNING("The udder is dry."))
+		to_chat(user, SPAN_WARNING("There is nothing left to collect."))
 		return
 	if(container.reagents.total_volume >= container.volume)
 		to_chat(user, SPAN_WARNING("The [container] is full."))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -147,7 +147,6 @@
 	var/datum/reagents/toxingland = null
 	var/toxin_type = /singleton/reagent/toxin/carpotoxin
 
-	var/is_Ginny = FALSE
 
 	var/list/butchering_products	//if anything else is created when butchering this creature, like bones and leather
 
@@ -192,7 +191,7 @@
 		udder.my_atom = src
 
 	if(has_toxingland)
-		toxingland = new(5)
+		toxingland = new(2)
 		toxingland.my_atom = src
 
 	if(LAZYLEN(natural_armor))
@@ -328,7 +327,7 @@
 
 	if(has_toxingland)
 		if(stat == CONSCIOUS)
-			if(toxingland &&prob(2))
+			if(toxingland && prob(3))
 				toxingland.add_reagent(toxin_type, rand(1, 2))
 
 	return 1
@@ -609,22 +608,19 @@
 			return
 
 	if(has_toxingland)
-		var/obj/item/reagent_containers/glass/Test = attacking_item
-		if(stat == CONSCIOUS && istype(Test) && Test.is_open_container())
+		var/obj/item/reagent_containers/glass/ctcontainer = attacking_item
+		if(istype(src, /mob/living/simple_animal/carp/fluff/ginny))
+			user.visible_message("[SPAN_BOLD("Ginny")] shies away from the [attacking_item] and stares at <b>\The [user]</b> judgementally.")
+			return
+		if(stat == CONSCIOUS && istype(ctcontainer) && ctcontainer.is_open_container())
 			if(toxingland.total_volume <= 0)
 				to_chat(user, SPAN_WARNING("There is no toxin left to harvest."))
 				return
-			if(Test.reagents.total_volume >= Test.volume)
+			if(ctcontainer.reagents.total_volume >= ctcontainer.volume)
 				to_chat(user, SPAN_WARNING("The [attacking_item] is full."))
 				return
 			user.visible_message("<b>\The [user]</b> extracts some toxin from \the [src].")
-			toxingland.trans_type_to(Test, toxin_type, rand(1, 3))
-			return
-
-	if(is_Ginny)
-		var/obj/item/reagent_containers/glass/beaker/Test = attacking_item
-		if(stat == CONSCIOUS && istype(Test) && Test.is_open_container())
-			user.visible_message("Ginny shies away and stares at <b>\The [user]</b> judgementally.")
+			toxingland.trans_type_to(ctcontainer, toxin_type, rand(1, 2))
 			return
 
 	if(istype(attacking_item, /obj/item/reagent_containers) || istype(attacking_item, /obj/item/stack/medical) || istype(attacking_item,/obj/item/gripper/))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -146,8 +146,8 @@
 	var/has_toxingland = FALSE
 	/// Defines whether or not this creature has a carpotoxin gland.
 	var/datum/reagents/toxingland = null
-	var/toxin_type = /singleton/reagent/toxin/carpotoxin
 	/// The contents of the toxin gland should always be carpotoxin.
+	var/toxin_type = /singleton/reagent/toxin/carpotoxin
 
 
 	var/list/butchering_products	//if anything else is created when butchering this creature, like bones and leather

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -143,6 +143,12 @@
 	var/datum/reagents/udder = null
 	var/milk_type = /singleton/reagent/drink/milk
 
+	var/has_toxingland = FALSE
+	var/datum/reagents/toxingland = null
+	var/toxin_type = /singleton/reagent/toxin/carpotoxin
+
+	var/is_Ginny = FALSE
+
 	var/list/butchering_products	//if anything else is created when butchering this creature, like bones and leather
 
 	var/psi_pingable = TRUE
@@ -184,6 +190,10 @@
 	if(has_udder)
 		udder = new(50)
 		udder.my_atom = src
+
+	if(has_toxingland)
+		toxingland = new(5)
+		toxingland.my_atom = src
 
 	if(LAZYLEN(natural_armor))
 		AddComponent(armor_type, natural_armor)
@@ -315,6 +325,11 @@
 		if(stat == CONSCIOUS)
 			if(udder && prob(5))
 				udder.add_reagent(milk_type, rand(5, 10))
+
+	if(has_toxingland)
+		if(stat == CONSCIOUS)
+			if(toxingland &&prob(2))
+				toxingland.add_reagent(toxin_type, rand(1, 2))
 
 	return 1
 
@@ -591,6 +606,25 @@
 				return
 			user.visible_message("<b>\The [user]</b> milks \the [src] using \the [attacking_item].")
 			udder.trans_type_to(G, milk_type, rand(5, 10))
+			return
+
+	if(has_toxingland)
+		var/obj/item/reagent_containers/glass/Test = attacking_item
+		if(stat == CONSCIOUS && istype(Test) && Test.is_open_container())
+			if(toxingland.total_volume <= 0)
+				to_chat(user, SPAN_WARNING("There is no toxin left to harvest."))
+				return
+			if(Test.reagents.total_volume >= Test.volume)
+				to_chat(user, SPAN_WARNING("The [attacking_item] is full."))
+				return
+			user.visible_message("<b>\The [user]</b> extracts some toxin from \the [src].")
+			toxingland.trans_type_to(Test, toxin_type, rand(1, 3))
+			return
+
+	if(is_Ginny)
+		var/obj/item/reagent_containers/glass/beaker/Test = attacking_item
+		if(stat == CONSCIOUS && istype(Test) && Test.is_open_container())
+			user.visible_message("Ginny shies away and stares at <b>\The [user]</b> judgementally.")
 			return
 
 	if(istype(attacking_item, /obj/item/reagent_containers) || istype(attacking_item, /obj/item/stack/medical) || istype(attacking_item,/obj/item/gripper/))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -265,17 +265,9 @@
 			if(C.has_udder)
 				return
 
-		if(istype(target, /mob/living/simple_animal/carp))
-			var/mob/living/simple_animal/spaceCarp = target
-			if(spaceCarp.has_toxingland)
-				return
-
-		if(istype(target, /mob/living/simple_animal/carp/fluff/ginny))
-			return
-
-		if(istype(target, /mob/living/simple_animal/hostile/carp))
-			var/mob/living/simple_animal/HostileCarp = target
-			if(HostileCarp.has_toxingland)
+		if(is_type_in_list(target, list(/mob/living/simple_animal/carp, /mob/living/simple_animal/hostile/carp)))
+			var/mob/living/simple_animal/carp_being_fed = target
+			if(istype(carp_being_fed, /mob/living/simple_animal/carp/fluff/ginny) || carp_being_fed.has_toxingland)
 				return
 
 		other_feed_message_start(user, target)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -238,6 +238,14 @@
 	if(istype(target, /mob/living/carbon/human))
 		H = target
 
+	var/mob/living/simple_animal/F //F for Fish
+	if(istype(target, /mob/living/simple_animal/carp))
+		F = target
+
+	var/mob/living/simple_animal/HC //G = Hostile Carp
+	if(istype(target, /mob/living/simple_animal/hostile/carp))
+		G = target
+
 	if(target == user)
 		if(istype(user, /mob/living/carbon/human))
 			H = user
@@ -263,6 +271,18 @@
 		if(isanimal(target))
 			var/mob/living/simple_animal/C = target
 			if(C.has_udder)
+				return
+
+		if(istype(target, /mob/living/simple_animal/carp))
+			F = target
+			if(F.has_toxingland)
+				return
+			if(F.is_Ginny)
+				return
+
+		if(istype(target, /mob/living/simple_animal/hostile/carp))
+			G = target
+			if(G.has_toxingland)
 				return
 
 		other_feed_message_start(user, target)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -242,7 +242,7 @@
 	if(istype(target, /mob/living/simple_animal/carp))
 		F = target
 
-	var/mob/living/simple_animal/HC //G = Hostile Carp
+	var/mob/living/simple_animal/G //G = Hostile Carp
 	if(istype(target, /mob/living/simple_animal/hostile/carp))
 		G = target
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -238,14 +238,6 @@
 	if(istype(target, /mob/living/carbon/human))
 		H = target
 
-	var/mob/living/simple_animal/F //F for Fish
-	if(istype(target, /mob/living/simple_animal/carp))
-		F = target
-
-	var/mob/living/simple_animal/G //G = Hostile Carp
-	if(istype(target, /mob/living/simple_animal/hostile/carp))
-		G = target
-
 	if(target == user)
 		if(istype(user, /mob/living/carbon/human))
 			H = user
@@ -274,15 +266,16 @@
 				return
 
 		if(istype(target, /mob/living/simple_animal/carp))
-			F = target
-			if(F.has_toxingland)
-				return
-			if(F.is_Ginny)
+			var/mob/living/simple_animal/spaceCarp = target
+			if(spaceCarp.has_toxingland)
 				return
 
+		if(istype(target, /mob/living/simple_animal/carp/fluff/ginny))
+			return
+
 		if(istype(target, /mob/living/simple_animal/hostile/carp))
-			G = target
-			if(G.has_toxingland)
+			var/mob/living/simple_animal/HostileCarp = target
+			if(HostileCarp.has_toxingland)
 				return
 
 		other_feed_message_start(user, target)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -262,12 +262,7 @@
 
 		if(isanimal(target))
 			var/mob/living/simple_animal/C = target
-			if(C.has_udder)
-				return
-
-		if(is_type_in_list(target, list(/mob/living/simple_animal/carp, /mob/living/simple_animal/hostile/carp)))
-			var/mob/living/simple_animal/carp_being_fed = target
-			if(istype(carp_being_fed, /mob/living/simple_animal/carp/fluff/ginny) || carp_being_fed.has_toxingland)
+			if(C.can_be_milked)
 				return
 
 		other_feed_message_start(user, target)

--- a/html/changelogs/ASmallCuteCat - carp-diem.yml
+++ b/html/changelogs/ASmallCuteCat - carp-diem.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ASmallCuteCat
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added the ability to harmlessly harvest small quantities of carpotoxin from space carps."
+  - qol: "Non-hostile space carps are now identified as tame, to avoid confusion. Added several new idle emotes to space carps."
+


### PR DESCRIPTION
Adds the ability to obtain small amounts carpotoxin from space carps without having to kill them! Beakers and buckets work, currently, I do not believe eyedroppers or syringes can be used to do this.

Friendly space carps are now identified as being tame, and I have also given them a few new idle emotes for additional cuteness.

You can harvest carpotoxin from hostile space carps, but good luck trying to do that while they're chomping your fingers...