### PR TITLE
PDA Charging Tweak

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/core.dm
+++ b/code/modules/modular_computers/computers/modular_computer/core.dm
@@ -1,9 +1,9 @@
 /obj/item/modular_computer/process()
+	handle_power() // Handles all computer power interaction
+
 	if(!enabled) // The computer is turned off
 		last_power_usage = 0
 		return FALSE
-
-	handle_power() // Handles all computer power interaction
 
 	if(damage > broken_damage)
 		shutdown_computer()

--- a/code/modules/modular_computers/computers/modular_computer/power.dm
+++ b/code/modules/modular_computers/computers/modular_computer/power.dm
@@ -13,25 +13,30 @@
 // Tries to use power from battery. Passing false as parameter results in this proc returning whether battery is functional or not.
 /obj/item/modular_computer/proc/battery_power(var/power_usage = FALSE)
 	apc_powered = FALSE
+
 	if(!battery_module || !battery_module.check_functionality() || battery_module.battery.charge <= 0)
 		return FALSE
-	if(battery_module.battery.use(power_usage * CELLRATE) || ((power_usage == 0) && battery_module.battery.charge))
+
+	if(power_usage <= 0 || battery_module.battery.use(power_usage * CELLRATE))
 		return TRUE
+
 	return FALSE
 
 // Tries to use power from APC, if present.
 /obj/item/modular_computer/proc/apc_power(var/power_usage = 0)
 	apc_powered = TRUE
+
 	// Tesla link was originally limited to machinery only, but this probably works too, and the benefit of being able to power all devices from an APC outweights
 	// the possible minor performance loss.
 	if(!tesla_link || !tesla_link.check_functionality())
 		return FALSE
+
 	var/area/A = get_area(src)
 	if(!istype(A) || !A.powered(EQUIP))
 		return FALSE
 
 	// At this point, we know that APC can power us for this tick. Check if we also need to charge our battery, and then actually use the power.
-	if(battery_module && (battery_module.battery.charge < battery_module.battery.maxcharge) && (power_usage > 0))
+	if(battery_module && (battery_module.battery.charge < battery_module.battery.maxcharge))
 		power_usage += tesla_link.passive_charging_rate
 		battery_module.battery.give(tesla_link.passive_charging_rate * CELLRATE)
 
@@ -50,8 +55,11 @@
 
 // Handles power-related things, such as battery interaction, recharging, shutdown when it's discharged
 /obj/item/modular_computer/proc/handle_power()
-	var/power_usage = screen_on ? base_active_power_usage : base_idle_power_usage
+	var/power_usage = 0
+
 	if(enabled)
+		power_usage = screen_on ? base_active_power_usage : base_idle_power_usage
+
 		for(var/obj/item/computer_hardware/H in get_all_components())
 			if(H.enabled)
 				power_usage += H.power_usage
@@ -62,4 +70,5 @@
 			power_has_failed = FALSE
 			update_icon()
 		return
+
 	power_failure()

--- a/html/changelogs/geeves-pda_charging.yml
+++ b/html/changelogs/geeves-pda_charging.yml
@@ -1,0 +1,6 @@
+author: Geeves
+
+delete-after: True
+
+changes:
+  - rscadd: "PDAs and other modular devices now charge from APCs even when turned off."


### PR DESCRIPTION
* PDAs and other modular devices now charge from APCs even when turned off.