### PR TITLE
Quick Armor Swap

### DIFF
--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -22,6 +22,7 @@
 			return
 
 		var/obj/item/clothing/accessory/A = attacking_item
+		A.before_attached(src, user)
 		if(can_attach_accessory(A))
 			user.drop_item()
 			attach_accessory(user, A)

--- a/code/modules/clothing/suits/modular_armor.dm
+++ b/code/modules/clothing/suits/modular_armor.dm
@@ -141,6 +141,14 @@
 		bomb = ARMOR_BOMB_PADDED
 	)
 
+/obj/item/clothing/accessory/armor_plate/before_attached(var/obj/item/clothing/clothing, var/mob/user)
+	if(!clothing.valid_accessory_slots || !(slot in clothing.valid_accessory_slots))
+		return
+	var/obj/item/clothing/accessory/armor_plate/existing_plate = locate() in clothing.accessories
+	if(!existing_plate)
+		return
+	clothing.remove_accessory(user, existing_plate)
+
 /obj/item/clothing/accessory/armor_plate/generic
 	name = "standard armor plate"
 	desc = "A light-weight kevlar armor plate in drab black colors. A galactic favourite of Zavodskoi fans."

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -83,6 +83,10 @@
 	accessory_mob_overlay.appearance_flags = RESET_ALPHA|RESET_COLOR
 	return accessory_mob_overlay
 
+/// Gets called before 'can_attach_accessory()' is called in clothing_accessories.dm
+/obj/item/clothing/accessory/proc/before_attached(var/obj/item/clothing/S, var/mob/user)
+	return
+
 //when user attached an accessory to S
 /obj/item/clothing/accessory/proc/on_attached(var/obj/item/clothing/S, var/mob/user)
 	if(!istype(S))

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -20,6 +20,14 @@
 	drop_sound = 'sound/items/drop/boots.ogg'
 	pickup_sound = 'sound/items/pickup/boots.ogg'
 
+/obj/item/clothing/accessory/leg_guard/before_attached(var/obj/item/clothing/clothing, var/mob/user)
+	if(!clothing.valid_accessory_slots || !(slot in clothing.valid_accessory_slots))
+		return
+	var/obj/item/clothing/accessory/leg_guard/existing_guard = locate() in clothing.accessories
+	if(!existing_guard)
+		return
+	clothing.remove_accessory(user, existing_guard)
+
 /obj/item/clothing/accessory/leg_guard/generic
 	name = "standard leg guards"
 	icon_state = "legguards_generic"
@@ -159,6 +167,14 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	drop_sound = 'sound/items/drop/axe.ogg'
 	pickup_sound = 'sound/items/pickup/axe.ogg'
+
+/obj/item/clothing/accessory/arm_guard/before_attached(var/obj/item/clothing/clothing, var/mob/user)
+	if(!clothing.valid_accessory_slots || !(slot in clothing.valid_accessory_slots))
+		return
+	var/obj/item/clothing/accessory/arm_guard/existing_guard = locate() in clothing.accessories
+	if(!existing_guard)
+		return
+	clothing.remove_accessory(user, existing_guard)
 
 /obj/item/clothing/accessory/arm_guard/generic
 	name = "standard arm guards"

--- a/html/changelogs/geeves-quick_swap.yml
+++ b/html/changelogs/geeves-quick_swap.yml
@@ -3,4 +3,4 @@ author: Geeves
 delete-after: True
 
 changes:
-  - rscadd: "You can now instantly replace the armor accesories on plate carriers by clicking on it with the new plate or guard you want to replace them with."
+  - rscadd: "You can now instantly replace the armor accessories on plate carriers by clicking on it with the new plate or guard you want to replace them with."

--- a/html/changelogs/geeves-quick_swap.yml
+++ b/html/changelogs/geeves-quick_swap.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "You can now instantly replace the armor accesories on plate carriers by clicking on it with the new plate or guard you want to replace them with."


### PR DESCRIPTION
* You can now instantly replace the armor accessories on plate carriers by clicking on it with the new plate or guard you want to replace them with.