### PR TITLE
Zavod shuttle now spawns on overmap

### DIFF
--- a/html/changelogs/hazelmouse-zavodshuttle.yml
+++ b/html/changelogs/hazelmouse-zavodshuttle.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "The Zavodskoi Shuttle offsite now correctly spawns onto the overmap."

--- a/maps/away/away_site/zavod_shuttle_destroyed/zavod_shuttle_destroyed.dm
+++ b/maps/away/away_site/zavod_shuttle_destroyed/zavod_shuttle_destroyed.dm
@@ -9,7 +9,6 @@
 	spawn_weight = 1
 	spawn_cost = 1
 	id = "destroyed zavod shuttle"
-	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 	unit_test_groups = list(1)
 

--- a/maps/away/away_site/zavod_shuttle_destroyed/zavod_shuttle_destroyed.dm
+++ b/maps/away/away_site/zavod_shuttle_destroyed/zavod_shuttle_destroyed.dm
@@ -9,6 +9,7 @@
 	spawn_weight = 1
 	spawn_cost = 1
 	id = "destroyed zavod shuttle"
+	template_flags = TEMPLATE_FLAG_SPAWN_GUARANTEED
 
 	unit_test_groups = list(1)
 

--- a/maps/away/away_site/zavod_shuttle_destroyed/zavod_shuttle_destroyed.dmm
+++ b/maps/away/away_site/zavod_shuttle_destroyed/zavod_shuttle_destroyed.dmm
@@ -1293,6 +1293,10 @@
 	},
 /turf/template_noop,
 /area/space)
+"NY" = (
+/obj/effect/overmap/visitable/zavod_shuttle_destroyed,
+/turf/simulated/floor/tiled/steel,
+/area/zavod_shuttle_destroyed)
 "Oh" = (
 /obj/structure/inflatable/door,
 /obj/effect/decal/cleanable/floor_damage/rust,
@@ -25937,7 +25941,7 @@ bz
 YW
 Sn
 nY
-Cj
+NY
 Cj
 nY
 qG


### PR DESCRIPTION
The overmap object wasn't placed on the map, so it wasn't spawning.

Resolves https://github.com/Aurorastation/Aurora.3/issues/19584
