### PR TITLE
Reduces Adhomian ghostrole spawn weight in the Badlands

### DIFF
--- a/html/changelogs/hazelmouse-ghostroletweaks.yml
+++ b/html/changelogs/hazelmouse-ghostroletweaks.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - balance: "Reduces the spawn chance of all Adhomian ghostroles in the Badlands by half."

--- a/maps/away/away_site/tajara/mining_jack/mining_jack.dm
+++ b/maps/away/away_site/tajara/mining_jack/mining_jack.dm
@@ -6,6 +6,7 @@
 	suffix = "mining_jack.dmm"
 
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL, SECTOR_GAKAL)
+	spawn_weight_sector_dependent = list(SECTOR_BADLANDS = 0.5)
 	spawn_weight = 1
 	ship_cost = 1
 	id = "tajara_mining_jack"

--- a/maps/away/away_site/tajara/scrapper/scrapper.dm
+++ b/maps/away/away_site/tajara/scrapper/scrapper.dm
@@ -6,6 +6,7 @@
 	suffix = "scrapper.dmm"
 
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL, SECTOR_GAKAL)
+	spawn_weight_sector_dependent = list(SECTOR_BADLANDS = 0.5)
 	spawn_weight = 1
 	ship_cost = 1
 	id = "tajara_scrapper"

--- a/maps/away/ships/dpra/hailstorm/hailstorm_ship.dm
+++ b/maps/away/ships/dpra/hailstorm/hailstorm_ship.dm
@@ -9,7 +9,7 @@
 	ship_cost = 1
 	spawn_weight = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/hailstorm_shuttle)
-	spawn_weight_sector_dependent = list(SECTOR_SRANDMARR = 2, SECTOR_GAKAL = 2)
+	spawn_weight_sector_dependent = list(SECTOR_SRANDMARR = 2, SECTOR_GAKAL = 2, SECTOR_BADLANDS = 0.5)
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_GAKAL)
 	unit_test_groups = list(1)
 

--- a/maps/away/ships/nka/nka_merchant/nka_merchant.dm
+++ b/maps/away/ships/nka/nka_merchant/nka_merchant.dm
@@ -9,7 +9,7 @@
 	ship_cost = 1
 	spawn_weight = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/nka_merchant_shuttle)
-	spawn_weight_sector_dependent = list(SECTOR_SRANDMARR = 2)
+	spawn_weight_sector_dependent = list(SECTOR_SRANDMARR = 2, SECTOR_BADLANDS = 0.5)
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_VALLEY_HALE, SECTOR_CORP_ZONE, SECTOR_TAU_CETI)
 
 	unit_test_groups = list(3)

--- a/maps/away/ships/pra/database_freighter/database_freighter.dm
+++ b/maps/away/ships/pra/database_freighter/database_freighter.dm
@@ -10,6 +10,7 @@
 	spawn_weight = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/database_freighter_shuttle)
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL)
+	spawn_weight_sector_dependent = list(SECTOR_BADLANDS = 0.5)
 
 	unit_test_groups = list(3)
 

--- a/maps/away/ships/pra/headmaster/headmaster_ship.dm
+++ b/maps/away/ships/pra/headmaster/headmaster_ship.dm
@@ -9,7 +9,7 @@
 	ship_cost = 1
 	spawn_weight = 1
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/headmaster_shuttle)
-	spawn_weight_sector_dependent = list(SECTOR_SRANDMARR = 2, SECTOR_NRRAHRAHUL = 2)
+	spawn_weight_sector_dependent = list(SECTOR_SRANDMARR = 2, SECTOR_NRRAHRAHUL = 2, SECTOR_BADLANDS = 0.5)
 	sectors = list(SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL)
 
 	unit_test_groups = list(3)

--- a/maps/away/ships/tajara/circus/adhomian_circus.dm
+++ b/maps/away/ships/tajara/circus/adhomian_circus.dm
@@ -5,7 +5,8 @@
 	prefix = "ships/tajara/circus/"
 	suffix = "adhomian_circus.dmm"
 
-	sectors = list(ALL_TAU_CETI_SECTORS, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL, SECTOR_GAKAL)
+	sectors = list(ALL_TAU_CETI_SECTORS, SECTOR_VALLEY_HALE, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL, SECTOR_GAKAL)
+	spawn_weight_sector_dependent = list(SECTOR_BADLANDS = 0.5)
 	spawn_weight = 1
 	ship_cost = 1
 	id = "adhomian_circus_ship"

--- a/maps/away/ships/tajara/circus/adhomian_circus.dm
+++ b/maps/away/ships/tajara/circus/adhomian_circus.dm
@@ -5,7 +5,7 @@
 	prefix = "ships/tajara/circus/"
 	suffix = "adhomian_circus.dmm"
 
-	sectors = list(ALL_TAU_CETI_SECTORS, SECTOR_VALLEY_HALE, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL, SECTOR_GAKAL)
+	sectors = list(ALL_TAU_CETI_SECTORS, SECTOR_VALLEY_HALE, SECTOR_BADLANDS, SECTOR_SRANDMARR, SECTOR_NRRAHRAHUL, SECTOR_GAKAL)
 	spawn_weight_sector_dependent = list(SECTOR_BADLANDS = 0.5)
 	spawn_weight = 1
 	ship_cost = 1

--- a/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dm
+++ b/maps/away/ships/tajara/taj_smuggler/tajaran_smuggler.dm
@@ -6,6 +6,7 @@
 	suffix = "tajaran_smuggler.dmm"
 
 	sectors = list(SECTOR_ROMANOVICH, SECTOR_CORP_ZONE, ALL_BADLAND_SECTORS, SECTOR_WEEPING_STARS)
+	spawn_weight_sector_dependent = list(SECTOR_BADLANDS = 0.5)
 	spawn_weight = 1
 	ship_cost = 1
 	id = "tajaran_smuggler"


### PR DESCRIPTION
See title. There's eight of them in total so they're taking up a disproportional amount of the ship pool in this sector in particular. This halves their spawn-weight to give other ghostroles a bit more room to breathe. 

Discussed with Tajara lore beforehand, cleared by Alb.

While I was in the area, also removes the empty space_bar.dm in the away sites folder. It had no .dmm, I'm not honestly sure why it wasn't deleted before.