### PR TITLE
Makes Miniature Fusion Reactor Circuit Boards Accessible

### DIFF
--- a/code/modules/research/designs/circuit/machine_circuits.dm
+++ b/code/modules/research/designs/circuit/machine_circuits.dm
@@ -161,6 +161,11 @@
 	req_tech = list(TECH_DATA = 3, TECH_POWER = 5, TECH_ENGINEERING = 5)
 	build_path = /obj/item/circuitboard/portgen/super
 
+/datum/design/circuit/machine/fusionportgen
+	name = "miniature fusion reactor"
+	req_tech = list(TECH_DATA = 3, TECH_POWER = 6, TECH_ENGINEERING = 6)
+	build_path = /obj/item/circuitboard/portgen/fusion
+
 /datum/design/circuit/machine/batteryrack
 	name = "Cell Rack PSU"
 	req_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 2)

--- a/html/changelogs/furrycactus-minifusionboards.yml
+++ b/html/changelogs/furrycactus-minifusionboards.yml
@@ -1,0 +1,58 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes:
+#   bugfix
+#     - (fixes bugs)
+#   wip
+#     - (work in progress)
+#   qol
+#     - (quality of life)
+#   soundadd
+#     - (adds a sound)
+#   sounddel
+#     - (removes a sound)
+#   rscadd
+#     - (adds a feature)
+#   rscdel
+#     - (removes a feature)
+#   imageadd
+#     - (adds an image or sprite)
+#   imagedel
+#     - (removes an image or sprite)
+#   spellcheck
+#     - (fixes spelling or grammar)
+#   experiment
+#     - (experimental change)
+#   balance
+#     - (balance changes)
+#   code_imp
+#     - (misc internal code change)
+#   refactor
+#     - (refactors code)
+#   config
+#     - (makes a change to the config files)
+#   admin
+#     - (makes changes to administrator tools)
+#   server
+#     - (miscellaneous changes to server)
+#################################
+
+# Your name.
+author: Furrycactus
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes:
+  - rscadd: "Added the circuitboard for the miniature fusion reactors to the circuit imprinter list. Also added a board and some spare tritium to Engineering Hard Storage as a potential backup power source, or for more energy intensive construction projects."


### PR DESCRIPTION
- Adds the circuit boards for the miniature fusion reactors to circuit imprinters.
- Also adds a spare board (but no parts) and some extra tritium to engineering hard storage. It could serve as an emergency power source for the Horizon in the event something goes catastrophically wrong with the main engines (provided Research can print upgraded parts too), or even be used for power when establishing an outpost on an exoplanet (I'm delusional).