### PR TITLE
Fixes Hivenet transmissions for characters with mononyms

### DIFF
--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -281,15 +281,16 @@
 /datum/language/bug/format_message(message, verb, speaker_mask)
 	var/message_color = colour
 	var/list/speaker_surname = splittext(speaker_mask, " ")
-	switch(speaker_surname[2])
-		if("Zo'ra")
-			message_color = "vaurca_zora"
-		if("C'thur")
-			message_color = "vaurca_cthur"
-		if("K'lax")
-			message_color = "vaurca_klax"
-		if("Lii'dra")
-			message_color = "vaurca_liidra"
+	if(length(speaker_surname) > 1)
+		switch(speaker_surname[2])
+			if("Zo'ra")
+				message_color = "vaurca_zora"
+			if("C'thur")
+				message_color = "vaurca_cthur"
+			if("K'lax")
+				message_color = "vaurca_klax"
+			if("Lii'dra")
+				message_color = "vaurca_liidra"
 	if(copytext(message, 1, 2) == "!")
 		return " projects <span class='message'><span class='[message_color]'>[copytext(message, 2)]</span></span>"
 	return "[verb], <span class='message'><span class='[message_color]'>\"[capitalize(message)]\"</span></span>"

--- a/html/changelogs/SimpleMaroon-ipchivenetfix.yml
+++ b/html/changelogs/SimpleMaroon-ipchivenetfix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: SimpleMaroon
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed characters with mononyms being unable to broadcast Hivenet using the Phalanx Receiver properly."


### PR DESCRIPTION
mainly for ipc characters with mononyms, who would otherwise transmit blank messages before the bugfix, like so:
![image](https://github.com/user-attachments/assets/347d1e7d-830d-4e18-ad20-05c455b70efc)
