### PR TITLE
Fixes SCC & TCAF flight helmets

### DIFF
--- a/code/modules/clothing/factions/biesel.dm
+++ b/code/modules/clothing/factions/biesel.dm
@@ -108,14 +108,6 @@
 	item_state = "tcaf_officer_uniform"
 	worn_state = "tcaf_officer_uniform"
 
-// Not to be confused with the TCFL variant. Redeclaring icon for clarity's sake, this isn't in the tcaf_uniform file.
-/obj/item/clothing/head/helmet/pilot/tcaf
-	name = "\improper TCAF flight helmet"
-	desc = "A pilot's helmet marked all over with the imagery of the Republic of Biesel, worn by the pilots of the Tau Ceti Armed Forces. It looks a little scuffed."
-	icon = 'icons/clothing/head/pilot_helmets.dmi'
-	icon_state = "tcaf_pilot"
-	item_state = "tcaf_pilot"
-
 // Identical sprites to the TCFL variant, just reflavoured.
 /obj/item/clothing/head/softcap/tcaf_cap
 	name = "TCAF uniform cap"

--- a/code/modules/clothing/head/pilot_helmet.dm
+++ b/code/modules/clothing/head/pilot_helmet.dm
@@ -146,8 +146,16 @@
 /obj/item/clothing/head/helmet/pilot/scc
 	name = "conglomerate flight helmet"
 	desc = "A pilot helmet with the deep colors of the Stellar Corporate Conglomerate. The highlight is a navy blue, and the mounted visor a striking, opaque cyan. The visor feeds its wearer in-flight information via an integrated heads-up display."
+	sprite_sheets = null // Can be filled in with unique species-specific sprites for races with snouts, see parent type. Keep null until sprites are implemented.
 	icon_state = "scc_pilot"
 	item_state = "scc_pilot"
+
+/obj/item/clothing/head/helmet/pilot/tcaf
+	name = "\improper TCAF flight helmet"
+	desc = "A pilot's helmet marked all over with the imagery of the Republic of Biesel, worn by the pilots of the Tau Ceti Armed Forces. It looks a little scuffed."
+	sprite_sheets = null // Can be filled in with unique species-specific sprites for races with snouts, see parent type. Keep null until sprites are implemented.
+	icon_state = "tcaf_pilot"
+	item_state = "tcaf_pilot"
 
 /obj/item/clothing/head/helmet/pilot/legion
 	name = "foreign legion flight helmet"

--- a/html/changelogs/hazelmouse-helmetfixes.yml
+++ b/html/changelogs/hazelmouse-helmetfixes.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: hazelmouse
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - bugfix: "SCC and TCAF flight helmets are no longer invisible on Unathi and Tajara."


### PR DESCRIPTION
The parent type for flight helmets defines unique head sprites for Tajara and Unathi, intended for variations with a longer visor to accommodate snouts. These aren't sprited for the SCC or TCAF variants, so they just turned out invisible ingame. This sets the definition to null for both of those until someone decides to sprite species variations for them.

Moves the TCAF flight helmet to pilot_helmet.dm for neatness.

Resolves https://github.com/Aurorastation/Aurora.3/issues/19968