### PR TITLE
Refactoring of camera coverage

### DIFF
--- a/html/changelogs/fabiank3-refactoring-camera-coverage.yml
+++ b/html/changelogs/fabiank3-refactoring-camera-coverage.yml
@@ -1,0 +1,7 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - qol: "Added cameras to missing angles or completely uncovered areas: Central ring (locker room entrance), bridge conference room, XO office, gym, telescience, secure artifact storage, deck two tool storage."
+  - qol: "Added lights and lightswitch to research secure artifact storage."


### PR DESCRIPTION
### Introduction

There are some angles or whole areas not covered by cameras. This is especially annoying for the AI.
This PR resolves some of those missing angles.

### What changed?

Cameras added to area:
- Central ring aft, deck three, entrance of locker room
- Bridge conference room
- XO office
- Gym
- Telescience
- Secure artifact storage
- Deck two tool storage

Other changes:
- Added lights and lightswitch to secure artifact storage

### Pictures of affected areas (before, AI-view)

![image](https://github.com/user-attachments/assets/cccb120b-6827-4f7a-accb-598fd4edea0c)
![image](https://github.com/user-attachments/assets/a191b0ab-ab0d-4824-b16f-695d81181929)
![image](https://github.com/user-attachments/assets/e68eebf4-22d8-4ecb-b17d-245bb94e6a1e)
![image](https://github.com/user-attachments/assets/918b5128-4a13-4cc2-bf65-2b230a7b24ea)
![image](https://github.com/user-attachments/assets/a8be7c39-1c1d-4e46-a799-56de7fb0d8f5)
![image](https://github.com/user-attachments/assets/0a55b8a1-5124-421b-bcee-eb9cf63590f2)
![image](https://github.com/user-attachments/assets/f7f847eb-7205-420b-8067-165c424ae612)

### Pictures of affected areas (after, AI-view)

![image](https://github.com/user-attachments/assets/ceb91966-8ec7-47b9-be27-ca74a6ffe000)
![image](https://github.com/user-attachments/assets/901753ca-20a2-48c1-a99c-ade83f643ee8)
![image](https://github.com/user-attachments/assets/c64737b6-6933-4df0-bee9-bc6498fe2d5c)
![image](https://github.com/user-attachments/assets/e2d95200-783d-42df-9a02-7699e5104186)
![image](https://github.com/user-attachments/assets/f79711ff-c7e5-4266-a563-221c56717dab)
![image](https://github.com/user-attachments/assets/28ca0e4f-f08b-42cf-9e49-9afd48d10c25)
