### PR TITLE
Re-adds stealth ling dna sting

### DIFF
--- a/code/game/gamemodes/changeling/helpers/_store.dm
+++ b/code/game/gamemodes/changeling/helpers/_store.dm
@@ -103,6 +103,13 @@ var/list/datum/power/changeling/powerinstances = list()
 //Stings and sting accessorries
 //Rest in pieces, unfat sting. - Geeves
 
+/datum/power/changeling/extract_dna
+	name = "Extract DNA Sting"
+	desc = "We silently sting a human and copy their DNA, allowing us to mimic their form."
+	genomecost = 0
+	allowduringlesserform = TRUE
+	verbpath = /mob/proc/changeling_extract_dna_sting
+
 /datum/power/changeling/boost_range
 	name = "Boost Range"
 	desc = "We evolve the ability to shoot our stingers at humans, with some preperation."

--- a/html/changelogs/tag114-dnasting.txt
+++ b/html/changelogs/tag114-dnasting.txt
@@ -1,0 +1,6 @@
+author: Tag114
+
+delete-after: True
+
+changes:
+  - bugfix: "Fixes changelings being unable to use the 'Extract DNA Sting' ability."

--- a/html/changelogs/tag114-dnasting.txt
+++ b/html/changelogs/tag114-dnasting.txt
@@ -1,6 +1,0 @@
-author: Tag114
-
-delete-after: True
-
-changes:
-  - rscadd: "Re-enables the ability for changelings to stealthily extract DNA from targets by stinging them."

--- a/html/changelogs/tag114-dnasting.txt
+++ b/html/changelogs/tag114-dnasting.txt
@@ -3,4 +3,4 @@ author: Tag114
 delete-after: True
 
 changes:
-  - bugfix: "Fixes changelings being unable to use the 'Extract DNA Sting' ability."
+  - rscadd: "Re-enables the ability for changelings to stealthily extract DNA from targets by stinging them."

--- a/html/changelogs/tag114-dnasting.yml
+++ b/html/changelogs/tag114-dnasting.yml
@@ -1,0 +1,6 @@
+author: Tag114
+
+delete-after: True
+
+changes:
+  - rscadd: "Re-enables the ability for changelings to stealthily extract DNA from targets by stinging them."


### PR DESCRIPTION
Adds the DNA extraction sting which currently exists in the code to the changeling ability store, enabling the ability in-game.

From what I can tell, the reason the ability is currently disabled is because it originally allowed changelings to gain more ability points without any risk, which is no longer the case as of the merging of https://github.com/Aurorastation/Aurora.3/pull/17140, which made it so that changelings only get a set amount of ability points and cannot gain more.

DNA extraction sting in its current form does not allow changelings to respec, that still requires changelings to absorb someone.