### PR TITLE
Deconstructable Shutters

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -251,6 +251,7 @@
 		while (cuts_needed)
 			welding = TRUE
 			to_chat(user, SPAN_NOTICE("You begin slicing through a support struct in the shutters. You see [cuts_needed] remaining."))
+
 			if(attacking_item.use_tool(src, user, cut_time, volume = 50) && WT.isOn())
 				welding = FALSE
 				cuts_needed--

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -239,14 +239,15 @@
 	// For replacing welded-off beams.
 	if(istype(attacking_item, /obj/item/stack/rods))
 		var/obj/item/stack/rods/R = attacking_item
-		if(cuts_needed == initial(cuts_needed))
+		if(cuts_needed >= initial(cuts_needed))
 			to_chat(usr, SPAN_NOTICE("\The [src] already has all the necessary support beams."))
 		else
 			to_chat(usr, SPAN_NOTICE("You begin to reinforce \the [src] with an additional support beam..."))
 			if (do_after(user, 30 SECONDS))
-				to_chat(usr, SPAN_NOTICE("You reinforce \the [src] with an additional support beam."))
-				R.use(1)
-				cuts_needed++
+				if(cuts_needed <= initial(cuts_needed))
+					to_chat(usr, SPAN_NOTICE("You reinforce \the [src] with an additional support beam."))
+					R.use(1)
+					cuts_needed++
 
 	// For welding off beams.
 	else if (attacking_item.iswelder() && !welding)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -225,6 +225,7 @@
 	closed_layer = CLOSED_DOOR_LAYER
 	var/cuts_needed = 6
 	var/cut_time = 15 SECONDS
+	var/welding = FALSE // Whether the shutter is currently being welded.
 
 /obj/machinery/door/blast/shutters/open
 	icon_state = "shutter0"
@@ -238,28 +239,33 @@
 		if(cuts_needed == 6)
 			to_chat(usr, SPAN_NOTICE("\The [src] already has all the necessary support structs."))
 		else
-			to_chat(usr, SPAN_NOTICE("You begin to reinforce \the [src] with an additional support struct."))
+			to_chat(usr, SPAN_NOTICE("You begin to reinforce \the [src] with an additional support struct..."))
 			if (do_after(user, 30 SECONDS))
 				to_chat(usr, SPAN_NOTICE("You reinforce \the [src] with an additional support struct."))
 				R.use(1)
 				cuts_needed++
 
 	// For welding off structs.
-	else if (attacking_item.iswelder())
+	else if (attacking_item.iswelder() && welding == FALSE)
 		var/obj/item/weldingtool/WT = attacking_item
 		while (cuts_needed)
+			welding = TRUE
 			to_chat(user, SPAN_NOTICE("You begin slicing through a support struct in the shutters. You see [cuts_needed] remaining."))
 			if(attacking_item.use_tool(src, user, cut_time, volume = 50) && WT.isOn())
+				welding = FALSE
 				cuts_needed--
 			else
+				welding = FALSE
 				break
 			if (cuts_needed)
 				to_chat(user, SPAN_NOTICE("You successfully cut a support struct! Now dislodged from its fitting, it clatters down to the floor."))
 				new /obj/item/stack/rods(src.loc)
+				welding = FALSE
 			else
+				welding = FALSE
 				qdel(src)
 				playsound(src, 'sound/items/Welder.ogg', 10, 1)
-				user.visible_message(SPAN_WARNING("The shutters were cut apart by \the [user]!"), SPAN_NOTICE("You slice through the shutters!"))
+				user.visible_message(SPAN_WARNING("The shutters were cut apart by \the [user]!"), SPAN_NOTICE("You slice straight through the shutters, opening the way!"))
 				new /obj/item/stack/rods(src.loc)
 				break
 
@@ -271,7 +277,7 @@
 	if (cuts_needed > 1)
 		. += SPAN_NOTICE("\The [src] seems to have [cuts_needed] intact support structs.")
 	else
-		. += SPAN_NOTICE("\The [src] seems to have [cuts_needed] intact support struct.")
+		. += SPAN_NOTICE("\The [src] seems to only have [cuts_needed] intact support struct! It's close to collapse!")
 
 // SUBTYPE: Odin
 // Found on the odin, or where people really shouldnt get into

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -244,7 +244,7 @@
 		else
 			to_chat(usr, SPAN_NOTICE("You begin to reinforce \the [src] with an additional support beam..."))
 			if (do_after(user, 30 SECONDS))
-				if(cuts_needed <= initial(cuts_needed))
+				if(cuts_needed < initial(cuts_needed))
 					to_chat(usr, SPAN_NOTICE("You reinforce \the [src] with an additional support beam."))
 					R.use(1)
 					cuts_needed++

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -258,9 +258,9 @@
 				welding = FALSE
 				break
 			if (cuts_needed)
+				welding = FALSE
 				to_chat(user, SPAN_NOTICE("You successfully cut a support struct! Now dislodged from its fitting, it clatters down to the floor."))
 				new /obj/item/stack/rods(src.loc)
-				welding = FALSE
 			else
 				welding = FALSE
 				qdel(src)

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -225,7 +225,8 @@
 	closed_layer = CLOSED_DOOR_LAYER
 	var/cuts_needed = 6
 	var/cut_time = 15 SECONDS
-	var/welding = FALSE // Whether the shutter is currently being welded.
+	//	/ Whether the shutter is currently being welded.
+	var/welding = FALSE
 
 /obj/machinery/door/blast/shutters/open
 	icon_state = "shutter0"

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -251,7 +251,7 @@
 		var/obj/item/weldingtool/WT = attacking_item
 		while (cuts_needed)
 			welding = TRUE
-			to_chat(user, SPAN_NOTICE("You begin slicing through a support beam in the shutters. You see [cuts_needed] remaining."))
+			to_chat(user, SPAN_NOTICE("You begin slicing through a support beam in \the [src]. You see [cuts_needed] remaining."))
 
 			if(attacking_item.use_tool(src, user, cut_time, volume = 50) && WT.isOn())
 				welding = FALSE
@@ -271,6 +271,8 @@
 				user.visible_message(SPAN_WARNING("\The [src] were cut apart by \the [user]!"), SPAN_NOTICE("You slice straight through \the [src], opening the way!"))
 				new /obj/item/stack/rods(src.loc)
 				break
+
+		welding = FALSE
 
 	return ..()
 

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -239,7 +239,7 @@
 	// For replacing welded-off beams.
 	if(istype(attacking_item, /obj/item/stack/rods))
 		var/obj/item/stack/rods/R = attacking_item
-		if(cuts_needed == 6)
+		if(cuts_needed == initial(cuts_needed))
 			to_chat(usr, SPAN_NOTICE("\The [src] already has all the necessary support beams."))
 		else
 			to_chat(usr, SPAN_NOTICE("You begin to reinforce \the [src] with an additional support beam..."))

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -265,7 +265,7 @@
 				welding = FALSE
 				qdel(src)
 				playsound(src, 'sound/items/Welder.ogg', 10, 1)
-				user.visible_message(SPAN_WARNING("The shutters were cut apart by \the [user]!"), SPAN_NOTICE("You slice straight through the shutters, opening the way!"))
+				user.visible_message(SPAN_WARNING("\The [src] were cut apart by \the [user]!"), SPAN_NOTICE("You slice straight through \the [src], opening the way!"))
 				new /obj/item/stack/rods(src.loc)
 				break
 

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -222,11 +222,24 @@
 	icon_state = "shutter1"
 	damage = SHUTTER_CRUSH_DAMAGE
 	closed_layer = CLOSED_DOOR_LAYER
+	var/cuts_needed = 6
+	var/cut_time = 20 SECONDS
 
 /obj/machinery/door/blast/shutters/open
 	icon_state = "shutter0"
 	density = FALSE
 	opacity = FALSE
+
+/obj/machinery/door/blast/shutters/attackby(obj/item/attacking_item, mob/user)
+	if (attacking_item.iswelder())
+		var/obj/item/weldingtool/WT = attacking_item
+		to_chat(user, SPAN_NOTICE("You begin slicing the shutters apart. This might take a while..."))
+		if(attacking_item.use_tool(src, user, 2000, volume = 50))
+			qdel(src)
+			playsound(src, 'sound/items/Welder.ogg', 10, 1)
+			user.visible_message(SPAN_WARNING("The shutters were cut apart by \the [user]!"), SPAN_NOTICE("You slice through the shutters!"))
+
+	return ..()
 
 // SUBTYPE: Odin
 // Found on the odin, or where people really shouldnt get into

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -256,18 +256,14 @@
 			to_chat(user, SPAN_NOTICE("You begin slicing through a support beam in \the [src]. You see [cuts_needed] remaining."))
 
 			if(attacking_item.use_tool(src, user, cut_time, volume = 50) && WT.isOn())
-				welding = FALSE
 				cuts_needed--
 			else
-				welding = FALSE
 				break
 
 			if (cuts_needed)
-				welding = FALSE
 				to_chat(user, SPAN_NOTICE("You successfully cut a support beam! Now dislodged from its fitting, it clatters down to the floor."))
 				new /obj/item/stack/rods(src.loc)
 			else
-				welding = FALSE
 				qdel(src)
 				playsound(src, 'sound/items/Welder.ogg', 10, TRUE)
 				user.visible_message(SPAN_WARNING("\The [src] were cut apart by \the [user]!"), SPAN_NOTICE("You slice straight through \the [src], opening the way!"))

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -266,7 +266,7 @@
 			else
 				welding = FALSE
 				qdel(src)
-				playsound(src, 'sound/items/Welder.ogg', 10, 1)
+				playsound(src, 'sound/items/Welder.ogg', 10, TRUE)
 				user.visible_message(SPAN_WARNING("\The [src] were cut apart by \the [user]!"), SPAN_NOTICE("You slice straight through \the [src], opening the way!"))
 				new /obj/item/stack/rods(src.loc)
 				break

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -215,7 +215,7 @@
 // Nicer looking, and also weaker, shutters. Found in kitchen and similar areas. Unlike blast doors, can be destroyed with a welder.
 /obj/machinery/door/blast/shutters
 	name = "shutter"
-	desc_extended = "This can be disassembled by cutting all six support structs off with a welding tool, and this process can be reversed by reinstalling support structs with use of steel rods."
+	desc_extended = "This can be disassembled by cutting all six support beams off with a welding tool, and this process can be reversed by reinstalling support beams with use of steel rods."
 	icon_state_open = "shutter0"
 	icon_state_opening = "shutterc0"
 	icon_state_closed = "shutter1"
@@ -234,24 +234,24 @@
 	opacity = FALSE
 
 /obj/machinery/door/blast/shutters/attackby(obj/item/attacking_item, mob/user)
-	// For replacing welded-off structs.
+	// For replacing welded-off beams.
 	if(istype(attacking_item, /obj/item/stack/rods))
 		var/obj/item/stack/rods/R = attacking_item
 		if(cuts_needed == 6)
-			to_chat(usr, SPAN_NOTICE("\The [src] already has all the necessary support structs."))
+			to_chat(usr, SPAN_NOTICE("\The [src] already has all the necessary support beams."))
 		else
-			to_chat(usr, SPAN_NOTICE("You begin to reinforce \the [src] with an additional support struct..."))
+			to_chat(usr, SPAN_NOTICE("You begin to reinforce \the [src] with an additional support beam..."))
 			if (do_after(user, 30 SECONDS))
-				to_chat(usr, SPAN_NOTICE("You reinforce \the [src] with an additional support struct."))
+				to_chat(usr, SPAN_NOTICE("You reinforce \the [src] with an additional support beam."))
 				R.use(1)
 				cuts_needed++
 
-	// For welding off structs.
+	// For welding off beams.
 	else if (attacking_item.iswelder() && welding == FALSE)
 		var/obj/item/weldingtool/WT = attacking_item
 		while (cuts_needed)
 			welding = TRUE
-			to_chat(user, SPAN_NOTICE("You begin slicing through a support struct in the shutters. You see [cuts_needed] remaining."))
+			to_chat(user, SPAN_NOTICE("You begin slicing through a support beam in the shutters. You see [cuts_needed] remaining."))
 
 			if(attacking_item.use_tool(src, user, cut_time, volume = 50) && WT.isOn())
 				welding = FALSE
@@ -262,7 +262,7 @@
 
 			if (cuts_needed)
 				welding = FALSE
-				to_chat(user, SPAN_NOTICE("You successfully cut a support struct! Now dislodged from its fitting, it clatters down to the floor."))
+				to_chat(user, SPAN_NOTICE("You successfully cut a support beam! Now dislodged from its fitting, it clatters down to the floor."))
 				new /obj/item/stack/rods(src.loc)
 			else
 				welding = FALSE
@@ -278,9 +278,9 @@
 /obj/machinery/door/blast/shutters/get_examine_text(mob/user, distance, is_adjacent, infix, suffix)
 	. = ..()
 	if (cuts_needed > 1)
-		. += SPAN_NOTICE("\The [src] seems to have [cuts_needed] intact support structs.")
+		. += SPAN_NOTICE("\The [src] seems to have [cuts_needed] intact support beams.")
 	else
-		. += SPAN_NOTICE("\The [src] seems to only have [cuts_needed] intact support struct! It's close to collapse!")
+		. += SPAN_NOTICE("\The [src] seems to only have [cuts_needed] intact support beam! It's close to collapse!")
 
 // SUBTYPE: Odin
 // Found on the odin, or where people really shouldnt get into

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -249,7 +249,7 @@
 				cuts_needed++
 
 	// For welding off beams.
-	else if (attacking_item.iswelder() && welding == FALSE)
+	else if (attacking_item.iswelder() && !welding)
 		var/obj/item/weldingtool/WT = attacking_item
 		while (cuts_needed)
 			welding = TRUE
@@ -260,14 +260,14 @@
 			else
 				break
 
+			new /obj/item/stack/rods(get_turf(src))
+
 			if (cuts_needed)
 				to_chat(user, SPAN_NOTICE("You successfully cut a support beam! Now dislodged from its fitting, it clatters down to the floor."))
-				new /obj/item/stack/rods(src.loc)
 			else
 				qdel(src)
 				playsound(src, 'sound/items/Welder.ogg', 10, TRUE)
 				user.visible_message(SPAN_WARNING("\The [src] were cut apart by \the [user]!"), SPAN_NOTICE("You slice straight through \the [src], opening the way!"))
-				new /obj/item/stack/rods(src.loc)
 				break
 
 		welding = FALSE

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -258,6 +258,7 @@
 			else
 				welding = FALSE
 				break
+
 			if (cuts_needed)
 				welding = FALSE
 				to_chat(user, SPAN_NOTICE("You successfully cut a support struct! Now dislodged from its fitting, it clatters down to the floor."))

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -223,7 +223,9 @@
 	icon_state = "shutter1"
 	damage = SHUTTER_CRUSH_DAMAGE
 	closed_layer = CLOSED_DOOR_LAYER
+	/// How many cutting periods shutters require before they're deconstructed.
 	var/cuts_needed = 6
+	/// How long each cutting period takes.
 	var/cut_time = 15 SECONDS
 	/// Whether the shutter is currently being welded.
 	var/welding = FALSE

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -225,7 +225,7 @@
 	closed_layer = CLOSED_DOOR_LAYER
 	var/cuts_needed = 6
 	var/cut_time = 15 SECONDS
-	//	/ Whether the shutter is currently being welded.
+	/// Whether the shutter is currently being welded.
 	var/welding = FALSE
 
 /obj/machinery/door/blast/shutters/open

--- a/html/changelogs/hazelmouse-weldable_shutters.yml
+++ b/html/changelogs/hazelmouse-weldable_shutters.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Shutters can now be deconstructed with a welding torch."


### PR DESCRIPTION
Introduces a way to deconstruct shutters with a welding torch. Takes 90 seconds in total, split into 15 seconds chunks so being pushed off the tile doesn't lose you over a minute of progress. Extends only to shutters, not blast doors. 