### PR TITLE
Ethanol No Longer Makes Unathi Automatically Vomit

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -184,10 +184,6 @@ ABSTRACT_TYPE(/singleton/reagent/alcohol)
 
 		if (!has_valid_aug && alien == IS_UNATHI) //unathi are poisoned by alcohol as well
 			M.adjustToxLoss(3 * removed * (strength / 100))
-			if(!M.lastpuke)
-				to_chat(M, SPAN_WARNING("Your gizzard lurches as the alcohol burns its way down your gullet!"))//Make it clear that you should not be drinking this.
-			var/mob/living/carbon/human/H = M
-			H.delayed_vomit()
 
 		if (has_valid_aug | alien != IS_UNATHI)
 			M.intoxication += (strength / 100) * removed * 6

--- a/html/changelogs/crozarius-unathialcoholpuke.yml
+++ b/html/changelogs/crozarius-unathialcoholpuke.yml
@@ -1,0 +1,6 @@
+
+author: Crozarius
+
+delete-after: True
+changes:
+  - qol: "Ethanol no longer automatically makes Unathi vomit."


### PR DESCRIPTION
After implementing this feature a few months ago, I've come to realize that the effect this has isn't really what I intended, and it doesn't really make much sense. Ethanol will still be toxic to Unathi.