### PR TITLE
Minor QoL Horizon tweaks

### DIFF
--- a/html/changelogs/hazelmouse-weirdquirks.yml
+++ b/html/changelogs/hazelmouse-weirdquirks.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - qol: "Resolves a few odd quirks of the Horizon's map, like misaligned objects. Patches a few holes in custodial access to maintenance, including to bar maintenance and behind the main lift."


### PR DESCRIPTION
Resolves a couple of the odd quirks on the Horizon that have piled up, including:

1. Aligning the cafe stools in the direction of the counter.
2. Fixing a misaligned APC in engineering maintenance.
3. Pixel shifting the bar glasses vendor so it doesn't overlap with the coffee machine.
4. Giving missing custodial access to a few maintenance hatches. Access on maintenance airlocks seems very inconsistent so I'm sure this isn't comprehensive, but janitors can now access bar maintenance, the areas of maintenance behind the main lift on deck two and three, and the area of maintenance between the garden and security maintenance. Custodial access appears separate from generic maintenance access, so I think it's just been forgotten in some recent remaps.
