### PR TITLE
Overloader balance tweaks

### DIFF
--- a/code/game/machinery/vending_types.dm
+++ b/code/game/machinery/vending_types.dm
@@ -1602,10 +1602,10 @@
 		/obj/item/storage/overloader/screenshaker = 5
 	)
 	prices = list(
-		/obj/item/storage/overloader/classic = 200,
-		/obj/item/storage/overloader/tranquil = 200,
-		/obj/item/storage/overloader/rainbow = 200,
-		/obj/item/storage/overloader/screenshaker = 200
+		/obj/item/storage/overloader/classic = 100,
+		/obj/item/storage/overloader/tranquil = 100,
+		/obj/item/storage/overloader/rainbow = 100,
+		/obj/item/storage/overloader/screenshaker = 100
 	)
 	contraband = list(
 		/obj/item/storage/overloader/rainbow = 2

--- a/code/game/objects/items/ipc_overloaders.dm
+++ b/code/game/objects/items/ipc_overloaders.dm
@@ -6,7 +6,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	contained_sprite = TRUE
 	var/uses = 2
-	var/effect_time = 120 SECONDS
+	var/effect_time = 90 SECONDS
 	var/effects = 4
 
 	var/static/list/step_up_effects = list(

--- a/code/game/objects/items/ipc_overloaders.dm
+++ b/code/game/objects/items/ipc_overloaders.dm
@@ -6,7 +6,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	contained_sprite = TRUE
 	var/uses = 2
-	var/effect_time = 30 SECONDS
+	var/effect_time = 120 SECONDS
 	var/effects = 4
 
 	var/static/list/step_up_effects = list(

--- a/html/changelogs/hazelmouse-overloaderebalance.yml
+++ b/html/changelogs/hazelmouse-overloaderebalance.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Overloaders now cost fewer credits and last substantially longer."


### PR DESCRIPTION
Halves the price of overloaders from 200 to 100. Free IPCs are an economically disadvantaged group so something aimed at them probably shouldn't be so expensive.

Triples the amount of time overloaders last. 30 seconds was too short a time for meaningful roleplay to occur, especially given how much they cost.