### PR TITLE
Fix powernet sensors for D1 engineering and command subgrid

### DIFF
--- a/html/changelogs/fabiank3-bugfix-disconnected-powernet-sensors.yml
+++ b/html/changelogs/fabiank3-bugfix-disconnected-powernet-sensors.yml
@@ -1,0 +1,7 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed power-monitoring sensors for D1 engineering and the command subgrid."
+  - bugfix: "Updated command substation camera name."


### PR DESCRIPTION
### Introduction
In the engineering power-monitor software, D1 engineering and command did not show any information.
The camera in the command substations is currently named "Telecommunications" (old location of Tcoms).

### What changed?

- Added missing wire-dots for both sensors of the D1 engi and command grid.
- Updated camera name of command substation.

_No visible changes to show._