### PR TITLE
Changed minimum IPC heights to reflect lore

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc.dm
@@ -5,7 +5,7 @@
 	category_name = "Integrated Positronic Chassis"
 	bodytype = BODYTYPE_IPC
 	species_height = HEIGHT_CLASS_SHORT
-	height_min = 100
+	height_min = 120
 	height_max = 250
 	age_min = 1
 	age_max = 60

--- a/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
+++ b/code/modules/mob/living/carbon/human/species/station/ipc/ipc_subspecies.dm
@@ -5,7 +5,7 @@
 	name_plural = "Shells"
 	bodytype = BODYTYPE_HUMAN
 	species_height = HEIGHT_CLASS_AVERAGE
-	height_min = 140
+	height_min = 145
 	height_max = 230
 	default_genders = list(MALE, FEMALE)
 	selectable_pronouns = list(MALE, FEMALE, PLURAL, NEUTER)
@@ -129,6 +129,7 @@
 	bald = 1
 	bodytype = BODYTYPE_IPC_INDUSTRIAL
 	species_height = HEIGHT_CLASS_HUGE
+	height_min = 180
 	mob_size = 12
 
 	unarmed_types = list(/datum/unarmed_attack/industrial, /datum/unarmed_attack/palm/industrial)
@@ -359,6 +360,7 @@
 	short_name = "xmf"
 	bodytype = BODYTYPE_IPC_INDUSTRIAL
 	species_height = HEIGHT_CLASS_TALL
+	height_min = 180
 
 	icobase = 'icons/mob/human_races/ipc/r_ind_xion.dmi'
 	deform = 'icons/mob/human_races/ipc/r_ind_xion.dmi'

--- a/html/changelogs/GeneralCamo - IPC Minimum Height.yml
+++ b/html/changelogs/GeneralCamo - IPC Minimum Height.yml
@@ -44,7 +44,7 @@
 #################################
 
 # Your name.
-author: ChangeMe
+author: GeneralCamo
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True

--- a/html/changelogs/GeneralCamo - IPC Minimum Height.yml
+++ b/html/changelogs/GeneralCamo - IPC Minimum Height.yml
@@ -1,0 +1,60 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: ChangeMe
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Changed the minimum height of baseline, bishop, and mobility IPCs from 100cm to 120cm."
+  - qol: "Changed the minimum height of shell IPCs from 100cm to 145cm."
+  - qol: "Changed the minimum height of G1, G2, and xion IPCs from 100cm to 180cm."


### PR DESCRIPTION
Per NobleRow:
![image](https://github.com/user-attachments/assets/6812f9fd-54e7-4671-9a71-b1e2ce4076af)

The extremely low values were questioned for IPCs. The old values were really small. This fixes it to lore-accurate values.