### PR TITLE
Fixed a runtime on deletion of paper stacks due to erroneous conversion of datum bracket access

### DIFF
--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -10,9 +10,16 @@
 	throw_speed = 1
 	layer = ABOVE_OBJ_LAYER
 	attack_verb = list("bapped")
-	var/page = 1    // current page
-	var/list/pages = list()  // Ordered list of pages as they are to be displayed. Can be different order than src.contents.
-	var/amount = 0 // How many sheet
+
+	/// current page
+	var/page = 1
+
+	/// Ordered list of pages as they are to be displayed. Can be different order than src.contents.
+	var/list/pages = list()
+
+	/// How many sheet
+	var/amount = 0
+
 	drop_sound = 'sound/items/drop/paper.ogg'
 	pickup_sound = 'sound/items/pickup/paper.ogg'
 
@@ -203,7 +210,7 @@
 
 
 		if(pages.len <= 1)
-			var/obj/item/paper/P = src.vars[1]
+			var/obj/item/paper/P = src.pages[1]
 			if(istype(loc, /obj/item/gripper)) //Hacky but without it there's a ghost icon with grippers and it all spills on the floor.
 				var/obj/item/gripper/G = loc
 				G.drop(get_turf(src), usr, FALSE)

--- a/html/changelogs/fluffyghost-fixpaperstackremovalruntime.yml
+++ b/html/changelogs/fluffyghost-fixpaperstackremovalruntime.yml
@@ -1,0 +1,59 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed a runtime on deletion of paper stacks due to erroneous conversion of datum bracket access."
+  - code_imp: "Some DMDocs."


### PR DESCRIPTION
Fixed a runtime on deletion of paper stacks due to erroneous conversion of datum bracket access.
Some DMDocs.

Potentially fixes #19888 