### PR TITLE
IPC Memory Wiper - Moving Lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/operations.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/operations.dm
@@ -30,6 +30,7 @@
 	new /obj/item/gun/energy/disruptorpistol/miniature(src)
 	new /obj/item/clothing/accessory/holster/waist(src)
 	new /obj/item/device/price_scanner(src)
+	new /obj/item/device/memorywiper(src)
 
 // Hangar Technician
 /obj/structure/closet/secure_closet/hangar_tech

--- a/code/game/objects/structures/crates_lockers/closets/secure/operations.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/operations.dm
@@ -29,8 +29,8 @@
 	new /obj/item/device/flashlight/marshallingwand(src)
 	new /obj/item/gun/energy/disruptorpistol/miniature(src)
 	new /obj/item/clothing/accessory/holster/waist(src)
-	new /obj/item/device/price_scanner(src)
 	new /obj/item/device/memorywiper(src)
+	new /obj/item/device/price_scanner(src)
 
 // Hangar Technician
 /obj/structure/closet/secure_closet/hangar_tech

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -44,7 +44,6 @@
 	new /obj/item/taperoll/science(src)
 	new /obj/item/gun/energy/disruptorpistol/miniature(src)
 	new /obj/item/clothing/accessory/holster/waist(src)
-	new /obj/item/device/memorywiper(src)
 	new /obj/item/storage/box/psireceiver(src)
 	new /obj/item/device/megaphone/sci(src)
 	new /obj/item/device/taperecorder(src)

--- a/html/changelogs/courierbravo-memorywiper-move.yml
+++ b/html/changelogs/courierbravo-memorywiper-move.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: CourierBravo
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added the memory wiper to the Operations Manager's locker."
+  - rscdel: "Removed the memory wiper from the Research Director's locker."


### PR DESCRIPTION
Moves the IPC memory wiper from the RD's locker to the OM's locker. It makes more sense for the OM to have it, since the Machinist is an operations overseen job, not a science overseen job.