### PR TITLE
More Sol recon ship fixes.

### DIFF
--- a/html/changelogs/Snowy1237-SolShipAssortedFixes.yml
+++ b/html/changelogs/Snowy1237-SolShipAssortedFixes.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Snowy1237
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes the Sol recon ship exterior airlocks not closing (and the doubled windoor)"

--- a/html/changelogs/Snowy1237-SolShipAssortedFixes.yml
+++ b/html/changelogs/Snowy1237-SolShipAssortedFixes.yml
@@ -56,4 +56,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
   - bugfix: "Fixes the Sol recon ship exterior airlocks not closing (and the doubled windoor)."
-    - bugfix: "Fixes the Sol recon ship stabilization locker being locked."
+  - bugfix: "Fixes the Sol recon ship stabilization locker being locked."

--- a/html/changelogs/Snowy1237-SolShipAssortedFixes.yml
+++ b/html/changelogs/Snowy1237-SolShipAssortedFixes.yml
@@ -55,4 +55,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes:
-  - bugfix: "Fixes the Sol recon ship exterior airlocks not closing (and the doubled windoor)"
+  - bugfix: "Fixes the Sol recon ship exterior airlocks not closing (and the doubled windoor)."
+    - bugfix: "Fixes the Sol recon ship stabilization locker being locked."

--- a/maps/away/ships/sol/sol_ssmd/ssmd_ship.dmm
+++ b/maps/away/ships/sol/sol_ssmd/ssmd_ship.dmm
@@ -4404,7 +4404,8 @@
 	},
 /obj/structure/closet/walllocker/medical/secure{
 	name = "Stabilization Kit";
-	pixel_x = 32
+	pixel_x = 32;
+	req_access = list(203)
 	},
 /obj/item/clothing/mask/breath/medical,
 /obj/item/clothing/mask/breath/medical,

--- a/maps/away/ships/sol/sol_ssmd/ssmd_ship.dmm
+++ b/maps/away/ships/sol/sol_ssmd/ssmd_ship.dmm
@@ -2727,9 +2727,6 @@
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/ssmd_shuttle)
 "hhf" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/external,
 /obj/effect/map_effect/marker/airlock{
@@ -2801,9 +2798,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/ssmd_corvette/brig)
 "hoJ" = (
-/obj/structure/railing/mapped{
-	dir = 4
-	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/door/airlock/external,
 /obj/machinery/access_button{
@@ -7276,10 +7270,6 @@
 	dir = 8;
 	req_access = list(203)
 	},
-/obj/machinery/door/window/northleft{
-	dir = 8;
-	req_access = list(203)
-	},
 /turf/simulated/floor/plating,
 /area/ship/ssmd_corvette/hangar)
 "vTv" = (
@@ -7308,10 +7298,6 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/door/window/northleft{
-	dir = 8;
-	req_access = list(203)
-	},
 /obj/machinery/door/window/northleft{
 	dir = 8;
 	req_access = list(203)


### PR DESCRIPTION
Fixes the exterior airlocks not closing due to a misplaced railing, and the doubled windoor for the associated air canisters.
Also fixes the access requirement for the stabilization locker.