### PR TITLE
Plate Accessory Stuff

### DIFF
--- a/code/__DEFINES/accessories.dm
+++ b/code/__DEFINES/accessories.dm
@@ -8,4 +8,12 @@
 #define ACCESSORY_SLOT_ARM_GUARDS		"arm guards"
 #define ACCESSORY_SLOT_ARMOR_PIN		"armor pin"
 #define ACCESSORY_SLOT_ARMOR_POCKETS 	"armor pockets"
-#define ACCESSORY_SLOT_HEAD             "head"
+#define ACCESSORY_SLOT_HEAD				"head"
+
+// Accessory Layering
+
+#define ACCESSORY_LOWEST_LAYER 0
+#define ACCESSORY_LAYER_LOWER 0
+#define ACCESSORY_LAYER_MIDDLE 1
+#define ACCESSORY_LAYER_UPPER 2
+#define ACCESSORY_HIGHEST_LAYER 2

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -398,6 +398,12 @@
 	for(var/obj/item/clothing/accessory/accessory as anything in accessories)
 		body_temperature_change += accessory.body_temperature_change
 
+/obj/item/clothing/CtrlClick(var/mob/user)
+	if(loc == user && LAZYLEN(accessories))
+		remove_accessory_handler(user, TRUE)
+		return
+	return ..()
+
 ///////////////////////////////////////////////////////////////////////
 // Ears: headsets, earmuffs and tiny objects
 /obj/item/clothing/ears

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -111,10 +111,29 @@
 
 /obj/item/clothing/proc/attach_accessory(mob/user, obj/item/clothing/accessory/A)
 	LAZYADD(accessories, A)
+
+	// sort the accessories so that they render correctly
+	var/list/new_accessory_list = list()
+	var/list/accessories_by_layer = list()
+
+	for(var/i = ACCESSORY_LOWEST_LAYER, i <= ACCESSORY_HIGHEST_LAYER, i++)
+		accessories_by_layer["[i]"] = list()
+
+	for(var/obj/item/clothing/accessory/accessory as anything in accessories)
+		accessories_by_layer["[accessory.accessory_layer]"] += accessory
+
+	for(var/i = ACCESSORY_LOWEST_LAYER, i <= ACCESSORY_HIGHEST_LAYER, i++)
+		var/list/layered_accessories = accessories_by_layer["[i]"]
+		for(var/obj/item/clothing/accessory/accessory as anything in layered_accessories)
+			new_accessory_list += accessory
+
+	accessories = new_accessory_list
+
 	A.on_attached(src, user)
-	src.verbs |= /obj/item/clothing/proc/removetie_verb
+	src.verbs |= /obj/item/clothing/proc/remove_accessory_verb
+
 	update_clothing_icon()
-	update_accessory_slowdown(user)
+	update_accessory_slowdown()
 	recalculate_body_temperature_change()
 
 /obj/item/clothing/proc/remove_accessory(mob/user, obj/item/clothing/accessory/A)
@@ -127,23 +146,27 @@
 	update_accessory_slowdown(user)
 	recalculate_body_temperature_change()
 
-/obj/item/clothing/proc/removetie_verb()
+/obj/item/clothing/proc/remove_accessory_verb()
 	set name = "Remove Accessory"
 	set category = "Object"
 	set src in usr
-	if(!isliving(usr))
+
+	remove_accessory_handler(usr)
+
+/obj/item/clothing/proc/remove_accessory_handler(var/mob/living/user, var/force_radial = FALSE)
+	if(!isliving(user))
 		return
 
-	var/mob/living/M = usr
-
-	if(use_check_and_message(M))
+	if(use_check_and_message(user))
 		return
 
 	if(!LAZYLEN(accessories))
 		return
 
+	var/try_reopen_radial_after_removal = FALSE
+
 	var/obj/item/clothing/accessory/A
-	if(LAZYLEN(accessories) > 1)
+	if(force_radial || LAZYLEN(accessories) > 1)
 		var/list/options = list()
 		for (var/obj/item/clothing/accessory/i in accessories)
 			var/image/radial_button = image(icon = i.icon, icon_state = i.icon_state)
@@ -153,12 +176,19 @@
 				radial_button.ClearOverlays()
 				radial_button.AddOverlays(overlay_image(i.icon, "[i.icon_state]_[i.worn_overlay]", flags=RESET_COLOR))
 			options[i] = radial_button
-		A = show_radial_menu(M, M, options, radius = 42, tooltips = TRUE)
+		A = show_radial_menu(user, user, options, radius = 42, tooltips = TRUE)
+		if(!A)
+			return
+		try_reopen_radial_after_removal = TRUE
 	else
 		A = accessories[1]
-	remove_accessory(usr,A)
-	if(!LAZYLEN(accessories))
-		verbs -= /obj/item/clothing/proc/removetie_verb
+
+	remove_accessory(usr, A)
+
+	if(try_reopen_radial_after_removal)
+		remove_accessory_handler(user, TRUE)
+	else if(!LAZYLEN(accessories))
+		verbs -= /obj/item/clothing/proc/remove_accessory_verb
 
 /obj/item/clothing/emp_act(severity)
 	. = ..()

--- a/code/modules/clothing/suits/modular_armor.dm
+++ b/code/modules/clothing/suits/modular_armor.dm
@@ -131,6 +131,7 @@
 	item_state = "plate_sec"
 	contained_sprite = TRUE
 	slot = ACCESSORY_SLOT_ARMOR_PLATE
+	accessory_layer = ACCESSORY_LAYER_LOWER
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	w_class = WEIGHT_CLASS_NORMAL
 	armor = list(

--- a/code/modules/clothing/under/accessories/accessory.dm
+++ b/code/modules/clothing/under/accessories/accessory.dm
@@ -8,16 +8,21 @@
 	slot_flags = SLOT_TIE
 	w_class = WEIGHT_CLASS_SMALL
 
+	sprite_sheets = list(
+		BODYTYPE_VAURCA_BULWARK = 'icons/mob/species/bulwark/accessories.dmi'
+	)
+
 	var/slot = ACCESSORY_SLOT_GENERIC
+
+	/// Determines how accessories will layer over eachother, with lower being beneath everything, and upper above
+	var/accessory_layer = ACCESSORY_LAYER_MIDDLE
+
 	var/obj/item/clothing/has_suit = null		//the suit the tie may be attached to
 	var/image/inv_overlay = null	//overlay used when attached to clothing.
 	var/overlay_in_inventory = TRUE // Whether the worn_overlay should apply when attached to an item of clothing.
 	var/image/accessory_mob_overlay = null
 	var/flippable = 0 //whether it has an attack_self proc which causes the icon to flip horizontally
 	var/flipped = 0
-	sprite_sheets = list(
-		BODYTYPE_VAURCA_BULWARK = 'icons/mob/species/bulwark/accessories.dmi'
-	)
 	var/protects_against_weather = FALSE
 
 /obj/item/clothing/accessory/Destroy()

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -8,6 +8,7 @@
 	item_state = "legguards_sec"
 	contained_sprite = TRUE
 	slot = ACCESSORY_SLOT_LEG_GUARDS
+	accessory_layer = ACCESSORY_LAYER_LOWER
 	w_class = WEIGHT_CLASS_NORMAL
 	armor = list(
 		melee = ARMOR_MELEE_KEVLAR,
@@ -148,6 +149,7 @@
 	item_state = "armguards_sec"
 	contained_sprite = TRUE
 	slot = ACCESSORY_SLOT_ARM_GUARDS
+	accessory_layer = ACCESSORY_LAYER_LOWER
 	body_parts_covered = HANDS|ARMS
 	armor = list(
 		melee = ARMOR_MELEE_KEVLAR,

--- a/html/changelogs/geeves-plate_accessory_stuff.yml
+++ b/html/changelogs/geeves-plate_accessory_stuff.yml
@@ -1,0 +1,8 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "You can now ctrl+click on any clothing item that has accessories attached to quickly open the accessory removal radial menu."
+  - rscadd: "Removing accessories with the radial accessory removal menu will now reopen that menu until either all the accessories are removed, or you click the close button."
+  - rscadd: "Plate Carrier armor accessories will now always render below other accessories, so you don't need to shuffle everything to layer them correctly."

--- a/html/changelogs/geeves-plate_accessory_stuff.yml
+++ b/html/changelogs/geeves-plate_accessory_stuff.yml
@@ -3,6 +3,6 @@ author: Geeves
 delete-after: True
 
 changes:
-  - rscadd: "You can now ctrl+click on any clothing item that has accessories attached to quickly open the accessory removal radial menu."
+  - rscadd: "You can now ctrl+click on any worn clothing item that has accessories attached to quickly open the accessory removal radial menu."
   - rscadd: "Removing accessories with the radial accessory removal menu will now reopen that menu until either all the accessories are removed, or you click the close button."
   - rscadd: "Plate Carrier armor accessories will now always render below other accessories, so you don't need to shuffle everything to layer them correctly."


### PR DESCRIPTION
* You can now ctrl+click on any worn clothing item that has accessories attached to quickly open the accessory removal radial menu.
* Removing accessories with the radial accessory removal menu will now reopen that menu until either all the accessories are removed, or you click the close button.
* Plate Carrier armor accessories will now always render below other accessories, so you don't need to shuffle everything to layer them correctly.