### PR TITLE
Kataphract bugfixes

### DIFF
--- a/html/changelogs/hazelmouse-katafixes.yml
+++ b/html/changelogs/hazelmouse-katafixes.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Resolved a few bugs with the Kataphract offship, including reducing its spawn weight and making it properly targetable in ship combat."

--- a/maps/away/ships/kataphracts/kataphract_ship.dm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dm
@@ -10,7 +10,6 @@
 	spawn_weight = 1
 	spawn_weight_sector_dependent = list(SECTOR_UUEOAESA = 1.5)
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_TAU_CETI, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_UUEOAESA, SECTOR_WEEPING_STARS)
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/kataphract_transport)
 	unit_test_groups = list(3)
 

--- a/maps/away/ships/kataphracts/kataphract_ship.dm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dm
@@ -7,9 +7,10 @@
 	suffix = "kataphract_ship.dmm"
 
 	ship_cost = 1
-	spawn_weight = 9
+	spawn_weight = 1
 	spawn_weight_sector_dependent = list(SECTOR_UUEOAESA = 1.5)
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_TAU_CETI, SECTOR_CORP_ZONE, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_UUEOAESA, SECTOR_WEEPING_STARS)
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/kataphract_transport)
 	unit_test_groups = list(3)
 
@@ -31,7 +32,7 @@
 	shiptype = "Specialist long-distance extended-duration combat utility"
 	vessel_mass = 10000
 	max_speed = 1/(2 SECONDS)
-	fore_dir = NORTH
+	fore_dir = SOUTH
 	vessel_size = SHIP_SIZE_SMALL
 	initial_generic_waypoints = list(
 		"nav_kataphract_ship_1",
@@ -110,7 +111,7 @@
 	max_speed = 1/(3 SECONDS)
 	burn_delay = 2 SECONDS
 	vessel_mass = 6000 //Ship has a lot of thrusters, so if its too low the shuttle goes too fast. Also, imagine a hard egg flying towards you.
-	fore_dir = WEST
+	fore_dir = NORTH
 	vessel_size = SHIP_SIZE_TINY
 
 /obj/machinery/computer/shuttle_control/explore/terminal/kataphract_transport

--- a/maps/away/ships/kataphracts/kataphract_ship.dmm
+++ b/maps/away/ships/kataphracts/kataphract_ship.dmm
@@ -137,18 +137,12 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/kataphract_chapter/sparring_chamber)
 "at" = (
-/obj/effect/map_effect/window_spawner/full/shuttle/mercenary{
-	spawn_firedoor = 1;
-	spawn_grille = 1
+/obj/machinery/atmospherics/unary/engine,
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, port thrusters"
 	},
-/obj/machinery/door/blast/regular/open{
-	id = "katamess"
-	},
-/obj/effect/landmark/entry_point/starboard{
-	name = "starboard, francisca"
-	},
-/turf/simulated/floor/plating,
-/area/kataphract_chapter/mess)
+/turf/simulated/floor/airless,
+/area/kataphract_chapter/portpropulsion)
 "au" = (
 /obj/effect/step_trigger/teleporter,
 /turf/space/transit/east,
@@ -268,7 +262,7 @@
 /area/kataphract_chapter/frankie)
 "aS" = (
 /obj/effect/landmark/entry_point/starboard{
-	name = "starboard, francisca"
+	name = "starboard, reactor"
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/kataphract_chapter/engineering)
@@ -536,11 +530,11 @@
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/kataphract_chapter/portpropulsion)
 "ca" = (
-/obj/effect/landmark/entry_point/north{
-	name = "north, bruiser"
+/obj/effect/landmark/entry_point/port{
+	name = "port, CIC"
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/kataphract_chapter/frankie)
+/area/kataphract_chapter/cic)
 "cb" = (
 /obj/machinery/computer/ship/helm/terminal,
 /turf/simulated/floor/tiled/full,
@@ -2051,7 +2045,7 @@
 /area/kataphract_chapter/sparring_chamber)
 "hr" = (
 /obj/effect/landmark/entry_point/starboard{
-	name = "starboard, francisca"
+	name = "starboard, rotary cannon"
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/kataphract_chapter/frankie)
@@ -3297,7 +3291,8 @@
 /obj/machinery/photocopier/faxmachine{
 	department = "HMV Supreme";
 	req_access = list(113);
-	req_one_access = null
+	req_one_access = null;
+	pixel_y = 5
 	},
 /obj/effect/floor_decal/corner_wide/dark_blue/full{
 	dir = 4
@@ -4213,20 +4208,27 @@
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/specoffice)
 "qz" = (
-/obj/effect/landmark/entry_point/port{
-	name = "port, thrusters"
+/obj/effect/landmark/entry_point/fore{
+	name = "fore, rotary cannon"
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/kataphract_chapter/portpropulsion)
+/area/kataphract_chapter/frankie)
 "qI" = (
 /turf/simulated/floor/wood,
 /area/kataphract_chapter/mess)
 "qK" = (
-/obj/effect/landmark/entry_point/starboard{
-	name = "starboard, francisca"
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary{
+	spawn_firedoor = 1;
+	spawn_grille = 1
 	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/kataphract_chapter/medical)
+/obj/machinery/door/blast/regular/open{
+	id = "katamess"
+	},
+/obj/effect/landmark/entry_point/starboard{
+	name = "starboard, kitchen"
+	},
+/turf/simulated/floor/plating,
+/area/kataphract_chapter/mess)
 "qM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -4475,12 +4477,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/kataphract_chapter/bruiser)
 "sG" = (
-/obj/machinery/atmospherics/unary/engine,
-/obj/effect/landmark/entry_point/south{
-	name = "south, port thrusters"
+/obj/effect/landmark/entry_point/port{
+	name = "port, propellant tank"
 	},
-/turf/simulated/floor/airless,
-/area/kataphract_chapter/portpropulsion)
+/turf/simulated/wall/shuttle/space_ship/mercenary,
+/area/kataphract_chapter/atmospherics)
 "sJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 9
@@ -4490,7 +4491,7 @@
 /area/kataphract_chapter/atmospherics)
 "sM" = (
 /obj/effect/landmark/entry_point/port{
-	name = "port, washroom"
+	name = "port, knightly quarters"
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/kataphract_chapter/specoffice)
@@ -4654,7 +4655,7 @@
 /area/kataphract_chapter/armoury)
 "uF" = (
 /obj/effect/landmark/entry_point/port{
-	name = "port, bruiser"
+	name = "port, bruiser cannon"
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/kataphract_chapter/bruiser)
@@ -4890,10 +4891,16 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/sparring_chamber)
 "yh" = (
-/obj/effect/landmark/entry_point/starboard{
-	name = "starboard, shuttle"
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary{
+	spawn_firedoor = 1
 	},
-/turf/simulated/wall/shuttle/space_ship/mercenary,
+/obj/machinery/door/blast/regular/open{
+	id = "kataphract_shuttle_shutters"
+	},
+/obj/effect/landmark/entry_point/east{
+	name = "starboard"
+	},
+/turf/simulated/floor/plating,
 /area/shuttle/kataphract_shuttle/main_compartment)
 "yi" = (
 /turf/simulated/wall/shuttle/space_ship/mercenary,
@@ -5117,8 +5124,8 @@
 	dir = 8;
 	id = "katabridgeshutter"
 	},
-/obj/effect/landmark/entry_point/north{
-	name = "north, bridge"
+/obj/effect/landmark/entry_point/fore{
+	name = "fore, bridge"
 	},
 /turf/simulated/floor/plating,
 /area/kataphract_chapter/bridge)
@@ -5303,15 +5310,15 @@
 	pixel_x = -28;
 	dir = 2
 	},
-/obj/effect/landmark/entry_point/north{
-	name = "north, airlock"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/airlock_sensor{
 	pixel_x = -28;
 	pixel_y = -8
+	},
+/obj/effect/landmark/entry_point/north{
+	name = "aft, thrusters"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/kataphract_shuttle/main_compartment)
@@ -5978,11 +5985,11 @@
 /turf/simulated/floor/tiled/white,
 /area/kataphract_chapter/toilets)
 "IU" = (
-/obj/effect/landmark/entry_point/port{
-	name = "port, shuttle"
+/obj/effect/landmark/entry_point/starboard{
+	name = "starboard, medical"
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
-/area/shuttle/kataphract_shuttle/main_compartment)
+/area/kataphract_chapter/medical)
 "Jb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6032,8 +6039,8 @@
 /turf/simulated/floor/tiled,
 /area/kataphract_chapter/portentry)
 "JF" = (
-/obj/effect/landmark/entry_point/north{
-	name = "north, bruiser"
+/obj/effect/landmark/entry_point/fore{
+	name = "fore, bruiser cannon"
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/kataphract_chapter/bruiser)
@@ -6404,12 +6411,12 @@
 /obj/effect/map_effect/window_spawner/full/shuttle/mercenary{
 	spawn_firedoor = 1
 	},
-/obj/effect/landmark/entry_point/south{
-	name = "south, cockpit"
-	},
 /obj/machinery/door/blast/regular/open{
 	id = "kataphract_shuttle_shutters";
 	dir = 4
+	},
+/obj/effect/landmark/entry_point/south{
+	name = "fore, cockpit"
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/kataphract_shuttle/main_compartment)
@@ -7005,8 +7012,8 @@
 /area/kataphract_chapter/starentry)
 "SG" = (
 /obj/machinery/atmospherics/unary/engine,
-/obj/effect/landmark/entry_point/south{
-	name = "south, port thrusters"
+/obj/effect/landmark/entry_point/aft{
+	name = "aft, starboard thrusters"
 	},
 /turf/simulated/floor/airless,
 /area/kataphract_chapter/starboardpropulsion)
@@ -7038,25 +7045,17 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/kataphract_shuttle/main_compartment)
 "Td" = (
-/obj/structure/table/rack,
-/obj/item/clothing/shoes/sandals/caligae/socks,
-/obj/item/clothing/shoes/sandals/caligae/socks,
-/obj/item/clothing/shoes/sandals/caligae/socks,
-/obj/item/clothing/suit/armor/unathi/hegemony,
-/obj/item/clothing/suit/armor/unathi/hegemony,
-/obj/item/clothing/suit/armor/unathi/hegemony,
-/obj/item/clothing/head/helmet/unathi/hegemony,
-/obj/item/clothing/head/helmet/unathi/hegemony,
-/obj/item/clothing/head/helmet/unathi/hegemony,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/clothing/glasses/sunglasses,
-/obj/effect/floor_decal/corner/red{
-	dir = 9
+/obj/effect/map_effect/window_spawner/full/shuttle/mercenary{
+	spawn_firedoor = 1
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
-/area/kataphract_chapter/armoury)
+/obj/machinery/door/blast/regular/open{
+	id = "kataphract_shuttle_shutters"
+	},
+/obj/effect/landmark/entry_point/west{
+	name = "port"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/kataphract_shuttle/main_compartment)
 "Tf" = (
 /obj/effect/landmark/entry_point/port{
 	name = "port, washroom"
@@ -7550,7 +7549,7 @@
 /area/space)
 "ZJ" = (
 /obj/effect/landmark/entry_point/starboard{
-	name = "starboard, francisca"
+	name = "starboard, armory"
 	},
 /turf/simulated/wall/shuttle/space_ship/mercenary,
 /area/kataphract_chapter/armoury)
@@ -33143,8 +33142,8 @@ iB
 lz
 mQ
 mQ
+qK
 mQ
-at
 mQ
 lz
 iB
@@ -33388,7 +33387,7 @@ iB
 iB
 iB
 iB
-qK
+le
 le
 le
 le
@@ -33637,7 +33636,7 @@ op
 TM
 iT
 le
-le
+IU
 le
 le
 le
@@ -34920,7 +34919,7 @@ JW
 RL
 DT
 dW
-dW
+qz
 iB
 iB
 iB
@@ -35172,7 +35171,7 @@ dW
 dW
 dW
 dW
-ca
+dW
 iB
 iB
 iB
@@ -35885,8 +35884,8 @@ iB
 Bi
 Bi
 bO
-bO
 yh
+Bi
 Bi
 Bi
 Bi
@@ -37397,8 +37396,8 @@ iB
 Bi
 Bi
 bO
-bO
-IU
+Td
+Bi
 Bi
 Bi
 Bi
@@ -38403,7 +38402,7 @@ iB
 iB
 iB
 iB
-sG
+nM
 Xy
 cW
 an
@@ -38655,7 +38654,7 @@ iB
 iB
 iB
 iB
-nM
+at
 lf
 mt
 mA
@@ -39413,7 +39412,7 @@ iB
 iB
 dQ
 dQ
-qz
+dQ
 dQ
 dQ
 mP
@@ -39921,7 +39920,7 @@ iB
 iB
 mL
 mL
-mL
+sG
 mL
 mL
 mL
@@ -40181,7 +40180,7 @@ iB
 iB
 iB
 Rv
-Rv
+ca
 Rv
 Rv
 Rv

--- a/maps/away/ships/tramp_freighter/tramp_freighter.dm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter.dm
@@ -10,7 +10,6 @@
 	ship_cost = 1
 	id = "tramp_freighter"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/freighter_shuttle)
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 	unit_test_groups = list(3)
 

--- a/maps/away/ships/tramp_freighter/tramp_freighter.dm
+++ b/maps/away/ships/tramp_freighter/tramp_freighter.dm
@@ -10,6 +10,7 @@
 	ship_cost = 1
 	id = "tramp_freighter"
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/freighter_shuttle)
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 	unit_test_groups = list(3)
 


### PR DESCRIPTION
Resolves a few bugs and quirks of the Kataphract ship, including making the entry points properly functional for ship combat and reducing the spawn weight from 9 to 1.