### PR TITLE
Fixed a bug where lists with number-only elements were not displaying

### DIFF
--- a/code/modules/admin/verbs/viewlist.dm
+++ b/code/modules/admin/verbs/viewlist.dm
@@ -46,13 +46,19 @@
 
 	data["listvar"] = list()
 
-	var/index = 1
-	for(var/k in viewed_list)
-		if(!isnull(viewed_list[k]))
-			data["listvar"] += list(list("key" = k, "value" = viewed_list[k]))
+	//Let's just compute it once instead of for every element
+	var/is_normal_list = IS_NORMAL_LIST(viewed_list)
+
+	for(var/index in 1 to length(viewed_list))
+		var/entry = viewed_list[index]
+
+		if(is_normal_list && IS_VALID_ASSOC_KEY(entry))
+			if(!isnull(viewed_list[entry]))
+				data["listvar"] += list(list("key" = entry, "value" = viewed_list[entry]))
+			else
+				data["listvar"] += list(list("key" = index, "value" = entry))
 		else
-			data["listvar"] += list(list("key" = index, "value" = k))
-			index++
+			data["listvar"] += list(list("key" = index, "value" = entry))
 
 	return data
 
@@ -82,6 +88,10 @@
 
 			if(!entry_to_open)
 				to_chat(usr, "No entry found to open!")
+				return FALSE
+
+			if(!isdatum(entry_to_open))
+				to_chat(usr, "The entry is not a datum!")
 				return FALSE
 
 			user_client.debug_variables_open(entry_to_open)

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -157,18 +157,35 @@
 	else if(islist(value))
 		var/list/L = value
 		vtext = "/list ([length(L)])"
+
+		//Let's just compute it once instead of for every element
+		var/is_normal_list = IS_NORMAL_LIST(L)
+
 		if(!(varname in view_variables_dont_expand) && length(L) > 0 && length(L) < 100)
 			extra += "<ul>"
-			for(var/index = 1 to length(L))
+
+			//Loop through the list and make the elements into html
+			for(var/index in 1 to length(L))
 				var/entry = L[index]
-				if(IS_NORMAL_LIST(L) && IS_VALID_ASSOC_KEY(entry))
+
+				//If the key is a valid associative key (not a number)
+				if(is_normal_list && IS_VALID_ASSOC_KEY(entry))
+
+					//The possibly associative key is actually referencing something, now we know the list is associative
 					if(!isnull(L[entry]))
 						extra += "<li>[index]: [make_view_variables_value(D, entry)] -> [make_view_variables_value(D, L[entry])]</li>"
+					//The possibly associative key is not referencing anything, so it's just a normal element in the list
 					else
 						extra += "<li>[index]: [make_view_variables_value(D, entry)]</li>"
+
+				//The list is a list with numbers as keys
+				else
+					extra += "<li>[index]: [make_view_variables_value(D, entry)]</li>"
+
 			extra += "</ul>"
+
 		else if(length(L) >= 100)
-			vtext = "([length(L)]): <ul><li><a href='?_src_=vars;datumview=[REF(L)];varnameview=[varname]'>List too large to display, click to view.</a></ul>"
+			vtext = "([length(L)]): <ul><li><a href='?_src_=vars;datumview=[REF(L)];varnameview=[varname];original_datum=[REF(D)]'>List too large to display, click to view.</a></ul>"
 
 	else
 		vtext = "[value]"

--- a/html/changelogs/fluffyghost-vvlistfixes.yml
+++ b/html/changelogs/fluffyghost-vvlistfixes.yml
@@ -1,0 +1,61 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: FluffyGhost
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixed a bug where lists with number-only elements were not displaying in VV."
+  - bugfix: "Fixed an issue with extended list viewer mishandling special lists and giving runtimes."
+  - code_imp: "VV list unwrapping is now faster."
+  - code_imp: "Some code comments and cleanup."


### PR DESCRIPTION
Fixed a bug where lists with number-only elements were not displaying in VV.
Fixed an issue with extended list viewer mishandling special lists and giving runtimes.
VV list unwrapping is now faster.
Some code comments and cleanup.