### PR TITLE
Uranium Portable Generator Fix

### DIFF
--- a/code/modules/power/portgen.dm
+++ b/code/modules/power/portgen.dm
@@ -411,6 +411,7 @@
 	board_path = "/obj/item/circuitboard/portgen/advanced"
 
 	power_gen = 50000 // 200 kW = safe max, 250 kW = unsafe max.
+	max_temperature = 340
 	temperature_gain = 60
 
 /obj/machinery/power/portgen/basic/advanced/UseFuel()

--- a/html/changelogs/furrycactus - uranium portgen fix.yml
+++ b/html/changelogs/furrycactus - uranium portgen fix.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Furrycactus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "Fixes the uranium-fueled advanced portable generator exploding when running at level 4."


### PR DESCRIPTION
Fixes the uranium-powered portable generator exploding when it's used at level 4. The safe heat threshold was supposed to be 300c, but a small variance of 16c was causing it to just surpass that and go into overheat when it's not supposed to.