### PR TITLE
IAC Rescue Ship Bugfixes

### DIFF
--- a/html/changelogs/furrycactus - iac update.yml
+++ b/html/changelogs/furrycactus - iac update.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Furrycactus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Updated and fixed some small bugs with the IAC Rescue Ship."

--- a/maps/away/ships/iac/iac_rescue_ship.dm
+++ b/maps/away/ships/iac/iac_rescue_ship.dm
@@ -265,3 +265,51 @@
 	landmark_tag = "nav_transit_iac_shuttle"
 
 	base_turf = /turf/space/transit/north
+
+// airlocks
+
+/obj/effect/map_effect/marker/airlock/iac_rescue_ship/port
+	name = "Port Airlock"
+	master_tag = "airlock_iac_rescue_port"
+
+/obj/effect/map_effect/marker/airlock/iac_rescue_ship/starboard
+	name = "Starboard Airlock"
+	master_tag = "airlock_iac_rescue_stbd"
+
+// docks
+
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_berth
+	name = "Dock, Port Berth"
+	landmark_tag = "nav_iac_rescue_port_berth"
+	master_tag = "airlock_iac_rescue_dock_port_berth"
+
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_fore
+	name = "Dock, Port Fore"
+	landmark_tag = "nav_iac_rescue_port_fore"
+	master_tag = "airlock_iac_rescue_dock_port_fore"
+
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_aft
+	name = "Dock, Port Aft"
+	landmark_tag = "nav_iac_rescue_port_aft"
+	master_tag = "airlock_iac_rescue_dock_port_aft"
+
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_berth
+	name = "Dock, Starboard Berth"
+	landmark_tag = "nav_iac_rescue_stbd_berth"
+	master_tag = "airlock_iac_rescue_dock_stbd_berth"
+
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_fore
+	name = "Dock, Starboard Fore"
+	landmark_tag = "nav_iac_rescue_stbd_fore"
+	master_tag = "airlock_iac_rescue_dock_stbd_fore"
+
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_aft
+	name = "Dock, Starboard Aft"
+	landmark_tag = "nav_iac_rescue_stbd_aft"
+	master_tag = "airlock_iac_rescue_dock_stbd_aft"
+
+/obj/effect/map_effect/marker/airlock/shuttle/iac_rescue_ship/shuttle
+	name = "IAC Ambulance Shuttle"
+	shuttle_tag = "IAC Ambulance Shuttle"
+	master_tag = "airlock_iac_rescue_shuttle"
+	cycle_to_external_air = TRUE

--- a/maps/away/ships/iac/iac_rescue_ship.dmm
+++ b/maps/away/ships/iac/iac_rescue_ship.dmm
@@ -43,6 +43,7 @@
 /obj/machinery/atmospherics/unary/freezer{
 	icon_state = "freezer"
 	},
+/obj/effect/floor_decal/industrial/outline/blue,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -67,11 +68,11 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/machinist)
 "ado" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/hangar)
 "adW" = (
@@ -133,12 +134,11 @@
 /obj/effect/shuttle_landmark/iac_rescue_ship/port_fore{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_fore";
-	master_tag = "airlock_iac_rescue_dock_port_fore";
-	landmark_tag = "nav_iac_rescue_port_fore"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_fore{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
 "aha" = (
@@ -149,12 +149,11 @@
 /obj/machinery/access_button{
 	pixel_x = -28
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_aft";
-	landmark_tag = "nav_iac_rescue_stbd_aft";
-	master_tag = "airlock_iac_rescue_dock_stbd_aft"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_aft{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
 "ahn" = (
@@ -212,10 +211,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_berth";
-	master_tag = "airlock_iac_rescue_dock_stbd_berth";
-	landmark_tag = "nav_iac_rescue_stbd_berth"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_berth{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
@@ -314,19 +311,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/engineering{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/engineering)
 "auL" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_aft";
-	master_tag = "airlock_iac_rescue_dock_port_aft";
-	landmark_tag = "nav_iac_rescue_port_aft"
-	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_aft{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
@@ -354,11 +351,11 @@
 /obj/effect/floor_decal/corner/yellow/full{
 	dir = 8
 	},
+/obj/structure/closet/radiation,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/structure/closet/radiation,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/engineering)
 "aAY" = (
@@ -422,12 +419,13 @@
 	pixel_x = -12;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_berth";
-	master_tag = "airlock_iac_rescue_dock_port_berth";
-	landmark_tag = "nav_iac_rescue_port_berth"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_berth{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
 "aHt" = (
@@ -450,7 +448,9 @@
 	req_access = list(211);
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/blue{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/pharmacy)
 "aHw" = (
@@ -496,7 +496,7 @@
 	dir = 1;
 	name = "Pressure Tank (Scrubbers)"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "aIu" = (
@@ -551,7 +551,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/yellow{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/coord)
 "aLC" = (
@@ -630,13 +632,15 @@
 "aXh" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
-	name = "Port Docks";
+	name = "EVA Preparation";
 	req_access = list(211)
 	},
 /obj/machinery/door/firedoor/multi_tile{
 	dir = 2
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/emergency_closet{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/evaprep)
 "bci" = (
@@ -702,12 +706,11 @@
 /obj/machinery/access_button{
 	pixel_x = 28
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_aft";
-	master_tag = "airlock_iac_rescue_dock_port_aft";
-	landmark_tag = "nav_iac_rescue_port_aft"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_aft{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
 "bfF" = (
@@ -834,12 +837,10 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock{
-	frequency = 1004;
-	master_tag = "airlock_horizon_deck_1_fore_1";
-	name = "airlock_iac_rescue_aft_stbd"
-	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/map_effect/marker/airlock/iac_rescue_ship/starboard{
+	req_one_access = list(211)
+	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/starboardengine)
 "bsr" = (
@@ -862,10 +863,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_berth";
-	master_tag = "airlock_iac_rescue_dock_stbd_berth";
-	landmark_tag = "nav_iac_rescue_stbd_berth"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_berth{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
@@ -911,12 +910,11 @@
 /area/ship/iac_rescue_ship/kitchen)
 "bFk" = (
 /obj/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_fore";
-	master_tag = "airlock_iac_rescue_dock_port_fore";
-	landmark_tag = "nav_iac_rescue_port_fore"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_fore{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
 "bHV" = (
@@ -927,7 +925,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "bIn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -1064,7 +1062,6 @@
 	dir = 4;
 	name = "Propellant Merge Valve"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -1073,6 +1070,7 @@
 	dir = 9;
 	pixel_y = 0
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -1252,7 +1250,7 @@
 	req_access = list(211);
 	name = "Engineering"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/engineering)
 "cqy" = (
@@ -1263,7 +1261,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "csk" = (
 /obj/structure/closet/walllocker{
@@ -1302,10 +1300,8 @@
 /obj/structure/bed/handrail{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_berth";
-	master_tag = "airlock_iac_rescue_dock_port_berth";
-	landmark_tag = "nav_iac_rescue_port_berth"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_berth{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
@@ -1319,10 +1315,8 @@
 /obj/structure/bed/handrail{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_berth";
-	master_tag = "airlock_iac_rescue_dock_stbd_berth";
-	landmark_tag = "nav_iac_rescue_stbd_berth"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_berth{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
@@ -1351,15 +1345,16 @@
 /area/ship/iac_rescue_ship/bridge)
 "cxf" = (
 /obj/machinery/seed_storage/garden,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/hydro)
 "czD" = (
-/obj/effect/floor_decal/industrial/warning,
 /obj/machinery/floodlight,
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/hangar)
 "cAV" = (
@@ -1577,10 +1572,8 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_fore";
-	master_tag = "airlock_iac_rescue_dock_stbd_fore";
-	landmark_tag = "nav_iac_rescue_stbd_fore"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_fore{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
@@ -1675,7 +1668,7 @@
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/bridge)
 "dey" = (
@@ -1694,8 +1687,8 @@
 	dir = 9
 	},
 /obj/structure/dispenser/oxygen,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/engineering)
 "dgo" = (
@@ -1703,7 +1696,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/portengine)
 "dkD" = (
@@ -1733,14 +1726,14 @@
 	pixel_x = -12;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
-	frequency = 1004;
-	master_tag = "airlock_horizon_deck_1_fore_1";
-	name = "airlock_iac_rescue_aft_port"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/obj/effect/map_effect/marker/airlock/iac_rescue_ship/port{
+	req_one_access = list(211)
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portengine)
 "dmm" = (
 /obj/effect/floor_decal/corner_wide/paleblue{
@@ -1783,7 +1776,9 @@
 	name = "Docking Arm Lockdown Blast Door";
 	id = "iac_docking_lockdown"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/blue{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/centralhallway)
 "dsu" = (
@@ -1894,7 +1889,7 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/pharmacy)
 "dAj" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/machinist)
 "dEO" = (
@@ -1980,12 +1975,12 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/medical)
 "dZw" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/portables_connector/aux,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/door/window/northleft{
 	dir = 2
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/portengine)
 "ebN" = (
@@ -2038,20 +2033,21 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/hatch_door/yellow{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/dorms)
 "ecX" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_fore";
-	master_tag = "airlock_iac_rescue_dock_stbd_fore";
-	landmark_tag = "nav_iac_rescue_stbd_fore"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_fore{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
 "egU" = (
@@ -2103,8 +2099,8 @@
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/portdocking)
 "eji" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/computer/ship/helm/terminal,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "ejl" = (
@@ -2112,12 +2108,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_fore";
-	master_tag = "airlock_iac_rescue_dock_port_fore";
-	landmark_tag = "nav_iac_rescue_port_fore"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_fore{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
 "ekU" = (
@@ -2191,7 +2186,7 @@
 /obj/machinery/door/window/northright{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/centralhallway)
 "eoK" = (
@@ -2223,12 +2218,13 @@
 /obj/effect/shuttle_landmark/iac_rescue_ship/port_berth{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_berth";
-	master_tag = "airlock_iac_rescue_dock_port_berth";
-	landmark_tag = "nav_iac_rescue_port_berth"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_berth{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
 "etL" = (
@@ -2331,7 +2327,7 @@
 /obj/machinery/vending/engineering{
 	req_access = list(211)
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/engineering)
 "eCV" = (
@@ -2375,11 +2371,11 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/forehallway)
 "eIH" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/starboardengine)
 "eKS" = (
@@ -2430,7 +2426,7 @@
 /obj/effect/floor_decal/corner/dark_blue/full{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/bridge)
 "eRf" = (
@@ -2708,7 +2704,7 @@
 /area/ship/iac_rescue_ship/dorms)
 "fty" = (
 /obj/structure/closet/firecloset/full,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/bridge)
 "fuA" = (
@@ -2726,7 +2722,6 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/engineering)
 "fwm" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/power/smes/buildable/horizon_shuttle,
 /obj/structure/cable/cyan{
 	d2 = 2;
@@ -2735,6 +2730,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/hatch/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/engineering)
 "fwM" = (
@@ -2859,7 +2855,7 @@
 "fHY" = (
 /obj/structure/lattice/catwalk,
 /obj/item/hullbeacon/red,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "fKv" = (
 /obj/structure/railing/mapped{
@@ -2942,7 +2938,7 @@
 /area/ship/iac_rescue_ship/forehallway)
 "fUw" = (
 /obj/structure/lattice/catwalk,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "fVz" = (
 /obj/effect/floor_decal/corner_wide/blue{
@@ -2997,7 +2993,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/starboardengine)
 "gcq" = (
@@ -3054,7 +3050,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/engineering{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/machinist)
 "gik" = (
@@ -3105,7 +3103,7 @@
 	dir = 4
 	},
 /obj/structure/railing/mapped,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "gqT" = (
 /obj/effect/floor_decal/corner_wide/blue{
@@ -3139,7 +3137,6 @@
 	},
 /obj/structure/railing/mapped,
 /obj/structure/closet/crate/freezer/kois/rations,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/spline/plain/black{
 	dir = 10
 	},
@@ -3147,6 +3144,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/hydro)
 "gwf" = (
@@ -3162,7 +3160,6 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/starboardengine)
 "gxW" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/aux,
 /obj/machinery/atmospherics/valve{
 	dir = 4;
@@ -3174,6 +3171,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -3293,7 +3291,7 @@
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "gJb" = (
@@ -3314,7 +3312,7 @@
 	dir = 4
 	},
 /obj/structure/railing/mapped,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "gLu" = (
 /turf/simulated/wall/shuttle/space_ship,
@@ -3402,6 +3400,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/industrial/hatch_door/yellow,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/bridge)
 "gTy" = (
@@ -3410,7 +3409,7 @@
 	dir = 4;
 	icon_state = "tube_empty"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/bridge)
 "gVm" = (
@@ -3461,13 +3460,11 @@
 /obj/structure/bed/handrail{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_berth";
-	master_tag = "airlock_iac_rescue_dock_stbd_berth";
-	landmark_tag = "nav_iac_rescue_stbd_berth"
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_berth{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
@@ -3495,12 +3492,10 @@
 	dir = 4;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
-	frequency = 1004;
-	master_tag = "airlock_horizon_deck_1_fore_1";
-	name = "airlock_iac_rescue_aft_port"
-	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/map_effect/marker/airlock/iac_rescue_ship/port{
+	req_one_access = list(211)
+	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/portengine)
 "hbN" = (
@@ -3535,7 +3530,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "heW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
@@ -3577,7 +3572,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/greengrid,
+/obj/effect/floor_decal/industrial/hatch_door/red,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/engineering)
 "hns" = (
 /obj/machinery/firealarm/north,
@@ -3604,10 +3600,10 @@
 /area/ship/iac_rescue_ship/afthallway)
 "hpp" = (
 /obj/machinery/vending/hydronutrients,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/hydro)
 "hqB" = (
@@ -3655,11 +3651,11 @@
 /obj/structure/lattice/catwalk,
 /obj/item/hullbeacon/green,
 /obj/structure/railing/mapped,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "hvh" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/hydroponics,
+/obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/hydro)
 "hvk" = (
@@ -3739,12 +3735,8 @@
 	pixel_x = 6;
 	pixel_y = 24
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_iac_rescue_shuttle";
-	req_one_access = list(211);
-	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle";
-	cycle_to_external_air = 1
+/obj/effect/map_effect/marker/airlock/shuttle/iac_rescue_ship/shuttle{
+	req_one_access = list(211)
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
@@ -3865,7 +3857,9 @@
 	name = "Docking Arm Lockdown Blast Door";
 	id = "iac_docking_lockdown"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/blue{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/centralhallway)
 "hOz" = (
@@ -3920,14 +3914,12 @@
 	pixel_y = 10;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
-	frequency = 1004;
-	master_tag = "airlock_horizon_deck_1_fore_1";
-	name = "airlock_iac_rescue_aft_stbd"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/obj/effect/map_effect/marker/airlock/iac_rescue_ship/starboard{
+	req_one_access = list(211)
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboardengine)
 "hRD" = (
 /obj/effect/floor_decal/corner/dark_green{
@@ -3944,21 +3936,22 @@
 	pixel_x = 12;
 	pixel_y = -28
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_berth";
-	master_tag = "airlock_iac_rescue_dock_port_berth";
-	landmark_tag = "nav_iac_rescue_port_berth"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_berth{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
 "hVh" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/portables_connector/aux,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/door/window/northright{
 	dir = 2
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/starboardengine)
 "hVP" = (
@@ -3971,10 +3964,8 @@
 	pixel_y = 28;
 	pixel_x = -6
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_berth";
-	master_tag = "airlock_iac_rescue_dock_port_berth";
-	landmark_tag = "nav_iac_rescue_port_berth"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_berth{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
@@ -4067,12 +4058,11 @@
 	pixel_y = -26;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_iac_rescue_shuttle";
-	req_one_access = list(211);
-	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle";
-	cycle_to_external_air = 1
+/obj/effect/map_effect/marker/airlock/shuttle/iac_rescue_ship/shuttle{
+	req_one_access = list(211)
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
@@ -4096,12 +4086,11 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_iac_rescue_shuttle";
-	req_one_access = list(211);
-	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle";
-	cycle_to_external_air = 1
+/obj/effect/map_effect/marker/airlock/shuttle/iac_rescue_ship/shuttle{
+	req_one_access = list(211)
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
@@ -4111,7 +4100,7 @@
 	dir = 1
 	},
 /obj/item/hullbeacon/green,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "iwK" = (
 /obj/machinery/vending/boozeomat{
@@ -4127,13 +4116,13 @@
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/fuel_port/hydrogen{
 	pixel_y = 32
 	},
 /obj/machinery/light/small/emergency{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/hatch/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "iyf" = (
@@ -4178,7 +4167,7 @@
 /obj/structure/closet/secure_closet/engineering_welding{
 	req_access = list(211)
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/engineering)
 "iDd" = (
@@ -4289,12 +4278,11 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_iac_rescue_shuttle";
-	req_one_access = list(211);
-	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle";
-	cycle_to_external_air = 1
+/obj/effect/map_effect/marker/airlock/shuttle/iac_rescue_ship/shuttle{
+	req_one_access = list(211)
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
@@ -4326,8 +4314,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/afthallway)
 "iMZ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/computer/shuttle_control/explore/terminal/iac_shuttle,
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "iNm" = (
@@ -4350,7 +4338,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/service{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/hydro)
 "iOh" = (
@@ -4383,12 +4373,8 @@
 	dir = 1
 	},
 /obj/effect/map_effect/marker_helper/airlock/out,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_iac_rescue_shuttle";
-	req_one_access = list(211);
-	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle";
-	cycle_to_external_air = 1
+/obj/effect/map_effect/marker/airlock/shuttle/iac_rescue_ship/shuttle{
+	req_one_access = list(211)
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
@@ -4438,12 +4424,11 @@
 /obj/effect/shuttle_landmark/iac_rescue_ship/starboard_fore{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_fore";
-	master_tag = "airlock_iac_rescue_dock_stbd_fore";
-	landmark_tag = "nav_iac_rescue_stbd_fore"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_fore{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
 "iZS" = (
@@ -4474,12 +4459,10 @@
 	dir = 8;
 	pixel_x = 20
 	},
-/obj/effect/map_effect/marker/airlock{
-	frequency = 1004;
-	master_tag = "airlock_horizon_deck_1_fore_1";
-	name = "airlock_iac_rescue_aft_stbd"
-	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/map_effect/marker/airlock/iac_rescue_ship/starboard{
+	req_one_access = list(211)
+	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/starboardengine)
 "jeT" = (
@@ -4514,12 +4497,8 @@
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_iac_rescue_shuttle";
-	req_one_access = list(211);
-	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle";
-	cycle_to_external_air = 1
+/obj/effect/map_effect/marker/airlock/shuttle/iac_rescue_ship/shuttle{
+	req_one_access = list(211)
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
@@ -4569,12 +4548,11 @@
 	pixel_x = 28;
 	pixel_y = 12
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_fore";
-	master_tag = "airlock_iac_rescue_dock_port_fore";
-	landmark_tag = "nav_iac_rescue_port_fore"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_fore{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
 "jqj" = (
@@ -4600,7 +4578,7 @@
 /obj/effect/floor_decal/corner/dark_blue{
 	dir = 5
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/custodial,
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/bridge)
 "jys" = (
@@ -4783,7 +4761,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/engineering{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/engineering)
 "jTd" = (
@@ -4868,7 +4848,8 @@
 	name = "Bathroom";
 	req_access = list(211)
 	},
-/turf/simulated/floor/tiled/freezer,
+/obj/effect/floor_decal/industrial/hatch_door/service,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/bathroom)
 "kak" = (
 /obj/machinery/door/blast/regular/open{
@@ -5145,7 +5126,7 @@
 /obj/effect/map_effect/map_helper/ruler_tiles_3,
 /obj/structure/lattice/catwalk,
 /obj/item/hullbeacon/green,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "kSj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5170,7 +5151,9 @@
 /obj/machinery/holosign/surgery{
 	id = 3
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/blue{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/surgery)
 "kVk" = (
@@ -5217,10 +5200,8 @@
 /area/ship/iac_rescue_ship/portengine)
 "laz" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/cyan,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_berth";
-	master_tag = "airlock_iac_rescue_dock_stbd_berth";
-	landmark_tag = "nav_iac_rescue_stbd_berth"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_berth{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
@@ -5272,7 +5253,7 @@
 /obj/machinery/computer/ship/navigation/terminal{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/bridge)
 "lgo" = (
@@ -5280,12 +5261,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_aft";
-	master_tag = "airlock_iac_rescue_dock_port_aft";
-	landmark_tag = "nav_iac_rescue_port_aft"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_aft{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
 "lgv" = (
@@ -5366,13 +5346,13 @@
 /obj/machinery/computer/ship/sensors/terminal{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/bridge)
 "lqf" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "lxs" = (
 /obj/effect/floor_decal/corner_wide/blue{
@@ -5427,12 +5407,11 @@
 	pixel_x = 28;
 	pixel_y = 12
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_aft";
-	master_tag = "airlock_iac_rescue_dock_port_aft";
-	landmark_tag = "nav_iac_rescue_port_aft"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_aft{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
 "lIW" = (
@@ -5441,7 +5420,7 @@
 	dir = 8
 	},
 /obj/structure/railing/mapped,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "lJs" = (
 /obj/effect/floor_decal/corner_wide/blue{
@@ -5459,10 +5438,8 @@
 /area/ship/iac_rescue_ship/starboarddocking)
 "lLX" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/cyan,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_berth";
-	master_tag = "airlock_iac_rescue_dock_port_berth";
-	landmark_tag = "nav_iac_rescue_port_berth"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_berth{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
@@ -5569,7 +5546,7 @@
 /area/ship/iac_rescue_ship/evaprep)
 "mfr" = (
 /obj/machinery/computer/ship/sensors/terminal,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "mfV" = (
@@ -5702,10 +5679,11 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "mvQ" = (
 /obj/machinery/telecomms/allinone/ship,
+/obj/effect/floor_decal/industrial/hatch/engineering,
 /turf/simulated/floor/tiled{
 	name = "cooled floor";
 	temperature = 278
@@ -5826,7 +5804,7 @@
 /obj/machinery/door/window/northright{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/centralhallway)
 "mQn" = (
@@ -5901,12 +5879,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_berth";
-	master_tag = "airlock_iac_rescue_dock_port_berth";
-	landmark_tag = "nav_iac_rescue_port_berth"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_berth{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
 "neA" = (
@@ -6017,19 +5996,18 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_aft";
-	landmark_tag = "nav_iac_rescue_stbd_aft";
-	master_tag = "airlock_iac_rescue_dock_stbd_aft"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_aft{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
 "nxu" = (
 /obj/effect/map_effect/map_helper/ruler_tiles_3,
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/mapped,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "nyj" = (
 /obj/effect/floor_decal/corner_wide/blue{
@@ -6055,14 +6033,12 @@
 	pixel_x = 26;
 	pixel_y = -10
 	},
-/obj/effect/map_effect/marker/airlock{
-	frequency = 1004;
-	master_tag = "airlock_horizon_deck_1_fore_1";
-	name = "airlock_iac_rescue_aft_port"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/obj/effect/map_effect/marker/airlock/iac_rescue_ship/port{
+	req_one_access = list(211)
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portengine)
 "nCS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -6104,12 +6080,12 @@
 /turf/simulated/floor/wood,
 /area/ship/iac_rescue_ship/dorms)
 "nJc" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/portables_connector/aux,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/door/window/northleft{
 	dir = 2
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/starboardengine)
 "nMu" = (
@@ -6136,10 +6112,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_berth";
-	master_tag = "airlock_iac_rescue_dock_port_berth";
-	landmark_tag = "nav_iac_rescue_port_berth"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_berth{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
@@ -6184,14 +6158,14 @@
 	pixel_x = 12;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock{
-	frequency = 1004;
-	master_tag = "airlock_horizon_deck_1_fore_1";
-	name = "airlock_iac_rescue_aft_stbd"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/obj/effect/map_effect/marker/airlock/iac_rescue_ship/starboard{
+	req_one_access = list(211)
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboardengine)
 "nSP" = (
 /obj/machinery/door/airlock/glass_service{
@@ -6200,6 +6174,7 @@
 	req_access = list(211)
 	},
 /obj/machinery/door/firedoor/noid,
+/obj/effect/floor_decal/industrial/hatch_door/service,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/hydro)
 "nTV" = (
@@ -6313,9 +6288,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/lattice/catwalk/indoor/grate,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/obj/effect/floor_decal/industrial/hatch_door/engineering,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/centralhallway)
 "okx" = (
 /turf/simulated/wall/shuttle/space_ship,
@@ -6400,11 +6374,11 @@
 	},
 /area/ship/iac_rescue_ship/bridge)
 "oyw" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/empty/carbon_dioxide,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/portengine)
 "oyE" = (
@@ -6463,7 +6437,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/hydro)
 "oCG" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/power/smes/buildable/third_party_shuttle,
 /obj/structure/cable/green{
 	icon_state = "0-2"
@@ -6471,6 +6444,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
 	},
+/obj/effect/floor_decal/industrial/hatch/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "oEh" = (
@@ -6519,14 +6493,12 @@
 	pixel_y = 10;
 	dir = 1
 	},
-/obj/effect/map_effect/marker/airlock{
-	frequency = 1004;
-	master_tag = "airlock_horizon_deck_1_fore_1";
-	name = "airlock_iac_rescue_aft_port"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/obj/effect/map_effect/marker/airlock/iac_rescue_ship/port{
+	req_one_access = list(211)
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portengine)
 "oLN" = (
 /obj/effect/landmark/entry_point/south{
@@ -6670,12 +6642,11 @@
 	pixel_y = 12
 	},
 /obj/effect/shuttle_landmark/iac_rescue_ship/starboard_aft,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_aft";
-	landmark_tag = "nav_iac_rescue_stbd_aft";
-	master_tag = "airlock_iac_rescue_dock_stbd_aft"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_aft{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
 "pfz" = (
@@ -6722,7 +6693,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/engineering{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/atmospherics)
 "phz" = (
@@ -6806,14 +6779,12 @@
 	pixel_x = -26;
 	pixel_y = -10
 	},
-/obj/effect/map_effect/marker/airlock{
-	frequency = 1004;
-	master_tag = "airlock_horizon_deck_1_fore_1";
-	name = "airlock_iac_rescue_aft_stbd"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
+/obj/effect/map_effect/marker/airlock/iac_rescue_ship/starboard{
+	req_one_access = list(211)
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
+/turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboardengine)
 "pvy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
@@ -6897,11 +6868,10 @@
 /obj/machinery/door/window/northleft{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/centralhallway)
 "pEN" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/autolathe,
 /obj/machinery/power/apc/super/east{
 	req_access = list(211)
@@ -6910,6 +6880,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/machinist)
 "pFS" = (
@@ -6937,14 +6908,10 @@
 	pixel_y = 6;
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_iac_rescue_shuttle";
-	req_one_access = list(211);
-	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle";
-	cycle_to_external_air = 1
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/shuttle/iac_rescue_ship/shuttle{
+	req_one_access = list(211)
+	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/iac_shuttle)
 "pGN" = (
@@ -6968,13 +6935,11 @@
 	frequency = 1337
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_fore";
-	master_tag = "airlock_iac_rescue_dock_port_fore";
-	landmark_tag = "nav_iac_rescue_port_fore"
-	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_fore{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
@@ -7001,11 +6966,12 @@
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/afthallway)
 "pKG" = (
-/obj/effect/floor_decal/industrial/warning,
 /obj/machinery/floodlight,
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/hangar)
 "pPY" = (
@@ -7030,12 +6996,13 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_berth";
-	master_tag = "airlock_iac_rescue_dock_stbd_berth";
-	landmark_tag = "nav_iac_rescue_stbd_berth"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_berth{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
 "pUZ" = (
@@ -7118,7 +7085,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "qfd" = (
 /turf/simulated/floor/tiled/white,
@@ -7143,12 +7110,11 @@
 	dir = 4
 	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_iac_rescue_shuttle";
-	req_one_access = list(211);
-	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle";
-	cycle_to_external_air = 1
+/obj/effect/map_effect/marker/airlock/shuttle/iac_rescue_ship/shuttle{
+	req_one_access = list(211)
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
@@ -7170,8 +7136,8 @@
 	dir = 4
 	},
 /obj/structure/closet/crate/freezer/rations,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/spline/plain/black,
+/obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/hydro)
 "qkm" = (
@@ -7274,7 +7240,7 @@
 	dir = 8
 	},
 /obj/structure/railing/mapped,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "qAL" = (
 /obj/machinery/recharger/wallcharger{
@@ -7297,12 +7263,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_berth";
-	master_tag = "airlock_iac_rescue_dock_stbd_berth";
-	landmark_tag = "nav_iac_rescue_stbd_berth"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_berth{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
 "qDv" = (
@@ -7327,12 +7294,13 @@
 "qEu" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube_empty"
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/ship/iac_rescue_ship/medical)
@@ -7413,12 +7381,8 @@
 	pixel_x = 12;
 	pixel_y = 40
 	},
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_iac_rescue_shuttle";
-	req_one_access = list(211);
-	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle";
-	cycle_to_external_air = 1
+/obj/effect/map_effect/marker/airlock/shuttle/iac_rescue_ship/shuttle{
+	req_one_access = list(211)
 	},
 /turf/simulated/floor,
 /area/shuttle/iac_shuttle)
@@ -7426,17 +7390,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_berth";
-	master_tag = "airlock_iac_rescue_dock_port_berth";
-	landmark_tag = "nav_iac_rescue_port_berth"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_berth{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
 "qMU" = (
 /obj/machinery/door/airlock/glass_service{
 	dir = 4;
-	name = "Hydroponics";
+	name = "Kitchen";
 	req_access = list(211)
 	},
 /obj/machinery/door/firedoor/noid{
@@ -7453,7 +7415,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/service{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/kitchen)
 "qPm" = (
@@ -7557,17 +7521,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/iac_rescue_ship/custodial)
-"qZx" = (
-/obj/machinery/door/airlock/maintenance{
+/obj/effect/floor_decal/industrial/hatch_door/custodial{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/structure/lattice/catwalk/indoor/grate,
-/turf/simulated/floor,
-/area/ship/iac_rescue_ship/centralhallway)
+/turf/simulated/floor/tiled/dark/full,
+/area/ship/iac_rescue_ship/custodial)
 "rbr" = (
 /obj/machinery/optable,
 /obj/effect/floor_decal/corner_wide/paleblue{
@@ -7652,12 +7610,11 @@
 /area/ship/iac_rescue_ship/portdocking)
 "roZ" = (
 /obj/machinery/door/airlock/external,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_aft";
-	landmark_tag = "nav_iac_rescue_stbd_aft";
-	master_tag = "airlock_iac_rescue_dock_stbd_aft"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_aft{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
 "rpg" = (
@@ -7704,7 +7661,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/noid,
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/hangar)
 "rtZ" = (
@@ -7782,7 +7739,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "rGp" = (
@@ -7828,7 +7785,7 @@
 /obj/machinery/computer/ship/navigation/terminal{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/security,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/bridge)
 "rMI" = (
@@ -7897,12 +7854,11 @@
 	pixel_x = -28;
 	pixel_y = 12
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_fore";
-	master_tag = "airlock_iac_rescue_dock_stbd_fore";
-	landmark_tag = "nav_iac_rescue_stbd_fore"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_fore{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
 "rRY" = (
@@ -7910,26 +7866,23 @@
 /obj/machinery/access_button{
 	pixel_x = -28
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_fore";
-	master_tag = "airlock_iac_rescue_dock_stbd_fore";
-	landmark_tag = "nav_iac_rescue_stbd_fore"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_fore{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
 "rTH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock{
-	frequency = 1004;
-	master_tag = "airlock_horizon_deck_1_fore_1";
-	name = "airlock_iac_rescue_aft_stbd"
-	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/light/small/emergency{
 	dir = 8
+	},
+/obj/effect/map_effect/marker/airlock/iac_rescue_ship/starboard{
+	req_one_access = list(211)
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/starboardengine)
@@ -7960,13 +7913,11 @@
 	pixel_x = -20;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_berth";
-	master_tag = "airlock_iac_rescue_dock_port_berth";
-	landmark_tag = "nav_iac_rescue_port_berth"
-	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_berth{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
@@ -7975,7 +7926,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "sah" = (
 /turf/simulated/floor/wood,
@@ -8019,14 +7970,6 @@
 /obj/structure/closet/crate/rad{
 	name = "radioactive fuel crate"
 	},
-/obj/item/stack/material/tritium/full{
-	pixel_y = 3;
-	pixel_x = 5
-	},
-/obj/item/stack/material/tritium/full{
-	pixel_y = 3;
-	pixel_x = 5
-	},
 /obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -8042,12 +7985,28 @@
 	pixel_x = -5;
 	pixel_y = 3
 	},
+/obj/item/stack/material/graphite/full{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/stack/material/tritium/full{
+	pixel_y = 3;
+	pixel_x = 5
+	},
+/obj/item/stack/material/tritium/full{
+	pixel_y = 3;
+	pixel_x = 5
+	},
+/obj/item/stack/material/tritium/full{
+	pixel_y = 3;
+	pixel_x = 5
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/engineering)
 "seG" = (
 /obj/structure/lattice/catwalk,
 /obj/item/hullbeacon/green,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "shf" = (
 /obj/machinery/power/portgen/basic/fusion,
@@ -8055,7 +8014,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/floor_decal/industrial/outline/service,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/engineering)
 "shz" = (
@@ -8137,10 +8096,8 @@
 	pixel_y = 10;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_aft";
-	master_tag = "airlock_iac_rescue_dock_port_aft";
-	landmark_tag = "nav_iac_rescue_port_aft"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_aft{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
@@ -8191,7 +8148,7 @@
 "sDF" = (
 /obj/structure/lattice/catwalk,
 /obj/item/hullbeacon/red,
-/turf/template_noop,
+/turf/space/dynamic,
 /area/ship/iac_rescue_ship/bridge)
 "sFD" = (
 /obj/effect/floor_decal/corner_wide/blue{
@@ -8268,10 +8225,8 @@
 /obj/structure/bed/handrail{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_berth";
-	master_tag = "airlock_iac_rescue_dock_stbd_berth";
-	landmark_tag = "nav_iac_rescue_stbd_berth"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_berth{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
@@ -8295,13 +8250,10 @@
 	},
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_iac_rescue_shuttle";
-	req_one_access = list(211);
-	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/shuttle/iac_rescue_ship/shuttle{
+	req_one_access = list(211)
+	},
 /turf/simulated/floor,
 /area/shuttle/iac_shuttle)
 "sXB" = (
@@ -8312,7 +8264,7 @@
 /obj/machinery/door/window/northleft{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/centralhallway)
 "sXO" = (
@@ -8429,12 +8381,12 @@
 /obj/structure/closet/secure_closet/engineering_electrical{
 	req_access = list(211)
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light_switch{
 	pixel_y = -20;
 	pixel_x = 6
 	},
 /obj/machinery/light/small,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/engineering)
 "tns" = (
@@ -8530,7 +8482,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/blue,
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/medical)
 "tyj" = (
@@ -8548,12 +8500,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/centralhallway)
-"tzA" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/tiled/dark/full,
-/area/ship/iac_rescue_ship/hydro)
 "tCo" = (
 /obj/machinery/smartfridge/secure,
 /turf/simulated/floor,
@@ -8668,12 +8614,10 @@
 	dir = 4;
 	pixel_x = -20
 	},
-/obj/effect/map_effect/marker/airlock{
-	frequency = 1004;
-	master_tag = "airlock_horizon_deck_1_fore_1";
-	name = "airlock_iac_rescue_aft_port"
-	},
 /obj/structure/lattice/catwalk/indoor/grate,
+/obj/effect/map_effect/marker/airlock/iac_rescue_ship/port{
+	req_one_access = list(211)
+	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/portengine)
 "tWD" = (
@@ -8799,7 +8743,7 @@
 	dir = 8
 	},
 /obj/structure/closet/crate/freezer/rations,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/emergency_closet,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "umh" = (
@@ -8809,7 +8753,7 @@
 	req_access = list(211);
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/blue,
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/medical)
 "uoC" = (
@@ -8839,12 +8783,10 @@
 /obj/structure/bed/handrail{
 	dir = 8
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_berth";
-	master_tag = "airlock_iac_rescue_dock_stbd_berth";
-	landmark_tag = "nav_iac_rescue_stbd_berth"
-	},
 /obj/machinery/light/small,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_berth{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
 "utA" = (
@@ -8888,10 +8830,8 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_aft";
-	landmark_tag = "nav_iac_rescue_stbd_aft";
-	master_tag = "airlock_iac_rescue_dock_stbd_aft"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_aft{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
@@ -9092,7 +9032,7 @@
 /obj/machinery/computer/ship/engines/terminal{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/bridge)
 "uTA" = (
@@ -9111,10 +9051,8 @@
 	pixel_y = 10;
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_fore";
-	master_tag = "airlock_iac_rescue_dock_port_fore";
-	landmark_tag = "nav_iac_rescue_port_fore"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_fore{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
@@ -9154,10 +9092,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/floor_decal/industrial/outline/service,
 /obj/machinery/power/portgen/basic{
 	anchored = 1
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/engineering)
 "vbD" = (
@@ -9229,20 +9167,19 @@
 /obj/machinery/alarm/north{
 	req_one_access = list(211)
 	},
+/obj/effect/floor_decal/industrial/outline/service,
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/hydro)
 "vjw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/aux{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock{
-	frequency = 1004;
-	master_tag = "airlock_horizon_deck_1_fore_1";
-	name = "airlock_iac_rescue_aft_port"
-	},
 /obj/structure/lattice/catwalk/indoor/grate,
 /obj/machinery/light/small/emergency{
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/iac_rescue_ship/port{
+	req_one_access = list(211)
 	},
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/portengine)
@@ -9254,7 +9191,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "vkY" = (
 /obj/machinery/power/apc/south{
@@ -9393,10 +9330,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_berth";
-	master_tag = "airlock_iac_rescue_dock_port_berth";
-	landmark_tag = "nav_iac_rescue_port_berth"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_berth{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
@@ -9418,13 +9353,11 @@
 	frequency = 1337
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_fore";
-	master_tag = "airlock_iac_rescue_dock_stbd_fore";
-	landmark_tag = "nav_iac_rescue_stbd_fore"
-	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_fore{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
@@ -9438,7 +9371,7 @@
 	name = "EVA Preparation";
 	req_access = list(211)
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/emergency_closet,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/evaprep)
 "vFx" = (
@@ -9455,10 +9388,10 @@
 /area/ship/iac_rescue_ship/hangar)
 "vKv" = (
 /obj/structure/closet/crate/freezer/kois/rations,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small/emergency{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/outline/firefighting_closet,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "vKH" = (
@@ -9532,6 +9465,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/blue,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/afthallway)
 "vSL" = (
@@ -9550,6 +9484,7 @@
 /area/ship/iac_rescue_ship/mainstorage)
 "vTl" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled,
 /area/ship/iac_rescue_ship/medical)
 "vTI" = (
@@ -9602,12 +9537,8 @@
 	frequency = 1337
 	},
 /obj/machinery/light/small/emergency,
-/obj/effect/map_effect/marker/airlock/shuttle{
-	name = "airlock_iac_rescue_shuttle";
-	req_one_access = list(211);
-	master_tag = "airlock_iac_rescue_shuttle";
-	shuttle_tag = "IAC Ambulance Shuttle";
-	cycle_to_external_air = 1
+/obj/effect/map_effect/marker/airlock/shuttle/iac_rescue_ship/shuttle{
+	req_one_access = list(211)
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
@@ -9694,13 +9625,11 @@
 "wvf" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_aft";
-	landmark_tag = "nav_iac_rescue_stbd_aft";
-	master_tag = "airlock_iac_rescue_dock_stbd_aft"
-	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_aft{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
@@ -9716,10 +9645,10 @@
 /obj/machinery/door/window/northleft{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/hatch/engineering,
 /turf/simulated/floor/tiled/dark/full,
 /area/shuttle/iac_shuttle)
 "wzg" = (
@@ -9736,7 +9665,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/template_noop,
+/turf/space/dynamic,
 /area/space)
 "wEW" = (
 /obj/machinery/vending/tool{
@@ -9765,7 +9694,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/emergency_closet{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/evaprep)
 "wMq" = (
@@ -9802,7 +9733,7 @@
 	dir = 1;
 	req_access = list(211)
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/bridge)
 "wUA" = (
@@ -9817,10 +9748,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_berth";
-	master_tag = "airlock_iac_rescue_dock_stbd_berth";
-	landmark_tag = "nav_iac_rescue_stbd_berth"
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_berth{
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
@@ -9849,6 +9778,9 @@
 	name = "Main Storage";
 	req_access = list(211);
 	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch_door/blue{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/mainstorage)
@@ -9965,6 +9897,9 @@
 	req_access = list(211);
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/hatch_door/engineering{
+	dir = 1
+	},
 /turf/simulated/floor/tiled{
 	name = "cooled floor";
 	temperature = 278
@@ -10000,21 +9935,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/bridge)
 "xxN" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/portables_connector/aux,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/machinery/door/window/northright{
 	dir = 2
 	},
+/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/portengine)
 "xzk" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/light/small/emergency,
+/obj/effect/floor_decal/industrial/outline/engineering,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/light/small/emergency,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/hangar)
 "xBq" = (
@@ -10051,7 +9986,9 @@
 	name = "Docking Arm Lockdown Blast Door";
 	id = "iac_docking_lockdown"
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/blue{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/iac_rescue_ship/centralhallway)
 "xFK" = (
@@ -10131,12 +10068,13 @@
 /obj/effect/shuttle_landmark/iac_rescue_ship/starboard_berth{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_berth";
-	master_tag = "airlock_iac_rescue_dock_stbd_berth";
-	landmark_tag = "nav_iac_rescue_stbd_berth"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_berth{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
 "xXK" = (
@@ -10160,12 +10098,13 @@
 	pixel_x = 12;
 	pixel_y = 28
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_stbd_berth";
-	master_tag = "airlock_iac_rescue_dock_stbd_berth";
-	landmark_tag = "nav_iac_rescue_stbd_berth"
-	},
 /obj/effect/map_effect/marker_helper/airlock/interior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/starboard_berth{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/starboarddocking)
 "ybH" = (
@@ -10193,23 +10132,20 @@
 /obj/structure/bed/handrail{
 	dir = 4
 	},
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_berth";
-	master_tag = "airlock_iac_rescue_dock_port_berth";
-	landmark_tag = "nav_iac_rescue_port_berth"
-	},
 /obj/machinery/light/small,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_berth{
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
 "yhq" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/shuttle_landmark/iac_rescue_ship/port_aft,
-/obj/effect/map_effect/marker/airlock/docking{
-	name = "airlock_iac_rescue_dock_port_aft";
-	master_tag = "airlock_iac_rescue_dock_port_aft";
-	landmark_tag = "nav_iac_rescue_port_aft"
-	},
 /obj/effect/map_effect/marker_helper/airlock/exterior,
+/obj/effect/map_effect/marker/airlock/docking/iac_rescue_ship/dock/port_aft{
+	req_one_access = null
+	},
+/obj/effect/floor_decal/industrial/hatch_door/red,
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/portdocking)
 "yiM" = (
@@ -10253,7 +10189,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch_door/blue,
 /turf/simulated/floor/tiled/white,
 /area/ship/iac_rescue_ship/medical)
 "yjO" = (
@@ -40995,7 +40931,7 @@ eoU
 nbZ
 cxf
 hPn
-tzA
+hvh
 hvh
 wjC
 tzl
@@ -44341,7 +44277,7 @@ nCS
 okx
 eww
 gVm
-qZx
+ojY
 sVX
 bLX
 bVq

--- a/maps/away/ships/iac/iac_rescue_ship.dmm
+++ b/maps/away/ships/iac/iac_rescue_ship.dmm
@@ -1944,13 +1944,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/corner/yellow{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/lattice/catwalk/indoor/grate,
+/turf/simulated/floor,
 /area/ship/iac_rescue_ship/engineering)
 "dOF" = (
 /obj/machinery/alarm/east{
@@ -7977,18 +7972,6 @@
 	name = "HIGH VOLTAGE";
 	pixel_y = 32
 	},
-/obj/item/stack/material/graphite/full{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/stack/material/graphite/full{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/stack/material/graphite/full{
-	pixel_x = -5;
-	pixel_y = 3
-	},
 /obj/item/stack/material/tritium/full{
 	pixel_y = 3;
 	pixel_x = 5
@@ -8000,6 +7983,18 @@
 /obj/item/stack/material/tritium/full{
 	pixel_y = 3;
 	pixel_x = 5
+	},
+/obj/item/stack/material/uranium/full{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/stack/material/uranium/full{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/stack/material/uranium/full{
+	pixel_x = -5;
+	pixel_y = 3
 	},
 /turf/simulated/floor/tiled/dark/full,
 /area/ship/iac_rescue_ship/engineering)
@@ -9092,10 +9087,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/portgen/basic{
+/obj/effect/floor_decal/industrial/outline/engineering,
+/obj/machinery/power/portgen/basic/advanced{
 	anchored = 1
 	},
-/obj/effect/floor_decal/industrial/outline/engineering,
 /turf/simulated/floor,
 /area/ship/iac_rescue_ship/engineering)
 "vbD" = (


### PR DESCRIPTION
Started as me fixing the airlock and docking markers and ended with me finding various little bugs that I missed when I remapped the ship a while back.

- Properly creates subtypes for the airlock/shuttle/docking markers specific to the IAC ship instead of just having them be variable edited versions of the main type.
- Fixed some incorrectly named airlocks.
- Adjusted some floor decals.
- Tweaked some access requirements.
- Returns the uranium-powered portable generator I originally intended for on account of #19978.