### PR TITLE
Fixes combustion turbine power grid

### DIFF
--- a/html/changelogs/fabiank3-bugfix-combustion-turbine-wiring.yml
+++ b/html/changelogs/fabiank3-bugfix-combustion-turbine-wiring.yml
@@ -1,0 +1,7 @@
+author: FabianK3
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixed unrealistic power readings throughout the combustion turbine power grid."
+  - rscadd: "Added a powernet sensor to the combustion turbine power grid."


### PR DESCRIPTION
### Introduction
The power grid of the new combustion turbine is behaving very weird. For example, the TEG outputs 300kW of power, but inspecting the wire with a multitool shows very random things like 12mW. The SMES shows a different value as well.

### Fix
I noticed that a lot of cabling has been used with the d1,d2 properties set, which the wiki states to not use. I replaced all cabling starting from the TEG up to the main grid with cabling without the d1,d2 properties. This fixed all power values in the power network. The TEG, cabling and SMES now show the exact same value of power available in the network.

Additionally i added a powernet sensor to the turbine grid, as it was missing.

_Edit: Grammar_