### PR TITLE
Fixes the SSRM ship voidsuits and shuttle dock

### DIFF
--- a/html/changelogs/Snowy1237-SolShipVoidsuitFix.yml
+++ b/html/changelogs/Snowy1237-SolShipVoidsuitFix.yml
@@ -56,3 +56,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Changed the voidsuis on the Sol Navy ship to be normal sol ones instead of the SSMD variant."
+  - bugfix: "The Sol recon ship airlock now cycles."

--- a/html/changelogs/Snowy1237-SolShipVoidsuitFix.yml
+++ b/html/changelogs/Snowy1237-SolShipVoidsuitFix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Snowy1237
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Changed the voidsuis on the Sol Navy ship to be normal sol ones instead of the SSMD variant."

--- a/html/changelogs/Snowy1237-SolShipVoidsuitFix.yml
+++ b/html/changelogs/Snowy1237-SolShipVoidsuitFix.yml
@@ -56,4 +56,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Changed the voidsuis on the Sol Navy ship to be normal sol ones instead of the SSMD variant."
-  - bugfix: "The Sol recon ship airlock now cycles."
+  - bugfix: "The Sol recon ship shuttle airlock now cycles."

--- a/maps/away/ships/sol/sol_ssmd/ssmd_ship.dmm
+++ b/maps/away/ships/sol/sol_ssmd/ssmd_ship.dmm
@@ -220,8 +220,8 @@
 /obj/machinery/light/colored/blue{
 	dir = 8
 	},
-/obj/machinery/suit_cycler/offship/sol/ssmd,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_cycler/offship/sol,
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/dorms)
 "aHC" = (
@@ -461,8 +461,8 @@
 /obj/machinery/light/colored/blue{
 	dir = 8
 	},
-/obj/machinery/suit_cycler/offship/sol/ssmd,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_cycler/offship/sol,
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/dorms)
 "bdq" = (
@@ -2586,8 +2586,8 @@
 /obj/effect/floor_decal/corner/grey{
 	dir = 5
 	},
-/obj/machinery/suit_cycler/offship/sol/ssmd,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_cycler/offship/sol,
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/dorms)
 "gKp" = (
@@ -2856,8 +2856,8 @@
 /obj/machinery/light/colored/blue{
 	dir = 4
 	},
-/obj/machinery/suit_cycler/offship/sol/ssmd,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/suit_cycler/offship/sol,
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/dorms)
 "hBs" = (

--- a/maps/away/ships/sol/sol_ssmd/ssmd_ship.dmm
+++ b/maps/away/ships/sol/sol_ssmd/ssmd_ship.dmm
@@ -2701,7 +2701,7 @@
 /obj/structure/bed/handrail{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/indoor/grate,
@@ -4119,7 +4119,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/portfoyer)
 "lwj" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/unary/vent_pump/high_volume/aux{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,


### PR DESCRIPTION
when the ship was updated the voidsuits were left as the SSMD variant instead of being updated, now it's fixed.

The shuttle airlock still starts closed but at least it can be cycled now.